### PR TITLE
kotlin: update to 1.5.10

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.5.0 v
+github.setup        JetBrains kotlin 1.5.10 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -16,16 +16,17 @@ license             Apache-2
 description         Statically typed programming language for the JVM, \
                     Android and the browser
 
-long_description    Kotlin is a pragmatic programming language for JVM \
-                    and Android that combines OO and functional features \
-                    and is focused on interoperability, safety, clarity \
-                    and tooling support.
+long_description    Kotlin is a modern but already mature programming \
+                    language aimed to make developers happier. It's \
+                    concise, safe, interoperable with Java and other \
+                    languages, and provides many ways to reuse code \
+                    between multiple platforms for productive programming.
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  3bfc147a506188cc67cf83b13c36255f3acc78dc \
-                    sha256  0343fc1f628fec1beccc9e534d2b8b7a0f8964b97e21563585d44d6d928ed1b7 \
-                    size    61733880
+checksums           rmd160  ba09d86eed57bada88ce0da2c164802b97c820e5 \
+                    sha256  2f8de1d73b816354055ff6a4b974b711c11ad55a68b948ed30b38155706b3c4e \
+                    size    61736399
 
 java.version        1.8+
 java.fallback       openjdk8
@@ -36,6 +37,11 @@ use_zip             yes
 use_configure       no
 
 build {}
+
+test.run    yes
+test.cmd    bin/kotlinc
+test.target
+test.args   -version
 
 pre-destroot {
     delete {*}[glob ${worksrcpath}/bin/*.bat]


### PR DESCRIPTION
#### Description

Update to Kotlin 1.5.10.

###### Tested on

macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?