### PR TITLE
revive: new port

### DIFF
--- a/devel/revive/Portfile
+++ b/devel/revive/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/mgechev/revive 1.0.7 v
+revision            0
+
+homepage            https://revive.run/
+
+description         Fast, configurable, extensible, flexible, and beautiful \
+                    linter for Go.
+
+long_description    ${description} ${name} is a drop-in replacement of golint. \
+                    ${name} provides a framework for development of custom \
+                    rules, and lets you define a strict preset for enhancing \
+                    your development & code review processes.
+
+platforms           darwin
+categories          devel
+license             MIT
+installs_libs       no
+
+maintainers         {@enckse voidedtech.com:enckse} \
+                    openmaintainer
+
+checksums           rmd160  48ba6c9a9df204671485e16c47a503c2538cc2c3 \
+                    sha256  281d2ae19edd2b285ad2489a1e6acb7b1f5c713964a6027a5d2d23d376ed0613 \
+                    size    680538
+
+github.tarball_from archive
+
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+}
+
+# FIXME: This port currently can't be tested without allowing go mod to fetch
+# dependencies during the testing phase (additional modules needed for testing).
+# See https://trac.macports.org/ticket/61192
+test.env-delete     GOPROXY=off GO111MODULE=off
+test.run            yes
+test.cmd            go test -v ./...


### PR DESCRIPTION
#### Description

A new port for [revive](https://revive.run/) which is a Go linter

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 arm64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
