### PR TITLE
py-urwid: update to 2.1.2

### DIFF
--- a/python/py-urwid/Portfile
+++ b/python/py-urwid/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        urwid urwid 2.0.1 release-
+github.setup        urwid urwid 2.1.2 release-
 name                py-${name}
 revision            0
 
@@ -20,9 +20,9 @@ long_description    \
 
 homepage            http://urwid.org/
 
-checksums           rmd160  35600850053629027be799fa0297a0a3b162063a \
-                    sha256  870fa60cb4cc7403be2e5e0d99e04dbe71183a036a6df630146827e64114c951 \
-                    size    588040
+checksums           rmd160  4d8666717bee9d9fdabcc1c7b551ff583a28e307 \
+                    sha256  c21112c3c524110dd5cad78f7987a9fe0c57a66b756e1e0385e572b946ec86d1 \
+                    size    607749
 
 python.versions     27 35 36 37 38 39
 


### PR DESCRIPTION
#### Description

- updates py-urwid to 2.1.2
- fixes py-mitmproxy 6.0.2 dependency issue (requires 'urwid>=2.1.1')

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
