### PR TITLE
fzf: Update to 0.27.1

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.27.0
+go.setup            github.com/junegunn/fzf 0.27.1
 revision            0
 
 categories          sysutils
@@ -14,9 +14,9 @@ description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  bf0def3dec71948144e7e0e0ce2b6264ab76588b \
-                        sha256  ddbe914a3ee1d839c492a7f97cc5697c4932b9056e7a2457e873f47706a8570d \
-                        size    183011
+                        rmd160  a67f9ca09cc345a20c1f111998d70b77a4c18b4f \
+                        sha256  d8ebb9e1d4603586aaafff8034052abd0c75dcdcdf83074fb7bb9383307a5478 \
+                        size    191651
 
 go.vendors          golang.org/x/text \
                         lock    v0.3.6 \


### PR DESCRIPTION
#### Description

See: https://github.com/junegunn/fzf/releases/tag/0.27.1.

Note: `port lint` shows some warnings. E.g.:
```
Warning: golang-text-v0.3.6.tar.gz - missing recommended checksum type: sha256
Warning: golang-text-v0.3.6.tar.gz - missing recommended checksum type: size
Warning: golang-text-v0.3.6.tar.gz - missing recommended checksum type: rmd160
```

Checksums and sizes are set for these go dependencies. Is this an issue with `port lint`?


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
