### PR TITLE
p5.26-io-socket-ssl: trivial change to retry build

### DIFF
--- a/perl/p5-io-socket-ssl/Portfile
+++ b/perl/p5-io-socket-ssl/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  4eb64fa2acc691675e02e4ad63f7643a14f313f7 \
                     sha256  40da40948ecc9c787ed39c95715872679eebfd54243721174993a2003e32ab0a \
                     size    248367
 
-if {${perl5.major} != ""} {
+if {${perl5.major} ne ""} {
     depends_build-append \
                     port:p${perl5.major}-io-socket-inet6 \
                     port:p${perl5.major}-io-socket-ip


### PR DESCRIPTION
Builds failed due to `p5.26-socket` temporarily removed

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
