### PR TITLE
doas doesn't install vidoas

### DIFF
--- a/sysutils/doas/Portfile
+++ b/sysutils/doas/Portfile
@@ -72,7 +72,7 @@ post-activate {
 notes "
 To complete the installation, run:
 
-\t${prefix}/bin/doas ${prefix}/sbin/vidoas
+\t${prefix}/bin/doas $EDITOR ${prefix}/etc/doas.conf
 
 Edit as necessary. (See the doas.conf manpage for additional information.)
 "


### PR DESCRIPTION
We don't install a vidoas command, so instead tell the user to run a command that has a better chance of working.