### PR TITLE
spice-gtk: Mark conflict between variants

### DIFF
--- a/gnome/spice-gtk/Portfile
+++ b/gnome/spice-gtk/Portfile
@@ -68,12 +68,12 @@ depends_lib-append  port:spice-protocol \
 configure.cppflags-append \
                     -D_XOPEN_SOURCE
 
-variant quartz {
+variant quartz conflicts x11 {
     # Quartz & X11 binaries are incompatible, although built similarly
     require_active_variants gtk3 quartz x11
 }
 
-variant x11 {
+variant x11 conflicts quartz {
     # Quartz & X11 binaries are incompatible, although built similarly
     require_active_variants gtk3 x11 quartz
 }

--- a/gnome/spice-gtk/Portfile
+++ b/gnome/spice-gtk/Portfile
@@ -45,6 +45,7 @@ post-patch {
 }
 
 depends_build-append \
+                    port:asciidoc \
                     port:intltool \
                     port:pkgconfig \
                     port:python${python_ver_no_dot} \


### PR DESCRIPTION
Variants +quartz and +x11 conflict, but are not actually marked as conflicting, meaning if a user just does `port variants spice-gtk` they'll think both can be installed. This fixes that.

#### Description
Before:
```
$ port variants spice-gtk
spice-gtk has the variants:
[+]quartz: Enable native macOS graphics support
   x11: Enable X11 support
$
```
After:
```
$ port variants
spice-gtk has the variants:
[+]quartz: Enable native macOS graphics support
     * conflicts with x11
   x11: Enable X11 support
     * conflicts with quartz
$
```

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

~~Note that I can't get spice-gtk to install for me; it didn't install before this PR and it doesn't install after.~~ The current commit that comprises this PR only touches the variant display; it doesn't affect the (failure to) build. Future commits to this branch may try to fix my build failures, though.
