### PR TITLE
git: update to 2.32.0

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.31.1
-revision            2
+version             2.32.0
+revision            0
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -24,13 +24,13 @@ distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}.tar.xz \
-                    rmd160  98b31ed7a2d36160c99e924a4d9c9636af59c4f5 \
-                    sha256  9f61417a44d5b954a5012b6f34e526a3336dcf5dd720e2bb7ada92ad8b3d6680 \
-                    size    6413368 \
+                    rmd160  f09cbd4baea0051bc9f0364c4a75be476e37a86f \
+                    sha256  68a841da3c4389847ecd3301c25eb7e4a51d07edf5f0168615ad6179e3a83623 \
+                    size    6551348 \
                     git-manpages-${version}.tar.xz \
-                    rmd160  35cac47de1c8dda0dc1c16ab65a1158015e15959 \
-                    sha256  5d0d443c57155da2f201584d4c8c5ad10a0a24ff3af3a7a77cdc8f56dddac702 \
-                    size    487784
+                    rmd160  3f1b7d3946961aa5d25e62674e73d3b681dc6b0e \
+                    sha256  19e3cb0425c94d4ad82984f41522e77c8e35093e15a891f8e7195617201f6ac1 \
+                    size    491868
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
@@ -143,9 +143,9 @@ variant pcre description {Use pcre} {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}.tar.xz \
-                            rmd160  621b1b07a680fe8603007f90986dd5140581e867 \
-                            sha256  ae94a6b128d1972a8b4041af9fc529ece96a9f2a13952ff843262ccb7bc1642c \
-                            size    1357592
+                            rmd160  77e0a51bb2ed0e4a2bc2550808ab367682d5c6ee \
+                            sha256  821bd3b5dfd31040bf9ed38ef02df3dcf063546127f07d59ec9669274e8b8818 \
+                            size    1381664
 
     patchfiles-append       patch-git-subtree.html.diff
 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
