### PR TITLE
mosquitto: Update to version 2.0.9

### DIFF
--- a/net/mosquitto/Portfile
+++ b/net/mosquitto/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                mosquitto
-version             1.5.8
-revision            2
+version             2.0.9
+revision            0
 
 categories          net devel
 platforms           darwin
@@ -23,9 +23,9 @@ long_description    \
 homepage            https://mosquitto.org
 master_sites        http://mosquitto.org/files/source/
 
-checksums           rmd160  3c84581f497fd8d191d8df5b6dc7658af650e711 \
-                    sha256  78d7e70c3794dc3a1d484b4f2f8d3addebe9c2da3f5a1cebe557f7d13beb0da4 \
-                    size    442834
+checksums           rmd160  6925455f51b6c79ebd160aba2f3709864aa5c05d \
+                    sha256  1b8553ef64a1cf5e4f4cfbe098330ae612adccd3d37f35b2db6f6fab501b01d4 \
+                    size    757878
 
 depends_build-append \
                     path:bin/xsltproc:libxslt


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This PR updates mosquitto to version 2.0.9, fixing a compilation error on macOS Big Sur. It basically applies the patch in this ticket: https://trac.macports.org/ticket/62416

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
