### PR TITLE
knot: migrate to py39-sphinx

### DIFF
--- a/net/knot/Portfile
+++ b/net/knot/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  ec6bdd127ff7b47f6020da50ce881c5ecb7046d3 \
                     size    1333296
 
 depends_build       port:pkgconfig \
-                    port:py38-sphinx
+                    port:py39-sphinx
 
 depends_lib         port:fstrm \
                     port:gnutls \


### PR DESCRIPTION
#### Description
…since Python 3.9 is now default.
Also to retry build for macOS 10.11 (`protobuf-c` was failing).
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
