### PR TITLE
kustomize: update to 4.1.4

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.1.3 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.1.4 kustomize/v
 revision            0
 
 categories          devel
@@ -23,18 +23,19 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  40a532da644f11c6ab3cffaf8e6f5af5a0780fcc \
-                    sha256  3865c0e11f4ca74474469d9d5bf8db57b1b87d6e133efb8258ca2b6d8e5d12b5 \
-                    size    25087377
+checksums           rmd160  e04fb9d3c960c2c5e4f4e1f28efb64925530a449 \
+                    sha256  8f1bf4b82e0e3f79a7066d1fdc5ef2b2d6b347d79c72af23bc14231f5fd6f682 \
+                    size    25213754
 
 build.dir           ${worksrcpath}/${name}
 
+set build_date      [exec date +%FT%T%z]
 build.args          -ldflags \" \
                         -s \
                         -w \
                         -X sigs.k8s.io/kustomize/api/provenance.version=${version} \
                         -X sigs.k8s.io/kustomize/api/provenance.gitCommit=unknown \
-                        -X sigs.k8s.io/kustomize/api/provenance.buildDate=unknown \
+                        -X sigs.k8s.io/kustomize/api/provenance.buildDate=${build_date} \
                     \"
 
 # FIXME: This port currently can't be built without allowing go mod to fetch


### PR DESCRIPTION
#### Description

Update to Kustomize 4.1.4.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?