### PR TITLE
isync: add +bdb variant

### DIFF
--- a/mail/isync/Portfile
+++ b/mail/isync/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    isync
 version                 1.4.2
-revision                0
+revision                1
 categories              mail
 platforms               darwin
 license                 GPL-2
@@ -28,7 +28,6 @@ depends_build           port:perl5 \
                         port:pkgconfig
 
 depends_lib             port:cyrus-sasl2 \
-                        port:db53 \
                         path:lib/libssl.dylib:openssl \
                         port:zlib
 
@@ -60,8 +59,13 @@ post-destroot {
     xinstall -m 644 -W ${worksrcpath} mbsync.plist ${destroot}${examples_dir}/${startupitem.plist}
 }
 
-configure.cppflags-append   -I${prefix}/include/db53
-configure.ldflags-append    -L${prefix}/lib/db53
+default_variants    +bdb
+
+variant bdb description {Enable support for the alternative UID storage scheme} {
+    configure.cppflags-append   -I${prefix}/include/db53
+    configure.ldflags-append    -L${prefix}/lib/db53
+    depends_lib-append          port:db53
+}
 
 notes "
 A sample configuration file has been installed in ${prefix}/share/doc/${name}/examples/mbsyncrc.sample.


### PR DESCRIPTION
#### Description

Adds the `+bdb` variant which can be used to enable db53 dependency which is required for `mdconvert` (converting mailbox format - less likely to be used executable)

This does make db53 an _optional_ dependency which, for isync on arm64, allows install that is blocked by https://trac.macports.org/ticket/62216

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 arm64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
