### PR TITLE
py-pyopencl: use compiler.cxx_standard 2011

### DIFF
--- a/python/py-pyopencl/Portfile
+++ b/python/py-pyopencl/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           cxx11 1.1
 
 set _name           pyopencl
 set _n              [string index ${_name} 0]
@@ -30,6 +29,8 @@ checksums           rmd160  e848810e5f8911bd3a3b4620ea7c3330cf5d872a \
 python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
+    compiler.cxx_standard 2011
+
     depends_build-append \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-numpy \


### PR DESCRIPTION
…instead of deprecated `cxx11 1.1` portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
