### PR TITLE
gwyddion: update to 2.59

### DIFF
--- a/science/gwyddion/Portfile
+++ b/science/gwyddion/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gwyddion
-version             2.55
+version             2.59
 revision            0
 categories          science x11
 platforms           darwin
@@ -20,10 +20,9 @@ master_sites        sourceforge:project/gwyddion/gwyddion/${version}
 use_xz              yes
 use_parallel_build  yes
 
-checksums           sha256  b1f1fe5ade7d667d005078f25c1b8b1523d18307ac451176ccd7c6b7bffe0050 \
-                    rmd160  1a4b007b3e25f638b43b0a00e0bf780805f0145b \
-                    size    4607560
-
+checksums           sha256  00f30e25e66dff3a7c26f5e084a6799501512963bfe13543391a24f2a0201019 \
+                    rmd160  5a2cdc6edd4c547d1523fcc21995e40f384c9905 \
+                    size    4903412
 depends_build       port:pkgconfig
 
 depends_lib         port:gtk2 \
@@ -68,8 +67,8 @@ post-destroot {
         reinplace "s|@PREFIX@|${prefix}|" ${destroot}${applications_dir}/gwyddion.app/Contents/MacOS/gwyddion
     }
     if {[variant_isset pygwy]} {
-    	set python.prefix   ${frameworks_dir}/Python.framework/Versions/2.7
-    	set python.site_packages    ${python.prefix}/lib/python2.7/site-packages/
+        set python.prefix   ${frameworks_dir}/Python.framework/Versions/2.7
+        set python.site_packages    ${python.prefix}/lib/python2.7/site-packages/
         xinstall -m 755 -d ${destroot}${python.site_packages}
         move ${destroot}${prefix}/lib/python2.7/site-packages/gwy.so ${destroot}${python.site_packages}
         move ${destroot}${prefix}/lib/python2.7/site-packages/gwy.la ${destroot}${python.site_packages}
@@ -94,11 +93,11 @@ post-activate {
 }
 
 platform darwin 8 {
-	post-activate {
-		if {[file exists ${prefix}/lib/pkgconfig/gl.pc]} {
+    post-activate {
+        if {[file exists ${prefix}/lib/pkgconfig/gl.pc]} {
             if {![variant_isset quartz]} {
-			    ui_msg "openGL support currently requires you to use MacPorts' X11 server (xorg-server) rather than Apple's."
+                ui_msg "openGL support currently requires you to use MacPorts' X11 server (xorg-server) rather than Apple's."
             }
-		}
-	}
+        }
+    }
 }


### PR DESCRIPTION
* update to version 2.59
* whitespace changes in Portfile

#### Description

gwyddion: update to 2.59

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [ X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ X] checked your Portfile with `port lint`?
- [X ] tried a full install with `sudo port -vst install`?
- [ X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
