### PR TITLE
p5-devel-checkbin: can use core EUMM

### DIFF
--- a/perl/p5-devel-checkbin/Portfile
+++ b/perl/p5-devel-checkbin/Portfile
@@ -15,9 +15,4 @@ platforms           darwin
 checksums           rmd160  0606582701fdcf424c61a0ea24515de767fa113c \
                     sha256  157f3db59c29ed1d49133a469cee772c885ad4ee64e8692a91b3ebfdbe2fe3e4
 
-if {${perl5.major} != ""} {
-    depends_lib-append \
-                    port:p${perl5.major}-extutils-makemaker
-    
-    supported_archs noarch
-}
+supported_archs     noarch


### PR DESCRIPTION
Newer EUMM was needed for p5.16-devel-checkbin: 1ceb04f7c5

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Perl 5.34.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
