### PR TITLE
go-tools: update to 0.1.4

### DIFF
--- a/devel/go-tools/Portfile
+++ b/devel/go-tools/Portfile
@@ -1,71 +1,32 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        golang tools 89232532d2d57ce53cc88eccb5d060e92f86729b
-version             20200630-[string range ${github.version} 0 7]
-epoch               6
+go.setup            github.com/golang/tools 0.1.4 v
+epoch               7
+revision            0
+
+
 name                go-tools
 categories          devel
 platforms           darwin freebsd linux
 license             BSD
-maintainers         {ciserlohn @ci42}
+maintainers         {ciserlohn @ci42} {@enckse voidedtech.com:enckse} openmaintainer
 description         Various packages and tools that support the Go programming language.
 long_description    $description
 
-checksums           rmd160  97410382ccbe3efce08e96756c63db33eb8b1703 \
-                    sha256  c451b5af8a10b06624d5ae92c33aa1b30beaf380e195d1373b333fde1553c15a \
-                    size    2484284
-		    
-depends_build	    port:go
+checksums           rmd160  4a07aa2d9d20513627c80639a13bc11dca3c17f6 \
+                    sha256  3d1e5e6f1908bd437c7b070fffea124216f1063eb5d7573c31ba8c665ddc77a1 \
+                    size    2823097
 
-universal_variant   no
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
 
-use_configure       no
-
-set gopath ${workpath}/go-tools
-
-set package_dir golang.org/x/tools
-
-post-extract {
-    set package_src_dir ${gopath}/src/${package_dir}
-    file mkdir ${package_src_dir}
-    foreach f [glob -directory ${worksrcpath} *] {
-        move ${f}/ ${package_src_dir}
-    }
-}
-
-set cmds { benchcmp bundle callgraph compilebench cover digraph
-           eg fiximports getgo go-contrib-init godex godoc
-           goimports gomvpkg gorename gotype goyacc guru html2article
-           present present2md splitdwarf ssadump stress stringer toolstash }
-
-set auth_cmds { authtest cookieauth gitauth netrcauth }
-
-set deps {
-    golang.org/x/net/websocket
-    golang.org/x/crypto/acme/autocert
-    golang.org/x/mod/semver
-    golang.org/x/xerrors
-    golang.org/x/xerrors
-    github.com/yuin/goldmark
-}
-
-build {
-    foreach dep $deps {
-        system -W ${workpath} "GOPATH=${gopath} go get -d ${dep}"
-    }
-    foreach auth $auth_cmds {
-        system -W ${workpath} "GOPATH=${gopath} go build ${package_dir}/cmd/auth/${auth}"
-    }
-    foreach cmd $cmds {
-        system -W ${workpath} "GOPATH=${gopath} go build ${package_dir}/cmd/${cmd}"
-    }
-}
+build.args          -o bin/ ./cmd/... ./cmd/auth/...
 
 destroot {
-    xinstall -W ${workpath} {*}${auth_cmds} {*}${cmds} ${destroot}${prefix}/bin
+    xinstall -m 755 {*}[glob ${worksrcpath}/bin/*] ${destroot}${prefix}/bin
 }
-
-livecheck.type      none


### PR DESCRIPTION
#### Description

- fix building using go 1.16 (set `GO111MODULE=off` if not using `go.mod`)
- update version to commit cd1d0887 (required new dep, removed duplicate dep...)
- replaced errant tabs on 2 lines

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 arm64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
