### PR TITLE
openjdk: update openjdk15-zulu to OpenJDK 15.0.4

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -393,10 +393,10 @@ subport openjdk15-openj9-large-heap {
 }
 
 subport openjdk15-zulu {
-    version      15.32.15
+    version      15.34.17
     revision     0
 
-    set openjdk_version 15.0.3
+    set openjdk_version 15.0.4
 
     description  Azul Zulu Community OpenJDK 15 (Medium Term Support)
     long_description ${long_description_zulu}
@@ -405,14 +405,14 @@ subport openjdk15-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  9b67ab3d55b7b358417dbd22e5d8c10d67ed4370 \
-                     sha256  87df2e9adc1e27c2ffe9a1f8b88d0ba3eeb4cc81c77fc6a3a02788e22484d07b \
-                     size    201723476
+        checksums    rmd160  b510fa41d6df9f92476248e9fd8a3333cc89e024 \
+                     sha256  73f284d1b5d150d6a286759c2d00ceafc4b50596399e9e9af0f1603c3dcb08de \
+                     size    201986189
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  1960d11a0302cefaad80d1895184b6a4fb9f8374 \
-                     sha256  200c210f2754b718b24a52dfe8801255ee69b44dc1de9ef6795e343909ea087a \
-                     size    176323405
+        checksums    rmd160  9b8cdb1bc888e01b0ee3e04efc00e0873c5ce852 \
+                     sha256  af9a181dbb38f8c7571b5d59359684b88a79ddda5b313adb2efab87221f53e2d \
+                     size    176383011
     }
 
     worksrcdir   ${distname}/zulu-15.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 15.0.4 (Zulu 15.34.17).

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?