### PR TITLE
skaffold: update to skaffold 1.26.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.26.0 v
+github.setup        GoogleContainerTools skaffold 1.26.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  c025418b3453be7d1a5f74ebb0c4154a95c9d28a \
-                    sha256  fca580e136532986eed1bd3b27bba570fdd740cab649428c36a09dfbe252c427 \
-                    size    23826371
+checksums           rmd160  4a98a05a655c91e3986e2b0cf56eb6468d66a3fe \
+                    sha256  b802c085807faed3ea6c7a76c95ca806e36b2378b39429c63608f7c622b9d408 \
+                    size    23827247
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.26.1.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?