### PR TITLE
gping, inetutils: indicate conflict

### DIFF
--- a/net/gping/Portfile
+++ b/net/gping/Portfile
@@ -11,6 +11,7 @@ platforms           darwin
 maintainers         {@harens gmail.com:harensdeveloper} \
                     openmaintainer
 license             MIT
+conflicts           inetutils
 
 description         ping, but with a graph
 long_description    {*}${description}

--- a/net/inetutils/Portfile
+++ b/net/inetutils/Portfile
@@ -17,6 +17,7 @@ platforms               darwin
 homepage                https://www.gnu.org/software/${name}/
 master_sites            gnu:${name}
 use_xz                  yes
+conflicts               gping
 
 checksums               rmd160  bf0750fba1acc0de3757993b4609395ea2732f1d \
                         sha256  e573d566e55393940099862e7f8994164a0ed12f5a86c3345380842bdc124722 \


### PR DESCRIPTION
Both install a gping binary.

Closes: https://trac.macports.org/ticket/63168

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
