### PR TITLE
google-cloud-sdk: update to 343.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             342.0.0
+version             343.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  21ac09869096a8fa2d351191229e91dd4c3cf8a4 \
-                    sha256  b0e5ffb852c129002f6499c25c1abcfa2a9f4e0ea49bbc9d0b19edf9d1f790e3 \
-                    size    89750433
+    checksums       rmd160  09790681917370cabb637b1bdd98a60e566abeef \
+                    sha256  d8995283683942eea299e95b677b43cc5faef0ce7bce6a427a4f62690149f289 \
+                    size    89919228
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  23b18c2575d152b4b07af3aea24b59b36f1bd197 \
-                    sha256  0453b4ffa084a4d8e0045a2f1586f9c54096d3efb771d8736c21d476c0fb30d7 \
-                    size    85993827
+    checksums       rmd160  7247017ebedaa4fa5c5bb7d60a926e507827009f \
+                    sha256  fbc2b8239ff312b964d39209b6138956acbf7e821c90abd0ac99a2abe5bc06b9 \
+                    size    86161349
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  b88af3e48625757fe400b2aa5c5b48d0cb90c8b0 \
-                    sha256  00adbaea088ccfdd2fe1eba17f6dd36902a819bdcfbc6dcc5e58c743d6d4af33 \
-                    size    85922302
+    checksums       rmd160  a06bda2c5ebe1d319db2d9670ac6c134ea029a7b \
+                    sha256  cec89645ccbf22f9850b6eb3726b1f93d82fd5b589ae89a300b4502213cbf61e \
+                    size    86087902
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 343.0.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?