### PR TITLE
openjdk16-zulu: update to 16.30.19 for arm64

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -472,7 +472,11 @@ subport openjdk16-openj9 {
 }
 
 subport openjdk16-zulu {
-    version      16.30.15
+    if {${configure.build_arch} eq "x86_64"} {
+        version      16.30.15
+    } elseif {${configure.build_arch} eq "arm64"} {
+        version      16.30.19
+    }
     revision     0
 
     set openjdk_version 16.0.1
@@ -489,9 +493,9 @@ subport openjdk16-zulu {
                      size    206494507
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  861151ded393157ef1a86a2329dedae57805154a \
-                     sha256  47f50e9c120130a77a77e65ccdb4ca4e101fe662bb429ba95668811c8618ab67 \
-                     size    195101232
+        checksums    rmd160  c8302a50ead48af69b715f5b74ba242c9012b05e \
+                     sha256  9c50ea8a1bbe5045164cbc6f244efab99a66595b8a1947356c653135ba640bc4 \
+                     size    195103125
     }
 
     worksrcdir   ${distname}/zulu-16.jdk


### PR DESCRIPTION
#### Description

Update Azul Zulu OpenJDK 16 for ARM64 to version 16.30.19.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?