### PR TITLE
caddy: update to 2.4.3

### DIFF
--- a/www/caddy/Portfile
+++ b/www/caddy/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/caddyserver/caddy 2.4.2 v
+go.setup            github.com/caddyserver/caddy 2.4.3 v
+revision            0
 categories          www
 platforms           darwin
 license             Apache-2
@@ -17,9 +18,9 @@ long_description    Caddy 2 is a powerful, enterprise-ready, open source web \
 homepage            https://caddyserver.com/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  dc8d24a570c8f7efaa5e3b9d4d74a8b002331c5d \
-                        sha256  22fcf8d4b2674416c3eb73241944718d402d874468c84705508da5a00ddbe665 \
-                        size    447534
+                        rmd160  b4f31316662fb3e6d69971b5672f6a31c752dc58 \
+                        sha256  ef8dd080b6b6d4f4747bdbad56281e6543de57c22a750b86d378cdcf28e0c0f1 \
+                        size    448429
 
 go.vendors          howett.net/plist \
                         repo    github.com/DHowett/go-plist \


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
