### PR TITLE
openjdk: update openjdk13-zulu to OpenJDK 13.0.8

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -325,10 +325,10 @@ subport openjdk13-openj9-large-heap {
 }
 
 subport openjdk13-zulu {
-    version      13.40.15
+    version      13.42.17
     revision     0
 
-    set openjdk_version 13.0.7
+    set openjdk_version 13.0.8
 
     description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
     long_description ${long_description_zulu}
@@ -337,14 +337,14 @@ subport openjdk13-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  f84e38dc8b92928b6aed9e35b6da3eb5f63e4b23 \
-                     sha256  a53b31c4eb6db57feceefd16ebadd07525514bdec8dbab6f9644e81ac1b97543 \
-                     size    200105932
+        checksums    rmd160  6b815bc7964d1caf720032378b0767c1337a415a \
+                     sha256  89b4e117f3543e0135c4bfd97ff07425a656af5c15e8c30165f01b0dec86563c \
+                     size    200259765
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  2422909438bbe13ce0810b4f57d111f514d1a842 \
-                     sha256  0dcca3161a2490792a9853c7d7bb511199f79cc58d3dab1b11af1c2fe22f06d8 \
-                     size    179462701
+        checksums    rmd160  297c7baae1b4fc7dbb40f58ff561f3d20eafc5e5 \
+                     sha256  b5104d5b0857e475217a58f8b62bb9e0b118abc1e0aa06b4398da4598dd57f72 \
+                     size    179620444
     }
 
     worksrcdir   ${distname}/zulu-13.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 13.0.8 (Zulu 13.42.17).

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?