### PR TITLE
treesheets: new port

### DIFF
--- a/editors/treesheets/Portfile
+++ b/editors/treesheets/Portfile
@@ -1,0 +1,77 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           wxWidgets 1.0
+
+github.setup        aardappel treesheets 5175451
+version             20210411
+revision            0
+
+homepage            http://strlen.com/treesheets
+
+description         Free-Form Data Organizer (Hierarchical Spreadsheet)
+
+long_description    {*}${description}
+
+categories          editors
+license             zlib
+platforms           darwin
+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  c6e758bbfb4d91d383fda66d6ff9d90908ec38a3 \
+                    sha256  6b76d44578627e67d9a56c665f8ea08d354ec87a127c57da6a7d2a9c8593d14a \
+                    size    2490516
+
+wxWidgets.use       wxWidgets-3.2
+
+set ts_app_dir      ${applications_dir}/TreeSheets.app
+set ts_libexec_dir  ${prefix}/libexec/${name}
+
+cmake.install_prefix \
+                    ${ts_libexec_dir}
+
+configure.env-append \
+                    PATH=$env(PATH):${wxWidgets.prefix}/bin
+
+build.env-append    PATH=$env(PATH):${wxWidgets.prefix}/bin
+
+github.tarball_from archive
+
+depends_lib-append port:${wxWidgets.port}
+
+post-destroot {
+    # Set up .app directory
+    file mkdir ${destroot}${ts_app_dir}/Contents/MacOS
+    file mkdir ${destroot}${ts_app_dir}/Contents/Resources
+
+    file copy ${worksrcpath}/osx/TreeSheets/App.icns \
+        ${destroot}${ts_app_dir}/Contents/Resources/
+
+    file copy ${worksrcpath}/osx/TreeSheets/TreeSheets/TreeSheets-Info.plist \
+        ${destroot}${ts_app_dir}/Contents/Info.plist
+
+    reinplace -E {s|\$\{PRODUCT_NAME\}|TreeSheets|} \
+        ${destroot}${ts_app_dir}/Contents/Info.plist
+
+    # Create and install wrapper script
+    set wrapper_script ${prefix}/bin/${name}
+
+    set wrapper_sh ${destroot}${wrapper_script}
+    set wsh [open ${wrapper_sh} w]
+    puts ${wsh} "#!/bin/sh"
+    puts ${wsh} "${ts_libexec_dir}/${name}"
+    close ${wsh}
+
+    file attributes ${destroot}${wrapper_script} -permissions 0755
+
+    reinplace -E {s|\$\{EXECUTABLE_NAME\}|wrapper.sh|} \
+        ${destroot}${ts_app_dir}/Contents/Info.plist
+
+    file copy ${destroot}${wrapper_script} \
+        ${destroot}${ts_app_dir}/Contents/MacOS/wrapper.sh
+}


### PR DESCRIPTION
New port for [TreeSheets](http://strlen.com/treesheets), a versatile open-source "hierarchical spreadsheet"

<img src="http://strlen.com/treesheets/docs/images/screenshots/screenshot_todo_half.png" />

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
