### PR TITLE
nuspell: remove dependency on boost

### DIFF
--- a/textproc/nuspell/Portfile
+++ b/textproc/nuspell/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        nuspell nuspell 4.2.0 v
-revision            0
+revision            1
 
 homepage            https://nuspell.github.io
 
@@ -19,18 +19,20 @@ long_description    Nuspell is a fast and safe spelling checker software \
 
 categories          textproc
 platforms           darwin
-license             LGPL-3
+license             LGPL-3+
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-depends_lib-append  port:boost \
-                    port:icu
+depends_lib-append  port:icu
 
 checksums           rmd160  29e8637a1f986b8c598c3f5028de82960b3108c1 \
                     sha256  5d210a1e1393a56ed94040e7f9417b3b8e47e493264dd5b87d8abbfef5599e39 \
                     size    382702
 
 compiler.cxx_standard 2017
+
+configure.args-append \
+                    -DBUILD_TESTING=OFF
 
 set hunspell_path   ${prefix}/share/hunspell
 


### PR DESCRIPTION
#### Description
This PR removes the incorrect dependency on `boost`, version 4.2.0 does not use this anymore (see [release notes](https://github.com/nuspell/nuspell/blob/4315ac68dee83ca87d8ce7e695c6acb44b9d85a8/CHANGELOG.md#420---2020-12-12)).

Additional changes:
- correct license since upstream allows a later version as well
- supply configure argument to not build the tests

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
