### PR TITLE
py-ctypeslib2: 2.3.2; 2.7 dropped upstream.

### DIFF
--- a/python/py-ctypeslib2/Portfile
+++ b/python/py-ctypeslib2/Portfile
@@ -4,9 +4,9 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
 
-github.setup            trolldbois ctypeslib 2.2.2
+github.setup            trolldbois ctypeslib 2.3.2
 name                    py-ctypeslib2
-python.versions         27 37 38 39
+python.versions         37 38 39
 python.default_version  39
 platforms               darwin
 license                 MIT
@@ -21,9 +21,9 @@ long_description        This fork of ctypeslib is mainly about using the \
                         code from C source code, instead of gccxml.
 
 checksums \
-    rmd160  f99e20769f606d44ddb34aff6e20183fd186aaa2 \
-    sha256  e968d0c60101fdebbd51f392bd6402e5bad415fa62dff23de79cc467d24c1eee \
-    size    76273
+    rmd160  938436348701b2bf6b4da0bced28c037f4e38204 \
+    sha256  934ddbc6c7b4277a059ea89427ffa715ebb921f2fd71e2b7ad765ea1e9eaa913 \
+    size    86918
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
Maintainer update.