### PR TITLE
welle.io: update to 2.3

### DIFF
--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -94,30 +94,30 @@ variant kiss_fft description {Use KISS FFT instead of FFTW} {
 
 if {${subport} eq ${name}} {
     # stable
-    github.setup            AlbrechtL welle.io 2.2 v
+    github.setup            AlbrechtL welle.io 2.3 v
     github.tarball_from     archive
     epoch                   1
     revision                0
 
     conflicts               welle.io-devel
 
-    checksums               rmd160  a1ccb59c335b90b898ea345ea7f69868ef8c9182 \
-                            sha256  4b72c2984a884cc2f02d1e501ead2a8b0323900f37cebf4aed016e84474e0259 \
-                            size    1651332
+    checksums               rmd160  f7d8290701e86e3859cf165910c0228ad63e965b \
+                            sha256  e7aa936bf46499ce0abbbf617dd7984ccdaade955a5afb0c86886a0873f015c0 \
+                            size    6771774
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${version}
 } else {
     # devel
-    github.setup            AlbrechtL welle.io debec2f163962b3341324db009cdd352d98f1e60
+    github.setup            AlbrechtL welle.io 66675c9a4160c644a5ade5bf7a0cd0647647f33c
     set githash             [string range ${github.version} 0 6]
-    version                 20210411+git${githash}
+    version                 20210522+git${githash}
 
     conflicts               welle.io
 
-    checksums               rmd160  e15b7a6cf677f31742a5ce5a3432e5eadddd668d \
-                            sha256  ed3cb548cdc0f05892db31d4606b6b17a0338ecfc9ea5cd8a39ebb808bc69266 \
-                            size    1670280
+    checksums               rmd160  b59b2c23af4405b0220980b21fa7c5da0f9640cb \
+                            sha256  84bcd5835e462bc2cb829df594ecc0accaa6e2c232c8ba1bc75dbf0cd30fdb3c \
+                            size    6772022
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${githash}


### PR DESCRIPTION
#### Description

update to 2.3
update welle.io-devel to 20210522

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
