### PR TITLE
macfuse: update to 4.2.0

### DIFF
--- a/fuse/macfuse/Portfile
+++ b/fuse/macfuse/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        osxfuse osxfuse 4.1.2 macfuse-
-revision            2
+github.setup        osxfuse osxfuse 4.2.0 macfuse-
+revision            0
 name                macfuse
 conflicts           osxfuse
 categories          fuse
@@ -24,9 +24,9 @@ github.tarball_from releases
 distname            ${name}-${version}
 use_dmg             yes
 
-checksums           rmd160  7ff7040962d5bec814638a78efcc1997690b0eda \
-                    sha256  9ff344de38bad5ac5eca5194da00a2ba35dd6afdb9039133b5446168f8edafdb \
-                    size    5830216
+checksums           rmd160  ba5890bccb55afc402b2d5c1a17c1e21056d8a58 \
+                    sha256  bf413e3aae887b6e8e8f8ad46152eb34575b7ff7f90d6cc55735ad00c5a4c7a6 \
+                    size    5975938
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     known_fail yes


### PR DESCRIPTION
###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
