### PR TITLE
sshfs: backport upstream commit

### DIFF
--- a/fuse/sshfs/files/sshfs.c.patch
+++ b/fuse/sshfs/files/sshfs.c.patch
@@ -10,3 +10,15 @@
  #include <assert.h>
  #include <stdio.h>
  #include <stdlib.h>
+@@ -3859,7 +3859,11 @@
+ 	}
+ #endif /* __APPLE__ */
+
++#ifdef __APPLE__
++	sshfs.blksize = 0;
++#else
+ 	sshfs.blksize = 4096;
++#endif
+ 	/* SFTP spec says all servers should allow at least 32k I/O */
+ 	sshfs.max_read = 32768;
+ 	sshfs.max_write = 32768;


### PR DESCRIPTION
* This commit backports libfuse/sshfs commit 667cf34

Original commit message:

    sshfs: fix another instance preventing use of global I/O size on
    macOS (#185)

    Following-up on [1], there was another instance where blksize was
    set to a non-zero value, thus making it impossible to configure
    global I/O size on macOS, and using [2] the hard-wired value of
    4096 bytes instead, resulting in uniformly poor performance [3].

    With this patch, setting I/O size to a reasonable large value,
    will result in much improved performance, e.g.:
      -o iosize=1048576

    [1] https://github.com/osxfuse/sshfs/commit/5c0dbfe3eb40100f9277e863926f2e7d7c9a5a4c
    [2] https://github.com/libfuse/sshfs/blob/4c21d696e9d46bebae0a936e2aec72326c5954ea/sshfs.c#L812
    [3] https://github.com/libfuse/sshfs/issues/11#issuecomment-339407557

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
