### PR TITLE
openjdk: update openjdk11-zulu to OpenJDK 11.0.12

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -257,10 +257,10 @@ subport openjdk11-openj9-large-heap {
 }
 
 subport openjdk11-zulu {
-    version      11.48.21
+    version      11.50.19
     revision     0
 
-    set openjdk_version 11.0.11
+    set openjdk_version 11.0.12
 
     description  Azul Zulu Community OpenJDK 11 (Long Term Support)
     long_description ${long_description_zulu}
@@ -269,14 +269,14 @@ subport openjdk11-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  49e6888a1ec6749b09ac5daf725e46d9cb02e8f2 \
-                     sha256  866b25c47aa3bedddc57fbe38fd7d2e0f888d314b85d1e88b2fb12100f3c166c \
-                     size    195386841
+        checksums    rmd160  2b136a6fbe8f0d9bcf52cf12a41099825f1fac07 \
+                     sha256  0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7 \
+                     size    195713033
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  62a60cf4ffaa67a4d0cc2627fae9dfa438f98a29 \
-                     sha256  0c52621329b0d148c816b4c21e91386240bf57eb53ecfc4a6201f59ee983dc18 \
-                     size    179158961
+        checksums    rmd160  c482f2433c9aa6451b915bb5b56c748e7f153436 \
+                     sha256  e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17 \
+                     size    179357206
     }
 
     worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 11.0.12 (Zulu 11.50.19).

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?