### PR TITLE
notmuch: Bump to version 0.32.2

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -6,17 +6,14 @@ PortGroup           conflicts_build             1.0
 PortGroup           perl5                       1.0
 
 name                notmuch
-version             0.31.2
+version             0.32.2
 revision            0
-platform darwin 20 {
-    revision        1
-}
 
 categories          mail
 platforms           darwin
 license             GPL-3+
 maintainers         {seichter.de:macports @rseichter} openmaintainer
-description         The mail indexer
+description         Fast, global-search and tag-based email system
 long_description    \"Not much mail\" is what Notmuch thinks about your email \
                     collection, even if you receive 12000 messages per month or have on the \
                     order of millions of messages that you’ve been saving for decades. \
@@ -26,11 +23,11 @@ long_description    \"Not much mail\" is what Notmuch thinks about your email \
 homepage            https://notmuchmail.org
 master_sites        ${homepage}/releases/
 use_xz              yes
-checksums           rmd160  566a65c82b23946bc2bde8a3505384555041097d \
-                    sha256  1456b63e04637094eefe7e6f9a45812ed419392a0322fe8b0f452dd06a4cfbef \
-                    size    713388
+checksums           rmd160  0774a51bb31ced939c898fffa0ee0c59b72dd3ad \
+                    sha256  8e0a7eb8ff2e6011ef48b2bf11d79b9c4bb74511cfe2987758b64898c2a2ded7 \
+                    size    725652
 
-set python_branch   3.8
+set python_branch   3.9
 set python_version  [string map {. {}} ${python_branch}]
 
 depends_build       port:bash-completion \


### PR DESCRIPTION
Also upgrades from Python 3.8 to 3.9.