### PR TITLE
py-requests: pin py35 to 2.25.1

### DIFF
--- a/python/py-requests/Portfile
+++ b/python/py-requests/Portfile
@@ -35,13 +35,23 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
 
-    depends_lib-append  port:py${python.version}-chardet \
+    depends_lib-append  port:py${python.version}-charset-normalizer \
                         port:py${python.version}-idna \
                         port:py${python.version}-urllib3 \
                         port:py${python.version}-certifi
 
-    if {${python.version} >= 30} {
-        depends_lib-append  port:py${python.version}-charset-normalizer
+    if {${python.version} <= 35} {
+        depends_lib-replace  port:py${python.version}-charset-normalizer \
+                             port:py${python.version}-chardet
+
+        if {${python.version} == 35} {
+            version          2.25.1
+            epoch            1
+            revision         0
+            checksums        rmd160  4a8a60da9b3619a53bd5a74245e58123702ae7e6 \
+                             sha256  27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
+                             size    102161
+        }
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

Support for py35 was dropped as of https://github.com/psf/requests/commit/f6c0619d892a41dcf84933810ffda89e9f6b10d4.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
