### PR TITLE
asciidoctor: update to 2.0.15

### DIFF
--- a/textproc/asciidoctor/Portfile
+++ b/textproc/asciidoctor/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           ruby 1.0
 
-ruby.setup          asciidoctor 2.0.12 gem {} rubygems ruby26
+ruby.setup          asciidoctor 2.0.15 gem {} rubygems ruby26
 name                asciidoctor
 
 # Prevent addition of the ruby interpreter version number as suffix to command line tools
@@ -26,6 +26,6 @@ long_description    Asciidoctor is a fast text processor and publishing \
                     and released under the MIT license.
 homepage            https://asciidoctor.org/
 
-checksums           rmd160  6965832f43f3b500d59e17104bde0f64122faeb0 \
-                    sha256  494eed109fd2160f0f974cd96d2ad34fa71f86e016e30e3af917f03dd04e53be \
-                    size    272896
+checksums           rmd160  dd2b7132d8980167364ef50f5c791a487a508d54 \
+                    sha256  c4120b16f7c054ee39e755b5b8cee6b248facaa4ec56b7ce493fd646aa8c744c \
+                    size    276480


### PR DESCRIPTION
#### Description

See: https://github.com/asciidoctor/asciidoctor/releases/tag/v2.0.15.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
