### PR TITLE
postgresql12: version bump to 12.7

### DIFF
--- a/databases/postgresql12-doc/Portfile
+++ b/databases/postgresql12-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql12-doc
 conflicts           postgresql93-doc postgresql94-doc postgresql95-doc \
     postgresql96-doc postgresql10-doc postgresql11-doc
-version             12.6
+version             12.7
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -22,9 +22,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql12
 
-checksums           rmd160  034ced8da6d4b56ea6e5450dc32156f41a3f2f98 \
-                    sha256  df7dd98d5ccaf1f693c7e1d0d084e9fed7017ee248bba5be0167c42ad2d70a09 \
-                    size    20771172
+checksums           rmd160  7a8e2a19b372076498782ae7f8285826d5f5fdc7 \
+                    sha256  8490741f47c88edc8b6624af009ce19fda4dc9b31c4469ce2551d84075d5d995 \
+                    size    20819005
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql12-server/Portfile
+++ b/databases/postgresql12-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql12-server
-version             12.6
+version             12.7
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql12/Portfile
+++ b/databases/postgresql12/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql12
-version             12.6
+version             12.7
 revision            0
 
 categories          databases
@@ -27,9 +27,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  034ced8da6d4b56ea6e5450dc32156f41a3f2f98 \
-                    sha256  df7dd98d5ccaf1f693c7e1d0d084e9fed7017ee248bba5be0167c42ad2d70a09 \
-                    size    20771172
+checksums           rmd160  7a8e2a19b372076498782ae7f8285826d5f5fdc7 \
+                    sha256  8490741f47c88edc8b6624af009ce19fda4dc9b31c4469ce2551d84075d5d995 \
+                    size    20819005
 
 use_bzip2           yes
 


### PR DESCRIPTION
See: https://trac.macports.org/ticket/63109

#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
