### PR TITLE
matterhorn: update to 50200.13.0

### DIFF
--- a/net/matterhorn/Portfile
+++ b/net/matterhorn/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           haskell_cabal 1.0
 
 name                matterhorn
-version             50200.12.0
+version             50200.13.0
 revision            0
-checksums           rmd160  74c512db62830e3bc1ea13a3a69e155262af561f \
-                    sha256  7861c3d3d2c75d935d8aee1d5711c89b3ebb745034001a5d6b50b217097b5d67 \
-                    size    934331
+checksums           rmd160  d8fdb31d2d4ebdaf34e688498c7ed2ff5d91de58 \
+                    sha256  a2ebc8b1eec4e56e82e1ccd53c98ee6233e699a5a3c56b47bf24cd2d8fc4d0f3 \
+                    size    948356
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
 


### PR DESCRIPTION
#### Description

###### Tested on
macOS 10.15.7 19H524 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?