### PR TITLE
fuse: new PortGroup

### DIFF
--- a/_resources/port1.0/group/fuse-1.0.tcl
+++ b/_resources/port1.0/group/fuse-1.0.tcl
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+#
+# This PortGroup chooses the right FUSE library to use.
+#
+# Usage:
+#
+# PortGroup           fuse 1.0
+#
+
+# use osxfuse up to OS X 10.11
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+
+    set fuse_port "osxfuse"
+    set fuse_path "lib/pkgconfig/fuse.pc"
+
+    configure.cflags-append -I${prefix}/include/osxfuse -I${prefix}/include/osxfuse/fuse
+    configure.cppflags-append -I${prefix}/include/osxfuse -I${prefix}/include/osxfuse/fuse
+
+} else {
+
+    set fuse_port "macfuse"
+    set fuse_path "lib/pkgconfig/fuse.pc"
+
+    configure.cflags-append -I${prefix}/include/fuse
+    configure.cppflags-append -I${prefix}/include/fuse
+
+}
+
+depends_lib-append \
+    path:${fuse_path}:${fuse_port}
+
+depends_build-append \
+    port:pkgconfig
+
+universal_variant no

--- a/fuse/archivemount/Portfile
+++ b/fuse/archivemount/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           fuse 1.0
 
 name                archivemount
 version             0.9.1
-revision            0
+revision            1
 categories          fuse
 platforms           darwin
 license             GPL-2
@@ -25,8 +26,5 @@ checksums           rmd160  332c5641072eb76f7aabae2b829254591c21a060 \
 
 patchfiles          patch-archivemount.diff
 
-depends_build-append \
-                    port:pkgconfig
-
-depends_lib-append  port:osxfuse \
-                    port:libarchive
+depends_lib-append \
+    port:libarchive

--- a/fuse/bindfs/Portfile
+++ b/fuse/bindfs/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           fuse 1.0
 
 name                bindfs
 version             1.15.1
-revision            0
+revision            1
 categories          fuse
 license             GPL-2+
 platforms           darwin
@@ -21,9 +22,3 @@ master_sites        ${homepage}downloads/
 checksums           rmd160  bd8eebc5f8d8a66d0015a8f43f0ee9b87f0c22d3 \
                     sha256  04dd3584a6cdf9af4344d403c62185ca9fab31ce3ae5a25d0101bc10936c68ab \
                     size    415676
-
-depends_build       port:pkgconfig
-depends_lib         port:osxfuse
-
-# osxfuse is not universal
-universal_variant   no

--- a/fuse/curlftpfs/Portfile
+++ b/fuse/curlftpfs/Portfile
@@ -1,8 +1,11 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           fuse 1.0
 
 name                curlftpfs
 version             0.9.2
-revision        2
+revision            3
 categories          fuse
 license             GPL      
 platforms           darwin
@@ -20,13 +23,15 @@ master_sites        sourceforge:project/curlftpfs/curlftpfs/${version}
 checksums           rmd160  16740731fc75b4249a8fddcae355ad1a9d408061 \
                     sha256  4eb44739c7078ba0edde177bdd266c4cfb7c621075f47f64c85a06b12b3c6958
 
-depends_build       port:pkgconfig
-depends_lib         port:curl port:osxfuse path:lib/pkgconfig/glib-2.0.pc:glib2 port:gettext port:libiconv port:zlib
+depends_lib-append \
+    port:curl \
+    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+    port:gettext \
+    port:libiconv \
+    port:zlib
 
-# osxfuse is not universal
-universal_variant   no
-
-patchfiles          patch-configure.diff
+patchfiles \
+    patch-configure.diff
 
 platform darwin {
     # http://sourceforge.net/tracker/?func=detail&aid=2799820&group_id=160565&atid=816359

--- a/fuse/encfs/Portfile
+++ b/fuse/encfs/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
+PortGroup           fuse 1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        vgough encfs 1.9.5 v
-revision            0
+revision            1
 categories          fuse
 platforms           darwin
 maintainers         nomaintainer
@@ -27,11 +28,10 @@ checksums           rmd160  1e33b38569eb527546527e3a24b0d83608c06feb \
                     sha256  4709f05395ccbad6c0a5b40a4619d60aafe3473b1a79bafb3aa700b1f756fd63 \
                     size    2798888
 
-depends_build-append \
-                    port:pkgconfig
-depends_lib-append  port:rlog path:lib/libssl.dylib:openssl port:osxfuse port:gettext port:boost
+depends_lib-append \
+    port:rlog \
+    path:lib/libssl.dylib:openssl \
+    port:gettext \
+    port:boost
 
 compiler.cxx_standard   2011
-
-# osxfuse is not universal
-universal_variant   no

--- a/fuse/ext2fuse/Portfile
+++ b/fuse/ext2fuse/Portfile
@@ -1,8 +1,10 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+PortGroup           fuse 1.0
 
 name                ext2fuse
 version             0.8.1
-revision            2
+revision            3
 categories          fuse
 license             GPL-2+
 platforms           darwin
@@ -16,18 +18,14 @@ homepage            http://ext2fuse.sourceforge.net/
 master_sites        sourceforge
 distname            ${name}-src-${version}
 
-checksums           md5 8926c6eeb9ea17846466ca4bd7143489 \
-                    sha1 6a13fce7842ead1485a4f48cb57c1272d990b5a5 \
-                    rmd160 7ba8c6f88550d1dcf4de235ab39dd13249e36eea
+checksums           rmd160  7ba8c6f88550d1dcf4de235ab39dd13249e36eea \
+                    sha256  431035797b2783216ec74b6aad5c721b4bffb75d2174967266ee49f0a3466cd9 \
+                    size    323336
 
-depends_build       port:pkgconfig
-depends_lib         port:osxfuse \
-                    port:e2fsprogs
+depends_lib \
+    port:e2fsprogs
 
-# e2fsprogs does not build for i386
-universal_variant   no
-
-configure.cflags-append -std=gnu89 
+configure.cflags-append -std=gnu89
 configure.cflags-append -D__FreeBSD__=10
 configure.cflags-append -I${prefix}/include/osxfuse/fuse
 configure.cflags-append -DENABLE_SWAPFS

--- a/fuse/ext4fuse/Portfile
+++ b/fuse/ext4fuse/Portfile
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           fuse 1.0
 PortGroup           github 1.0
 
 github.setup        gerard ext4fuse 0.1.3 v
+revision            1
 categories          fuse
 license             GPL-2
 platforms           darwin
@@ -16,15 +18,11 @@ long_description    Implementation of the ext4 filesystem in user space, \
 checksums           rmd160  33b3f6c3a72f86daec20fe191340f9a1e3294c70 \
                     sha256  9fdf0d1855d62d6ab108157d627e62b4996144a8eb49a38b094712f924448694
 
-depends_build-append \
-                    port:pkgconfig
-depends_lib-append  path:lib/libfuse.dylib:osxfuse \
-                    port:libiconv
+depends_lib-append \
+    port:libiconv
 
 use_configure       no
 
-# osxfuse is not universal
-universal_variant   no
 build.env           CC=${configure.cc} \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
                     "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]"

--- a/fuse/mhddfs/Portfile
+++ b/fuse/mhddfs/Portfile
@@ -1,25 +1,27 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
 
-name mhddfs
-version 0.1.10
-revision        3
-categories fuse
-license GPL-3+
-maintainers nomaintainer
+PortSystem          1.0
+PortGroup           fuse 1.0
 
-description  FUSE-based filesystem for combined mountpoints
-long_description This FUSE-based file system allows mount points (or directories) to be \
-                 combined, simulating a single big volume which can merge several hard disks.
+name                mhddfs
+version             0.1.10
+revision            4
+categories          fuse
+license             GPL-3+
+maintainers         nomaintainer
+description         FUSE-based filesystem for combined mountpoints
+long_description    This FUSE-based file system allows mount points (or directories) to be \
+    combined, simulating a single big volume which can merge several hard disks.
+homepage            http://mhddfs.uvw.ru/
+platforms           macosx
+master_sites        ${homepage}downloads/
 
-homepage http://mhddfs.uvw.ru/
-platforms macosx
-master_sites    ${homepage}downloads/
-checksums       md5 6ea5e65a4595f71cbe534eb08028c0b8 \
-                sha1 98566e854453924b8e426120b85aa7088a0853ee \
-                rmd160 ff0502d220d4eb3aaa0c37ebf6989be66518d2b8
+checksums           rmd160  ff0502d220d4eb3aaa0c37ebf6989be66518d2b8 \
+                    sha256  ec0485b028a3f53d49165f717e641dc02d8e581fd4dce3cd0065d2089d8e6c8e \
+                    size    27419
 
-depends_build port:pkgconfig
-depends_lib port:osxfuse port:libiconv
+depends_lib \
+    port:libiconv
 
 patchfiles patch-main.c.diff
 

--- a/fuse/mp3fs/Portfile
+++ b/fuse/mp3fs/Portfile
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           fuse 1.0
 PortGroup           github 1.0
 
 github.setup        khenriks mp3fs 0.91 v
+revision            1
 github.tarball_from releases
 categories          fuse
 license             GPL-3+
@@ -23,12 +25,7 @@ homepage            https://khenriks.github.io/${name}/
 checksums           rmd160 1992a61ba191dc8e73f5fcf29ef1a2aae040587c \
                     sha256 a47b5e351b7660e6f535a3c5b489c5a8191209957f8c0b8d066a5c221e8ecf92
 
-depends_build       port:pkgconfig
-
-depends_lib         port:osxfuse \
-                    port:flac \
-                    port:lame \
-                    port:libid3tag
-
-# osxfuse is not universal
-universal_variant   no
+depends_lib-append \
+    port:flac \
+    port:lame \
+    port:libid3tag

--- a/fuse/ntfs-3g/Portfile
+++ b/fuse/ntfs-3g/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           fuse 1.0
 
 name                ntfs-3g
 version             2017.3.23
-revision            1
+revision            2
 categories          fuse
 platforms           darwin
 maintainers         nomaintainer
@@ -31,13 +32,7 @@ checksums           rmd160  aae0cd7a2560ad87ba41832f1b34af5aaaa38739 \
 livecheck.type      regex
 livecheck.regex     {stable version</span></b> is <a href="https://tuxera.com/opensource/ntfs-3g_ntfsprogs-(.+?)\.tgz"}
 
-depends_build       port:pkgconfig
-
-depends_lib         path:lib/pkgconfig/fuse.pc:osxfuse \
-                    port:ossp-uuid
-
-# osxfuse is not universal
-universal_variant   no
+depends_lib         port:ossp-uuid
 
 # Use default PKG_CONFIG_PATH to avoid picking up a FUSE installation
 # in /usr/local (see #30537)

--- a/fuse/offlinefs/Portfile
+++ b/fuse/offlinefs/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
+PortGroup           fuse 1.0
 
 name                offlinefs
 version             0.4.6
-revision            3
+revision            4
 categories          fuse
 platforms           darwin
 maintainers         nomaintainer
@@ -28,17 +29,14 @@ livecheck.distname  offlinefs
 
 use_autoreconf      yes
 
-depends_build       port:automake \
-                    port:autoconf \
-                    port:libtool \
-                    port:pkgconfig
+depends_lib \
+    port:dbus \
+    port:libconfuse
 
-depends_lib         port:osxfuse \
-                    port:dbus \
-                    port:libconfuse 
+patchfiles \
+    patch-src-Makefile.in.diff \
+    patch-src-Makefile.am.diff
 
-patchfiles          patch-src-Makefile.in.diff \
-                    patch-src-Makefile.am.diff
 pre-destroot {
     file mkdir ${destroot}/sbin
 }

--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -28,6 +28,8 @@ long_description    FUSE for OS X implements a mechanism that makes it \
 
 homepage            https://osxfuse.github.io/
 
+conflicts           macfuse
+
 livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     "FUSE for macOS (\\d+(?:\\.\\d+)*)"

--- a/fuse/py-fuse/Portfile
+++ b/fuse/py-fuse/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 PortGroup github    1.0
 PortGroup python    1.0
+PortGroup fuse      1.0
 
 github.setup        libfuse python-fuse 0.2.1
 name                py-fuse
-revision            3
+revision            4
 categories          fuse python
 license             LGPL
 maintainers         {dports @drkp} openmaintainer
@@ -22,12 +23,6 @@ checksums           rmd160  c0acad069284e3adba7db8aaf957c7d228c488fc \
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:pkgconfig
-    depends_lib-append      port:osxfuse
-
-    # osxfuse is not universal
-    universal_variant   no
-
     platform darwin {
         patchfiles      patch-_fusemodule.c
     }

--- a/fuse/s3fs/Portfile
+++ b/fuse/s3fs/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           fuse 1.0
 
 github.setup        s3fs-fuse s3fs 1.84 v
+revision            1
 categories          fuse
-
 platforms           darwin
 maintainers         {adfernandes @adfernandes} openmaintainer
 description         Amazon S3 filesystem for FUSE
@@ -20,13 +21,9 @@ checksums           rmd160  2dddf2b187689f91da32c0601285b0be3e8a155c \
                     sha256  de4d54e96ae111696f822f1a682a33c6649e6e5c44ec9a1d3d847ab72c75fb0f \
                     size    153052
 
-depends_build       port:pkgconfig
-depends_lib         port:curl \
-                    port:libxml2 \
-                    path:lib/pkgconfig/fuse.pc:osxfuse \
-                    bin:ssh:openssh
-
-# osxfuse is -universal
-universal_variant   no
-
 use_autoreconf      yes
+
+depends_lib-append \
+    port:curl \
+    port:libxml2 \
+    bin:ssh:openssh

--- a/fuse/sshfs/Portfile
+++ b/fuse/sshfs/Portfile
@@ -2,8 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           fuse 1.0
 
 github.setup        libfuse sshfs 2.10 sshfs-
+revision            1
 categories          fuse
 
 platforms           darwin
@@ -20,19 +22,17 @@ long_description    This is a filesystem client based on the \
 license             GPL-2
 
 checksums           rmd160  9c940d816480a6ffba9d43d257f7fcc2484d06f3 \
-                    sha256  640096693c8bf7dfebebb40bb05bb363ef4b5515105262c8c35b823a8c3f9c14
-                    
-depends_build       port:pkgconfig
-depends_lib         port:gettext \
-                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    path:lib/pkgconfig/fuse.pc:osxfuse \
-                    port:libiconv \
-                    bin:ssh:openssh
+                    sha256  640096693c8bf7dfebebb40bb05bb363ef4b5515105262c8c35b823a8c3f9c14 \
+                    size    58307
+
 
 patch.pre_args      -p1
 patchfiles          patch-configure.ac.diff
 
-# osxfuse is -universal
-universal_variant   no
-
 use_autoreconf      yes
+
+depends_lib-append \
+    port:gettext \
+    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+    port:libiconv \
+    bin:ssh:openssh


### PR DESCRIPTION
#### Description

This PortGroup chooses the right FUSE library to use.
It is the follow-up of https://github.com/macports/macports-ports/pull/10620

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9028 x86_64
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
