### PR TITLE
dcm2niix: 1.0.20210317

### DIFF
--- a/science/dcm2niix/Portfile
+++ b/science/dcm2niix/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        rordenlab dcm2niix 1.0.20181125 v
+github.setup        rordenlab dcm2niix 1.0.20210317 v
 version             ${github.version}
 
 categories          science
@@ -19,25 +19,32 @@ license             BSD MIT
 platforms           darwin
 
 checksums \
-    rmd160  518b52a35c422511f0f5f73154b14dcaddb5f033 \
-    sha256  d766c345a41954b21d4dc1d90c2c5ddc6425e36228e6d9d8abccd03fc5427c06 \
-    size    312848
+    rmd160  be682c4b9c028655ac4bfd5d22253400a659de11 \
+    sha256  bd23413a59a686301d580ad6f98c5ec079bf61c7431485ddcd112b7a4ba363db \
+    size    389955
 
-depends_build-append    port:git \
-                        port:py37-sphinx
+variant docs description {Install man pages} {
+    depends_build-append    port:py39-sphinx \
+                            port:py39-sphinxcontrib-applehelp \
+                            port:py39-sphinxcontrib-devhelp \
+                            port:py39-sphinxcontrib-htmlhelp \
+                            port:py39-sphinxcontrib-jsmath \
+                            port:py39-sphinxcontrib-qthelp \
+                            port:py39-sphinxcontrib-serializinghtml
+    configure.args-append   -DBUILD_DOCS=ON
+}
 
 depends_lib-append      port:openjpeg \
                         port:yaml-cpp \
                         port:zlib
 
 configure.args-append   -DUSE_OPENJPEG=ON \
-                        -DBUILD_DOCS=ON \
                         -DBATCH_VERSION=ON \
                         -DZLIB_IMPLEMENTATION=custom \
                         -DZLIB_ROOT=${prefix}
 
 patch {
-    reinplace "/NAMES/s/$/ sphinx-build-3.7/" docs/CMakeLists.txt
+    reinplace "/NAMES/s/$/ sphinx-build-3.9/" docs/CMakeLists.txt
 }
 
 post-destroot {


### PR DESCRIPTION
Maintainer update. Move documentation build (with much larger dependency tree) into +docs.