### PR TITLE
retroarch: update to 1.9.5

### DIFF
--- a/emulators/retroarch/Portfile
+++ b/emulators/retroarch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        libretro RetroArch 1.9.4 v
+github.setup        libretro RetroArch 1.9.5 v
 revision            0
 
 name                retroarch
@@ -15,9 +15,9 @@ categories          emulators games
 description         Frontend for the libretro API.
 long_description    {*}${description}
 
-checksums           rmd160  4a343884b6420b3148abcbe9265a5a45a6fada9c \
-                    sha256  ef890445fd4979981be55f97f24a0e2c123411b7d9637665c6448e12d180eb29 \
-                    size    40034227
+checksums           rmd160  adf3770a2ce0f4dc4c116f1e36ff922c80ac2ca2 \
+                    sha256  575454e0004f8cf2d46d3d801010f76ee937d787d9977efb28ccec77b77aba4d \
+                    size    40042823
 
 # See https://github.com/libretro/RetroArch/issues/8641
 patchfiles          patch-${name}-library-dirs.diff


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
