### PR TITLE
gnss-sdr-[devel]: fix building crashes

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -24,7 +24,7 @@ if {${subport} eq "gnss-sdr"} {
         This port is kept up with the GNSS-SDR release, which is typically updated every few months.
 
     github.setup        gnss-sdr gnss-sdr 0.0.14 v
-    revision            2
+    revision            3
     checksums           rmd160 71e9bbb7e125396be06d97b26f333e9e2bb4a9be \
                         sha256 48ba64073a995aa6f835c7a0cb775a741db9475359b036ca4245a65a6c1135fd \
                         size   4269976
@@ -33,6 +33,10 @@ if {${subport} eq "gnss-sdr"} {
 
     depends_lib-append  port:volk-gnss-sdr
 
+    # temporary patch to fix building crashes with the message:
+    # "read jobs pipe: Resource temporarily unavailable.  Stop."
+    patchfiles-append \
+        patch-fix-building.diff
 }
 
 
@@ -40,11 +44,11 @@ subport gnss-sdr-devel {
     long_description    ${description}: \
         This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
     name      gnss-sdr-devel
-    github.setup gnss-sdr gnss-sdr 7405e63f022c6ef7f98c7cb4266742a167579f2e
-    version   20210529-[string range ${github.version} 0 7]
-    checksums rmd160 a62a81221e3f08eb40321c8697fcc63ba83797f8 \
-              sha256 77ad6bf785a772bbd652c178d2561dd91853919fa3a2c7afad2986b9c9fe57ea \
-              size   4349028
+    github.setup gnss-sdr gnss-sdr 3c74930c7d253c70b9ab52e6a76ab8f6a155810e
+    version   20210531-[string range ${github.version} 0 7]
+    checksums rmd160 8449855911e5fd114a8b4141fd8a9741d0f5dc0f \
+              sha256 9d81599ed7cbcc5b5658040408353133b5791bf15b310031524a5e8b4fa81571 \
+              size   4349096
     revision  0
 
     conflicts gnss-sdr

--- a/science/gnss-sdr/files/patch-fix-building.diff
+++ b/science/gnss-sdr/files/patch-fix-building.diff
@@ -1,0 +1,13 @@
+--- src/tests/CMakeLists.txt.orig	2021-05-31 10:10:26.000000000 +0200
++++ src/tests/CMakeLists.txt	2021-05-31 10:11:28.000000000 +0200
+@@ -30,6 +30,10 @@
+         "--build" "${CMAKE_BINARY_DIR}/gtest-${GNSSSDR_GTEST_LOCAL_VERSION}"
+         "--config" $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:Debug>$<$<CONFIG:Coverage>:Debug>$<$<CONFIG:O2WithASM>:RelWithDebInfo>$<$<CONFIG:O3WithASM>:RelWithDebInfo>$<$<CONFIG:ASAN>:Debug>
+     )
++    if(CMAKE_VERSION VERSION_GREATER 3.12)
++        # Parallel building of gtest causes problems in some environments (e.g. Macports buildings)
++        set(GTEST_BUILD_COMMAND ${GTEST_BUILD_COMMAND} "--parallel 1")
++    endif()
+     if(CMAKE_GENERATOR STREQUAL Xcode)
+         set(GTEST_BUILD_COMMAND "xcodebuild" "-configuration" $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel> "-target" "gtest_main")
+     endif()

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -37,11 +37,11 @@ subport volk-gnss-sdr-devel {
         This port is kept up with the VOLK-GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of VOLK-GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
 
     name      volk-gnss-sdr-devel
-    github.setup gnss-sdr gnss-sdr 7405e63f022c6ef7f98c7cb4266742a167579f2e
-    version   20210529-[string range ${github.version} 0 7]
-    checksums rmd160 a62a81221e3f08eb40321c8697fcc63ba83797f8 \
-              sha256 77ad6bf785a772bbd652c178d2561dd91853919fa3a2c7afad2986b9c9fe57ea \
-              size   4349028
+    github.setup gnss-sdr gnss-sdr 3c74930c7d253c70b9ab52e6a76ab8f6a155810e
+    version   20210531-[string range ${github.version} 0 7]
+    checksums rmd160 8449855911e5fd114a8b4141fd8a9741d0f5dc0f \
+              sha256 9d81599ed7cbcc5b5658040408353133b5791bf15b310031524a5e8b4fa81571 \
+              size   4349096
     revision  0
 
     conflicts volk-gnss-sdr


### PR DESCRIPTION
#### Description

gnss-sdr and gnss-sdr-devel were intermittently crashing at building time. It seems that building gtest inside the project was causing building errors with the message "read jobs pipe: Resource temporarily unavailable.  Stop.".

Passing the option `--parallel 1` to CMake when building gtest seems to fix the issue.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4
Xcode 12.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
