### PR TITLE
mecab-base: try to fix build on 10.8 and earlier

### DIFF
--- a/textproc/mecab-base/Portfile
+++ b/textproc/mecab-base/Portfile
@@ -24,7 +24,8 @@ checksums           rmd160  a06fa0c0eb44eef8c45171b769b43c655971ac4a \
 
 depends_lib         port:libiconv
 
-patchfiles          patch-configure.diff
+patchfiles-append   patch-configure.diff \
+                    patch-ltmain.sh.diff
 
 configure.args      --mandir=${prefix}/share/man \
                     --with-libiconv-prefix=${prefix}

--- a/textproc/mecab-base/files/patch-ltmain.sh.diff
+++ b/textproc/mecab-base/files/patch-ltmain.sh.diff
@@ -1,0 +1,22 @@
+Backported from newer libtool:
+
+From c0c49f289f22ae670066657c60905986da3b555f Mon Sep 17 00:00:00 2001
+From: Titus von Boxberg <titus@v9g.de>
+Date: Sun, 19 Feb 2012 15:33:48 -0600
+Subject: [PATCH] Accept clang's -stdlib linker flag.
+
+--- ltmain.sh.orig	2013-02-15 02:07:57.000000000 -0600
++++ ltmain.sh	2021-06-19 22:25:31.000000000 -0500
+@@ -5850,10 +5850,11 @@
+       # @file                GCC response files
+       # -tp=*                Portland pgcc target processor selection
+       # --sysroot=*          for sysroot support
++      # -stdlib=*            select c++ std lib with clang
+       # -O*, -flto*, -fwhopr*, -fuse-linker-plugin GCC link-time optimization
+       -64|-mips[0-9]|-r[0-9][0-9]*|-xarch=*|-xtarget=*|+DA*|+DD*|-q*|-m*| \
+       -t[45]*|-txscale*|-p|-pg|--coverage|-fprofile-*|-F*|@*|-tp=*|--sysroot=*| \
+-      -O*|-flto*|-fwhopr*|-fuse-linker-plugin)
++      -O*|-flto*|-fwhopr*|-fuse-linker-plugin|-stdlib=*)
+         func_quote_for_eval "$arg"
+ 	arg="$func_quote_for_eval_result"
+         func_append compile_command " $arg"


### PR DESCRIPTION
#### Description
At least [10.7](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/56930/steps/install-port/logs/stdio) and [10.8](https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/50398/steps/install-port/logs/stdio) builds fail due to outdated libtool not passing `-stdlib=libc++`:
```
/bin/sh ../libtool --tag=CXX   --mode=link /usr/bin/clang++  -pipe -Os -stdlib=libc++ -arch x86_64 -Wall  -no-undefined -version-info 2:0:0 -L/opt/local/lib -Wl,-headerpad_max_install_names -arch x86_64 -o libmecab.la -rpath /opt/local/lib viterbi.lo tagger.lo utils.lo eval.lo iconv_utils.lo dictionary_rewriter.lo dictionary_generator.lo dictionary_compiler.lo context_id.lo connector.lo nbest_generator.lo writer.lo string_buffer.lo param.lo tokenizer.lo char_property.lo dictionary.lo feature_index.lo lbfgs.lo learner_tagger.lo learner.lo libmecab.lo  -lpthread -lpthread  -lstdc++ -liconv
libtool: link: /usr/bin/clang++ -dynamiclib  -o .libs/libmecab.2.dylib  .libs/viterbi.o .libs/tagger.o .libs/utils.o .libs/eval.o .libs/iconv_utils.o .libs/dictionary_rewriter.o .libs/dictionary_generator.o .libs/dictionary_compiler.o .libs/context_id.o .libs/connector.o .libs/nbest_generator.o .libs/writer.o .libs/string_buffer.o .libs/param.o .libs/tokenizer.o .libs/char_property.o .libs/dictionary.o .libs/feature_index.o .libs/lbfgs.o .libs/learner_tagger.o .libs/learner.o .libs/libmecab.o   -L/opt/local/lib -lpthread -lstdc++ /opt/local/lib/libiconv.dylib  -Os -arch x86_64 -Wl,-headerpad_max_install_names -arch x86_64   -install_name  /opt/local/lib/libmecab.2.dylib -compatibility_version 3 -current_version 3.0 -Wl,-single_module
Undefined symbols for architecture x86_64:
  "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::find(char const*, unsigned long, unsigned long) const", referenced from:
      MeCab::replace_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in utils.o

…

ld: symbol(s) not found for architecture x86_64
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Only patch phase tested.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
