### PR TITLE
micronaut: update to 2.5.4

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.5.3 v
+github.setup    micronaut-projects micronaut-starter 2.5.4 v
 revision        0
 name            micronaut
 categories      java
@@ -54,14 +54,19 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  6134f9b4a25ff359990b258b00ac4984dd342f77 \
-                sha256  ab725f1fb376ffa8f5df07daab8f4435882b33443836abac50a0f8b7eb5fdd8e \
-                size    20080069
+checksums       rmd160  ee996cccf0e4846ee566a7e54da8d2ce0bd1ee25 \
+                sha256  d33a470182fdc32376c322317f13c2c33cc9deb303fa4a215cf50fe56c20c6a8 \
+                size    20124817
 
 use_zip         yes
 use_configure   no
 
 build {}
+
+test.run    yes
+test.cmd    bin/mn
+test.target
+test.args   --version
 
 destroot {
     set target ${destroot}${prefix}/share/java/${name}


### PR DESCRIPTION
#### Description

Update to Micronaut 2.5.4.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?