### PR TITLE
google-cloud-sdk: update to 349.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             348.0.0
+version             349.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4c8388379626206f39e17fc2372d0ec68d034055 \
-                    sha256  a8846a7a31fe4c11bc47e4f4069bf20675d7e4f5bd442dfe82f4ddd90746b30c \
-                    size    90520193
+    checksums       rmd160  1cf167b86aa656015a5ac7a8c3e66b6c04fab4b7 \
+                    sha256  6b4d9b8aa91f0c647f97967e21daa71fc8a7c843f36e1832d5562f2cce0667da \
+                    size    90625752
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  dde20e2dc22b4b0aeef940b6a610924592d80198 \
-                    sha256  7ab7d3b1c5ebedffb253c85b3cc6574be2c2cd4881c57ec0254d58f9b9bf02c0 \
-                    size    86770070
+    checksums       rmd160  50f46754a95ff2b986375974e80431131fd1c6a7 \
+                    sha256  94f4a277921a6942f337b0db15c5ae1c44949822af41a8a8ce9746ca8f6a6138 \
+                    size    86873422
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  de407800da9e6864a3f3ded02631da1dfc1e9319 \
-                    sha256  f90d261a4138618e4b6837a30dc907166f777648f007e0fac0906a787fcf3563 \
-                    size    86690875
+    checksums       rmd160  1672e80c30048d54f7dab5bf298cc1e9ed888286 \
+                    sha256  ab834e7cc081ebf4acf271951defcb9e7d8db9a1fd910bdce332489b1c999c43 \
+                    size    86795240
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 349.0.0.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?