### PR TITLE
nektarpp: Update to 5.0.2, require boost 1.71 using PG

### DIFF
--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -4,9 +4,12 @@ PortSystem              1.0
 PortGroup               cmake 1.1
 PortGroup               mpi 1.0
 PortGroup               gitlab 1.0
+PortGroup               boost 1.0
 
 gitlab.instance         https://gitlab.nektar.info
-gitlab.setup            nektar nektar 5.0.1 v
+gitlab.setup            nektar nektar 5.0.2 v
+
+boost.version           1.71
 
 name                    nektarpp
 
@@ -32,10 +35,10 @@ distfiles               ${main_distfile}:main \
                         tetgen-1.5.zip:thirdparty \
                         triangle-1.6.zip:thirdparty
 
-checksums               nektar-5.0.1.tar.bz2 \
-                        rmd160  95a2af5c1a7d96f64f1ecf387abc1b0ffb943d8e \
-                        sha256  b95d6c54c162633b768b8e797e7f9ef1e2222a28f0ffb0cbd8c9049cfcc27907 \
-                        size    51521684 \
+checksums               nektar-5.0.2.tar.bz2 \
+                        rmd160  1b093fc9616a1b522198d55323da2bbb35315f36 \
+                        sha256  956ad44e400cf50b0aa01955c9568a6c5fa9d1ac5438039a3f1f3d8b88ba4c8b \
+                        size    51514235 \
                         tetgen-1.5.zip \
                         rmd160  d8785f4ca6b26608ec9423f7574a0e736380370a \
                         sha256  52207793198746de14abcb30a0aeed617d7348ff37544e7d7e65aaaa76d7fa70 \
@@ -49,7 +52,8 @@ checksums               nektar-5.0.1.tar.bz2 \
 # third-party dependencies.
 extract.only            ${main_distfile}
 
-patchfiles              no-homebrew.patch
+patchfiles              no-homebrew.patch \
+                        fusion-copy-constructor.patch
 
 compiler.cxx_standard   2011
 cmake.build_type        Release
@@ -57,7 +61,6 @@ cmake.build_type        Release
 mpi.setup
 
 depends_lib-append      port:arpack \
-                        port:boost \
                         port:fftw-3 \
                         port:opencascade \
                         port:scotch \
@@ -136,7 +139,7 @@ foreach s ${pythons_suffixes} {
     variant ${p} description "Build the Python ${v} bindings" conflicts {*}${c} "
         depends_lib-append      port:${p} \
                                 port:py${s}-numpy \
-                                port:boost-numpy
+                                port:boost[boost::version_nodot]-numpy
 
         configure.args-append   -DNEKTAR_BUILD_PYTHON=ON \
                                 -DNEKTAR_PYTHON3_STATUS=ON \

--- a/science/nektarpp/files/fusion-copy-constructor.patch
+++ b/science/nektarpp/files/fusion-copy-constructor.patch
@@ -1,0 +1,12 @@
+Patch issue with missing copy constructor.
+--- library/LibUtilities/BasicUtils/ParseUtils.cpp.orig
++++ library/LibUtilities/BasicUtils/ParseUtils.cpp
+@@ -56,6 +56,8 @@ struct PushBackFunctor
+ {
+     PushBackFunctor(std::vector<T> &in) : m_vec(in) {}
+ 
++    PushBackFunctor(const PushBackFunctor &in) : m_vec(in.m_vec) {}
++
+     /**
+      * @brief Pushes back values onto #m_vec as given by @p num.
+      */


### PR DESCRIPTION
#### Description

Update nektar++ version to 5.0.2, switch to boost 1.71 using new boost PG.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->