### PR TITLE
openjdk: add openjdk7-zulu subport

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -78,6 +78,27 @@ if {${subport} eq "openjdk"} {
     replaced_by  openjdk${version}
 }
 
+subport openjdk7-zulu {
+    version      7.46.0.11
+    revision     0
+
+    set openjdk_version 7.0.302
+
+    description  Azul Zulu Community OpenJDK 7 (Long Term Support)
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    checksums    rmd160  d4f87b0e4ee901c24fca82eb7f74904ad8ee8eb5 \
+                 sha256  d452c081b7c55f3b26878ef0522911976302c6f47f4bd4b92057cef9161c556c \
+                 size    68486614
+
+    worksrcdir   ${distname}/zulu-7.jdk
+
+    configure.cxx_stdlib libstdc++
+}
+
 subport openjdk8 {
     version      8u292
     revision     0
@@ -536,6 +557,11 @@ set destroot_target ${destroot}${target}
 destroot {
     xinstall -m 755 -d ${destroot_target}
     copy ${worksrcpath}/Contents ${destroot_target}
+
+    if {${subport} eq "openjdk7-zulu"} {
+        # MacPorts reports this file as broken
+        delete ${destroot_target}/Contents/Home/jre/lib/xawt/libmawt.dylib
+    }
 }
 
 notes "


### PR DESCRIPTION
#### Description

Add subport for Azul Zulu OpenJDK 7 (Long Term Support).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?