### PR TITLE
tmux: update to 3.2a

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,14 +3,14 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 3.2
+github.setup    tmux tmux 3.2a
 if {${subport} eq ${name}} {
     revision        0
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux a08f1c8c59787408529463c985929e5ae1c67211
-    version         20200504-[string range ${github.version} 0 6]
+    github.setup    tmux tmux 96ad8280b28283eb01e7789f5bafd2e1f6cde139
+    version         20210610-[string range ${github.version} 0 6]
     revision        0
     conflicts       tmux
 }
@@ -30,14 +30,14 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  25a9c3db68f423d8f828207759f66f785ee10121 \
-                            sha256  664d345338c11cbe429d7ff939b92a5191e231a7c1ef42f381cebacb1e08a399 \
-                            size    646457
+    checksums               rmd160  36ae9170204ff723acc56036ce449854a88cb4ca \
+                            sha256  551553a4f82beaa8dadc9256800bcc284d7c000081e47aa6ecbb6ff36eacd05f \
+                            size    648394
 }
 subport tmux-devel {
-    checksums               rmd160  c379f7faa81473a610380261d0110ab580c053de \
-                            sha256  6ea3edc022326df0d902b3260c8f568bb0eae49b13e9952338ee8dc700e8e85c \
-                            size    751410
+    checksums               rmd160  b4ef42164a1bf711db984242ed36bc97f2297f53 \
+                            sha256  6ad5fbc3d0adeaf2cfaddb0c8cd75276b623fbc77da3fabf66796cd3c47e27be \
+                            size    819238
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh
@@ -69,6 +69,5 @@ post-destroot {
 }
 
 notes "If you want integration with system pasteboard consider installing port tmux-pasteboard as well"
-
 
 github.livecheck.regex {([0-9.]+[a-z]?)}


### PR DESCRIPTION
tmux: update to 3.2a
tmux: update tmux-devel to latest commit (96ad8280b28283eb01e7789f5bafd2e1f6cde139)

#### Description

###### Type(s)

- [x] update

###### Tested on

macOS 10.14.6 18G9216
Xcode 11.3.1 11C504

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?