### PR TITLE
hashcat: update to 6.2.1

### DIFF
--- a/security/hashcat/Portfile
+++ b/security/hashcat/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               makefile 1.0
 
-github.setup            hashcat hashcat 6.1.1 v
+github.setup            hashcat hashcat 6.2.1 v
 github.tarball_from     archive
 
 categories              security
@@ -25,7 +25,7 @@ homepage                https://hashcat.net/hashcat/
 
 build.target            {}
 
-checksums               rmd160  ded2fc1bdbf71836f260df35a909fdc660b780f6 \
-                        sha256  39c140bbb3c0bdb1564bfa9b9a1cff49115a42f4c9c19e9b066b617aea309f80 \
-                        size    5385180
+checksums               rmd160  d254ac888a12bb9b40060f27734e51a4c28f361f \
+                        sha256  4994e9ee8ef050881d5c7986b2b95a3abf2114f79e4dbaa28a537f8e2ad5c93b \
+                        size    5815254
 


### PR DESCRIPTION
#### Description
- hashcat: update to 6.2.1 from GitHub
- MacPorts can't find archive due to GitHub redirects
- `make` in unpacked archive ends with the following error:
```
Undefined symbols for architecture x86_64:
  "_libiconv", referenced from:
      _run_cracker in combined.NATIVE.a(backend.NATIVE.o)
      _thread_calc_stdin in combined.NATIVE.a(dispatch.NATIVE.o)
      _get_next_word in combined.NATIVE.a(wordlist.NATIVE.o)
      _count_words in combined.NATIVE.a(wordlist.NATIVE.o)
  "_libiconv_close", referenced from:
      _thread_calc_stdin in combined.NATIVE.a(dispatch.NATIVE.o)
      _wl_data_destroy in combined.NATIVE.a(wordlist.NATIVE.o)
  "_libiconv_open", referenced from:
      _run_cracker in combined.NATIVE.a(backend.NATIVE.o)
      _thread_calc_stdin in combined.NATIVE.a(dispatch.NATIVE.o)
      _wl_data_init in combined.NATIVE.a(wordlist.NATIVE.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [hashcat] Error 1
make: *** Waiting for unfinished jobs....`
```


###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
