### PR TITLE
binutils: update to 2.37

### DIFF
--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -66,6 +66,11 @@ array set crossbinutils.versions_info {
         sha256  e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0 \
         size    22772248
     }}
+    2.37 {xz {
+        rmd160  55280d11b786b931cb53819bc5b3b5d6b6b4383d \
+        sha256  820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c \
+        size    22916924
+    }}
 }
 
 proc crossbinutils.setup {target version} {

--- a/devel/binutils/Portfile
+++ b/devel/binutils/Portfile
@@ -3,11 +3,12 @@
 PortSystem          1.0
 
 name                binutils
-version             2.36.1
+version             2.37
+revision            0
 
-checksums           rmd160  65047a9edd726380fa1e117514513c86b77cf3a0 \
-                    sha256  e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0 \
-                    size    22772248
+checksums           rmd160  55280d11b786b931cb53819bc5b3b5d6b6b4383d \
+                    sha256  820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c \
+                    size    22916924
 
 description         FSF Binutils for native development.
 long_description    Free Software Foundation development toolchain ("binutils") \


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
