### PR TITLE
py-requests: update to 2.26.0

### DIFF
--- a/python/py-requests/Portfile
+++ b/python/py-requests/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-requests
-version             2.25.1
-revision            1
+version             2.26.0
+revision            0
 categories-append   devel
 platforms           darwin
 license             Apache-2
@@ -27,9 +27,9 @@ long_description    Most existing Python modules for dealing HTTP \
 
 homepage            https://requests.readthedocs.io/
 
-checksums           rmd160  4a8a60da9b3619a53bd5a74245e58123702ae7e6 \
-                    sha256  27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
-                    size    102161
+checksums           rmd160  0b532167e01570e015b9abd52bb7d442d93a50bd \
+                    sha256  b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7 \
+                    size    104433
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Created with [seaport](https://seaport.rtfd.io/), the modern MacPorts portfile updater.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.1 20C69
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?