### PR TITLE
maxima-devel: fix git.url

### DIFF
--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -41,7 +41,7 @@ subport maxima-devel {
     version     5.43-dev-20200126
     revision    17
     fetch.type  git
-    git.url     ht¯tps://git.code.sf.net/p/maxima/code
+    git.url     https://git.code.sf.net/p/maxima/code
     git.branch  d806e84c719a9fcf023f8829535f593ce9bb7d0c
 
     use_autoreconf  yes


### PR DESCRIPTION
#### Description
Should fix fetch error:

    fatal: protocol 'ht¯tps' is not supported
  

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
