### PR TITLE
crossgcc-1.0: Updated compiler blacklist gcc11

### DIFF
--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -113,6 +113,8 @@ proc crossgcc.setup {target version} {
     set crossgcc.version $version
 
     uplevel {
+        PortGroup       compiler_blacklist_versions 1.0
+
         name            ${crossgcc.target}-gcc
         version         ${crossgcc.version}
         categories      cross devel
@@ -260,6 +262,19 @@ proc crossgcc.setup {target version} {
         # Failed to build with clang from Xcode 4.5
         # fatal error: error in backend: ran out of registers during register allocation
         compiler.blacklist  {clang >= 421 < 422}
+
+        # Section taken from gcc11
+        if {${version} >= 11.0} {
+            # https://trac.macports.org/ticket/29067
+            # https://trac.macports.org/ticket/29104
+            # https://trac.macports.org/ticket/47996
+            # https://trac.macports.org/ticket/58493
+            compiler.blacklist-append {clang < 800} gcc-4.0 *gcc-4.2 {llvm-gcc-4.2 < 2336.1} {macports-clang-3.[4-7]}
+
+            # https://build.macports.org/builders/ports-10.13_x86_64-builder/builds/105513/steps/install-port/logs/stdio
+            # c++/v1/functional:1408:2: error: no member named 'fancy_abort' in namespace 'std::__1'; did you mean simply 'fancy_abort'?
+            compiler.blacklist-append {clang < 1000}
+        }
 
         universal_variant no
 


### PR DESCRIPTION
Conditionally append compiler blacklist for gcc11+ only

Added the missing compiler_blacklist_versions PortGroup without this the compiler just default to /usr/bin/clang (tested on OS X 10.9)

revision bumped i686-w64-mingw32-gcc & x86_64-w64-mingw32-gcc

Closes https://trac.macports.org/ticket/62901

#### Description

This was tested on an OS X 10.9 VM, prior versions of mingw-bootstrap etc were removed prior to testing to ensure this worked correctly.
```
--->  Fetching distfiles for i686-w64-mingw32-gcc-bootstrap
--->  Verifying checksums for i686-w64-mingw32-gcc-bootstrap
--->  Extracting i686-w64-mingw32-gcc-bootstrap
--->  Applying patches to i686-w64-mingw32-gcc-bootstrap
--->  Configuring i686-w64-mingw32-gcc-bootstrap
--->  Building i686-w64-mingw32-gcc-bootstrap
--->  Staging i686-w64-mingw32-gcc-bootstrap into destroot
Warning: i686-w64-mingw32-gcc-bootstrap installs files outside the common directory structure.
--->  Installing i686-w64-mingw32-gcc-bootstrap @11.1.0_0
--->  Activating i686-w64-mingw32-gcc-bootstrap @11.1.0_0
--->  Cleaning i686-w64-mingw32-gcc-bootstrap
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.9.5 13F1911 x86_64
Xcode Command Line Tools installed via `xcode-select —install`
```
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
```

###### Verification <!-- (delete not applicable items) -->


- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

