### PR TITLE
neovim: switch back to LuaJIT

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -33,7 +33,7 @@ depends_lib             port:gettext \
                         port:libvterm \
                         port:libtermkey \
                         port:unibilium \
-                        port:msgpack1 \
+                        port:msgpack \
                         path:lib/libluajit-5.1.2.dylib:luajit \
                         port:lua51-lpeg \
                         port:lua51-mpack \

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -33,7 +33,6 @@ depends_lib             port:gettext \
                         port:libvterm \
                         port:libtermkey \
                         port:unibilium \
-                        port:jemalloc \
                         port:msgpack1 \
                         path:lib/libluajit-5.1.2.dylib:luajit \
                         port:lua51-lpeg \
@@ -43,8 +42,7 @@ depends_lib             port:gettext \
 cmake.out_of_source     yes
 
 configure.args-append   -DUSE_BUNDLED=OFF \
-                        -DLUA_PRG=${prefix}/bin/luajit \
-                        -DENABLE_JEMALLOC=ON
+                        -DLUA_PRG=${prefix}/bin/luajit
 
 notes {
     If you want to share your existing Vim configuration with Neovim, you can add these symlinks:

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -5,7 +5,7 @@ PortGroup github 1.0
 PortGroup cmake 1.0
 
 github.setup            neovim neovim 0.4.4 v
-revision                1
+revision                2
 categories              editors
 platforms               darwin
 maintainers             {raimue @raimue} \
@@ -35,17 +35,15 @@ depends_lib             port:gettext \
                         port:unibilium \
                         port:jemalloc \
                         port:msgpack1 \
-                        port:lua \
-                        port:lua-lpeg \
-                        port:lua-mpack \
-                        port:lua-luabitop \
-                        port:luv
+                        path:lib/libluajit-5.1.2.dylib:luajit \
+                        port:lua51-lpeg \
+                        port:lua51-mpack \
+                        port:luv-luajit
 
 cmake.out_of_source     yes
 
 configure.args-append   -DUSE_BUNDLED=OFF \
-                        -DPREFER_LUA=ON \
-                        -DLUA_PRG=${prefix}/bin/lua \
+                        -DLUA_PRG=${prefix}/bin/luajit \
                         -DENABLE_JEMALLOC=ON
 
 notes {


### PR DESCRIPTION
#### Description
Upstream officially supports Lua 5.1 or LuaJIT only, and Neovim 0.5 will only build with either of them, see https://github.com/neovim/neovim/issues/12415.

Note: `luv` and `luv-luajit` confict with each other, so upgrading requires manual intervention (deactivation).

P.S. Last switch to Lua 5.3 was made because we did not have ports for the `lua51-*` dependencies. It builds, but was not thoroughly tested in regard to Lua functionalities.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1030 x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
