### PR TITLE
gmt6: update to 6.2.0

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -10,8 +10,8 @@ github.tarball_from releases
 distname            ${github.project}-${github.version}-src
 revision            9
 subport gmt6 {
-    github.setup    GenericMappingTools gmt 6.1.1
-    revision        2
+    github.setup    GenericMappingTools gmt 6.2.0
+    revision        0
     epoch           1
 }
 categories          science
@@ -43,9 +43,9 @@ if {${subport} eq "gmt5"} {
                         sha256  078d4997507cb15344c74a874568985e45bdbd6d3a72d330c74c47f4c0359bb1 \
                         size    59175704
 } else {
-    checksums           rmd160  cbedfd353f7d6b38c9e6625f02129da4f655e365 \
-                        sha256  d476cba999340648146ef53ab4a3f64858cbd2f5511cdec9f7f06f3fb7896625 \
-                        size    54252072
+    checksums           rmd160  2818673fdde5e1187a3c7e70028833ebc817dcc8 \
+                        sha256  a01f0a14d48bbc0b14855670f366df3cb8238f0ccdfa26fe744968b4f1c14d54 \
+                        size    56104264
 }
 
 depends_lib         port:curl \


### PR DESCRIPTION
#### Description

This simply updates gmt6 to version 6.2.0 and resets the revision to 0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1
Xcode 12.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
