### PR TITLE
buku: update to 4.6

### DIFF
--- a/www/buku/Portfile
+++ b/www/buku/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        jarun buku 4.5 v
-revision            1
-checksums           rmd160  2d9bae34717c962c69f5474cda95f391677e2fb2 \
-                    sha256  e043ca1467e6f5740648951b05ef09f57b241dd5a70d27637e78e3e586498ef5 \
-                    size    488981
+github.setup        jarun buku 4.6 v
+revision            0
+checksums           rmd160  a664585e4b22af2d2df5234f9ae1ac6684670007 \
+                    sha256  fead7e20364b710ac9205f1c03684ba351dcbe25d4d4c5c233de5817c05abe6f \
+                    size    491881
 
 description         A command-line bookmark manager
 long_description    buku is a powerful bookmark manager written in \
@@ -32,6 +32,9 @@ maintainers         {isi.edu:calvin @cardi} openmaintainer
 license             GPL-3
 
 python.default_version  39
+
+depends_build-append \
+                    port:py${python.version}-setuptools
 
 depends_lib-append  port:py${python.version}-beautifulsoup4 \
                     port:py${python.version}-certifi \


### PR DESCRIPTION
#### Description
buku: update to 4.6
* add py-setuptools as a build dependency

###### Tested on
macOS 10.15.7 19H524 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
