### PR TITLE
gpodder: prepare for Python 3.10

### DIFF
--- a/gnome/gpodder/Portfile
+++ b/gnome/gpodder/Portfile
@@ -56,7 +56,6 @@ if {[variant_isset python36]} {
     python.default_version  39
 }
 
-set python.branch   "[string range ${python.version} 0 end-1].[string index ${python.version} end]"
 set my_python "${frameworks_dir}/Python.framework/Versions/${python.branch}"
 
 depends_lib-append \


### PR DESCRIPTION
`python.branch` already set by python 1.0 portgroup


#### Description
See https://lists.macports.org/pipermail/macports-dev/2020-October/042521.html
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
