### PR TITLE
google-cloud-sdk: update to 342.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             341.0.0
+version             342.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e61036d27c6fba06cb8cd728821aa33323b95493 \
-                    sha256  c9dfa743922f59a6ad0058f889aefcca0460b4865e6cbc8c8325be16d9569961 \
-                    size    89560033
+    checksums       rmd160  21ac09869096a8fa2d351191229e91dd4c3cf8a4 \
+                    sha256  b0e5ffb852c129002f6499c25c1abcfa2a9f4e0ea49bbc9d0b19edf9d1f790e3 \
+                    size    89750433
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f5fd3bbe726f87ef5e5b48d5e26504052db30387 \
-                    sha256  e7c13e1159b9a9652b2fb96b776f73b58f145fb53e0d4c13c4cba1a6dd01b800 \
-                    size    85805575
+    checksums       rmd160  23b18c2575d152b4b07af3aea24b59b36f1bd197 \
+                    sha256  0453b4ffa084a4d8e0045a2f1586f9c54096d3efb771d8736c21d476c0fb30d7 \
+                    size    85993827
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  932e14a1f73671f1ae9d82db33932a59764ebb87 \
-                    sha256  30c7d8f86ac13ee1bba5e2defe3a8fa9703733561192b82ff9c900065ed14c1b \
-                    size    85734394
+    checksums       rmd160  b88af3e48625757fe400b2aa5c5b48d0cb90c8b0 \
+                    sha256  00adbaea088ccfdd2fe1eba17f6dd36902a819bdcfbc6dcc5e58c743d6d4af33 \
+                    size    85922302
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 342.0.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?