### PR TITLE
lagrange: update to 1.5.2

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.5.0 v
+github.setup        skyjake lagrange 1.5.2 v
 github.tarball_from releases
 categories          net gemini
 platforms           darwin
@@ -19,9 +19,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  0ab0b064d91e1608362743480afb426d15254fe8 \
-                    sha256  da298e0cb366e7a9616a4ed294397e543f69ff4e40d1b5af90ea9d8dc36c317e \
-                    size    20403900
+checksums           rmd160  ec6fc9ee4543b7f47b62dac101e16c6186554698 \
+                    sha256  3be4d5b383726f725301bf757e06dcd2d30de1aa50431943387c9aa0df8d0a3f \
+                    size    20409523
 
 depends_build-append \
                     port:pkgconfig
@@ -32,7 +32,7 @@ depends_lib-append  port:libsdl2 \
                     port:pcre \
                     port:zlib
 
-compiler.cxx_standard 2011
+compiler.c_standard 2011
 compiler.blacklist-append {clang < 800}
 
 destroot {


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
