### PR TITLE
gmic: Disable parallel building

### DIFF
--- a/science/gmic/Portfile
+++ b/science/gmic/Portfile
@@ -60,6 +60,10 @@ patchfiles          patch-CMakeLists.txt.diff \
 
 compiler.cxx_standard           2011
 
+# Uses more memory per compile process than we can accommodate on our
+# automated build system. See https://github.com/dtschump/gmic/issues/325
+use_parallel_build              no
+
 subport ${name}-qt {
     description-append          (GUI application)
 


### PR DESCRIPTION
#### Description

Disable parallel building

Closes: https://trac.macports.org/ticket/54370

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
