### PR TITLE
ipmitool: Update to latest; minor cleanup

### DIFF
--- a/sysutils/ipmitool/Portfile
+++ b/sysutils/ipmitool/Portfile
@@ -9,12 +9,12 @@ PortGroup       legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 # Using head of ipmitool until next release for openssl build fixes
-github.setup    ipmitool ipmitool 84469a9c5486b12db727c129a89ec6b584588f66
-version         1.8.18.20200616
+github.setup    ipmitool ipmitool 11c7605c0d5423f90f399f5e830d1095089f38a1
+version         1.8.18.20210622
 revision        0
-checksums       rmd160  868587a9abff4e50793c93310aa0f626a9a83974 \
-                sha256  788a50b7f86140926eb24ab31a3805bc868b7650207995f9a911c677e0d70af4 \
-                size    625527
+checksums       rmd160  273ded688a39ca722d5de4a7a11497b37e9833b9 \
+                sha256  f5e7c03254e3714fd14f5780833c028a03f97fa9a9832ff95644a80969e1411a \
+                size    638260
 
 categories      sysutils
 license         BSD
@@ -45,21 +45,14 @@ depends_lib     path:lib/libssl.dylib:openssl \
 
 github.tarball_from archive
 
-configure.args --enable-intf-lanplus --enable-ipmishell
+configure.args  --enable-intf-lanplus \
+                --enable-ipmishell \
+                --mandir=${prefix}/share/man
+
 configure.cppflags-append   -Ds6_addr16=__u6_addr.__u6_addr16
 
 compiler.c_standard    2011
-# Work around MacPorts base C11 compiler selection bug.
-# https://github.com/macports/macports-base/pull/196
-compiler.blacklist-append {clang < 500}
 
 pre-configure {
     system -W ${worksrcpath} "./bootstrap"
 }
-
-post-patch {
-    reinplace {/DOWNLOAD/s/ -#/ -L/} configure.ac
-    reinplace "s|\$(INSTALL_DATA)|ginstall -m 0644|" Makefile.am
-}
-
-configure.args-append  --mandir=${prefix}/share/man


### PR DESCRIPTION
Updated to latest version; I was getting timeouts on lan+ serial connections with the last version, this _seems_ to be better behaved. Other changes:

- The _reinplace_ steps are no longer needed when I build (Catalina 10.15.7 / XC 12.4) — the first is obsoleted by [changes](https://github.com/ipmitool/ipmitool/commit/3452cf1ca24ddddaba84e99495dbd651ae686236) [upstream](https://github.com/ipmitool/ipmitool/commit/b302d8202cb31fc62ad74d1bc373698972025160), but (full disclosure) I haven't dug into why the second is no longer needed.
- The c11 blacklist fix is [now in base](https://github.com/macports/macports-base/pull/196).
- Minor cleanup to configure.args