### PR TITLE
stressdrive: new port

### DIFF
--- a/sysutils/stressdrive/Portfile
+++ b/sysutils/stressdrive/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+
+github.setup        rentzsch stressdrive 1.3.2
+categories          sysutils
+platforms           darwin
+maintainers         {@toy yandex.com:bstj} openmaintainer
+license             MIT
+
+set danger          "DANGER: ${name} will overwrite, without warning, all \
+                    data on the given drive. Be sure to double-check the \
+                    drive you're aiming it at (diskutil list or Disk \
+                    Utility.app > Select Drive > Info > Disk Identifier)."
+
+description         Tool meant to verify correct operation of a drive
+long_description    ${description} by filling a drive up with random data \
+                    and ensuring all the data can be correctly read back. \
+                    \n${danger}
+
+notes               "${danger}"
+
+checksums           rmd160  abab2499c1fe405b8df447b2a9b8aa3b7e5775f3 \
+                    sha256  ecb51c26fa299464bf7627242ef4047a56061d706b8552fbc30b2ab3fa44ee55 \
+                    size    7298
+
+depends_lib         port:openssl
+
+xcode.build.settings \
+                    HEADER_SEARCH_PATHS=${prefix}/include \
+                    LIBRARY_SEARCH_PATHS=${prefix}/lib \
+                    OTHER_LDFLAGS=-lcrypto
+xcode.destroot.settings \
+                    HEADER_SEARCH_PATHS=${prefix}/include \
+                    LIBRARY_SEARCH_PATHS=${prefix}/lib \
+                    OTHER_LDFLAGS=-lcrypto
+
+xcode.destroot.path ${prefix}/bin


### PR DESCRIPTION
#### Description

Tool meant to verify correct operation of a drive.

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
