### PR TITLE
lagrange: update to 1.5.0

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.4.2 v
+github.setup        skyjake lagrange 1.5.0 v
 github.tarball_from releases
 categories          net gemini
 platforms           darwin
@@ -19,9 +19,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  acf293474f235dec311e61b5cb11ded3dd57f3e6 \
-                    sha256  02f2666642ddb498b68689a725e06dc750e77ae6d96b77fa0453f0def5dcd1be \
-                    size    21616139
+checksums           rmd160  0ab0b064d91e1608362743480afb426d15254fe8 \
+                    sha256  da298e0cb366e7a9616a4ed294397e543f69ff4e40d1b5af90ea9d8dc36c317e \
+                    size    20403900
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
