### PR TITLE
detekt-cli: Update to version 1.17.1

### DIFF
--- a/java/detekt-cli/Portfile
+++ b/java/detekt-cli/Portfile
@@ -6,11 +6,8 @@ PortGroup           github  1.0
 
 name                detekt-cli
 
-github.setup        detekt detekt 1.17.0 v
+github.setup        detekt detekt 1.17.1 v
 revision            0
-
-# The resulting .jar uses the version of the latest release candidate.
-set buildversion ${version}-RC3
 
 categories          java devel
 license             Apache-2
@@ -24,9 +21,9 @@ homepage            https://detekt.github.io
 github.tarball_from archive
 
 distname            v${version}
-checksums           sha256  4acf2bed2b978061723929eee7565452f99a445c72feb319e2eb16bed857a854 \
-                    rmd160  cd14bddbb2c3d2b693a1d7a24546b53eac030e9c \
-                    size    2600156
+checksums           sha256  61d6c0fe68a5510b77b3212e73bd612ddb3be8842e6ecf97c8eaf5316d2d0ede \
+                    rmd160  4ffe331edb7c65be252dd2966304343833207c25 \
+                    size    2600608
 
 java.fallback       openjdk11
 java.version        1.8+
@@ -40,7 +37,7 @@ build.target        ${name}:shadowJar
 destroot {
     set javadir ${destroot}${prefix}/share/java
     xinstall -m 755 -d ${javadir}/${name}
-    xinstall -m 644 ${worksrcpath}/${name}/build/libs/${name}-${buildversion}-all.jar ${javadir}/${name}/${name}.jar
+    xinstall -m 644 ${worksrcpath}/${name}/build/libs/${name}-${version}-all.jar ${javadir}/${name}/${name}.jar
 
     # Install the wrapper script
     xinstall -m 755 ${filespath}/detekt ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description

See: https://github.com/detekt/detekt/releases/tag/v1.17.1.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
