### PR TITLE
py-ctypeslib2: Don't search; use depended-upon libclang.

### DIFF
--- a/python/py-ctypeslib2/Portfile
+++ b/python/py-ctypeslib2/Portfile
@@ -6,6 +6,7 @@ PortGroup               github 1.0
 
 github.setup            trolldbois ctypeslib 2.3.2
 name                    py-ctypeslib2
+revision                1
 python.versions         37 38 39
 python.default_version  39
 platforms               darwin
@@ -29,6 +30,9 @@ if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-clang
 
+    # Use the libclang that is provided by pyXX-clang (via its +clangY variant)
+    patchfiles              init_py.patch
+
     post-destroot {
         set DOCDIR ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${DOCDIR}
@@ -38,7 +42,7 @@ if {${name} ne ${subport}} {
     }
 }
 
-foreach {old} {34 35 36} {
+foreach {old} {27 34 35 36} {
     subport py${old}-${python.rootname} "
         replaced_by py${python.default_version}-${python.rootname}
         PortGroup obsolete 1.0

--- a/python/py-ctypeslib2/files/init_py.patch
+++ b/python/py-ctypeslib2/files/init_py.patch
@@ -1,18 +1,31 @@
---- ctypeslib/__init__.py.orig	2018-04-02 16:24:35.000000000 -0500
-+++ ctypeslib/__init__.py	2018-04-02 16:25:16.000000000 -0500
-@@ -20,13 +20,8 @@
- 
- # configure python-clang to use the local clang library
+--- ctypeslib/__init__.py.orig	2021-05-25 09:57:00.000000000 -0500
++++ ctypeslib/__init__.py	2021-05-25 09:59:28.000000000 -0500
+@@ -23,24 +23,11 @@
  try:
--    from ctypes.util import find_library
+     from ctypes.util import find_library
+     from clang import cindex
 -    # debug for python-haystack travis-ci
--    for version in ["libclang", "clang", "clang-6.0", "clang-5.0", "clang-4.0", "clang-3.9", "clang-3.8", "clang-3.7"]:
+-    v1 = ["clang-%d" % _ for _ in range(14, 6, -1)]
+-    v2 = ["clang-%.1f" % _ for _ in range(6, 3, -1)]
+-    v_list = v1 + v2 + ["clang-3.9", "clang-3.8", "clang-3.7"]
+-    for version in ["libclang", "clang"] + v_list:
 -        if find_library(version) is not None:
--            from clang import cindex
 -            cindex.Config.set_library_file(find_library(version))
 -            break
-+    from clang import cindex
-+    cindex.Config.set_library_file("%%LIBCLANG%%")
+-    else:
+-        if os.name == "posix" and sys.platform == "darwin":
+-            # On darwin, consider either Xcode or CommandLineTools.
+-            for f in ['/Applications/Xcode.app/Contents/Frameworks/libclang.dylib',
+-                      '/Library/Developer/CommandLineTools/usr/lib/libclang.dylib']:
+-                if os.path.exists(f):
+-                    cindex.Config.set_library_file(f)
+-
++    # The (MacPorts) installed clang module already knows (and depends upon)
++    # the appropriate libclang; don't go searching for something else.
+     def clang_version():
+-        return cindex.Config.library_file
++        cfg = cindex.Config()
++        return cfg.get_filename()
  except ImportError as e:
      print(e)
  


### PR DESCRIPTION
Maintainer update.

Rather than search, always use the libclang that has been installed via `pyXX-clang +clangYY -> clang-YY` dependency chain.

Mark py27 version as replaced_by.