### PR TITLE
ripgrep: update to 13.0.0

### DIFF
--- a/textproc/ripgrep/Portfile
+++ b/textproc/ripgrep/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        BurntSushi ripgrep 12.1.1
+github.setup        BurntSushi ripgrep 13.0.0
+github.tarball_from archive
 categories          textproc
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -17,66 +18,67 @@ long_description    ripgrep is a command line search tool that combines the \
                     raw speed of GNU grep.
 
 cargo.crates \
-    aho-corasick                  0.7.10   8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada  \
-    atty                          0.2.14   d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8  \
-    autocfg                       1.0.0    f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d  \
-    base64                        0.12.1   53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42  \
-    bitflags                      1.2.1    cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693  \
-    bstr                          0.2.13   31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931  \
-    bytecount                     0.6.0    b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e  \
-    byteorder                     1.3.4    08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de  \
-    cc                            1.0.54   7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311  \
-    cfg-if                        0.1.10   4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822  \
-    clap                          2.33.1   bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129  \
-    crossbeam-channel             0.4.2    cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061  \
-    crossbeam-utils               0.7.2    c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8  \
-    encoding_rs                   0.8.23   e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171  \
-    encoding_rs_io                0.1.7    1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83  \
-    fnv                           1.0.7    3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1  \
-    fs_extra                      1.1.0    5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674  \
-    glob                          0.3.0    9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574  \
-    hermit-abi                    0.1.13   91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71  \
-    itoa                          0.4.5    b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e  \
-    jemalloc-sys                  0.3.2    0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45  \
-    jemallocator                  0.3.2    43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69  \
-    lazy_static                   1.4.0    e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646  \
-    libc                          0.2.71   9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49  \
-    log                           0.4.8    14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7  \
-    maybe-uninit                  2.0.0    60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00  \
-    memchr                        2.3.3    3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400  \
-    memmap                        0.7.0    6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b  \
-    num_cpus                      1.13.0   05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3  \
-    packed_simd                   0.3.3    a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220  \
-    pcre2                         0.2.3    85b30f2f69903b439dd9dc9e824119b82a55bf113b29af8d70948a03c1b11ab1  \
-    pcre2-sys                     0.2.2    876c72d05059d23a84bd9fcdc3b1d31c50ea7fe00fe1522b4e68cd3608db8d5b  \
-    pkg-config                    0.3.17   05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677  \
-    proc-macro2                   1.0.17   1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101  \
-    quote                         1.0.6    54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea  \
-    regex                         1.3.9    9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6  \
-    regex-automata                0.1.9    ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4  \
-    regex-syntax                  0.6.18   26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8  \
-    ryu                           1.0.4    ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1  \
-    same-file                     1.0.6    93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502  \
-    serde                         1.0.110  99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c  \
-    serde_derive                  1.0.110  818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984  \
-    serde_json                    1.0.53   993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2  \
-    strsim                        0.8.0    8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a  \
-    syn                           1.0.27   ef781e621ee763a2a40721a8861ec519cb76966aee03bb5d00adb6a31dc1c1de  \
-    termcolor                     1.1.0    bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f  \
-    textwrap                      0.11.0   d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060  \
-    thread_local                  1.0.1    d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14  \
-    unicode-width                 0.1.7    caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479  \
-    unicode-xid                   0.2.0    826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c  \
-    walkdir                       2.3.1    777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d  \
-    winapi                        0.3.8    8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6  \
-    winapi-i686-pc-windows-gnu    0.4.0    ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6  \
-    winapi-util                   0.1.5    70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178  \
-    winapi-x86_64-pc-windows-gnu  0.4.0    712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+    aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bstr                            0.2.16  90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279 \
+    bytecount                        0.6.2  72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e \
+    cc                              1.0.68  4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787 \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    crossbeam-channel                0.5.1  06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4 \
+    crossbeam-utils                  0.8.5  d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db \
+    encoding_rs                     0.8.28  80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065 \
+    encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    fs_extra                         1.2.0  2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394 \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    hermit-abi                      0.1.18  322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c \
+    itoa                             0.4.7  dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736 \
+    jemalloc-sys                     0.3.2  0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45 \
+    jemallocator                     0.3.2  43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69 \
+    jobserver                       0.1.22  972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.97  12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6 \
+    libm                             0.1.4  7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a \
+    log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
+    memchr                           2.4.0  b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc \
+    memmap2                          0.3.0  20ff203f7bdc401350b1dbaa0355135777d25f41c0bbc601851bbd6cf61e8ff5 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    once_cell                        1.7.2  af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3 \
+    packed_simd_2                    0.3.5  0e64858a2d3733fdd61adfdd6da89aa202f7ff0e741d2fc7ed1e452ba9dc99d7 \
+    pcre2                            0.2.3  85b30f2f69903b439dd9dc9e824119b82a55bf113b29af8d70948a03c1b11ab1 \
+    pcre2-sys                        0.2.5  dec30e5e9ec37eb8fbf1dea5989bc957fd3df56fbee5061aa7b7a99dbb37b722 \
+    pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
+    proc-macro2                     1.0.27  f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038 \
+    quote                            1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
+    regex                            1.5.4  d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461 \
+    regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
+    regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    serde                          1.0.126  ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03 \
+    serde_derive                   1.0.126  963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43 \
+    serde_json                      1.0.64  799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    syn                             1.0.73  f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7 \
+    termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                     1.1.3  8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
+    walkdir                          2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  a1acb9fd8f3c59533538e846976f1f59f95aa0c2 \
-                    sha256  d3a4b97f5dfa0da3351eef751e6541abd6f07793e7e54fff30ef06461bcfb05a \
-                    size    480716
+                    rmd160  841ccf8bc96143260e6c750d147ff78d8784903e \
+                    sha256  0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2 \
+                    size    505536
 
 depends_build-append \
                     port:asciidoc \


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
