### PR TITLE
lz4: add patch to close CVE-2021-3520

### DIFF
--- a/archivers/lz4/Portfile
+++ b/archivers/lz4/Portfile
@@ -6,6 +6,7 @@ PortGroup           muniversal 1.0
 PortGroup           clang_dependency 1.0
 
 github.setup        lz4 lz4 1.9.3 v
+revision            1
 categories          archivers
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             BSD GPL-2+
@@ -25,7 +26,8 @@ checksums           rmd160  eb4044b51231dbcbc00b804f524a909a38cefc36 \
                     sha256  fbc4711bbad8b61eaa716acba0cde14afa1301fe06dd8f2abb268f3763370c98 \
                     size    321018
 
-patchfiles          gen_manual.patch
+patchfiles          gen_manual.patch \
+                    CVE-2021-3520.patch
 
 use_configure       no
 

--- a/archivers/lz4/files/CVE-2021-3520.patch
+++ b/archivers/lz4/files/CVE-2021-3520.patch
@@ -1,0 +1,20 @@
+From 8301a21773ef61656225e264f4f06ae14462bca7 Mon Sep 17 00:00:00 2001
+From: Jasper Lievisse Adriaanse <j@jasper.la>
+Date: Fri, 26 Feb 2021 15:21:20 +0100
+Subject: [PATCH] Fix potential memory corruption with negative memmove() size
+
+---
+ lib/lz4.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- lib/lz4.c
++++ lib/lz4.c
+@@ -1665,7 +1665,7 @@ LZ4_decompress_generic(
+                  const size_t dictSize         /* note : = 0 if noDict */
+                  )
+ {
+-    if (src == NULL) { return -1; }
++    if ((src == NULL) || (outputSize < 0)) { return -1; }
+ 
+     {   const BYTE* ip = (const BYTE*) src;
+         const BYTE* const iend = ip + srcSize;


### PR DESCRIPTION
#### Description

Close a security issue.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
