### PR TITLE
google-cloud-sdk: update to 345.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             344.0.0
+version             345.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  78b796be339cc613de4e6d083571a77dba28152b \
-                    sha256  2f4f2ce0f435c93a23043c0731efcfe3bd0aeacd57ddce0937231a5c7512dda6 \
-                    size    90077859
+    checksums       rmd160  51280d335f12158d6a7e96c2596d4781af3b1cd7 \
+                    sha256  ed1e2d4df975a29755f3aa5ced605cf4db47ffbf7dbf36465524cde57b02d1c0 \
+                    size    90188110
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  979efa7eb38df221756e7b0131c3d365afa8494f \
-                    sha256  0fee32f7d1e3a4f4af83552762dce0414c639cb745746b25b325470294161e76 \
-                    size    86324153
+    checksums       rmd160  686b1875797de316954a20311b63e94238818329 \
+                    sha256  705d2b82f711e042d930bf96103291f472d7a1aab5a152bfed2896d595d811dd \
+                    size    86431672
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  0084a3e561c22866c80b42142b03620dff15fe00 \
-                    sha256  24e7f69c4512f9f30c39ec59e60a5ba9bf13eba4e1d892d9d88dc87a33fe9e32 \
-                    size    86249850
+    checksums       rmd160  9bc83394ac7a4e2001e605c8998a8555524aa742 \
+                    sha256  4db070e65d5dba33efd2c2d744845aaa1dac56f94e5e439604800ffa0bf27dff \
+                    size    86355324
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 345.0.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?