### PR TITLE
duckdb: enable parquet and full text search extensions

### DIFF
--- a/databases/duckdb/Portfile
+++ b/databases/duckdb/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
 
 github.setup        cwida duckdb 0.2.7 v
-revision            0
+revision            1
 
 homepage            https://www.duckdb.org
 
@@ -31,6 +31,9 @@ patch {
     reinplace {/find_program(CCACHE_PROGRAM ccache)/ d} \
         ${worksrcpath}/CMakeLists.txt
 }
+
+configure.args-append -DBUILD_PARQUET_EXTENSION=TRUE \
+                      -DBUILD_FTS_EXTENSION=TRUE
 
 fetch.type          git
 


### PR DESCRIPTION
#### Description

adds a variant to duckdb that enables support for Apache Parquet. 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
macOS 10.15.7 19H2 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
