### PR TITLE
GitUp: new port

### DIFF
--- a/devel/GitUp/Portfile
+++ b/devel/GitUp/Portfile
@@ -1,0 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+if {[vercmp $xcodeversion 12.2] < 0 || ${os.major} < 20} {
+    version             1.1.3
+    checksums \
+        rmd160  7d05dc36ad80f3157e5d22ee214d30c5ac7e2954 \
+        sha256  0bf407b2efb1bbce6e5af54bd9788107067268e5aa9003c290e089de4a7c7fb9 \
+        size    35852906
+} else {
+    version             1.2
+    checksums \
+        rmd160  c8c5eab4cf5bfed8abe934d57ea34cb8b8b769f4 \
+        sha256  3b8934cfd72f6fad899bf95e7e5b983e6a3543e2ce2226005463b5e7f872e216 \
+        size    21309896
+}
+
+github.setup            git-up GitUp ${version} v
+
+categories              devel
+platforms               darwin
+license                 GPL-3
+maintainers             {@knapoc knapoc} openmaintainer
+description             GitUp is a native macOS git client
+long_description        GitUp provides features such as a live and interactive repo graph \
+                        unlimited redo/undo, snapshots for 1-click rollbacks, visual commit \
+                        splitter and many more
+homepage                https://gitup.co
+
+
+fetch.type              git
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+patchfiles              patch-disable-sparkle.diff \
+                        patch-disable-clt-install.diff \
+                        patch-libgit2.diff
+
+if {[vercmp ${version} 1.1.3] == 0} {
+    patchfiles-append   patch-exclude-arm-below-bigsur.diff
+}
+
+use_configure           no
+use_xcode               yes
+
+variant clt description {Installs GitUp command line tool} {
+}
+
+default_variants        +clt
+
+build {
+    system -W ${build.dir}/GitUp "xcodebuild -derivedDataPath ${build.dir} -configuration Release -scheme Application 'CODE_SIGN_IDENTITY=' CODE_SIGNING_REQUIRED=NO 'CODE_SIGN_ENTITLEMENTS='"
+}
+
+destroot {
+    copy ${build.dir}/Build/Products/Release/GitUp.app ${destroot}${applications_dir}
+}
+
+if {[variant_isset clt]} {
+    post-destroot {
+        ln -s ${applications_dir}/GitUp.app/Contents/SharedSupport/gitup ${destroot}${prefix}/bin/gitup
+    }
+}

--- a/devel/GitUp/files/patch-disable-clt-install.diff
+++ b/devel/GitUp/files/patch-disable-clt-install.diff
@@ -1,0 +1,32 @@
+diff --git GitUp/Application/AppDelegate.m GitUp/Application/AppDelegate.m
+index 2efe0c1..1b0daec 100644
+--- GitUp/Application/AppDelegate.m
++++ GitUp/Application/AppDelegate.m
+@@ -265,6 +265,9 @@ - (void)applicationDidFinishLaunching:(NSNotification*)notification {
+   // First launch has completed
+   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kUserDefaultsKey_FirstLaunch];
+ 
++  // Skip command line tool installation
++  [[NSUserDefaults standardUserDefaults] setBool:true forKey:kUserDefaultsKey_SkipInstallCLT];
++
+   // Create tool message port
+   CFMessagePortContext context = {0, (__bridge void*)self, NULL, NULL, NULL};
+   _messagePort = CFMessagePortCreateLocal(kCFAllocatorDefault, CFSTR(kToolPortName), _MessagePortCallBack, &context, NULL);
+diff --git GitUp/Application/Base.lproj/MainMenu.xib GitUp/Application/Base.lproj/MainMenu.xib
+index 528efb4..3602656 100644
+--- GitUp/Application/Base.lproj/MainMenu.xib
++++ GitUp/Application/Base.lproj/MainMenu.xib
+@@ -31,13 +31,6 @@
+                                     <action selector="checkForUpdates:" target="Voe-Tx-rLC" id="Bx2-39-dyN"/>
+                                 </connections>
+                             </menuItem>
+-                            <menuItem isSeparatorItem="YES" id="gLG-bh-eJk"/>
+-                            <menuItem title="Install Command Line Tool…" id="f9m-On-7Ly">
+-                                <modifierMask key="keyEquivalentModifierMask"/>
+-                                <connections>
+-                                    <action selector="installTool:" target="Voe-Tx-rLC" id="vFd-eA-ejg"/>
+-                                </connections>
+-                            </menuItem>
+                             <menuItem isSeparatorItem="YES" id="dst-2l-Azr"/>
+                             <menuItem title="Preferences…" keyEquivalent="," id="smQ-Fd-MMe">
+                                 <connections>

--- a/devel/GitUp/files/patch-disable-sparkle.diff
+++ b/devel/GitUp/files/patch-disable-sparkle.diff
@@ -1,0 +1,31 @@
+diff --git GitUp/Application/AppDelegate.m GitUp/Application/AppDelegate.m
+index 2efe0c1..3a1908f 100644
+--- GitUp/Application/AppDelegate.m
++++ GitUp/Application/AppDelegate.m
+@@ -265,6 +265,9 @@ - (void)applicationDidFinishLaunching:(NSNotification*)notification {
+   // First launch has completed
+   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kUserDefaultsKey_FirstLaunch];
+ 
++  // Disable sparkle
++  [[NSUserDefaults standardUserDefaults] setBool:true forKey:kUserDefaultsKey_DisableSparkle];
++
+   // Create tool message port
+   CFMessagePortContext context = {0, (__bridge void*)self, NULL, NULL, NULL};
+   _messagePort = CFMessagePortCreateLocal(kCFAllocatorDefault, CFSTR(kToolPortName), _MessagePortCallBack, &context, NULL);
+diff --git GitUp/Application/Base.lproj/MainMenu.xib GitUp/Application/Base.lproj/MainMenu.xib
+index 528efb4..711833c 100644
+--- GitUp/Application/Base.lproj/MainMenu.xib
++++ GitUp/Application/Base.lproj/MainMenu.xib
+@@ -25,12 +25,6 @@
+                                     <action selector="showAboutPanel:" target="Voe-Tx-rLC" id="uMT-pN-nex"/>
+                                 </connections>
+                             </menuItem>
+-                            <menuItem title="Check for Updates…" id="RvP-51-UEO">
+-                                <modifierMask key="keyEquivalentModifierMask"/>
+-                                <connections>
+-                                    <action selector="checkForUpdates:" target="Voe-Tx-rLC" id="Bx2-39-dyN"/>
+-                                </connections>
+-                            </menuItem>
+                             <menuItem isSeparatorItem="YES" id="gLG-bh-eJk"/>
+                             <menuItem title="Install Command Line Tool…" id="f9m-On-7Ly">
+                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/devel/GitUp/files/patch-exclude-arm-below-bigsur.diff
+++ b/devel/GitUp/files/patch-exclude-arm-below-bigsur.diff
@@ -1,0 +1,87 @@
+diff --git GitUp/GitUp.xcodeproj/project.pbxproj GitUp/GitUp.xcodeproj/project.pbxproj
+index 3efcbfe..4ec7628 100644
+--- GitUp/GitUp.xcodeproj/project.pbxproj
++++ GitUp/GitUp.xcodeproj/project.pbxproj
+@@ -657,6 +657,7 @@
+ 			isa = XCBuildConfiguration;
+ 			baseConfigurationReference = E27E37571B86F670000A551A /* Debug.xcconfig */;
+ 			buildSettings = {
++				EXCLUDED_ARCHS = arm64;
+ 				SDKROOT = macosx;
+ 			};
+ 			name = Debug;
+@@ -665,6 +666,8 @@
+ 			isa = XCBuildConfiguration;
+ 			baseConfigurationReference = E27E37591B86F670000A551A /* Release.xcconfig */;
+ 			buildSettings = {
++				EXCLUDED_ARCHS = arm64;
++				ONLY_ACTIVE_ARCH = YES;
+ 				SDKROOT = macosx;
+ 			};
+ 			name = Release;
+@@ -676,6 +679,7 @@
+ 				BUNDLE_VERSION = 0;
+ 				BUNDLE_VERSION_STRING = 1.1;
+ 				CODE_SIGN_ENTITLEMENTS = Application/GitUp.entitlements;
++				EXCLUDED_ARCHS = arm64;
+ 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
+ 				INFOPLIST_FILE = Application/Info.plist;
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+@@ -692,10 +696,12 @@
+ 				BUNDLE_VERSION = 0;
+ 				BUNDLE_VERSION_STRING = 1.1;
+ 				CODE_SIGN_ENTITLEMENTS = Application/GitUp.entitlements;
++				EXCLUDED_ARCHS = arm64;
+ 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/Third-Party";
+ 				INFOPLIST_FILE = Application/Info.plist;
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+ 				MARKETING_VERSION = 1.1.3;
++				ONLY_ACTIVE_ARCH = YES;
+ 				PRODUCT_BUNDLE_IDENTIFIER = co.gitup.mac;
+ 				PRODUCT_NAME = GitUp;
+ 			};
+diff --git GitUpKit/GitUpKit.xcodeproj/project.pbxproj GitUpKit/GitUpKit.xcodeproj/project.pbxproj
+index 4c950e8..38a8d73 100644
+--- GitUpKit/GitUpKit.xcodeproj/project.pbxproj
++++ GitUpKit/GitUpKit.xcodeproj/project.pbxproj
+@@ -1826,6 +1826,7 @@
+ 				DYLIB_COMPATIBILITY_VERSION = 1;
+ 				DYLIB_CURRENT_VERSION = 1;
+ 				DYLIB_INSTALL_NAME_BASE = "@rpath";
++				EXCLUDED_ARCHS = arm64;
+ 				INFOPLIST_FILE = Info.plist;
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+ 				PRODUCT_BUNDLE_IDENTIFIER = co.gitup.kit;
+@@ -1842,8 +1843,10 @@
+ 				DYLIB_COMPATIBILITY_VERSION = 1;
+ 				DYLIB_CURRENT_VERSION = 1;
+ 				DYLIB_INSTALL_NAME_BASE = "@rpath";
++				EXCLUDED_ARCHS = arm64;
+ 				INFOPLIST_FILE = Info.plist;
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
++				ONLY_ACTIVE_ARCH = YES;
+ 				PRODUCT_BUNDLE_IDENTIFIER = co.gitup.kit;
+ 				PRODUCT_NAME = GitUpKit;
+ 				SDKROOT = macosx;
+@@ -1855,6 +1858,7 @@
+ 			isa = XCBuildConfiguration;
+ 			baseConfigurationReference = E27E37501B86F5D1000A551A /* Debug.xcconfig */;
+ 			buildSettings = {
++				EXCLUDED_ARCHS = arm64;
+ 				HEADER_SEARCH_PATHS = (
+ 					"Third-Party/libgit2/include",
+ 					"Third-Party/libsqlite3/$(GITUP_PLATFORM)/include",
+@@ -1872,11 +1876,13 @@
+ 			isa = XCBuildConfiguration;
+ 			baseConfigurationReference = E27E37521B86F5D1000A551A /* Release.xcconfig */;
+ 			buildSettings = {
++				EXCLUDED_ARCHS = arm64;
+ 				HEADER_SEARCH_PATHS = (
+ 					"Third-Party/libgit2/include",
+ 					"Third-Party/libsqlite3/$(GITUP_PLATFORM)/include",
+ 					"Third-Party/libssh2/$(GITUP_PLATFORM)/include",
+ 				);
++				ONLY_ACTIVE_ARCH = YES;
+ 				OTHER_LDFLAGS = (
+ 					"Third-Party/libsqlite3/$(GITUP_PLATFORM)/lilibsqlite3.a",
+ 					"Third-Party/libssl/$(GITUP_PLATFORM)/lilibcrypto.a",

--- a/devel/GitUp/files/patch-libgit2.diff
+++ b/devel/GitUp/files/patch-libgit2.diff
@@ -1,0 +1,13 @@
+diff --git GitUpKit/Third-Party/libgit2/src/diff_generate.c GitUpKit/Third-Party/libgit2/src/diff_generate.c
+index 568fb9743..776f443ef 100644
+--- GitUpKit/Third-Party/libgit2/src/diff_generate.c
++++ GitUpKit/Third-Party/libgit2/src/diff_generate.c
+@@ -24,7 +24,7 @@
+ 	(((DIFF)->base.opts.flags & (FLAG)) == 0)
+ #define DIFF_FLAG_SET(DIFF,FLAG,VAL) (DIFF)->base.opts.flags = \
+ 	(VAL) ? ((DIFF)->base.opts.flags | (FLAG)) : \
+-	((DIFF)->base.opts.flags & ~(VAL))
++	((DIFF)->base.opts.flags & ~(FLAG))
+ 
+ typedef struct {
+ 	struct git_diff base;


### PR DESCRIPTION
#### Description

add GitUp port to MacPorts.

* add Portfile for GitUp
* disable Sparkle updates
* replace CLT installation with port variant

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
