### PR TITLE
gitlab-runner: update to 14.0.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 14.0.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 14.0.1 v
 
 categories          devel
 platforms           darwin
@@ -22,9 +22,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  df34acefddb28f1ccce7f55fd1cfa31050684d6d \
-                    sha256  1db6477bbce113164519059ae15627476d3adab95d829ef622dc3f1c36253aab \
-                    size    8847902
+checksums           rmd160  a49de1e7f4daab8b415aa4404d6aa4f11e310a51 \
+                    sha256  22fe41816bb288c6f6513214f0d1d68d33d298aeaa9cd3a4f0a8393e6b20415f \
+                    size    8848429
 
 set build_date      [exec date +%FT%T%z]
 # Reproduce the "build_simple" target from the upstream Makefile


### PR DESCRIPTION
#### Description

Update to GitLab Runner 14.0.1.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?