### PR TITLE
MoarVM, nqp, rakudo: update to 2021.05

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                MoarVM
-version             2021.03
+version             2021.05
 categories          lang devel
 platforms           darwin
 license             Artistic-2 MIT BSD ISC public-domain
@@ -16,15 +16,16 @@ long_description    MoarVM is a virtual machine built especially for \
 homepage            https://moarvm.org/
 master_sites        https://moarvm.org/releases/
 
-checksums           rmd160  8aa615f905022753538ff7201ef5cd2417947687 \
-                    sha256  8a0cf32273e473af884f409a02ad13c4aed5646628facf86544f6b3757e5cacf \
-                    size    5449879
+
 
 # TODO: https://github.com/MoarVM/MoarVM/issues/321
 # conflicts         dyncall libtommath libuv
 conflicts           libtommath
 
-# configure.cflags-append \
+checksums           rmd160  32665b40603d03f79a1ab21969123c906aa3b515 \
+                    sha256  b14c8778664e3bcaed9cfde3c7b3a3b1898be5f839efee7464979e3954a6a897 \
+                    size    5448573
+
 #                   -I${prefix}/include/libtommath
 depends_build       port:perl5 \
                     port:pkgconfig

--- a/lang/nqp/Portfile
+++ b/lang/nqp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Raku nqp 2021.03
+github.setup        Raku nqp 2021.05
 description         A lightweight Perl-6 like language for virtual machines
 long_description    This is "Not Quite Perl" -- a lightweight Perl 6-like \
                     environment for virtual machines.  The key feature of \
@@ -21,9 +21,9 @@ platforms           darwin
 github.tarball_from \
                     releases
 
-checksums           rmd160  2259f2cde330358fe71f17ae9f200829bf72d5ef \
-                    sha256  73498f685b8efbd54e43176d41a8f001c32abd27bcb0a801dcd69d38f4e61c11 \
-                    size    3986989
+checksums           rmd160  a9a4cb0ff5088574df53c2fe045244f09af4ccc4 \
+                    sha256  b43cf9d25a8b3187c7e132e1edda647d58bc353ca0fb534cc9aa0f8df7fff73f \
+                    size    5204115
 
 depends_build       port:perl5
 

--- a/lang/rakudo/Portfile
+++ b/lang/rakudo/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rakudo rakudo 2021.03
+github.setup        rakudo rakudo 2021.05
 description         Perl6 compiler
 long_description    Rakudo is a compiler for the Perl 6 language (version 6.d) \
                     Rakudo is built using NQP (Not Quite Perl 6), which in \
@@ -19,9 +19,9 @@ homepage            https://rakudo.org/
 github.tarball_from \
                     releases
 
-checksums           rmd160  8777e22c91a2d1298412e5f04ddb4c0c547025fd \
-                    sha256  98eb57fa0f4953aa6617111f36a2706799d8082b42e22c37cf104a918d914ec2 \
-                    size    5713393
+checksums           rmd160  e5d3e902062b1ff74c73c94a9966e4aba583fb13 \
+                    sha256  538633ed2eb742d15972742ffb5e9ccae1b238fca053565da48ee9bdc96a3341 \
+                    size    5726333
 
 depends_build       port:perl5
 


### PR DESCRIPTION
#### Description

Update MoarVM, nqp and rakudo to 2021.05

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
