### PR TITLE
tig: update to 2.5.4

### DIFF
--- a/devel/tig/Portfile
+++ b/devel/tig/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonas tig 2.5.3 tig-
+github.setup        jonas tig 2.5.4 tig-
 github.tarball_from releases
-checksums           rmd160  f7e6083f31fac0de05916124bae50efca0f08a56 \
-                    sha256  e528068499d558beb99a0a8bca30f59171e71f046d76ee5d945d35027d3925dc \
-                    size    1165632
+checksums           rmd160  cb3fd5a5ca5380bfbcf55a528b89cc297ee0cce6 \
+                    sha256  c48284d30287a6365f8a4750eb0b122e78689a1aef8ce1d2961b6843ac246aa7 \
+                    size    1167930
 
 categories          devel
 maintainers         {cal @neverpanic} \


### PR DESCRIPTION
#### Description

See: https://github.com/jonas/tig/releases/tag/tig-2.5.4.


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
