### PR TITLE
dspdfviewer: add missing dependency on boost

### DIFF
--- a/office/dspdfviewer/Portfile
+++ b/office/dspdfviewer/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           qt5 1.0
 
 github.setup        dannyedel dspdfviewer 1.15.1 v
+revision            1
 categories          office
 platforms           darwin
 license             GPL-2+
@@ -27,10 +28,8 @@ checksums           rmd160  82b190c46afe5fdf1feb5d121cf9a25a53da9612 \
 qt5.depends_component \
                     qttools
 
-depends_build-append \
-                    port:boost
-
 depends_lib-append \
+                    port:boost \
                     port:poppler-qt5
 
 # Use prerendered pdfs for testing instead of requiring a pdflatex installation


### PR DESCRIPTION
#### Description

boost is needed at run time (as confirmed by `otool` and `symbols`). Move it to depends_lib.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
