### PR TITLE
logisim-evolution: set fallback dep to openjdk16

### DIFF
--- a/cad/logisim-evolution/Portfile
+++ b/cad/logisim-evolution/Portfile
@@ -5,7 +5,7 @@ PortGroup           java 1.0
 PortGroup           github 1.0
 
 github.setup        reds-heig logisim-evolution 3.5.0 v
-revision            0
+revision            1
 
 categories          cad education java
 platforms           darwin
@@ -22,8 +22,10 @@ checksums           rmd160  87b24defcabd6ab81333bc1c52c76928a64bdab1 \
                     sha256  8b52f1ce57205f68c396d12637ccb1d6955f631987c2e6b4247acce31116cbe4 \
                     size    40050282
 
-java.version        9+
-java.fallback       openjdk11
+# non-LTS Java required for jpackage
+# Set to LTS Java 17 when released
+java.version        14+
+java.fallback       openjdk16
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Following from the recent update https://github.com/macports/macports-ports/commit/b90614c7aea403a02dc9b328ef27f4765263d586.

[10.12_x86_64-builder log](https://build.macports.org/builders/ports-10.12_x86_64-builder/builds/149069/steps/install-port/logs/stdio):

```
> java.io.IOException: Cannot run program "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/bin/jpackage": error=2, No such file or directory
```

`jpackage` is available in openjdk14+, so this PR sets the portfile to use openjdk 16, since 14 and 15 are obsolete. Not using LTS openjdk 8 or 11 however isn't good practice. 

What I didn't realise was that trace mode wouldn't pick up on this error since openjdk installs outside of the standard prefix.

My thoughts were to set to openjdk 16 now, and set it to LTS 17 when it comes out? CC @chrstphrchvz.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
