### PR TITLE
nheko, openimageio, openal-soft, poppler, xaos: compiler blacklist cleanup

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.1
-PortGroup               compiler_blacklist_versions 1.0
 if {${subport} eq "openal-soft" && [variant_isset gui]} {
 PortGroup               qt5 1.0
 }
@@ -47,13 +46,6 @@ depends_lib-append      port:libmysofa \
 
 compiler.cxx_standard   2014
 compiler.thread_local_storage   yes
-
-# Fix for incorrect MacPorts compiler selection, tracked by:
-# https://trac.macports.org/ticket/61418
-# Ticket specific to openal-soft build errors, caused by the former:
-# https://trac.macports.org/ticket/61431
-compiler.blacklist      \
-                        {clang < 800.0.38}
 
 configure.args-append   -DALSOFT_EXAMPLES=OFF \
                         -DALSOFT_UTILS=ON \

--- a/graphics/openimageio/Portfile
+++ b/graphics/openimageio/Portfile
@@ -28,8 +28,6 @@ compiler.cxx_standard   2014
 # http://lists.llvm.org/pipermail/llvm-bugs/2013-November/031552.html
 # Seen on OSX 10.9 and older.
 compiler.blacklist-append {clang < 700}
-# error: thread-local storage is not supported for the current target
-compiler.blacklist-append {clang < 800}
 # OpenVDB header files use C++14 features
 configure.args-append   -DCMAKE_CXX_STANDARD=14
 

--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           gobject_introspection 1.0
 PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
@@ -60,8 +59,6 @@ gobject_introspection yes
 compiler.cxx_standard 2014
 compiler.c_standard 1999
 compiler.thread_local_storage yes
-# Apple clang < 800.0.38 does not really support thread local storage
-compiler.blacklist-append {clang < 800.0.38}
 
 patchfiles-append   patch-check-boost.diff
 

--- a/graphics/xaos/Portfile
+++ b/graphics/xaos/Portfile
@@ -4,7 +4,6 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               qmake5 1.0
 PortGroup               legacysupport 1.1
-PortGroup               compiler_blacklist_versions 1.0
 
 github.setup            xaos-project XaoS 4.2.1 release-
 revision                1
@@ -50,7 +49,6 @@ qt5.min_version         5.7
 compiler.thread_local_storage yes
 
 compiler.cxx_standard   2011
-compiler.blacklist-append { clang < 800 }
 
 destroot {
     # See tools/deploy-mac for the origin of the following four steps:

--- a/net/nheko/Portfile
+++ b/net/nheko/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           qt5 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        nheko-reborn nheko 0.7.2 v
 categories          net chat
@@ -23,9 +22,6 @@ checksums           rmd160  67e1790fabb3105c6ea19bdf04a2bfd4151b94a0 \
 
 compiler.cxx_standard  2014
 compiler.thread_local_storage yes
-
-# keep this until https://trac.macports.org/ticket/61418 is resolved
-compiler.blacklist-append {clang < 800.0.38}
 
 if {(${os.major} < 16)} {
     pre-fetch {


### PR DESCRIPTION
nheko, openimageio, openal-soft, poppler:
macports/macports-base#214 included in MacPorts 2.7.0 (released over two weeks ago) 
See: https://trac.macports.org/ticket/61418

xaos: compiler blacklist is redundant due to
macports/macports-base#161

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
