### PR TITLE
autorestic: new port

### DIFF
--- a/sysutils/autorestic/Portfile
+++ b/sysutils/autorestic/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/cupcakearmy/autorestic 1.1.1 v
+revision            0
+
+categories          sysutils
+maintainers         {gmail.com: smanojkarthick @manojkarthick} \
+                    openmaintainer
+license             Apache-2
+
+description         High level CLI utility for restic
+
+long_description    Autorestic is a wrapper around the amazing restic. \
+                    While being amazing the restic cli can be a bit overwhelming \
+                    and difficult to manage if you have many different location \
+                    that you want to backup to multiple locations. \
+                    This utility is aimed at making this easier.
+
+homepage            https://autorestic.vercel.app/
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  eaa983effb821052c0d7071beb09635245a2f745 \
+                        sha256  19779b2582dd871f2a0f6707dc7054f0a96b283d5ef6031bc1d6d7625160f5c2 \
+                        size    186465
+
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
+
+depends_run         port:restic
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Autorestic is a wrapper around restic for making backing up to multiple locations easier. This port cannot be built without downloading deps during the build phase. Ref: https://trac.macports.org/ticket/61192

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
