### PR TITLE
openjdk: update openjdk11-graalvm to 21.2.0

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -215,7 +215,7 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      21.1.0
+    version      21.2.0
     revision     0
 
     description  GraalVM Community Edition based on OpenJDK 11
@@ -225,9 +225,9 @@ subport openjdk11-graalvm {
     distname     graalvm-ce-java11-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java11-${version}
     
-    checksums    rmd160  61d5ec36d1671168fbcc236e4653a3be24198a69 \
-                 sha256  b53cd5a085fea39cb27fc0e3974f00140c8bb774fb2854d72db99e1be405ae2b \
-                 size    396142137
+    checksums    rmd160  7a1f0185f67022ad7f9ba5540a438580edd10792 \
+                 sha256  f62cdc44a031731aa221426724a55eb09c79d6b2e9275ae3ca7003da5884ca36 \
+                 size    399511612
 }
 
 subport openjdk11-openj9 {


### PR DESCRIPTION
#### Description

Update GraalVM based on OpenJDK 11 to 21.2.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?