### PR TITLE
zabbix[45]: Update to latest; fix --nitpick

### DIFF
--- a/net/zabbix4/Portfile
+++ b/net/zabbix4/Portfile
@@ -1,4 +1,5 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           active_variants 1.1
 
@@ -17,13 +18,13 @@ long_description    Zabbix is the ultimate open source availability and \
                     performance monitoring solution. Zabbix offers advanced \
                     monitoring, alerting, and visualization features today \
                     which are missing in other monitoring systems, even some \
-                    of the best commercial ones. 
+                    of the best commercial ones.
 
 array set VERSIONS {
-    4  4.0.30
+    4  4.0.32
     42 4.2.8
     44 4.4.10
-    5  5.0.11
+    5  5.0.13
 }
 
 set zver            [regsub -all {[^\d]} ${subport} {}]
@@ -44,15 +45,16 @@ dist_subdir         zabbix${zver}
 if {$zver == 4} {
     livecheck.regex     "zabbix-(4\\.0\\.\[0-9\]+).tar.gz"
     checksums \
-        rmd160  78b4813461538f198c71437b176288a78704a7e2 \
-        sha256  90fb0d8f0c18e8f49e047f01b7cca9692680bb8285df33fe2c44f01c5418089e \
-        size    17599032
+        rmd160  cc24cbcf0d70891ac2cc00c96d2f5baa3997be77 \
+        sha256  05ae28e5495e3465f7e33f4e50fe1d1d4d981fbfbff698e733fd65a29a28f6aa \
+        size    17606713
 }
 
 if {$zver == 42 || $zver == 44} {
     # REMOVE JANUARY 2022
     revision        1
     PortGroup       obsolete 1.0
+
     replaced_by     zabbix5
     livecheck.type  none
 }
@@ -60,9 +62,9 @@ if {$zver == 42 || $zver == 44} {
 if {$zver == 5} {
     livecheck.regex     "zabbix-(5\\.0\\.\[0-9\]+).tar.gz"
     checksums \
-        rmd160  ea00037d52e23f74c2104755933eb35c34a4dabd \
-        sha256  caf1f53ce0abb252b4edc5462ee8a2b0acf9b755e9731dd4000983cc11053077 \
-        size    20350104
+        rmd160  cd68fd239c96100a0c4eb895cfdc07026a9976e1 \
+        sha256  7cd2b4d423261b452054728048c49d5aaa0ff26033c67c3ee0423f1048055165 \
+        size    21076927
 }
 
 patchfiles          log_and_pid_locations.patch
@@ -165,7 +167,7 @@ if {[isFlavor agent ${subport}]} {
     destroot {}
 } else {
     long_description-append "This port provides the central server component."
-    conflicts-append        zabbix zabbix2 zabbix3
+    conflicts-append        zabbix3
 
     depends_lib-append      port:curl \
                             port:OpenIPMI \
@@ -195,6 +197,11 @@ if {[isFlavor agent ${subport}]} {
          do sleep 1; let x--; \[ \$x -le 0 \] && break; done"
     startupitem.logfile     ${prefix}/var/log/zabbix/zabbix_server.launch
     startupitem.netchange   yes
+
+    # This *increases* the values if needed, but otherwise leaves them alone.
+    startupitem.init \
+        {bump() { [ `sysctl -n $1` -lt $2 ] && sysctl $1=$2 ; } } \
+        "bump kern.sysv.shmall 32768 && bump kern.sysv.shmmax 134217728"
 
     destroot.keepdirs \
         ${destroot}${prefix}/etc/zabbix${zver}/zabbix_server.conf.d \
@@ -346,7 +353,7 @@ post-destroot {
         #file copy ${worksrcpath}/upgrades \
         #    ${destroot}${prefix}/share/zabbix/
 
-        # Set permissions for etc (protect passwords) 
+        # Set permissions for etc (protect passwords)
         system "chmod ug+rwX,o-rwx ${destroot}${prefix}/etc/zabbix${zver}/*"
         system "chown -R zabbix:zabbix ${destroot}${prefix}/etc/zabbix${zver}"
     }
@@ -416,6 +423,11 @@ if {[isFlavor agent ${subport}]} {
     notes "
 ####
 #### Begin ZABBIX${zver} local server installation section ####
+
+  !! LOADING ZABBIX${zver} WILL *INCREASE* THESE sysctl VALUES TO BE AT LEAST:
+    kern.sysv.shmall=32768 kern.sysv.shmmax=134217728
+  This can be adjusted in the file below, but resets after an upgrade:
+    ${prefix}/etc/LaunchDaemons/org.macports.zabbix${zver}-server/zabbix${zver}-server.wrapper
 
  (Installing with +full_server will add all of the dependants; configuration
   will still be required.)


### PR DESCRIPTION
Maintainer update.

Also adds setting of SysV shared memory variables as part of 'load' process, rather than relying on /etc/sysctl.conf