### PR TITLE
memcachedb, memcacheq: Fix implicit declaration of functions

### DIFF
--- a/sysutils/memcachedb/Portfile
+++ b/sysutils/memcachedb/Portfile
@@ -1,13 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   github 1.0
 
-name                        memcachedb
-version                     1.2.0
-revision                    2
+github.setup                stvchu memcachedb 1.2.0 v
+revision                    3
+checksums                   rmd160  023e26d09b4ceae751bd7717c769a3b5c1e214d6 \
+                            sha256  6eba6e5adda1bc23db6bbcf4930537ccdc33fa00402ed91157faadeb86996e0f \
+                            size    149236
+
 categories                  sysutils
 platforms                   darwin
 maintainers                 gmail.com:cofyc.jackson
+license                     BSD
 
 description                 A distributed key-value storage system designed \
                             for persistent.
@@ -23,19 +28,14 @@ long_description            MemcacheDB is a distributed key-value storage \
                             of features including transaction and replication \
                             are supported.
 
-homepage                    http://memcachedb.org/
 master_sites                googlecode
-
-checksums                   sha1    fe817ed3a340a65dd6998f35d87a0d9555830d04 \
-                            rmd160  023e26d09b4ceae751bd7717c769a3b5c1e214d6
 
 configure.args              --with-libevent=${prefix}
 
 depends_lib                 port:libevent \
                             port:db47
 
+patchfiles                  64-bit.patch
+
 configure.cflags-append     -I${prefix}/include/db47
 configure.ldflags-append    -L${prefix}/lib/db47
-
-livecheck.type              regex
-livecheck.regex             MemcacheDB (\\d+(?:\\.\\d+)*) is released

--- a/sysutils/memcachedb/files/64-bit.patch
+++ b/sysutils/memcachedb/files/64-bit.patch
@@ -1,0 +1,147 @@
+Fix some warnings on 64-bit compiler
+https://github.com/stvchu/memcachedb/commit/9f601db6d4965bf9c254cb2bfaa1639ce6375ec9
+--- item.c.orig	2008-10-14 00:40:58.000000000 -0500
++++ item.c	2021-07-16 02:57:13.000000000 -0500
+@@ -188,18 +188,18 @@
+     ntotal = ITEM_ntotal(it);
+     if (ntotal > settings.item_buf_size){
+         if (settings.verbose > 1) {
+-            fprintf(stderr, "ntotal: %d, use free() directly.\n", ntotal);
++            fprintf(stderr, "ntotal: %"PRIuS", use free() directly.\n", ntotal);
+         }
+         free(it);   
+     }else{
+         if (0 != item_add_to_freelist(it)) {
+             if (settings.verbose > 1) {
+-                fprintf(stderr, "ntotal: %d, add a item buffer to freelist fail, use free() directly.\n", ntotal);
++                fprintf(stderr, "ntotal: %"PRIuS", add a item buffer to freelist fail, use free() directly.\n", ntotal);
+             }
+             free(it);   
+         }else{
+             if (settings.verbose > 1) {
+-                fprintf(stderr, "ntotal: %d, add a item buffer to freelist.\n", ntotal);
++                fprintf(stderr, "ntotal: %"PRIuS", add a item buffer to freelist.\n", ntotal);
+             }
+         }
+     }
+--- memcachedb.c.orig	2008-10-14 00:40:58.000000000 -0500
++++ memcachedb.c	2021-07-16 02:57:13.000000000 -0500
+@@ -837,26 +837,26 @@
+ #endif /* !WIN32 */
+ 
+         STATS_LOCK();
+-        pos += sprintf(pos, "STAT pid %u\r\n", pid);
+-        pos += sprintf(pos, "STAT uptime %ld\r\n", now - stats.started);
+-        pos += sprintf(pos, "STAT time %ld\r\n", now);
++        pos += sprintf(pos, "STAT pid %ld\r\n", (long)pid);
++        pos += sprintf(pos, "STAT uptime %"PRIuS"\r\n", now - stats.started);
++        pos += sprintf(pos, "STAT time %"PRIuS"\r\n", now);
+         pos += sprintf(pos, "STAT version " VERSION "\r\n");
+-        pos += sprintf(pos, "STAT pointer_size %d\r\n", 8 * sizeof(void *));
++        pos += sprintf(pos, "STAT pointer_size %"PRIuS"\r\n", 8 * sizeof(void *));
+ #ifndef WIN32
+         pos += sprintf(pos, "STAT rusage_user %ld.%06ld\r\n", usage.ru_utime.tv_sec, usage.ru_utime.tv_usec);
+         pos += sprintf(pos, "STAT rusage_system %ld.%06ld\r\n", usage.ru_stime.tv_sec, usage.ru_stime.tv_usec);
+ #endif /* !WIN32 */
+-        pos += sprintf(pos, "STAT ibuffer_size %u\r\n", settings.item_buf_size);
+-        pos += sprintf(pos, "STAT curr_connections %u\r\n", stats.curr_conns - 1); /* ignore listening conn */
+-        pos += sprintf(pos, "STAT total_connections %u\r\n", stats.total_conns);
+-        pos += sprintf(pos, "STAT connection_structures %u\r\n", stats.conn_structs);
+-        pos += sprintf(pos, "STAT cmd_get %llu\r\n", stats.get_cmds);
+-        pos += sprintf(pos, "STAT cmd_set %llu\r\n", stats.set_cmds);
+-        pos += sprintf(pos, "STAT get_hits %llu\r\n", stats.get_hits);
+-        pos += sprintf(pos, "STAT get_misses %llu\r\n", stats.get_misses);
+-        pos += sprintf(pos, "STAT bytes_read %llu\r\n", stats.bytes_read);
+-        pos += sprintf(pos, "STAT bytes_written %llu\r\n", stats.bytes_written);
+-        pos += sprintf(pos, "STAT threads %u\r\n", settings.num_threads);
++        pos += sprintf(pos, "STAT item_buf_size %"PRIuS"\r\n", settings.item_buf_size);
++        pos += sprintf(pos, "STAT curr_connections %"PRIu32"\r\n", stats.curr_conns - 1); /* ignore listening conn */
++        pos += sprintf(pos, "STAT total_connections %"PRIu32"\r\n", stats.total_conns);
++        pos += sprintf(pos, "STAT connection_structures %"PRIu32"\r\n", stats.conn_structs);
++        pos += sprintf(pos, "STAT cmd_get %"PRIu64"\r\n", stats.get_cmds);
++        pos += sprintf(pos, "STAT cmd_set %"PRIu64"\r\n", stats.set_cmds);
++        pos += sprintf(pos, "STAT get_hits %"PRIu64"\r\n", stats.get_hits);
++        pos += sprintf(pos, "STAT get_misses %"PRIu64"\r\n", stats.get_misses);
++        pos += sprintf(pos, "STAT bytes_read %"PRIu64"\r\n", stats.bytes_read);
++        pos += sprintf(pos, "STAT bytes_written %"PRIu64"\r\n", stats.bytes_written);
++        pos += sprintf(pos, "STAT threads %d\r\n", settings.num_threads);
+         pos += sprintf(pos, "END");
+         STATS_UNLOCK();
+         out_string(c, temp);
+@@ -1196,7 +1196,7 @@
+         if (delta >= value) value = 0;
+         else value -= delta;
+     }
+-    vlen = sprintf(buf, "%llu", value);
++    vlen = sprintf(buf, "%"PRId64, value);
+ 
+     /* flags was already lost - so recover them from ITEM_suffix(it) */
+     flags = (int) strtol(ITEM_suffix(old_it), (char **) NULL, 10);
+@@ -1412,8 +1412,8 @@
+         process_stat(c, tokens, ntokens);
+ 
+     } else if (ntokens >= 2 && ntokens <= 3 && (strcmp(tokens[COMMAND_TOKEN].value, "flush_all") == 0)) {
+-        out_string(c, "OK");
+-        return;
++
++        out_string(c, "ERROR");
+ 
+     } else if (ntokens == 2 && (strcmp(tokens[COMMAND_TOKEN].value, "version") == 0)) {
+ 
+--- memcachedb.h.orig	2008-10-14 00:40:58.000000000 -0500
++++ memcachedb.h	2021-07-16 02:57:13.000000000 -0500
+@@ -81,10 +81,29 @@
+ # include <unistd.h>
+ #endif
+ 
++/* 64-bit Portable printf */
++/* printf macros for size_t, in the style of inttypes.h */
++#ifdef _LP64
++#define __PRIS_PREFIX "z"
++#else
++#define __PRIS_PREFIX
++#endif
++
++/* Use these macros after a % in a printf format string
++   to get correct 32/64 bit behavior, like this:
++   size_t size = records.size();
++   printf("%"PRIuS"\n", size); */
++
++#define PRIdS __PRIS_PREFIX "d"
++#define PRIxS __PRIS_PREFIX "x"
++#define PRIuS __PRIS_PREFIX "u"
++#define PRIXS __PRIS_PREFIX "X"
++#define PRIoS __PRIS_PREFIX "o"
++
+ struct stats {
+-    unsigned int  curr_conns;
+-    unsigned int  total_conns;
+-    unsigned int  conn_structs;
++    uint32_t      curr_conns;
++    uint32_t      total_conns;
++    uint32_t      conn_structs;
+     uint64_t      get_cmds;
+     uint64_t      set_cmds;
+     uint64_t      get_hits;
+--- stats.c.orig	2008-10-14 00:40:58.000000000 -0500
++++ stats.c	2021-07-16 02:57:13.000000000 -0500
+@@ -18,6 +18,7 @@
+  */
+   
+ #include "memcachedb.h"
++#include <stdlib.h>
+ #include <db.h>
+ 
+ void stats_bdb(char *temp){
+--- thread.c.orig	2008-10-14 00:40:58.000000000 -0500
++++ thread.c	2021-07-16 02:57:13.000000000 -0500
+@@ -329,7 +329,8 @@
+     pthread_cond_signal(&init_cond);
+     pthread_mutex_unlock(&init_lock);
+ 
+-    return (void*) event_base_loop(me->base, 0);
++    event_base_loop(me->base, 0);
++    return NULL; 
+ }
+ 
+ 

--- a/sysutils/memcacheq/Portfile
+++ b/sysutils/memcacheq/Portfile
@@ -1,33 +1,33 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   github 1.0
 
-name                        memcacheq
-version                     0.2.0
-revision                    2
+github.setup                stvchu memcacheq 0.2.1 v
+revision                    0
+checksums                   rmd160  56fbde56ddad39b43cd49fd0b2d19d96b3ac824c \
+                            sha256  ace33313568959b5a301dda491f63af09793987b73fd15abd3fb613829eda07e \
+                            size    128860
+
 categories                  sysutils
 platforms                   darwin
 maintainers                 gmail.com:cofyc.jackson
+license                     BSD
 
 description                 Simple Queue Service over Memcache.
 
 long_description            MemcacheQ is a memcachedb variant that provides \
                             simple message queue service.
 
-homepage                    http://memcachedb.org/memcacheq/
-master_sites                googlecode
-
-checksums                   sha1    fc373e02335301cbfe4c00420bdf8592ca2bf95a \
-                            rmd160  7a8b7e4658915d011d148bcd6427a0aa13aaa908
+github.tarball_from         archive
 
 depends_lib                 port:libevent \
                             port:db47
+
+patchfiles                  implicit.patch
 
 configure.args              --with-libevent=${prefix}
 
 configure.cflags-append     -std=gnu89
 configure.cppflags-append   -I${prefix}/include/db47
 configure.ldflags-append    -L${prefix}/lib/db47
-
-livecheck.type              regex
-livecheck.regex             ${name}-(\\d+(?:\\.\\d+){2,})\\.

--- a/sysutils/memcacheq/files/implicit.patch
+++ b/sysutils/memcacheq/files/implicit.patch
@@ -1,0 +1,13 @@
+Fix:
+memcacheq.c:2222:15: error: implicit declaration of function 'daemonize' [-Werror,-Wimplicit-function-declaration]
+https://github.com/stvchu/memcacheq/issues/7
+--- memcacheq.c.orig	2014-12-16 22:29:10.000000000 -0600
++++ memcacheq.c	2021-07-16 02:40:55.000000000 -0500
+@@ -69,6 +69,7 @@
+ /*
+  * forward declarations
+  */
++static int daemonize(int nochdir, int noclose);
+ static void drive_machine(conn *c);
+ static int new_socket(struct addrinfo *ai);
+ static int server_socket(const int port, const bool is_udp);


### PR DESCRIPTION
#### Description

memcacheq: Update to 0.2.1. Fix implicit function declaration. Indicate BSD license. Project has moved to GitHub.

Closes: https://trac.macports.org/ticket/63250
See: https://trac.macports.org/ticket/53467

memcachedb: Add an upstream patch to fix implicit declaration of functions and other issues. Indicate BSD license. Project has moved to GitHub.

Closes: https://trac.macports.org/ticket/63244
See: https://trac.macports.org/ticket/53467

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
