### PR TITLE
simg2img: update to 1.1.4

### DIFF
--- a/sysutils/simg2img/Portfile
+++ b/sysutils/simg2img/Portfile
@@ -3,7 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        anestisb android-simg2img 1.1.3
+#github.setup        anestisb android-simg2img 1.1.4
+# 2807b36 is 3 commits after 1.1.4: includes minor cleanup and build flag fix
+github.setup        anestisb android-simg2img 2807b36
+version             1.1.4
 name                simg2img
 categories          sysutils
 platforms           darwin
@@ -14,35 +17,35 @@ description         Tool to convert Android sparse images to raw images
 
 long_description    ${description}
 
-checksums           rmd160  39da89cefc9040c07288cba3cab62874cc74473d \
-                    sha256  2a441cdf8d7f1e378098d2da548d472bd31a312ecc17310f50a9ca2e01b8018f \
-                    size    23263
+checksums           rmd160  54a3457aa795a3f73aa383a6c2f98fa6b056152d \
+                    sha256  df878f928fd6e6f8d7d990b56412adc8afbc08f7822f05a843d326461bee71e8 \
+                    size    23968
+
+# Avoid rebuilding during destroot
+patchfiles-append   Makefile.patch
 
 use_configure       no
 
-depends_lib         port:zlib
+depends_lib-append  port:zlib
 
 variant universal {}
 
 destroot.args-append    PREFIX=${destroot}${prefix}
 
+# Remove after 2022-06-18
 subport ${name}-devel {
-    github.setup    anestisb android-simg2img a8514caa7ccdc5f1a03c2a88b0d38b7e6bdc421d
-    name            simg2img-devel
+    PortGroup       obsolete 1.0
+
     version         20191105
-
-    checksums       rmd160  f7410710330f468ecef1e563298c4af2274a5bef \
-                    sha256  adb34203a4872296de953e1d6e32d07c8357af967923cc702fabca5ff933d50c \
-                    size    23938
-
-    conflicts       simg2img
-
-    compiler.cxx_standard   2017
+    revision        1
+    replaced_by     ${name}
 }
 
 if {${subport} eq ${name}} {
     conflicts       simg2img-devel
 }
+
+compiler.cxx_standard 2017
 
 build.args-append   CC="${configure.cc} [get_canonical_archflags cc]" \
                     CXX="${configure.cxx} [get_canonical_archflags cxx]"

--- a/sysutils/simg2img/files/Makefile.patch
+++ b/sysutils/simg2img/files/Makefile.patch
@@ -1,0 +1,44 @@
+The $(LIB_NAME) target does not output a file called $(LIB_NAME),
+so it and any dependents are always rebuilt, such as during
+`make install`. Using the output file $(SLIB) as the target name
+and in dependents avoids this.
+
+Upstream-Status: Submitted (https://github.com/anestisb/android-simg2img/pull/33)
+
+--- Makefile.orig	2020-06-19 10:02:43.000000000 -0500
++++ Makefile	2021-06-18 13:02:09.000000000 -0500
+@@ -69,7 +69,7 @@
+ .PHONY: default all clean install
+ 
+ default: all
+-all: $(LIB_NAME) simg2img simg2simg img2simg append2simg
++all: $(SLIB) simg2img simg2simg img2simg append2simg
+ 
+ install: all
+ 	install -d $(PREFIX)/bin $(PREFIX)/lib $(PREFIX)/include/sparse
+@@ -77,20 +77,20 @@
+ 	install -m 0755 $(SLIB) $(PREFIX)/lib
+ 	install -m 0644 $(HEADERS) $(PREFIX)/include/sparse
+ 
+-$(LIB_NAME): $(LIB_OBJS)
++$(SLIB): $(LIB_OBJS)
+ 		$(AR) rc $(SLIB) $(LIB_OBJS)
+ 		$(RANLIB) $(SLIB)
+ 
+-simg2img: $(SIMG2IMG_SRCS) $(LIB_NAME)
++simg2img: $(SIMG2IMG_SRCS) $(SLIB)
+ 		$(CXX) $(CPPFLAGS) $(LIB_INCS) -o simg2img $< $(LDFLAGS)
+ 
+-simg2simg: $(SIMG2SIMG_SRCS) $(LIB_NAME)
++simg2simg: $(SIMG2SIMG_SRCS) $(SLIB)
+ 		$(CXX) $(CPPFLAGS) $(LIB_INCS) -o simg2simg $< $(LDFLAGS)
+ 
+-img2simg: $(IMG2SIMG_SRCS) $(LIB_NAME)
++img2simg: $(IMG2SIMG_SRCS) $(SLIB)
+ 		$(CXX) $(CPPFLAGS) $(LIB_INCS) -o img2simg $< $(LDFLAGS)
+ 
+-append2simg: $(APPEND2SIMG_SRCS) $(LIB_NAME)
++append2simg: $(APPEND2SIMG_SRCS) $(SLIB)
+ 		$(CXX) $(CPPFLAGS) $(LIB_INCS) -o append2simg $< $(LDFLAGS)
+ 
+ %.o: %.cpp .depend


### PR DESCRIPTION
Replace `simg2img-devel` (which was already at 1.1.4) with `simg2img`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
