### PR TITLE
gobject_introspection PG: tweak to handle using CMake

### DIFF
--- a/_resources/port1.0/group/gobject_introspection-1.0.tcl
+++ b/_resources/port1.0/group/gobject_introspection-1.0.tcl
@@ -34,7 +34,11 @@ proc gobject_introspection_pg::append_env { phase var } {
 
 proc gobject_introspection_pg::gobject_introspection_setup {} {
     if {![option gobject_introspection]} {
-        configure.args-append       --disable-introspection
+        if { [string match *cmake* [option configure.cmd] ] } {
+            configure.args-append   -DENABLE_GOBJECT_INTROSPECTION=OFF
+        } else {
+            configure.args-append   --disable-introspection
+        }
     } else {
         depends_lib-append          port:gobject-introspection
         platform darwin 8 {
@@ -45,7 +49,11 @@ proc gobject_introspection_pg::gobject_introspection_setup {} {
             build.cmd-replace       [portbuild::build_getmaketype] ${prefix_frozen}/bin/gmake
         }
 
-        configure.args-append       --enable-introspection
+        if { [string match *cmake* [option configure.cmd] ] } {
+            configure.args-append   -DENABLE_GOBJECT_INTROSPECTION=ON            
+        } else {
+            configure.args-append   --enable-introspection
+        }
 
         #########################################################################################
         # In order to get the GObject Introspection system to respect MacPorts settings,


### PR DESCRIPTION
#### Description

Tweak the gobject_introspection PG to handle using CMake. Behavior remains the same if not using CMake, but when using CMake adds the typical define for enabling or disabling gobject_introspection.

I'm guessing I'm seeing this because I'm running CMake 3.20.3 to test to see how well it works. It might be that CMake 3.19.8 (current MP version) allows this flag somehow, though I'd guess it ignores it. See for example the `poppler` port, which uses CMake for configuration. I have not tried the older CMake, as this PR will fix whatever it was experiencing along with making the PG more compatible with future CMake.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5 20G5042c x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
