### PR TITLE
antibody: fix version information

### DIFF
--- a/sysutils/antibody/Portfile
+++ b/sysutils/antibody/Portfile
@@ -4,6 +4,8 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/getantibody/antibody 6.1.1 v
+revision            1
+
 categories          sysutils
 maintainers         {@danieltrautmann danieltrautmann.com:me} openmaintainer
 license             MIT
@@ -23,6 +25,8 @@ checksums           ${distname}${extract.suffix} \
                         rmd160  684869d6e480e946fb5ab63a64fd82f48120eb76 \
                         sha256  fb8fd2562ec7816c9824d08f3e5acd7f3d9bf22c944c4a87750ecf3d28952e03 \
                         size    53634
+
+build.pre_args      -ldflags '-X main.version=${version}'
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \


### PR DESCRIPTION
#### Description

Fix `antibody --version` value from `dev` to the release version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
