### PR TITLE
py-igraph: add external_igraph variant

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-igraph
 python.rootname     python-igraph
 version             0.9.4
-revision            0
+revision            1
 categories-append   math science
 platforms           darwin
 license             GPL-2+
@@ -27,19 +27,57 @@ checksums           rmd160  f15a1da7e4163285b15de7a413a0f0727925926c \
                     sha256  b1e4e3b8ea438f85e17874d0b0836107b437ebe68ae0b3be13d2ad399f45405d \
                     size    3611998
 
+variant external_igraph description {Use external igraph library} { }
+
 if {${name} ne ${subport}} {
     compiler.c_standard     1999
     compiler.cxx_standard   2011
 
-    depends_lib-append      port:py${python.version}-texttable \
-                            port:arpack \
-                            port:glpk \
-                            port:gmp \
-                            port:libxml2 \
-                            port:SuiteSparse_CXSparse
+    depends_lib-append      port:py${python.version}-texttable
 
-    depends_build-append    port:py${python.version}-setuptools \
-                            path:bin/cmake:cmake
+    depends_build-append    port:py${python.version}-setuptools
+
+    if {[variant_isset external_igraph]} {
+        # Build with external igraph library
+
+        depends_lib-append      port:igraph
+
+        depends_build-append    path:bin/pkg-config:pkgconfig
+
+        # To avoid building the vendored igraph, --use-pkg-config must be passed not only
+        # to setup.py build, but also to setup.py install. When updating post-0.9.4,
+        # check if this is still necessary.
+        build.args-append       --use-pkg-config
+        destroot.args-append    --use-pkg-config
+    } else {
+        # Build with vendored igraph library
+
+        depends_lib-append      port:arpack \
+                                port:glpk \
+                                port:gmp \
+                                port:libxml2 \
+                                port:SuiteSparse_CXSparse
+
+        depends_build-append    path:bin/cmake:cmake
+
+        set extra_cmake_args {
+            -DUSE_CCACHE=OFF
+            -DBUILD_SHARED_LIBS=OFF
+            -DIGRAPH_ENABLE_LTO=AUTO
+            -DIGRAPH_GLPK_SUPPORT=ON
+            -DIGRAPH_GRAPHML_SUPPORT=ON
+            -DIGRAPH_USE_INTERNAL_ARPACK=OFF
+            -DIGRAPH_USE_INTERNAL_BLAS=OFF
+            -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF
+            -DIGRAPH_USE_INTERNAL_GLPK=OFF
+            -DIGRAPH_USE_INTERNAL_GMP=OFF
+            -DIGRAPH_USE_INTERNAL_LAPACK=OFF
+            -DIGRAPH_OPENMP_SUPPORT=OFF
+            -DBLA_VENDOR=Apple
+        }
+
+        build.env-append        IGRAPH_CMAKE_EXTRA_ARGS=[join $extra_cmake_args]
+    }
 
     # python-igraph optionally makes use of these, and some tests depend on them.
     # If they are not installed, the corresponding tests will simply be skipped.
@@ -48,23 +86,10 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-pandas \
                             port:py${python.version}-scipy
 
-    set extra_cmake_args {
-        -DUSE_CCACHE=OFF
-        -DBUILD_SHARED_LIBS=OFF
-        -DIGRAPH_ENABLE_LTO=AUTO
-        -DIGRAPH_GLPK_SUPPORT=ON
-        -DIGRAPH_GRAPHML_SUPPORT=ON
-        -DIGRAPH_USE_INTERNAL_ARPACK=OFF
-        -DIGRAPH_USE_INTERNAL_BLAS=OFF
-        -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF
-        -DIGRAPH_USE_INTERNAL_GLPK=OFF
-        -DIGRAPH_USE_INTERNAL_GMP=OFF
-        -DIGRAPH_USE_INTERNAL_LAPACK=OFF
-        -DBLA_VENDOR=Apple
-        -DIGRAPH_OPENMP_SUPPORT=OFF
-    }
-
-    build.env-append        IGRAPH_CMAKE_EXTRA_ARGS=[join $extra_cmake_args]
+    # Patch added for 0.9.4 to prevent linking both to libc++ and libstdc++
+    # See https://github.com/igraph/python-igraph/commit/2ccf9e9b88c37fc277dbd8eb8e0bce0a73e33cae
+    # Safe to remove from future versions.
+    patchfiles              patch-use-correct-cpp-stdlib.diff
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]

--- a/python/py-igraph/files/patch-use-correct-cpp-stdlib.diff
+++ b/python/py-igraph/files/patch-use-correct-cpp-stdlib.diff
@@ -1,0 +1,46 @@
+diff --git a/setup.py b/setup.py
+index 5f2e4a5..9163cab 100644
+--- setup.py
++++ setup.py
+@@ -420,6 +420,11 @@ class BuildConfiguration(object):
+                     extra_libraries = os.environ["IGRAPH_EXTRA_DYNAMIC_LIBRARIES"].split(',')
+                     buildcfg.libraries.extend(extra_libraries)
+ 
++                # Remove C++ standard library as we will use the C++ linker
++                for lib in ("c++", "stdc++"):
++                    if lib in buildcfg.libraries:
++                        buildcfg.libraries.remove(lib)
++
+                 # Prints basic build information
+                 buildcfg.print_build_info()
+ 
+@@ -664,11 +669,6 @@ class BuildConfiguration(object):
+     def replace_static_libraries(self, only=None, exclusions=None):
+         """Replaces references to libraries with full paths to their static
+         versions if the static version is to be found on the library path."""
+-        building_on_windows = building_on_windows_msvc()
+-
+-        if not building_on_windows and "stdc++" not in self.libraries:
+-            self.libraries.append("stdc++")
+-
+         if exclusions is None:
+             exclusions = []
+ 
+@@ -757,6 +757,7 @@ buildcfg.process_args_from_command_line()
+ 
+ # Define the extension
+ sources = glob.glob(os.path.join("src", "_igraph", "*.c"))
++sources.append(os.path.join("src", "_igraph", "force_cpp_linker.cpp"))
+ igraph_extension = Extension("igraph._igraph", sources)
+ 
+ description = """Python interface to the igraph high performance graph
+diff --git a/src/_igraph/force_cpp_linker.cpp b/src/_igraph/force_cpp_linker.cpp
+new file mode 100644
+index 0000000..d78b8f3
+--- /dev/null
++++ src/_igraph/force_cpp_linker.cpp
+@@ -0,0 +1,4 @@
++/* The purpose of this file is to make Python use the C++ linker instead of
++ * the standard C linker because igraph's core static library needs the C++
++ * standard library */
++


### PR DESCRIPTION

#### Description

 * add external_igraph variant
 * fix linking to both libc++ and libstdc++

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9028 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
