### PR TITLE
s5cmd: new port

### DIFF
--- a/net/s5cmd/Portfile
+++ b/net/s5cmd/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/peak/s5cmd 1.2.1 v
+set git_commit      3fc01af
+revision            0
+
+categories          net
+maintainers         {gmail.com:smanojkarthick @manojkarthick} \
+                    openmaintainer
+
+license             MIT
+
+description         Parallel S3 and local filesystem execution tool.
+
+long_description    s5cmd is a very fast S3 and local filesystem execution tool. \
+                    It comes with support for a multitude of operations including \
+                    tab completion and wildcard support for files, which can be very \
+                    handy for your object storage workflow while working with large number of files.
+
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  04f8f62c39bf6328d3117ae357e8c5fbbe42ac53 \
+                        sha256  b28539d69bbb04c5f88f0c8287631465bc06239be8b1741576df844bc6a2c33f \
+                        size    2704732
+
+build.cmd           make
+build.args          build
+build.env-replace   GO111MODULE=off GO111MODULE=on
+
+installs_libs       no
+
+# replace the build version and git commit
+patch {
+    reinplace "s|-X=github.com/peak/s5cmd/version.Version=\$\(VERSION\)|-X=github.com/peak/s5cmd/version.Version=${version}|" \
+        ${worksrcpath}/Makefile
+
+    reinplace "s|-X=github.com/peak/s5cmd/version.GitCommit=\$\(BUILD\)|-X=github.com/peak/s5cmd/version.GitCommit=${git_commit}|" \
+       ${worksrcpath}/Makefile
+}
+
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
s5cmd is a very fast S3 manipulation tool that is faster than the AWS CLI for S3 operations.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.2.3 20D91 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
