### PR TITLE
math/r: build with implicit dependencies, remove dependency on openmp

### DIFF
--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -103,6 +103,8 @@ configure.args              --disable-openmp \
                             --without-x \
                             --with-included-gettext
 
+configure.cflags-append -Wno-implicit-function-declaration
+
 if {${os.platform} eq "darwin" && ${os.major} < 13} {
     configure.args-append --disable-openmp
 }
@@ -198,7 +200,7 @@ variant java description {enable Java} {
     configure.args-replace --disable-java --enable-java
 }
 
-default_variants +cairo +recommended +openmp
+default_variants +cairo +recommended
 
 if {![variant_isset quartz]} {
     default_variants-append +x11


### PR DESCRIPTION
math/r: build with implicit dependencies, remove dependency on openmp

Closes: https://trac.macports.org/ticket/62626