### PR TITLE
3mux: update to 1.1.0

### DIFF
--- a/sysutils/3mux/Portfile
+++ b/sysutils/3mux/Portfile
@@ -3,60 +3,82 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/aaronjanse/3mux 0.3.0 v
+go.setup            github.com/aaronjanse/3mux 1.1.0 v
+revision            0
 categories          sysutils
 maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 license             MIT
 
 description         Terminal multiplexer inspired by i3
 
-long_description    ${description}
+long_description    ${name} is a terminal multiplexer with out-of-the-box \
+                    support for search, mouse-controlled scrollback, and i3-like \
+                    keybindings. Imagine tmux with a smaller learning curve and \
+                    more user-friendly defaults.
+
+# See https://github.com/aaronjanse/3mux/issues/121
+patchfiles          patch-TMPDIR.diff
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  c0afe1aedb6bbfb04861c01b8e791e6552f40a20 \
-                        sha256  2dc1702ac56524b9db9b6efca7eb7cd9adb4d9ffbd624a6556be20b8178a8246 \
-                        size    10333671
+                        rmd160  75fa569a0f6e43c08cacaefb82807c933d1cc007 \
+                        sha256  335aeb24036cfb1ae0462ba88f29b208adde202b673d35034aa639ea765e5931 \
+                        size    10342007
 
-go.vendors          github.com/BurntSushi/toml \
-                        lock    v0.3.1 \
-                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
-                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
-                        size    42087 \
-                    github.com/BurntSushi/xdg \
-                        lock    e80d3446fea1 \
-                        rmd160  95f5b466e59d445aabbbed3532f9df95839cdcef \
-                        sha256  ddfc963c7ce12e917c2f546f4c54530b6724abc90a34734de93f64696704d1c6 \
-                        size    2790 \
-                    github.com/creack/pty \
-                        lock    v1.1.7 \
-                        rmd160  06ce51de1e7f9a347eee40c40189c6e0c9a13d13 \
-                        sha256  150b50e6eb2fec8c7e904e54be1aacfbb1df09b5a97ef7b77284fea8ac44fc3c \
-                        size    8168 \
-                    github.com/kr/pty \
-                        lock    v1.1.8 \
-                        rmd160  7fc6efad080de4926974713c76d2e74daf254e48 \
-                        sha256  1ea6bd7570dd02351d383c35d2900bca5295a58721afcabbc76b0d9ffbef956c \
-                        size    2120 \
+go.vendors          golang.org/x/text \
+                        lock    v0.3.2 \
+                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
+                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
+                        size    7168458 \
+                    golang.org/x/sys \
+                        lock    059865788121 \
+                        rmd160  6547b831afd7544cf84853c58d6744887e97d4af \
+                        sha256  ac404719da5dc2f0fcf63e45e8791173391c13e0b19ce9894d6df664d8e773f2 \
+                        size    1052860 \
+                    golang.org/x/crypto \
+                        lock    06a226fb4e37 \
+                        rmd160  0f11f7dda23b2dfd20a436eae805e768e7a91b9b \
+                        sha256  a9b23e5976f0bc8cea58568726a2c0b5e11e8d213323e0d5dc6f309266431013 \
+                        size    1728444 \
+                    github.com/sevlyar/go-daemon \
+                        lock    v0.1.5 \
+                        rmd160  5ae4481cac8b47e4b46ae6a97c724b73b3a3a46f \
+                        sha256  5a0f7a0267b778cdc93bd741294b57100bd5238fe23edd6fed223f9821294603 \
+                        size    64137 \
+                    github.com/nu7hatch/gouuid \
+                        lock    179d4d0c4d8d \
+                        rmd160  0a5432c115b8f8ec2e914809add53ac73c879cb4 \
+                        sha256  8049096c9cc5cb114e80acb40b4183e6cf6772ed44b5a271c6a305db80e55568 \
+                        size    3744 \
+                    github.com/npat-efault/poller \
+                        lock    v2.0.0 \
+                        rmd160  299be58c639eb6126e6cfd55da3994511bd6bc6f \
+                        sha256  c86fabfe1b2267434e4590a3190e7beb7e626352f49c7fa0e5389011721da5d5 \
+                        size    15854 \
                     github.com/mattn/go-runewidth \
                         lock    v0.0.9 \
                         rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
                         sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
                         size    16716 \
-                    golang.org/x/crypto \
-                        lock    056763e48d71 \
-                        rmd160  4c39311fe21dd3b728ebbf38dbcfb7f8849d38ca \
-                        sha256  023286029642de2f3d50ec3b96e1d049c6a52598c6acba7147bfbfeb7628ff2a \
-                        size    1727880 \
-                    golang.org/x/sys \
-                        lock    97732733099d \
-                        rmd160  d83b94fd587bc3799316510e1e5cfda7ff2425e8 \
-                        sha256  62c7cd8777af259c0266055a99d3d67c80a77506104a14a9678547c808010f73 \
-                        size    1350306 \
-                    golang.org/x/text \
-                        lock    v0.3.0 \
-                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
-                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
-                        size    6102563
+                    github.com/kardianos/osext \
+                        lock    2bc1f35cddc0 \
+                        rmd160  9a45814aa98c9eb32b6c46ceb00e760d486c71ef \
+                        sha256  ed51f32d6729696e216d051b3955c22161a970aaef01c1819d85ad179e51ba41 \
+                        size    4904 \
+                    github.com/aaronjanse/pty \
+                        lock    v1.1.14 \
+                        rmd160  7776a5bd976d9c0568d63c428f306b0e2e36c1c1 \
+                        sha256  dae029f63312271c55d456dba5f44f92364b0695229ceb6a8e40d405779a22be \
+                        size    9593 \
+                    github.com/BurntSushi/xdg \
+                        lock    e80d3446fea1 \
+                        rmd160  95f5b466e59d445aabbbed3532f9df95839cdcef \
+                        sha256  ddfc963c7ce12e917c2f546f4c54530b6724abc90a34734de93f64696704d1c6 \
+                        size    2790 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/

--- a/sysutils/3mux/files/patch-TMPDIR.diff
+++ b/sysutils/3mux/files/patch-TMPDIR.diff
@@ -1,0 +1,14 @@
+--- main.go.original	2021-06-27 18:46:05.000000000 +0100
++++ main.go	2021-06-27 18:55:34.000000000 +0100
+@@ -34,10 +34,7 @@
+ const BUG_REPORT_URL = "https://github.com/aaronjanse/3mux/issues"
+ 
+ func init() {
+-	tmp := os.Getenv("TMPDIR")
+-	if tmp == "" {
+-		tmp = "/tmp"
+-	}
++	const tmp = "/tmp"
+ 
+ 	threemuxDir = path.Join(tmp, "3mux")
+ 	os.MkdirAll(threemuxDir, 0700)


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/62563

#### Description

Patched the following be setting the TMPDIR to `/tmp`: https://github.com/aaronjanse/3mux/issues/121

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
