### PR TITLE
hashcat: update to 6.2.3

### DIFF
--- a/security/hashcat/Portfile
+++ b/security/hashcat/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               makefile 1.0
 
-github.setup            hashcat hashcat 6.2.2 v
+github.setup            hashcat hashcat 6.2.3 v
 github.tarball_from     archive
 
 categories              security
@@ -25,7 +25,6 @@ homepage                https://hashcat.net/hashcat/
 
 build.target            {}
 
-checksums               rmd160  07d6752f1be2340fb7b95a1c8adec5d9a5a73d55 \
-                        sha256  0e34c47f7505c4efb885cf893083386ee847d508f5711906281071f14a1c7a75 \
-                        size    6174692
-
+checksums               rmd160  8bb501834a320aaac3de149c5ab39c2eb89ee968 \
+                        sha256  c0be1c6693ee1f35c7bef1f79bf9e30a954f717ef42d00e37787aaeff3271e51 \
+                        size    6222424


### PR DESCRIPTION
#### Description

- This release adds an entire new compute backend (HIP), CPU hardware monitor support, several new hash-modes, bug fixes and improvements.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
