### PR TITLE
py-clang: 12.0.1; only carry three versions

### DIFF
--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 # meta-version; bump whenever underlying variants are updated. Needed to
 # support portindex (variants can't have different versions.)
-version                 5
+version                 6
 # Needed for change to meta-versioning
 epoch                   1
 name                    py-clang
@@ -21,10 +21,10 @@ homepage \
 
 supported_archs         noarch
 
-livecheck.url           https://github.com/llvm/llvm-project/tags
+livecheck.url           https://api.github.com/repos/llvm/llvm-project/git/refs/tags
 # Update this to the most recent clang supported
-livecheck.version       11.1.0
-livecheck.regex         {releases\/tag\/llvmorg-([\d.]+)\"}
+livecheck.version       12.0.1
+livecheck.regex         {llvmorg-([\d.]+)\"}
 
 if {${name} ne ${subport}} {
     # Share llvm's downloads
@@ -35,32 +35,18 @@ if {${name} ne ${subport}} {
      cfe-3.7.1.src.tar.xz \
       rmd160  185b0f75970bc50682766a21794440578db87b5d \
       sha256  56e2164c7c2a1772d5ed2a3e57485ff73ff06c97dff12edbeea1acc4412b0674 \
-     cfe-5.0.2.src.tar.xz \
-      rmd160  e4aa04b8aaa39d7c222d33b0e95b8d06c423d229 \
-      sha256  fa9ce9724abdb68f166deea0af1f71ca0dfa9af8f7e1261f2cae63c280282800 \
-     cfe-6.0.1.src.tar.xz \
-      rmd160  c280cd2037b19f9bd733944b765f9ca23b35e0a4 \
-      sha256  7c243f1485bddfdfedada3cd402ff4792ea82362ff91fbdac2dae67c6026b667 \
-     cfe-7.0.1.src.tar.xz \
-      rmd160  914adafed7c97e5ebab15a437670906c404cb8bd \
-      sha256  a45b62dde5d7d5fdcdfa876b0af92f164d434b06e9e89b5d0b1cbc65dfe3f418 \
-     cfe-8.0.1.src.tar.xz \
-      rmd160  8bec1ef0e0e49000886d8caed5ef42fb56a418b2 \
-      sha256  70effd69f7a8ab249f66b0a68aba8b08af52aa2ab710dfb8a0fba102685b1646 \
-     clang-9.0.1.src.tar.xz \
-      rmd160  424b98b3b6252f119fc06c8dfbc8fb1344531e88 \
-      sha256  5778512b2e065c204010f88777d44b95250671103e434f9dc7363ab2e3804253 \
-     clang-10.0.1.src.tar.xz \
-      rmd160  15b8a3b6c6f1a2896146006b30fbcf104be7c2b6 \
-      sha256  f99afc382b88e622c689b6d96cadfa6241ef55dca90e87fc170352e12ddb2b24 \
      clang-11.1.0.src.tar.xz \
       rmd160  6da46dc07e6ce8bf33c6342812e3c89498bb2b27 \
-      sha256  0a8288f065d1f57cb6d96da4d2965cbea32edc572aa972e466e954d17148558b
+      sha256  0a8288f065d1f57cb6d96da4d2965cbea32edc572aa972e466e954d17148558b \
+     clang-12.0.1.src.tar.xz \
+      rmd160  662d890fe81218fbf79c25540eb09c7664bc5b8a \
+      sha256  6e912133bcf56e9cfe6a346fa7e5c52c2cde3e4e48b7a6cc6fcc7c75047da45f
 
     depends_build-append    port:py${python.version}-setuptools
 
-    set clanglist       {37    50    60    70    80    90    10     11}
-    set clangvlist      {3.7.1 5.0.2 6.0.1 7.0.1 8.0.1 9.0.1 10.0.1 11.1.0}
+    # Keeping 37 around for old systems; otherwise two latest releases.
+    set clanglist       {37    11     12}
+    set clangvlist      {3.7.1 11.1.0 12.0.1}
 
     foreach cvnum $clanglist {
         # Explictly use (and depend on) the libclang we select during install
@@ -94,9 +80,8 @@ if {${name} ne ${subport}} {
                 reinplace {s/version=.*/version=\"${clang_version}\",/} setup.py
             }
             livecheck.version   ${clang_version}
-            # Yes, I didn't bother escaping the '.'s
             livecheck.regex \
-                \" ([string range $clang_version 0 2].\\\[0-9\\\]+): \"
+                \"llvmorg-([string range $clang_version 0 1]\\\\.\\\[0-9.\\\]+)\\\"\"
         "
     }
 
@@ -105,27 +90,17 @@ if {${name} ne ${subport}} {
     test.target         -m unittest discover -v
 
     if {![variant_isset clang37] &&
-        ![variant_isset clang50] &&
-        ![variant_isset clang60] &&
-        ![variant_isset clang70] &&
-        ![variant_isset clang80] &&
-        ![variant_isset clang90] &&
-        ![variant_isset clang10] &&
-        ![variant_isset clang11]} {
-        default_variants +clang11
+        ![variant_isset clang11] &&
+        ![variant_isset clang12]} {
+        default_variants +clang12
     }
 
     pre-extract {
         # Will never hit this when installing from packages, which is OK, as
         # they will have the default variant set above.
         if {![variant_isset clang37] &&
-            ![variant_isset clang50] &&
-            ![variant_isset clang60] &&
-            ![variant_isset clang70] &&
-            ![variant_isset clang80] &&
-            ![variant_isset clang90] &&
-            ![variant_isset clang10] &&
-            ![variant_isset clang11]} {
+            ![variant_isset clang11] &&
+            ![variant_isset clang12]} {
             ui_error "At least one of the clangNN variants must be active."
             return -code error "Unsupported (no) variants selected."
         }


### PR DESCRIPTION
Maintainer update.