### PR TITLE
p5-tk-tablematrix: ensure MacPorts’ X11 is used

### DIFF
--- a/perl/p5-tk-tablematrix/Portfile
+++ b/perl/p5-tk-tablematrix/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Tk-TableMatrix 1.26
-revision            0
+revision            1
 
 platforms           darwin
 maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
@@ -41,6 +41,9 @@ checksums           rmd160  b48ba0199975036f5a343f49d710a81eef56dccf \
 if {${perl5.major} ne ""} {
     depends_lib-append \
                     port:p${perl5.major}-tk
+
+    configure.args-append \
+                    X11=${prefix}
 
     # avoid conflict with Perl/Tk (as done by Debian)
     post-destroot {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools
Perl 5.32.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
