### PR TITLE
py-rpy2: Add openmp default variant to mirror R Portfile

### DIFF
--- a/python/py-rpy2/Portfile
+++ b/python/py-rpy2/Portfile
@@ -6,8 +6,8 @@ PortGroup           python 1.0
 
 name                py-rpy2
 version             3.4.5
-revision            0
-categories-append   science
+revision            1
+categories-append   math science
 platforms           darwin
 license             {MPL-1.1 LGPL-2.1+}
 
@@ -59,14 +59,22 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools
 
     # To continue using your custom R installation instead of MacPorts' R,
-    # you have to remove this dependency line and make sure that your R
+    # you must remove this dependency line and make sure that your R
     # is in MacPorts' binpath, see your macports.conf for details.
     depends_lib-append  port:R
 
     # https://trac.macports.org/ticket/61327
-    if {![catch {set result [active_variants R openmp]}]} {
-        compiler.openmp_version 4.0
+    variant openmp description {enable parallelism support using OpenMP} {
+        # Please mirror the version used in math/R/Portfile
+        compiler.openmp_version 4.5
+
+        require_active_variants R openmp
+
+        notes-append "
+            Support OpenMP, mirroring the R port."
     }
+    # Please mirror the default used in math/R/Portfile
+    default_variants +openmp
 
     livecheck.type  none
 }


### PR DESCRIPTION
py-rpy2: Add openmp default variant to mirror R Portfile

* Add openmp default variant to mirror R Portfile
* Fixes: https://github.com/macports/macports-ports/commit/b4aa8b2166a93b177815077c912a3df9d0d58d0d#r52426267

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
