### PR TITLE
macfuse: codesign binaries for arm64

### DIFF
--- a/fuse/macfuse/Portfile
+++ b/fuse/macfuse/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        osxfuse osxfuse 4.1.2 macfuse-
+revision            1
 name                macfuse
 conflicts           osxfuse
 categories          fuse
@@ -46,16 +47,16 @@ post-extract {
 use_configure       no
 
 build {
-    system -W ${pkg} "codesign --remove-signature \
-        usr/local/lib/libfuse.2.dylib \
-        Library/Frameworks/macFUSE.framework/Versions/A/macFUSE"
-
     system -W ${pkg} "install_name_tool -id ${prefix}/lib/libfuse.2.dylib \
         usr/local/lib/libfuse.2.dylib"
 
     system -W ${pkg} "install_name_tool \
         -id ${prefix}/Library/Frameworks/macFUSE.framework/Versions/A/macFUSE \
         -change /usr/local/lib/libfuse.2.dylib ${prefix}/lib/libfuse.2.dylib \
+        Library/Frameworks/macFUSE.framework/Versions/A/macFUSE"
+
+    system -W ${pkg} "codesign -fs - \
+        usr/local/lib/libfuse.2.dylib \
         Library/Frameworks/macFUSE.framework/Versions/A/macFUSE"
 }
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/63019

###### Type(s)

- [x] bugfix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?