### PR TITLE
libjpeg-turbo: Support non-Altivec PowerPC

### DIFF
--- a/graphics/libjpeg-turbo/Portfile
+++ b/graphics/libjpeg-turbo/Portfile
@@ -38,6 +38,7 @@ checksums           sha1    6bf63c869105d341011cd4915816de888338231a \
                     sha256  bef89803e506f27715c5627b1e3219c95b80fc31465d4452de2a909d382e4444 \
                     size    2255497
 
+configure.args      -DWITH_JPEG8=ON
 if {![info exists universal_possible]} {
     set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
 }
@@ -50,8 +51,12 @@ if {${universal_possible} && [variant_isset universal]} {
 } elseif {${configure.build_arch} in {i386 x86_64}} {
     depends_build-append port:nasm
     configure.env       ASM_NASM=${prefix}/bin/nasm
+} elseif {${configure.build_arch} eq "ppc"} {
+    if {[catch {sysctl hw.vectorunit} result] || $result == 0} {
+        configure.args-append   -DWITH_SIMD=OFF
+        archive_sites
+    }
 }
-configure.args      -DWITH_JPEG8=1
 
 variant java description "Add Java support" {
     PortGroup           java 1.0


### PR DESCRIPTION
The CMake file supplied by libjpeg-turbo 2.1.0 incorrectly detects SIMD support on G3 processors. As a result, dynamic libraries are produced which will not load on the host machine. This patch forces SIMD to be disabled on G3 processors.

Closes: https://trac.macports.org/ticket/63259

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
