### PR TITLE
lilypond: make each subport have its own revision field

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -43,6 +43,7 @@ compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         2.22.1
+    revision        3
     conflicts       lilypond-devel
     checksums       rmd160  efb911332e0b96011340d7a21ad091881aae9cd0 \
                     sha256  72ac2d54c310c3141c0b782d4e0bef9002d5519cf46632759b1f03ef6969cc30 \
@@ -56,7 +57,7 @@ if {${subport} eq ${name}} {
     }
 } else {
     version         2.23.3
-    revision        0
+    revision        3
     conflicts       lilypond
     checksums       rmd160  1321f179f97471b6b62834c387c426e4580620b5 \
                     sha256  8a833696f7c6d2d4b4ae162ffd0836216c63c3765ea14069d6632d320d6bc308 \
@@ -64,8 +65,6 @@ if {${subport} eq ${name}} {
 
     set livecheck_url "development.html"
 }
-
-revision            3
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 homepage            https://lilypond.org


### PR DESCRIPTION
Otherwise the revision field can never be reset to zero if a new version is
available.

###### Type(s)
- [x] enhancement
