### PR TITLE
ispc: fix SDK version detection

### DIFF
--- a/lang/ispc/Portfile
+++ b/lang/ispc/Portfile
@@ -50,6 +50,9 @@ if { ${subport} eq ${name} } {
 
     patchfiles           patch-CMakeLists.txt.diff
 
+    # More reliable SDK version detection
+    patchfiles-append    patch-CMakeLists.txt-2.diff
+
     post-patch {
         if {${os.platform} eq "darwin" && ${os.major} >= 18} {
             set sdkroot ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk

--- a/lang/ispc/files/patch-CMakeLists.txt-2.diff
+++ b/lang/ispc/files/patch-CMakeLists.txt-2.diff
@@ -1,0 +1,36 @@
+Use xcrun or xcodebuild to determine macOS SDK version
+
+This approach should be more reliable than grepping the SDK path,
+and allow using an SDK whose path doesn’t indicate the version.
+
+Upstream-Status: Submitted (https://github.com/ispc/ispc/pull/2115)
+
+--- CMakeLists.txt.orig	2021-06-11 19:41:24.000000000 -0500
++++ CMakeLists.txt	2021-07-10 04:33:11.000000000 -0500
+@@ -156,10 +156,22 @@
+         set(ISPC_MACOS_SDK_PATH "${ISPC_MACOS_SDK_PATH_NEW}")
+     endif()
+ 
+-    # Grepping path to figure out the version is not the most reliable way,
+-    # but it seems to be the most practical.
+-    string(REGEX MATCH "MacOSX([0-9]*.[0-9]*).sdk" _ ${ISPC_MACOS_SDK_PATH})
+-    set(SDK_VER "${CMAKE_MATCH_1}")
++    message(STATUS "Trying xcodebuild...")
++    set(command "xcodebuild" "-sdk" "${ISPC_MACOS_SDK_PATH}" "-version" "SDKVERSION")
++    execute_process(COMMAND ${command}
++        RESULT_VARIABLE XCODEBUILD_OK
++        ERROR_QUIET
++        OUTPUT_VARIABLE SDK_VER
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++    )
++    if (NOT ${XCODEBUILD_OK} EQUAL 0)
++        message(STATUS "Trying xcrun...")
++        set(command "xcrun" "-sdk" "${ISPC_MACOS_SDK_PATH}" "--show-sdk-version")
++        execute_process(COMMAND ${command}
++            OUTPUT_VARIABLE SDK_VER
++            OUTPUT_STRIP_TRAILING_WHITESPACE
++        )
++    endif()
+     message(STATUS "MacOS_SDK version: ${SDK_VER}")
+ 
+     if ("${SDK_VER}" STREQUAL "")


### PR DESCRIPTION
#### Description
See ispc/ispc#2115
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools (macOS 10.15.6 SDK)

Only patch/configure phases tested (with `use_xcode yes` commented out), which shows desired output (notice SDK version 10.15.6 instead of 10.15):
```
-- Using macOS SDK path /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
-- MacOS_SDK version: 10.15.6
-- MacOS_SDK does NOT supports ARM (SDK ver < 11.0)
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
