### PR TITLE
py-pyperclip: update to 1.8.2

### DIFF
--- a/python/py-pyperclip/Portfile
+++ b/python/py-pyperclip/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pyperclip
-version             1.7.0
+version             1.8.2
 revision            0
 
 platforms           darwin
@@ -17,9 +17,9 @@ long_description    ${description}. It currently handles only plain text.
 
 homepage            https://github.com/asweigart/pyperclip
 
-checksums           rmd160  27e0dafd44932b4c6258d662e74c79be1893b5de \
-                    sha256  979325468ccf682104d5dcaf753f869868100631301d3e72f47babdea5700d1c \
-                    size    15977
+checksums           rmd160  bb84104cab29f10769e9f37dd56aad7493844d3c \
+                    sha256  105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57 \
+                    size    20920
 
 python.versions     27 35 36 37 38 39
 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
