### PR TITLE
gitlab-runner: update to 14.0.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 13.12.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 14.0.0 v
 
 categories          devel
 platforms           darwin
@@ -22,15 +22,16 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  750d2150e025d34b92174844aef6aedfbf248a4d \
-                    sha256  4423ec46b5a9fb836bae5598558949acf9c46f3874b05548d0bc648c2583049e \
-                    size    8616716
+checksums           rmd160  df34acefddb28f1ccce7f55fd1cfa31050684d6d \
+                    sha256  1db6477bbce113164519059ae15627476d3adab95d829ef622dc3f1c36253aab \
+                    size    8847902
 
+set build_date      [exec date +%FT%T%z]
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \
     -X ${go.package}/common.VERSION=${version} \
     -X ${go.package}/common.REVISION=unknown \
-    -X ${go.package}/common.BUILT=unknown \
+    -X ${go.package}/common.BUILT=${build_date} \
     -X ${go.package}/common.BRANCH=unknown \
     -s -w"
 build.args          -ldflags \"${go_ldflags}\" -o out/binaries/${name} ${go.package}


### PR DESCRIPTION
#### Description

Update to GitLab Runner 14.0.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?