### PR TITLE
exim: another attempt to fix 10.11 build

### DIFF
--- a/mail/exim/Portfile
+++ b/mail/exim/Portfile
@@ -69,6 +69,7 @@ configure {
     reinplace "s|# TLS_INCLUDE=-I/usr/local/openssl/include|TLS_INCLUDE=-I${prefix}/include/openssl|g" ${worksrcpath}/Local/Makefile
     reinplace "s|# INCLUDE=.*|INCLUDE=-I${prefix}/include|g" ${worksrcpath}/Local/Makefile
     reinplace "s|PCRE_LIBS=-lpcre|PCRE_LIBS=-L${prefix}/lib -lpcre|g" ${worksrcpath}/Local/Makefile
+    reinplace "1i\\\nEXTRALIBS=\$(MACPORTS_LEGACY_SUPPORT_LDFLAGS)\n" ${worksrcpath}/OS/Makefile-Darwin
     reinplace "s|CC=cc|CC=${configure.cc}|g" ${worksrcpath}/OS/Makefile-Darwin
     reinplace "s|X11=/usr/X11R6|X11=${prefix}|g" ${worksrcpath}/OS/Makefile-Darwin
     reinplace "s|# Exim: OS-specific make file for Darwin (Mac OS X).|INCLUDE=-I${prefix}/include/db48|g" ${worksrcpath}/OS/Makefile-Darwin


### PR DESCRIPTION
#### Description
Following up from #10985 
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Not tested on affected platforms, but using
```
build.env-append MACPORTS_LEGACY_SUPPORT_LDFLAGS=-lbogus
```
generates an error in a command I would expect it to.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
