### PR TITLE
hugo: update to 0.85.0

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.84.2 v
+go.setup            github.com/gohugoio/hugo 0.85.0 v
 revision            0
-checksums           rmd160  cd6a7d161ff723c3320b0986eece17599305ae13 \
-                    sha256  bad78428ac2b101e4f8be0915f0336aeb4e108e7ae27ad741bb677c1a3a6fc97 \
-                    size    38963881
+checksums           rmd160  26c566f497a615736be590ec2121ce3358111b57 \
+                    sha256  a2eee56b6edf660fd7814041963e9e6f6fe9a59c19fddeb14694e9959a681fe9 \
+                    size    38969502
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.85.0

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?