### PR TITLE
[volk]-gnss-sdr: migrate to boost PG

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
+PortGroup           boost 1.0
 
 name                gnss-sdr
 maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @carlesfernandez} openmaintainer
@@ -24,7 +25,7 @@ if {${subport} eq "gnss-sdr"} {
         This port is kept up with the GNSS-SDR release, which is typically updated every few months.
 
     github.setup        gnss-sdr gnss-sdr 0.0.14 v
-    revision            3
+    revision            4
     checksums           rmd160 71e9bbb7e125396be06d97b26f333e9e2bb4a9be \
                         sha256 48ba64073a995aa6f835c7a0cb775a741db9475359b036ca4245a65a6c1135fd \
                         size   4269976
@@ -49,7 +50,7 @@ subport gnss-sdr-devel {
     checksums rmd160 8449855911e5fd114a8b4141fd8a9741d0f5dc0f \
               sha256 9d81599ed7cbcc5b5658040408353133b5791bf15b310031524a5e8b4fa81571 \
               size   4349096
-    revision  0
+    revision  1
 
     conflicts gnss-sdr
 
@@ -75,7 +76,6 @@ depends_build-append \
     port:pkgconfig
 
 depends_lib-append  \
-    port:boost \
     port:armadillo \
     port:google-glog \
     port:lapack \
@@ -136,8 +136,6 @@ configure.args-append \
 configure.args-append \
     -DARMADILLO_INCLUDE_DIR=${prefix}/include \
     -DARMADILLO_LIBRARY=${prefix}/lib/libarmadillo.dylib \
-    -DBoost_INCLUDE_DIR=${prefix}/include \
-    -DBoost_LIBRARY_DIR_RELEASE=${prefix}/lib \
     -DGLOG_INCLUDE_DIR=${prefix}/include/glog \
     -DGLOG_LIBRARY=${prefix}/lib/libglog.dylib \
     -DGNUTLS_INCLUDE_DIR=${prefix}/include \
@@ -216,33 +214,5 @@ if {![variant_isset osmosdr]} {
 
     configure.args-append \
         -DENABLE_OSMOSDR=OFF
-
-}
-
-variant array description "Install ${name} with support for CTTC's antenna array front-end as signal source (experimental)" {
-
-    configure.args-append \
-        -DENABLE_ARRAY=ON
-
-}
-
-if {![variant_isset array]} {
-
-    configure.args-append \
-        -DENABLE_ARRAY=OFF
-
-}
-
-variant gn3s description "Install ${name} with support for the GN3S dongle as signal source (experimental)" {
-
-    configure.args-append \
-        -DENABLE_GN3S=ON
-
-}
-
-if {![variant_isset gn3s]} {
-
-    configure.args-append \
-        -DENABLE_GN3S=OFF
 
 }

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
+PortGroup           boost 1.0
 
 name                volk-gnss-sdr
 maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @carlesfernandez} openmaintainer
@@ -23,7 +24,7 @@ if {${subport} eq "volk-gnss-sdr"} {
         This port is kept up with the VOLK-GNSS-SDR release, which is typically updated every few months.
 
     github.setup        gnss-sdr gnss-sdr 0.0.14 v
-    revision            1
+    revision            2
     checksums           rmd160 71e9bbb7e125396be06d97b26f333e9e2bb4a9be \
                         sha256 48ba64073a995aa6f835c7a0cb775a741db9475359b036ca4245a65a6c1135fd \
                         size   4269976
@@ -42,7 +43,7 @@ subport volk-gnss-sdr-devel {
     checksums rmd160 8449855911e5fd114a8b4141fd8a9741d0f5dc0f \
               sha256 9d81599ed7cbcc5b5658040408353133b5791bf15b310031524a5e8b4fa81571 \
               size   4349096
-    revision  0
+    revision  1
 
     conflicts volk-gnss-sdr
 
@@ -63,8 +64,7 @@ depends_build-append port:pkgconfig
 
 depends_lib-append \
     path:lib/libvolk.dylib:volk \
-    port:orc \
-    port:boost
+    port:orc
 
 # specify the Python dependencies; these are checked for at configure,
 # then used for building, but not at runtime.


### PR DESCRIPTION
#### Description

Migrate gnss-sdr and volk-gnss-sdr to boost PortGroup.

Removed variants +array and +gn3s of the gnss-sdr port, they are abandoned and didn't work for ages.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4
Xcode 12.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
