### PR TITLE
bitwarden-cli: update to 1.17.1

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        bitwarden cli 1.17.0 v
+github.setup        bitwarden cli 1.17.1 v
 revision            0
 
 name                bitwarden-cli
@@ -16,9 +16,9 @@ description         Bitwarden password manager CLI
 long_description    CLI implementation of the Bitwarden password manager.
 homepage            https://bitwarden.com
 
-checksums           rmd160  827b77216b912bda642690939c1b5b3362a51a1a \
-                    sha256  8d667918cf4d6e72ae7feb18833f1254fdd119e0f3fefe2fe15ab8c0277d79dd \
-                    size    21415236
+checksums           rmd160  021d70a42872384c7ab944eafef20a32f07bbcc5 \
+                    sha256  9d5c5a997c73b84aeb43db4c7be93d3fa6443f83ade35a4953b0f1c6862c00c2 \
+                    size    19576812
 
 github.tarball_from releases
 distname            bw-macos-${version}


### PR DESCRIPTION
#### Description
See: https://github.com/bitwarden/cli/releases/tag/v1.17.1.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
