### PR TITLE
protobuf-c: fix build on macOS 10.11 and earlier

### DIFF
--- a/devel/protobuf-c/Portfile
+++ b/devel/protobuf-c/Portfile
@@ -34,6 +34,9 @@ depends_lib     port:protobuf3-cpp
 
 compiler.cxx_standard 2011
 
+# error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
+compiler.blacklist-append {clang < 900}
+
 configure.args  --disable-silent-rules
 
 test.run        yes


### PR DESCRIPTION

#### Description

See https://ports.macports.org/port/protobuf-c/builds: builders for macOS 10.11 and earlier (except for 10.7 and earlier where newer MacPorts clang is used) fail due to an issue resembling 
https://trac.macports.org/ticket/61751

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
