### PR TITLE
*-w64-mingw32-widl: Add compiler blacklist

### DIFF
--- a/cross/mingw-w64/Portfile
+++ b/cross/mingw-w64/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        mirror mingw-w64 9.0.0 v
 set mingw_name      w64-mingw32
@@ -63,6 +64,9 @@ if {${subport} ne ${name}} {
 
     # *-widl subports
     if {${mingw_comp} eq "widl"} {
+        # Need a compiler that supports __builtin_ms_va_list
+        compiler.blacklist-append   {*gcc-[3-4].*} {clang < 800} {macports-clang-3.*}
+
         configure.args-append       --program-prefix="${mingw_target}-"
     # *-headers subports'
     } elseif {${mingw_comp} eq "headers"} {


### PR DESCRIPTION
Need a compiler that supports __builtin_ms_va_list

#### Description

To compile `*-w64-mingw32-widl`  compiler that supports `__builtin_ms_va_list` is required, so added a compiler blacklist to ensure a compatible compiler is selected.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
`xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance`
macOS 10.9.5 13F1911 x86_64

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
