### PR TITLE
kitty: Update to 0.21.0

### DIFF
--- a/aqua/kitty/Portfile
+++ b/aqua/kitty/Portfile
@@ -5,9 +5,9 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 PortGroup           gpg_verify 1.0
 
-github.setup        kovidgoyal kitty 0.20.3 v
+github.setup        kovidgoyal kitty 0.21.0 v
 github.tarball_from releases
-revision            1
+revision            0
 
 categories          aqua
 platforms           macosx
@@ -30,12 +30,14 @@ if {${os.major} <= 15} {
 use_xz              yes
 
 checksums           ${distfiles} \
-                    rmd160  a7cbd429a0cb1aaa2e3029338791c341d68f76b5 \
-                    sha256  b6117d436ce5997a3449fa9ca0d3ce5a577e309e2b196ed006dc33564739cc87 \
-                    size    3487500
+                    rmd160  160888f887f341eef97edcf0f78bcc05de642a17 \
+                    sha256  7fd6bd5b562d0849aca387bfc9012f84aa897dbbcacfe21036388944f5d94a4f \
+                    size    4337360
 
+# To verify the signature during the update, set it to "yes" and then reset
+# the value to "no" back.
 gpg_verify.use_gpg_verification \
-                    yes
+                    no
 
 if {[option gpg_verify.use_gpg_verification]} {
     extract.only    ${distfiles}

--- a/aqua/kitty/files/patch-kitty-no-deprecated-declarations.diff
+++ b/aqua/kitty/files/patch-kitty-no-deprecated-declarations.diff
@@ -6,6 +6,6 @@
          'OVERRIDE_CFLAGS', (
 -            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {std}'
 +            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wno-deprecated-declarations -Wall -Wstrict-prototypes {std}'
-             f' -pedantic-errors {werror} {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
+             f' {werror} {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
              f' -pipe {march} -fvisibility=hidden {fortify_source}'
          )


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
