### PR TITLE
kubectx: update to 0.9.4

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ahmetb kubectx 0.9.3 v
-revision            1
+github.setup        ahmetb kubectx 0.9.4 v
+revision            0
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -15,9 +15,9 @@ description         Power tools for kubectl
 long_description    kubectx helps you switch between clusters back and forth. \
                     kubens helps you switch between Kubernetes namespaces smoothly.
 
-checksums           rmd160  6b5c706da0b9c4d9ee01ba1214964542615a8a4f \
-                    sha256  d9083c82a80c8192da406c76c9d7b5bca04bf4be10c6d195055e4af3a790ed13 \
-                    size    520535
+checksums           rmd160  63b2b1f45a352baa6e05bd65baf425d1b13cd0bc \
+                    sha256  85ff8ff3882c4b5eda4d7c90e98d7fca8bdab54cb54a71fb11e7ad0b291439ed \
+                    size    520687
 
 depends_run         path:${prefix}/bin/kubectl:kubectl-1.21
 


### PR DESCRIPTION
#### Description

Update to kubectx 0.9.4.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?