### PR TITLE
spring-boot-cli: update to 2.4.6

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.4.5
+version         2.4.6
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  52568aee7019576aeec48c5eeef842badea0043b \
-                sha256  44a7238ad89dfc1d5abbf412256f8423f32f54d5a17b44b572de4eaf5aac9f04 \
-                size    11694538
+checksums       rmd160  81a79aebe66cc4f578d5b8d087a8d4b43c860364 \
+                sha256  56799a4ed776f53f307c90e77b3e7ba0fd6c15fccb385c05ab1dd2a029d4126f \
+                size    11694100
 
 worksrcdir      spring-${version}.RELEASE
 
@@ -42,6 +42,11 @@ java.version    1.8+
 java.fallback   openjdk8
 
 build {}
+
+test.run    yes
+test.cmd    bin/spring
+test.target
+test.args   --version
 
 destroot {
     set target ${destroot}${prefix}/share/java/${name}


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.4.6, and added a test.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?