### PR TITLE
libgcc11: use as default on 10.6

### DIFF
--- a/_resources/port1.0/compilers/gcc_compilers.tcl
+++ b/_resources/port1.0/compilers/gcc_compilers.tcl
@@ -5,16 +5,13 @@
 
 global os.major os.arch
 
-if { ${os.major} >= 11 } {
+if { ${os.major} >= 10 } {
     lappend compilers macports-gcc-11 macports-gcc-10
 }
 
 if { ${os.arch} ne "arm" } {
-    if { ${os.major} >= 11 } {
-        lappend compilers macports-gcc-9
-    }
     if { ${os.major} >= 10 } {
-        lappend compilers macports-gcc-8
+        lappend compilers macports-gcc-9 macports-gcc-8
     }
     if { ${os.major} < 20 } {
         lappend compilers macports-gcc-7 macports-gcc-6 macports-gcc-5

--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -81,8 +81,6 @@ default compilers.allow_arguments_mismatch no
 if {${os.major} < 10} {
     # see https://trac.macports.org/ticket/57135
     set compilers.gcc_default gcc7
-} elseif {${os.major} < 11} {
-    set compilers.gcc_default gcc8
 } else {
     set compilers.gcc_default gcc11
 }
@@ -99,10 +97,7 @@ if { ${os.arch} eq "arm" } {
         lappend gcc_versions 5 6 7
     }
     if { ${os.major} >= 10 } {
-        lappend gcc_versions 8
-    }
-    if { ${os.major} >= 11 } {
-        lappend gcc_versions 9 10 11 devel
+        lappend gcc_versions 8 9 10 11 devel
     }
 }
 # GCC version providing the primary runtime
@@ -110,11 +105,7 @@ if { ${os.arch} eq "arm" } {
 if { ${os.major} < 10 } {
     set gcc_main_version 7
 } else {
-    if { ${os.major} < 11 } {
-        set gcc_main_version 8
-    } else {
-        set gcc_main_version 10
-    }
+    set gcc_main_version 11
 }
 ui_debug "GCC versions for Darwin ${os.major} ${os.arch} - ${gcc_versions}"
 foreach ver ${gcc_versions} {

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -168,7 +168,7 @@ use_parallel_build  yes
 destroot.target     install install-info-host
 
 # Is this gcc release supported here.
-if { ${os.major} < 11 } {
+if { ${os.major} < 10 } {
     known_fail  yes
     pre-fetch {
         ui_error "${name} ${version} is not supported on Darwin ${os.major} ${os.arch}"

--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -196,7 +196,7 @@ use_parallel_build  yes
 destroot.target     install install-info-host
 
 # Is this gcc release supported here.
-if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+if { ${os.platform} eq "darwin" && ${os.major} < 10 } {
     known_fail   yes
     pre-fetch {
         ui_error "${name} ${version} is not supported on Darwin ${os.major}"
@@ -224,6 +224,14 @@ if { ${subport} ne ${name}} {
     # Activate hack for new libgcc
     # https://trac.macports.org/wiki/PortfileRecipes#deactivatehack
     pre-activate {
+        if {![catch {set installed [lindex [registry_active libgcc8] 0]}]} {
+            # Extract the epoch of the installed libgcc8
+            set _epoch [lindex $installed 5]
+            # If < 5 need to deactivate
+            if {[vercmp $_epoch 5] < 0} {
+                registry_deactivate_composite libgcc8 "" [list ports_nodepcheck 1]
+            }
+        }
         if {![catch {set installed [lindex [registry_active libgcc10] 0]}]} {
             # Extract the epoch of the installed libgcc9
             set _epoch [lindex $installed 5]

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -8,11 +8,11 @@ PortGroup conflicts_build              1.0
 PortGroup xcode_workaround             1.0
 PortGroup cltversion                   1.0
 
-epoch               4
+epoch               5
 name                gcc8
 version             8.5.0
 revision            0
-subport             libgcc8 { revision 0 }
+subport             libgcc8 { revision 1 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -42,7 +42,10 @@ checksums           rmd160  e7f3dedec67864006bf9f7e358817ce713b4476e \
 # If it is, libgcc8 installs a full runtime, otherwise it only installs
 # what is missing from newer libgccX builds.
 # NOTE : The logic here must match that in the libgcc port.
-set isLastSupported [ expr ${os.major} < 11 ]
+#set isLastSupported [ expr ${os.major} < 10 ]
+
+# libgcc8 is currently not the last supported libgcc for any system
+set isLastSupported false
 
 patchfiles          patch-fix-libgccjit-soname
 
@@ -126,6 +129,12 @@ configure.args      --enable-languages=[join ${gcc_configure_langs} ","] \
 # it only determines how std::call_once works
 configure.args-append \
                     --disable-tls
+
+# on 10.6.8 building with the system gcc compilers leads to
+# bootstrap comparison failures
+platform darwin 10 {
+    compiler.blacklist-append *gcc-3.* *gcc-4.*
+}
 
 if { ${os.platform} eq "darwin" } {
     if { [vercmp ${xcodeversion} 12.5] >= 0 || [ vercmp ${cltversion} 12.5 ] >= 0 } {

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -157,7 +157,7 @@ use_parallel_build  yes
 destroot.target     install install-info-host
 
 # Is this gcc release supported here.
-if { ${os.major} < 11 || ${os.arch} eq "arm" } {
+if { ${os.major} < 10 || ${os.arch} eq "arm" } {
     known_fail  yes
     pre-fetch {
         ui_error "${name} ${version} is not supported on Darwin ${os.major} ${os.arch}"

--- a/lang/libgcc/Portfile
+++ b/lang/libgcc/Portfile
@@ -5,7 +5,7 @@ PortGroup select    1.0
 
 epoch               3
 name                libgcc
-version             4.0
+version             5.0
 revision            0
 
 conflicts           libgcc-devel
@@ -34,11 +34,7 @@ variant universal   { }
 if { ${os.major} < 10 } {
     set gcc_version 7
 } else {
-    if { ${os.major} < 11 } {
-        set gcc_version 8
-    } else {
-        set gcc_version 11
-    }
+    set gcc_version 11
 }
 depends_lib port:libgcc${gcc_version}
 


### PR DESCRIPTION
this brings all reasonably supported systems into
parity so all use gcc11 / libgcc11

simplifies logic considerably

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode 3.2

I have not tested this on the i386 10.6.8 system.

```
$ port -v installed | grep gcc
  gcc5 @5.5.0_6 (active) requested_variants='' platform='darwin 10' archs='x86_64' date='2020-11-11T23:08:55-0800'
  gcc6 @6.5.0_6+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2020-11-11T15:57:32-0800'
  gcc7 @7.5.0_2+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-20T14:46:48-0700'
  gcc8 @8.5.0_0+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-19T00:26:11-0700'
  gcc9 @9.4.0_0+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-19T11:32:18-0700'
  gcc10 @10.3.0_0+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-19T14:27:26-0700'
  gcc11 @11.1.0_2+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-18T04:07:55-0700'
  gcc48 @4.8.5_5+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2018-10-18T08:19:43-0700'
  gcc_select @0.1_9 (active) requested_variants='' platform='darwin 10' archs='noarch' date='2020-11-01T09:55:10-0800'
  libgcc @4.0_0+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-05-15T00:12:33-0700'
  libgcc6 @6.5.0_4+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2019-05-06T00:26:20-0700'
  libgcc7 @7.5.0_0+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2019-11-18T14:45:24-0800'
  libgcc8 @8.5.0_1+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-20T11:41:23-0700'
  libgcc9 @9.4.0_0+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-18T09:27:32-0700'
  libgcc10 @10.3.0_1+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-18T09:31:16-0700'
  libgcc11 @11.1.0_2+universal (active) requested_variants='+universal' platform='darwin 10' archs='i386 x86_64' date='2021-06-18T00:51:20-0700'
```