### PR TITLE
micronaut: update to 2.5.6

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.5.5 v
+github.setup    micronaut-projects micronaut-starter 2.5.6 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  eba23e37b302c8ef88bdf135b9ce4a05c1a37ee3 \
-                sha256  00c3238c17a8817fef2834509fd2f9139119bef28485419867ff166d209ce5f6 \
-                size    20142519
+checksums       rmd160  14ae3e19b8b528cf0a2c68a865201fc9559c6bc6 \
+                sha256  e927d1e2861914173bbdbddf5abe273b7e2c4960e67a8158752a700d59e14fd7 \
+                size    20144805
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.5.6.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?