### PR TITLE
openjdk: update openjdk8-zulu to OpenJDK 8u302

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -155,10 +155,14 @@ subport openjdk8-openj9 {
 }
 
 subport openjdk8-zulu {
-    version      8.54.0.21
+    if {${configure.build_arch} eq "x86_64"} {
+        version      8.56.0.21
+    } elseif {${configure.build_arch} eq "arm64"} {
+        version      8.56.0.23
+    }
     revision     0
 
-    set openjdk_version 8.0.292
+    set openjdk_version 8.0.302
 
     description  Azul Zulu Community OpenJDK 8 (Long Term Support)
     long_description ${long_description_zulu}
@@ -167,14 +171,14 @@ subport openjdk8-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  886fe3a9b2161d63ce14bd10be8f571984e4f82d \
-                     sha256  369e0d0d76d73cb161978ff07d7020820bb3cd2465f6f91219bb6492e302f4dd \
-                     size    108162260
+        checksums    rmd160  1dc569a8943abb351878b2e51ec3810904b34da7 \
+                     sha256  497c1d6eae5f3943a1c5f74be7bb8a650d6b0dc3bf069973d6d04f45c3daaf88 \
+                     size    108061992
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  cafab852e7263d3b1077b7b37f8d9019f4d3797a \
-                     sha256  2cf0af3118dd4b6244724308b190587804a76ad7919b6da5c377392a1d4f8817 \
-                     size    105926746
+        checksums    rmd160  74eaf41d309ec8a3c11968ad1766b1108ec540a9 \
+                     sha256  4482990c96e87519f52725b0bf3a6171510e3da268d55b793d1bf6eeb6485030 \
+                     size    105811540
     }
 
     worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 8u302.

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?