### PR TITLE
repo: update to 2.15

### DIFF
--- a/python/repo/Portfile
+++ b/python/repo/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 
 name                repo
 epoch               20160202
-version             1.23
+version             2.15
 license             Apache-2
 categories          python
 platforms           darwin
 maintainers         nomaintainer
 supported_archs     noarch
 
-description         tool that helps to manage Android Git repositories 
+description         tool that helps to manage Android Git repositories
 long_description    \
             Repo is a tool that we built on top of Git. Repo helps us \
             manage the many Git repositories, does the uploads to our \
@@ -22,11 +22,12 @@ long_description    \
 homepage            https://source.android.com/source/developing.html
 master_sites        https://storage.googleapis.com/git-repo-downloads/
 
-checksums           sha256  e147f0392686c40cfd7d5e6f332c6ee74c4eab4d24e2694b3b0a0c037bf51dc5 \
-                    rmd160  20308ab7a6ea6d7c9666af5ff9f393f1a768c7f9
+checksums           sha256  b449697154231b531b2233272b6404316b48468b438318aa2a1943d24eba5df3 \
+                    rmd160  bd66b05256b6906b9035cfbf38b81f4e11a2c3cf \
+                    size    44704
 
 depends_run         port:git
-extract.suffix      
+extract.suffix
 extract.only
 use_configure       no
 build               { }
@@ -35,5 +36,5 @@ destroot            {
 }
 
 livecheck.type      regex
-livecheck.url       https://source.android.com/source/downloading
-livecheck.regex     {For version (\d+(?:\.\d+)+), the [[:alnum:]-]+ checksum for repo}
+livecheck.url       https://gerrit.googlesource.com/git-repo/
+livecheck.regex     {v(\d+(?:\.\d+)+)}


### PR DESCRIPTION
#### Description

Update to repo 2.15.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?