### PR TITLE
py-sphinx-autodoc-typehints: New port

### DIFF
--- a/python/py-sphinx-autodoc-typehints/Portfile
+++ b/python/py-sphinx-autodoc-typehints/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sphinx-autodoc-typehints
+version             1.12.0
+revision            0
+categories-append   textproc devel
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {outlook.de:judaew @judaew} openmaintainer
+
+description         Type hints (PEP 484) support for the Sphinx autodoc extension
+long_description    \
+    This extension allows you to use Python 3 annotations for documenting \
+    acceptable argument types and return value types of functions.
+homepage            https://github.com/agronholm/sphinx-autodoc-typehints
+
+checksums           rmd160  ed1fb33fe6786ae54afbcae751c2fc76a3a21309 \
+                    sha256  193617d9dbe0847281b1399d369e74e34cd959c82e02c7efde077fca908a9f52 \
+                    size    19494
+
+python.versions     36 37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-setuptools_scm
+    depends_run-append \
+                        port:py${python.version}-sphinx
+
+    livecheck.type      none
+}


### PR DESCRIPTION
Version 1.12.0

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
