### PR TITLE
bwping: fix clock_gettime() issues on older systems

### DIFF
--- a/net/bwping/Portfile
+++ b/net/bwping/Portfile
@@ -2,6 +2,8 @@
 
 PortSystem              1.0
 
+PortGroup               legacysupport 1.1
+
 name                    bwping
 version                 2.3
 categories              net
@@ -23,3 +25,6 @@ checksums               rmd160  204f1550b4cbc792acfa764a8e54c6168bd41ed8 \
                         size    115310
 
 configure.args          --mandir=${prefix}/share/man/
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
