### PR TITLE
scrcpy: update to 1.18

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           meson 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        Genymobile scrcpy 1.17 v
-revision            1
+github.setup        Genymobile scrcpy 1.18 v
+revision            0
 
 categories          multimedia
 platforms           darwin
@@ -24,13 +24,13 @@ extract.only        ${distfiles}
 distfiles-append    ${name}-server-v${version}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b0909f342a61e6001fe1643df98f38d0dcc99641 \
-                    sha256  b3f5490970dbef6f50725b4d46ba07baed9c7eb19696e71029257a01044c6664 \
-                    size    266684 \
+                    rmd160  6f93f6b2dfa50c5e1bcce43ec14d777bfb9574e3 \
+                    sha256  a857724aac428853e24c870a7fc3dad43ae1d4bf7c35c470eae3e00fb3db5c46 \
+                    size    299534 \
                     ${name}-server-v${version} \
-                    rmd160  59bc2a451016f5c5f11a22643a441a19e3a78b9b \
-                    sha256  11b5ad2d1bc9b9730fb7254a78efd71a8ff46b1938ff468e47a21b653a1b6725 \
-                    size    34930
+                    rmd160  a0a96d90f96f2c747204db2f7df087b5eb2ca91b \
+                    sha256  641c5c6beda9399dfae72d116f5ff43b5ed1059d871c9ebc3f47610fd33c51a3 \
+                    size    37330
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

~~scrcpy server appears to stay the same (hence the same checksums).~~

So much for that. I wonder why it didn't error out when I tried installing it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
