### PR TITLE
syncthing: update to 1.17.0

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.16.1 v
+go.setup            github.com/syncthing/syncthing 1.17.0 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,9 +18,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  c63a3fe5d9bc2345330f6e5675ebe5308f0462e2 \
-                        sha256  1cedb69a7ef3f692c123138e6d36187ee41e738127112f31cdfd6ffa0cecf16e \
-                        size    6086654
+                        rmd160  a8b3922fae38aaa9396c0a08aafec866e474ffa0 \
+                        sha256  eb6ed1718f677e38e7a02e22c06577914dd27a2aecde95ffa1f011905003b565 \
+                        size    6092970
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -44,10 +44,22 @@ go.vendors          gopkg.in/yaml.v3 \
                         size    31647 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.23.0 \
-                        rmd160  b9954ce9dc927216440d55f850073bbf47113143 \
-                        sha256  41a885f3290ce459bcd4251a6df0787ead449c835a718f8f46342cad1dc26b85 \
-                        size    1214926 \
+                        lock    v1.26.0 \
+                        rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
+                        sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
+                        size    1270531 \
+                    google.golang.org/grpc \
+                        repo    github.com/grpc/grpc-go \
+                        lock    v1.26.0 \
+                        rmd160  e831a775462a0399cb97ec0889174512f9d8bdc8 \
+                        sha256  494fb4767284855e46275a06d3a743068e62b2d0da903d824336ad94d6caf1f7 \
+                        size    765450 \
+                    google.golang.org/genproto \
+                        repo    github.com/googleapis/go-genproto \
+                        lock    24fa4b261c55 \
+                        rmd160  93f6926ff96d990032f4ef7cefa1d9744624799f \
+                        sha256  51c44148d4eb2ef9225af6a2a0308e0237619f582ba0d0a2b8a51b5a967afa1d \
+                        size    5332236 \
                     golang.org/x/xerrors \
                         lock    5ec99f83aff1 \
                         rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
@@ -59,50 +71,50 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  7ee4ceea7cc41925aa41c185d17886694bcd611cb9896be15e578a491c8594c0 \
                         size    2683296 \
                     golang.org/x/time \
-                        lock    3af7569d3a1e \
-                        rmd160  6ec4017fbe0897df74acfb012623482602c33dae \
-                        sha256  c918feb3b40248a7b153f402b25a1fed5726ff73fa448c067cd9a1899df5e1f5 \
-                        size    9625 \
+                        lock    f8bda1e9f3ba \
+                        rmd160  f8d3e8f61490936cad49b715f1c36b40b1ece39d \
+                        sha256  99f4d738462c7e441e7fb349ed353e87616be780659f25f50a2a4fca5b7a2b0f \
+                        size    9662 \
                     golang.org/x/text \
-                        lock    v0.3.4 \
-                        rmd160  2b9cc1c618efac6184ba3cc497945bfe8299878b \
-                        sha256  4f7508324739fdddcc1bf653a755608aa8ed0119d297ba7460d812e67d661e6a \
-                        size    8347767 \
+                        lock    v0.3.6 \
+                        rmd160  e3da48fcc60d98e202458228188bf6dac408e309 \
+                        sha256  6b2d69df22b5ba1634bc6730c3f03404db499536a96c48b8016da80ced804450 \
+                        size    8356058 \
                     golang.org/x/sys \
-                        lock    b64e53b001e4 \
-                        rmd160  eb9c17a2964f138171e208deb3c3ebc8a9f8ff02 \
-                        sha256  5bc19a2c586a4703fcd4bca3fe19d093dd9bd614527cfb96c3845dcd1b49a6f9 \
-                        size    1103887 \
+                        lock    d19ff857e887 \
+                        rmd160  2ed08c61c86e3546de28692ad78e8b0097c472ea \
+                        sha256  129834fa0c0c2139853fee97ffd7872d75f9398735db82e2f445595a7a1697e2 \
+                        size    1232340 \
                     golang.org/x/net \
-                        lock    ff519b6c9102 \
-                        rmd160  78d6174e2b669f537a5df1e2945d47f737b9e7ae \
-                        sha256  abe822419126a02ff65c26fe14994787b0d29a1b7633471fd3ed04c3e6b1c150 \
-                        size    1248882 \
+                        lock    89ef3d95e781 \
+                        rmd160  d7ce678a4df908e249c02e1bd027cb36ca9f0919 \
+                        sha256  2bbf2441a2a203e2376baddb6c5de37bb63a3b46010b0c9bfdf631d0128e83dc \
+                        size    1247545 \
                     golang.org/x/mod \
                         lock    v0.3.0 \
                         rmd160  0f19d3d89a7745c9877e5095399e24bdb2a79908 \
                         sha256  d4e740958a7d07574b73c6b6a5ab717cd0bc219416e47c5950fe3cefab414f92 \
                         size    93933 \
                     golang.org/x/crypto \
-                        lock    9e8e0b390897 \
-                        rmd160  bd4738a1bbf4d94ec5f840e7425ffa473c6b97bd \
-                        sha256  1b740a92e71e7215af0a8c3651c5e4925eaaf0f49e718ffd2dc8310452894236 \
-                        size    1732591 \
+                        lock    83a5a9bb288b \
+                        rmd160  c7750005747d7fada41ca0933f9937f0f26f9034 \
+                        sha256  3ed5b0a92055b3010d0a40b71c331c6921e211ba6f03074308ab555a405e0d67 \
+                        size    1726599 \
                     github.com/vitrun/qart \
                         lock    bf64b92db6b0 \
                         rmd160  50ea47d1b1d0b60138845f21d57cad0ac7e5e632 \
                         sha256  58579d35e03703699b3ea56a096b665739a77b462ac18a29102c7c776e48d279 \
                         size    23968 \
                     github.com/urfave/cli \
-                        lock    v1.22.4 \
-                        rmd160  fc14cf328e371c1f0f3baceea5df4d4de63ca134 \
-                        sha256  60f4eecd8fe79ace077fe6517f0d4f3950901bfbcc66ddc83cd944e7ddab4c79 \
-                        size    78058 \
+                        lock    v1.22.5 \
+                        rmd160  f26fef0516efcbf556d953be02bcfb0ae60a9c22 \
+                        sha256  2122a2b193a2d096f3792e4f8d6a7bb2a504a0d5bba7b0d1bfe81707917831a3 \
+                        size    78154 \
                     github.com/thejerf/suture \
-                        lock    v4.0.0 \
-                        rmd160  8d577b993b9e9014c30103bc664e89e67e60d7f7 \
-                        sha256  b64ec71c02bc46d3f700c5adf4e36b08e6ab5e99f43298f82dd6ee9386f539ba \
-                        size    37634 \
+                        lock    v4.0.1 \
+                        rmd160  d5655c5791b8d08099693beb048e416826d0516d \
+                        sha256  aa987047e44c1d21d83cb35f125a9c19eb28a27c3def64bb3ff725536dc3a751 \
+                        size    38106 \
                     github.com/syndtr/goleveldb \
                         lock    d9e9293bd0f7 \
                         rmd160  1c363aa498b3fae0918bf839dcaa673193080f50 \
@@ -114,55 +126,55 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  5c1ed415aa68c8cf7e369c49e50922a446def96b652a67b1b0fec5e8cb28fd59 \
                         size    58257 \
                     github.com/stretchr/testify \
-                        lock    v1.6.1 \
-                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
-                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
-                        size    84248 \
-                    github.com/shurcooL/sanitized_anchor_name \
-                        lock    v1.0.0 \
-                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
-                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
-                        size    2144 \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
                     github.com/shirou/gopsutil \
-                        lock    v3.20.11 \
-                        rmd160  60f9e1f1df95377b0600872e7be6553b69787b8b \
-                        sha256  ef56a4256848df47f3c22adba3c6baf13fbf42525920b23e6949851b575c04f3 \
-                        size    284015 \
+                        lock    v3.21.4 \
+                        rmd160  9a9ebaa7f4e3ad8b33e643f2ec5f320704697056 \
+                        sha256  4ef011dda9dabe9cee7db167d30616cf2034293c755090c6973dab88b68b426c \
+                        size    283931 \
+                    github.com/sclevine/spec \
+                        lock    v1.4.0 \
+                        rmd160  9e0712b9319670603040a683b0d1d96c87462c53 \
+                        sha256  c253580600294f2cb6ef134816cdca7327b93ae67bc3d01ee903cbf57fac100c \
+                        size    13501 \
                     github.com/sasha-s/go-deadlock \
                         lock    v0.2.0 \
                         rmd160  e9a7e7a4994c375c6fbf1a2773e37e1cd3bf2325 \
                         sha256  5ff9df5b6d65603320a4839fe4ba24ce00284291032f035f17c2ea9ce3fe8676 \
                         size    9959 \
                     github.com/russross/blackfriday \
-                        lock    v2.0.1 \
-                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
-                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
-                        size    79665 \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
                     github.com/rcrowley/go-metrics \
-                        lock    10cdbea86bc0 \
-                        rmd160  7b4f842f6213dba7801a22e09d51c7af089a8251 \
-                        sha256  8d07891e7f30110a7fc528237b86b067e1ade791f38d68019a5030a29081fbc9 \
-                        size    37568 \
+                        lock    cf1acfcdf475 \
+                        rmd160  0f0e9748c602b9bf7473e907cfc28d7c33328a32 \
+                        sha256  ca8446ddf4e9c684b76ab8216220b700e6e9fc1ae69b5ba59c845b09c87c787f \
+                        size    37582 \
                     github.com/prometheus/procfs \
-                        lock    v0.2.0 \
-                        rmd160  7ce571274023d4a96649d6e9216a79a43469523d \
-                        sha256  88ef0f9d6f482b5d9d45f2668bca578096114fd959b1e01f1272e57ab5f8ce77 \
-                        size    157409 \
+                        lock    v0.6.0 \
+                        rmd160  ae0e0bcf1c664eacc18c03ec77973f0212dce472 \
+                        sha256  4ffc099c6f2ce85a7681e09462e465b140556743a248f4b3bdc665498f3380b1 \
+                        size    169970 \
                     github.com/prometheus/common \
-                        lock    v0.14.0 \
-                        rmd160  3d5ae8b32dc487071c5534703c64d845f4c818ed \
-                        sha256  87d2b4bdfd7a09edd3b695cb40e391f5dae87ae4c0114fa5700afa4c36e3e124 \
-                        size    124246 \
+                        lock    v0.18.0 \
+                        rmd160  4a65e9893ce9836d491af99dcb86475849cb095b \
+                        sha256  d6f4463151f2c4eaa183512668382f6d40120f6905cc5cc7a254163efa5c10c3 \
+                        size    123706 \
                     github.com/prometheus/client_model \
                         lock    v0.2.0 \
                         rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
                         sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
                         size    10985 \
                     github.com/prometheus/client_golang \
-                        lock    v1.8.0 \
-                        rmd160  bb9642634eb3d2d57591edd2c45e6a91f98505be \
-                        sha256  37366f9bc01b5f804c29064d80f7c629c3a2104be9ae24134b6e6b47a1259775 \
-                        size    175680 \
+                        lock    v1.10.0 \
+                        rmd160  7f4395fec6846f595f0625c6288f4b520c805e62 \
+                        sha256  4ca1349fc8fac34193f250e66cef415465a85f5d32f69360fa43962a73252ca6 \
+                        size    176332 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -179,15 +191,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  edff5d2606e098d2418c09b2d9f24ddeb840f1eb22920a8b7e8da2ff39b23d9d \
                         size    6817 \
                     github.com/oschwald/maxminddb-golang \
-                        lock    v1.6.0 \
-                        rmd160  86c6ca33cd6ac16da7a566946f54a86e140b70b1 \
-                        sha256  8c265096a73a04ece9153ac0138074b0bd40b927e0d32e3b80deadba81c9010d \
-                        size    21377 \
+                        lock    v1.8.0 \
+                        rmd160  df12137865d3ed774cfa8a2280fadb1cc3f70666 \
+                        sha256  a97543b5273e1ac29ce20cd691d8e7df4e38d320cc3a161ed4773db582fefff5 \
+                        size    25015 \
                     github.com/oschwald/geoip2-golang \
-                        lock    v1.4.0 \
-                        rmd160  fc325eebed54d5c7c5f7945b8447d807536f0f82 \
-                        sha256  0f702ef1efa02abd2a70a5fbd33353338c7f67acaaafea707a162ec30ddb5d0b \
-                        size    7750 \
+                        lock    v1.5.0 \
+                        rmd160  b904a315a009ba73d834ec2f843e2fa0e0f9b40f \
+                        sha256  4730f81213989b0c32c857b033f5dfe049f664d9959a3c1f8c534183eecd0874 \
+                        size    9608 \
                     github.com/onsi/gomega \
                         lock    v1.10.3 \
                         rmd160  3ce67285e98fcf47d6ae18e2a50b6685c132e323 \
@@ -214,10 +226,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a949004fc78e2d46faa48efbc8d6e00fa6bc12602ccc9338e0490d12e0707ce8 \
                         size    21288 \
                     github.com/minio/sha256-simd \
-                        lock    v0.1.1 \
-                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
-                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
-                        size    65042 \
+                        lock    v1.0.0 \
+                        rmd160  29205a140c1f8c8dc222f02bd25c61942043da81 \
+                        sha256  f189fa3cd24b867bcfece8f1af38b41d00fa7fffd16f56964c8e80101e498eab \
+                        size    49035 \
                     github.com/maxbrunsfeld/counterfeiter \
                         lock    v6.3.0 \
                         rmd160  6de0ee901ff8b710410086de41ea0110b33baeb9 \
@@ -234,15 +246,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
                         size    4549 \
                     github.com/maruel/panicparse \
-                        lock    v1.5.1 \
-                        rmd160  c8ea9da4d1a8fe96cefd2ca3b5ded74bad7b89e3 \
-                        sha256  903a5fd94d31df7ec39c3482926ff69182e0fd9ae5891850d7fb26570eb73f41 \
-                        size    1219072 \
+                        lock    v1.6.1 \
+                        rmd160  6f7b6c1f0ea3b1d065dc8e8e1c0aa42d3db90434 \
+                        sha256  2ae2b9dc73270d6a0222347bf290b44b45d80a82c181c19183165c9952de0c6b \
+                        size    169712 \
                     github.com/marten-seemann/qtls-go1-15 \
-                        lock    v0.1.1 \
-                        rmd160  a292bd4cc78e1f395ec65180d3e47e85b6aa55a1 \
-                        sha256  dca45a0ba054751a908de41055d292b0020e9ccbc959b52231b1f8027fe17da1 \
-                        size    413727 \
+                        lock    v0.1.4 \
+                        rmd160  370ab7801f30cbfdf823274dc0ad68c6b492b969 \
+                        sha256  e0e690f3333659b7732af5ccab65044f09aa89dafa7158410c5f8ca5e451fe13 \
+                        size    413757 \
                     github.com/marten-seemann/qtls \
                         lock    v0.10.0 \
                         rmd160  560c030e5cd2045dc65345b67ce0257ec709ac65 \
@@ -254,15 +266,20 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  2589e82385f612cc4b45ab0bad5ae105d36d823a137245520d71e90009f4f17f \
                         size    495534 \
                     github.com/lib/pq \
-                        lock    v1.8.0 \
-                        rmd160  3bdbb0bd8abc244e2a17318be93ca6e9ba11d982 \
-                        sha256  429ff821078da5e4b4e4d8b7fc7dd9d9bd5c625164f5fb20d2af14d3ce2bebdd \
-                        size    101968 \
+                        lock    v1.10.1 \
+                        rmd160  8b194b5ee4d2e5b01c7c6fdb3223313cd1f248b1 \
+                        sha256  6667ba0c01e7dfd9df0b02fe602ce02fe08be86a4dec983cc25c42bd03f388e7 \
+                        size    103819 \
                     github.com/kr/text \
                         lock    v0.1.0 \
                         rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
                         sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
                         size    8691 \
+                    github.com/klauspost/cpuid \
+                        lock    v2.0.6 \
+                        rmd160  d6973fc3d7158db97407b1456195822b8e84008a \
+                        sha256  3a8fe2a0c4424273a5fa76c9eb437e53e8dd9c506a1b0ee48669f02c20d58d1b \
+                        size    341436 \
                     github.com/kballard/go-shellquote \
                         lock    95032a82bc51 \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
@@ -279,50 +296,60 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  7c43c94b1194bb43b497ab4e480403403c34076d87715915abb9502120e192ee \
                         size    4783 \
                     github.com/jackpal/gateway \
-                        lock    v1.0.6 \
-                        rmd160  3b78ee895c6d3d02bbc65ad2ed24aee73020815f \
-                        sha256  9ccb9f16909c0a992b2b0f319937d73778c7b97eae57fd6a0a1aa0faf0b11d41 \
-                        size    4907 \
+                        lock    v1.0.7 \
+                        rmd160  fedb91688ad268a2541da0bcb43bc9f9b5bb4b08 \
+                        sha256  b81239de1505e024ad5af4d2bbecee1fa9bc8594cce7197d5362a174443de9d0 \
+                        size    6064 \
                     github.com/hashicorp/golang-lru \
-                        lock    v0.5.1 \
-                        rmd160  dd02645a94c90ef435ed1662531754761e4a4d8b \
-                        sha256  d9393f70b3fcd62d078e0ceefe9f6605d5086a986ba6cd7ed268b980eb1b6bf4 \
-                        size    12986 \
+                        lock    v0.5.4 \
+                        rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
+                        sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
+                        size    13435 \
+                    github.com/grpc-ecosystem/grpc-gateway \
+                        lock    v1.9.5 \
+                        rmd160  f8386b54c5da2f6c3a0cf5b106ee4481ed42459b \
+                        sha256  266f0c8f49e8ab16b4dcfbd66b126e4e0d8c63ff8a6e0d8702e38734bb5650f7 \
+                        size    303364 \
                     github.com/greatroar/blobloom \
-                        lock    v0.5.0 \
-                        rmd160  57f4c4fbc0679178345214eb6eea91fb81743434 \
-                        sha256  4ce1f963d013784a2fd2ca195a857825ce7a9ec6929aa495dc21b558964e0c19 \
-                        size    21793 \
+                        lock    v0.7.0 \
+                        rmd160  2f7d414a0bd3e0d71ecc829ee6b94dcb49f60374 \
+                        sha256  3d02ed5e34cc084f91c752985fefb3eccf5e5b082b0aa745a4b17367696473c2 \
+                        size    24919 \
                     github.com/google/go-cmp \
-                        lock    v0.4.0 \
-                        rmd160  2d73ccb9863b49adb03196aff7c41a7048e646fb \
-                        sha256  e7274fa6cc337c12123a02acc907524b7c3c234af59b2c924664300a57cb3ea0 \
-                        size    81597 \
+                        lock    v0.5.5 \
+                        rmd160  5caef57da3ce09c102ed270168afa2a5200c2c47 \
+                        sha256  be284023d91976ef03d13cb5670e338c09a0a0da9925d7de457f44e33aebb724 \
+                        size    102365 \
                     github.com/golang/snappy \
                         lock    v0.0.1 \
                         rmd160  a10055b1a93ad290e600742c23156dbd55afe046 \
                         sha256  5ca0dcca007398f298a6386af5d4696faba962b6a625e3aa3961d212078722b8 \
                         size    62627 \
                     github.com/golang/protobuf \
-                        lock    v1.4.3 \
-                        rmd160  f07e841d9c9706e08d3ec3b6440a6b7e42d54392 \
-                        sha256  a53f353ad911974ab0483ae25d4f0cdb4f0ea508b69a786062e4743df2ab3959 \
-                        size    171996 \
+                        lock    v1.5.2 \
+                        rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
+                        sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
+                        size    171736 \
                     github.com/golang/mock \
-                        lock    v1.4.4 \
-                        rmd160  ad4c6bd70c06881810d56fbd5d4b4ddfb701fae0 \
-                        sha256  921ea11f2a10c4f6225fd3057893a5ee8c5d9b2ca17cb8f9de3a361a0f3899a1 \
-                        size    55151 \
+                        lock    v1.5.0 \
+                        rmd160  d52e6bcf001864ba50f79333a8d5aa60aedb3d97 \
+                        sha256  9ab3a093ccfb9d18118ebf969153ea1a350a530be7cf647bbc73ac7a4e018cf8 \
+                        size    66435 \
                     github.com/golang/groupcache \
-                        lock    8c9f03a8e57e \
-                        rmd160  b2514822acfad511ef9c9909f251cf18a3347ccd \
-                        sha256  ba910d9b0c49b9e15e605c6f5f373e2a2eeae2e7c59ed72bd6866446f6a5f94e \
-                        size    26050 \
+                        lock    41bb18bfe9da \
+                        rmd160  dba4526dc11102f7cfc3ee7be23cb1416793e35b \
+                        sha256  03b46be967afa501b74a1bf72211b08d6e8f6b2a3b42335105480b6df6e51980 \
+                        size    26110 \
+                    github.com/golang/glog \
+                        lock    23def4e6c14b \
+                        rmd160  b5bd9166cd1e073a035b5bbd3c4d9febf2c917a7 \
+                        sha256  2826d20759090e909ba0f8771def236ad6433fc3e44bdc28374b309efe3e57cf \
+                        size    19662 \
                     github.com/gogo/protobuf \
-                        lock    v1.3.1 \
-                        rmd160  16be6b4d8879c774e3b9d9fc29d80cf770632f88 \
-                        sha256  393dda8c157457ce1b3d4003f9012b25528c76b1492d7ba52c9bd7b66c901c13 \
-                        size    2038446 \
+                        lock    v1.3.2 \
+                        rmd160  c16e6e6fb8f26d3d1ceef9e99fa4dfb5899878fd \
+                        sha256  d24f8e0b99dbc6ffaa0731490bf80d3ab4cb0b332bcf4b57e3fd830c60e0960b \
+                        size    2040306 \
                     github.com/gobwas/glob \
                         lock    v0.2.3 \
                         rmd160  1f472cf991498a8091446eb788fe85e0c5403185 \
@@ -334,15 +361,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  55590e7d9e56e30094fd487a2dcf4926aa4bb82471f21f33131b606a6ce41294 \
                         size    51683 \
                     github.com/go-ldap/ldap \
-                        lock    v3.2.4 \
-                        rmd160  65db901b347e566447389d2610ac64497d63ff17 \
-                        sha256  d4abc208216be303cf853d386e06fd6c86945afccee6660d7575219f290a7505 \
-                        size    86908 \
+                        lock    v3.3.0 \
+                        rmd160  9bda09ecd67007658ded7fe00362f5b2a1c2ccc7 \
+                        sha256  87b05f1c1b77604027279bd57975561c0df8afecd44fe5a07d7684132e8e3d05 \
+                        size    88572 \
                     github.com/go-asn1-ber/asn1-ber \
-                        lock    v1.5.1 \
-                        rmd160  7713d9357f56bee2c54d80f56268903abfc30145 \
-                        sha256  fcf9c74ff49338b5ef8a57555fcfb0d279999c3b4a4fcb9754fbf3772a77b208 \
-                        size    16310 \
+                        lock    v1.5.3 \
+                        rmd160  6bc758f34bd2021f3040c6c822e17cc92bf8c41e \
+                        sha256  4b12e2c5a146cdc3bab9e5f8fbf837e70a0c63e07093afcb324036ae4ee6da9e \
+                        size    16348 \
                     github.com/getsentry/raven-go \
                         lock    v0.2.0 \
                         rmd160  c564a8e9061642f60d401b6ab5b26961feec3212 \
@@ -374,7 +401,7 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  da946f9c267dc73f01fb14126655c6f5dfe16b84ee91a1e0646f0d88a140cc8d \
                         size    8066 \
                     github.com/cpuguy83/go-md2man \
-                        lock    f79a8a8ca69d \
+                        lock    v2.0.0 \
                         rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
                         sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
                         size    52040 \
@@ -394,10 +421,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
                         size    9300 \
                     github.com/certifi/gocertifi \
-                        lock    2c3bb06c6054 \
-                        rmd160  ecd5d6480238932222640c0486475ae516e9f318 \
-                        sha256  7d4569b405660ffcd4eb36d911a112d0e88a2c20141275e2aaad46b112d032c7 \
-                        size    158977 \
+                        lock    83314bf6d27c \
+                        rmd160  ff0f7caa0af747a712a14978c9a73e7e83522e2c \
+                        sha256  189f8fae6a73c216f5a9db697ca534d456dd423bc0a18ab1c0f82e68b4d96ca2 \
+                        size    147057 \
                     github.com/ccding/go-stun \
                         lock    v0.1.3 \
                         rmd160  0f44206289f1515e2022efb959b830e839b0627f \
@@ -419,10 +446,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
                         size    10874 \
                     github.com/alecthomas/kong \
-                        lock    v0.2.12 \
-                        rmd160  7e4eb2c2b1bb08ede1dfc78540becd5ed9e207aa \
-                        sha256  8a2d5fd67faee4ee5eaef031b1ea14b4bb7a356ce76b72a1ad04df2ee85efcd3 \
-                        size    283874 \
+                        lock    v0.2.16 \
+                        rmd160  65b1addf71c0dfbe97e41c732c9b80ed84af0d07 \
+                        sha256  b4d96a83d95fb0012206360f16dd020dd51bb30e5c8e6cd50e28b62a3073d92f \
+                        size    287153 \
                     github.com/StackExchange/wmi \
                         lock    cbe66965904d \
                         rmd160  1c28ff3f595532ab67c85f5232c9228cf97d65d9 \
@@ -434,15 +461,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  0ff7e70a3c8a7b828f007c296d4152b334eaf79715122a5e9bf19f404c901044 \
                         size    8130 \
                     github.com/AudriusButkevicius/recli \
-                        lock    v0.0.5 \
-                        rmd160  1596db1035aafd77ffa11ed3373f9382ada081e2 \
-                        sha256  6ead3d46eebdc505730eeeb67f1f51db8f5685a289a21bb8652ded419e98355c \
-                        size    12375 \
+                        lock    v0.0.6 \
+                        rmd160  70988c80ee5c85ee9699f2a13a199cee694a5f42 \
+                        sha256  543c0a8ad8a9f2f9dc33585a8cdd5b7c3f8d19907f9833dd0a978edc56679768 \
+                        size    12410 \
                     github.com/AudriusButkevicius/pfilter \
-                        lock    7468b85d810a \
-                        rmd160  ae256c2bccf0a0ad889cee14e8244ffe4635c501 \
-                        sha256  1676b316eb16e30a5cdff9e3ca4115ade3b1da9d15d23ff68dd12629d56ab80b \
-                        size    3280
+                        lock    e9aaf99ab213 \
+                        rmd160  f4cdd90365edfd44e6783c4f6f99e919102374ed \
+                        sha256  605f6d99454282ffc3b9c134075dd031e94075cf563276c02fc7513342f6342a \
+                        size    18636
 
 build.cmd           ${go.bin} run build.go
 build.target        install syncthing


### PR DESCRIPTION
#### Description
Updates syncthing to 1.17.0
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
