### PR TITLE
gsl: change to single 'doc' variant

### DIFF
--- a/math/gsl/Portfile
+++ b/math/gsl/Portfile
@@ -34,8 +34,6 @@ patchfiles-append   dynamic_lookup-11.patch
 configure.args      --infodir=${prefix}/share/info \
                     --mandir=${prefix}/share/man
 
-use_parallel_build  yes
-
 test.run            yes
 test.target         check
 
@@ -46,38 +44,23 @@ post-activate {
 compilers.choose    cc
 compilers.setup
 
-if {[variant_isset doc_python27]} { set PythonVersion 27 }
-if {[variant_isset doc_python35]} { set PythonVersion 35 }
-if {[variant_isset doc_python36]} { set PythonVersion 36 }
-if {[variant_isset doc_python37]} { set PythonVersion 37 }
-if {[variant_isset doc_python38]} { set PythonVersion 38 }
-if {[variant_isset doc_python39]} { set PythonVersion 39 }
+variant doc description {Build documentation} {
+    set python_version 3.9
+    set python_ver_no_dot [string map {. {}} ${python_version}]
 
-variant doc_python27 conflicts doc_python35 doc_python36 doc_python37 doc_python38 doc_python39 description {Install PDF and HTML documentation using Python 2.7} {}
-variant doc_python35 conflicts doc_python27 doc_python36 doc_python37 doc_python38 doc_python39 description {Install PDF and HTML documentation using Python 3.5} {}
-variant doc_python36 conflicts doc_python27 doc_python35 doc_python37 doc_python38 doc_python39 description {Install PDF and HTML documentation using Python 3.6} {}
-variant doc_python37 conflicts doc_python27 doc_python35 doc_python36 doc_python38 doc_python39 description {Install PDF and HTML documentation using Python 3.7} {}
-variant doc_python38 conflicts doc_python27 doc_python35 doc_python36 doc_python37 doc_python39 description {Install PDF and HTML documentation using Python 3.8} {}
-variant doc_python39 conflicts doc_python27 doc_python35 doc_python36 doc_python37 doc_python38 description {Install PDF and HTML documentation using Python 3.9} {}
-
-if {[variant_isset doc_python27] || [variant_isset doc_python35] || [variant_isset doc_python36] || [variant_isset doc_python37] || [variant_isset doc_python38] || [variant_isset doc_python39]} {
     depends_build   port:ghostscript \
                     bin:latexmk:latexmk \
                     bin:latex:texlive \
                     port:texlive-latex-extra \
-                    port:py${PythonVersion}-sphinx \
-                    port:py${PythonVersion}-sphinx_rtd_theme \
-                    port:py${PythonVersion}-sphinxcontrib-websupport
+                    port:py${python_ver_no_dot}-sphinx \
+                    port:py${python_ver_no_dot}-sphinx_rtd_theme \
+                    port:py${python_ver_no_dot}-sphinxcontrib-websupport
 
-    ## for python>=3.5, typing has been installed as a standard library
-    if {${PythonVersion} < 35} {
-        depends_build-append port:py${PythonVersion}-typing
-    }
+    patchfiles-append \
+                    patch-python_version.diff
 
-    patchfiles-append patch-python_version.diff
     post-patch {
-        set PythonBranch [string index ${PythonVersion} 0].[string range ${PythonVersion} 1 end]
-        reinplace "s|__MACPORTS_SPHINX_BUILD__|sphinx-build-${PythonBranch}|g" ${worksrcpath}/doc/Makefile.in
+        reinplace "s|__MACPORTS_SPHINX_BUILD__|sphinx-build-${python_version}|g" ${worksrcpath}/doc/Makefile.in
     }
 
     post-build {
@@ -86,9 +69,8 @@ if {[variant_isset doc_python27] || [variant_isset doc_python35] || [variant_iss
     }
 
     post-destroot {
-        xinstall -d -m 755 ${destroot}${prefix}/share/doc/${name}
-        xinstall -c -m 644 ${worksrcpath}/doc/_build/latex/gsl-ref.pdf ${destroot}${prefix}/share/doc/${name}
-        xinstall -d -m 755 ${destroot}${prefix}/share/doc/${name}/
+        xinstall -d ${destroot}${prefix}/share/doc/${name}
+        xinstall -c -m 0644 ${worksrcpath}/doc/_build/latex/gsl-ref.pdf ${destroot}${prefix}/share/doc/${name}
         copy ${worksrcpath}/doc/_build/html ${destroot}${prefix}/share/doc/${name}/
     }
 }


### PR DESCRIPTION
#### Description
Have one `doc` variant that installs the documentation and specify which Python version to use (i.e., follow the default in the python PG). 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
