### PR TITLE
Add boost171 and boost176 ports, with isolated builds, and a new boost PG to handle configuration

### DIFF
--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -8,7 +8,7 @@
 namespace eval boost { }
 
 options boost.version
-default boost.version 1.71
+default boost.version 1.76
 
 options boost.depends_type
 default boost.depends_type lib

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+#
+# Usage:
+# PortGroup     boost 1.0
+#
+# This port group handles setting ports up to build against specific boost versions
+
+namespace eval boost { }
+
+options boost.version
+default boost.version 1.71
+
+options boost.depends_type
+default boost.depends_type lib
+
+options boost.cmake_option_name
+default boost.cmake_option_name Boost_INCLUDE_DIR
+
+proc boost::version {} {
+    return [option boost.version]
+}
+
+proc boost::version_nodot {} {
+    return [string map {. {}} [boost::version]]
+}
+
+proc boost::install_area {} {
+    global prefix
+    return ${prefix}/libexec/boost[boost::version_nodot]
+}
+
+proc boost::include_dir {} {
+    return [boost::install_area]/include
+}
+
+proc boost::lib_dir {} {
+    return [boost::install_area]/lib
+}
+
+proc boost::configure {} {
+    global cmake.build_dir
+
+    # Set the requested boost dependency
+    depends_[option boost.depends_type]-append port:boost[boost::version_nodot]
+
+    # Append to the build flags to find the isolated headers/libs
+    configure.cppflags-prepend -isystem[boost::include_dir]
+    configure.ldflags-prepend  -L[boost::lib_dir]
+
+    # are we using cmake ?
+    if { [info exists cmake.build_dir] } {
+        ui_debug "Detected Cmake PG in use"
+        configure.args-append -D[option boost.cmake_option_name]=[boost::include_dir]
+    }
+
+}
+port::register_callback boost::configure

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -30,7 +30,7 @@ proc boost::version_nodot {} {
 
 proc boost::install_area {} {
     global prefix
-    return ${prefix}/libexec/boost[boost::version_nodot]
+    return ${prefix}/libexec/boost/boost[boost::version_nodot]
 }
 
 proc boost::include_dir {} {

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -44,7 +44,7 @@ proc boost::configure {} {
     depends_[option boost.depends_type]-append port:boost[boost::version_nodot]
 
     # Append to the build flags to find the isolated headers/libs
-    configure.cppflags-prepend -isystem[boost::include_dir]
+    configure.cxxflags-prepend -isystem[boost::include_dir]
     configure.ldflags-prepend  -L[boost::lib_dir]
 
     # are we using cmake ?

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -30,7 +30,7 @@ proc boost::version_nodot {} {
 
 proc boost::install_area {} {
     global prefix
-    return ${prefix}/libexec/boost/[boost::version]
+    return ${prefix}/libexec/boost/boost[boost::version]
 }
 
 proc boost::include_dir {} {

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -30,7 +30,7 @@ proc boost::version_nodot {} {
 
 proc boost::install_area {} {
     global prefix
-    return ${prefix}/libexec/boost/boost[boost::version_nodot]
+    return ${prefix}/libexec/boost/[boost::version]
 }
 
 proc boost::include_dir {} {

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -30,7 +30,7 @@ proc boost::version_nodot {} {
 
 proc boost::install_area {} {
     global prefix
-    return ${prefix}/libexec/boost/boost[boost::version]
+    return ${prefix}/libexec/boost/[boost::version]
 }
 
 proc boost::include_dir {} {

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -13,6 +13,12 @@ default boost.version 1.76
 options boost.depends_type
 default boost.depends_type lib
 
+set boost_last_version_nodot ""
+set boost_last_depends       ""
+set boost_last_cxxflags      ""
+set boost_last_ldflags       ""
+set boost_last_cmake_flags   ""
+
 proc boost::version {} {
     return [option boost.version]
 }
@@ -34,22 +40,59 @@ proc boost::lib_dir {} {
     return [boost::install_area]/lib
 }
 
-proc boost::configure {} {
+proc boost::configure_build {} {
     global cmake.build_dir
+    global boost_last_version_nodot boost_last_depends boost_last_cxxflags
+    global boost_last_ldflags boost_last_cmake_flags
+
+    if { ${boost_last_version_nodot} eq [boost::version_nodot] &&
+         ${boost_last_depends} eq [option boost.depends_type] } return
+
+    ui_debug "Configure build [boost::version]"
 
     # Set the requested boost dependency
+    if { ${boost_last_version_nodot} ne "" && ${boost_last_depends} ne "" } {
+        depends_${boost_last_depends}-delete port:boost${boost_last_version_nodot} 
+    }
+    set boost_last_depends       [option boost.depends_type]
+    set boost_last_version_nodot [boost::version_nodot]
     depends_[option boost.depends_type]-append port:boost[boost::version_nodot]
 
     # Append to the build flags to find the isolated headers/libs
-    configure.cxxflags-prepend -isystem[boost::include_dir]
-    configure.ldflags-prepend  -L[boost::lib_dir]
+    if { ${boost_last_cxxflags} ne "" } {
+        configure.cxxflags-delete ${boost_last_cxxflags}
+    }
+    if { ${boost_last_ldflags} ne "" } {
+        configure.ldflags-delete ${boost_last_ldflags}
+    }
+    set boost_last_cxxflags -isystem[boost::include_dir]
+    set boost_last_ldflags  -L[boost::lib_dir]
+    configure.cxxflags-prepend ${boost_last_cxxflags}
+    configure.ldflags-prepend  ${boost_last_ldflags}
 
     # are we using cmake ?
     if { [info exists cmake.build_dir] } {
         ui_debug "Detected Cmake PG in use"
-        configure.args-append -DBoost_INCLUDE_DIR=[boost::include_dir] \
-                              -DBoost_DIR=[boost::install_area]
+        if { ${boost_last_cmake_flags} ne "" } {
+            foreach flag ${boost_last_cmake_flags} {
+                configure.args-delete ${flag}
+            }
+        }
+        set boost_last_cmake_flags [list -DBoost_INCLUDE_DIR=[boost::include_dir] -DBoost_DIR=[boost::install_area]]
+        foreach flag ${boost_last_cmake_flags} {
+            configure.args-append ${flag}
+        }
     }
 
 }
-port::register_callback boost::configure
+
+port::register_callback boost::configure_build
+
+boost::configure_build
+
+proc boost::set_boost_parameters {option action args} {
+    if {$action ne  "set"} return
+    boost::configure_build
+}
+option_proc boost.version      boost::set_boost_parameters
+option_proc boost.depends_type boost::set_boost_parameters

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -18,6 +18,7 @@ set boost_last_depends       ""
 set boost_last_cxxflags      ""
 set boost_last_ldflags       ""
 set boost_last_cmake_flags   ""
+set boost_last_cmake         0
 
 proc boost::version {} {
     return [option boost.version]
@@ -43,10 +44,11 @@ proc boost::lib_dir {} {
 proc boost::configure_build {} {
     global cmake.build_dir
     global boost_last_version_nodot boost_last_depends boost_last_cxxflags
-    global boost_last_ldflags boost_last_cmake_flags
+    global boost_last_ldflags boost_last_cmake_flags boost_last_cmake
 
     if { ${boost_last_version_nodot} eq [boost::version_nodot] &&
-         ${boost_last_depends} eq [option boost.depends_type] } return
+         ${boost_last_depends} eq [option boost.depends_type] &&
+         ${boost_last_cmake} eq [info exists cmake.build_dir] } return
 
     ui_debug "Configure build [boost::version]"
 
@@ -73,6 +75,7 @@ proc boost::configure_build {} {
     # are we using cmake ?
     if { [info exists cmake.build_dir] } {
         ui_debug "Detected Cmake PG in use"
+        set boost_last_cmake 1
         if { ${boost_last_cmake_flags} ne "" } {
             foreach flag ${boost_last_cmake_flags} {
                 configure.args-delete ${flag}

--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -13,9 +13,6 @@ default boost.version 1.71
 options boost.depends_type
 default boost.depends_type lib
 
-options boost.cmake_option_name
-default boost.cmake_option_name Boost_INCLUDE_DIR
-
 proc boost::version {} {
     return [option boost.version]
 }
@@ -50,7 +47,8 @@ proc boost::configure {} {
     # are we using cmake ?
     if { [info exists cmake.build_dir] } {
         ui_debug "Detected Cmake PG in use"
-        configure.args-append -D[option boost.cmake_option_name]=[boost::include_dir]
+        configure.args-append -DBoost_INCLUDE_DIR=[boost::include_dir] \
+                              -DBoost_DIR=[boost::install_area]
     }
 
 }

--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -16,7 +16,7 @@ checksums       rmd160 a46b886ca26993610c84615fca4340ad3f955f81 \
 license         Boost-1
 categories      devel
 platforms       darwin
-maintainers     {michaelld @michaelld} openmaintainer
+maintainers     {michaelld @michaelld} {@mascguy} openmaintainer
 
 description     Collection of portable C++ source libraries
 

--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -27,12 +27,10 @@ long_description \
     which work well with the C++ Standard Library.
 
 homepage        http://www.boost.org
-master_sites    https://dl.bintray.com/boostorg/release/${version}/source/
+master_sites    https://boostorg.jfrog.io/artifactory/main/release/${version}/source/
 set distver     [join [split ${version} .] _]
 distname        boost_${distver}
 use_bzip2       yes
-
-dist_subdir     boost
 
 depends_lib     port:zlib \
                 port:expat \

--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -16,7 +16,7 @@ checksums       rmd160  308544f184f04e4f192ac6a1118f6db787558ee6 \
 license         Boost-1
 categories      devel
 platforms       darwin
-maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
+maintainers     {mcalhoun @MarcusCalhoun-Lopez} {@mascguy} openmaintainer
 
 description     Collection of portable C++ source libraries
 

--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -47,6 +47,8 @@ post-extract {
     }
 }
 
+set bprefix ${prefix}/libexec/boost/${name}
+
 # patch-apple-clang-no-libcxx.diff fixes a clang configuration error
 # that occurs on OS X 10.7 and 10.8 due to the assumption that if
 # clang is the compiler in use it must be using libc++.  Apple Clang
@@ -127,7 +129,7 @@ configure.universal_args
 
 post-configure {
 
-    reinplace -E "s|-install_name \"|&${prefix}/libexec/${name}/lib/|" \
+    reinplace -E "s|-install_name \"|&${bprefix}/lib/|" \
         ${worksrcpath}/tools/build/src/tools/darwin.jam
 
     set compileflags ""
@@ -170,7 +172,7 @@ destroot.cmd    ${worksrcpath}/b2
 destroot.post_args
 
 pre-destroot {
-    destroot.args {*}${build.args} --prefix=${destroot}${prefix}/libexec/${name}
+    destroot.args {*}${build.args} --prefix=${destroot}${bprefix}
     system "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
 }
 
@@ -293,7 +295,7 @@ variant docs description {Enable building documentation} {
 }
 
 post-destroot {
-    delete file {*}[glob ${destroot}${prefix}/libexec/${name}/include/boost/python/numpy*]
+    delete file {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*]
 }
 
 if {[mpi_variant_isset]} {
@@ -325,7 +327,7 @@ if {[mpi_variant_isset]} {
             xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
                 ${destroot}${site_packages}/boost
 
-            set f ${destroot}${prefix}/libexec/${name}/lib/mpi.so
+            set f ${destroot}${bprefix}/lib/mpi.so
             if {[info exists ${f}]} {
                 set l ${site_packages}/boost/mpi.so
                 move ${f} ${destroot}${l}

--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -3,6 +3,7 @@
 PortSystem      1.0
 PortGroup       mpi 1.0
 PortGroup       active_variants 1.1
+PortGroup       compiler_blacklist_versions 1.0
 
 name            boost169
 
@@ -47,7 +48,9 @@ post-extract {
     }
 }
 
-set bprefix ${prefix}/libexec/boost/${name}
+# Install prefix for this port
+set branch  [join [lrange [split ${version} .] 0 1] .]
+set bprefix ${prefix}/libexec/boost/${branch}
 
 # patch-apple-clang-no-libcxx.diff fixes a clang configuration error
 # that occurs on OS X 10.7 and 10.8 due to the assumption that if
@@ -95,6 +98,9 @@ proc write_jam s {
 
 compilers.choose   cc cxx
 mpi.setup          -gcc
+
+# clang: error: unknown argument: '-fcoalesce-templates'
+compiler.blacklist-append {clang > 1100}
 
 # NOTE: although technically Boost does not require C++11 compliance
 # for building, doing so allows for building on more OSs than without.

--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -174,7 +174,9 @@ pre-destroot {
     system "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
 }
 
-post-destroot {
+proc boost_docs_install {} {
+    global prefix destroot worksrcpath name
+
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     set l [expr [string length ${worksrcpath}] + 1]
@@ -189,6 +191,12 @@ post-destroot {
         } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
             xinstall -m 644 ${f} ${dest}
         }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
     }
 }
 
@@ -263,66 +271,69 @@ variant no_single description {Disable building single-threaded libraries} {
     build.args-append   threading=multi
 }
 
-    patchfiles-append patch-disable-numpy-extension.diff
+patchfiles-append patch-disable-numpy-extension.diff
 
-    variant regex_match_extra description \
-        "Enable access to extended capture information of submatches in Boost.Regex" {
-        notes-append "
-        You enabled the +regex_match_extra variant\; see the following page for an\
-        exhaustive list of the consequences of this feature:
+variant regex_match_extra description \
+    "Enable access to extended capture information of submatches in Boost.Regex" {
+    notes-append "
+    You enabled the +regex_match_extra variant\; see the following page for an\
+    exhaustive list of the consequences of this feature:
 
     http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
 "
 
-        post-patch {
-            reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
-                ${worksrcpath}/boost/regex/user.hpp
-        }
+    post-patch {
+        reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
+            ${worksrcpath}/boost/regex/user.hpp
+    }
+}
+
+variant docs description {Enable building documentation} {
+    # No configure changes, etc; we simply check 'variant_isset' elsewhere
+}
+
+post-destroot {
+    delete file {*}[glob ${destroot}${prefix}/libexec/${name}/include/boost/python/numpy*]
+}
+
+if {[mpi_variant_isset]} {
+
+    # see https://trac.macports.org/ticket/49748
+    # see http://www.openradar.me/25313838
+    configure.ldflags-append -Lstage/lib
+
+    # There is a conflict with debug support.
+    # The issue has been reported to both the MacPorts team and the boost team, as per:
+    # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+    if {[variant_isset debug]} {
+        return -code error "+debug variant conflicts with mpi"
     }
 
-    post-destroot {
-        delete file {*}[glob ${destroot}${prefix}/libexec/${name}/include/boost/python/numpy*]
+    configure.args-delete   --without-libraries=mpi
+
+    post-configure {
+        write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
     }
 
-    if {[mpi_variant_isset]} {
+    if {![catch python_dir]} {
 
-        # see https://trac.macports.org/ticket/49748
-        # see http://www.openradar.me/25313838
-        configure.ldflags-append -Lstage/lib
+        patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
 
-        # There is a conflict with debug support.
-        # The issue has been reported to both the MacPorts team and the boost team, as per:
-        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
-        if {[variant_isset debug]} {
-            return -code error "+debug variant conflicts with mpi"
-        }
+        post-destroot {
+            set site_packages [python_dir]
+            xinstall -d ${destroot}${site_packages}/boost
+            xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                ${destroot}${site_packages}/boost
 
-        configure.args-delete   --without-libraries=mpi
-
-        post-configure {
-            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
-        }
-
-        if {![catch python_dir]} {
-
-            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
-
-            post-destroot {
-                set site_packages [python_dir]
-                xinstall -d ${destroot}${site_packages}/boost
-                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
-                    ${destroot}${site_packages}/boost
-
-                set f ${destroot}${prefix}/libexec/${name}/lib/mpi.so
-                if {[info exists ${f}]} {
-                    set l ${site_packages}/boost/mpi.so
-                    move ${f} ${destroot}${l}
-                    system "install_name_tool -id ${l} ${destroot}${l}"
-                }
+            set f ${destroot}${prefix}/libexec/${name}/lib/mpi.so
+            if {[info exists ${f}]} {
+                set l ${site_packages}/boost/mpi.so
+                move ${f} ${destroot}${l}
+                system "install_name_tool -id ${l} ${destroot}${l}"
             }
-
         }
     }
+}
 
 livecheck.type  none
 

--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -8,7 +8,7 @@ PortGroup       compiler_blacklist_versions 1.0
 name            boost169
 
 version         1.69.0
-revision        2
+revision        3
 
 checksums       rmd160  308544f184f04e4f192ac6a1118f6db787558ee6 \
                 sha256  8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406 \

--- a/devel/boost171/Portfile
+++ b/devel/boost171/Portfile
@@ -1,0 +1,483 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       mpi 1.0
+PortGroup       active_variants 1.1
+
+name            boost171
+
+version         1.71.0
+# Revision is set below in the `if {$subport eq $name} { ... }` statement
+# The boost-numpy subport has its own revision number
+checksums       rmd160 a46b886ca26993610c84615fca4340ad3f955f81 \
+                sha256 d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee \
+                size   100124647
+
+license         Boost-1
+categories      devel
+platforms       darwin
+maintainers     {michaelld @michaelld} openmaintainer
+
+description     Collection of portable C++ source libraries
+
+long_description \
+    Boost provides free portable peer-reviewed C++ \
+    libraries. The emphasis is on portable libraries \
+    which work well with the C++ Standard Library.
+
+homepage        http://www.boost.org
+master_sites    https://boostorg.jfrog.io/artifactory/main/release/${version}/source/
+set distver     [join [split ${version} .] _]
+distname        boost_${distver}
+use_bzip2       yes
+
+depends_lib     port:bzip2 \
+                port:expat \
+                port:icu \
+                port:libiconv \
+                port:lzma \
+                port:zlib \
+                port:zstd
+
+post-extract {
+    fs-traverse dir ${workpath} {
+        if {[file isdirectory ${dir}]} {
+            file attributes ${dir} -permissions a+rx
+        }
+    }
+}
+
+# Install prefix for this port
+set bprefix ${prefix}/libexec/${name}
+
+# patch-apple-clang-no-libcxx.diff fixes a clang configuration error
+# that occurs on OS X 10.7 and 10.8 due to the assumption that if
+# clang is the compiler in use it must be using libc++.  Apple Clang
+# uses libstdc++ by default on these OS versions.  The patch adds an
+# additional BOOST_* configuration flag that is set if Apple clang is
+# being used but libc++ is not.  This flag is then used to prevent
+# boost or a dependent package from using functions such as
+# std::forward that are only available in libc++.  Fixes build of
+# libcdr on these OS versions without affecting build on 10.6 and less
+# (where clang is not the default compiler) or 10.9 and up (where
+# libc++ is the default).
+
+patchfiles-append patch-apple-clang-no-libcxx.diff
+
+# libcxxabi installed by the libcxx port on the buildbot does not
+# have the cxa_thread_atexit support, so until this is fixed
+# we have to force thread_local off on < 10.7 when using libc++
+patchfiles-append patch-boost-libcpp-force-thread-local-off.diff
+
+# temporary patch to fix: explicit template instanciations in
+# boost::serialization don't get exported with all compilers; this fix
+# is already in the boost repo & will be part of a future release. See
+# also the following tickets:
+# https://trac.macports.org/ticket/48717
+# https://svn.boost.org/trac/boost/ticket/11671
+patchfiles-append patch-export_serialization_explicit_template_instantiations.diff
+
+# revert the default tagged library name changes in 1.69.0 <
+# libboost_<component>-<threading>-<arch>.dylib > back to 1.68.0
+# format: libboost_<component>-<threading>.dylib; where <component> is
+# the component name (e.g., system, thread), <threading> is either mt
+# or st (multi or single), and <arch> is the build arch (x86, x64,
+# p64, p32).
+patchfiles-append patch-revert-lib-name-tagged.diff
+
+# see https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append patch-compiler.diff
+post-patch {
+    reinplace "s|__MACPORTS_CXX__|${configure.cxx}|g" ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
+}
+
+# see https://github.com/boostorg/build/issues/440
+patchfiles-append patch-clang_version.diff
+
+# temporary patch to add basic support for arm64,
+# both alone as well as +universal
+patchfiles-append patch-add-support-for-arm64.diff
+
+proc write_jam s {
+    global worksrcpath
+    set config [open ${worksrcpath}/user-config.jam a]
+    puts ${config} ${s}
+    close ${config}
+}
+
+compilers.choose   cc cxx
+mpi.setup          -gcc
+
+# NOTE: although technically Boost does not require C++11 compliance
+# for building, doing so allows for building on more OSs than without.
+# Further: Building Boost using C++11 compliance does not seem to then
+# require ports depending on Boost to also require C++11 compliance,
+# and requiring it does make such building easier for those ports.
+configure.cxxflags-append -std=gnu++11
+compiler.cxx_standard     2011
+
+# It turns out that ccache and distcc can produce boost libraries that, although they
+# compile without warning, have all sorts of runtime errors especially with pointer corruption.
+# Since most people will now use MacPorts' pre-compiled boost, this should not be a problem.
+configure.ccache    no
+configure.distcc    no
+
+configure.cmd       ./bootstrap.sh
+configure.args      --without-libraries=python \
+                    --without-libraries=mpi \
+                    --with-icu=${prefix}
+
+# boost build scripts default to clang on darwin
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.args-append --with-toolset=gcc
+}
+
+if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+    configure.args-append   --without-libraries=context \
+                            --without-libraries=coroutine
+}
+
+configure.universal_args
+
+post-configure {
+
+    reinplace -E "s|-install_name \"|&${bprefix}/lib/|" \
+        ${worksrcpath}/tools/build/src/tools/darwin.jam
+
+    set compileflags ""
+    if {[string length ${configure.sdkroot}] != 0} {
+        set compileflags "<compileflags>\"-isysroot ${configure.sdkroot}\""
+    }
+
+    set cxx_stdlibflags {}
+    if {[string match *clang* ${configure.cxx}]} {
+        set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+    }
+
+    # see https://trac.macports.org/ticket/55857
+    # see https://svn.boost.org/trac10/ticket/13454
+    write_jam "using darwin : : ${configure.cxx} : <asmflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cxxflags>\"${configure.cxxflags} [get_canonical_archflags cxx] ${cxx_stdlibflags}\" ${compileflags} <linkflags>\"${configure.ldflags} ${cxx_stdlibflags}\" : ;"
+
+}
+
+build.cmd       ${worksrcpath}/b2
+build.target
+build.args      -d2 \
+                --layout=tagged \
+                --debug-configuration \
+                --user-config=user-config.jam \
+                -sBZIP2_INCLUDE=${prefix}/include \
+                -sBZIP2_LIBPATH=${prefix}/lib \
+                -sEXPAT_INCLUDE=${prefix}/include \
+                -sEXPAT_LIBPATH=${prefix}/lib \
+                -sZLIB_INCLUDE=${prefix}/include \
+                -sZLIB_LIBPATH=${prefix}/lib \
+                -sICU_PATH=${prefix} \
+                variant=release \
+                threading=single,multi \
+                link=static,shared \
+                runtime-link=shared \
+                -j${build.jobs} \
+                --no-cmake-config
+
+destroot.cmd    ${worksrcpath}/b2
+destroot.post_args
+
+pre-destroot {
+    destroot.args {*}${build.args} --prefix=${destroot}${bprefix}
+    system "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
+}
+
+proc boost_docs_install {} {
+    global prefix destroot worksrcpath name
+
+    set docdir ${bprefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    set l [expr [string length ${worksrcpath}] + 1]
+    fs-traverse f [glob -directory ${worksrcpath} *] {
+        set dest ${destroot}${docdir}/[string range ${f} ${l} end]
+        if {[file isdirectory ${f}]} {
+            if {[file tail ${f}] eq "example"} {
+                copy ${f} ${dest}
+                continue
+            }
+            xinstall -d ${dest}
+        } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
+            xinstall -m 644 ${f} ${dest}
+        }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
+    }
+}
+
+set pythons_suffixes {27 35 36 37 38 39}
+
+set pythons_ports {}
+foreach s ${pythons_suffixes} {
+    lappend pythons_ports python${s}
+}
+
+proc python_dir {} {
+    global pythons_suffixes
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            set p python[string index ${s} 0].[string index ${s} 1]
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach s ${pythons_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string index ${s} 1]
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    if { ${s} > 30 } { set bppatch "patch-boost-python3.diff" } else { set bppatch "" }
+    variant ${p} description "Build Boost.Python for Python ${v}" conflicts {*}${c} debug "
+
+        # There is a conflict with python and debug support, so we should really change the 'variant' line above
+        # to end with 'conflicts ${c} debug' above. However, we leave it enabled for those who want to try it.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+
+        depends_lib-append      port:${p}
+        configure.args-delete   --without-libraries=python
+        configure.args-append   --with-python=${prefix}/bin/python${v} --with-python-root=${prefix}/bin/python${v}
+
+        patchfiles-append   ${bppatch} patch-tools-build-src-tools-python.jam.diff \
+                            patch-tools-build-src-tools-python-2.jam.diff
+
+        post-patch {
+            reinplace s|@FRAMEWORKS_DIR@|${frameworks_dir}| ${worksrcpath}/tools/build/src/tools/python.jam
+        }
+    "
+}
+
+if {![variant_isset debug]} {
+    set selected_python python39
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            set selected_python python${s}
+        }
+    }
+    default_variants +${selected_python}
+}
+
+default_variants +no_single +no_static
+
+variant debug description {Builds debug versions of the libraries as well} {
+    build.args-delete   variant=release
+    build.args-append   variant=debug,release
+}
+
+variant no_static description {Disable building static libraries} {
+    build.args-delete   link=static,shared
+    build.args-append   link=shared
+}
+
+variant no_single description {Disable building single-threaded libraries} {
+    build.args-delete   threading=single,multi
+    build.args-append   threading=multi
+}
+
+subport ${name}-numpy {
+    revision 0
+    description Boost.Numpy library
+    long_description {*}${description}
+    depends_lib port:boost
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            depends_lib-append port:py${s}-numpy
+            require_active_variants boost python${s}
+        }
+    }
+    if {[variant_isset no_static]} {
+        require_active_variants boost no_static
+    } else {
+        require_active_variants boost "" no_static
+    }
+    if {[variant_isset no_single]} {
+        require_active_variants boost no_single
+    } else {
+        require_active_variants boost "" no_single
+    }
+}
+
+if {$subport eq $name} {
+
+    revision 0
+
+    patchfiles-append patch-disable-numpy-extension.diff
+
+    variant regex_match_extra description \
+        "Enable access to extended capture information of submatches in Boost.Regex" {
+        notes-append "
+        You enabled the +regex_match_extra variant\; see the following page for an\
+        exhaustive list of the consequences of this feature:
+
+    http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
+"
+
+        post-patch {
+            reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
+                ${worksrcpath}/boost/regex/user.hpp
+        }
+    }
+
+    variant docs description {Enable building documentation} {
+        # No configure changes, etc; we simply check 'variant_isset' elsewhere
+    }
+
+    post-destroot {
+        delete file {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*]
+    }
+
+    if {[mpi_variant_isset]} {
+
+        # see https://trac.macports.org/ticket/49748
+        # see http://www.openradar.me/25313838
+        configure.ldflags-append -Lstage/lib
+
+        # There is a conflict with debug support.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+        if {[variant_isset debug]} {
+            return -code error "+debug variant conflicts with mpi"
+        }
+
+        configure.args-delete   --without-libraries=mpi
+
+        post-configure {
+            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
+        }
+
+        if {![catch python_dir]} {
+
+            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
+
+            post-destroot {
+                set site_packages [python_dir]
+                xinstall -d ${destroot}${site_packages}/boost
+                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                    ${destroot}${site_packages}/boost
+
+                set f ${destroot}${bprefix}/lib/mpi.so
+                if {[info exists ${f}]} {
+                    set l ${site_packages}/boost/mpi.so
+                    move ${f} ${destroot}${l}
+                    system "install_name_tool -id ${l} ${destroot}${l}"
+                }
+            }
+
+        }
+    }
+
+    livecheck.type  none
+} else {
+    post-destroot {
+        move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}
+        move {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*] ${destroot}${bprefix}
+        # if an mpi variant *and* a python variant is selected, then a binary
+        # python module called mpi.so gets installed, so delete ${frameworks_dir}
+        delete ${destroot}${bprefix}${frameworks_dir} \
+            ${destroot}${bprefix}/include \
+            ${destroot}${bprefix}/lib \
+            ${destroot}${bprefix}/share
+        file mkdir ${destroot}${bprefix}/lib ${destroot}${bprefix}/include/boost/python
+        move {*}[glob ${destroot}${bprefix}/libboost_numpy*] ${destroot}${bprefix}/lib
+        move {*}[glob ${destroot}${bprefix}/numpy*] ${destroot}${bprefix}/include/boost/python
+    }
+
+    livecheck.type  none
+}
+
+if {![info exists universal_possible]} {
+    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
+}
+if {!${universal_possible} || ![variant_isset universal]} {
+    if {[lsearch ${build_arch} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm
+    } else {
+        if {[lsearch ${build_arch} ppc*] != -1} {
+            build.args-append architecture=power
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            if {[lsearch ${build_arch} *86*] != -1} {
+                build.args-append architecture=x86
+            } else {
+                pre-fetch {
+                    error "Current value of 'build_arch' (${build_arch}) is not supported."
+                }
+            }
+            if {[lsearch ${build_arch} *64] != -1} {
+                build.args-append address-model=64
+            } else {
+                build.args-append address-model=32
+            }
+        }
+    }
+}
+
+variant universal {
+    build.args-append   pch=off
+
+    if {[lsearch ${configure.universal_archs} arm*] != -1} {
+        build.args-append address-model=64 architecture=combined
+    } else {
+        if {[lsearch ${configure.universal_archs} ppc*] != -1} {
+            if {[lsearch ${configure.universal_archs} *86*] != -1} {
+                build.args-append architecture=combined
+            } else {
+                build.args-append architecture=power
+            }
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            build.args-append architecture=x86
+        }
+        if {[lsearch ${configure.universal_archs} *64] != -1} {
+            if {[lsearch ${configure.universal_archs} i386] != -1 || [lsearch ${configure.universal_archs} ppc] != -1} {
+                build.args-append address-model=32_64
+                if {[lsearch ${configure.universal_archs} ppc64] == -1} {
+                    post-patch {
+                        reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
+                    }
+                }
+            } else {
+                build.args-append address-model=64
+            }
+        } else {
+            build.args-append address-model=32
+        }
+    }
+}
+
+platform powerpc {
+    build.args-append   --disable-long-double
+}
+
+platform darwin 8 powerpc {
+    if {[variant_isset universal]} {
+        build.args-append   macosx-version=10.4
+    }
+}
+
+# As of Boost 1.70.0, Boost provides CMake find scripts for itself
+# that are installed by default. Those provided in 1.70.0 were broken
+# in multiple ways; many fixed were added before 1.71.0. That said,
+# we're not installing them by default at this time, but instead
+# providing an option to install them for testing / evaluation
+# purposes. We will likely enable these scripts in the future since it
+# is likely that CMake will stop providing them once the
+# Boost-provided version is stable.
+variant cmake_scripts description {Install Boost CMake find scripts} {
+    build.args-delete --no-cmake-config
+}

--- a/devel/boost171/Portfile
+++ b/devel/boost171/Portfile
@@ -48,7 +48,7 @@ post-extract {
 }
 
 # Install prefix for this port
-set bprefix ${prefix}/libexec/${name}
+set bprefix ${prefix}/libexec/boost/${name}
 
 # patch-apple-clang-no-libcxx.diff fixes a clang configuration error
 # that occurs on OS X 10.7 and 10.8 due to the assumption that if

--- a/devel/boost171/Portfile
+++ b/devel/boost171/Portfile
@@ -16,7 +16,7 @@ checksums       rmd160 a46b886ca26993610c84615fca4340ad3f955f81 \
 license         Boost-1
 categories      devel
 platforms       darwin
-maintainers     {michaelld @michaelld} openmaintainer
+maintainers     {michaelld @michaelld} {@mascguy} openmaintainer
 
 description     Collection of portable C++ source libraries
 

--- a/devel/boost171/Portfile
+++ b/devel/boost171/Portfile
@@ -48,7 +48,8 @@ post-extract {
 }
 
 # Install prefix for this port
-set bprefix ${prefix}/libexec/boost/${name}
+set branch  [join [lrange [split ${version} .] 0 1] .]
+set bprefix ${prefix}/libexec/boost/${branch}
 
 # patch-apple-clang-no-libcxx.diff fixes a clang configuration error
 # that occurs on OS X 10.7 and 10.8 due to the assumption that if

--- a/devel/boost171/files/patch-add-support-for-arm64.diff
+++ b/devel/boost171/files/patch-add-support-for-arm64.diff
@@ -1,0 +1,56 @@
+--- tools/build/src/tools/darwin.jam.orig
++++ tools/build/src/tools/darwin.jam
+@@ -431,6 +431,7 @@
+     local support-ppc64 = 1 ;
+     
+     osx-version ?= $(.host-osx-version) ;
++    local osx-version-split = [ regex.split $(osx-version) \\. ] ;
+ 
+     switch $(osx-version)
+     {
+@@ -440,7 +441,7 @@
+         }
+         
+         case * :
+-        if $(osx-version) && ! [ version.version-less [ regex.split $(osx-version) \\. ] : 10 6 ]
++        if $(osx-version) && ! [ version.version-less $(osx-version-split) : 10 6 ]
+         {
+             # When targeting 10.6:
+             # - gcc 4.2 will give a compiler errir if ppc64 compilation is requested
+@@ -452,7 +453,16 @@
+     {
+         case combined : 
+         {
+-            if $(address-model) = 32_64 {
++            if ! [ version.version-less $(osx-version-split) : 11 0 ]
++            {
++                # macOS 11.0 "Big Sur" and later is always 64-bit ...
++                if ( $(address_model) = 32 || $(address_model) = 32_64 ) {
++                    echo "'address_model' contains 32; macOS 11 or later builds 64 only; overriding" ;
++                    address-model = 64 ;
++                }
++                # ... and "combined" means Intel and ARM
++                options = -arch x86_64 -arch arm64 ;
++            } else if $(address-model) = 32_64 {
+                 if $(support-ppc64) {
+                     options = -arch i386 -arch ppc -arch x86_64 -arch ppc64 ;                    
+                 } else {
+@@ -500,8 +510,18 @@
+         
+         case arm :
+         {
++            if ! [ version.version-less $(osx-version-split) : 11 0 ]
++            {
++                # macOS 11.0 "Big Sur" and later is always 64-bit
++                if ( $(address_model) = 32 || $(address_model) = 32_64 ) {
++                    echo "'address_model' contains 32; macOS 11 or later builds 64 only; overriding" ;
++                    address-model = 64 ;
++                }
++            }
+             if $(instruction-set) {
+                 options = -arch$(_)$(instruction-set) ;
++            } else if $(address-model) = 64 {
++                options = -arch arm64 ;
+             } else {
+                 options = -arch arm ;
+             }

--- a/devel/boost171/files/patch-apple-clang-no-libcxx.diff
+++ b/devel/boost171/files/patch-apple-clang-no-libcxx.diff
@@ -1,0 +1,35 @@
+--- boost/config/compiler/clang.hpp
++++ boost/config/compiler/clang.hpp
+@@ -248,6 +248,16 @@
+ #  define BOOST_NO_CXX11_INLINE_NAMESPACES
+ #endif
+ 
++// Apple Clang uses libc++ by default on Mavericks (OS X 10.9)  and higher
++// Apple Clang uses libstdc++ by default on Mountain Lion (OS X 10.8) and lower
++
++#ifdef __APPLE__
++#include <ciso646>
++#ifndef _LIBCPP_VERSION
++#  define BOOST_APPLE_CLANG_NO_LIBCXX
++#endif
++#endif
++
+ #if !__has_feature(cxx_override_control)
+ #  define BOOST_NO_CXX11_FINAL
+ #endif
+--- boost/multi_index/detail/vartempl_support.hpp
++++ boost/multi_index/detail/vartempl_support.hpp
+@@ -40,11 +40,12 @@
+  */
+ 
+ #include <boost/config.hpp>
+ 
+ #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)||\
+-    defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
++    defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)||\
++    defined(BOOST_APPLE_CLANG_NO_LIBCXX)
+ 
+ #include <boost/move/core.hpp>
+ #include <boost/move/utility.hpp>
+ #include <boost/preprocessor/arithmetic/add.hpp>
+ #include <boost/preprocessor/arithmetic/sub.hpp>

--- a/devel/boost171/files/patch-boost-libcpp-force-thread-local-off.diff
+++ b/devel/boost171/files/patch-boost-libcpp-force-thread-local-off.diff
@@ -1,0 +1,13 @@
+--- boost/config/stdlib/libcpp.hpp
++++ boost/config/stdlib/libcpp.hpp
+@@ -15,6 +15,10 @@
+ #  endif
+ #endif
+ 
++#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
++#  define BOOST_NO_CXX11_THREAD_LOCAL
++#endif
++
+ #define BOOST_STDLIB "libc++ version " BOOST_STRINGIZE(_LIBCPP_VERSION)
+ 
+ #define BOOST_HAS_THREADS

--- a/devel/boost171/files/patch-boost-python3.diff
+++ b/devel/boost171/files/patch-boost-python3.diff
@@ -1,0 +1,22 @@
+--- libs/mpi/src/python/datatypes.cpp.orig
++++ libs/mpi/src/python/datatypes.cpp
+@@ -13,6 +13,10 @@
+ #include <boost/mpi/python/serialize.hpp>
+ #include <boost/mpi.hpp>
+ 
++#if PY_MAJOR_VERSION >= 3
++#define PyInt_Type PyLong_Type
++#endif
++
+ namespace boost { namespace mpi { namespace python {
+ 
+ void export_datatypes()
+--- libs/mpi/build/__init__.py.orig
++++ libs/mpi/build/__init__.py
+@@ -6,5 +6,5 @@
+     import mpi
+     sys.setdlopenflags(flags)
+ else:
+-    import mpi
++    from . import mpi
+ 

--- a/devel/boost171/files/patch-clang_version.diff
+++ b/devel/boost171/files/patch-clang_version.diff
@@ -1,0 +1,31 @@
+From 40960b23338da0a359d6aa83585ace09ad8804d2 Mon Sep 17 00:00:00 2001
+From: Bo Anderson <mail@boanderson.me>
+Date: Sun, 29 Mar 2020 14:55:08 +0100
+Subject: [PATCH] Fix compiler version check on macOS
+
+Fixes #440.
+---
+ src/tools/darwin.jam | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/darwin.jam b/src/tools/darwin.jam
+index 8d477410b0..97e7ecb851 100644
+--- tools/build/src/tools/darwin.jam
++++ tools/build/src/tools/darwin.jam
+@@ -137,13 +137,14 @@ rule init ( version ? : command * : options * : requirement * )
+     # - Set the toolset generic common options.
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
++    real-version = [ regex.split $(real-version) \\. ] ;
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
++    if [ version.version-less $(real-version) : 4 0 ]
+     {
+         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+     }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
++    if [ version.version-less $(real-version) : 4 2 ]
+     {
+         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+     }

--- a/devel/boost171/files/patch-compiler.diff
+++ b/devel/boost171/files/patch-compiler.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/clang-darwin.jam.orig	2019-08-14 05:03:50.000000000 -0700
++++ tools/build/src/tools/clang-darwin.jam	2019-08-28 08:47:22.000000000 -0700
+@@ -49,7 +49,7 @@
+ #   compile and link options allow you to specify addition command line options for each version
+ rule init ( version ? :  command * : options * )
+ {
+-    command = [ common.get-invocation-command clang-darwin : clang++ 
++    command = [ common.get-invocation-command clang-darwin : __MACPORTS_CXX__
+         : $(command) : /usr/bin /usr/local/bin ] ;
+ 
+     # Determine the version

--- a/devel/boost171/files/patch-disable-numpy-extension.diff
+++ b/devel/boost171/files/patch-disable-numpy-extension.diff
@@ -1,0 +1,22 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -843,18 +843,7 @@
+     local full-cmd = $(interpreter-cmd)" -c \"$(full-cmd)\"" ;
+     debug-message "running command '$(full-cmd)'" ;
+     local result = [ SHELL $(full-cmd) : strip-eol : exit-status ] ;
+-    if $(result[2]) = 0
+-    {
+-        .numpy = true ;
+-        .numpy-include = $(result[1]) ;
+-        debug-message "NumPy enabled" ;
+-    }
+-    else
+-    {
+-        debug-message "NumPy disabled. Reason:" ;
+-        debug-message "  $(full-cmd) aborted with " ;
+-        debug-message "  $(result[1])" ;
+-    }
++    debug-message "NumPy disabled." ;
+ 
+     #
+     # End autoconfiguration sequence.

--- a/devel/boost171/files/patch-export_serialization_explicit_template_instantiations.diff
+++ b/devel/boost171/files/patch-export_serialization_explicit_template_instantiations.diff
@@ -1,0 +1,512 @@
+--- libs/serialization/src/basic_text_iprimitive.cpp.orig
++++ libs/serialization/src/basic_text_iprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@ namespace boost {
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_iprimitive<std::istream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::istream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_oprimitive.cpp.orig
++++ libs/serialization/src/basic_text_oprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@ namespace boost {
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_oprimitive<std::ostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::ostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_wiprimitive.cpp.orig
++++ libs/serialization/src/basic_text_wiprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_iprimitive<std::wistream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::wistream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_woprimitive.cpp.orig
++++ libs/serialization/src/basic_text_woprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_oprimitive<std::wostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::wostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_xml_grammar.ipp.orig
++++ libs/serialization/src/basic_xml_grammar.ipp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ #include <algorithm>
+ #include <boost/config.hpp> // typename
+ 
+--- libs/serialization/src/binary_iarchive.cpp.orig
++++ libs/serialization/src/binary_iarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -23,14 +27,14 @@ namespace boost {
+ namespace archive {
+ 
+ // explicitly instantiate for this type of stream
+-template class detail::archive_serializer_map<binary_iarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_iarchive,
+     std::istream::char_type, 
+     std::istream::traits_type
+ >;
+-template class basic_binary_iarchive<binary_iarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_iarchive, 
+     std::istream::char_type, 
+     std::istream::traits_type
+--- libs/serialization/src/binary_oarchive.cpp.orig
++++ libs/serialization/src/binary_oarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of binary stream
+@@ -23,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_oarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+ >;
+-template class basic_binary_oarchive<binary_oarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+--- libs/serialization/src/binary_wiarchive.cpp.orig
++++ libs/serialization/src/binary_wiarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,14 +29,14 @@ namespace boost {
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class detail::archive_serializer_map<binary_wiarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_wiarchive,
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_iarchive<binary_wiarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_wiarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/binary_woarchive.cpp.orig
++++ libs/serialization/src/binary_woarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_woarchive.hpp>
++#pragma GCC visibility pop
+ 
+ // explicitly instantiate for this type of text stream
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -25,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_woarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_oarchive<binary_woarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/polymorphic_iarchive.cpp.orig
++++ libs/serialization/src/polymorphic_iarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_iarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_iarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_iarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/polymorphic_oarchive.cpp.orig
++++ libs/serialization/src/polymorphic_oarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_oarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_oarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_oarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/text_iarchive.cpp.orig
++++ libs/serialization/src/text_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_iarchive>;
+-template class basic_text_iarchive<text_iarchive> ;
+-template class text_iarchive_impl<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_iarchive_impl<text_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_oarchive.cpp.orig
++++ libs/serialization/src/text_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@ namespace boost {
+ namespace archive {
+ 
+ //template class basic_text_oprimitive<std::ostream> ;
+-template class detail::archive_serializer_map<text_oarchive>;
+-template class basic_text_oarchive<text_oarchive> ;
+-template class text_oarchive_impl<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_oarchive_impl<text_oarchive> ;
+ 
+ } // namespace serialization
+ } // namespace boost
+--- libs/serialization/src/text_wiarchive.cpp.orig
++++ libs/serialization/src/text_wiarchive.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,9 +29,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_wiarchive>;
+-template class basic_text_iarchive<text_wiarchive> ;
+-template class text_wiarchive_impl<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_wiarchive_impl<text_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_woarchive.cpp.orig
++++ libs/serialization/src/text_woarchive.cpp
+@@ -15,7 +15,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_woarchive>;
+-template class basic_text_oarchive<text_woarchive> ;
+-template class text_woarchive_impl<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_woarchive_impl<text_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_grammar.cpp.orig
++++ libs/serialization/src/xml_grammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -67,7 +69,7 @@ namespace boost {
+ namespace archive {
+ 
+ // explicit instantiation of xml for 8 bit characters
+-template class basic_xml_grammar<char>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<char>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_iarchive.cpp.orig
++++ libs/serialization/src/xml_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_iarchive>;
+-template class basic_xml_iarchive<xml_iarchive> ;
+-template class xml_iarchive_impl<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_iarchive_impl<xml_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_oarchive.cpp.orig
++++ libs/serialization/src/xml_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_oarchive>;
+-template class basic_xml_oarchive<xml_oarchive> ;
+-template class xml_oarchive_impl<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_oarchive_impl<xml_oarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wgrammar.cpp.orig
++++ libs/serialization/src/xml_wgrammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -149,7 +151,7 @@ namespace boost {
+ namespace archive {
+ 
+ // explicit instantiation of xml for wide characters
+-template class basic_xml_grammar<wchar_t>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<wchar_t>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wiarchive.cpp.orig
++++ libs/serialization/src/xml_wiarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_wiarchive>;
+-template class basic_xml_iarchive<xml_wiarchive> ;
+-template class xml_wiarchive_impl<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_wiarchive_impl<xml_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_woarchive.cpp.orig
++++ libs/serialization/src/xml_woarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_woarchive>;
+-template class basic_xml_oarchive<xml_woarchive> ;
+-template class xml_woarchive_impl<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_woarchive_impl<xml_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost

--- a/devel/boost171/files/patch-libs-mpi-build-Jamfile.v2.diff
+++ b/devel/boost171/files/patch-libs-mpi-build-Jamfile.v2.diff
@@ -1,0 +1,26 @@
+--- libs/mpi/build/Jamfile.v2.orig
++++ libs/mpi/build/Jamfile.v2
+@@ -49,6 +49,7 @@
+     <link>shared:<define>BOOST_MPI_DYN_LINK=1
+   : # Default build
+     <link>shared
++    <threading>multi
+   : # Usage requirements
+     <library>../../serialization/build//boost_serialization
+     <library>/mpi//mpi [ mpi.extra-requirements ]
+@@ -95,6 +96,7 @@
+                 <python>$(py$(N)-version)
+               : # Default build
+                 <link>shared
++                <threading>multi
+               : # Usage requirements
+                 <library>/mpi//mpi [ mpi.extra-requirements ]
+               ;
+@@ -122,6 +124,7 @@
+                 <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
+                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
+                 <link>shared <runtime-link>shared
++                <threading>multi
+                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+                 <python>$(py$(N)-version)
+               ;

--- a/devel/boost171/files/patch-revert-lib-name-tagged.diff
+++ b/devel/boost171/files/patch-revert-lib-name-tagged.diff
@@ -1,0 +1,11 @@
+--- boostcpp.jam.orig
++++ boostcpp.jam
+@@ -163,7 +163,7 @@
+             <base> <threading> <runtime> ;
+     case 1.69 :
+         .format-name-args =
+-            <base> <threading> <runtime> <arch-and-model> ;
++            <base> <threading> <runtime> ;
+     }
+ }
+ else if $(layout) = system

--- a/devel/boost171/files/patch-tools-build-src-tools-python-2.jam.diff
+++ b/devel/boost171/files/patch-tools-build-src-tools-python-2.jam.diff
@@ -1,0 +1,16 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -542,6 +542,13 @@
+         libraries ?= $(default-library-path) ;
+         includes ?= $(default-include-path) ;
+     }
++    else if $(target-os) = darwin
++    {
++        includes ?= $(prefix)/Headers ;
++
++        local lib = $(exec-prefix)/lib ;
++        libraries ?= $(lib)/python$(version)/config $(lib) ;
++    }
+     else
+     {
+         includes ?= $(prefix)/include/python$(version) ;

--- a/devel/boost171/files/patch-tools-build-src-tools-python.jam.diff
+++ b/devel/boost171/files/patch-tools-build-src-tools-python.jam.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -431,7 +431,7 @@
+     version ?= $(.version-countdown) ;
+ 
+     local prefix
+-      = [ GLOB /System/Library/Frameworks /Library/Frameworks
++      = [ GLOB @FRAMEWORKS_DIR@
+           : Python.framework ] ;
+ 
+     return $(prefix)/Versions/$(version)/bin/python ;

--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       compiler_blacklist_versions 1.0
 PortGroup       mpi 1.0
 PortGroup       active_variants 1.1
 
@@ -30,6 +31,9 @@ master_sites    https://boostorg.jfrog.io/artifactory/main/release/${version}/so
 set distver     [join [split ${version} .] _]
 distname        boost_${distver}
 use_bzip2       yes
+
+compiler.blacklist-append \
+                {clang < 1000}
 
 depends_lib     port:bzip2 \
                 port:expat \

--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -1,0 +1,478 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       mpi 1.0
+PortGroup       active_variants 1.1
+
+name            boost176
+
+version         1.76.0
+# Revision is set below in the `if {$subport eq $name} { ... }` statement
+# The boost-numpy subport has its own revision number
+checksums       rmd160  b1da5df10d7e0fd07d864973f106d4376b7e375b \
+                sha256  f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41 \
+                size    110073117
+
+license         Boost-1
+categories      devel
+platforms       darwin
+maintainers     {michaelld @michaelld} openmaintainer
+
+description     Collection of portable C++ source libraries
+
+long_description \
+    Boost provides free portable peer-reviewed C++ \
+    libraries. The emphasis is on portable libraries \
+    which work well with the C++ Standard Library.
+
+homepage        http://www.boost.org
+master_sites    https://boostorg.jfrog.io/artifactory/main/release/${version}/source/
+set distver     [join [split ${version} .] _]
+distname        boost_${distver}
+use_bzip2       yes
+
+depends_lib     port:bzip2 \
+                port:expat \
+                port:icu \
+                port:libiconv \
+                port:lzma \
+                port:zlib \
+                port:zstd
+
+post-extract {
+    fs-traverse dir ${workpath} {
+        if {[file isdirectory ${dir}]} {
+            file attributes ${dir} -permissions a+rx
+        }
+    }
+}
+
+# Install prefix for this port
+set bprefix ${prefix}/libexec/${name}
+
+# patch-apple-clang-no-libcxx.diff fixes a clang configuration error
+# that occurs on OS X 10.7 and 10.8 due to the assumption that if
+# clang is the compiler in use it must be using libc++.  Apple Clang
+# uses libstdc++ by default on these OS versions.  The patch adds an
+# additional BOOST_* configuration flag that is set if Apple clang is
+# being used but libc++ is not.  This flag is then used to prevent
+# boost or a dependent package from using functions such as
+# std::forward that are only available in libc++.  Fixes build of
+# libcdr on these OS versions without affecting build on 10.6 and less
+# (where clang is not the default compiler) or 10.9 and up (where
+# libc++ is the default).
+
+patchfiles-append patch-apple-clang-no-libcxx.diff
+
+# libcxxabi installed by the libcxx port on the buildbot does not
+# have the cxa_thread_atexit support, so until this is fixed
+# we have to force thread_local off on < 10.7 when using libc++
+patchfiles-append patch-boost-libcpp-force-thread-local-off.diff
+
+# temporary patch to fix: explicit template instanciations in
+# boost::serialization don't get exported with all compilers; this fix
+# is already in the boost repo & will be part of a future release. See
+# also the following tickets:
+# https://trac.macports.org/ticket/48717
+# https://svn.boost.org/trac/boost/ticket/11671
+patchfiles-append patch-export_serialization_explicit_template_instantiations.diff
+
+# revert the default tagged library name changes in 1.69.0 <
+# libboost_<component>-<threading>-<arch>.dylib > back to 1.68.0
+# format: libboost_<component>-<threading>.dylib; where <component> is
+# the component name (e.g., system, thread), <threading> is either mt
+# or st (multi or single), and <arch> is the build arch (x86, x64,
+# p64, p32).
+patchfiles-append patch-revert-lib-name-tagged.diff
+
+# see https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append patch-compiler.diff
+post-patch {
+    reinplace "s|__MACPORTS_CXX__|${configure.cxx}|g" ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
+}
+
+proc write_jam s {
+    global worksrcpath
+    set config [open ${worksrcpath}/user-config.jam a]
+    puts ${config} ${s}
+    close ${config}
+}
+
+compilers.choose   cc cxx
+mpi.setup          -gcc
+
+# NOTE: although technically Boost does not require C++11 compliance
+# for building, doing so allows for building on more OSs than without.
+# Further: Building Boost using C++11 compliance does not seem to then
+# require ports depending on Boost to also require C++11 compliance,
+# and requiring it does make such building easier for those ports.
+configure.cxxflags-append -std=gnu++11
+compiler.cxx_standard   2011
+
+# It turns out that ccache and distcc can produce boost libraries that, although they
+# compile without warning, have all sorts of runtime errors especially with pointer corruption.
+# Since most people will now use MacPorts' pre-compiled boost, this should not be a problem.
+configure.ccache    no
+configure.distcc    no
+
+configure.cmd       ./bootstrap.sh
+configure.args      --without-libraries=python \
+                    --without-libraries=mpi \
+                    --with-icu=${prefix}
+
+# boost build scripts default to clang on darwin
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.args-append --with-toolset=gcc
+}
+
+if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+    configure.args-append   --without-libraries=context \
+                            --without-libraries=coroutine
+}
+
+configure.universal_args
+
+post-configure {
+
+    reinplace -E "s|-install_name \"|&${bprefix}/lib/|" \
+        ${worksrcpath}/tools/build/src/tools/darwin.jam
+
+    set compileflags ""
+    if {[string length ${configure.sdkroot}] != 0} {
+        set compileflags "<compileflags>\"-isysroot ${configure.sdkroot}\""
+    }
+
+    set cxx_stdlibflags {}
+    if {[string match *clang* ${configure.cxx}]} {
+        set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+    }
+
+    # see https://trac.macports.org/ticket/55857
+    # see https://svn.boost.org/trac10/ticket/13454
+    write_jam "using darwin : : ${configure.cxx} : <asmflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cxxflags>\"${configure.cxxflags} [get_canonical_archflags cxx] ${cxx_stdlibflags}\" ${compileflags} <linkflags>\"${configure.ldflags} ${cxx_stdlibflags}\" : ;"
+
+}
+
+build.cmd       ${worksrcpath}/b2
+build.target
+build.args      -d2 \
+                --layout=tagged \
+                --debug-configuration \
+                --user-config=user-config.jam \
+                -sBZIP2_INCLUDE=${prefix}/include \
+                -sBZIP2_LIBPATH=${prefix}/lib \
+                -sEXPAT_INCLUDE=${prefix}/include \
+                -sEXPAT_LIBPATH=${prefix}/lib \
+                -sZLIB_INCLUDE=${prefix}/include \
+                -sZLIB_LIBPATH=${prefix}/lib \
+                -sICU_PATH=${prefix} \
+                variant=release \
+                threading=single,multi \
+                link=static,shared \
+                runtime-link=shared \
+                -j${build.jobs} \
+                --no-cmake-config
+
+destroot.cmd    ${worksrcpath}/b2
+destroot.post_args
+
+pre-destroot {
+    destroot.args {*}${build.args} --prefix=${destroot}${bprefix}
+    system "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
+}
+
+proc boost_docs_install {} {
+    global prefix destroot worksrcpath name
+
+    set docdir ${bprefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    set l [expr [string length ${worksrcpath}] + 1]
+    fs-traverse f [glob -directory ${worksrcpath} *] {
+        set dest ${destroot}${docdir}/[string range ${f} ${l} end]
+        if {[file isdirectory ${f}]} {
+            if {[file tail ${f}] eq "example"} {
+                copy ${f} ${dest}
+                continue
+            }
+            xinstall -d ${dest}
+        } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
+            xinstall -m 644 ${f} ${dest}
+        }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
+    }
+}
+
+set pythons_suffixes {27 35 36 37 38 39}
+
+set pythons_ports {}
+foreach s ${pythons_suffixes} {
+    lappend pythons_ports python${s}
+}
+
+proc python_dir {} {
+    global pythons_suffixes
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            set p python[string index ${s} 0].[string index ${s} 1]
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach s ${pythons_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string index ${s} 1]
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    if { ${s} > 30 } { set bppatch "patch-boost-python3.diff" } else { set bppatch "" }
+    variant ${p} description "Build Boost.Python for Python ${v}" conflicts {*}${c} debug "
+
+        # There is a conflict with python and debug support, so we should really change the 'variant' line above
+        # to end with 'conflicts ${c} debug' above. However, we leave it enabled for those who want to try it.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+
+        depends_lib-append      port:${p}
+        configure.args-delete   --without-libraries=python
+        configure.args-append   --with-python=${prefix}/bin/python${v} --with-python-root=${prefix}/bin/python${v}
+
+        patchfiles-append   ${bppatch} patch-tools-build-src-tools-python.jam.diff \
+                            patch-tools-build-src-tools-python-2.jam.diff
+
+        post-patch {
+            reinplace s|@FRAMEWORKS_DIR@|${frameworks_dir}| ${worksrcpath}/tools/build/src/tools/python.jam
+        }
+    "
+}
+
+if {![variant_isset debug]} {
+    set selected_python python39
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            set selected_python python${s}
+        }
+    }
+    default_variants +${selected_python}
+}
+
+default_variants +no_single +no_static
+
+variant debug description {Builds debug versions of the libraries as well} {
+    build.args-delete   variant=release
+    build.args-append   variant=debug,release
+}
+
+variant no_static description {Disable building static libraries} {
+    build.args-delete   link=static,shared
+    build.args-append   link=shared
+}
+
+variant no_single description {Disable building single-threaded libraries} {
+    build.args-delete   threading=single,multi
+    build.args-append   threading=multi
+}
+
+subport ${name}-numpy {
+    revision 0
+    description Boost.Numpy library
+    long_description {*}${description}
+    depends_lib port:boost
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            depends_lib-append port:py${s}-numpy
+            require_active_variants boost python${s}
+        }
+    }
+    if {[variant_isset no_static]} {
+        require_active_variants boost no_static
+    } else {
+        require_active_variants boost "" no_static
+    }
+    if {[variant_isset no_single]} {
+        require_active_variants boost no_single
+    } else {
+        require_active_variants boost "" no_single
+    }
+}
+
+if {$subport eq $name} {
+
+    revision 0
+
+    patchfiles-append patch-disable-numpy-extension.diff
+
+    variant regex_match_extra description \
+        "Enable access to extended capture information of submatches in Boost.Regex" {
+        notes-append "
+        You enabled the +regex_match_extra variant\; see the following page for an\
+        exhaustive list of the consequences of this feature:
+
+    http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
+"
+
+        post-patch {
+            reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
+                ${worksrcpath}/boost/regex/user.hpp
+        }
+    }
+
+    variant docs description {Enable building documentation} {
+        # No configure changes, etc; we simply check 'variant_isset' elsewhere
+    }
+
+    post-destroot {
+        delete file {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*]
+    }
+
+    if {[mpi_variant_isset]} {
+
+        # see https://trac.macports.org/ticket/49748
+        # see http://www.openradar.me/25313838
+        configure.ldflags-append -Lstage/lib
+
+        # There is a conflict with debug support.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+        if {[variant_isset debug]} {
+            return -code error "+debug variant conflicts with mpi"
+        }
+
+        configure.args-delete   --without-libraries=mpi
+
+        post-configure {
+            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
+        }
+
+        if {![catch python_dir]} {
+
+            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
+
+            post-destroot {
+                set site_packages [python_dir]
+                xinstall -d ${destroot}${site_packages}/boost
+                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                    ${destroot}${site_packages}/boost
+
+                set f ${destroot}${bprefix}/lib/mpi.so
+                if {[info exists ${f}]} {
+                    set l ${site_packages}/boost/mpi.so
+                    move ${f} ${destroot}${l}
+                    system "install_name_tool -id ${l} ${destroot}${l}"
+                }
+            }
+
+        }
+    }
+
+    livecheck.type  regex
+    livecheck.url   http://www.boost.org/users/download/
+    livecheck.regex Version (\\d+\\.\\d+\\.\\d+)</span>
+} else {
+    post-destroot {
+        move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}
+        move {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*] ${destroot}${bprefix}
+        # if an mpi variant *and* a python variant is selected, then a binary
+        # python module called mpi.so gets installed, so delete ${frameworks_dir}
+        delete ${destroot}${bprefix}${frameworks_dir} \
+            ${destroot}${bprefix}/include \
+            ${destroot}${bprefix}/lib \
+            ${destroot}${bprefix}/share
+        file mkdir ${destroot}${bprefix}/lib ${destroot}${bprefix}/include/boost/python
+        move {*}[glob ${destroot}${bprefix}/libboost_numpy*] ${destroot}${bprefix}/lib
+        move {*}[glob ${destroot}${bprefix}/numpy*] ${destroot}${bprefix}/include/boost/python
+    }
+
+    livecheck.type  none
+}
+
+if {![info exists universal_possible]} {
+    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
+}
+if {!${universal_possible} || ![variant_isset universal]} {
+    if {[lsearch ${build_arch} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm
+    } else {
+        if {[lsearch ${build_arch} ppc*] != -1} {
+            build.args-append architecture=power
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            if {[lsearch ${build_arch} *86*] != -1} {
+                build.args-append architecture=x86
+            } else {
+                pre-fetch {
+                    error "Current value of 'build_arch' (${build_arch}) is not supported."
+                }
+            }
+            if {[lsearch ${build_arch} *64] != -1} {
+                build.args-append address-model=64
+            } else {
+                build.args-append address-model=32
+            }
+        }
+    }
+}
+
+variant universal {
+    build.args-append   pch=off
+
+    if {[lsearch ${configure.universal_archs} arm*] != -1} {
+        build.args-append address-model=64 architecture=combined
+    } else {
+        if {[lsearch ${configure.universal_archs} ppc*] != -1} {
+            if {[lsearch ${configure.universal_archs} *86*] != -1} {
+                build.args-append architecture=combined
+            } else {
+                build.args-append architecture=power
+            }
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            build.args-append architecture=x86
+        }
+        if {[lsearch ${configure.universal_archs} *64] != -1} {
+            if {[lsearch ${configure.universal_archs} i386] != -1 || [lsearch ${configure.universal_archs} ppc] != -1} {
+                build.args-append address-model=32_64
+                if {[lsearch ${configure.universal_archs} ppc64] == -1} {
+                    post-patch {
+                        reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
+                    }
+                }
+            } else {
+                build.args-append address-model=64
+            }
+        } else {
+            build.args-append address-model=32
+        }
+    }
+}
+
+platform powerpc {
+    build.args-append   --disable-long-double
+}
+
+platform darwin 8 powerpc {
+    if {[variant_isset universal]} {
+        build.args-append   macosx-version=10.4
+    }
+}
+
+# As of Boost 1.70.0, Boost provides CMake find scripts for itself
+# that are installed by default. Those provided in 1.70.0 were broken
+# in multiple ways; many fixed were added before 1.71.0. That said,
+# we're not installing them by default at this time, but instead
+# providing an option to install them for testing / evaluation
+# purposes. We will likely enable these scripts in the future since it
+# is likely that CMake will stop providing them once the
+# Boost-provided version is stable.
+variant cmake_scripts description {Install Boost CMake find scripts} {
+    build.args-delete --no-cmake-config
+}

--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -48,7 +48,7 @@ post-extract {
 }
 
 # Install prefix for this port
-set bprefix ${prefix}/libexec/${name}
+set bprefix ${prefix}/libexec/boost/${name}
 
 # patch-apple-clang-no-libcxx.diff fixes a clang configuration error
 # that occurs on OS X 10.7 and 10.8 due to the assumption that if

--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -16,7 +16,7 @@ checksums       rmd160  b1da5df10d7e0fd07d864973f106d4376b7e375b \
 license         Boost-1
 categories      devel
 platforms       darwin
-maintainers     {michaelld @michaelld} openmaintainer
+maintainers     {michaelld @michaelld} {@mascguy} openmaintainer
 
 description     Collection of portable C++ source libraries
 

--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -48,7 +48,8 @@ post-extract {
 }
 
 # Install prefix for this port
-set bprefix ${prefix}/libexec/boost/${name}
+set branch  [join [lrange [split ${version} .] 0 1] .]
+set bprefix ${prefix}/libexec/boost/${branch}
 
 # patch-apple-clang-no-libcxx.diff fixes a clang configuration error
 # that occurs on OS X 10.7 and 10.8 due to the assumption that if

--- a/devel/boost176/files/patch-apple-clang-no-libcxx.diff
+++ b/devel/boost176/files/patch-apple-clang-no-libcxx.diff
@@ -1,0 +1,35 @@
+--- boost/config/compiler/clang.hpp
++++ boost/config/compiler/clang.hpp
+@@ -248,6 +248,16 @@
+ #  define BOOST_NO_CXX11_INLINE_NAMESPACES
+ #endif
+ 
++// Apple Clang uses libc++ by default on Mavericks (OS X 10.9)  and higher
++// Apple Clang uses libstdc++ by default on Mountain Lion (OS X 10.8) and lower
++
++#ifdef __APPLE__
++#include <ciso646>
++#ifndef _LIBCPP_VERSION
++#  define BOOST_APPLE_CLANG_NO_LIBCXX
++#endif
++#endif
++
+ #if !__has_feature(cxx_override_control)
+ #  define BOOST_NO_CXX11_FINAL
+ #endif
+--- boost/multi_index/detail/vartempl_support.hpp
++++ boost/multi_index/detail/vartempl_support.hpp
+@@ -40,11 +40,12 @@
+  */
+ 
+ #include <boost/config.hpp>
+ 
+ #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)||\
+-    defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
++    defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)||\
++    defined(BOOST_APPLE_CLANG_NO_LIBCXX)
+ 
+ #include <boost/move/core.hpp>
+ #include <boost/move/utility.hpp>
+ #include <boost/preprocessor/arithmetic/add.hpp>
+ #include <boost/preprocessor/arithmetic/sub.hpp>

--- a/devel/boost176/files/patch-boost-libcpp-force-thread-local-off.diff
+++ b/devel/boost176/files/patch-boost-libcpp-force-thread-local-off.diff
@@ -1,0 +1,13 @@
+--- boost/config/stdlib/libcpp.hpp
++++ boost/config/stdlib/libcpp.hpp
+@@ -15,6 +15,10 @@
+ #  endif
+ #endif
+ 
++#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
++#  define BOOST_NO_CXX11_THREAD_LOCAL
++#endif
++
+ #define BOOST_STDLIB "libc++ version " BOOST_STRINGIZE(_LIBCPP_VERSION)
+ 
+ #define BOOST_HAS_THREADS

--- a/devel/boost176/files/patch-boost-python3.diff
+++ b/devel/boost176/files/patch-boost-python3.diff
@@ -1,0 +1,22 @@
+--- libs/mpi/src/python/datatypes.cpp.orig
++++ libs/mpi/src/python/datatypes.cpp
+@@ -13,6 +13,10 @@
+ #include <boost/mpi/python/serialize.hpp>
+ #include <boost/mpi.hpp>
+ 
++#if PY_MAJOR_VERSION >= 3
++#define PyInt_Type PyLong_Type
++#endif
++
+ namespace boost { namespace mpi { namespace python {
+ 
+ void export_datatypes()
+--- libs/mpi/build/__init__.py.orig
++++ libs/mpi/build/__init__.py
+@@ -6,5 +6,5 @@
+     import mpi
+     sys.setdlopenflags(flags)
+ else:
+-    import mpi
++    from . import mpi
+ 

--- a/devel/boost176/files/patch-compiler.diff
+++ b/devel/boost176/files/patch-compiler.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/clang-darwin.jam.orig	2021-05-30 15:15:28.000000000 +0100
++++ tools/build/src/tools/clang-darwin.jam	2021-05-30 15:16:03.000000000 +0100
+@@ -54,7 +54,7 @@
+ #   compile and link options allow you to specify addition command line options for each version
+ rule init ( version ? :  command * : options * )
+ {
+-    command = [ common.get-invocation-command clang-darwin : clang++
++    command = [ common.get-invocation-command clang-darwin : __MACPORTS_CXX__
+         : $(command) : /usr/bin /usr/local/bin ] ;
+ 
+     # Determine the version

--- a/devel/boost176/files/patch-disable-numpy-extension.diff
+++ b/devel/boost176/files/patch-disable-numpy-extension.diff
@@ -1,0 +1,22 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -843,18 +843,7 @@
+     local full-cmd = $(interpreter-cmd)" -c \"$(full-cmd)\"" ;
+     debug-message "running command '$(full-cmd)'" ;
+     local result = [ SHELL $(full-cmd) : strip-eol : exit-status ] ;
+-    if $(result[2]) = 0
+-    {
+-        .numpy = true ;
+-        .numpy-include = $(result[1]) ;
+-        debug-message "NumPy enabled" ;
+-    }
+-    else
+-    {
+-        debug-message "NumPy disabled. Reason:" ;
+-        debug-message "  $(full-cmd) aborted with " ;
+-        debug-message "  $(result[1])" ;
+-    }
++    debug-message "NumPy disabled." ;
+ 
+     #
+     # End autoconfiguration sequence.

--- a/devel/boost176/files/patch-export_serialization_explicit_template_instantiations.diff
+++ b/devel/boost176/files/patch-export_serialization_explicit_template_instantiations.diff
@@ -1,0 +1,512 @@
+--- libs/serialization/src/basic_text_iprimitive.cpp.orig
++++ libs/serialization/src/basic_text_iprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@ namespace boost {
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_iprimitive<std::istream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::istream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_oprimitive.cpp.orig
++++ libs/serialization/src/basic_text_oprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@ namespace boost {
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_oprimitive<std::ostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::ostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_wiprimitive.cpp.orig
++++ libs/serialization/src/basic_text_wiprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_iprimitive<std::wistream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::wistream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_woprimitive.cpp.orig
++++ libs/serialization/src/basic_text_woprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_oprimitive<std::wostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::wostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_xml_grammar.ipp.orig
++++ libs/serialization/src/basic_xml_grammar.ipp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ #include <algorithm>
+ #include <boost/config.hpp> // typename
+ 
+--- libs/serialization/src/binary_iarchive.cpp.orig
++++ libs/serialization/src/binary_iarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -23,14 +27,14 @@ namespace boost {
+ namespace archive {
+ 
+ // explicitly instantiate for this type of stream
+-template class detail::archive_serializer_map<binary_iarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_iarchive,
+     std::istream::char_type, 
+     std::istream::traits_type
+ >;
+-template class basic_binary_iarchive<binary_iarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_iarchive, 
+     std::istream::char_type, 
+     std::istream::traits_type
+--- libs/serialization/src/binary_oarchive.cpp.orig
++++ libs/serialization/src/binary_oarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of binary stream
+@@ -23,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_oarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+ >;
+-template class basic_binary_oarchive<binary_oarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+--- libs/serialization/src/binary_wiarchive.cpp.orig
++++ libs/serialization/src/binary_wiarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,14 +29,14 @@ namespace boost {
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class detail::archive_serializer_map<binary_wiarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_wiarchive,
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_iarchive<binary_wiarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_wiarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/binary_woarchive.cpp.orig
++++ libs/serialization/src/binary_woarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_woarchive.hpp>
++#pragma GCC visibility pop
+ 
+ // explicitly instantiate for this type of text stream
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -25,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_woarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_oarchive<binary_woarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/polymorphic_iarchive.cpp.orig
++++ libs/serialization/src/polymorphic_iarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_iarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_iarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_iarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/polymorphic_oarchive.cpp.orig
++++ libs/serialization/src/polymorphic_oarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_oarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_oarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_oarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/text_iarchive.cpp.orig
++++ libs/serialization/src/text_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_iarchive>;
+-template class basic_text_iarchive<text_iarchive> ;
+-template class text_iarchive_impl<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_iarchive_impl<text_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_oarchive.cpp.orig
++++ libs/serialization/src/text_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@ namespace boost {
+ namespace archive {
+ 
+ //template class basic_text_oprimitive<std::ostream> ;
+-template class detail::archive_serializer_map<text_oarchive>;
+-template class basic_text_oarchive<text_oarchive> ;
+-template class text_oarchive_impl<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_oarchive_impl<text_oarchive> ;
+ 
+ } // namespace serialization
+ } // namespace boost
+--- libs/serialization/src/text_wiarchive.cpp.orig
++++ libs/serialization/src/text_wiarchive.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,9 +29,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_wiarchive>;
+-template class basic_text_iarchive<text_wiarchive> ;
+-template class text_wiarchive_impl<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_wiarchive_impl<text_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_woarchive.cpp.orig
++++ libs/serialization/src/text_woarchive.cpp
+@@ -15,7 +15,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_woarchive>;
+-template class basic_text_oarchive<text_woarchive> ;
+-template class text_woarchive_impl<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_woarchive_impl<text_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_grammar.cpp.orig
++++ libs/serialization/src/xml_grammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -67,7 +69,7 @@ namespace boost {
+ namespace archive {
+ 
+ // explicit instantiation of xml for 8 bit characters
+-template class basic_xml_grammar<char>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<char>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_iarchive.cpp.orig
++++ libs/serialization/src/xml_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_iarchive>;
+-template class basic_xml_iarchive<xml_iarchive> ;
+-template class xml_iarchive_impl<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_iarchive_impl<xml_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_oarchive.cpp.orig
++++ libs/serialization/src/xml_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_oarchive>;
+-template class basic_xml_oarchive<xml_oarchive> ;
+-template class xml_oarchive_impl<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_oarchive_impl<xml_oarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wgrammar.cpp.orig
++++ libs/serialization/src/xml_wgrammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -149,7 +151,7 @@ namespace boost {
+ namespace archive {
+ 
+ // explicit instantiation of xml for wide characters
+-template class basic_xml_grammar<wchar_t>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<wchar_t>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wiarchive.cpp.orig
++++ libs/serialization/src/xml_wiarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_wiarchive>;
+-template class basic_xml_iarchive<xml_wiarchive> ;
+-template class xml_wiarchive_impl<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_wiarchive_impl<xml_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_woarchive.cpp.orig
++++ libs/serialization/src/xml_woarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_woarchive>;
+-template class basic_xml_oarchive<xml_woarchive> ;
+-template class xml_woarchive_impl<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_woarchive_impl<xml_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost

--- a/devel/boost176/files/patch-libs-mpi-build-Jamfile.v2.diff
+++ b/devel/boost176/files/patch-libs-mpi-build-Jamfile.v2.diff
@@ -1,0 +1,26 @@
+--- libs/mpi/build/Jamfile.v2.orig
++++ libs/mpi/build/Jamfile.v2
+@@ -49,6 +49,7 @@
+     <link>shared:<define>BOOST_MPI_DYN_LINK=1
+   : # Default build
+     <link>shared
++    <threading>multi
+   : # Usage requirements
+     <library>../../serialization/build//boost_serialization
+     <library>/mpi//mpi [ mpi.extra-requirements ]
+@@ -95,6 +96,7 @@
+                 <python>$(py$(N)-version)
+               : # Default build
+                 <link>shared
++                <threading>multi
+               : # Usage requirements
+                 <library>/mpi//mpi [ mpi.extra-requirements ]
+               ;
+@@ -122,6 +124,7 @@
+                 <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
+                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
+                 <link>shared <runtime-link>shared
++                <threading>multi
+                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+                 <python>$(py$(N)-version)
+               ;

--- a/devel/boost176/files/patch-revert-lib-name-tagged.diff
+++ b/devel/boost176/files/patch-revert-lib-name-tagged.diff
@@ -1,0 +1,11 @@
+--- boostcpp.jam.orig
++++ boostcpp.jam
+@@ -163,7 +163,7 @@
+             <base> <threading> <runtime> ;
+     case 1.69 :
+         .format-name-args =
+-            <base> <threading> <runtime> <arch-and-model> ;
++            <base> <threading> <runtime> ;
+     }
+ }
+ else if $(layout) = system

--- a/devel/boost176/files/patch-tools-build-src-tools-python-2.jam.diff
+++ b/devel/boost176/files/patch-tools-build-src-tools-python-2.jam.diff
@@ -1,0 +1,16 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -542,6 +542,13 @@
+         libraries ?= $(default-library-path) ;
+         includes ?= $(default-include-path) ;
+     }
++    else if $(target-os) = darwin
++    {
++        includes ?= $(prefix)/Headers ;
++
++        local lib = $(exec-prefix)/lib ;
++        libraries ?= $(lib)/python$(version)/config $(lib) ;
++    }
+     else
+     {
+         includes ?= $(prefix)/include/python$(version) ;

--- a/devel/boost176/files/patch-tools-build-src-tools-python.jam.diff
+++ b/devel/boost176/files/patch-tools-build-src-tools-python.jam.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -431,7 +431,7 @@
+     version ?= $(.version-countdown) ;
+ 
+     local prefix
+-      = [ GLOB /System/Library/Frameworks /Library/Frameworks
++      = [ GLOB @FRAMEWORKS_DIR@
+           : Python.framework ] ;
+ 
+     return $(prefix)/Versions/$(version)/bin/python ;

--- a/gis/mapnik/Portfile
+++ b/gis/mapnik/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem          1.0
 PortGroup           conflicts_build 1.0
+PortGroup           boost 1.0
 
 name                mapnik
 version             3.0.23
-revision            2
+revision            3
 categories          gis devel
 platforms           darwin
 license             LGPL-2.1
@@ -36,14 +37,12 @@ checksums           rmd160  14ec14c48ab790c8c3a2d30d51f8dd23b4dcd470 \
                     sha256  4b1352e01f7ce25ab099e586d7ae98e0b74145a3bf94dd365cb0a2bdab3b9dc2 \
                     size    10110103
 
-set boost_port      boost169
-set boost_path      ${prefix}/libexec/boost/${boost_port}
+boost.version       1.69
 
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:${boost_port} \
-                    port:harfbuzz \
+depends_lib-append  port:harfbuzz \
                     port:icu \
                     port:libpng \
                     path:include/turbojpeg.h:libjpeg-turbo \
@@ -113,20 +112,13 @@ configure.args      CXX="\$CXX" \
                     CPP_TESTS=False \
                     FREETYPE_CONFIG=${prefix}/bin/freetype-config \
                     PROJ_INCLUDES=${prefix}/lib/proj49/include \
-                    PROJ_LIBS=${prefix}/lib/proj49/lib \
-                    BOOST_INCLUDES=${boost_path}/include \
-                    BOOST_LIBS=${boost_path}/lib
+                    PROJ_LIBS=${prefix}/lib/proj49/lib
 
 foreach lib {ICU PNG JPEG TIFF CAIRO SQLITE HB WEBP} {
     configure.args-append   ${lib}_INCLUDES=${prefix}/include \
                             ${lib}_LIBS=${prefix}/lib
 }
 
-# avoid conflicts_build-append port:boost
-configure.cppflags-prepend \
-                        -I${boost_path}/include
-configure.ldflags-prepend \
-                        -L${boost_path}/lib
 destroot.destdir
 
 pre-configure {

--- a/gis/mapnik/Portfile
+++ b/gis/mapnik/Portfile
@@ -112,7 +112,9 @@ configure.args      CXX="\$CXX" \
                     CPP_TESTS=False \
                     FREETYPE_CONFIG=${prefix}/bin/freetype-config \
                     PROJ_INCLUDES=${prefix}/lib/proj49/include \
-                    PROJ_LIBS=${prefix}/lib/proj49/lib
+                    PROJ_LIBS=${prefix}/lib/proj49/lib \
+                    BOOST_INCLUDES=[boost::include_dir] \
+                    BOOST_LIBS=[boost::lib_dir]
 
 foreach lib {ICU PNG JPEG TIFF CAIRO SQLITE HB WEBP} {
     configure.args-append   ${lib}_INCLUDES=${prefix}/include \

--- a/gis/mapnik/Portfile
+++ b/gis/mapnik/Portfile
@@ -36,10 +36,13 @@ checksums           rmd160  14ec14c48ab790c8c3a2d30d51f8dd23b4dcd470 \
                     sha256  4b1352e01f7ce25ab099e586d7ae98e0b74145a3bf94dd365cb0a2bdab3b9dc2 \
                     size    10110103
 
+set boost_port      boost169
+set boost_path      ${prefix}/libexec/boost/${boost_port}
+
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:boost \
+depends_lib-append  port:${boost_port} \
                     port:harfbuzz \
                     port:icu \
                     port:libpng \
@@ -110,13 +113,20 @@ configure.args      CXX="\$CXX" \
                     CPP_TESTS=False \
                     FREETYPE_CONFIG=${prefix}/bin/freetype-config \
                     PROJ_INCLUDES=${prefix}/lib/proj49/include \
-                    PROJ_LIBS=${prefix}/lib/proj49/lib
+                    PROJ_LIBS=${prefix}/lib/proj49/lib \
+                    BOOST_INCLUDES=${boost_path}/include \
+                    BOOST_LIBS=${boost_path}/lib
 
-foreach lib {BOOST ICU PNG JPEG TIFF CAIRO SQLITE HB WEBP} {
-    configure.args-append   ${lib}_INCLUDES=${prefix}/include
-    configure.args-append   ${lib}_LIBS=${prefix}/lib
+foreach lib {ICU PNG JPEG TIFF CAIRO SQLITE HB WEBP} {
+    configure.args-append   ${lib}_INCLUDES=${prefix}/include \
+                            ${lib}_LIBS=${prefix}/lib
 }
 
+# avoid conflicts_build-append port:boost
+configure.cppflags-prepend \
+                        -I${boost_path}/include
+configure.ldflags-prepend \
+                        -L${boost_path}/lib
 destroot.destdir
 
 pre-configure {
@@ -136,19 +146,6 @@ post-destroot {
     xinstall -d -m 755 ${destroot}${prefix}/share/${name}
     copy ${worksrcpath}/demo ${destroot}${prefix}/share/${name}
 }
-
-depends_lib-replace     port:boost \
-                        port:boost169
-configure.args-replace  BOOST_INCLUDES=${prefix}/include \
-                        BOOST_INCLUDES=${prefix}/libexec/boost169/include \
-                        BOOST_LIBS=${prefix}/lib \
-                        BOOST_LIBS=${prefix}/libexec/boost169/lib
-
-# avoid conflicts_build-append port:boost
-configure.cppflags-prepend \
-                        -I${prefix}/libexec/boost169/include
-configure.ldflags-prepend \
-                        -L${prefix}/libexec/boost169/lib
 
 livecheck.type      regex
 livecheck.url       http://mapnik.org/pages/downloads.html

--- a/graphics/opencolorio/Portfile
+++ b/graphics/opencolorio/Portfile
@@ -3,9 +3,12 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake  1.1
+PortGroup           boost 1.0
+
+boost.depends_type  build
 
 github.setup        AcademySoftwareFoundation OpenColorIO 1.1.1 v
-revision            1
+revision            2
 name                opencolorio
 categories          graphics
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -50,11 +53,6 @@ depends_build-append \
 configure.args-append \
     -DOCIO_BUILD_TRUELIGHT=OFF \
     -DOCIO_BUILD_NUKE=OFF
-
-# from CMakeLists.txt:
-#    Need to also get the boost headers here, as yaml-cpp 0.5.0+ requires them.
-depends_build-append \
-    port:boost
 
 depends_lib-append  \
     port:yaml-cpp \

--- a/lang/opensaml/Portfile
+++ b/lang/opensaml/Portfile
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           boost 1.0
 
 name                opensaml
 version             3.2.0
+revision            1
 categories          lang shibboleth security xml
 license             Apache-2
 maintainers         {snc @nerdling} {scantor @scantor}
@@ -13,9 +15,10 @@ homepage            http://www.opensaml.org/
 master_sites        http://shibboleth.net/downloads/c++-opensaml/${version}/
 use_bzip2           yes
 
+boost.depends_type  build
+
 platforms           darwin
-depends_build       port:boost \
-                    port:pkgconfig
+depends_build       port:pkgconfig
 depends_lib         port:xmltooling \
                     port:xml-security-c \
                     port:xercesc3 \
@@ -25,8 +28,8 @@ checksums           rmd160  bd13d16a65773a7ffc438cc3252676bad139402b \
                     sha256  8c3ba09febcb622f930731f8766e57b3c154987e8807380a4228fbf90e6e1441 \
                     size    589626
 
-configure.args      --disable-static
-
+configure.args      --disable-static \
+                    --with-boost=[boost::install_area]
 
 livecheck.type      regex
 livecheck.url       http://shibboleth.net/downloads/c++-opensaml/latest/

--- a/mail/astroid/Portfile
+++ b/mail/astroid/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           boost 1.0
 
 github.setup        astroidmail astroid 0.15 v
-revision            0
+revision            1
 
 description         Astroid Mail
 long_description    A graphical threads-with-tags style, lightweight and fast, e-mail client for Notmuch
@@ -29,7 +30,6 @@ depends_build-append \
                     port:scdoc
 
 depends_lib-append  path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk \
-                    port:boost \
                     port:gtkmm3 \
                     port:libsass \
                     port:notmuch \

--- a/mail/astroid/Portfile
+++ b/mail/astroid/Portfile
@@ -25,6 +25,8 @@ checksums           rmd160  a7babb6609724a7b8fe950bc1321ee61b2af7609 \
 compiler.cxx_standard 2014
 compiler.blacklist-append {clang < 800}
 
+boost.version       1.71
+
 depends_build-append \
                     port:pkgconfig \
                     port:scdoc

--- a/math/xylib/Portfile
+++ b/math/xylib/Portfile
@@ -1,10 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           boost 1.0
+
+boost.depends_type  build
 
 name                xylib
 version             1.2
-revision            2
+revision            3
 categories          math
 platforms           darwin
 maintainers         ryandesign openmaintainer
@@ -22,8 +25,6 @@ use_bzip2           yes
 
 checksums           rmd160  69f2bb1d11305912eecd488b06ec0b46ae807119 \
                     sha256  8a32a0f201e47c8f0665da44af6a1eac0aa06aa9bb61a7bd226bb723e9aebebf
-
-depends_build       port:boost
 
 depends_lib         port:bzip2 \
                     port:zlib

--- a/math/xylib/Portfile
+++ b/math/xylib/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           boost 1.0
 
 boost.depends_type  build
+boost.version       1.71
 
 name                xylib
 version             1.2

--- a/science/dssp/Portfile
+++ b/science/dssp/Portfile
@@ -32,8 +32,6 @@ post-patch {
     reinplace "s|3\.1\.2|${version}|g" ${worksrcpath}/configure.ac
 }
 
-boost.version       1.76
-
 configure.cmd       ./autogen.sh && ./configure
 configure.args      --disable-silent-rules \
                     --with-boost=[boost::install_area]

--- a/science/dssp/Portfile
+++ b/science/dssp/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           boost 1.0
 
 github.setup        cmbi dssp 3.1.4
-revision            0
+revision            1
 name                dssp
 
 platforms           darwin
@@ -13,7 +14,7 @@ license             Boost-1
 maintainers         {reneeotten @reneeotten} openmaintainer
 
 description         DSSP automates protein secondary structure assignment.
-long_description    ${description}
+long_description    {*}${description}
 
 checksums           rmd160  511c97d4383c80b9ca01c910547deb38a2941cce \
                     sha256  2f412f48d4e89d8ad1a1f0b401b451bc4030c58108e84a81a71f20125d54db58 \
@@ -25,16 +26,17 @@ depends_build-append \
                     port:bzip2 \
                     port:libtool
 
-depends_lib-append  port:boost
-
 compiler.cxx_standard   2011
 
 post-patch {
     reinplace "s|3\.1\.2|${version}|g" ${worksrcpath}/configure.ac
 }
 
+boost.version       1.76
+
 configure.cmd       ./autogen.sh && ./configure
-configure.args      --disable-silent-rules
+configure.args      --disable-silent-rules \
+                    --with-boost=[boost::install_area]
 
 build.env           CC=${configure.cc} \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \

--- a/science/gerbil/Portfile
+++ b/science/gerbil/Portfile
@@ -30,6 +30,8 @@ depends_lib         port:opencv4 \
                     port:gdal \
                     port:tbb
 
+boost.version       1.71
+
 cmake.out_of_source yes
 configure.args-append \
                     -DOpenCV_DIR="${prefix}/libexec/opencv4/cmake" \

--- a/science/gerbil/Portfile
+++ b/science/gerbil/Portfile
@@ -33,8 +33,7 @@ depends_lib         port:opencv4 \
 cmake.out_of_source yes
 configure.args-append \
                     -DOpenCV_DIR="${prefix}/libexec/opencv4/cmake" \
-                    -DCMAKE_BUILD_TYPE=Release \
-                    -DBoost_DIR="[boost::install_area]"
+                    -DCMAKE_BUILD_TYPE=Release
 
 # the gerbil makefiles do not provide an install target
 destroot {

--- a/science/gerbil/Portfile
+++ b/science/gerbil/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           qt5 1.0
+PortGroup           boost 1.0
 
 github.setup        gerbilvis gerbil 5a7705fe1170f812a6cd0e79a1a853f4d8aec2cf
 version             2020-05-06-5a7705f
@@ -26,7 +27,6 @@ long_description    \
 homepage            http://gerbilvis.org/
 
 depends_lib         port:opencv4 \
-                    port:boost \
                     port:gdal \
                     port:tbb
 
@@ -34,7 +34,7 @@ cmake.out_of_source yes
 configure.args-append \
                     -DOpenCV_DIR="${prefix}/libexec/opencv4/cmake" \
                     -DCMAKE_BUILD_TYPE=Release \
-                    -DBoost_DIR="${prefix}"
+                    -DBoost_DIR="[boost::install_area]"
 
 # the gerbil makefiles do not provide an install target
 destroot {

--- a/science/gerbil/Portfile
+++ b/science/gerbil/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 
 github.setup        gerbilvis gerbil 5a7705fe1170f812a6cd0e79a1a853f4d8aec2cf
 version             2020-05-06-5a7705f
-revision            3
+revision            4
 checksums           rmd160  9b3f9ac2589a4f3b2ae12db6b02fdcd924886ec4 \
                     sha256  1eb67522c0629a885f940ce333880982528c0ef23ee5a3b27aaddf9facf72d6f \
                     size    2301204


### PR DESCRIPTION
See https://trac.macports.org/ticket/59834 and discussion below

 - Add a new boost176 port that builds the 1.76.0 version, and installs it isolated under `${prefix}/libexec/boost/${name}`
 - Add a new boost171 port that builds the 1.71.0 version, and installs it isolated under `${prefix}/libexec/boost/${name}`
 - Add a new boost PG that handles configuration of ports needing boost, to find the isolated builds.
 - Update boost169 to install via new isolation scheme `${prefix}/libexec/boost/${name}`

The PG is likely to need further enhancements as it is tried with more ports, to accommodate as far as possible all the various ways ports build, but it works with a handful of randomly picked examples I include here.

Update dependent ports to utilize new PG and isolation:
- astroid
- dssp
- gerbil
- mapnik
- opencolorio
- xylib