### PR TITLE
kustomize: update to 4.1.3

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.1.2 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.1.3 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  1002f9f8bdf84704697b18ded15f97c628ebce0f \
-                    sha256  8095d910f6ae252172014203d00d78a96aa6b3eb285a8e3bbaa9ec018c22331f \
-                    size    25475014
+checksums           rmd160  40a532da644f11c6ab3cffaf8e6f5af5a0780fcc \
+                    sha256  3865c0e11f4ca74474469d9d5bf8db57b1b87d6e133efb8258ca2b6d8e5d12b5 \
+                    size    25087377
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 4.1.3.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?