### PR TITLE
openssh: fix +fido2 variant

### DIFF
--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             8.4p1
-revision            4
+revision            5
 categories          net
 platforms           darwin
 maintainers         nomaintainer
@@ -201,6 +201,7 @@ if {${name} eq ${subport}} {
     variant fido2 description "Enable fido2 support" {
         configure.args-delete  --without-security-key-builtin
         configure.args-append  --with-security-key-builtin
+        patchfiles-append      openssh-8.4p1-fido2.patch
         depends_lib-append      port:libfido2
     }
 

--- a/net/openssh/files/openssh-8.4p1-fido2.patch
+++ b/net/openssh/files/openssh-8.4p1-fido2.patch
@@ -1,0 +1,53 @@
+Fix for +fido2 variant compilation for 8.4p1.
+
+Addresses https://trac.macports.org/ticket/62890.
+
+The first part of this is a commit picked from upstream making sure that the
+correct variant of the "sha2.h" file is being included.
+
+The second part seemed to be necessary for exactly the same reason in
+sk-usbhid.c although it was not applied upstream and doesn't seem to need to be.
+I simply remove the reference to <sha2.h> because the openbsd-compat version is
+already referenced in "includes.h".
+
+
+
+From 86cc8ce002ea10e88a4c5d622a8fdfab8a7d261f Mon Sep 17 00:00:00 2001
+From: Damien Miller <djm@mindrot.org>
+Date: Sat, 3 Oct 2020 13:38:55 +1000
+Subject: [PATCH] use relative rather than system include here
+
+---
+ openbsd-compat/sha2.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/openbsd-compat/sha2.c b/openbsd-compat/sha2.c
+index e36cc24e..ce936e26 100644
+--- a/openbsd-compat/sha2.c
++++ b/openbsd-compat/sha2.c
+@@ -45,7 +45,7 @@
+ #define MAKE_CLONE(x, y)       void __ssh_compat_make_clone_##x_##y(void)
+ 
+ #include <string.h>
+-#include <sha2.h>
++#include "openbsd-compat/sha2.h"
+ 
+ /*
+  * UNROLLED TRANSFORM LOOP NOTE:
+-- 
+
+
+
+
+--- a/sk-usbhid.c
++++ b/sk-usbhid.c
+@@ -26,9 +26,6 @@
+ #include <stdio.h>
+ #include <stddef.h>
+ #include <stdarg.h>
+-#ifdef HAVE_SHA2_H
+-#include <sha2.h>
+-#endif
+ 
+ #ifdef WITH_OPENSSL
+ #include <openssl/opensslv.h>


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/62890

#### Description

Allows the `+fido2` variant of `openssh` to compile so that it can be used with security keys.

Does *not* bring the port up to date with upstream as that would require the patch for the `+gsskex` variant to be updated.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Existing tests do not run on my system either before or after this patch. I believe the issue to be something to do with the sandboxing of the `sshd` instance fired up during testing. It's possible this is macOS version specific.

I have tested `ssh` itself, the security key functionality in particular, and `ssh-add`. Other binaries at least fire up and give their versions.