### PR TITLE
curl: fix +darwinssl variant 

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -60,7 +60,7 @@ if {${name} eq ${subport}} {
                                 --without-nghttp2 \
                                 --without-nss \
                                 --without-ssl \
-                                --without-darwinssl \
+                                --without-secure-transport \
                                 --disable-ares \
                                 --disable-ldap \
                                 --disable-ldaps \
@@ -147,7 +147,7 @@ if {${name} eq ${subport}} {
     }
 
     variant darwinssl conflicts gnutls mbedtls ssl wolfssl description {Allow secure connections using Apple OS native TLS} {
-        configure.args-replace  --without-darwinssl --with-darwinssl
+        configure.args-replace  --without-secure-transport --with-secure-transport
         configure.args-append   --without-ca-bundle
     }
 
@@ -207,7 +207,7 @@ if {${name} eq ${subport}} {
     variant ssl conflicts darwinssl gnutls mbedtls wolfssl description {Allow secure connections using OpenSSL} {
         depends_lib-append      path:lib/libssl.dylib:openssl \
                                 path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
-        configure.args-replace  --without-ssl --with-ssl=${prefix}
+        configure.args-replace  --without-ssl --with-openssl=${prefix}
         configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 


### PR DESCRIPTION
#### Description

Fix curl +darwinssl variant.
The '--with-darwinssl' configure script switch has not worked for a while.
Update port file to use '--with-secure-transport' instead.

(without the fix, curl +darwinssl builds without ssl support at all, since --with-darwinssl was being silently ignored by curl's configure script; upstream curl was recently updated in master (not yet released) to fail the build as of curl/curl@5731d5a).

I also updated the '--with-ssl' switch to the synonymous but more explicit --with-openssl switch.
The reason for this is that '--with-ssl' and '--without-ssl' are not symmetric: the former enables openssl, the latter disables ALL ssl backends. This should make the +ssl variant clearer. Functionally nothing changes.


###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.3 12C33

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
