### PR TITLE
cppcheck: update to 2.5

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                danmar cppcheck 2.4.1
+github.setup                danmar cppcheck 2.5
 revision                    0
 
 categories                  devel
@@ -21,9 +21,9 @@ long_description            Cppcheck is an analysis tool for C and C++ code. Unl
 
 github.tarball_from         archive
 
-checksums                   rmd160  4aafb5e0830564e05ee18aca0a7a44402a07a32e \
-                            sha256  11a9d9fe5305a105561655c45d2cd83cb30fbc87b41d0569de1b00a1a314867f \
-                            size    3761646
+checksums                   rmd160  1a5cbfb5f18146580ff12c71375d1b8bae3d8220 \
+                            sha256  dc27154d799935c96903dcc46653c526c6f4148a6912b77d3a50cb35dabd82e1 \
+                            size    3792628
 
 set python_branch   3.9
 set python_version  [string map {"." ""} ${python_branch}]


### PR DESCRIPTION
#### Description
- update to latest version


###### Tested on
<macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
