### PR TITLE
mingw32-crt: Workaround "Too many open files"

### DIFF
--- a/cross/mingw-w64/Portfile
+++ b/cross/mingw-w64/Portfile
@@ -92,6 +92,9 @@ if {${subport} ne ${name}} {
         # but in fact it's GCC that needs CRT at runtime, not the other way around.
         if {${mingw_comp} eq "crt"} {
             depends_build-append    bin:${mingw_target}-gcc:${mingw_target}-gcc-bootstrap
+            
+            # Resolves "Too many open files in system"
+            use_parallel_build  no
         # *-winpthreads
         } else {
             # winpthreads needs at least stage 2 compiler (or the final one)


### PR DESCRIPTION
Building in parallel with higher CPU cores results in "Too many open files" from dlltool, not building in parallel resolves this problem.

#### Description

Here is the relevant section from `main.log`
```
:info:build i686-w64-mingw32-dlltool: bfd_open failed open stub file: dfxvs01181.o: Too many open files in system
:info:build i686-w64-mingw32-dlltool: i686-w64-mingw32-dlltool: bfd_open failed open stub file: dvxvs00563.o: Too many open files in systembfd_open failed open stub file: dlxvs01110.o: Too many open files in system
```
Here are links to similar issues;
- https://sourceware.org/bugzilla/show_bug.cgi?id=24723
- https://sourceware.org/bugzilla/show_bug.cgi?id=23573

Ether the issue is really binutils bfd to gcc11 is at fault, no I haven't opened a bug currently as I don't currently have an account to do this and my inbox/spam don't contain any registration email currently.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3 20E232 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
