### PR TITLE
drupal7: update to 7.81

### DIFF
--- a/www/drupal7/Portfile
+++ b/www/drupal7/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                drupal7
-version             7.80
+version             7.81
 revision            0
 categories          www php
 license             GPL-2
@@ -23,18 +23,18 @@ homepage            https://drupal.org
 distname            drupal-${version}
 master_sites        https://ftp.drupal.org/files/projects/
 
-checksums           rmd160  3403b29c38bc4c9ec7e1884d981ce95f18292479 \
-                    sha256  6ceb98a3dc7146ac0cd00a9dd7d6861b70c3ffec2297b3c3e8523e8e3dd9a45a \
-                    size    3342293
+checksums           rmd160  871a0407cfffb39527907e0609b9610f8eaad6ac \
+                    sha256  605c701fb976bcadc3c2486fb48ad3df65f8581e08ad48597d6ef970504815fb \
+                    size    3347970
 
 depends_lib         port:apache2 \
-                    port:php54 \
+                    port:php74 \
                     path:bin/mysql_config5:mysql57 \
-                    port:php54-gd \
-                    port:php54-mbstring
+                    port:php74-gd \
+                    port:php74-mbstring
 
 variant sqlite conflicts postgresql postgresql83 description "use sqlite instead of mysql5" {
-    depends_lib-append      port:php54-sqlite
+    depends_lib-append      port:php74-sqlite
     depends_lib-delete      path:bin/mysql_config5:mysql57
 }
 


### PR DESCRIPTION
`php54` is end-of-life since 2015-09-03; switch to `php74`

#### Description
https://www.drupal.org/project/drupal/releases/7.81
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
