### PR TITLE
gopass: update to 1.12.7

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.12.6 v
+go.setup            github.com/gopasspw/gopass 1.12.7 v
 categories          security
 maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 license             MIT
@@ -15,9 +15,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  aebe3ed87e58779368143d40391cd64cd57898c6 \
-                        sha256  e4f4db9707baab3ee85e40dd11bb092c51b444ecc85d72aa9867a7a9f57029ce \
-                        size    2172856
+                        rmd160  937843d97d4cd24492aef4ffbc695fb535c31757 \
+                        sha256  f3ca341db9f35b5c52e651358ff5292b99d38f4c0bb0ebb2a824f753cd56af48 \
+                        size    2175394
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -43,7 +43,7 @@ go.vendors          rsc.io/qr \
                         size    31616 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    f2d1f6c \
+                        lock    v1.26.0 \
                         rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
                         sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
                         size    1270531 \
@@ -149,10 +149,10 @@ go.vendors          rsc.io/qr \
                         sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
                         size    3366 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
+                        lock    v0.0.13 \
+                        rmd160  91c4e10ae78db94432a94bc7f9816df4093ec8d7 \
+                        sha256  6a6b35588efb0abec5a951246775a4cb47fab11ff161715875de4c02c9cdf309 \
+                        size    4445 \
                     github.com/mattn/go-colorable \
                         lock    v0.1.8 \
                         rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
@@ -209,10 +209,10 @@ go.vendors          rsc.io/qr \
                         sha256  a053e731deda2d4baf00b362a8f55f7eeac5528115468013aeccb4acf05f2bd3 \
                         size    397048 \
                     github.com/google/go-cmp \
-                        lock    v0.5.5 \
-                        rmd160  5caef57da3ce09c102ed270168afa2a5200c2c47 \
-                        sha256  be284023d91976ef03d13cb5670e338c09a0a0da9925d7de457f44e33aebb724 \
-                        size    102365 \
+                        lock    v0.5.6 \
+                        rmd160  b93086d92bddc7a3b593fb637776f055c022049f \
+                        sha256  fa1ca0f00fe02f645c4ed12ef753ff6c46b6621db01e09d96599cf1fd990aebe \
+                        size    104422 \
                     github.com/golang/protobuf \
                         lock    v1.5.2 \
                         rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
@@ -229,10 +229,10 @@ go.vendors          rsc.io/qr \
                         sha256  54c06c5988808eca9affe01cabe122e02ba4af5763f29fff1c341dce1424aa21 \
                         size    62423 \
                     github.com/fatih/color \
-                        lock    v1.10.0 \
-                        rmd160  d33ae416337f02c181700fe76c05aec814791423 \
-                        sha256  2caf3481614a1a3dcbec15506d9549867a8538e60a8f3d057a619557ec6faa9b \
-                        size    1267972 \
+                        lock    v1.12.0 \
+                        rmd160  71a007da8ad943b7e3b070ab9a272e576adad676 \
+                        sha256  69e7bf877a72e225b3d9f424ca644a17f67209f5e311e910f1650cdb7f1b62a8 \
+                        size    10712 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
@@ -278,12 +278,18 @@ go.vendors          rsc.io/qr \
                         rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
                         sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
                         size    5023 \
+                    filippo.io/edwards25519 \
+                        repo    github.com/FiloSottile/edwards25519 \
+                        lock    v1.0.0-beta.3 \
+                        rmd160  50832cf6734e20eba82bc207307785e42e3f7887 \
+                        sha256  a5b1335f41d769caa2193aa1b176f0cc9cfb47f380afb8d308c51c0f7dc6a91e \
+                        size    78117 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
-                        lock    v1.0.0-rc.1 \
-                        rmd160  10a37fc487515eccc4844cd7e1ccd21fbb97a17c \
-                        sha256  b283719783aebee710ca0cd40cdf1348bfb2a3566d498c794321b7aff18e0bc4 \
-                        size    47017
+                        lock    v1.0.0-rc.3 \
+                        rmd160  3ec904a8771f1f6553ddfbab782ef1123b367f65 \
+                        sha256  73b676e994d1190e3957d57e631af8aaabd8a775e2cf9c2601addbfd1fdaf09d \
+                        size    59027
 
 set go_ldflags      "-s -w -X main.version=${version}"
 build.args          -ldflags \"${go_ldflags}\"


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.12.7)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
