### PR TITLE
fortran-utils: new port

### DIFF
--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -12,7 +12,7 @@ maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
 homepage        https://sourceforge.net/projects/fortran-utils/
 master_sites    sourceforge
 use_bzip2       yes
-worksrcdir      {}
+extract.mkdir   yes
 checksums       rmd160  353e753b2084f3eab5cf9cfd9c2ccf4e983f05b5 \
                 sha256  b2a25ae867a7755fb8d839ca5dd59a24888d12d217aea6ddfd57aceda888b197 \
                 size    7689

--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -1,21 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       makefile 1.0
 
 name            fortran-utils
 version         1.2
 revision        0
+checksums       rmd160  353e753b2084f3eab5cf9cfd9c2ccf4e983f05b5 \
+                sha256  b2a25ae867a7755fb8d839ca5dd59a24888d12d217aea6ddfd57aceda888b197 \
+                size    7689
+
 categories      devel
 platforms       darwin
 license         BSD
 maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+installs_libs   no
+
 homepage        https://sourceforge.net/projects/fortran-utils/
 master_sites    sourceforge
 use_bzip2       yes
-extract.mkdir   yes
-checksums       rmd160  353e753b2084f3eab5cf9cfd9c2ccf4e983f05b5 \
-                sha256  b2a25ae867a7755fb8d839ca5dd59a24888d12d217aea6ddfd57aceda888b197 \
-                size    7689
 
 description     Tools for use with Fortran77 code
 
@@ -24,18 +27,10 @@ long_description \
     \n- fpr: transform Fortran's carriage control conventions to UNIX line printer conventions \
     \n- fsplit: split a multi-routine Fortran file into individual files
 
+extract.mkdir   yes
 
-installs_libs   no
-use_configure   no
-build {
-    foreach p [list fpr fsplit] {
-        system -W ${worksrcpath}/${p} "${configure.cc} ${configure.cflags} ${configure.ldflags} [get_canonical_archflags cc] -o ${p} ${p}.c"
-    }
-}
+build.type      bsd
 
-destroot {
-    xinstall -m 0755 -W ${worksrcpath} fpr/fpr fsplit/fsplit ${destroot}${prefix}/bin
-    xinstall -m 0444 -W ${worksrcpath} fpr/fpr.1 fsplit/fsplit.1 ${destroot}${prefix}/share/man/man1/
-}
+destroot.args   BINDIR=${prefix}/bin
 
-livecheck.type   none
+livecheck.type  none

--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -36,7 +36,7 @@ build {
 
 destroot {
     xinstall -m 0755 -W ${worksrcpath} fpr/fpr fsplit/fsplit ${destroot}${prefix}/bin
-    xinstall -m 0444 -W ${worksrcpath} fpr/fpr.1 fsplit/fsplit.1 ${destroot}${prefix}/share/man/man1/fsplit.1
+    xinstall -m 0444 -W ${worksrcpath} fpr/fpr.1 fsplit/fsplit.1 ${destroot}${prefix}/share/man/man1/
 }
 
 livecheck.type   none

--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -24,7 +24,6 @@ long_description \
     \n- fpr: transform Fortran's carriage control conventions to UNIX line printer conventions \
     \n- fsplit: split a multi-routine Fortran file into individual files
 
-notes "This version has patches from FreeBSD and NetBSD."
 
 installs_libs   no
 use_configure   no

--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -29,8 +29,9 @@ notes "This version has patches from FreeBSD and NetBSD."
 installs_libs   no
 use_configure   no
 build {
-    system -W ${worksrcpath}/fsplit "${configure.cc} -o fsplit fsplit.c"
-    system -W ${worksrcpath}/fpr    "${configure.cc} -o fpr    fpr.c"
+    foreach p [list fpr fsplit] {
+        system -W ${worksrcpath}/${p} "${configure.cc} ${configure.cflags} ${configure.ldflags} [get_canonical_archflags cc] -o ${p} ${p}.c"
+    }
 }
 
 destroot {

--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            fortran-utils
+version         1.2
+revision        0
+categories      devel
+platforms       darwin
+license         BSD
+maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+homepage        https://sourceforge.net/projects/fortran-utils/
+master_sites    sourceforge
+extract.suffix  .tar.bz2
+worksrcdir      {}
+checksums       rmd160  353e753b2084f3eab5cf9cfd9c2ccf4e983f05b5 \
+                sha256  b2a25ae867a7755fb8d839ca5dd59a24888d12d217aea6ddfd57aceda888b197 \
+                size    7689
+
+description     Tools for use with Fortran77 code
+
+long_description \
+    The fortran-utils are: \
+    \n- fpr: transform Fortran's carriage control conventions to UNIX line printer conventions \
+    \n- fsplit: split a multi-routine Fortran file into individual files
+
+notes "This version has patches from FreeBSD and NetBSD."
+
+supported_archs noarch
+installs_libs   no
+use_configure   no
+build {
+    system -W ${worksrcpath}/fsplit "${configure.cc} -o fsplit fsplit.c"
+    system -W ${worksrcpath}/fpr    "${configure.cc} -o fpr    fpr.c"
+}
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath}/fsplit fsplit ${destroot}${prefix}/bin
+    xinstall -m 0755 -W ${worksrcpath}/fpr    fpr    ${destroot}${prefix}/bin
+    xinstall -m 0444 -W ${worksrcpath}/fsplit fsplit.1 ${destroot}${prefix}/share/man/man1/fsplit.1
+    xinstall -m 0444 -W ${worksrcpath}/fpr    fpr.1    ${destroot}${prefix}/share/man/man1/fpr.1
+}
+
+livecheck.type   none

--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -11,7 +11,7 @@ license         BSD
 maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
 homepage        https://sourceforge.net/projects/fortran-utils/
 master_sites    sourceforge
-extract.suffix  .tar.bz2
+use_bzip2       yes
 worksrcdir      {}
 checksums       rmd160  353e753b2084f3eab5cf9cfd9c2ccf4e983f05b5 \
                 sha256  b2a25ae867a7755fb8d839ca5dd59a24888d12d217aea6ddfd57aceda888b197 \

--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -26,7 +26,6 @@ long_description \
 
 notes "This version has patches from FreeBSD and NetBSD."
 
-supported_archs noarch
 installs_libs   no
 use_configure   no
 build {

--- a/devel/fortran-utils/Portfile
+++ b/devel/fortran-utils/Portfile
@@ -34,10 +34,8 @@ build {
 }
 
 destroot {
-    xinstall -m 0755 -W ${worksrcpath}/fsplit fsplit ${destroot}${prefix}/bin
-    xinstall -m 0755 -W ${worksrcpath}/fpr    fpr    ${destroot}${prefix}/bin
-    xinstall -m 0444 -W ${worksrcpath}/fsplit fsplit.1 ${destroot}${prefix}/share/man/man1/fsplit.1
-    xinstall -m 0444 -W ${worksrcpath}/fpr    fpr.1    ${destroot}${prefix}/share/man/man1/fpr.1
+    xinstall -m 0755 -W ${worksrcpath} fpr/fpr fsplit/fsplit ${destroot}${prefix}/bin
+    xinstall -m 0444 -W ${worksrcpath} fpr/fpr.1 fsplit/fsplit.1 ${destroot}${prefix}/share/man/man1/fsplit.1
 }
 
 livecheck.type   none


### PR DESCRIPTION
Tools for use with Fortran77 code.

#### Description

###### Type(s)
- [*] enhancement

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [*] checked your Portfile with `port lint`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
