### PR TITLE
openbabel: update to 3.1.1, add openbabel2 to track 2.x branch

### DIFF
--- a/gnome/gnome-chemistry-utils/Portfile
+++ b/gnome/gnome-chemistry-utils/Portfile
@@ -6,6 +6,7 @@ PortGroup           active_variants 1.1
 name                gnome-chemistry-utils
 version             0.14.17
 set major           [join [lrange [split ${version} .] 0 1] .]
+revision            1
 
 categories          gnome science chemistry
 platforms           darwin linux freebsd
@@ -14,7 +15,7 @@ license             GPL-3
 
 description         This package provides a set of Gtk3-based applications for drawing \
                     and viewing molecules, crystals and spectra.
-                    
+
 long_description    This package provides the following programs: \
                     \n-  GChem3D displays molecule structures in 3D \
                     \n-  GChemCalc provides calculations for chemistry \
@@ -37,7 +38,7 @@ depends_build       port:pkgconfig \
                     port:autoconf \
                     port:automake \
                     port:libtool
-                    
+
 depends_lib         port:desktop-file-utils \
                     port:rarian \
                     port:shared-mime-info \
@@ -45,7 +46,7 @@ depends_lib         port:desktop-file-utils \
                     port:gtk3 \
                     port:goffice \
                     port:gnumeric \
-                    port:openbabel \
+                    port:openbabel2 \
                     port:bodr \
                     port:chemical-mime-data \
                     port:gnome-mime-data \

--- a/kde/kalzium/Portfile
+++ b/kde/kalzium/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kalzium
 version             4.14.3
-revision            3
+revision            4
 categories          kde kde4 chemistry
 license             GPL-2+ LGPL-2+
 maintainers         {nicos @NicosPavlov}
@@ -20,7 +20,7 @@ use_xz              yes
 checksums           rmd160  79c3d78183b71829835b8b623a44152ee84e85fe \
                     sha256  4b8d086c942874c56b4835079991f2d86289d163d2dbb3e86390270c758317e5
 
-depends_lib-append  port:eigen port:openbabel \
+depends_lib-append  port:eigen port:openbabel2 \
                     port:libkdeedu port:ocaml
 
 #Binaries do not link to openssl, nor use the ssl backend of kdelibs4

--- a/python/py-openbabel/Portfile
+++ b/python/py-openbabel/Portfile
@@ -7,6 +7,8 @@ PortGroup           python 1.0
 
 name                py-openbabel
 version             2.4.1
+revision            1
+
 categories-append   science chemistry devel
 platforms           darwin freebsd
 license             GPL-2
@@ -39,24 +41,24 @@ if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools \
                         port:eigen \
                         port:swig-python
-    
-    depends_lib-append  port:openbabel
+
+    depends_lib-append  port:openbabel2
 
     pre-build {
         foreach ifile {openbabel-python.i stereo.i} {
             copy ${worksrcpath}/../$ifile ${worksrcpath}
         }
     }
-    
-    build.env-append    OPENBABEL_INSTALL=${prefix} 
+
+    build.env-append    OPENBABEL_INSTALL=${prefix}
     build.target        build_ext
     build.args-append   -I${prefix}/include/openbabel-2.0:${prefix}/include/eigen2
-    
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -m 755 -d ${destroot}${docdir}
         xinstall -m 644 -W ${worksrcpath} README.rst ${destroot}${docdir}
     }
-    
+
     livecheck.type      none
 }

--- a/science/chemtool/Portfile
+++ b/science/chemtool/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                chemtool
 version             1.6.14
-revision            1
+revision            2
 categories          science chemistry
 platforms           darwin
 maintainers         nomaintainer
@@ -21,7 +21,7 @@ checksums           rmd160  bd3560bbfe6d95f9eb5dbafbb2cc3710a52cd04c \
 
 depends_build       port:pkgconfig
 depends_lib         port:gtk2 \
-                    port:openbabel \
+                    port:openbabel2 \
                     port:fig2dev
 
 configure.args      --mandir=${prefix}/share/man

--- a/science/ghemical/Portfile
+++ b/science/ghemical/Portfile
@@ -5,6 +5,8 @@ PortSystem          1.0
 name                ghemical
 version             3.0.0
 set release_date    20111012
+revision            1
+
 categories          science
 license             GPL-2+
 platforms           darwin
@@ -36,7 +38,7 @@ depends_build       port:pkgconfig \
 depends_lib         port:gtk2 \
                     port:libglade2 \
                     port:gtkglext \
-                    port:openbabel \
+                    port:openbabel2 \
                     port:libghemical \
                     port:liboglappth
 

--- a/science/openbabel/Portfile
+++ b/science/openbabel/Portfile
@@ -1,38 +1,85 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           wxWidgets 1.0
 
-# Keep relevant lines in sync between openbabel and py-openbabel.
+github.setup        openbabel openbabel 3-1-1 openbabel-
+conflicts           openbabel2
+version             [string map {- .} ${github.version}]
+revision            0
 
-name                openbabel
-version             2.4.1
 categories          science devel chemistry
 license             GPL-2
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {reneeotten @reneeoten} openmaintainer
 
-description         A chemistry file translation program.
-long_description    Open Babel is a free, open-source version \
-                    of the Babel chemistry file translation program. \
-                    OpenBabel is a project designed to pick up where \
-                    Babel left off, as a cross-platform program and \
-                    library designed to interconvert between many \
-                    file formats used in molecular modeling and \
-                    computational chemistry.
+description         Open Babel is a chemical toolbox designed to speak the many languages \
+                    of chemical data
+long_description    ${description}. It's an open, collaborative project allowing anyone to \
+                    search, convert, analyze, or store data from molecular modeling, chemistry, \
+                    solid-state materials, biochemistry, or related areas.
 
-homepage            http://openbabel.sourceforge.net/
-master_sites        sourceforge:project/openbabel/openbabel/${version}
+checksums           rmd160  09af42638ab54b7ed912bd6e238d99a707ec45c7 \
+                    sha256  43659247010d663d4b7927ba53e4a803cf2ea955d7066dc69a4bc41748503f23 \
+                    size    36694321
 
-checksums           rmd160  317c15ebbe7f2f86c5ec7d54230487853545cfc4 \
-                    sha256  204136582cdfe51d792000b20202de8950218d617fd9c6e18cee36706a376dfc
+
+compiler.cxx_standard   2011
+
+patchfiles-append   patch-cmake-coordgen.diff
+patch.pre_args      -p1
+
+set py_ver          3.9
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+
+configure.args-append \
+                    -DBUILD_GUI=OFF \
+                    -DBUILD_TESTING=OFF \
+                    -DRUN_SWIG=ON \
+                    -DPYTHON_BINDINGS=ON \
+                    -DPYTHON_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/${py_ver}/bin/python${py_ver} \
+                    -DENABLE_OPENMP=OFF \
+                    -DOPTIMIZE_NATIVE=OFF
 
 depends_build-append \
-                    port:eigen \
-                    port:pkgconfig
+                    port:eigen3 \
+                    port:pkgconfig \
+                    port:swig
 
-depends_lib         path:lib/pkgconfig/cairo.pc:cairo port:libiconv port:libxml2 port:zlib
+depends_lib-append  port:boost \
+                    port:coordgen \
+                    path:lib/pkgconfig/cairo.pc:cairo \
+                    port:libxml2 \
+                    port:maeparser \
+                    port:python${py_ver_nodot} \
+                    port:rapidjson \
+                    port:zlib
 
-configure.args-append -DBUILD_GUI=OFF \
-                      -DBUILD_TESTING=OFF \
-                      -DPYTHON_BINDINGS=OFF
+variant native description {Enable CPU-specific optimizations} {
+    configure.args-replace \
+                    -DOPTIMIZE_NATIVE=OFF \
+                    -DOPTIMIZE_NATIVE=ON
+}
+
+variant gui description {Build the OpenBabelGUI} {
+    wxWidgets.use   wxWidgets-3.2
+
+    depends_lib-append \
+                    port:${wxWidgets.port}
+
+    configure.args-replace \
+                    -DBUILD_GUI=OFF \
+                    -DBUILD_GUI=ON
+
+    configure.args-append \
+                    -DwxWidgets_CONFIG_EXECUTABLE=${wxWidgets.wxconfig}
+}
+
+# install the Python package at the correct place; cannot figure out
+# how to tell CMake this directly....
+post-destroot {
+    xinstall -d ${destroot}${frameworks_dir}/Python.framework/Versions/${py_ver}/lib/python${py_ver}/site-packages
+    move ${destroot}${prefix}/lib/python${py_ver}/site-packages/openbabel ${destroot}${frameworks_dir}/Python.framework/Versions/${py_ver}/lib/python${py_ver}/site-packages
+}

--- a/science/openbabel/files/patch-cmake-coordgen.diff
+++ b/science/openbabel/files/patch-cmake-coordgen.diff
@@ -1,0 +1,47 @@
+From b6887a8a82162278983a8489e365e61a0372b1b8 Mon Sep 17 00:00:00 2001
+From: Benny Siegert <bsiegert@gmail.com>
+Date: Wed, 4 Nov 2020 20:31:17 +0100
+Subject: [PATCH] Do not search for coordgen template files.
+
+The coordgen upstream does not install the template file. It is
+also not required at runtime, since its contents are compiled into
+the coordgen library itself.
+
+Fixes #2214
+---
+ cmake/modules/Findcoordgen.cmake | 13 +------------
+ 1 file changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/cmake/modules/Findcoordgen.cmake b/cmake/modules/Findcoordgen.cmake
+index ded0a4de7..9bc5c9557 100644
+--- a/cmake/modules/Findcoordgen.cmake
++++ b/cmake/modules/Findcoordgen.cmake
+@@ -6,7 +6,6 @@
+ #
+ # coordgen_INCLUDE_DIRS   - CoordGen's includes directory
+ # coordgen_LIBRARIES      - CoordGen's shared libraries
+-# coordgen_TEMPLATE_FILE  - CoordGen templates file
+ #
+ #
+ 
+@@ -28,19 +27,9 @@ find_library(coordgen_LIBRARIES
+ )
+ message(STATUS "coordgen libraries set as '${coordgen_LIBRARIES}'")
+ 
+-# Just in case, add parent directory above libraries to templates search hints
+-get_filename_component(libs_parent_dir ${coordgen_LIBRARIES} PATH)
+-find_file(coordgen_TEMPLATE_FILE
+-    NAMES templates.mae
+-    HINTS ${coordgen_DIR} ${libs_parent_dir}
+-    PATH_SUFFIXES "share" "share/coordgen"
+-    DOC "templates file for coordgen"
+-)
+-message(STATUS "coordgen templates file set as '${coordgen_TEMPLATE_FILE}'")
+-
+ find_package_handle_standard_args(coordgen FOUND_VAR coordgen_FOUND
+                                   REQUIRED_VARS coordgen_INCLUDE_DIRS
+-                                  coordgen_LIBRARIES coordgen_TEMPLATE_FILE)
++                                  coordgen_LIBRARIES)
+ 
+ 
+ 

--- a/science/openbabel2/Portfile
+++ b/science/openbabel2/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+# Keep relevant lines in sync between openbabel and py-openbabel.
+
+github.setup        openbabel openbabel 2-4-1 openbabel-
+name                openbabel2
+conflicts           openbabel
+version             [string map {- .} ${github.version}]
+revision            0
+
+categories          science devel chemistry
+license             GPL-2
+platforms           darwin
+maintainers         nomaintainer
+
+description         A chemistry file translation program.
+long_description    Open Babel is a free, open-source version \
+                    of the Babel chemistry file translation program. \
+                    OpenBabel is a project designed to pick up where \
+                    Babel left off, as a cross-platform program and \
+                    library designed to interconvert between many \
+                    file formats used in molecular modeling and \
+                    computational chemistry.
+
+homepage            http://openbabel.sourceforge.net/
+
+checksums           rmd160  0587a3d3dd24c485ff9a680ff83145f052b504f4 \
+                    sha256  a58c6540fd07de7c40bd30e4218f8ade36d743b2ecc307df6cfb4c195d1600cb \
+                    size    6668659
+
+depends_build-append \
+                    port:eigen \
+                    port:pkgconfig
+
+depends_lib-append \
+                    path:lib/pkgconfig/cairo.pc:cairo \
+                    port:libiconv \
+                    port:libxml2 \
+                    port:zlib
+
+configure.args-append \
+                    -DBUILD_GUI=OFF \
+                    -DBUILD_TESTING=OFF \
+                    -DPYTHON_BINDINGS=OFF
+
+livecheck.type      none


### PR DESCRIPTION
#### Description
- openbabel2: rename port from openbabel
  - update dependents to depend on openbabel2
  - conflicts with openbabel, to be updated to 3.x
- openbabel: update to 3.1.1
  - add variants `native` and `gui`


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? Only for `openbabel` for `openbabel2` and its dependents nothing has changed, so it either builds or not depending on the current status.
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
