### PR TITLE
boost: add new variant 'docs', disabled by default

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -185,7 +185,9 @@ pre-destroot {
     system "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
 }
 
-post-destroot {
+proc boost_docs_install {} {
+    global prefix destroot worksrcpath name
+
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     set l [expr [string length ${worksrcpath}] + 1]
@@ -200,6 +202,12 @@ post-destroot {
         } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
             xinstall -m 644 ${f} ${dest}
         }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
     }
 }
 
@@ -299,7 +307,7 @@ subport boost-numpy {
 
 if {$subport eq $name} {
 
-    revision 3
+    revision 4
 
     patchfiles-append patch-disable-numpy-extension.diff
 
@@ -316,6 +324,10 @@ if {$subport eq $name} {
             reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
                 ${worksrcpath}/boost/regex/user.hpp
         }
+    }
+
+    variant docs description {Enable building documentation} {
+        # No configure changes, etc; we simply check 'variant_isset' elsewhere
     }
 
     post-destroot {


### PR DESCRIPTION
#### Description

Add new variant `docs`, disabled by default. Provides a lighter-weight `boost` install, with the file count reduced from 38,258 to 14,042.

Closes: [62182 - boost: don't install docs by default](https://trac.macports.org/ticket/62182)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
