### PR TITLE
google-cloud-sdk: update to 348.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             347.0.0
+version             348.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  c593509a208cf4bda82add2bc66254fa07cafa02 \
-                    sha256  d745d251d3a26796d9bb4fddc1d7f7103da88998aa93099424457d812fceddbe \
-                    size    90339680
+    checksums       rmd160  4c8388379626206f39e17fc2372d0ec68d034055 \
+                    sha256  a8846a7a31fe4c11bc47e4f4069bf20675d7e4f5bd442dfe82f4ddd90746b30c \
+                    size    90520193
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  905b5a8af76531b9ae41aba3c6fcd528aa905300 \
-                    sha256  8d7d86fd0d1db564b864fa830059a55621de31a66ccfeb4974d288696be4316e \
-                    size    86585489
+    checksums       rmd160  dde20e2dc22b4b0aeef940b6a610924592d80198 \
+                    sha256  7ab7d3b1c5ebedffb253c85b3cc6574be2c2cd4881c57ec0254d58f9b9bf02c0 \
+                    size    86770070
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  976c78c8094f012afe94f27db9d5c1813eacb811 \
-                    sha256  1196c980ccc465272f6aa48a6b2e5a0ee6b255a20ad73654cea007813d1ccd99 \
-                    size    86511193
+    checksums       rmd160  de407800da9e6864a3f3ded02631da1dfc1e9319 \
+                    sha256  f90d261a4138618e4b6837a30dc907166f777648f007e0fac0906a787fcf3563 \
+                    size    86690875
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 348.0.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?