### PR TITLE
py27-matplotlib: revbump after updating qhull

### DIFF
--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -55,7 +55,7 @@ if {${name} ne ${subport}} {
 
     if {${python.version} eq 27} {
         version     2.2.5
-        revision    2
+        revision    3
         checksums   rmd160  4532a205e8f40d6f40346b2e461d3dca144b38b9 \
                     sha256  a3037a840cd9dfdc2df9fee8af8f76ca82bfab173c0f9468193ca7a89a2b60ea \
                     size    36678633
@@ -72,7 +72,7 @@ if {${name} ne ${subport}} {
                     patch-v2-jquery-ui.diff
     } elseif {${python.version} eq 35} {
         version     3.0.3
-        revision    3
+        revision    4
         checksums   rmd160  98ecd1ca25d555bde5d43fcaef800f7436d7d738 \
                     sha256  e1d33589e32f482d0a7d1957bf473d43341115d40d33f578dad44432e47df7b7 \
                     size    36640137


### PR DESCRIPTION
#### Description

I still had some old copy of `py27-matplotlib` installed and noticed macports complaining about it being broken after update (files installed by `qhull` were changed).

It could be that some other subports shipping an older version are affected as well, I didn't explicitly check those.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G9016 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
