### PR TITLE
spatialindex: update to 1.9.3

### DIFF
--- a/devel/spatialindex/Portfile
+++ b/devel/spatialindex/Portfile
@@ -1,32 +1,30 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
 
+github.setup        libspatialindex libspatialindex 1.9.3
+github.tarball_from archive
 name                spatialindex
-version             1.8.5
-#revision            0
+revision            0
+
 categories          devel science
 platforms           darwin
 license             MIT
-
 maintainers         nomaintainer
 
 description         ${name} provides a general framework for developing \
                     spatial indices.
-
 long_description    {*}${description} \
                     Currently it defines generic interfaces, provides simple \
                     main memory and disk based storage managers and a robust \
                     implementation of an R*-tree, an MVR-tree and a TPR-tree.
 
-homepage            http://libspatialindex.org/
-master_sites        http://download.osgeo.org/libspatialindex
+homepage            https://libspatialindex.org/
 
-distname            ${name}-src-${version}
-use_bzip2           yes
+checksums           rmd160  482054dd3b20f49055e6bc7a1b948fd51ffe62fe \
+                    sha256  7b44340a3edc55c11abfc453bb60f148b29f569cef9e1148583e76132e9c7379 \
+                    size    737444
 
-checksums           rmd160  63df2e6c579e91d90de406357cedb89b420e3ca7 \
-                    sha256  31ec0a9305c3bd6b4ad60a5261cba5402366dd7d1969a8846099717778e9a50a
-
-livecheck.url       ${master_sites}
-livecheck.regex     <a href=\"${name}(?:-src)?-(.*).tar.gz\"
+compiler.cxx_standard   2011

--- a/gis/qgis/Portfile
+++ b/gis/qgis/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 PortGroup           qt4     1.0
 
 github.setup        qgis QGIS 2_18_17 final-
-revision            4
+revision            5
 name                qgis
 version             [string map {_ .} ${github.version}]
 categories          gis

--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -10,7 +10,7 @@ PortGroup           active_variants 1.1
 github.setup        qgis QGIS 3_18_3 final-
 name                qgis3
 version             [string map {_ .} ${github.version}]
-revision            0
+revision            1
 categories          gis
 maintainers         {vince @Veence} openmaintainer
 description         QGIS 3 is a user-friendly GIS based on Qt 5
@@ -134,7 +134,7 @@ variant server description "Builds with the server (FCGI) option" {
     configure.args-append   "-DWITH_SERVER=ON"
 }
 
- 
+
 # Database variants (from the GDAL port)
 set postgresql_suffixes {13 12 11 10 95 96}
 


### PR DESCRIPTION
#### Description
- update `spatialindex` to version 1.9.3; switch upstream to GitHub, use CMake
- rev-bump `qgis` and `qgis3`, which I *think* is required as the library version changed. 

previous version:
```
% otool -L /opt/local/lib/libspatialindex.dylib
/opt/local/lib/libspatialindex.dylib:
	/opt/local/lib/libspatialindex.4.dylib (compatibility version 5.0.0, current version 5.1.0)
```

after update:
```
% otool -L /opt/local/lib/libspatialindex.dylib
/opt/local/lib/libspatialindex.dylib:
	/opt/local/lib/libspatialindex.6.dylib (compatibility version 6.0.0, current version 6.1.1)
```

###### Tested on
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->