### PR TITLE
perl5: address problematic baked-in values

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -24,15 +24,15 @@ master_sites        https://www.cpan.org/src/5.0/
 # - sha256
 # - size
 set perl5.versions_info {
-    5.16 3 9 f25fdd72449156a7cbe989e8bd339fdba1afabc0  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8  13724906
-    5.18 4 8 d97181a98f7acc80125b0d2a182a6a2cd7542ceb  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5  14059430
-    5.20 3 7 499846a1c92e00dd357cb782bc14787b8cd47051  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b  13743405
-    5.22 4 5 54fdbcbf249134dc7d82b693417900286201b5e7  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71  13745983
-    5.24 4 4 8d6b67fc6d58334b2fdbfa9d6d7456265dca1f4e  e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10  14125130
-    5.26 3 4 84ed404407c198ca2b8194c374c7914d941b6f49  9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477  14539342
-    5.28 3 1 d2ae86e19666b689cad4c866e7d95c6491fd50c1  77dc1ddf541643af14d585867d3d0741cce45d0dbe8f1467024e63165d9e2fc5  12382032
-    5.30 3 0 7aaec213f6537a53abd8fd97bb96d91b681cdf1e  6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4  12375128
-    5.32 1 0 ad9013fa389e3e73940c90b7d4ffd542a0cafc70  57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309  12610988
+    5.16 3 10 f25fdd72449156a7cbe989e8bd339fdba1afabc0  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8  13724906
+    5.18 4 9 d97181a98f7acc80125b0d2a182a6a2cd7542ceb  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5  14059430
+    5.20 3 8 499846a1c92e00dd357cb782bc14787b8cd47051  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b  13743405
+    5.22 4 6 54fdbcbf249134dc7d82b693417900286201b5e7  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71  13745983
+    5.24 4 5 8d6b67fc6d58334b2fdbfa9d6d7456265dca1f4e  e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10  14125130
+    5.26 3 5 84ed404407c198ca2b8194c374c7914d941b6f49  9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477  14539342
+    5.28 3 2 d2ae86e19666b689cad4c866e7d95c6491fd50c1  77dc1ddf541643af14d585867d3d0741cce45d0dbe8f1467024e63165d9e2fc5  12382032
+    5.30 3 1 7aaec213f6537a53abd8fd97bb96d91b681cdf1e  6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4  12375128
+    5.32 1 1 ad9013fa389e3e73940c90b7d4ffd542a0cafc70  57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309  12610988
 }
 
 foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5.size} ${perl5.versions_info} {
@@ -208,6 +208,17 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
 
         post-build {
             reinplace -E {s/-arch [a-z0-9_]+//g} \
+                ${worksrcpath}/lib/Config_heavy.pl
+            reinplace -E {s/-mmacosx-version-min=[0-9.]+//g} \
+                ${worksrcpath}/lib/Config_heavy.pl
+            reinplace "s|${configure.cc}|/usr/bin/cc|g" \
+                ${worksrcpath}/lib/Config.pm \
+                ${worksrcpath}/lib/Config_heavy.pl \
+                ${worksrcpath}/config.h
+            reinplace -E {s|-isysroot[[:space:]]*[^[:space:]]+\.sdk||g} \
+                ${worksrcpath}/lib/Config_heavy.pl \
+                ${worksrcpath}/config.h
+            reinplace -E {s|-Wl,-syslibroot,[^[:space:]]+\.sdk||g} \
                 ${worksrcpath}/lib/Config_heavy.pl
         }
 


### PR DESCRIPTION
Use generic `/usr/bin/cc` for compiler since the specific one used to
build perl may not be available at runtime. Remove flags specifying SDK
and deployment target since different ones may be specified in the
environment at runtime, and, similar to the compiler, the SDK that was
used at build time may not be available at runtime.

Fixes: https://trac.macports.org/ticket/59786
Fixes: https://trac.macports.org/ticket/62440

#### Description

There is of course still more work to be done in collaboration with upstream, but this should deal with the main problems that we are commonly seeing.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix
