### PR TITLE
direnv: Update in version 2.28.0

### DIFF
--- a/devel/direnv/Portfile
+++ b/devel/direnv/Portfile
@@ -18,37 +18,74 @@ long_description    \
     directory. This allows project-specific environment variables without \
     cluttering the \"~/.profile\" file.
 
-# deprecate the devel port, if installed
-# can be removed after 20210125
-subport direnv-devel {
+go.setup  github.com/direnv/direnv 2.28.0 v
+revision  0
 
-    PortGroup   obsolete 1.0
-    replaced_by direnv
-    version     20191231-ab4d188d
-    revision    1
-    depends_build
-    depends_lib
-
-}
-
-if {${name} eq ${subport}} {
-
-    go.setup  github.com/direnv/direnv 2.26.0 v
-    checksums rmd160 75709a28fb8aee1bb936c1c944ab06d2364a40dc \
-              sha256 2c31ec65f340b66654b1fa029db0a0ed7a52d40c1b7ab710256348b26158724f \
-              size   1378813
-    revision  0
-
-    depends_build-append port:shfmt
-
-    build.cmd make
-    build.target all
-
-    destroot {
-        system "cd ${worksrcpath} && make install DESTDIR=${destroot}${prefix}"
-    }
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
 
 # override github information
 
 homepage https://direnv.net/
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  93085e4d9f63878a7efd864d4119491b9949ef90 \
+                        sha256  ef30014d09ac2c5459defce8bcdc46742f495caa7cbf48fe2c288cb2f88d8f93 \
+                        size    87229
+
+go.vendors          github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087 \
+                    github.com/direnv/go-dotenv \
+                        lock    4cce6d1a66f7bc8dc730eab85cab6af1b801abed \
+                        rmd160  0706031952b057ee4d11416dc2bc1b90678f9ec1 \
+                        sha256  784ae615cd839c35193929575c5d0b1b2d276a808f80d235c3e0ef8ae374f117 \
+                        size    3728 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    golang.org/x/crypto \
+                        lock 87dc89f01550 \
+                        rmd160  fe423943cd10a4dbe4bf5956abdcd4feb7fcba71 \
+                        sha256  452b5b4bbf469674ca6b50a856785641c45e3eb6c2ef8675cc618f5ea68dfa88 \
+                        size    1709161 \
+                    golang.org/x/mod \
+                        lock v0.4.1 \
+                        rmd160  c96b842a5189b7efca5466e347b279cfeebd8fbf \
+                        sha256  9370678c647c8fbab251e6d06eb6420c7c8be01cd97b5177a7205fce5128205a \
+                        size    102768 \
+                    golang.org/x/net \
+                        lock    3b0461eec859 \
+                         rmd160 24dae39afb612a8977e6f4a91596c64d15dd3664 \
+                         sha256 15f077bb408fb71b22e4015312be5fab7010576e824fdbfdfdb697b611621197 \
+                         size   1099249 \
+                    golang.org/x/sync \
+                        lock    112230192c58 \
+                        rmd160  37a8b11def31e2ad355002a8671245962be359f6 \
+                        sha256  951a6df1dadb061510f1c646197dd8f8a7c7842729d02c6a68a86bce66349f79 \
+                        size    16832 \
+                    golang.org/x/sys \
+                        lock    b77594299b42 \
+                        rmd160  7e54355c0025dc83f1507b6c03b7a59f8df0040b \
+                        sha256  26cacb991c0f1851edbe364c15e47d93e488f2700fc70be40e41aaeb01a9ebfb \
+                        size    1534714 \
+                    golang.org/x/text \
+                        lock v0.3.0 \
+                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
+                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
+                        size    6102563 \
+                    golang.org/x/tools \
+                        lock    298f0cb1881e \
+                        rmd160  6c23716885a92d5294df41c016d7640c04db9dee \
+                        sha256  20cc8a79e64c263ab6151c1c37e6360c0c24225761cf5e23394ec42f77f2bf77 \
+                        size    2301788 \
+                    golang.org/x/xerrors \
+                        lock    1b5146add898 \
+                        rmd160  2cc4b800c18d0a62360e39184f2a99b1ebd49a95 \
+                        sha256  6369e59584a604215ed9649649fe273e46295d3fb8d5a811f4028844c861faaa \
+                        size    12201


### PR DESCRIPTION
#### Description

Update direnv in version 2.28.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
