### PR TITLE
Mysql8 is GA, update socket paths

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1343,9 +1343,8 @@ mysql.default_socket, mysqli.default_socket and pdo_mysql.default_socket\
 to the path to your MySQL server's socket file.
 
 For mysql5, use ${prefix}/var/run/mysql5/mysqld.sock
-For mysql51, use ${prefix}/var/run/mysql51/mysqld.sock
-For mysql55, use ${prefix}/var/run/mysql55/mysqld.sock
-For mysql56, use ${prefix}/var/run/mysql56/mysqld.sock
+For mysql57, use ${prefix}/var/run/mysql57/mysqld.sock
+For mysql80, use ${prefix}/var/run/mysql80/mysqld.sock
 For mariadb, use ${prefix}/var/run/mariadb/mysqld.sock
 For percona, use ${prefix}/var/run/percona/mysqld.sock
 "


### PR DESCRIPTION
#### Description

Mysql 51, 55, 56 no longer officially supported. Php should inform users on path to sockets for newer versions (i.e. mysql 57 and 80)

###### Type(s)

- [ ] enhancement
 
