### PR TITLE
elftoolchain: Fix implicit func decls; other fixes

### DIFF
--- a/devel/elftoolchain/Portfile
+++ b/devel/elftoolchain/Portfile
@@ -1,7 +1,11 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem      1.0
+PortGroup       makefile 1.0
 
 name            elftoolchain
 version         0.7.1
+revision        1
 categories      devel
 platforms       darwin
 license         BSD
@@ -13,11 +17,12 @@ long_description \
     the tools nm, ar, as, elfdump and more.
 
 homepage        http://elftoolchain.sourceforge.net/
-master_sites    sourceforge
+master_sites    sourceforge:project/${name}/Sources/${name}-${version}/
 use_bzip2 yes
 
 checksums       rmd160  9e341f86573d80dd2b390d79cf82f239ecd279ff \
-                sha256  44f14591fcf21294387215dd7562f3fb4bec2f42f476cf32420a6bbabb2bd2b5
+                sha256  44f14591fcf21294387215dd7562f3fb4bec2f42f476cf32420a6bbabb2bd2b5 \
+                size    5361427
 
 depends_build   port:bmake \
                 port:bison \
@@ -25,20 +30,18 @@ depends_build   port:bmake \
 
 depends_lib     port:libarchive
 
-patchfiles      patch-mk.diff \
-                patch-byteorder-macros.diff
+patchfiles      patch-byteorder-macros.diff \
+                patch-libelftc-make-toolchain-version.diff \
+                patch-mk.diff \
+                patch-mk-elftoolchain.tex.mk.diff
 
-post-patch {
-    reinplace "s:@PREFIX@:${prefix}:g" ${worksrcpath}/mk/elftoolchain.prog.mk
-}
+universal_variant no
 
-use_configure no
+makefile.prefix_name prefix
 
 build.type      bsd
 build.cmd       ${prefix}/bin/bmake
-build.args      CC=${configure.cc} \
-                prefix=${prefix} \
-                BINDIR=${prefix}/bin \
+build.args      BINDIR=${prefix}/bin \
                 LIBDIR=${prefix}/lib/elftoolchain \
                 SHLIBDIR=${prefix}/lib/elftoolchain \
                 INCSDIR=${prefix}/include/elftoolchain \
@@ -51,14 +54,7 @@ build.args-append WITH_TESTS=no
 # Exclude docs to avoid pulling in a full TeX distribution
 build.args-append MKTEX=no
 
-destroot.target install
-destroot.args   prefix=${prefix} \
-                BINDIR=${prefix}/bin \
-                LIBDIR=${prefix}/lib/elftoolchain \
-                SHLIBDIR=${prefix}/lib/elftoolchain \
-                INCSDIR=${prefix}/include/elftoolchain \
-                MANDIR=${prefix}/share/man \
-                MANTARGET=man
+destroot.args   {*}${build.args}
 
 # Do not strip binaries as that leads to errors
 destroot.args-append STRIP=
@@ -74,7 +70,7 @@ post-destroot {
     foreach f [glob -tails -directory ${destroot}${prefix}/bin *] {
         set nf elftc-$f
         move ${destroot}${prefix}/bin/$f ${destroot}${prefix}/bin/$nf
-        ln -s ${prefix}/bin/$nf ${destroot}${prefix}/libexec/${name}/$f
+        ln -s ../../bin/$nf ${destroot}${prefix}/libexec/${name}/$f
     }
     foreach f [glob ${destroot}${prefix}/share/man/man{1,5}/*] {
         move $f [file dirname $f]/elftc-[file tail $f]

--- a/devel/elftoolchain/files/patch-byteorder-macros.diff
+++ b/devel/elftoolchain/files/patch-byteorder-macros.diff
@@ -1,28 +1,10 @@
---- ar/write.c	2012-04-24 04:33:40.000000000 +0200
-+++ ar/write.c	2012-09-25 11:27:38.000000000 +0200
-@@ -43,6 +43,11 @@
+--- common/_elftc.h.orig	2015-08-31 14:53:08.000000000 -0500
++++ common/_elftc.h	2021-07-02 09:05:24.000000000 -0500
+@@ -374,6 +374,7 @@
  
- ELFTC_VCSID("$Id: write.c 2496 2012-04-24 02:33:40Z jkoshy $");
+ #include <libkern/OSByteOrder.h>
+ #define	htobe32(x)	OSSwapHostToBigInt32(x)
++#define	htole32(x)	OSSwapHostToLittleInt32(x)
+ #define	roundup2	roundup
  
-+#ifdef __APPLE__
-+#include <libkern/OSByteOrder.h>
-+#define htobe32(x) OSSwapHostToBigInt32(x)
-+#endif
-+
- #define _ARMAG_LEN 8		/* length of the magic string */
- #define _ARHDR_LEN 60		/* length of the archive header */
- #define _INIT_AS_CAP 128	/* initial archive string table size */
---- elfcopy/archive.c	2012-02-25 01:00:13.000000000 +0100
-+++ elfcopy/archive.c	2012-02-25 01:00:27.000000000 +0100
-@@ -42,6 +42,11 @@
- 
- ELFTC_VCSID("$Id: archive.c 2370 2011-12-29 12:48:12Z jkoshy $");
- 
-+#ifdef __APPLE__
-+#include <libkern/OSByteOrder.h>
-+#define htobe32(x) OSSwapHostToBigInt32(x)
-+#endif
-+
- #define _ARMAG_LEN 8		/* length of ar magic string */
- #define _ARHDR_LEN 60		/* length of ar header */
- #define _INIT_AS_CAP 128	/* initial archive string table size */
+ #define	ELFTC_BYTE_ORDER			_BYTE_ORDER

--- a/devel/elftoolchain/files/patch-libelftc-make-toolchain-version.diff
+++ b/devel/elftoolchain/files/patch-libelftc-make-toolchain-version.diff
@@ -1,0 +1,21 @@
+Don't use svnversion or git describe since we're not using a svn wc or
+git clone and since the svnversion or git commands might not exist.
+--- libelftc/make-toolchain-version.orig	2016-02-16 16:58:35.000000000 -0600
++++ libelftc/make-toolchain-version	2021-07-02 13:06:53.000000000 -0500
+@@ -64,6 +64,8 @@
+ curdir=`pwd`
+ cd ${top} || usage "ERROR: Cannot change directory to \"${top}\"."
+ 
++versionstring=
++if false; then
+ if [ -d CVS ]; then		# Look for CVS (NetBSD).
+     versionstring=" cvs:unknown"
+ else				# Try git (DragonFlyBSD).
+@@ -82,6 +84,7 @@
+     echo "ERROR: cannot determine a revision number." 1>&2
+     exit 1
+ fi
++fi
+ 
+ cd ${curdir} || usage "Cannot change back to ${curdir}."
+ 

--- a/devel/elftoolchain/files/patch-mk-elftoolchain.tex.mk.diff
+++ b/devel/elftoolchain/files/patch-mk-elftoolchain.tex.mk.diff
@@ -1,0 +1,12 @@
+Change non-portable echo -n to printf.
+--- mk/elftoolchain.tex.mk.orig	2012-08-27 22:39:09.000000000 -0500
++++ mk/elftoolchain.tex.mk	2021-07-02 10:41:45.000000000 -0500
+@@ -88,7 +88,7 @@
+ .else
+ 
+ all clean clobber depend install obj:	.PHONY .SILENT
+-	echo -n WARNING: make \"${.TARGET}\" in \"${.CURDIR:T}\" skipped:
++	printf "WARNING: make \"%s\" in \"%s\" skipped:" "${.TARGET}" "${.CURDIR:T}"
+ .if	defined(MKTEX) && ${MKTEX} == "yes"
+ 	echo " missing tools."
+ .else

--- a/devel/elftoolchain/files/patch-mk.diff
+++ b/devel/elftoolchain/files/patch-mk.diff
@@ -1,20 +1,8 @@
 --- mk/elftoolchain.prog.mk.orig	2017-06-11 16:21:28.000000000 +0200
 +++ mk/elftoolchain.prog.mk	2017-06-11 16:21:47.000000000 +0200
-@@ -50,6 +50,11 @@
- LDFLAGS+=	-L/usr/pkg/lib
- .endif
- 
-+.if ${OS_HOST} == "Darwin"
-+CFLAGS+=       -I@PREFIX@/include
-+LDFLAGS+=      -L@PREFIX@/lib
-+.endif
-+
- #
- # Handle lex(1) and yacc(1) in a portable fashion.
- #
 --- mk/os.Darwin.mk	(revision 3546)
 +++ mk/os.Darwin.mk	(working copy)
-@@ -3,6 +3,6 @@
+@@ -3,6 +3,5 @@
  # Build definitions for Darwin
  
  # Apple ships libarchive, but for some reason does not provide the headers.
@@ -22,5 +10,4 @@
 -LDFLAGS+=	-L/usr/local/opt/libarchive/lib
 -CFLAGS+=	-I/usr/local/opt/libarchive/include
 +# Build against a MacPorts-provided libarchive library and headers.
-+# LDFLAGS/CFLAGS for libarchive have to be added in mk/elftoolchain.prog.mk to
-+# respect the library search order.
++# LDFLAGS/CFLAGS for libarchive have to be set in the environment.


### PR DESCRIPTION
#### Description

Fix implicit declaration of function htole32 which caused build failure
on Xcode 12 and later.

Closes: https://trac.macports.org/ticket/62419

Remove unneeded additions of defines of htobe32 in archive.c and write.c
because it's already defined in _elftc.h. Use makefile portgroup to
simplify using the right compiler and flags. Copy build.args to
destroot.args programmatically to avoid code duplication. Don't need to
set destroot.target since it's already set by base. Remove unneeded
addition of CFLAGS and LDFLAGS in elftoolchain.prog.mk since the
makefile portgroup already sets them. Patch make-toolchain-version to no
longer use svnversion or git describe since we're not using a working
copy or clone and since those utilities might not be installed. Create
relative symlinks rather than absolute. Fix erroneously formatted
warning in elftoolchain.tex.mk by changing echo -n to printf. Specify
full sourceforge path to avoid redirects and fetch failures. Add size to
checksums. Add modeline.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
