### PR TITLE
makefile 1.0 portgroup: clean up MacPorts < 2.7.0 handling

### DIFF
--- a/_resources/port1.0/group/makefile-1.0.tcl
+++ b/_resources/port1.0/group/makefile-1.0.tcl
@@ -44,28 +44,6 @@ default muniversal.arch_tools  {}
 default use_configure           no
 default universal_variant       yes
 
-# please remove when 7c91604 has been in a released MacPorts version for at least two weeks
-# see https://github.com/macports/macports-base/commit/7c91604891fa0d071b8d598490c4dc2edb8e0031
-if {![info exists compiler.log_verbose_output]} {
-    options compiler.log_verbose_output
-    default compiler.log_verbose_output yes
-}
-
-# please remove when a86f95c has been in a released MacPorts version for at least two weeks
-# see https://github.com/macports/macports-base/commit/a86f95c5ab86ee52c8fec2271e005591179731de
-if {![info exists compiler.limit_flags]} {
-    options compiler.limit_flags
-    default compiler.limit_flags        no
-}
-
-# please remove when 8a088c3 has been in a released MacPorts version for at least two weeks
-# see https://github.com/macports/macports-base/commit/8a088c30d80c7c3eca10848f28835e1c180229b1
-if {"shellescape" ni [info commands shellescape]} {
-    proc shellescape {arg} {
-        return [regsub -all -- {[^A-Za-z0-9.:@%/+=_-]} $arg {\\&}]
-    }
-}
-
 namespace eval makefile_pg {
 }
 


### PR DESCRIPTION
MacPorts 2.7.0 included macports/macports-base#163, macports/macports-base#165, and macports/macports-base@8a088c3

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
