### PR TITLE
Python PG: add outdated_versions. [RFC]

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -14,6 +14,8 @@
 # python.default_version: which version will be installed if the user asks
 #   for py-foo rather than pyXY-foo
 # python.consistent_destroot: set consistent environment values in build and destroot phases
+# python.obsolete_versions: Versions which are no longer available.
+#   These will be set replaced_by py${python.default_version}-foo
 #
 # Note: setting these options requires name to be set beforehand
 

--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -56,7 +56,8 @@ default python.rootname {[regsub ^py- [option name] ""]}
 default master_sites    {pypi:[string index ${python.rootname} 0]/${python.rootname}}
 default distname        {${python.rootname}-${version}}
 
-options python.versions python.version python.default_version
+options python.versions python.version python.default_version \
+        python.obsolete_versions
 option_proc python.versions python_set_versions
 default python.default_version {[python_get_default_version]}
 default python.version         {[python_get_version]}
@@ -91,6 +92,23 @@ proc python_set_env_compilers {phase} {
     foreach tag [option compwrap.compilers_to_wrap] {
         if {[option configure.${tag}] ne ""} {
             ${phase}.env-append [string toupper $tag]=[compwrap::wrap_compiler ${tag}]
+        }
+    }
+}
+
+option_proc python.obsolete_versions python_set_obsolete
+proc python_set_obsolete {option action args} {
+    if {$action ne "set"} {
+        return
+    }
+    global name subport python.rootname
+    if {[string match py-* $name]} {
+        foreach v [option $option] {
+            subport py${v}-${python.rootname} {
+                global python.default_version
+                replaced_by py${python.default_version}-${python.rootname}
+                PortGroup obsolete 1.0
+            }
         }
     }
 }


### PR DESCRIPTION
Any interest in adding an (implemented in this PR) outdated_versions setting to the python PortGroup?

Usage:

```
PortGroup                   python 1.0
[...]
python.outdated_versions    26 36
```

where each listed version will have a stub port with `replaced_by py${python.default_version}-foo` generated.

Or is there an existing and similarly terse approach that I've missed?