### PR TITLE
logcat-colorize: migrate to boost PG

### DIFF
--- a/devel/logcat-colorize/Portfile
+++ b/devel/logcat-colorize/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
+PortGroup           boost 1.0
 
 github.setup        carlonluca logcat-colorize 0.10.0 v
-revision            0
+revision            1
 github.tarball_from archive
 license             Apache-2
 categories          devel
@@ -19,8 +20,7 @@ long_description    logcat-colorize is a parser for the output of the \
 checksums           rmd160  f246db541822e9336e1d67326b355aa1676de558 \
                     sha256  f50428e81c343944660522b31faad3857c8e7b3207c4d258a9cb41513f820a02 \
                     size    789935
-depends_lib         port:boost
 compiler.cxx_standard \
                     2011
 build.target
-build.args-append   BOOSTDIR=${prefix}
+build.args-append   BOOSTDIR=[boost::install_area]


### PR DESCRIPTION
#### Description

Migrate to boost PG.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?