### PR TITLE
ruby-build: update to 20210707

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20210405 v
+github.setup        rbenv ruby-build 20210707 v
 categories          ruby
 license             MIT
 platforms           darwin
@@ -14,9 +14,9 @@ maintainers         {mojca @mojca} openmaintainer
 description         Compile and install Ruby
 long_description    ${description}
 
-checksums           rmd160  404a68b5211cd4d59f47fcc2b02f4f7a8c05b6dd \
-                    sha256  5c41b11f0eeff79bd07a4d94d7ed63a5e7912e947d13d513a02581ea085199ac \
-                    size    70718
+checksums           rmd160  6c1bb4b83b8c0e476c111b3bc2c4ba247476ed67 \
+                    sha256  e6b6bbd90e2fd15dcf219c4e3ad1c97926c83912c9b12b82722bbc3e32a01acc \
+                    size    71597
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update ruby-build. Supports new versions just released (2.6.8, 2.7.4, 3.0.2)

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->