### PR TITLE
java portgroup: Continue to skip check

### DIFF
--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -35,7 +35,7 @@ pre-fetch {
         # If still not present, error out
         if { ${java_version_not_found} } {
             global os.platform os.major
-            if {${os.platform} eq "darwin" && ${os.major} == 20} {
+            if {${os.platform} eq "darwin" && ${os.major} >= 20} {
                 # The following check is broken on macOS 11 Big Sur so we
                 # temporarily give up on ensuring an exact Java version. See
                 # https://trac.macports.org/ticket/61445


### PR DESCRIPTION
#### Description

This check is still necessary post-Big Sur.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0 21A5268h
Xcode 13.0 13A5155e 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
