### PR TITLE
coreutils-uutils: new port

### DIFF
--- a/sysutils/coreutils-uutils/Portfile
+++ b/sysutils/coreutils-uutils/Portfile
@@ -1,0 +1,249 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+name                coreutils-uutils
+revision            0
+github.setup        uutils coreutils 0.0.7
+github.tarball_from archive
+categories          textproc
+platforms           darwin
+maintainers         {gmail.com:davidgilman1 @dgilman} \
+                    openmaintainer
+license             MIT
+
+description         File, shell and text utilities
+long_description    A rewrite of GNU coreutils in rust
+
+cargo.crates \
+    Inflector                                           0.11.4  fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3 \
+    aho-corasick                                        0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
+    ansi_term                                           0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    ansi_term                                           0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    arrayref                                             0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                                             0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    atty                                                0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                                              1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    binary-heap-plus                                     0.4.1  4f068638f8ff9e118a9361e66a411eff410e7fb3ecaa23bf9272324f8fc606d7 \
+    bit-set                                              0.5.2  6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de \
+    bit-vec                                              0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
+    bitflags                                             1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                                        0.5.11  afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587 \
+    block-buffer                                         0.2.0  1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814 \
+    bstr                                                0.2.16  90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279 \
+    byte-tools                                           0.2.0  560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40 \
+    byteorder                                            1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
+    cc                                                  1.0.68  4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787 \
+    cfg-if                                              0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                                               1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chrono                                              0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
+    clap                                                2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    cloudabi                                             0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    compare                                              0.1.0  120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3 \
+    constant_time_eq                                     0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    conv                                                 0.3.3  78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299 \
+    coz                                                  0.1.3  cef55b3fe2f5477d59e12bc792e8b3c95a25bd099eadcfae006ecea136de76e2 \
+    cpp                                                  0.5.6  4875a08600be48dcc9cb6ee07f104a3e0752e95184dede6a30044d6480bf50e8 \
+    cpp_build                                            0.4.0  c47531e7e09532ad4827098729794f5e1a5b1c2ccbb5e295498d2e7ab451c445 \
+    cpp_common                                           0.4.0  79e39149a7943affa02f5b6e347ca2840a129cc78d5883ee229f0f1c4027d628 \
+    cpp_common                                           0.5.6  df78ad28e5fe814285016779fb3d3b874520c799a847e6190bf2b834cc4ff283 \
+    cpp_macros                                           0.5.6  4f93a21e618c10abc84ebb63ffa5952e1f7a4568b8141d542d5ef860e4a8fc25 \
+    cpp_syn                                             0.12.0  a8cd649bf5b3804d92fe12a60c7698f5a538a6033ed8a668bf5241d4d4f1644e \
+    cpp_synmap                                           0.3.0  897e4f9cdbe2874edd3ffe53718ee5d8b89e2a970057b2c93d3214104f2e90b6 \
+    cpp_synom                                           0.12.0  1fc8da5694233b646150c785118f77835ad0a49680c7f312a10ef30957c67b6d \
+    crossbeam-channel                                    0.5.1  06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4 \
+    crossbeam-deque                                      0.8.0  94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9 \
+    crossbeam-epoch                                      0.9.5  4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd \
+    crossbeam-utils                                      0.8.5  d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db \
+    crossterm                                           0.20.0  c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d \
+    crossterm_winapi                                     0.8.0  3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507 \
+    ctor                                                0.1.20  5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d \
+    custom_derive                                        0.1.7  ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9 \
+    data-encoding                                        2.1.2  f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97 \
+    diff                                                0.1.12  0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499 \
+    digest                                               0.6.2  e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a \
+    dns-lookup                                           1.0.5  093d88961fd18c4ecacb8c80cd0b356463ba941ba11e0e01f9cf5271380b79dc \
+    dunce                                                1.0.2  453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541 \
+    either                                               1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    env_logger                                           0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
+    fake-simd                                            0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    file_diff                                            1.0.0  31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5 \
+    filetime                                            0.2.14  1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8 \
+    fnv                                                  1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    fs_extra                                             1.2.0  2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394 \
+    fuchsia-cprng                                        0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    generic-array                                        0.8.4  b2297fb0e3ea512e380da24b52dca3924028f59df5e3a17a18f81d8349ca7ebe \
+    getopts                                             0.2.21  14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5 \
+    getrandom                                           0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
+    getrandom                                            0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
+    glob                                                0.2.11  8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb \
+    glob                                                 0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    globset                                              0.4.8  10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd \
+    half                                                 1.7.1  62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3 \
+    heck                                                 0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
+    hermit-abi                                          0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    hex                                                  0.2.0  d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa \
+    hostname                                             0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
+    if_rust_version                                      1.0.0  46dbcb333e86939721589d25a3557e180b52778cb33c7fdfe9e0158ff790d5ec \
+    instant                                             0.1.10  bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d \
+    ioctl-sys                                            0.5.2  5e2c4b26352496eaaa8ca7cfa9bd99e93419d3f7983dc6e99c2a35fe9e33504a \
+    itertools                                            0.8.2  f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484 \
+    itertools                                           0.10.1  69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf \
+    kernel32-sys                                         0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    lazy_static                                          1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                                                0.2.85  7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3 \
+    locale                                               0.2.2  5fdbe492a9c0238da900a1165c42fc5067161ce292678a6fe80921f30fe307fd \
+    lock_api                                             0.4.4  0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb \
+    log                                                 0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
+    lscolors                                             0.7.1  d24b894c45c9da468621cdd615a5a79ee5e5523dd4f75c76ebc03d458940c16e \
+    match_cfg                                            0.1.0  ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4 \
+    maybe-uninit                                         2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
+    md5                                                  0.3.8  79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48 \
+    memchr                                               1.0.2  148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a \
+    memchr                                               2.4.0  b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc \
+    memoffset                                            0.6.4  59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9 \
+    mio                                                  0.7.7  e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7 \
+    miow                                                 0.3.7  b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21 \
+    nix                                                 0.13.1  4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b \
+    nix                                                 0.20.0  fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a \
+    nodrop                                              0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
+    ntapi                                                0.3.6  3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44 \
+    num-bigint                                           0.4.0  4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512 \
+    num-integer                                         0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-traits                                          0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    num_cpus                                            1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    number_prefix                                        0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
+    numtoa                                               0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
+    once_cell                                            1.8.0  692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56 \
+    onig                                                 4.3.3  8518fcb2b1b8c2f45f0ad499df4fda6087fc3475ca69a185c173b8315d2fb383 \
+    onig_sys                                            69.1.0  388410bf5fa341f10e58e6db3975f4bea1ac30247dd79d37a9e5ced3cb4cc3b0 \
+    ouroboros                                            0.9.5  fbeff60e3e37407a80ead3e9458145b456e978c4068cddbfea6afb48572962ca \
+    ouroboros_macro                                      0.9.5  03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2 \
+    output_vt100                                         0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
+    parking_lot                                         0.11.1  6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb \
+    parking_lot_core                                     0.8.3  fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018 \
+    paste                                               0.1.18  45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880 \
+    paste-impl                                          0.1.18  d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6 \
+    pkg-config                                          0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
+    platform-info                                        0.1.0  16ea9cd21d89bffb387b6c7363d23bead0807be9de676c671b474dd29e7436d3 \
+    ppv-lite86                                          0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    pretty_assertions                                    0.7.2  1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b \
+    proc-macro-error                                     1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr                                1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro-hack                                     0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
+    proc-macro2                                         1.0.27  f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038 \
+    quick-error                                          1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+    quick-error                                          2.0.1  a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3 \
+    quickcheck                                           0.9.2  a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f \
+    quote                                               0.3.15  7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a \
+    quote                                                1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
+    rand                                                 0.5.6  c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9 \
+    rand                                                 0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand                                                 0.8.4  2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8 \
+    rand_chacha                                          0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_chacha                                          0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_core                                            0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                                            0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_core                                            0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_core                                            0.6.3  d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7 \
+    rand_hc                                              0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_hc                                              0.3.1  d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7 \
+    rand_pcg                                             0.2.1  16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
+    rayon                                                1.5.1  c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90 \
+    rayon-core                                           1.9.1  d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e \
+    redox_syscall                                       0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    redox_syscall                                        0.2.9  5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee \
+    redox_termios                                        0.1.2  8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f \
+    regex                                                1.5.4  d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461 \
+    regex-automata                                      0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
+    regex-syntax                                        0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
+    remove_dir_all                                       0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    retain_mut                                           0.1.3  e9c17925a9027d298a4603d286befe3f9dc0e8ed02523141914eb628798d6e5b \
+    rlimit                                               0.4.0  49b02d62c38353a6fce45c25ca19783e25dd5f495ca681c674a4ee15aa4c1536 \
+    rust-ini                                            0.13.0  3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2 \
+    same-file                                            1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    scopeguard                                           1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    sha1                                                 0.6.0  2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d \
+    sha2                                                 0.6.0  7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a \
+    sha3                                                 0.6.0  26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0 \
+    signal-hook                                          0.3.9  470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39 \
+    signal-hook-mio                                      0.2.1  29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4 \
+    signal-hook-registry                                 1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
+    smallvec                                            0.6.14  b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0 \
+    smallvec                                             1.6.1  fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e \
+    socket2                                             0.3.19  122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e \
+    stable_deref_trait                                   1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
+    strsim                                               0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    strum                                               0.20.0  7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c \
+    strum_macros                                        0.20.1  ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149 \
+    syn                                                 1.0.73  f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7 \
+    tempfile                                             3.2.0  dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22 \
+    term_grid                                            0.1.7  230d3e804faaed5a39b08319efb797783df2fd9671b39b7596490cb486d702cf \
+    term_size                                            0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
+    termion                                              1.5.6  077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e \
+    termsize                                             0.1.6  5e86d824a8e90f342ad3ef4bd51ef7119a9b681b0cc9f8ee7b2852f02ccd2517 \
+    textwrap                                            0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thiserror                                           1.0.26  93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2 \
+    thiserror-impl                                      1.0.26  060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745 \
+    time                                                0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+    typenum                                             1.13.0  879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06 \
+    unicode-segmentation                                 1.8.0  8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b \
+    unicode-width                                        0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                                          0.0.4  8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc \
+    unicode-xid                                          0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
+    unindent                                             0.1.7  f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7 \
+    unix_socket                                          0.5.0  6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564 \
+    users                                               0.10.0  aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486 \
+    vec_map                                              0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                                        0.9.3  5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe \
+    void                                                 1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    walkdir                                              2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
+    wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi                         0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
+    wild                                                 2.0.4  035793abb854745033f01a07647a79831eba29ec0be377205f2a25b0aa830020 \
+    winapi                                               0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                                               0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-build                                         0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu                           0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                                          0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu                         0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    xattr                                                0.2.2  244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c
+
+checksums-append    ${distname}${extract.suffix} \
+                    rmd160  c5a028c84e0d45b8761bbee4ead64c306de55d37 \
+                    sha256  066359e9548940ee99c3d8911e951d5091aa1f2d7d409cb577c811f3993a1e7d \
+                    size    1783965
+
+build.pre_args-append --features macos
+
+set binaries {
+    arch base32 base64 basename cat chgrp chmod chown chroot cksum comm cp csplit
+    cut date df dircolors dirname du echo env expand expr factor false fmt fold
+    groups hashsum head hostid hostname id install join kill link ln logname ls
+    md5sum mkdir mkfifo mknod mktemp more mv nice nl nohup nproc numfmt od paste
+    pathchk pinky printenv printf ptx pwd readlink realpath relpath rm rmdir seq
+    sha1sum sha224sum sha256sum sha3-224sum sha3-256sum sha3-384sum sha3-512sum
+    sha384sum sha3sum sha512sum shake128sum shake256sum shred shuf sleep sort split
+    stat stdbuf sum sync tac tail tee test timeout touch tr true truncate tsort
+    tty uname unexpand uniq unlink uptime users wc who whoami yes
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/target/[cargo.rust_platform]/release/coreutils ${destroot}${prefix}/bin/
+    xinstall -m 755 -d ${destroot}${prefix}/libexec/uutils
+
+    foreach binary ${binaries} {
+            ln -s ${prefix}/bin/coreutils ${destroot}${prefix}/libexec/uutils/${binary}
+            ln -s ${prefix}/bin/coreutils ${destroot}${prefix}/bin/uu-${binary}
+        }
+}
+
+notes "
+    The utilities provided by coreutils-uutils are prefixed with 'uu-' by default.
+    For example, ls becomes uu-ls.
+
+    If you want to use the uutils coreutils by default, add this directory to the front of your PATH environment variable:
+        ${prefix}/libexec/uutils
+"


### PR DESCRIPTION
#### Description
New clone of GNU coreutils, but written in Rust. Still heavily under construction.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1030 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
