### PR TITLE
py-{numpy,scipy}: update to latest version

### DIFF
--- a/python/py-beniget/Portfile
+++ b/python/py-beniget/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-beniget
+version             0.4.0
+revision            0
+
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             BSD
+maintainers         {reneeotten @reneeotten} openmaintainer
+
+description         Extract semantic information about static Python code
+long_description    ${description}
+
+homepage            https://github.com/serge-sans-paille/beniget/
+
+checksums           rmd160  94fcb98bf5331b315eaee8e907974d8d56719cf6 \
+                    sha256  72bbd47b1ae93690f5fb2ad3902ce1ae61dcd868ce6cfbf33e9bad71f9ed8749 \
+                    size    16157
+
+python.versions     37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-gast
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst \
+            LICENSE ${destroot}${docdir}
+    }
+
+    test.run        yes
+
+    livecheck.type  none
+}

--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -14,10 +14,10 @@ maintainers             {michaelld @michaelld} openmaintainer
 description             The core utilities for the scientific library scipy for Python
 long_description        ${description}
 
-github.setup            numpy numpy 1.20.3 v
-checksums               rmd160  5de8a16b4ce19febd04c96fb8d16f49176c70acb \
-                        sha256  8d6274c1836132ae0d993d8a8cff9ba53f51762c9707874222821867ad38518e \
-                        size    7358754
+github.setup            numpy numpy 1.21.0 v
+checksums               rmd160  fe84702d6269eef4273021a623276d37e3ff7489 \
+                        sha256  36be3c84051fc39000de80e7ce8aa2cd0154b47ff1968ce89295bd02ca30da93 \
+                        size    8529394
 revision                0
 
 if {${name} ne ${subport}} {
@@ -96,7 +96,6 @@ if {${name} ne ${subport}} {
                             -gcc46 -gcc47 -gcc48 -g95
 
     depends_lib-append      port:fftw-3 \
-                            port:py${python.version}-nose \
                             port:py${python.version}-cython
 
     pre-build {

--- a/python/py-pythran/Portfile
+++ b/python/py-pythran/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pythran
+version             0.9.11
+revision            0
+
+categories-append   devel
+platforms           darwin
+license             BSD
+maintainers         {reneeotten @reneeotten} openmaintainer
+
+description         Ahead of Time compiler for numeric kernels
+long_description    ${description}
+
+homepage            https://github.com/serge-sans-paille/pythran
+
+checksums           rmd160  37de6c0929a4f507e3e2a94f070cad4d3390aaaf \
+                    sha256  a317f91e2aade9f6550dc3bf40b5caeb45b7e012daf27e2b3e4ad928edb01667 \
+                    size    3764841
+
+python.versions     37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-pytest-runner \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-beniget \
+                    port:py${python.version}-decorator \
+                    port:py${python.version}-gast \
+                    port:py${python.version}-networkx \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-ply \
+                    port:py${python.version}-six
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst Changelog \
+            LICENSE ${destroot}${docdir}
+    }
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type  none
+}

--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -7,10 +7,10 @@ PortGroup               github 1.0
 PortGroup               compilers 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            scipy scipy 1.6.3 v
-checksums               rmd160  6707517e6453672754d29de617b4f97a16273af0 \
-                        sha256  df43ae5800a551a29a0ac3f12f53ae1039605dc412729c911e2558442fa48e92 \
-                        size    21924207
+github.setup            scipy scipy 1.7.0 v
+checksums               rmd160  a63f8c30d0a6901afcef88d132d240ec413d9d06 \
+                        sha256  055b52003fd7746b930fa8125744489fb977b96cdfee97ed0f3ada5bdb35fa14 \
+                        size    23187422
 revision                0
 
 name                    py-scipy
@@ -85,7 +85,18 @@ if {${name} ne ${subport}} {
 
     } else {
 
-        depends_lib-append port:py${python.version}-mypy
+        # current release, which uses Boost
+        PortGroup           boost 1.0
+        boost.version       1.71
+        patchfiles-append   patch-allow-MP-boost.diff
+
+        # force disable STDC THREADS from <threads.h> and instead just use __thread
+        # https://trac.macports.org/ticket/62488
+        patchfiles-append   patch-use__STDC_NO_THREADS__.diff
+
+        depends_build-append \
+                            port:py${python.version}-pythran
+        depends_lib-append  port:py${python.version}-mypy
 
         compiler.c_standard 2011
         compiler.cxx_standard 2014
@@ -97,14 +108,10 @@ if {${name} ne ${subport}} {
     }
 
     depends_lib-append      port:py${python.version}-numpy \
-                            port:py${python.version}-nose \
                             port:py${python.version}-pybind11
 
     depends_build-append    port:swig-python \
                             port:py${python.version}-pip
-
-    depends_test-append     port:py${python.version}-py \
-                            port:py${python.version}-pytest
 
     worksrcdir              ${distname}
     build.env-append        "CCFLAGS=-I${prefix}/include -L${prefix}/lib"

--- a/python/py-scipy/files/patch-allow-MP-boost.diff
+++ b/python/py-scipy/files/patch-allow-MP-boost.diff
@@ -1,0 +1,48 @@
+--- scipy/_lib/_boost_utils.py.orig
++++ scipy/_lib/_boost_utils.py
+@@ -1,10 +1,29 @@
+ '''Helper functions to get location of header files.'''
+ 
++import os
+ import pathlib
+ from typing import Union
+ 
+ 
+ def _boost_dir(ret_path: bool = False) -> Union[pathlib.Path, str]:
+     '''Directory where root Boost/ directory lives.'''
++    # options
++    # 1: see if the submodule is in use
+     p = pathlib.Path(__file__).parent / 'boost'
+-    return p if ret_path else str(p)
++    if os.path.exists(p / 'README.md'):
++        return p
++    # 2: from a shell environment variable, in order of checking
++    # these are the top-level PREFIX for where Boost is installed
++    # such that `include/boost` and `lib` are subdirectories
++    p_env = ['BOOST_ROOT', 'BOOST_DIR', 'BOOSTROOT', 'BOOSTDIR']
++    for t_p in p_env:
++        print('checking for shell enviroment variable', t_p)
++        t_p_v = os.getenv(t_p)
++        print('value is', t_p_v)
++        if t_p_v is not None:
++            if os.path.exists(pathlib.Path(t_p_v) / 'include' / 'boost'):
++                print('path exists; returning this Boost path')
++                return t_p_v
++    # Boost not found!!
++    raise RuntimeError("Missing the `boost` submodule! Run `git submodule "
++                           "update --init` to fix this.")
+--- scipy/_lib/setup.py.orig
++++ scipy/_lib/setup.py
+@@ -5,9 +5,9 @@
+ def check_boost_submodule():
+     from scipy._lib._boost_utils import _boost_dir
+ 
+-    if not os.path.exists(_boost_dir(ret_path=True) / 'README.md'):
+-        raise RuntimeError("Missing the `boost` submodule! Run `git submodule "
+-                           "update --init` to fix this.")
++    #if not os.path.exists(_boost_dir(ret_path=True) / 'README.md'):
++    #    raise RuntimeError("Missing the `boost` submodule! Run `git submodule "
++    #                       "update --init` to fix this.")
+ 
+ 
+ def build_clib_pre_build_hook(cmd, ext):

--- a/python/py-scipy/files/patch-use__STDC_NO_THREADS__.diff
+++ b/python/py-scipy/files/patch-use__STDC_NO_THREADS__.diff
@@ -1,0 +1,54 @@
+--- scipy/integrate/setup.py.orig
++++ scipy/integrate/setup.py
+@@ -37,9 +37,9 @@
+     config.add_library('mach', sources=mach_src, config_fc={'noopt': (__file__, 1)},
+                        _pre_build_hook=pre_build_hook)
+     config.add_library('quadpack', sources=quadpack_src, _pre_build_hook=pre_build_hook)
+-    config.add_library('lsoda', sources=lsoda_src, _pre_build_hook=pre_build_hook)
+-    config.add_library('vode', sources=vode_src, _pre_build_hook=pre_build_hook)
+-    config.add_library('dop', sources=dop_src, _pre_build_hook=pre_build_hook)
++    config.add_library('lsoda', sources=lsoda_src, _pre_build_hook=pre_build_hook, macros=[('__STDC_NO_THREADS__',1)])
++    config.add_library('vode', sources=vode_src, _pre_build_hook=pre_build_hook, macros=[('__STDC_NO_THREADS__',1)])
++    config.add_library('dop', sources=dop_src, _pre_build_hook=pre_build_hook, macros=[('__STDC_NO_THREADS__',1)])
+ 
+     # Extensions
+     # quadpack:
+--- scipy/linalg/setup.py.orig
++++ scipy/linalg/setup.py
+@@ -59,7 +59,8 @@
+     config.add_extension('_flapack',
+                          sources=sources,
+                          depends=depends,
+-                         extra_info=lapack_opt
++                         extra_info=lapack_opt,
++                         define_macros=[('__STDC_NO_THREADS__',1)]
+                          )
+ 
+     if uses_blas64():
+@@ -96,7 +97,8 @@
+     ext = config.add_extension('_interpolative',
+                                sources=[join('src', 'id_dist', 'src', '*.f'),
+                                         "interpolative.pyf"],
+-                               extra_info=lapack_opt
++                               extra_info=lapack_opt,
++                               define_macros=[('__STDC_NO_THREADS__',1)]
+                                )
+     ext._pre_build_hook = gfortran_legacy_flag_hook
+ 
+--- scipy/optimize/setup.py.orig
++++ scipy/optimize/setup.py
+@@ -78,10 +78,13 @@
+                          depends=[join('tnc', 'tnc.h')],
+                          **numpy_nodepr_api)
+ 
++    local_macros = numpy_nodepr_api
++    local_macros['define_macros'].append(('__STDC_NO_THREADS__',1))
++
+     config.add_extension('_cobyla',
+                          sources=[join('cobyla', x) for x in [
+                              'cobyla.pyf', 'cobyla2.f', 'trstlp.f']],
+-                         **numpy_nodepr_api)
++                         **local_macros)
+ 
+     sources = ['minpack2.pyf', 'dcsrch.f', 'dcstep.f']
+     config.add_extension('minpack2',


### PR DESCRIPTION
This PR updates `py-scipy` and `py-numpy` to their latest upstream versions (1.7.0 and 1.21.0, respectively). 
For the SciPy update a few new dependencies are required as `pythran` is a build dependency; secondly it now uses `fetch.type git` and calls `git submodule` to get the vendored `boost` dependency. 

Please note that NumPy upstream states ```Warning: there are unresolved problems compiling NumPy 1.21.0 with gcc-11.1 .``` However, it seems to build fine and there are only a few test failures - 5 compared to 2 failures in v1.20.3; the four new failures are all in `typing/tests/test_typing.py`.

SciPy has some more issues in that the test-suite segfaults (in `optimize/tests/test_linprog.py`), but that also happens for both versions. It would be nice to fix that though, as it does work fine when installing with `pip` in a `virtualenv` or when using `conda`.

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`? A few test-failures, see above
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
