### PR TITLE
mysql56: update to 5.6.51

### DIFF
--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -9,7 +9,7 @@ deprecated.upstream_support no
 
 name                mysql56
 set name_mysql      ${name}
-version             5.6.50
+version             5.6.51
 # Set revision_client and revision_server to 0 on
 # version bump.
 set revision_client 0
@@ -57,9 +57,9 @@ if {$subport eq $name} {
     # VERSION file to VERSION.txt below (c++17 conflict)
     patchfiles-append   patch-mysql56-version-change.diff
 
-    checksums           rmd160  e95ba4b422b57d19c4d7f322da5e160049a5f28a \
-                        sha256  efc48d8160a66b50fc498bb42ea730c3b6f30f036b709a7070d356edd645923e \
-                        size    32409084
+    checksums           rmd160  c6c43b04fc34fb9ceb55eb6f5be9ce4ea3bff56d \
+                        sha256  262ccaf2930fca1f33787505dd125a7a04844f40d3421289a51974b5935d9abc \
+                        size    32411131
 
     depends_lib-append  path:lib/libssl.dylib:openssl \
                         port:ncurses \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
https://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-51.html
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Only patch phase tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
