### PR TITLE
zbar: use configure.python to select interpreter

### DIFF
--- a/graphics/zbar/Portfile
+++ b/graphics/zbar/Portfile
@@ -13,7 +13,7 @@ checksums               rmd160  7798643049e311e3e706d84568f3d7fb9f172d72 \
                         size    1005314
 
 categories              graphics
-maintainers             @knapoc openmaintainer
+maintainers             @Knapoc openmaintainer
 
 description             ZBar is an open source software suite for reading bar codes from \
                         various sources
@@ -66,7 +66,7 @@ variant gtk3 description {Include GTK 3 Widget} {
 variant python39 description {Include Python 3.9 binding} {
     depends_lib-append      port:python39
     configure.args-replace  --without-python --with-python
-    configure.env-append    PYTHON=${prefix}/bin/python3.9
+    configure.python        ${prefix}/bin/python3.9
 }
 
 variant x11 {


### PR DESCRIPTION
#### Description

As requested in the [commit](https://github.com/macports/macports-ports/commit/901fa8a08ca7e39ff829bac103c5c7b2002dbf28#r52746213) conversation, the `python39`-variant now uses `configure.python` instead of manual environmental variables.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
