### PR TITLE
glade: Add [+]webkit2gtk variant

### DIFF
--- a/devel/glade/Portfile
+++ b/devel/glade/Portfile
@@ -34,11 +34,9 @@ depends_build       port:pkgconfig \
 
 depends_lib         port:gdk-pixbuf2 \
                     port:gtk3 \
-                    port:libxml2 \
-                    path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
+                    port:libxml2
 
-depends_run         port:desktop-file-utils \
-                    port:devhelp
+depends_run         port:desktop-file-utils
 
 gobject_introspection yes
 
@@ -53,6 +51,7 @@ configure.optflags  -O0
 configure.args      --enable-gladeui \
                     --enable-debug \
                     --disable-python \
+                    --disable-webkit2gtk \
                     --disable-silent-rules
 
 configure.cflags-append \
@@ -104,6 +103,14 @@ if {![variant_isset python27] && \
     ![variant_isset python38]} {
     default_variants +python38
 }
+
+variant webkit2gtk description {Enable WebKit widgets catalog} {
+    configure.args-replace  --disable-webkit2gtk --enable-webkit2gtk
+    depends_lib-append      path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
+    depends_run-append      port:devhelp
+}
+
+default_variants +webkit2gtk
 
 notes "
 To view the Glade Interface Designer Manual (GTK+ 3 version), use


### PR DESCRIPTION
#### Description

The variant enables the WebKit2GTK+ widget catalog. When disabled, `webkit2-gtk` is removed as a library dependency, and `devhelp` (which independently requires `webkit2-gtk`) is removed as a run-time dependency.

Tested up through the configure phase. Output snippet with `-webkit2gtk`:

```
:info:configure Configuration:
:info:configure     Source code location:    .
:info:configure     Compiler:        /opt/local/bin/gcc-mp-7
:info:configure     Debug Enabled:           yes
:info:configure     GTK+ UNIX Print Widgets: yes
:info:configure     PYTHON Widgets support:  yes
:info:configure     Gladeui Catalog:         yes
:info:configure     WebKit2GTK+ Catalog:     no
:info:configure     Introspection Data:      yes
:info:configure     Build Reference Manual:  no
:info:configure     Build Manual Pages:      yes
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
