### PR TITLE
spring-boot-cli: update to 2.5.1

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.5.0
+version         2.5.1
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  b49324a39459202ee72d7fb58661009267a7fc3f \
-                sha256  69b41c6d95eca479cc13132f1d5216a125b16790ce890127d6737fbbcee7938a \
-                size    13890505
+checksums       rmd160  1de86b18dade2c8077bd6db9e4252b3ff8920fbf \
+                sha256  5f787aea547f6f11bd83d71772f2ea24727b916b2a3c9b25e5973bff14f7dfd6 \
+                size    13891096
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.5.1.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?