### PR TITLE
w3m-devel: update version to commit e37579c1

### DIFF
--- a/www/w3m/Portfile
+++ b/www/w3m/Portfile
@@ -40,7 +40,9 @@ if {${name} eq ${subport}} {
                     size    2202328
 
     patchfiles      debian/010_upstream.patch \
-                    debian/020_debian.patch
+                    debian/020_debian.patch \
+                    patch-longjmp.diff \
+                    patch-errlist.diff
 
     patch.pre_args  -p1
 
@@ -50,12 +52,12 @@ if {${name} eq ${subport}} {
 subport w3m-devel {
     PortGroup       github 1.0
 
-    github.setup    tats w3m b65f7b243dc156f0b6b7dfa0dae4152942e33bea
-    version         20200823
+    github.setup    tats w3m e37579c13c466b0704b2c3ce17edd2ecf0cc9f36
+    version         20210228
 
-    checksums       rmd160  4f9e4ccbe1238fde5e34a94e86f13badd397242f \
-                    sha256  1c1001d3189ed38305a7cb70b7588560e921444dac0b738ae5715fc2b4f6008e \
-                    size    2195656
+    checksums       rmd160  18e81fd9b6edfb775bd590e77510c267598526ba \
+                    sha256  2eaf3b6dc120fadc7a0e7556e836f6937fa2b83b8df934a8113f3ed52c7934a1 \
+                    size    2189233
 
     conflicts       w3m
 }

--- a/www/w3m/files/patch-errlist.diff
+++ b/www/w3m/files/patch-errlist.diff
@@ -1,0 +1,54 @@
+commit f1fd7215d2e031679b64f647744bab3da710716c
+Author: Parag Nemade <pnemade@redhat.com>
+Date:   2020-11-22T21:13:27+09:00
+
+    Fix FTBFS due to redefinition of sys_errlist
+    
+    Origin: https://src.fedoraproject.org/rpms/w3m/c/99f30870caac12a3949b6736aa70b7233f4414d5?branch=master
+    Bug-Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1038009
+    Bug-MacPorts: https://trac.macports.org/ticket/61356
+
+diff --git a/etc.c b/etc.c
+index 16d1295..801b098 100644
+--- a/etc.c
++++ b/etc.c
+@@ -634,24 +634,6 @@ strerror(int errno)
+ }
+ #endif				/* not HAVE_STRERROR */
+ 
+-#ifndef HAVE_SYS_ERRLIST
+-char **sys_errlist;
+-
+-prepare_sys_errlist()
+-{
+-    int i, n;
+-
+-    i = 1;
+-    while (strerror(i) != NULL)
+-	i++;
+-    n = i;
+-    sys_errlist = New_N(char *, n);
+-    sys_errlist[0] = "";
+-    for (i = 1; i < n; i++)
+-	sys_errlist[i] = strerror(i);
+-}
+-#endif				/* not HAVE_SYS_ERRLIST */
+-
+ int
+ next_status(char c, int *status)
+ {
+diff --git a/main.c b/main.c
+index 2d08762..7bcf898 100644
+--- a/main.c
++++ b/main.c
+@@ -435,10 +435,6 @@ main(int argc, char **argv, char **envp)
+     textdomain(PACKAGE);
+ #endif
+ 
+-#ifndef HAVE_SYS_ERRLIST
+-    prepare_sys_errlist();
+-#endif				/* not HAVE_SYS_ERRLIST */
+-
+     NO_proxy_domains = newTextList();
+     fileToDelete = newTextList();
+ 

--- a/www/w3m/files/patch-longjmp.diff
+++ b/www/w3m/files/patch-longjmp.diff
@@ -1,0 +1,22 @@
+commit 428f9e82676e3525f89b0d62a28af566ffc717a5
+Author: Parag A Nemade <pnemade@fedoraproject.org>
+Date:   2020-11-22T21:16:07+09:00
+
+    Fix compilation error "too few arguments to function 'longjmp'"
+    
+    Origin: https://src.fedoraproject.org/rpms/w3m/c/e7a12fa28cfbfbb0115ec74994092c1d3b8351d8?branch=master
+    Bug-MacPorts: https://trac.macports.org/ticket/61356
+
+diff --git a/config.h.in b/config.h.in
+index 6ab3008..7c03d3c 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -181,7 +181,7 @@ typedef RETSIGTYPE MySignalHandler;
+ #endif /* __MINGW32_VERSION */
+ #else
+ # define SETJMP(env) setjmp(env)
+-# define LONGJMP(env,val) longjmp(env)
++# define LONGJMP(env,val) longjmp(env, val)
+ # define JMP_BUF jmp_buf
+ #endif
+ 


### PR DESCRIPTION
#### Description

- Update `w3m-devel` to the latest tagged release from the repository (February 28th 2021)
- "Patched" `w3m` to build as it currently didn't for me or during CI (related: https://trac.macports.org/ticket/61356)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 arm64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
