### PR TITLE
sfm: new port

### DIFF
--- a/sysutils/sfm/Portfile
+++ b/sysutils/sfm/Portfile
@@ -1,0 +1,18 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               makefile 1.0
+PortGroup               legacysupport 1.0
+
+github.setup            afify sfm 0.1 v
+categories              sysutils
+license                 ISC
+maintainers             {@sikmir gmail.com:sikmir} openmaintainer
+platforms               darwin
+description             Simple file manager
+long_description        ${name} is a simple file manager for unix-like systems.
+
+checksums               rmd160  ba2330bea106a13b47c939c57b966b64274e2b3e \
+                        sha256  56b2a11a097a5d8af37896d0dd79b5c2371e80173b5ae8a5f1b2490a934afa75 \
+                        size    28169


### PR DESCRIPTION
#### Description
[**sfm**](https://github.com/afify/sfm) is a simple file manager for unix-like systems (no dependencies).

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
