### PR TITLE
Libsndfilefix

### DIFF
--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -1,49 +1,54 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           cmake 1.0
-PortGroup           github 1.0
+PortSystem              1.0
+PortGroup               cmake   1.0
+PortGroup               github  1.0
 
 # the cmake build of libsndfile had a faulty compatibility_version, fixed in this recent commit
-github.setup        libsndfile libsndfile 0cbfc93a3e1a08136a15eb9ced2054402dff6233
-version             1.0.31
-revision            1
-categories          audio
-maintainers         nomaintainer
-platforms           darwin
+github.setup            libsndfile libsndfile 0cbfc93a3e1a08136a15eb9ced2054402dff6233
+version                 1.0.31
+revision                1
 
-description         read and write files containing sampled sound
-long_description    \
-	libsndfile is a C library for reading and writing files	\
-	containing sampled sound through one standard library interface. \
-	libsndfile has the following main features: \
-	ability to read and write a large number of file formats, \
-	a simple, elegant and easy to use API, \
-	and on the fly format conversion.
-license             LGPL-2.1+
-checksums           \
-      rmd160  63200f3e013ce8123a24be09774088806fd63045 \
-      sha256  7cfed3665928c927870a5a56eca3bd7531445c0c41d91289807cf96b3909ee8f \
-      size    680686
-depends_build-append  port:pkgconfig
-depends_lib           port:flac port:libogg port:libvorbis
+categories              audio
+maintainers             nomaintainer
+platforms               darwin
 
-patchfiles            patch-CMakeLists.txt.diff
+description             read and write files containing sampled sound
 
-configure.args-append -DBUILD_REGTEST=OFF \
-                      -DBUILD_SHARED_LIBS=ON \
-                      -DENABLE_EXTERNAL_LIBS=ON \
-                      -DENABLE_EXPERIMENTAL=OFF
+long_description        libsndfile is a C library for reading and writing files \
+                        containing sampled sound through one standard library interface. \
+                        libsndfile has the following main features: \
+                        ability to read and write a large number of file formats, \
+                        a simple, elegant and easy to use API, \
+                        and on the fly format conversion.
+
+license                 LGPL-2.1+
+
+checksums               rmd160  63200f3e013ce8123a24be09774088806fd63045 \
+                        sha256  7cfed3665928c927870a5a56eca3bd7531445c0c41d91289807cf96b3909ee8f \
+                        size    680686
+
+depends_build-append    port:pkgconfig
+depends_lib-append      port:flac \
+                        port:libogg \
+                        port:libvorbis \
+
+patchfiles              patch-CMakeLists.txt.diff
+
+configure.args-append   -DBUILD_REGTEST=OFF \
+                        -DBUILD_SHARED_LIBS=ON \
+                        -DENABLE_EXTERNAL_LIBS=ON \
+                        -DENABLE_EXPERIMENTAL=OFF
 
 variant no_external_libs description {Disable FLAC, Ogg and Vorbis support} {
-    depends_build-delete  port:pkgconfig
-    depends_lib-delete    port:flac port:libogg port:libvorbis
-    configure.args-append -DENABLE_EXTERNAL_LIBS=OFF
-    configure.args-delete -DENABLE_EXTERNAL_LIBS=ON
+    depends_build-delete    port:pkgconfig
+    depends_lib-delete      port:flac port:libogg port:libvorbis
+    configure.args-append   -DENABLE_EXTERNAL_LIBS=OFF
+    configure.args-delete   -DENABLE_EXTERNAL_LIBS=ON
 }
 
 variant experimental description {Enable experimental support for Opus, Speex} {
-    depends_lib-append    port:libopus port:speex
-    configure.args-append -DENABLE_EXPERIMENTAL=ON
-    configure.args-delete -DENABLE_EXPERIMENTAL=OFF
+    depends_lib-append      port:libopus port:speex
+    configure.args-append   -DENABLE_EXPERIMENTAL=ON
+    configure.args-delete   -DENABLE_EXPERIMENTAL=OFF
 }

--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -4,8 +4,10 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 
-github.setup        libsndfile libsndfile 1.0.31
-revision            0
+# the cmake build of libsndfile had a faulty compatibility_version, fixed in this recent commit
+github.setup        libsndfile libsndfile 0cbfc93a3e1a08136a15eb9ced2054402dff6233
+version             1.0.31
+revision            1
 categories          audio
 maintainers         nomaintainer
 platforms           darwin
@@ -20,9 +22,9 @@ long_description    \
 	and on the fly format conversion.
 license             LGPL-2.1+
 checksums           \
-      rmd160  8663673c3f8eaf463c7b499c732c53c9bba03c04 \
-      sha256  f082718e84a27d99c0e349151344b71dc2032e7aa2d799af0da48a8a270aa06a \
-      size    662676
+      rmd160  63200f3e013ce8123a24be09774088806fd63045 \
+      sha256  7cfed3665928c927870a5a56eca3bd7531445c0c41d91289807cf96b3909ee8f \
+      size    680686
 depends_build-append  port:pkgconfig
 depends_lib           port:flac port:libogg port:libvorbis
 

--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -3,6 +3,10 @@
 PortSystem              1.0
 PortGroup               cmake   1.0
 PortGroup               github  1.0
+PortGroup               legacysupport 1.0
+
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
 
 # the cmake build of libsndfile had a faulty compatibility_version, fixed in this recent commit
 github.setup            libsndfile libsndfile 0cbfc93a3e1a08136a15eb9ced2054402dff6233


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->



NB: @jmroot indicated he preferred to switch back to the autotools build instead of continuing on with the cmake build. Either way is fine with me, I just did this to get moving on again, and thought I'd leave this for consideration if you want to do this instead.