### PR TITLE
thefuck: Update to version 3.31

### DIFF
--- a/python/thefuck/Portfile
+++ b/python/thefuck/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                thefuck
-version             3.30
-revision            2
+version             3.31
+revision            0
 
 categories-append   sysutils
 platforms           darwin
@@ -18,9 +18,9 @@ long_description    The Fuck is {*}${description}.
 
 homepage            https://github.com/nvbn/thefuck
 
-checksums           rmd160  3e6e88f13fbeb30b08e5fe60795b57ad7fab38b3 \
-                    sha256  32b41db4360a810d8e761e80fe09868ce634476ee1829e26869d49484b7a95cc \
-                    size    76888
+checksums           rmd160  a1c32711c0dc3de87ffc9b2dc9305cd2e4b8bf43 \
+                    sha256  6e6083e6c94fe948fcb9c6083baee30ba4cf3f09ffd30cd9564d6473db271941 \
+                    size    85523
 
 python.versions     39
 


### PR DESCRIPTION
#### Description
Update to version 3.31

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
