### PR TITLE
kubectx: update kubectl dependency to 1.21

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        ahmetb kubectx 0.9.3 v
-revision            0
+revision            1
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -19,7 +19,7 @@ checksums           rmd160  6b5c706da0b9c4d9ee01ba1214964542615a8a4f \
                     sha256  d9083c82a80c8192da406c76c9d7b5bca04bf4be10c6d195055e4af3a790ed13 \
                     size    520535
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.19
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.21
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update kubectl dependency to the most recent version (1.21).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?