### PR TITLE
kubectl: build from source for 1.21, 1.20, & 1.19

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -18,28 +18,44 @@ maintainers             {@patarra gmail.com:patarra} \
 
 subport kubectl_select {}
 
+set source_build        no
+
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
 set latestVersion       kubectl-1.21
 
 subport kubectl-1.21 {
+    set source_build    yes
+
     set patchNumber     2
-    checksums           rmd160  16d618be1dabdf6bbebcdaa3eb19c98a6ebfaeee \
-                        sha256  4a6c072223d5944b98601fc9f4cfdc5652ff0919ca91210b7eed5c83f2422fa1 \
-                        size    52540272
+    revision            1
+
+    # because source_build is yes, this is the checksum of the kubernetes
+    # source tarball
+    checksums           rmd160  e32b00e8b34f90888f85a1d49cd4cc19edc89eae \
+                        sha256  1173f1ea1b6d291666715f54c7d6dd9c54357c0f80aa453f243fd7b3a7498972 \
+                        size    36081553
 }
 
 subport kubectl-1.20 {
+    set source_build    yes
+
     set patchNumber     4
-    checksums           rmd160  6a96b5e7fcc550198ddf4056ee3b0a644bd4b78c \
-                        sha256  37f593731b8c9913bf2a3bfa36dacb3058dc176c7aeae2930c783822ea03a573 \
-                        size    46263664
+    revision            1
+
+    checksums           rmd160  ace075d1556d3f990a415a694dcd7ba89568bf2d \
+                        sha256  79ee11e306d948afe18c3265023218470956f5434daf52340188339ec322a5db \
+                        size    34447748
 }
 
 subport kubectl-1.19 {
+    set source_build    yes
+
     set patchNumber     8
-    checksums           rmd160  598965501bd55a2c84db22ebca1d131b6beff61a \
-                        sha256  51e937f4d863a41299952428616aece20c7289548c08239db50dcb9f826c46ff \
-                        size    49442736
+    revision            1
+
+    checksums           rmd160  6c388189031d21318206ab7e289459a0ed6b465b \
+                        sha256  b18e17fe404b3e004339ec686455b7db3feccf46a6077be49745101ea2e8fff3 \
+                        size    33500607
 }
 
 subport kubectl-1.18 {
@@ -136,43 +152,75 @@ if {${subport} == ${name}} {
     livecheck.type     none
 
 } else {
-    PortGroup           github 1.0
-
-    supported_archs     x86_64
-    depends_run         port:kubectl_select
 
     set baseVersion     [lindex [split ${subport} "-"] 1]
     set patchVersion    ${baseVersion}.${patchNumber}
     set baseName        kubectl${baseVersion}
-    github.setup        kubernetes kubectl ${patchVersion}
+
+    if ${source_build} {
+        # Build kubectl from source
+
+        PortGroup           golang 1.0
+
+        go.setup            github.com/kubernetes/kubernetes ${patchVersion} v
+        go.package          k8s.io/kubernetes
+
+        build.cmd           make
+        build.target        kubectl
+
+        github.tarball_from archive
+
+        use_parallel_build  no
+
+        depends_build-append \
+                            port:bash
+
+        destroot {
+            xinstall ${worksrcpath}/_output/bin/kubectl \
+                ${destroot}${prefix}/bin/kubectl${baseVersion}
+        }
+    } else {
+        # Use Darwin amd64 pre-built binary
+
+        PortGroup           github 1.0
+
+        github.setup        kubernetes kubectl ${patchVersion}
+        supported_archs     x86_64
+
+        master_sites        https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/darwin/amd64
+        distname            kubectl
+        dist_subdir         ${name}/${version}
+        extract.suffix
+        extract.only
+
+        use_configure       no
+
+        build {}
+
+        destroot {
+            xinstall ${distpath}/kubectl \
+                ${destroot}${prefix}/bin/kubectl${baseVersion}
+
+            # legacysupport tweaks don't work, since the install here is from
+            # a binary tarball ... have to tweak the binary to use the legacy
+            # support library, which in turn uses the System.B library.
+            legacysupport::relink_libSystem ${destroot}${prefix}/bin/kubectl${baseVersion}
+        }
+    }
+
+    depends_run         port:kubectl_select
 
     description         Kubernetes cluster CLI
     long_description    Command line interface for running commands against \
                         Kubernetes clusters
 
-    master_sites        https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/darwin/amd64
-    distname            kubectl
-    dist_subdir         ${name}/${version}
-    extract.suffix
-    extract.only
-
-    use_configure       no
-
-    build {
+    post-build {
         file copy ${filespath}/kubectlX.YY.template ${workpath}/${baseName}
         reinplace "s|@@BASE_VERSION@@|${baseVersion}|g" ${workpath}/${baseName}
         reinplace "s|@@PORT_NAME@@|${subport}|g" ${workpath}/${baseName}
     }
 
-    destroot {
-        xinstall ${distpath}/kubectl \
-            ${destroot}${prefix}/bin/kubectl${baseVersion}
-
-        # legacysupport tweaks don't work, since the install here is from
-        # a binary tarball ... have to tweak the binary to use the legacy
-        # support library, which in turn uses the System.B library.
-        legacysupport::relink_libSystem ${destroot}${prefix}/bin/kubectl${baseVersion}
-
+    post-destroot {
         set completionsPath ${destroot}${prefix}/share/${subport}/completion
         xinstall -d ${completionsPath}
         exec ${destroot}${prefix}/bin/kubectl${baseVersion} completion bash \


### PR DESCRIPTION
Adds the option to build kubectl from source instead of using the pre-built amd64 binary.  This option is enabled for kubectl-1.21, kubectl-1.20, and kubectl-1.19.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
