### PR TITLE
hugo: update to 0.84.2

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.84.1 v
+go.setup            github.com/gohugoio/hugo 0.84.2 v
 revision            0
-checksums           rmd160  a25462b021daee3c878bfeaebcf764e6aab074d3 \
-                    sha256  272509463fe388b670af47cefae9faf29140793a4c528a55eebdf0f8ca6d336b \
-                    size    38960337
+checksums           rmd160  cd6a7d161ff723c3320b0986eece17599305ae13 \
+                    sha256  bad78428ac2b101e4f8be0915f0336aeb4e108e7ae27ad741bb677c1a3a6fc97 \
+                    size    38963881
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.84.2

###### Tested on
macOS 10.15.7 19H524 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
