### PR TITLE
hugin-app: build against boost 1.71

### DIFF
--- a/graphics/hugin-app/Portfile
+++ b/graphics/hugin-app/Portfile
@@ -33,6 +33,7 @@ compiler.cxx_standard   2011
 
 perl5.branches          5.28
 wxWidgets.use           wxWidgets-3.0-cxx11
+boost.version           1.71
 
 checksums               rmd160  d16c364779a48451b3b222a0dd0efa46535e6ddc \
                         sha256  8ba6bdfea246313f142f17f42e066c6888f51b72e4f8814b5e1c84ff56a95a3e \


### PR DESCRIPTION
#### Description

Building against boost 1.76, which is currently the default used by the boost portgroup, fails with the following error:

```
:info:build Undefined symbols for architecture x86_64:
:info:build   "boost::filesystem::detail::recur_dir_itr_imp::increment(boost::system::error_code*)", referenced from:
:info:build       boost::filesystem::recursive_directory_iterator::increment() in pto_move.cpp.o
:info:build   "boost::filesystem::detail::directory_iterator_construct(boost::filesystem::directory_iterator&, boost::filesystem::path const&, boost::system:>
:info:build       boost::filesystem::directory_iterator::directory_iterator(boost::filesystem::path const&) in pto_move.cpp.o
:info:build   "boost::filesystem::detail::copy_file(boost::filesystem::path const&, boost::filesystem::path const&, boost::filesystem::detail::copy_option, b>
:info:build       PTOCopyMove(bool, boost::filesystem::path, boost::filesystem::path, bool) in pto_move.cpp.o
:info:build   "boost::filesystem::absolute(boost::filesystem::path const&, boost::filesystem::path const&)", referenced from:
:info:build       RebaseFilename(boost::filesystem::path, boost::filesystem::path&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::alloc>
:info:build       checkDestinationDirectory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::filesystem::path&) >
:info:build       PTOCopyMove(bool, boost::filesystem::path, boost::filesystem::path, bool) in pto_move.cpp.o
:info:build       _main in pto_move.cpp.o
:info:build ld: symbol(s) not found for architecture x86_64
:info:build clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Boost 1.71 matches the version that was used before b25b206. CCing @cjones051073 as he introduced the use of the boost PG in that commit.

*Note*: The hugin-app port is out of date and maybe newer versions would build against boost 1.76.

Fixes: https://trac.macports.org/ticket/63095

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
