### PR TITLE
gopass: Update to 1.12.6

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.10.1 v
+go.setup            github.com/gopasspw/gopass 1.12.6 v
 categories          security
 maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 license             MIT
@@ -12,10 +12,12 @@ description         The slightly more awesome Standard Unix Password Manager for
 long_description    {*}${description}
 homepage            https://www.gopass.pw
 
+depends_lib-append  port:gnupg2
+
 checksums           ${distname}${extract.suffix} \
-                        rmd160  2542e8efd52e32d9c29d668acb55b1e50aa3ab96 \
-                        sha256  43db894eaa2f123269ffdc0178bb93ec5cdae043f78c35cf15a17fa476e07a1e \
-                        size    475938
+                        rmd160  aebe3ed87e58779368143d40391cd64cd57898c6 \
+                        sha256  e4f4db9707baab3ee85e40dd11bb092c51b444ecc85d72aa9867a7a9f57029ce \
+                        size    2172856
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -30,20 +32,10 @@ go.vendors          rsc.io/qr \
                         sha256  9b17efa7751a66942c72f54e62716574bc34561bdcdaf8337bea3612e85a7025 \
                         size    61955 \
                     gopkg.in/yaml.v3 \
-                        lock    eeeca48fe776 \
-                        rmd160  fa7f02bf2d79fd300b4db2107596674b41479412 \
-                        sha256  33580a955d8c31b781de66dbc7a3c9940ab842a39eb3eb92e696a82307f7d570 \
-                        size    88775 \
-                    gopkg.in/yaml.v2 \
-                        lock    v2.3.0 \
-                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
-                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
-                        size    72838 \
-                    gopkg.in/ini.v1 \
-                        lock    v1.57.0 \
-                        rmd160  d9421555b1f9a82bc62fe56b99bd291c040d3d58 \
-                        sha256  044b205ad0bcc0500c3b52e7b2700db1994c9428f1fe4b4b8668195cba6026e1 \
-                        size    48422 \
+                        lock    496545a6307b \
+                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
+                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
+                        size    90145 \
                     gopkg.in/check.v1 \
                         lock    8fa46927fb4f \
                         rmd160  c84f37dc900224c5e9e6e16ed5acc0d625583bc1 \
@@ -51,85 +43,76 @@ go.vendors          rsc.io/qr \
                         size    31616 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.25.0 \
-                        rmd160  ca1a78077118747c660917e50c4273d69b0f04ea \
-                        sha256  5bc3eb5d7160ab9ae45255d6b718c1cf9e9ed80c244b7527bced50370ae18620 \
-                        size    1259096 \
+                        lock    f2d1f6c \
+                        rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
+                        sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
+                        size    1270531 \
+                    google.golang.org/appengine \
+                        repo    github.com/golang/appengine \
+                        lock    v1.6.7 \
+                        rmd160  32e6de431630b8126df1d04e36eba2abb57626f1 \
+                        sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
+                        size    333026 \
                     golang.org/x/xerrors \
                         lock    5ec99f83aff1 \
                         rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
-                    golang.org/x/text \
-                        lock    v0.3.3 \
-                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
-                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
-                        size    7745597 \
+                    golang.org/x/term \
+                        lock    72f3dc4e9b72 \
+                        rmd160  1427b5158f35c3f52a9db9c627d0234c15883561 \
+                        sha256  4cd03aeed351110019c384f469fde517b7e506285bd82147611d9d461ba0b30b \
+                        size    15007 \
                     golang.org/x/sys \
-                        lock    1030fc2bf1d9 \
-                        rmd160  e2ec51a20810f433fb425c722c7c1cdb0cff6b56 \
-                        sha256  bfa31b28391b0be6f37b9a9371405d2fe3920b3fdf5d8f1408d858f25db1829a \
-                        size    1058430 \
+                        lock    37df388d1f33 \
+                        rmd160  8b8d8283c49539d82519ae2ab8a956f52dc4dc26 \
+                        sha256  755b9c1befa705fec85a4381faa474cb0435bb7b0a28f2e969d5a62c66339753 \
+                        size    1219510 \
+                    golang.org/x/oauth2 \
+                        lock    5e61552d6c78 \
+                        rmd160  83dc2e1f196d85fc3f81b0a419f9cfc6b99bd1f5 \
+                        sha256  5e2d7cec4d0de80a086551a8b1443ebd8caaa094388c64d01076454f5ce85aca \
+                        size    78978 \
                     golang.org/x/net \
-                        lock    ab3426394381 \
-                        rmd160  e74cee73965d58ff027e1ba0e0131f9630125409 \
-                        sha256  49fe6598268f2cc9b50dea06a00f5c03c71a54d2893ebf9fbfa193486b65cd83 \
-                        size    1177682 \
+                        lock    e915ea6b2b7d \
+                        rmd160  c50582099618a5484b843bd9ec9951d7faa10016 \
+                        sha256  39758186bcf8fab55e659434e0b9e3a7c31445e4be0c6ad4de02044876d9ac57 \
+                        size    1249423 \
                     golang.org/x/crypto \
-                        lock    123391ffb6de \
-                        rmd160  4afdc76f139facd878c228d85dee3698de13f793 \
-                        sha256  1b8f464f2d4faca0ac6ac7eac18b2b1118c1ac9ff8f6b7ffc976fb0ebedc520f \
-                        size    1732579 \
+                        lock    4f45737414dc \
+                        rmd160  bcb326a0dae5b4b3e09c9813124af96df85c7088 \
+                        sha256  415ceaf7f4f678acdf9eeab47f7faf96a501e98d9f3eebe263d7c532d32af3e7 \
+                        size    1726572 \
                     github.com/xrash/smetrics \
-                        lock    89a2a8a1fb0b \
-                        rmd160  350ca8872823c2d934da9a0da957e1d373542d92 \
-                        sha256  565b0a0b533971f54a767d0709b8370e92f4919f0df83552c2d45ef5f13c95ce \
-                        size    1823868 \
+                        lock    039620a65673 \
+                        rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
+                        sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
+                        size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.2.0 \
-                        rmd160  4a6ffb4a39be12c9239c971e0faa5118206066ad \
-                        sha256  b7bfbd0ff7fdedb839dec9b56d026fc6bcc4db534e3bb9fce3a9da6604945818 \
-                        size    3404076 \
+                        lock    v2.3.0 \
+                        rmd160  fec9e73bc45d02b2afe43e8d9c76398722494e4b \
+                        sha256  3138857026c9564559b3e734b9b8abfeda57354fc4aa87717879882bff68ef09 \
+                        size    3408338 \
                     github.com/stretchr/testify \
-                        lock    v1.6.1 \
-                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
-                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
-                        size    84248 \
-                    github.com/smartystreets/goconvey \
-                        lock    v1.6.4 \
-                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
-                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
-                        size    1478824 \
-                    github.com/smartystreets/assertions \
-                        lock    v1.0.0 \
-                        rmd160  8fedd5565a5283a7708236397595879588dc9787 \
-                        sha256  0d65770741aba0134c82bdc4a8a7192ca2e17b4f0ea6d9785b811a1c97c8c06f \
-                        size    84426 \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
                     github.com/skip2/go-qrcode \
                         lock    da1b6568686e \
                         rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
                         sha256  28f73bbd2c7f78308c9189c5c8abb2a329b3e02f11dec7a54254c457630ad581 \
                         size    36689 \
-                    github.com/shurcooL/sanitized_anchor_name \
-                        lock    v1.0.0 \
-                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
-                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
-                        size    2144 \
-                    github.com/sergi/go-diff \
-                        lock    v1.1.0 \
-                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
-                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
-                        size    43569 \
                     github.com/schollz/closestmatch \
                         lock    1fbe626be92e \
                         rmd160  0c09dba0d527a6046585125a6fb2a93bc08c635c \
                         sha256  52174a0c7551cbaeb0253dd9a00506e285877fe2cb464c6c79dcf65ed02f7ec9 \
                         size    623995 \
                     github.com/russross/blackfriday \
-                        lock    v2.0.1 \
-                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
-                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
-                        size    79665 \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -146,25 +129,15 @@ go.vendors          rsc.io/qr \
                         sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
                         size    9405 \
                     github.com/nbutton23/zxcvbn-go \
-                        lock    ae427f1e4c1d \
-                        rmd160  6649ad02c877632f50bd7c713fe98359fa307f71 \
-                        sha256  5cad3f266a9c9882c83c103e38b32179c4a0087dbac9f13a84d09484468a670c \
-                        size    980120 \
+                        lock    fa2cb2858354 \
+                        rmd160  17c2ab9843836ee904acced65d6d22f13a4b614c \
+                        sha256  5f33a658c9daf086423450a9ad27297f7589ce58c1e4ddff3bb623ef8da276ae \
+                        size    881860 \
                     github.com/muesli/crunchy \
                         lock    v0.4.0 \
                         rmd160  3029073bbcf95a9154c93b01803f3b48d7a3ec7e \
                         sha256  039c5f45b9d1f7a02562cad503749bce7820d510657f720d2db2ea593093d438 \
                         size    7791 \
-                    github.com/modern-go/reflect2 \
-                        lock    v1.0.1 \
-                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
-                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
-                        size    14407 \
-                    github.com/modern-go/concurrent \
-                        lock    bacd9c7ef1dd \
-                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
-                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
-                        size    7533 \
                     github.com/mitchellh/go-ps \
                         lock    v1.0.0 \
                         rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
@@ -175,31 +148,16 @@ go.vendors          rsc.io/qr \
                         rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
                         sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
                         size    3366 \
-                    github.com/minio/sha256-simd \
-                        lock    v0.1.1 \
-                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
-                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
-                        size    65042 \
-                    github.com/minio/minio-go \
-                        lock    v6.0.57 \
-                        rmd160  d401b7f4def782f30507795ae600515d43b98b2f \
-                        sha256  c677a90c3972340a817eadef6c27904d0bf6f408a6c7e02dc55c9e4e1eb5b079 \
-                        size    220801 \
-                    github.com/minio/md5-simd \
-                        lock    v1.1.0 \
-                        rmd160  7929f1dc43d777a143a826c47948490d8ed121e0 \
-                        sha256  49d89141ce43f38098b264acf3b3d9341d553a1f82816485f1c036e18deb2b58 \
-                        size    99242 \
                     github.com/mattn/go-isatty \
                         lock    v0.0.12 \
                         rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
                         sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
                         size    4549 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.7 \
-                        rmd160  47f774c77efaa0bbcd982cb65bed426d047780ba \
-                        sha256  68de4e31d97da97efc400096c599ea37c6cf1cb91501004f05a1017f4653f926 \
-                        size    9570 \
+                        lock    v0.1.8 \
+                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
+                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
+                        size    9576 \
                     github.com/martinhoefling/goxkcdpwgen \
                         lock    7dc3d102eca3 \
                         rmd160  f8b32dbe86765d33f5f6e57cc3047f6951bd6957 \
@@ -210,26 +168,11 @@ go.vendors          rsc.io/qr \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
                         sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
                         size    8702 \
-                    github.com/klauspost/cpuid \
-                        lock    v1.3.1 \
-                        rmd160  0c161f6a90600c80e908141c2a81130ba703307e \
-                        sha256  8db60afc9f494af07150fff47e676377588d36fb5ee3cc181ec59ff35c238c79 \
-                        size    367163 \
                     github.com/kballard/go-shellquote \
                         lock    95032a82bc51 \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
                         sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
                         size    4335 \
-                    github.com/jtolds/gls \
-                        lock    v4.20.0 \
-                        rmd160  31d8656bd6c1426338ceaac9535198244248b254 \
-                        sha256  04069406ca336d355eab62b4ab9e84b820ac968ac1e20bd3777efec2d3843446 \
-                        size    7305 \
-                    github.com/json-iterator/go \
-                        lock    v1.1.10 \
-                        rmd160  963a70cf0a7d056f6b00fb2224687895612a35e2 \
-                        sha256  e82947d6f32c1cf730c796409eabc8051c208c2eafabe793d196d448529a7f0f \
-                        size    83377 \
                     github.com/jsimonetti/pwscheme \
                         lock    76804708ecad \
                         rmd160  88e53d2efe5fafd457fd5a101b6ba9b58353a1bf \
@@ -241,40 +184,40 @@ go.vendors          rsc.io/qr \
                         sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
                         size    13435 \
                     github.com/hashicorp/go-multierror \
-                        lock    v1.1.0 \
-                        rmd160  868d9a6f0732cba1b2dfbb73556b6a194c797c03 \
-                        sha256  9bd88c4f96aa4c4dcca5c0124e48f540c59754586653924b5e4b7de3af0f8c4a \
-                        size    12091 \
+                        lock    v1.1.1 \
+                        rmd160  94493cc3074dc39be0de76f04fa2a44a405d0a42 \
+                        sha256  52e986cca6d6335bfcd23b4867f884311cfb5ca060325496b6692029797d64e2 \
+                        size    13805 \
                     github.com/hashicorp/errwrap \
-                        lock    v1.0.0 \
-                        rmd160  d9bf75f667d7bec9b4b11ca34de7ca722495b914 \
-                        sha256  49e80cf52f294ce69fcc8cd26f06b8d8cee2623f6e0012df871b355fb7b17787 \
-                        size    8351 \
-                    github.com/gopherjs/gopherjs \
-                        lock    0766667cb4d1 \
-                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
-                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
-                        size    217261 \
+                        lock    v1.1.0 \
+                        rmd160  25e655fc958685dd949900eea8c3d97f33d85eab \
+                        sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
+                        size    8586 \
+                    github.com/gopasspw/pinentry \
+                        lock    v0.0.2 \
+                        rmd160  c15d7e73f53a29be1322a9e8858caeb9f4cb3ff9 \
+                        sha256  6f7d313a77b7f38c904bced510cadaa5f82f8a005325519797778212a70215cc \
+                        size    3133 \
                     github.com/google/go-querystring \
-                        lock    v1.0.0 \
-                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
-                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
-                        size    7536 \
+                        lock    v1.1.0 \
+                        rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
+                        sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
+                        size    10418 \
                     github.com/google/go-github \
-                        lock    v17.0.0 \
-                        rmd160  2c1917adfc161a2252354d558352180079005d8d \
-                        sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
-                        size    212064 \
+                        lock    v33.0.0 \
+                        rmd160  a4f9b14f9a388303fb72a03539b538512435f243 \
+                        sha256  a053e731deda2d4baf00b362a8f55f7eeac5528115468013aeccb4acf05f2bd3 \
+                        size    397048 \
                     github.com/google/go-cmp \
-                        lock    v0.5.1 \
-                        rmd160  f557725ca7d868edfc5d70b1d69bd33570ef5c81 \
-                        sha256  e2c3dc6f5e6e07e5034cad315b76919ee7a7dbdf122ff76eeabd2d8b719a3d57 \
-                        size    99629 \
+                        lock    v0.5.5 \
+                        rmd160  5caef57da3ce09c102ed270168afa2a5200c2c47 \
+                        sha256  be284023d91976ef03d13cb5670e338c09a0a0da9925d7de457f44e33aebb724 \
+                        size    102365 \
                     github.com/golang/protobuf \
-                        lock    v1.4.2 \
-                        rmd160  fbf4477bc008421fde463d79f7bc54a36de91db2 \
-                        sha256  206d74f8fd066bb178135ee9c092e986f8a1e1104df242e148e99e5a839e4ef2 \
-                        size    171802 \
+                        lock    v1.5.2 \
+                        rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
+                        sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
+                        size    171736 \
                     github.com/gokyle/twofactor \
                         lock    v1.0.1 \
                         rmd160  639cb3e1e214c43cd212bbec6faae070a2acbc4c \
@@ -286,15 +229,10 @@ go.vendors          rsc.io/qr \
                         sha256  54c06c5988808eca9affe01cabe122e02ba4af5763f29fff1c341dce1424aa21 \
                         size    62423 \
                     github.com/fatih/color \
-                        lock    v1.9.0 \
-                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
-                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
-                        size    1231337 \
-                    github.com/dominikschulz/github-releases \
-                        lock    v0.0.3 \
-                        rmd160  eeda323288295e66045e21fe0bf27e151fbd67ea \
-                        sha256  2e134b870e1ba46cf42d2c914013c6a98f0c19f4e30ff071aeb2c48606b3c58c \
-                        size    2162 \
+                        lock    v1.10.0 \
+                        rmd160  d33ae416337f02c181700fe76c05aec814791423 \
+                        sha256  2caf3481614a1a3dcbec15506d9549867a8538e60a8f3d057a619557ec6faa9b \
+                        size    1267972 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
@@ -305,11 +243,6 @@ go.vendors          rsc.io/qr \
                         rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
                         sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
                         size    52040 \
-                    github.com/client9/misspell \
-                        lock    v0.3.4 \
-                        rmd160  35b385cb5e39e9505eccbca18ffa2799240710be \
-                        sha256  8193021639e3f4f30db19cb469ac7f43d56d2200eb7749fd868a69319f95fcf1 \
-                        size    239605 \
                     github.com/chzyer/test \
                         lock    a1ea475d72b1 \
                         rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
@@ -336,31 +269,21 @@ go.vendors          rsc.io/qr \
                         sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
                         size    6334 \
                     github.com/blang/semver \
-                        lock    1a9109f8c4a1 \
-                        rmd160  b4ebb77c1acc4a111b6f947b959678d88685b475 \
-                        sha256  db45cea3471269c894f1ad024826047b6175f1b87b0c71ac4b12180608a3e07a \
-                        size    15415 \
+                        lock    v4.0.0 \
+                        rmd160  ab0e0d974dcbc784840d4bcc76584242436c51fa \
+                        sha256  bf4d622c039173a4e0903738d8b5c788c3c63bb8cfa7485611f38aece3504d0f \
+                        size    27781 \
                     github.com/atotto/clipboard \
-                        lock    v0.1.2 \
-                        rmd160  4a0617ed814da771a9701f36b2be950301e153df \
-                        sha256  d3923f2514644b13032c76bf75fd66ef4e581afd8a86e186a300d1da12f688b3 \
-                        size    4476 \
-                    github.com/alecthomas/binary \
-                        lock    fb1b1d9c299c \
-                        rmd160  8757238e059f322ce724d9f18e42ccd2c6de5b55 \
-                        sha256  4c9dcedb409590df9c9c5b3977d423b39ec12a705396a66a4d6cfec0cd8d7399 \
-                        size    4410 \
-                    github.com/BurntSushi/toml \
-                        lock    v0.3.1 \
-                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
-                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
-                        size    42087 \
+                        lock    v0.1.4 \
+                        rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
+                        sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
+                        size    5023 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
-                        lock    v1.0.0-beta4 \
-                        rmd160  40729805449116617866c1b16cf4e588f752a3b3 \
-                        sha256  f0525db9eba63f3163ce8374b9e7f1cf4851bb424d3470db0d04646060879790 \
-                        size    36023
+                        lock    v1.0.0-rc.1 \
+                        rmd160  10a37fc487515eccc4844cd7e1ccd21fbb97a17c \
+                        sha256  b283719783aebee710ca0cd40cdf1348bfb2a3566d498c794321b7aff18e0bc4 \
+                        size    47017
 
 set go_ldflags      "-s -w -X main.version=${version}"
 build.args          -ldflags \"${go_ldflags}\"


### PR DESCRIPTION
#### Description
See: https://github.com/gopasspw/gopass/releases/tag/v1.12.6.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
