### PR TITLE
Update libfmt (6.2.0) -> (7.1.3)

### DIFF
--- a/devel/libfmt/Portfile
+++ b/devel/libfmt/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake  1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           conflicts_build 1.0
 
-github.setup        fmtlib fmt 6.2.0
+github.setup        fmtlib fmt 7.1.3
 name                libfmt
 homepage            https://fmt.dev
 categories          devel
@@ -19,9 +19,9 @@ long_description    \
     fmt (formerly cppformat) is an open-source formatting library. \
     It can be used as a safe alternative to printf or as a fast alternative to C++ IOStreams.
 
-checksums           rmd160  f889aa1482832a170cabf73625092c123d65d1d8 \
-                    sha256  ad53b9cb55bf3d4199766a399ae8ff2ea4ea72b462205f7afc464d770d5e1e47 \
-                    size    733517
+checksums           rmd160  f3a0e347258ace0101949ebff8af8cc47c3b43b8 \
+                    sha256  7a60502080a9ecbda829098dacb1d73d31145f3b469eeff0633b359b343d2084 \
+                    size    770117
 
 conflicts_build     gtest
 


### PR DESCRIPTION
#### Description

Updates libfmt to 7.1.3, which also resolves [Issue 61352](https://trac.macports.org/ticket/61352).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.3.1 20E241 arm64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?