### PR TITLE
gocryptfs: new port

### DIFF
--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -1,0 +1,151 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+PortGroup           fuse 1.0
+
+go.setup            github.com/rfjakob/gocryptfs 2.0.1 v
+revision            0
+
+categories          fuse
+maintainers         {bochtler.io:macports @MarcelBochtler} \
+                    openmaintainer
+license             MIT
+platforms           darwin
+description         Encrypted overlay filesystem written in Go
+long_description    ${description}
+homepage            https://nuetzlich.net/gocryptfs/
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  9a14c4c28f1c5dc9870f8ac4fed689df085c01dd \
+                        sha256  081780386c64c52fa85c16f6b4b149e39a25b41d28e9c14aeff70c1a3a40e85a \
+                        size    1346999
+
+set gitversionfuse  "62c5aa1919a7"
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    gopkg.in/check.v1 \
+                        lock    20d25e280405 \
+                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
+                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
+                        size    30360 \
+                    golang.org/x/sys \
+                        lock    bc7a7d42d5c3 \
+                        rmd160  4129d5e430533da9682b13d9c5d36ff1dca5e4d7 \
+                        sha256  a3ce9da1a5661d4d6dd758f7535c2a9454f8e092a771fbcb133d820a029b2651 \
+                        size    1053520 \
+                    golang.org/x/net \
+                        lock    d3edc9973b7e \
+                        rmd160  b08d361eb4650a79a1dfe28a7952f47c7c91be24 \
+                        sha256  d756ad97da46b0ac38910edc052b9cb7b26eb2ae44faa34f5bab2c379aae2ba8 \
+                        size    1174398 \
+                    golang.org/x/crypto \
+                        lock    4b2356b1ed79 \
+                        rmd160  9626217915a27506de4cc7c3d57bf8cf25cd042f \
+                        sha256  cdc724a31e0ea3a638f365d667cb66c8ff49aaaac9f0e82fddde5ef267bba0af \
+                        size    1728714 \
+                    github.com/stretchr/testify \
+                        lock    v1.5.1 \
+                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
+                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
+                        size    78702 \
+                    github.com/sabhiram/go-gitignore \
+                        lock    d3107576ba94 \
+                        rmd160  0ac0382d1570aa565b546ef0a0ac1e89779677ad \
+                        sha256  8d8a491e6a894f0cf1999e9003f36510d33b032ef7b5da4ad4fb2cf23e6554cd \
+                        size    7608 \
+                    github.com/rfjakob/eme \
+                        lock    v1.1.1 \
+                        rmd160  6a0da855d02259b13b2a3c3eedb28684d77e5b7d \
+                        sha256  f078b25e14f5ccfd70fd3193bad07df2fc59f027f0a365933e47bdadefabb7e9 \
+                        size    23424 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/xattr \
+                        lock    v0.4.1 \
+                        rmd160  5e94780d05150c19b5a97136811d8ffc1466f604 \
+                        sha256  86800e346c68162119293586010f32bcac20344293b97755ef4f11a1191b3c05 \
+                        size    8307 \
+                    github.com/kylelemons/godebug \
+                        lock    d65d576e9348 \
+                        rmd160  929cd615eff16a0c5ba2145b809b10016587a387 \
+                        sha256  9cbb2db613bd3a62e2e3f39776c690fb0d2c320d2aa5391868ad16d2de28c10c \
+                        size    14796 \
+                    github.com/jacobsa/reqtrace \
+                        lock    245c9e0234cb \
+                        rmd160  872beac620d3eebbc1a343d1d2ca65f2dc6778bd \
+                        sha256  e8ca3f8de13ce0f35c1cb2bb9c9be220c82f28a0a1ca80557e2afbbdf396a0c4 \
+                        size    7808 \
+                    github.com/jacobsa/ogletest \
+                        lock    80d50a735a11 \
+                        rmd160  d839d0d084bc62e25d23d65cee882b427b537c00 \
+                        sha256  8e9eef43d47e4fc12b6e614bd6c97d102eabec107eabe72493763d45325501fd \
+                        size    24200 \
+                    github.com/jacobsa/oglemock \
+                        lock    e94d794d06ff \
+                        rmd160  cee16f043ba80e59483d3bfadf783077f8239110 \
+                        sha256  5474b9f5228d6eda866293feb9c07729a55195fabd2cd77cd1c30e5291830ad9 \
+                        size    35506 \
+                    github.com/jacobsa/oglematchers \
+                        lock    141901ea67cd \
+                        rmd160  5c5dd8416ee4a236632eaa4fc1a1e5ce737eee45 \
+                        sha256  4a45ac5d5b5c15af45761f15e3e14f4739b1cd79cd9493ddcd4744f65edc4b52 \
+                        size    43827 \
+                    github.com/jacobsa/crypto \
+                        lock    9f44e2d11115 \
+                        rmd160  0cbf3ba64ed7e4a65ad9e5083efe103deb2137f7 \
+                        sha256  8c230508b648a74dfecf86015965bd89c78b98a2e5988ee7ab538940db078390 \
+                        size    3653945 \
+                    github.com/hanwen/go-fuse \
+                        lock    ${gitversionfuse} \
+                        rmd160  60efe988c58e58c307bf86e3271ea7c419cd19eb \
+                        sha256  6fd20e10d9b30020f1cdee312c2906f85904894858bcd9248cf36e5912f2022f \
+                        size    204291 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.0 \
+                        rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \
+                        sha256  810a597004388d68bb92d8aa612375419ba1080dd5fc2c66dd41b58f0ba4442c \
+                        size    42348
+
+# Build date should not be set to a variable value as this would prevent reproducible builds.
+# Not setting it results in defaulting to '0000-00-00' when using the --version flag.
+set builddate       "build_date_not_set"
+set ldflags         "-X \"main.GitVersion=${version}\" -X \"main.GitVersionFuse=${gitversionfuse}\" -X \"main.BuildDate=${builddate}\""
+
+depends_build-append \
+                    port:pandoc
+
+build.args          -ldflags="${ldflags}"
+
+# According to [1] there is no benefit to build gocryptfs with openssl on M1 Macs.
+# According to [2] on most modern CPUs openssl provides no speed benefits. I confirmed this by tests on
+# my Intel i7 Macbook Pro 2019. Therefore reducing the dependencies and defaulting to build it without openssl.
+# [1]: https://github.com/rfjakob/gocryptfs/issues/556#issuecomment-848185514
+# [2]: https://github.com/rfjakob/gocryptfs/wiki/CPU-Benchmarks
+variant openssl description {Build with openssl support} {
+    depends_lib-append  path:lib/libcrypto.dylib:openssl
+}
+
+if {![variant_isset openssl]} {
+    build.env           CGO_ENABLED=0
+    build.args-append   -tags without_openssl
+}
+
+post-build {
+    system -W ${worksrcpath}/Documentation "sh MANPAGE-render.bash"
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${worksrcpath}/Documentation/gocryptfs.1 ${destroot}${prefix}/share/man/man1
+    xinstall -m 0755 ${worksrcpath}/Documentation/gocryptfs-xray.1 ${destroot}${prefix}/share/man/man1
+    xinstall -m 0755 ${worksrcpath}/Documentation/statfs.1 ${destroot}${prefix}/share/man/man1
+}
+
+github.livecheck.regex (v\\d+\\.\\d+(\\.\\d+)?)


### PR DESCRIPTION
#### Description

Add gocryptfs an encrypted overlay filesystem written in Go.

Resolves https://trac.macports.org/ticket/59623

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?


