### PR TITLE
leiningen: update to 2.9.6

### DIFF
--- a/devel/leiningen/Portfile
+++ b/devel/leiningen/Portfile
@@ -5,9 +5,9 @@ PortGroup           java 1.0
 # *sigh* can't seem to get the git portgroup to have additional distfiles, so do everything manually
 
 name                leiningen
-version             2.9.3
+version             2.9.6
 categories          devel java
-maintainers         openmaintainer easieste
+maintainers         {easieste @easye} openmaintainer
 platforms           darwin
 supported_archs     noarch
 license             EPL-1
@@ -16,9 +16,6 @@ description         A build tool for Clojure designed to not set your hair on fi
 long_description    {*}${description}
 
 homepage            https://leiningen.org
-
-# Not entirely sure if this is needed at this point
-depends_run         port:jline
 
 master_sites \
     https://github.com/technomancy/leiningen/archive/:source \
@@ -30,13 +27,13 @@ distfiles           \
 
 checksums           \
     ${version}.tar.gz \
-                    rmd160  a944bd0f10a167089f3b1bf974072d8e729e8eae \
-                    sha256  98cc1e58ebe0d71fede73ae6c7699f1b9b944650d57a220e576bc95a3185b846 \
-                    size    754027 \
+                    rmd160  fb157ce84899f859de97c71b5e6a32ed898f9534 \
+                    sha256  2f3b8a7eb710bd3a266975387f216bd4a3bace2f1b0a1f0ae88a93d919d813d9 \
+                    size    923578 \
     leiningen-${version}-standalone.zip \
-                    rmd160  e76a97cf17e6e94e89b0b242042bb4fef7916112 \
-                    sha256  23e1df18bc97226d570f47335a8d543e1b759ea303544ea57d5309be3dedcbbb \
-                    size    14670316
+                    rmd160  25f881f605a4b6b7548489279db23bd86f47c2a3 \
+                    sha256  41c543f73eec4327dc20e60d5d820fc2a9dc772bc671610b9c385d9c4f5970b8 \
+                    size    12760940
 
 java.version    1.8+
 


### PR DESCRIPTION
`jline` dependency was unused

#### Description
https://github.com/technomancy/leiningen/blob/2.9.6/NEWS.md
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
