### PR TITLE
dcm2niix: Fix <= 10.6; revbump for others

### DIFF
--- a/science/dcm2niix/Portfile
+++ b/science/dcm2niix/Portfile
@@ -7,6 +7,10 @@ PortGroup           github 1.0
 github.setup        rordenlab dcm2niix 1.0.20210317 v
 version             ${github.version}
 
+# Bumped to force re-build linking against MP's yaml-cpp and openjpeg (rather
+# than private versions.)
+revision            1
+
 categories          science
 maintainers         {eborisch @eborisch} openmaintainer
 
@@ -39,6 +43,11 @@ depends_lib-append      port:openjpeg \
                         port:zlib
 
 depends_build-append    port:pkgconfig
+
+if {${os.major} <= 10} {
+    # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own
+    depends_build-append    port:git
+}
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
Maintainer update.
(Hopefully) fixes https://trac.macports.org/ticket/62974

Earlier successful builds of some flavors on the buildbot used private (static, compiled in) versions of yaml-cpp and openjpeg; rev-bump to force rebuild linking against MP provided versions.