### PR TITLE
gh: update to 1.12.0 and build from source

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -1,53 +1,59 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           legacysupport 1.1
+PortGroup           golang 1.0
 
-github.setup        cli cli 1.11.0 v
+go.setup            github.com/cli/cli 1.12.0 v
 revision            0
 name                gh
+
+homepage            https://cli.github.com
+
+description         GitHub’s official command line tool
+
+long_description    ${name} is GitHub on the command line. It brings pull \
+                    requests, issues, and other GitHub concepts to the \
+                    terminal next to where you are already working with git \
+                    and your code.
+
 categories          devel
-platforms           darwin
-supported_archs     x86_64
 license             MIT
 maintainers         {l2dy @l2dy} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
-
-description         The GitHub CLI
-long_description    gh is GitHub on the command line, and it's now available in beta.
-
-homepage            https://cli.github.com
-
-# oauthClientID in the repository is meant for development
-# https://github.com/cli/cli/blob/v0.5.4/context/config_setup.go#L21
-github.tarball_from releases
-distname            gh_${version}_macOS_amd64
-
-checksums           rmd160  7dbe2bd9214209dc3ca1978218eb257a419d1d05 \
-                    sha256  cfd57a26f33e535a02cb014b9ee605b44b615a4bc9c0ec308e704fc33fa3b3a0 \
-                    size    7086979
-
-use_configure       no
 installs_libs       no
 
-build {}
+checksums           rmd160  b63956dd35e7c735cce637222b07d8602ba95c23 \
+                    sha256  e0a3f1d4bc9e2561e080314dfbff294602e782c16fcfb17e5b9f67f89a1c145a \
+                    size    525949
+
+github.tarball_from archive
+
+# Allow Go to fetch dependencies at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
+build.cmd           make
+build.pre_args-append \
+                    GH_VERSION=${version}
+build.args          bin/${name} manpages
+
+patch {
+    # Do not override GOOS, GOARCH, GOARM and other environment variables
+    reinplace -E \
+        {s|GOOS= GOARCH= GOARM= GOFLAGS= CGO_ENABLED= go build|go build|g} \
+        ${worksrcpath}/Makefile
+}
 
 destroot {
     xinstall -m 0755 -W ${worksrcpath} bin/gh ${destroot}${prefix}/bin
 
-    # gh works on 10.10 and newer without legacysupport. standard
-    # legacysupport tweaks don't work, since the install here is from
-    # a binary tarball ... have to tweak the binary to use the legacy
-    # support library, which in turn uses the System.B library.
-    if {${os.major} <= 13} {
-        system -W ${destroot}${prefix}/bin "install_name_tool -change /usr/lib/libSystem.B.dylib ${prefix}/lib/libMacportsLegacySupport.dylib gh"
-    }
-
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} LICENSE ${destroot}${docdir}
+
+    # Man pages
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 {*}[glob ${worksrcpath}/share/man/man1/*] \
+        ${destroot}${prefix}/share/man/man1
 
     # Shell completions
     xinstall -d ${destroot}${prefix}/share/bash-completion/completions


### PR DESCRIPTION
- build from source instead of using amd64 pre-built binary
- build and install man pages
- remove legacysupport additions. That is now done by the golang portgroup

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
