### PR TITLE
py-{emcee3,json5}: update to latest versions

### DIFF
--- a/python/py-emcee3/Portfile
+++ b/python/py-emcee3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-emcee3
-version             3.0.2
+version             3.1.0
 python.rootname     emcee
 
 maintainers         {aronnax @lpsinger} openmaintainer
@@ -22,9 +22,9 @@ platforms           darwin
 supported_archs     noarch
 license             MIT
 
-checksums           rmd160  b136daa9c9f4a3f8fe9e5294f551ceb39fc537a2 \
-                    sha256  035a44d7594fdd03efd10a522558cdfaa080e046ad75594d0bf2aec80ec35388 \
-                    size    4054969
+checksums           rmd160  7b7d7509681a60df3d2c5829d425c65495dd45c8 \
+                    sha256  ce7dd8910989044ed6b752a41977eaa9fcc91703a6473b5f96289585b061ff56 \
+                    size    2868282
 
 python.versions     36 37 38 39
 
@@ -32,7 +32,8 @@ if {${name} ne ${subport}} {
     conflicts       py${python.version}-emcee
 
     depends_build-append \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools_scm \
+                    port:py${python.version}-wheel
 
     depends_lib-append \
                     port:py${python.version}-numpy

--- a/python/py-json5/Portfile
+++ b/python/py-json5/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dpranke pyjson5 0.9.5 v
+github.setup        dpranke pyjson5 0.9.6 v
 revision            0
 name                py-json5
 
@@ -19,9 +19,9 @@ long_description \
   ${description}. JSON5 extends the JSON data interchange format to make it \
   slightly more usable as a configuration language.
 
-checksums           rmd160  942ef9c2163f9ace5982077a68f480f1265ae660 \
-                    sha256  2eaefd6a0ad37aa965960963704b41e9534532e91bb5f124db779ac82fcad720 \
-                    size    109264
+checksums           rmd160  c5130e9c1bf17d673f8ac16885c3b32539c11128 \
+                    sha256  1f5b216d5b31e6f0da90989c33c90a01f3188d3f3c96705781b1912f80df91a1 \
+                    size    109958
 
 if {${subport} ne ${name}} {
     livecheck.type  none


### PR DESCRIPTION
#### Description
Update `py-emcee3` and `py-json5` to their latest versions.

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->