### PR TITLE
mediawiki.el: update to 2.3.1

### DIFF
--- a/editors/mediawiki.el/Portfile
+++ b/editors/mediawiki.el/Portfile
@@ -1,17 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 PortGroup github 1.0
 
 github.setup            hexmode mediawiki-el 2.3.1
-set myname              mediawiki.el
-categories              editors 
+name                    mediawiki.el
+categories              editors
 license                 GPL-3
 maintainers             {easieste @easye} openmaintainer
 description             An Emacs mode for editing MediaWiki content
 long_description        ${description}
 homepage                http://www.emacswiki.org/emacs/MediaWikiMode
 platforms               darwin
-distname                ${version}
 
 checksums           rmd160  4f011a2efac2f406958361ef8063d703658a9f57 \
                     sha256  80fb1d3ba5d1f66388b0758cee70e2a27299f4a5244b6d13fd29466851c020ab \
@@ -24,7 +24,7 @@ depends_lib         port:emacs
 build {}
 destroot {
     file mkdir ${destroot}${prefix}/share/emacs/site-lisp
-    file copy ${workpath}/${worksrcdir}/${myname} \
+    file copy ${workpath}/${worksrcdir}/${name} \
         ${destroot}${prefix}/share/emacs/site-lisp
     set docdir ${destroot}${prefix}/share/docs/${name}
     file mkdir ${docdir}
@@ -33,7 +33,7 @@ destroot {
     file copy ${worksrcpath}/README.mediawiki ${docdir}
 }
 
-notes "To use ${myname}, add the following to your ~/.emacs:\n\
+notes "To use ${name}, add the following to your ~/.emacs:\n\
 \n\
     (require 'mediawiki)\n\
 \n\

--- a/editors/mediawiki.el/Portfile
+++ b/editors/mediawiki.el/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup github 1.0
+PortSystem              1.0
+PortGroup               github 1.0
 
 github.setup            hexmode mediawiki-el 2.3.1
 name                    mediawiki.el
@@ -13,13 +13,13 @@ long_description        ${description}
 homepage                http://www.emacswiki.org/emacs/MediaWikiMode
 platforms               darwin
 
-checksums           rmd160  4f011a2efac2f406958361ef8063d703658a9f57 \
-                    sha256  80fb1d3ba5d1f66388b0758cee70e2a27299f4a5244b6d13fd29466851c020ab \
-                    size    36627
+checksums               rmd160  4f011a2efac2f406958361ef8063d703658a9f57 \
+                        sha256  80fb1d3ba5d1f66388b0758cee70e2a27299f4a5244b6d13fd29466851c020ab \
+                        size    36627
 
-use_configure       no
+use_configure           no
 
-depends_lib         port:emacs
+depends_lib             port:emacs
 
 build {}
 destroot {

--- a/editors/mediawiki.el/Portfile
+++ b/editors/mediawiki.el/Portfile
@@ -1,8 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem 1.0
+PortGroup github 1.0
 
-name                    mediawiki.el
-version                 2.2.4.1
+github.setup            hexmode mediawiki-el 2.3.1
+set myname              mediawiki.el
 categories              editors 
 license                 GPL-3
 maintainers             {easieste @easye} openmaintainer
@@ -10,28 +11,29 @@ description             An Emacs mode for editing MediaWiki content
 long_description        ${description}
 homepage                http://www.emacswiki.org/emacs/MediaWikiMode
 platforms               darwin
-distname                mediawiki.el
-master_sites            https://launchpadlibrarian.net/127264410/
+distname                ${version}
 
-checksums           rmd160  35b75da2e09931bfd0b4b0746a599c6fac60a024 \
-                    sha256  9ebc5c1156af54bb533eae7273ef567c2f0cadbe870be9b4759ea70a214ff351
-extract.suffix
+checksums           rmd160  4f011a2efac2f406958361ef8063d703658a9f57 \
+                    sha256  80fb1d3ba5d1f66388b0758cee70e2a27299f4a5244b6d13fd29466851c020ab \
+                    size    36627
+
 use_configure       no
 
 depends_lib         port:emacs
 
-extract {
-    file copy ${distpath}/mediawiki.el ${worksrcpath}
-}
-
 build {}
 destroot {
     file mkdir ${destroot}${prefix}/share/emacs/site-lisp
-    file copy  ${workpath}/${worksrcdir}  \
+    file copy ${workpath}/${worksrcdir}/${myname} \
         ${destroot}${prefix}/share/emacs/site-lisp
+    set docdir ${destroot}${prefix}/share/docs/${name}
+    file mkdir ${docdir}
+    xinstall -m 644 ${worksrcpath}/ChangeLog ${docdir}
+    file copy ${worksrcpath}/LICENSE ${docdir}
+    file copy ${worksrcpath}/README.mediawiki ${docdir}
 }
 
-notes "To use ${name}, add the following to your ~/.emacs:\n\
+notes "To use ${myname}, add the following to your ~/.emacs:\n\
 \n\
     (require 'mediawiki)\n\
 \n\


### PR DESCRIPTION
#### Description

This updates mediawiki.el to version 2.3.1, and also makes the port get its sources from GitHub now. It is intended to fix [Trac bug 61089](https://trac.macports.org/ticket/61089). 

###### Type(s)
- [x] update

###### Tested on
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (in this PR, not in the original commit message though)
- [ ] checked your Portfile with `port lint`? So, there's some issues here; I forget whether it's ok to simply override the name set by the GitHub PortGroup:
```
$ port -v lint --nitpick
--->  Verifying Portfile for mediawiki-el
OK: Line 1 has emacs/vim Mode
Warning: Line 2 should be a newline (after modeline)
Warning: Line 7 has trailing whitespace before newline
OK: Found PortSystem 1.0
OK: Found PortGroup github-1.0
OK: Found required variable: name
OK: Found required variable: version
OK: Found required variable: description
OK: Found required variable: long_description
OK: Found required variable: categories
OK: Found required variable: maintainers
OK: Found required variable: platforms
OK: Found required variable: homepage
OK: Found required variable: master_sites
OK: Found required variable: checksums
OK: Found required variable: license
OK: Found optional variable: epoch
OK: Found optional variable: revision
OK: Found platform: darwin
OK: Found primary category: editors
OK: Found dependency: emacs
OK: Portfile parent directory matches primary category
Error: Portfile directory mediawiki.el does not match port name mediawiki-el
--->  1 errors and 2 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
