### PR TITLE
google-cloud-sdk: update to 341.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             340.0.0
+version             341.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4e4a824bd36871dd8e5bce8b6426d165c7a52b1a \
-                    sha256  f72220861a448842866b07ecda53634483771867cc36f64051cf9c79b110e831 \
-                    size    89377113
+    checksums       rmd160  e61036d27c6fba06cb8cd728821aa33323b95493 \
+                    sha256  c9dfa743922f59a6ad0058f889aefcca0460b4865e6cbc8c8325be16d9569961 \
+                    size    89560033
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  eda3a7aab4cb67af30bb0fed5d05cdc07015e11d \
-                    sha256  ad746cceaef1ca8dce3a7d72c1482d2db5f1336f38e7863b168db2211f82e8a9 \
-                    size    85625473
+    checksums       rmd160  f5fd3bbe726f87ef5e5b48d5e26504052db30387 \
+                    sha256  e7c13e1159b9a9652b2fb96b776f73b58f145fb53e0d4c13c4cba1a6dd01b800 \
+                    size    85805575
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  239fbd03cea5bbe17c1a985083f77180434f88b1 \
-                    sha256  9455f566a144df17ed52289fbe4aaaaa8447ddd7ae5b0868bce9824052f8955b \
-                    size    85554659
+    checksums       rmd160  932e14a1f73671f1ae9d82db33932a59764ebb87 \
+                    sha256  30c7d8f86ac13ee1bba5e2defe3a8fa9703733561192b82ff9c900065ed14c1b \
+                    size    85734394
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 341.0.0.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?