### PR TITLE
libnotify: Fix build on Tiger

### DIFF
--- a/devel/libnotify/Portfile
+++ b/devel/libnotify/Portfile
@@ -41,6 +41,11 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
 # ensure g-ir-scanner uses correct link command
 build.env-append    "CC=${configure.cc} [get_canonical_archflags cc]"
 
+platform darwin 8 {
+    # meson on Tiger cannot use rpaths, so we workaround with this to find dylib
+    destroot.env-append    "DYLD_LIBRARY_PATH=${build_dir}/libnotify"
+}
+
 pre-activate {
 	if {${os.major} == 11 && ${os.minor} < 2 && ${os.platform} eq "darwin"} {
 		ui_error "You must first update to OS X 10.7.2."


### PR DESCRIPTION
In order to build documentation, libnotify requires a workaround for lack of `@rpath` on Tiger.

Closes: https://trac.macports.org/ticket/63264

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
