### PR TITLE
gopass-jsonapi: new port

### DIFF
--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -1,0 +1,323 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/gopasspw/gopass-jsonapi 1.11.1 v
+categories          security
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+license             MIT
+
+description         Gopass Browser Bindings
+long_description    ${name} enables communication with gopass via JSON messages
+homepage            https://www.gopass.pw
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  40e637d225158548d4f7bdc778616530263e0cb8 \
+                        sha256  33391c930cacc081e3ee912edda35db99c7c6970b0c31365c2695c79b896519c \
+                        size    30282
+
+go.vendors          rsc.io/qr \
+                        repo    github.com/rsc/qr \
+                        lock    v0.2.0 \
+                        rmd160  f642fe01c13937615e5a975e6a1932f8dc25359a \
+                        sha256  1d69d5a13366a84a1484abdec5affd7f5781016469f4b43b1a26f5fa5c93497b \
+                        size    18816 \
+                    mvdan.cc/unparam \
+                        repo    github.com/mvdan/unparam \
+                        lock    aac4ce9116a7 \
+                        rmd160  5f3b6fdd383e7e1e10178c07c823a60a454946fb \
+                        sha256  3d3d7ed607dd493ad5822f1cad60647850f44a753990d92add18263eafdf526d \
+                        size    18695 \
+                    gopkg.in/yaml.v3 \
+                        lock    eeeca48fe776 \
+                        rmd160  fa7f02bf2d79fd300b4db2107596674b41479412 \
+                        sha256  33580a955d8c31b781de66dbc7a3c9940ab842a39eb3eb92e696a82307f7d570 \
+                        size    88775 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.60.1 \
+                        rmd160  aea42f00ec6f7c0bdc0cda906257b0b7aba80a37 \
+                        sha256  3db6855d923d5719ddfaa7a3f1a8910723f8bd943692205c045509e797bda82f \
+                        size    49265 \
+                    golang.org/x/xerrors \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
+                    golang.org/x/tools \
+                        lock    v0.1.0 \
+                        rmd160  ed8549ff61216e862597412cca9a2f3cd3448147 \
+                        sha256  7ee4ceea7cc41925aa41c185d17886694bcd611cb9896be15e578a491c8594c0 \
+                        size    2683296 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    golang.org/x/sys \
+                        lock    22da62e12c0c \
+                        rmd160  15c235353d480b46af88f988d1cb58ee77194ea6 \
+                        sha256  2ef3888e228c2e10bd71add7c893d88260477cad9c5d529d95e899e62b57916b \
+                        size    1106946 \
+                    golang.org/x/net \
+                        lock    f5854403a974 \
+                        rmd160  cfaf8471269327bcdce1142b44ded72a4584ddf9 \
+                        sha256  a1fcb7946757072ba7453de05fa82e9b977318307a88082c5e4b24057885babb \
+                        size    1178342 \
+                    golang.org/x/mod \
+                        lock    v0.4.1 \
+                        rmd160  c96b842a5189b7efca5466e347b279cfeebd8fbf \
+                        sha256  9370678c647c8fbab251e6d06eb6420c7c8be01cd97b5177a7205fce5128205a \
+                        size    102768 \
+                    golang.org/x/crypto \
+                        lock    afb6bcd081ae \
+                        rmd160  2a2fa932dfa1539a791ca41226d24f032134d57a \
+                        sha256  1b923ba81aeed05b2ba90627bccc8297a9914c1d708599f1dd3003b843f64115 \
+                        size    1732317 \
+                    github.com/xrash/smetrics \
+                        lock    89a2a8a1fb0b \
+                        rmd160  350ca8872823c2d934da9a0da957e1d373542d92 \
+                        sha256  565b0a0b533971f54a767d0709b8370e92f4919f0df83552c2d45ef5f13c95ce \
+                        size    1823868 \
+                    github.com/urfave/cli \
+                        lock    v2.3.0 \
+                        rmd160  fec9e73bc45d02b2afe43e8d9c76398722494e4b \
+                        sha256  3138857026c9564559b3e734b9b8abfeda57354fc4aa87717879882bff68ef09 \
+                        size    3408338 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/sergi/go-diff \
+                        lock    v1.1.0 \
+                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
+                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
+                        size    43569 \
+                    github.com/russross/blackfriday \
+                        lock    v2.0.1 \
+                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
+                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
+                        size    79665 \
+                    github.com/rs/xid \
+                        lock    v1.2.1 \
+                        rmd160  2cff9628752a94fc62ab0e83436c61df7195eed1 \
+                        sha256  38881e009bacdbf91f6e586207b346eb9ec93f06335331c07a5e0b2ad41ee3f6 \
+                        size    9555 \
+                    github.com/rivo/uniseg \
+                        lock    v0.2.0 \
+                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
+                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
+                        size    44037 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.5 \
+                        rmd160  aa952a560c3aa5102bfb3e55f12facf048379adf \
+                        sha256  830bdee7f05aa76353c113075a864359762a502c6d6a1f72bfb7055247c0539b \
+                        size    19579 \
+                    github.com/muesli/crunchy \
+                        lock    v0.4.0 \
+                        rmd160  3029073bbcf95a9154c93b01803f3b48d7a3ec7e \
+                        sha256  039c5f45b9d1f7a02562cad503749bce7820d510657f720d2db2ea593093d438 \
+                        size    7791 \
+                    github.com/modern-go/reflect2 \
+                        lock    v1.0.1 \
+                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
+                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
+                        size    14407 \
+                    github.com/modern-go/concurrent \
+                        lock    bacd9c7ef1dd \
+                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
+                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
+                        size    7533 \
+                    github.com/mitchellh/go-ps \
+                        lock    v1.0.0 \
+                        rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
+                        sha256  8e158a59a9b7e407b27a4cf6100f33648b7c8bffb4ac07bd074f43d4796afa87 \
+                        size    7631 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/minio/sha256-simd \
+                        lock    v0.1.1 \
+                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
+                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
+                        size    65042 \
+                    github.com/minio/minio-go \
+                        lock    v7.0.7 \
+                        rmd160  f7269c3b9de8bf8a2545cb947ff1edc9631b5f19 \
+                        sha256  d23d5ee4dcbec90b8797afee393283558fb81cb7f35bd228003219cad19ff0ec \
+                        size    236183 \
+                    github.com/minio/md5-simd \
+                        lock    v1.1.0 \
+                        rmd160  7929f1dc43d777a143a826c47948490d8ed121e0 \
+                        sha256  49d89141ce43f38098b264acf3b3d9341d553a1f82816485f1c036e18deb2b58 \
+                        size    99242 \
+                    github.com/mgechev/revive \
+                        lock    v1.0.3 \
+                        rmd160  ae31793eae0b8282d9ef6625bba195297a5995b8 \
+                        sha256  ef458affcef4c0ff5d121c7ec9a93bc506591e1f6689a8f31e0420375f01c025 \
+                        size    671733 \
+                    github.com/mgechev/dots \
+                        lock    c36f7dcfbb81 \
+                        rmd160  0965efd20f37d8b2e22c9fdc3b820a214ef80577 \
+                        sha256  3b1e1c80d3727e2ccdf4e37e3ee7d3d1c3044d7cf40d1e39aed56927da986be6 \
+                        size    6429 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.10 \
+                        rmd160  96c878eca004d6cf8f49ecf3cde98335e7f21499 \
+                        sha256  b78084ce55bc5aaa31d337dcb59624d748fe39006a3df29143fae203065e2a22 \
+                        size    16787 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.8 \
+                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
+                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
+                        size    9576 \
+                    github.com/klauspost/cpuid \
+                        lock    v1.3.1 \
+                        rmd160  0c161f6a90600c80e908141c2a81130ba703307e \
+                        sha256  8db60afc9f494af07150fff47e676377588d36fb5ee3cc181ec59ff35c238c79 \
+                        size    367163 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/json-iterator/go \
+                        lock    v1.1.10 \
+                        rmd160  963a70cf0a7d056f6b00fb2224687895612a35e2 \
+                        sha256  e82947d6f32c1cf730c796409eabc8051c208c2eafabe793d196d448529a7f0f \
+                        size    83377 \
+                    github.com/hashicorp/golang-lru \
+                        lock    v0.5.4 \
+                        rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
+                        sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
+                        size    13435 \
+                    github.com/hashicorp/go-multierror \
+                        lock    v1.1.0 \
+                        rmd160  868d9a6f0732cba1b2dfbb73556b6a194c797c03 \
+                        sha256  9bd88c4f96aa4c4dcca5c0124e48f540c59754586653924b5e4b7de3af0f8c4a \
+                        size    12091 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.0.0 \
+                        rmd160  d9bf75f667d7bec9b4b11ca34de7ca722495b914 \
+                        sha256  49e80cf52f294ce69fcc8cd26f06b8d8cee2623f6e0012df871b355fb7b17787 \
+                        size    8351 \
+                    github.com/gopasspw/gopass \
+                        lock    ddfe7bfc979f \
+                        rmd160  02b1a9037c034fa114eedc39c0ff7da7ce43f9e7 \
+                        sha256  e2806614c1b7e87b6e7d47d014f4227417c448d35368fb40db97176a3bd23697 \
+                        size    489358 \
+                    github.com/google/uuid \
+                        lock    v1.1.1 \
+                        rmd160  69112e9735ecc1d5360a3cc31531f8be661a007f \
+                        sha256  70be7dec37826f2cbe13acfe534ce74cbb2107c1e348eb4e8365f7d900002e40 \
+                        size    13552 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/google/go-github \
+                        lock    v17.0.0 \
+                        rmd160  2c1917adfc161a2252354d558352180079005d8d \
+                        sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
+                        size    212064 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.2 \
+                        rmd160  5021dfa1c1da165c38f7a1a0b78794204233735f \
+                        sha256  6631e46f37f68fde3c411c90e9b9186526903a2123222f08de658547b1caafca \
+                        size    99774 \
+                    github.com/gokyle/twofactor \
+                        lock    v1.0.1 \
+                        rmd160  639cb3e1e214c43cd212bbec6faae070a2acbc4c \
+                        sha256  c69fa4f30d2f7a1f8a1781a2bffd4009bd90a69d6a33806b33bdfe73863db258 \
+                        size    22514 \
+                    github.com/godbus/dbus \
+                        lock    8a1682060722 \
+                        rmd160  90cbb8302b7c386e2685633781ec52c8e3f0424f \
+                        sha256  54c06c5988808eca9affe01cabe122e02ba4af5763f29fff1c341dce1424aa21 \
+                        size    62423 \
+                    github.com/fatih/structtag \
+                        lock    v1.2.0 \
+                        rmd160  dceb529f2caa7a1a18aac46d1b3a54cd374f3f4a \
+                        sha256  105214157a39939be2459ce35cf884c34f5f83069a974865691039110e629353 \
+                        size    5707 \
+                    github.com/fatih/color \
+                        lock    v1.10.0 \
+                        rmd160  d33ae416337f02c181700fe76c05aec814791423 \
+                        sha256  2caf3481614a1a3dcbec15506d9549867a8538e60a8f3d057a619557ec6faa9b \
+                        size    1267972 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v2.0.0 \
+                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
+                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
+                        size    52040 \
+                    github.com/cenkalti/backoff \
+                        lock    v2.2.1 \
+                        rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
+                        sha256  4f6a3d7d9fdc5e02522faed8e96539476f646ab64983633a92ea1b71e18bca4f \
+                        size    8633 \
+                    github.com/caspr-io/yamlpath \
+                        lock    502e8d113a9b \
+                        rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
+                        sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
+                        size    6334 \
+                    github.com/blang/semver \
+                        lock    v3.5.1 \
+                        rmd160  f3746971886e0aa556800bfd543d2f4a89a69767 \
+                        sha256  5f5743805f1baf458ddf2dd8f49c553aa1f5c9667feadf357143602489d3587f \
+                        size    14842 \
+                    github.com/atotto/clipboard \
+                        lock    v0.1.2 \
+                        rmd160  4a0617ed814da771a9701f36b2be950301e153df \
+                        sha256  d3923f2514644b13032c76bf75fd66ef4e581afd8a86e186a300d1da12f688b3 \
+                        size    4476 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    filippo.io/age \
+                        repo    github.com/FiloSottile/age \
+                        lock    v1.0.0-beta4 \
+                        rmd160  40729805449116617866c1b16cf4e588f752a3b3 \
+                        sha256  f0525db9eba63f3163ce8374b9e7f1cf4851bb424d3470db0d04646060879790 \
+                        size    36023
+
+build.args          -ldflags '-X main.version=${version}'
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
gopass-jsonapi is missed after #11249.

[gopass 1.12.0](https://github.com/gopasspw/gopass/releases/tag/v1.12.0):

> NOTE: This release drops the integrations that were moved to their own repos,
> i.e. git-credential-gopass, gopass-hibp, gopass-jsonapi and
> gopass-summon-provider.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
