### PR TITLE
pulseaudio: Support for 10.4

### DIFF
--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -77,6 +77,10 @@ patchfiles          patch-man-Makefile.am.diff \
                     patch-src_daemon_default.pa.in-skip-consolekit-and-systemdlogin.diff \
                     patch-configure.ac-no-Werror.diff
 
+platform darwin 8 {
+    patchfiles-append   patch-src_modules_macosx_module_coreaudio_device.c-tiger-compat.diff
+}
+
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 post-patch {
     xinstall -m 755 ${filespath}/autogen.sh ${worksrcpath}

--- a/audio/pulseaudio/files/patch-src_modules_macosx_module_coreaudio_device.c-tiger-compat.diff
+++ b/audio/pulseaudio/files/patch-src_modules_macosx_module_coreaudio_device.c-tiger-compat.diff
@@ -1,0 +1,30 @@
+--- src/modules/macosx/module-coreaudio-device.c.old
++++ src/modules/macosx/module-coreaudio-device.c
+@@ -77,7 +78,7 @@
+ 
+ struct userdata {
+     AudioObjectID object_id;
+-    AudioDeviceIOProcID proc_id;
++    AudioDeviceIOProc proc_id;
+ 
+     pa_thread_mq thread_mq;
+     pa_asyncmsgq *async_msgq;
+@@ -885,7 +896,8 @@
+     pa_log_debug("%u frames per IOProc\n", (unsigned int) frames);
+ 
+     /* create one ioproc for both directions */
+-    err = AudioDeviceCreateIOProcID(u->object_id, io_render_proc, u, &u->proc_id);
++    err = AudioDeviceAddIOProc(u->object_id, io_render_proc, u);
++    u->proc_id = io_render_proc;
+     if (err) {
+         pa_log("AudioDeviceCreateIOProcID() failed (err = %08x\n).", (int) err);
+         goto fail;
+@@ -967,7 +979,7 @@
+ 
+     if (u->proc_id) {
+         AudioDeviceStop(u->object_id, u->proc_id);
+-        AudioDeviceDestroyIOProcID(u->object_id, u->proc_id);
++        AudioDeviceRemoveIOProc(u->object_id, u->proc_id);
+     }
+ 
+     property_address.mSelector = kAudioDevicePropertyStreamFormat;


### PR DESCRIPTION
Uses older CoreAudio API when compiling on Tiger. Successfully plays sound on PowerPC / 10.4.11.

See https://trac.macports.org/ticket/50057

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
