### PR TITLE
m4: use older regnames on Tiger

### DIFF
--- a/devel/m4/Portfile
+++ b/devel/m4/Portfile
@@ -29,6 +29,10 @@ checksums       rmd160  c67f853c8aaaad4300ab3cb3a3effa0c0fd8b24a \
                 sha256  b306a91c0fd93bc4280cfc2e98cb7ab3981ff75a187bea3293811f452c89a8c8 \
                 size    2150054
 
+platform darwin 8 {
+    patchfiles-append      patch-m4-use-older-regnames-on-tiger.diff
+}
+
 configure.args  --disable-silent-rules \
                 --program-prefix=g \
                 --with-packager=MacPorts \

--- a/devel/m4/files/patch-m4-use-older-regnames-on-tiger.diff
+++ b/devel/m4/files/patch-m4-use-older-regnames-on-tiger.diff
@@ -1,0 +1,29 @@
+--- ./lib/sigsegv.c.orig	2021-05-29 12:41:18.000000000 -0700
++++ ./lib/sigsegv.c	2021-05-29 12:43:06.000000000 -0700
+@@ -562,7 +562,7 @@
+      - 'ucontext_t' and 'struct __darwin_ucontext' in <sys/_types/_ucontext.h>,
+      - 'struct __darwin_mcontext64' in <i386/_mcontext.h>, and
+      - 'struct __darwin_x86_thread_state64' in <mach/i386/_structs.h>.  */
+-#  define SIGSEGV_FAULT_STACKPOINTER  ((ucontext_t *) ucp)->uc_mcontext->__ss.__rsp
++#  define SIGSEGV_FAULT_STACKPOINTER  ((ucontext_t *) ucp)->uc_mcontext->ss.rsp
+ 
+ # elif defined __i386__
+ 
+@@ -570,7 +570,7 @@
+      - 'ucontext_t' and 'struct __darwin_ucontext' in <sys/_types/_ucontext.h>,
+      - 'struct __darwin_mcontext32' in <i386/_mcontext.h>, and
+      - 'struct __darwin_i386_thread_state' in <mach/i386/_structs.h>.  */
+-#  define SIGSEGV_FAULT_STACKPOINTER  ((ucontext_t *) ucp)->uc_mcontext->__ss.__esp
++#  define SIGSEGV_FAULT_STACKPOINTER  ((ucontext_t *) ucp)->uc_mcontext->ss.esp
+ 
+ # elif defined __arm64__
+ 
+@@ -586,7 +586,7 @@
+      - 'ucontext_t' and 'struct __darwin_ucontext' in <sys/_structs.h>,
+      - 'struct __darwin_mcontext' in <ppc/_structs.h>, and
+      - 'struct __darwin_ppc_thread_state' in <mach/ppc/_structs.h>.  */
+-#  define SIGSEGV_FAULT_STACKPOINTER  ((ucontext_t *) ucp)->uc_mcontext->__ss.__r1
++#  define SIGSEGV_FAULT_STACKPOINTER  ((ucontext_t *) ucp)->uc_mcontext->ss.r1
+ 
+ # endif
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

This fixes the build on Tiger i386, which is where I tested it. The test run passes most tests, looks acceptable to me.

I still have to check this on Tiger PPC -- there is another section of regnames that might need to be fixed for PPC too.
