### PR TITLE
gitlab-runner: update to 13.12.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,11 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.11.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 13.12.0 v
 
 categories          devel
 platforms           darwin
-supported_archs     x86_64
 maintainers         {breun.nl:nils @breun} openmaintainer
 license             MIT
 
@@ -23,9 +22,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  3fd9420cc931b303a757a970e82be88eee4d2c44 \
-                    sha256  7bc15d89f7b0551c4dd236d3ef846cf7840175fa1638fa58d0ccd12f3c04a56b \
-                    size    8283526
+checksums           rmd160  750d2150e025d34b92174844aef6aedfbf248a4d \
+                    sha256  4423ec46b5a9fb836bae5598558949acf9c46f3874b05548d0bc648c2583049e \
+                    size    8616716
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 13.12.0. Also no longer restricted supported architectures to x86_64.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?