### PR TITLE
cmake: update to 3.20.5

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -43,10 +43,10 @@ subport cmake-devel {
 
 if {${subport} eq ${name}} {
 
-    gitlab.setup    cmake cmake 3.19.8 v
-    checksums       rmd160  052886bb4ebbc72db12d501eca21ebe7639329d3 \
-                    sha256  25488ebb26b588acd5b63d8ccf3722909b3b2206ab2b2180086a2202fa3fbc3c \
-                    size    7150690
+    gitlab.setup    cmake cmake 3.20.5 v
+    checksums       rmd160  f0f13ae525878d7929dcc95f322d224e7b47443d \
+                    sha256  54dd3e0dcd64e27ff8442071aacc4f5a9605896b5701de46d76f22d686238eba \
+                    size    7264123
     revision        0
 
     gitlab.livecheck.regex {([0-9.]+)}

--- a/devel/cmake/files/patch-cmake-leopard-tiger.diff
+++ b/devel/cmake/files/patch-cmake-leopard-tiger.diff
@@ -1,13 +1,13 @@
 --- Source/cmMachO.h
 +++ Source/cmMachO.h
 @@ -6,6 +6,7 @@
- 
+
  #include <iosfwd>
  #include <string>
 +#include <memory>
- 
- #if !defined(CMAKE_USE_MACH_PARSER)
- #  error "This file may be included only if CMAKE_USE_MACH_PARSER is enabled."
+
+ #if !defined(CMake_USE_MACH_PARSER)
+ #  error "This file may be included only if CMake_USE_MACH_PARSER is enabled."
 --- Utilities/cmlibuv/src/unix/core.c
 +++ Utilities/cmlibuv/src/unix/core.c
 @@ -530,10 +530,24 @@

--- a/devel/cmake/files/patch-fix-system-prefix-path.diff
+++ b/devel/cmake/files/patch-fix-system-prefix-path.diff
@@ -1,6 +1,6 @@
 --- Modules/Platform/Darwin.cmake.orig
 +++ Modules/Platform/Darwin.cmake
-@@ -237,7 +237,9 @@
+@@ -233,7 +233,9 @@
      endforeach()
    endif()
  endif()
@@ -12,7 +12,7 @@
 +# prepend the MacPorts prefix to CMAKE_SYSTEM_PREFIX_PATH
 +# might already exist after this if the user has specified it
 +list(INSERT CMAKE_SYSTEM_PREFIX_PATH 0
-+  __PREFIX__
++  /opt/local
 +)
 --- Modules/Platform/UnixPaths.cmake.orig
 +++ Modules/Platform/UnixPaths.cmake

--- a/devel/cmake/files/patch-qt5gui.diff
+++ b/devel/cmake/files/patch-qt5gui.diff
@@ -1,6 +1,6 @@
 --- Source/QtDialog/CMakeLists.txt.orig
 +++ Source/QtDialog/CMakeLists.txt
-@@ -206,7 +206,8 @@
+@@ -288,7 +288,8 @@
      OUTPUT_NAME CMake
      MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
      MACOSX_BUNDLE_SHORT_VERSION_STRING "${CMAKE_BUNDLE_VERSION}"
@@ -10,7 +10,7 @@
      MACOSX_BUNDLE_COPYRIGHT "${copyright_line}"
      MACOSX_BUNDLE_GUI_IDENTIFIER "org.cmake.cmake"
      )
-@@ -245,8 +246,12 @@
+@@ -327,8 +328,12 @@
  endif()
  
  if(APPLE)


### PR DESCRIPTION
#### Description

update cmake to 3.20.5. I've been using 3.20 for a while now and, while it does have slight tweaks from 3.19, it seems very backwards compatible. 3.21 is going to be released soon, so now's as a good a time as any to update MP's CMake.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5 20G5042c x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
