### PR TITLE
py-onnx: dependencies cleanup

### DIFF
--- a/python/py-onnx/Portfile
+++ b/python/py-onnx/Portfile
@@ -53,17 +53,8 @@ if {${name} ne ${subport}} {
         port:py${python.version}-protobuf3 \
         port:py${python.version}-setuptools \
         port:py${python.version}-six \
+        port:py${python.version}-typing_extensions \
         port:pybind11
-
-    if { ${python.version} < 35 } {
-        depends_lib-append \
-            port:py${python.version}-typing \
-    }
-
-    if { ${python.version} >= 37 } {
-        depends_lib-append \
-            port:py${python.version}-typing_extensions
-    }
 
     depends_test-append \
         port:py${python.version}-nbval \


### PR DESCRIPTION
#### Description
Port ended up being submitted without subports for Python < 3.5: https://github.com/macports/macports-ports/pull/6096#discussion_r363580380
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
