### PR TITLE
fzf: Update to 0.27.2

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.27.1
+go.setup            github.com/junegunn/fzf 0.27.2
 revision            0
 
 categories          sysutils
@@ -14,9 +14,9 @@ description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  a67f9ca09cc345a20c1f111998d70b77a4c18b4f \
-                        sha256  d8ebb9e1d4603586aaafff8034052abd0c75dcdcdf83074fb7bb9383307a5478 \
-                        size    191651
+                        rmd160  577e575ab9b9104694dd8ec2ad914b2b86553d8c \
+                        sha256  68aef240eb89c59a6e699dcc7341833a9be48483c663c16e9a4650ea18d2de4c \
+                        size    191979
 
 go.vendors          golang.org/x/text \
                         lock    v0.3.6 \


### PR DESCRIPTION
#### Description

See: https://github.com/junegunn/fzf/releases/tag/0.27.2.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
