### PR TITLE
hugo: update to 0.84.1

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.84.0 v
+go.setup            github.com/gohugoio/hugo 0.84.1 v
 revision            0
-checksums           rmd160  2e72ec4b070eb10463160099442ad5d9c0c1afed \
-                    sha256  40a7d3210b2e1dc2236ed88ee187ab7b105e427ca786d2096aedb20ffc52d665 \
-                    size    38859572
+checksums           rmd160  a25462b021daee3c878bfeaebcf764e6aab074d3 \
+                    sha256  272509463fe388b670af47cefae9faf29140793a4c528a55eebdf0f8ca6d336b \
+                    size    38960337
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.84.1

###### Tested on
macOS 10.15.7 19H524 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?