### PR TITLE
terraform: add subport for Terraform 1.0

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -15,7 +15,14 @@ maintainers             {emcrisostomo @emcrisostomo} \
                         openmaintainer
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       terraform-0.15
+set latestVersion       terraform-1.0
+
+subport terraform-1.0 {
+    set patchNumber     0
+    checksums           rmd160  6b515ed4b5dfe151539ec9cc117e86d4794c9120 \
+                        sha256  b67f5e25a73866b83880fd6fbc5e57add3ed893a31eda26b748aea4afc7255c4 \
+                        size    33803531
+}
 
 subport terraform-0.15 {
     set patchNumber     5
@@ -58,7 +65,7 @@ if {${subport} eq ${name}} {
     PortGroup           obsolete 1.0
 
     replaced_by         ${latestVersion}
-    version             0.15.5
+    version             1.0.0
     revision            0
 
 } elseif {${subport} eq "terraform_select"} {


### PR DESCRIPTION
#### Description

Terraform has officially [hit 1.0](https://www.hashicorp.com/resources/celebrating-terraform-1-0).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
