### PR TITLE
openjdk: update openjdk7-zulu to 7.48.0.11

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -79,10 +79,10 @@ if {${subport} eq "openjdk"} {
 }
 
 subport openjdk7-zulu {
-    version      7.46.0.11
+    version      7.48.0.11
     revision     0
 
-    set openjdk_version 7.0.302
+    set openjdk_version 7.0.312
 
     description  Azul Zulu Community OpenJDK 7 (Long Term Support)
     long_description ${long_description_zulu}
@@ -90,9 +90,9 @@ subport openjdk7-zulu {
     master_sites https://cdn.azul.com/zulu/bin/
 
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  d4f87b0e4ee901c24fca82eb7f74904ad8ee8eb5 \
-                 sha256  d452c081b7c55f3b26878ef0522911976302c6f47f4bd4b92057cef9161c556c \
-                 size    68486614
+    checksums    rmd160  e67ace4cc674397e28700838101f7b200ac8a2a2 \
+                 sha256  303ccd606307ce37f48ffbaeccaaee72fa3445eb1503c99ae181b372b72701e3 \
+                 size    68501413
 
     worksrcdir   ${distname}/zulu-7.jdk
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 7.48.0.11 (OpenJDK 7u312b01).

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?