### PR TITLE
skaffold: update to 1.25.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.24.1 v
+github.setup        GoogleContainerTools skaffold 1.25.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  bf619b4ec70cf26cd1886bc47d1e9351c0b283b1 \
-                    sha256  3718d8cda86b4e9906fc194ee7605272071a23e1b1651e78147fd3c33e0cc173 \
-                    size    23752401
+checksums           rmd160  0594ec5c8396950cd3a406bdb566ea8719999427 \
+                    sha256  de267c84d95d13bc6358821d352d716c597f76d7ba842c982e99d76be510c485 \
+                    size    23764164
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.25.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?