### PR TITLE
keystore-explorer: fix livecheck

### DIFF
--- a/security/keystore-explorer/Portfile
+++ b/security/keystore-explorer/Portfile
@@ -54,4 +54,4 @@ destroot {
 # run livecheck against upstream
 livecheck.version       ${version}
 livecheck.url           https://github.com/kaikramer/keystore-explorer/tags
-livecheck.regex         "archive/v${github.livecheck.regex}.tar.gz"
+livecheck.regex         "archive/refs/tags/v${github.livecheck.regex}.tar.gz"


### PR DESCRIPTION
###### Tested on

macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?