### PR TITLE
grass7: fix bool redefinition conflict with GDAL 3.3

### DIFF
--- a/gis/grass7/Portfile
+++ b/gis/grass7/Portfile
@@ -8,7 +8,7 @@ PortGroup           debug 1.0
 github.setup        OSGeo grass 7.8.5
 name                grass7
 set main_version    [join [lrange [split ${version} "."] 0 1] ""]
-revision            3
+revision            4
 set realVersion     ${version}
 #distname           grass-${version}
 distname            grass-${realVersion}
@@ -44,6 +44,7 @@ depends_lib         port:bzip2 \
 patchfiles          patch-configure.diff \
                     patch-Install_make.diff  \
                     patch-grass.py.diff \
+                    patch-bool-fix.diff \
                     patch-libraster_gdal_c.diff
 
 configure.args-append \

--- a/gis/grass7/files/patch-bool-fix.diff
+++ b/gis/grass7/files/patch-bool-fix.diff
@@ -1,0 +1,72 @@
+--- vector/v.hull/chull.c.orig	2021-05-29 15:37:11.000000000 +0200
++++ vector/v.hull/chull.c	2021-05-29 18:39:54.000000000 +0200
+@@ -22,6 +22,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <math.h>
++#include <stdbool.h>
+ 
+ #include <grass/gis.h>
+ #include <grass/vector.h>
+@@ -29,10 +30,6 @@
+ 
+ #include "globals.h"
+ 
+-/*Define Boolean type */
+-typedef enum
+-{ BFALSE, BTRUE } bool;
+-
+ /* Define vertex indices. */
+ #define X   0
+ #define Y   1
+@@ -76,10 +73,10 @@
+ };
+ 
+ /* Define flags */
+-#define ONHULL   	BTRUE
+-#define REMOVED  	BTRUE
+-#define VISIBLE  	BTRUE
+-#define PROCESSED	BTRUE
++#define ONHULL   	true
++#define REMOVED  	true
++#define VISIBLE  	true
++#define PROCESSED	true
+ 
+ /* Global variable definitions */
+ tVertex vertices = NULL;
+@@ -436,7 +433,7 @@
+     tFace f;
+     tEdge e, temp;
+     long int vol;
+-    bool vis = BFALSE;
++    bool vis = false;
+ 
+ 
+     /* Mark faces visible from p. */
+@@ -446,7 +443,7 @@
+ 
+ 	if (vol < 0) {
+ 	    f->visible = VISIBLE;
+-	    vis = BTRUE;
++	    vis = true;
+ 	}
+ 	f = f->next;
+     } while (f != faces);
+@@ -454,7 +451,7 @@
+     /* If no faces are visible from p, then p is inside the hull. */
+     if (!vis) {
+ 	p->onhull = !ONHULL;
+-	return BFALSE;
++	return false;
+     }
+ 
+     /* Mark edges in interior of visible region for deletion.
+@@ -470,7 +467,7 @@
+ 	    e->newface = MakeConeFace(e, p);
+ 	e = temp;
+     } while (e != edges);
+-    return BTRUE;
++    return true;
+ }
+ 
+ /*---------------------------------------------------------------------


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/62989

#### Description

Patches a local (GRASS source) (re-)definition of `bool` which conflicts with GDAL 3.3.0 version's added inclusion of `stdbool.h`.

This issue has already been addressed upstreams and this patch is only needed until the release of GRASS 7.8.6.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H114 x86_64
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
