### PR TITLE
saml2aws: Mark as unsupported on < 10.9

### DIFF
--- a/security/saml2aws/Portfile
+++ b/security/saml2aws/Portfile
@@ -309,6 +309,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  b33af1f522aefa76f028853a7e4cda5fe32f5a121bdae489043339c12e0d3f61 \
                         size    23282
 
+if {${os.platform} eq "darwin" && ${os.major} < 13} {
+    # The github.com/keybase/go-keychain dependency requires >= 10.9
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} requires OS X 10.9 or greater"
+        return -code error "unsupported platform version"
+    }
+}
+
 build.pre_args      -trimpath -ldflags \"-s -w -X main.Version=${version}\"
 build.args          ./cmd/${name}
 


### PR DESCRIPTION
#### Description

The github.com/keybase/go-keychain dependency requires at least OS X
10.9. Buildbots for older OS X versions are currently failing builds
because of this.

Set the known_fail flag so Buildbots skip the build per Ryan [1], and
display an error at pre-fetch notifying that the OS isn't supported.

[1] https://lists.macports.org/pipermail/macports-dev/2020-October/042480.html

Refs: https://trac.macports.org/ticket/62928

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3 20E232 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
