### PR TITLE
blueutil: Update to version 2.9.0

### DIFF
--- a/sysutils/blueutil/Portfile
+++ b/sysutils/blueutil/Portfile
@@ -4,12 +4,12 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   makefile 1.0
 
-github.setup                toy blueutil 2.8.0 v
+github.setup                toy blueutil 2.9.0 v
 revision                    0
-checksums                   sha1    cb8f18db7cdaa5ece8aed4271b1ac814a8cfe6dd \
-                            rmd160  f4998213e02554e2d3965fa9453643731c3bd3bd \
-                            sha256  eda62a3429b7bf2d6fb0729a7f8770cfeb13a45b0d5e03f122c69443b025f83e \
-                            size    17310
+checksums                   sha1    e5874592fd0da67ecf05a09d7eaa4026f2eb049e \
+                            rmd160  8e39accbd6b46b18fa1691d994a4ee4e06c5ed84 \
+                            sha256  bf7bd529bfe2fcd3f2437bec4d20472eeceae2aee87f0fccf69197b8fe372b96 \
+                            size    18515
 
 categories                  sysutils
 platforms                   darwin


### PR DESCRIPTION
#### Description

Update blueutil to v2.9.0
Trac ticket: https://trac.macports.org/ticket/62957

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3 20E232 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
