### PR TITLE
openjdk: update homepage for Azul Zulu OpenJDK

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -521,7 +521,7 @@ if {${os.platform} eq "darwin"} {
 if {[string match *-graalvm ${subport}]} {
     homepage     https://www.graalvm.org
 } elseif {[string match *-zulu ${subport}]} {
-    homepage     https://www.azul.com/downloads/zulu-community/
+    homepage     https://www.azul.com/downloads/
 } else {
     homepage     https://adoptopenjdk.net
 }


### PR DESCRIPTION
#### Description

Azul Zulu OpenJDK has moved from https://www.azul.com/downloads/zulu-community/ to https://www.azul.com/downloads/. The old URL redirects to the new one, so I didn't think this warrants bumping the revision of all Azul Zulu OpenJDK subports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?