### PR TITLE
py-{astroid,importlib-metadata,pandas,pylint,qtconsole}: update to latest versions

### DIFF
--- a/python/py-astroid/Portfile
+++ b/python/py-astroid/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-astroid
-version             2.5.8
+version             2.6.2
 revision            0
 
 categories-append   devel
@@ -26,15 +26,14 @@ long_description    The aim of this module is to provide a common \
 
 homepage            https://github.com/pycqa/astroid
 
-checksums           rmd160  10ad23b644cce4203b40966f73f83e5c518303e8 \
-                    sha256  2476b7f0d6cec13f4c1f53b54bea2ce072310ac9fc7acb669d5270190c748042 \
-                    size    185727
+checksums           rmd160  f9a12871c8db54e490a94c4cebae938103041c5f \
+                    sha256  38b95085e9d92e2ca06cf8b35c12a74fa81da395a6f9e65803742e6509c05892 \
+                    size    187749
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-pytest-runner \
-                        port:py${python.version}-setuptools \
-                        port:py${python.version}-setuptools_scm
+                        port:py${python.version}-setuptools
 
     depends_lib-append  port:py${python.version}-lazy_object_proxy \
                         port:py${python.version}-wrapt
@@ -57,8 +56,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-backports-functools_lru_cache
 
         depends_build-delete \
-                            port:py${python.version}-pytest-runner \
-                            port:py${python.version}-setuptools_scm
+                            port:py${python.version}-pytest-runner
 
         depends_lib-delete  port:py${python.version}-typed-ast
     } elseif {${python.version} eq 35} {
@@ -76,8 +74,6 @@ if {${name} ne ${subport}} {
         }
 
         depends_lib-append  port:py${python.version}-six
-        depends_build-delete \
-                            port:py${python.version}-setuptools_scm
     }
 
     depends_test-append port:py${python.version}-pytest

--- a/python/py-importlib-metadata/Portfile
+++ b/python/py-importlib-metadata/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-importlib-metadata
 python.rootname     importlib_metadata
-version             4.0.1
+version             4.6.1
 revision            0
 categories-append   devel
 platforms           darwin
@@ -22,9 +22,9 @@ long_description    ${description}
 
 homepage            https://importlib-metadata.readthedocs.io/
 
-checksums           rmd160  3b12f2250b2cc64c07249c41b0215d8e46d9436b \
-                    sha256  8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581 \
-                    size    42189
+checksums           rmd160  147a719f21a8ea90d28dbb27201a6a8e8d9fadfc \
+                    sha256  079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac \
+                    size    39801
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pandas/Portfile
+++ b/python/py-pandas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pandas
-version             1.2.4
+version             1.3.0
 revision            0
 categories-append   science
 license             BSD
@@ -20,9 +20,9 @@ long_description    ${description}
 
 homepage            https://pandas.pydata.org
 
-checksums           rmd160  edb56bddc6f3b1fab9db2fdf4e7f6af1a84ea7a4 \
-                    sha256  649ecab692fade3cbfcf967ff936496b0cfba0af00a55dfaacd82bdda5cb2279 \
-                    size    5469105
+checksums           rmd160  e8354c7f48a1d05e845a9ffe22a99dbacadb578d \
+                    sha256  c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2 \
+                    size    4721119
 
 if {${name} ne ${subport}} {
     if {${python.version} eq 27} {

--- a/python/py-pylint/Portfile
+++ b/python/py-pylint/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pylint
-version             2.8.3
-revision            1
+version             2.9.3
+revision            0
 
 categories-append   devel
 platforms           darwin
@@ -29,9 +29,9 @@ long_description    Pylint is a tool that checks for errors in python code, \
 
 homepage            https://pylint.org
 
-checksums           rmd160  cb78ed7f8b54d3b64c908978e374c4db851479ca \
-                    sha256  0a049c5d47b629d9070c3932d13bff482b12119b6a241a93bc460b0be16953c8 \
-                    size    745073
+checksums           rmd160  8993fb2b3a2b7a110f6bddf482921c8245f46bd9 \
+                    sha256  23a1dc8b30459d78e9ff25942c61bb936108ccbe29dd9e71c01dc8274961709a \
+                    size    314663
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -74,14 +74,6 @@ if {${name} ne ${subport}} {
                             size    680364
     }
 
-    if {${python.version} >= 36} {
-        post-patch {
-            # relax package requirements
-            reinplace "s|astroid==2.5.6|astroid|" ${worksrcpath}/setup.cfg
-            reinplace "s|astroid==2.5.6|astroid|" ${worksrcpath}/pylint.egg-info/requires.txt
-        }
-    }
-
     depends_run-append  port:pylint_select
 
     post-destroot {
@@ -95,8 +87,6 @@ if {${name} ne ${subport}} {
                     ${destroot}${prefix}/share/doc/${subport}/_static
             }
         }
-        xinstall -m 0644 -W ${worksrcpath} ChangeLog README.rst \
-            ${destroot}${prefix}/share/doc/${subport}
         file delete ${destroot}${python.pkgd}/logilab/__init__.py
     }
 

--- a/python/py-qtconsole/Portfile
+++ b/python/py-qtconsole/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-qtconsole
-version             5.1.0
+version             5.1.1
 revision            0
 
 categories-append   devel
@@ -21,9 +21,9 @@ long_description    ${description}
 
 homepage            https://jupyter.org
 
-checksums           rmd160  585d5ce8f9dbc56ed9986678eafd6366ee7ac2b9 \
-                    sha256  12c734494901658787339dea9bbd82f3dc0d5e394071377a1c77b4a0954d7d8b \
-                    size    428856
+checksums           rmd160  c667ddeb22faa64e63a58b17a1c750514bebb75d \
+                    sha256  bbc34bca14f65535afcb401bc74b752bac955e5313001ba640383f7e5857dc49 \
+                    size    428840
 
 if {${name} ne ${subport}} {
     if {${python.version} in "27 35"} {


### PR DESCRIPTION
#### Description
Update various Python ports maintained by @stromnov to their latest versions: `py-astroid`, `py-importlib-metadata`, `py-pandas`, `py-pylint`, `py-qtconsole` (see commit messages).

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
