### PR TITLE
pcre, pcre2: update to 8.45 and 10.37

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 
 name                pcre
 if {${subport} eq ${name}} {
-    version         8.44
+    version         8.45
     revision        0
     platform darwin 20 {
-        revision    1
+        revision    0
     }
 }
 subport pcre2 {
-    version         10.36
+    version         10.37
     revision        0
 }
 categories          devel
@@ -40,12 +40,12 @@ master_sites        sourceforge:project/pcre/${subport}/${version} \
 distname            ${subport}-${version}
 use_bzip2           yes
 
-set rmd160(pcre)    55a361bbbc3481590d6e75880e70f866302d6e40
-set sha256(pcre)    19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d
-set size(pcre)      1577611
-set rmd160(pcre2)   bfef32337552edc06ad66d18ecde40ad4dea998a
-set sha256(pcre2)   a9ef39278113542968c7c73a31cfcb81aca1faa64690f400b907e8ab6b4a665c
-set size(pcre2)     1722310
+set rmd160(pcre)    9792fbed380a39be36674e74839b9a2a6a4ce65a
+set sha256(pcre)    4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8
+set size(pcre)      1578809
+set rmd160(pcre2)   260daa9d31e76ecc428e84ab3f2ed3ba41b7ee37
+set sha256(pcre2)   4d95a96e8b80529893b4562be12648d798b957b1ba1aae39606bbc2ab956d270
+set size(pcre2)     1729384
 checksums           rmd160  $rmd160(${subport}) \
                     sha256  $sha256(${subport}) \
                     size    $size(${subport})


### PR DESCRIPTION
#### Description

CC @Schamschula, who has frequently updated the port previously.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
