### PR TITLE
gh: build source only for macOS 10.13 and above, use pre-built amd64 binary for older systems.

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -1,10 +1,32 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           golang 1.0
 
-go.setup            github.com/cli/cli 1.12.1 v
-revision            0
+version             1.12.1
+revision            1
+
+# Github CLI is failing to build on 10.12 and below.
+# So in that case, use the pre-built binary tarball.
+if {${os.major} >= 17} {
+    set source_build yes
+} else {
+    set source_build no
+}
+
+if ${source_build} {
+    PortGroup       golang 1.0
+
+    go.setup        github.com/cli/cli ${version} v
+} else {
+    PortGroup       github 1.0
+    PortGroup       legacysupport 1.1
+
+    github.setup    cli cli ${version} v
+
+    platforms       darwin
+    supported_archs x86_64
+}
+
 name                gh
 
 homepage            https://cli.github.com
@@ -23,30 +45,55 @@ maintainers         {l2dy @l2dy} \
                     openmaintainer
 installs_libs       no
 
-checksums           rmd160  d89e8227bd55cb1bb73778b970a49969e94668b3 \
+if ${source_build} {
+    # Allow Go to fetch dependencies at build time
+    build.env-delete    GO111MODULE=off GOPROXY=off
+    build.cmd           make
+    build.pre_args-append \
+                        GH_VERSION=${version}
+    build.args          bin/${name} manpages
+
+    use_parallel_build  no
+
+    checksums       rmd160  d89e8227bd55cb1bb73778b970a49969e94668b3 \
                     sha256  14ef58fb2f09da1d66194527e1e8b637d28d972d273a6a627056aa960a9a9121 \
                     size    526443
 
-github.tarball_from archive
+    github.tarball_from archive
 
-# Allow Go to fetch dependencies at build time
-build.env-delete    GO111MODULE=off GOPROXY=off
-build.cmd           make
-build.pre_args-append \
-                    GH_VERSION=${version}
-build.args          bin/${name} manpages
+    patch {
+        # Do not override GOOS, GOARCH, GOARM and other environment variables
+        reinplace -E \
+            {s|GOOS= GOARCH= GOARM= GOFLAGS= CGO_ENABLED= go build|go build|g} \
+            ${worksrcpath}/Makefile
+    }
 
-use_parallel_build  no
+} else {
+    build {}
 
-patch {
-    # Do not override GOOS, GOARCH, GOARM and other environment variables
-    reinplace -E \
-        {s|GOOS= GOARCH= GOARM= GOFLAGS= CGO_ENABLED= go build|go build|g} \
-        ${worksrcpath}/Makefile
+    distname        gh_${version}_macOS_amd64
+
+    checksums       rmd160  2bf9eddc7f0d776ce9cb1a5b2093acbb76bbc336 \
+                    sha256  3e41308ad7d8a186ed9f21ee984948284ef1d843f9309d1c142d8a9d2dfd9aa4 \
+                    size    7105813
+
+    github.tarball_from releases
+
+    use_configure   no
 }
 
 destroot {
     xinstall -m 0755 -W ${worksrcpath} bin/gh ${destroot}${prefix}/bin
+
+    if {!$source_build} {
+        # gh works on 10.10 and newer without legacysupport. standard
+        # legacysupport tweaks don't work, since the install here is from
+        # a binary tarball ... have to tweak the binary to use the legacy
+        # support library, which in turn uses the System.B library.
+        if {${os.major} <= 13} {
+            system -W ${destroot}${prefix}/bin "install_name_tool -change /usr/lib/libSystem.B.dylib ${prefix}/lib/libMacportsLegacySupport.dylib gh"
+        }
+    }
 
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
