### PR TITLE
mp4v2: Update to 4.1.6 from TechSmith fork

### DIFF
--- a/multimedia/mp4v2/Portfile
+++ b/multimedia/mp4v2/Portfile
@@ -1,14 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup    github 1.0
+
+github.setup        TechSmith mp4v2 4.1.6 Release-ThirdParty-MP4v2-
 
 name                mp4v2
-conflicts           mp4v2-devel
-version             2.0.0
 revision            1
-checksums           rmd160  1b309ec6480dd06fac2e1e72ab666ca123e714d8 \
-                    sha256  0319b9a60b667cf10ee0ec7505eb7bdc0a2e21ca7a93db96ec5bd758e3428338 \
-                    size    495672
+checksums           rmd160  646d541676f3e80a9a3a44f341eebda0713074f4 \
+                    sha256  bd4749f3bf4715decdbf032d5e550429297cc33ced248cd2f95dcb4e89083879 \
+                    size    4321700
 
 categories          multimedia
 license             MPL-1.1 BSD-old
@@ -21,13 +22,9 @@ long_description    The mp4v2 library provides an API to create and modify mp4 \
 homepage            https://code.google.com/p/mp4v2/
 platforms           darwin
 
-master_sites        googlecode
-
 depends_build       port:help2man
 
-use_bzip2           yes
-
-patchfiles          configure-version.patch
+patchfiles          configure-version.patch mp4tags-metadata.patch
 
 post-patch {
     reinplace "s|@@VERSION@@|${version}|g" \
@@ -50,7 +47,3 @@ platform darwin {
 variant universal {
     configure.args-append  --disable-gch
 }
-
-livecheck.type      regex
-livecheck.url       https://code.google.com/p/mp4v2/downloads/list
-livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"

--- a/multimedia/mp4v2/files/configure-version.patch
+++ b/multimedia/mp4v2/files/configure-version.patch
@@ -6,7 +6,7 @@
  
 -m4_define([PRJ_version],ifelse(
 -    PRJ_repo_type,[stable],m4_format([%s],PRJ_repo_branch),
--    m4_format([%s-r%d],PRJ_repo_branch,PRJ_repo_rev)))
+-    m4_format([%s-r%s],PRJ_repo_branch,PRJ_repo_rev)))
 +m4_define([PRJ_version],[@@VERSION@@])
  
  ###############################################################################

--- a/multimedia/mp4v2/files/mp4tags-metadata.patch
+++ b/multimedia/mp4v2/files/mp4tags-metadata.patch
@@ -1,0 +1,122 @@
+Patch from https://github.com/sandreas/mp4v2
+--- util/mp4tags.cpp
++++ util/mp4tags.cpp
+@@ -62,8 +62,27 @@ using namespace mp4v2::util;
+ #define OPT_RELEASEDATE  'y'
+ #define OPT_ARTISTID     'z'
+ #define OPT_COMPOSERID   'Z'
++#define OPT_SORT_NAME    'f'
++#define OPT_SORT_ARTIST   'F'
++#define OPT_SORT_ALBUM_ARTIST   'J'
++#define OPT_SORT_ALBUM   'k'
++#define OPT_SORT_COMPOSER   'K'
++#define OPT_SORT_TV_SHOW   'W'
++#define OPT_PURCHASE_DATE   'U'
++
++#define OPT_STRING  "r:A:a:b:c:C:d:D:e:E:g:G:H:i:I:j:l:L:m:M:n:N:o:O:p:P:B:R:s:S:t:T:U:x:X:w:y:z:Z:f:F:J:k:K:W:"
++
++
++// fFJkKqQuUVWxXYz   (h=help, v=version, r=remove)
++/*
++- MP4TagsSetSortName          ( tags, "my sortName" );  // J
++- MP4TagsSetSortArtist        ( tags, "my sortArtist" ); // f
++- MP4TagsSetSortAlbumArtist   ( tags, "my sortAlbumArtist" ); // F
++- MP4TagsSetSortAlbum         ( tags, "my sortAlbum" ); u
++- MP4TagsSetSortComposer      ( tags, "my sortComposer" ); r
++- MP4TagsSetSortTVShow        ( tags, "my sortTVShow" ); W
++*/
+ 
+-#define OPT_STRING  "r:A:a:b:c:C:d:D:e:E:g:G:H:i:I:j:l:L:m:M:n:N:o:O:p:P:B:R:s:S:t:T:x:X:w:y:z:Z:"
+ 
+ #define ELEMENT_OF(x,i) x[int(i)]
+ 
+@@ -110,6 +129,13 @@ static const char* const help_text =
+     "  -y, -year        NUM  Set the release date\n"
+     "  -z, -artistid    NUM  Set the artist ID\n"
+     "  -Z, -composerid  NUM  Set the composer ID\n"
++    "  -f, -sortname    STR  Set the sort name\n"
++    "  -F, -sortartist  STR  Set the sort artist\n"
++    "  -k, -sortalbum   STR  Set the sort album\n"
++    "  -W, -sorttvshow  STR  Set the sort tv show\n"
++    "  -J, -sortalbumartist STR  Set the sort album artist\n"
++    "  -K, -sortcomposer    STR  Set the sort composer\n"
++    "  -U, -purchasedate    STR  Set the purchase date\n"
+     "  -r, -remove      STR  Remove tags by code (e.g. \"-r cs\"\n"
+     "                        removes the comment and song tags)";
+ 
+@@ -155,8 +181,15 @@ extern "C" int
+         { "composerid",  prog::Option::REQUIRED_ARG, 0, OPT_COMPOSERID   },
+         { "remove",      prog::Option::REQUIRED_ARG, 0, OPT_REMOVE       },
+         { "albumartist", prog::Option::REQUIRED_ARG, 0, OPT_ALBUM_ARTIST },
+-        { "category",    prog::Option::REQUIRED_ARG, 0, OPT_CATEGORY },
+-        { "rating",      prog::Option::REQUIRED_ARG, 0, OPT_RATING },
++        { "category",    prog::Option::REQUIRED_ARG, 0, OPT_CATEGORY     },
++        { "rating",      prog::Option::REQUIRED_ARG, 0, OPT_RATING       },
++        { "sortname",    prog::Option::REQUIRED_ARG, 0, OPT_SORT_NAME    },
++        { "sortartist",  prog::Option::REQUIRED_ARG, 0, OPT_SORT_ARTIST  },
++        { "sortalbum",   prog::Option::REQUIRED_ARG, 0, OPT_SORT_ALBUM   },
++        { "sorttvshow",  prog::Option::REQUIRED_ARG, 0, OPT_SORT_TV_SHOW },
++        { "sortalbumartist",   prog::Option::REQUIRED_ARG, 0, OPT_SORT_ALBUM_ARTIST },
++        { "sortcomposer",      prog::Option::REQUIRED_ARG, 0, OPT_SORT_COMPOSER     },
++        { "purchasedate",      prog::Option::REQUIRED_ARG, 0, OPT_PURCHASE_DATE },
+         { NULL, prog::Option::NO_ARG, 0, 0 }
+     };
+ 
+@@ -381,6 +414,27 @@ extern "C" int
+                     case OPT_RATING:
+                         MP4TagsSetContentRating(mdata, NULL);
+                         break;
++                    case OPT_SORT_NAME:
++                        MP4TagsSetSortName( mdata, NULL );
++                        break;
++                    case OPT_SORT_ARTIST:
++                        MP4TagsSetSortArtist( mdata, NULL );
++                        break;
++                    case OPT_SORT_ALBUM_ARTIST:
++                        MP4TagsSetSortAlbumArtist( mdata, NULL );
++                        break;
++                    case OPT_SORT_ALBUM:
++                        MP4TagsSetSortAlbum( mdata, NULL );
++                        break;
++                    case OPT_SORT_COMPOSER:
++                        MP4TagsSetSortComposer( mdata, NULL );
++                        break;
++                    case OPT_SORT_TV_SHOW:
++                        MP4TagsSetSortTVShow( mdata, NULL );
++                        break;
++                    case OPT_PURCHASE_DATE:
++                        MP4TagsSetPurchaseDate( mdata, NULL );
++                        break;
+                 }
+             }
+         }
+@@ -588,6 +642,28 @@ extern "C" int
+                         MP4TagsSetContentRating(mdata, &rating);
+                         break;
+                     }
++
++                    case OPT_SORT_NAME:
++                        MP4TagsSetSortName( mdata, tags[i] );
++                        break;
++                    case OPT_SORT_ARTIST:
++                        MP4TagsSetSortArtist( mdata, tags[i] );
++                        break;
++                    case OPT_SORT_ALBUM_ARTIST:
++                        MP4TagsSetSortAlbumArtist( mdata, tags[i] );
++                        break;
++                    case OPT_SORT_ALBUM:
++                        MP4TagsSetSortAlbum( mdata, tags[i] );
++                        break;
++                    case OPT_SORT_COMPOSER:
++                        MP4TagsSetSortComposer( mdata, tags[i] );
++                        break;
++                    case OPT_SORT_TV_SHOW:
++                        MP4TagsSetSortTVShow( mdata, tags[i] );
++                        break;
++                    case OPT_PURCHASE_DATE:
++                        MP4TagsSetPurchaseDate( mdata, tags[i] );
++                        break;
+                 }
+             }
+         }
+


### PR DESCRIPTION
#### Description

[mp4v2](https://code.google.com/archive/p/mp4v2/) hasn't been updated in almost a decade. @TechSmith continues to maintain a [fork](https://github.com/TechSmith/mp4v2). https://trac.macports.org/ticket/53467 has, for a long time, requested that ports hosted on Google Code (which was made read-only in 2012) should be updated, including mp4v2, and suggests precisely this fork as the replacement repository. I have also added a patch from @sandreas, who has a separate [fork](https://github.com/sandreas/mp4v2) that is also (somewhat) maintained. This specific patch is currently the main difference to the @TechSmith repo, it's useful on its own and would be required if we ever add a port for https://github.com/sandreas/m4b-tool.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 arm64
Xcode 12.5 12E262

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
