### PR TITLE
qgis3: compiler blacklist cleanup

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake   1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github  1.0
 PortGroup           qt5     1.0
 PortGroup           active_variants 1.1
@@ -71,8 +70,6 @@ post-patch {
     reinplace -E "s|#ifdef Q_OS_MAC$|#if 0|" \
         ${worksrcpath}/src/app/layout/qgslayoutdesignerdialog.cpp
 }
-
-compiler.blacklist      {clang < 500}
 
 cmake.install_prefix    ${applications_dir}
 


### PR DESCRIPTION
Redundant due to `compiler.cxx_standard 2011`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
