### PR TITLE
google-cloud-sdk: update to 346.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             345.0.0
+version             346.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  51280d335f12158d6a7e96c2596d4781af3b1cd7 \
-                    sha256  ed1e2d4df975a29755f3aa5ced605cf4db47ffbf7dbf36465524cde57b02d1c0 \
-                    size    90188110
+    checksums       rmd160  939e2bb45a4049e9e085559462e5f249b8f81876 \
+                    sha256  85493c0c5aba8fce9f8e7d1886bc0916db44bd0847cbf862cf87435fc8d729ff \
+                    size    90254396
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  686b1875797de316954a20311b63e94238818329 \
-                    sha256  705d2b82f711e042d930bf96103291f472d7a1aab5a152bfed2896d595d811dd \
-                    size    86431672
+    checksums       rmd160  12e8f924060af1782dfb93ef6b1f7c3db905cbae \
+                    sha256  632164280208c050f015c9d04fa805c05478e80518a0fe667b413df55ab926ee \
+                    size    86501616
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  9bc83394ac7a4e2001e605c8998a8555524aa742 \
-                    sha256  4db070e65d5dba33efd2c2d744845aaa1dac56f94e5e439604800ffa0bf27dff \
-                    size    86355324
+    checksums       rmd160  6341ca4da37a8f5167580a2969de4025c45561c1 \
+                    sha256  707948f45c8cc01012a92e3aff8af3701a89777bccdeec905310f70951c75bdb \
+                    size    86424611
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 346.0.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?