### PR TITLE
npm-1.0: new portgroup

### DIFF
--- a/_resources/port1.0/group/npm-1.0.tcl
+++ b/_resources/port1.0/group/npm-1.0.tcl
@@ -1,0 +1,127 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# This PortGroup is mainly used for npm ports (e.g. npm7). It helps setting up conflicts/dependencies/etc.
+#
+# Usage:
+#
+#     PortGroup            npm 1.0
+#     npm.setup            version
+#
+# It also makes publically accessible which node version each NPM/yarn depends on.
+# This can be accessed via [node_version NPM_VERSION]
+# e.g. npm7: [node_version 7] returns 16 for nodejs16
+#      yarn: [node_version yarn]
+
+
+# Set the minimum and maximum versions of npm
+# Required for livecheck and for setting conflicts
+# Also used by javascript portgroup
+options npm.maximum_version npm.minimum_version
+default npm.maximum_version 7
+default npm.minimum_version 3
+
+
+# This publically makes accessible which node version goes with which npm/yarn.
+# N.B. the npm.major of yarn is "yarn"
+proc node_version {npm.major} {
+    global os.major
+
+    # The platform is already darwin, so no need to double check
+    if {${npm.major} <= 5 || ${os.major} < 13} {
+        return 8
+    } else {
+        return 16
+    }
+}
+
+use_configure       no
+
+# Set all npm-specific attributes in npm.setup
+# This is only used by npm-based ports
+options npm.major npm.version
+proc npm.setup {npm_version} {
+    global prefix destroot distname conflicts
+    global npm.major npm.version npm.maximum_version npm.minimum_version
+    global PortInfo
+
+    npm.version         ${npm_version}
+
+    # This returns the first number of the npm version
+    # e.g. 7 for npm7
+    npm.major           [lindex [split ${npm.version} .] 0]
+
+    if {!([info exists PortInfo(name)] && (${PortInfo(name)} ne "npm${npm.major}"))} {
+        name            npm${npm.major}
+    }
+
+    categories          devel
+    platforms           darwin
+    license             MIT
+
+    supported_archs     noarch
+
+    homepage            https://www.npmjs.com/
+
+    description         node package manager
+    long_description    npm is a package manager for node. \
+                        You can use it to install and publish your node programs. \
+                        It manages dependencies and does other cool stuff.
+
+    worksrcdir          "package"
+
+    version             ${npm.version}
+
+    master_sites        https://registry.npmjs.org/npm/-/
+    distname            npm-${npm.version}
+    extract.suffix      .tgz
+
+    # Add all the conflicts
+    for {set index ${npm.minimum_version}} { $index <= ${npm.maximum_version} } { incr index } {
+        if {${index} ne ${npm.major}} {
+            lappend conflicts npm${index}
+        }
+    }
+
+    depends_lib         port:nodejs[node_version ${npm.major}]
+    
+    destroot.destdir    --prefix=${destroot}${prefix}
+    
+    # As of npm5 installing from a directory will result in a symlink being used. 
+    # Change the install to use the built in pack functionality instead.
+    if {${npm.major} >= 5} {
+        build {
+            system -W ${worksrcpath} "NPM_CONFIG_UNSAFE_PERM=false ${prefix}/bin/node bin/npm-cli.js pack"
+        }
+    
+        destroot.cmd        ${prefix}/bin/node ./bin/npm-cli.js
+        destroot.args       --global ${distname}.tgz
+    } else {
+        build               {}
+        
+        destroot.cmd        ${prefix}/bin/node ./cli.js
+        destroot.args       --global .
+    }
+
+    post-destroot {
+        set completions_path ${destroot}${prefix}/share/bash-completion/completions/
+        xinstall -d ${completions_path}
+        xinstall -m 644 ${worksrcpath}/lib/utils/completion.sh ${completions_path}/npm
+    }
+
+    notes "
+    It is not recommended to install packages globally. But if you do so\
+    please be aware that they won't get cleaned up when you deactivate\
+    or uninstall npm${npm.major}. Globally installed packages will remain in\
+    ${prefix}/lib/node_modules/ until you manually delete them.
+    "
+    
+    livecheck.type      regex
+    livecheck.url       https://registry.npmjs.org/npm
+
+    # The latest version of npm has a slightly different livecheck
+    if {${npm.maximum_version} eq ${npm.major}} {
+        livecheck.regex \"latest\":"(.*?)"
+    } else {
+        livecheck.regex \"latest-${npm.major}\":"(.*?)"
+    }
+}

--- a/devel/npm3/Portfile
+++ b/devel/npm3/Portfile
@@ -1,42 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           npm 1.0
 
-name                npm3
-version             3.10.10
+npm.setup           3.10.10
 revision            3
-
-categories          devel
-platforms           darwin
-license             MIT
 maintainers         {ciserlohn @ci42}
 
-supported_archs     noarch
-
-description         node package manager
-long_description    npm is a package manager for node. \
-                    You can use it to install and publish your node programs. \
-                    It manages dependencies and does other cool stuff.
-
-conflicts           npm4 npm5 npm6 npm7
-
-homepage            http://www.npmjs.org/
-
-master_sites        http://registry.npmjs.org/npm/-/
-
-distname            npm-${version}
-
-extract.suffix      .tgz
-
-checksums           rmd160  b6a6049f561d9e5f54578ca897a51b3db79fad68 \
+# Please keep the sha1 - users can use it to validate sha values
+# published on npmjs.org for the package
+checksums           sha1    5b1d577e4c8869d6c8603bc89e9cd1637303e46e \
+                    rmd160  b6a6049f561d9e5f54578ca897a51b3db79fad68 \
                     sha256  1a7cd203ac30fd1417326d576ca5c66ae2ae6a2bf1ada151bee2fc0d6965f99a \
                     size    3210648
-
-worksrcdir          "package"
-
-depends_lib         path:bin/node:nodejs8
-
-use_configure       no
 
 patchfiles          patch-lib-update.js.diff
 
@@ -68,26 +44,3 @@ post-patch {
         reinplace "s|/usr/bin/env node|${prefix}/bin/node|" ${f}
     }
 }
-
-build {}
-
-destroot.cmd        ${prefix}/bin/node ./cli.js
-destroot.args       --global .
-destroot.destdir    --prefix=${destroot}${prefix}
-
-post-destroot {
-    set completions_path ${destroot}${prefix}/share/bash-completion/completions/
-    xinstall -d ${completions_path}
-    xinstall -m 644 ${worksrcpath}/lib/utils/completion.sh ${completions_path}/npm
-}
-
-notes "
-It is not recommended to install packages globally. But if you do so\
-please be aware that they won't get cleaned up when you deactivate\
-or uninstall ${name}. Globally installed packages will remain in\
-${prefix}/lib/node_modules/ until you manually delete them.
-"
-
-livecheck.type      regex
-livecheck.url       http://registry.npmjs.org/npm
-livecheck.regex     {"latest-3":"(.*?)"}

--- a/devel/npm4/Portfile
+++ b/devel/npm4/Portfile
@@ -1,42 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           npm 1.0
 
-name                npm4
-version             4.6.1
+npm.setup           4.6.1
 revision            2
-
-categories          devel
-platforms           darwin
-license             MIT
 maintainers         {ciserlohn @ci42}
 
-supported_archs     noarch
-
-description         node package manager
-long_description    npm is a package manager for node. \
-                    You can use it to install and publish your node programs. \
-                    It manages dependencies and does other cool stuff.
-
-conflicts           npm3 npm5 npm6 npm7
-
-homepage            http://www.npmjs.org/
-
-master_sites        http://registry.npmjs.org/npm/-/
-
-distname            npm-${version}
-
-extract.suffix      .tgz
-
-checksums           rmd160  f78373f0de0e3466101a3b73a0fd3cf3e140661f \
+# Please keep the sha1 - users can use it to validate sha values
+# published on npmjs.org for the package
+checksums           sha1    f8eb1ad00dc58a5514363b41ca5342817f0bd646 \
+                    rmd160  f78373f0de0e3466101a3b73a0fd3cf3e140661f \
                     sha256  ba858e926aaaacb886a92861e6683607b2eb11809e994917e1db299604da50d2 \
                     size    3844646
-
-worksrcdir          "package"
-
-depends_lib         path:bin/node:nodejs8
-
-use_configure       no
 
 patchfiles          patch-lib-update.js.diff
 
@@ -66,26 +42,3 @@ post-patch {
         reinplace "s|/usr/bin/env node|${prefix}/bin/node|" ${f}
     }
 }
-
-build {}
-
-destroot.cmd        ${prefix}/bin/node ./cli.js
-destroot.args       --global .
-destroot.destdir    --prefix=${destroot}${prefix}
-
-post-destroot {
-    set completions_path ${destroot}${prefix}/share/bash-completion/completions/
-    xinstall -d ${completions_path}
-    xinstall -m 644 ${worksrcpath}/lib/utils/completion.sh ${completions_path}/npm
-}
-
-notes "
-It is not recommended to install packages globally. But if you do so\
-please be aware that they won't get cleaned up when you deactivate\
-or uninstall ${name}. Globally installed packages will remain in\
-${prefix}/lib/node_modules/ until you manually delete them.
-" 
-
-livecheck.type      regex
-livecheck.url       http://registry.npmjs.org/npm
-livecheck.regex     {"next-4":"(.*?)"}

--- a/devel/npm5/Portfile
+++ b/devel/npm5/Portfile
@@ -1,49 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           npm 1.0
 
-name                npm5
-version             5.10.0
+npm.setup           5.10.0
 revision            1
-
-categories          devel
-platforms           darwin
-license             MIT
 maintainers         { ether.org.za:light @dylanbr } openmaintainer
 
-supported_archs     noarch
-
-description         node package manager
-long_description    npm is a package manager for node. \
-                    You can use it to install and publish your node programs. \
-                    It manages dependencies and does other cool stuff.
-
-conflicts           npm3 npm4 npm6 npm7
-
-homepage            https://www.npmjs.com/
-
-master_sites        http://registry.npmjs.org/npm/-/
-
-distname            npm-${version}
-
-extract.suffix      .tgz
-
+# Please keep the sha1 - users can use it to validate sha values
+# published on npmjs.org for the package
 checksums           sha1    3bec62312c94a9b0f48f208e00b98bf0304b40db \
                     rmd160  37691467e52ef07af35afc8ab3a3467b9191a5f8 \
                     sha256  c6fe903b4b9cd3ba01dcb530dbf00140e91f5b36c344710421676468e8e4fea3 \
                     size    6732593
-
-worksrcdir          "package"
-
-depends_lib         path:bin/node:nodejs8
-
-platform darwin {
-    if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs8 path:bin/node:nodejs6
-    }
-}
-
-use_configure       no
 
 patchfiles          patch-lib-update.js.diff
 
@@ -82,28 +51,3 @@ post-patch {
         reinplace "s|/usr/bin/env node|${prefix}/bin/node|" ${f}
     }
 }
-
-build {
-    system -W ${worksrcpath} "NPM_CONFIG_UNSAFE_PERM=false ${prefix}/bin/node bin/npm-cli.js pack"
-}
-
-destroot.cmd        ${prefix}/bin/node ./bin/npm-cli.js
-destroot.args       --global ${distname}.tgz
-destroot.destdir    --prefix=${destroot}${prefix}
-
-post-destroot {
-    set completions_path ${destroot}${prefix}/share/bash-completion/completions/
-    xinstall -d ${completions_path}
-    xinstall -m 644 ${worksrcpath}/lib/utils/completion.sh ${completions_path}/npm
-}
-
-notes "
-It is not recommended to install packages globally. But if you do so\
-please be aware that they won't get cleaned up when you deactivate\
-or uninstall ${name}. Globally installed packages will remain in\
-${prefix}/lib/node_modules/ until you manually delete them.
-"
-
-livecheck.type      regex
-livecheck.url       http://registry.npmjs.org/npm
-livecheck.regex     {"latest-5":"(.*?)"}

--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -1,29 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           npm 1.0
 
-name                npm6
-version             6.14.13
+npm.setup           6.14.13
 revision            1
-categories          devel
-platforms           darwin
-supported_archs     noarch
-license             MIT
 maintainers         {ciserlohn @ci42} openmaintainer
-description         node package manager
-long_description    npm is a package manager for node. \
-                    You can use it to install and publish your node programs. \
-                    It manages dependencies and does other cool stuff.
-
-conflicts           npm3 npm4 npm5 npm7
-
-homepage            https://www.npmjs.com/
-
-master_sites        https://registry.npmjs.org/npm/-/
-
-distname            npm-${version}
-
-extract.suffix      .tgz
 
 # Please keep the sha1 - users can use it to validate sha values
 # published on npmjs.org for the package
@@ -31,18 +13,6 @@ checksums           sha1    e88bcb6c48209869c40b5cedad8a1508e58e6f30 \
                     rmd160  029ad30ceb83ba144d7c3599dfcc903abcdc010e \
                     sha256  29f58763d9bc29291ff513bcef1c1a2d75e09f8ff882010c43b4b7dcdb56ab9c \
                     size    5758507
-
-worksrcdir          "package"
-
-depends_lib         path:bin/node:nodejs16
-
-platform darwin {
-    if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs16 path:bin/node:nodejs8
-    }
-}
-
-use_configure       no
 
 patchfiles          patch-lib-update.js.diff
 
@@ -76,27 +46,3 @@ post-patch {
     }
 }
 
-build {
-    system -W ${worksrcpath} "NPM_CONFIG_UNSAFE_PERM=false ${prefix}/bin/node bin/npm-cli.js pack"
-}
-
-destroot.cmd        ${prefix}/bin/node ./bin/npm-cli.js
-destroot.args       --global ${distname}.tgz
-destroot.destdir    --prefix=${destroot}${prefix}
-
-post-destroot {
-    set completions_path ${destroot}${prefix}/share/bash-completion/completions/
-    xinstall -d ${completions_path}
-    xinstall -m 644 ${worksrcpath}/lib/utils/completion.sh ${completions_path}/npm
-}
-
-notes "
-It is not recommended to install packages globally. But if you do so\
-please be aware that they won't get cleaned up when you deactivate\
-or uninstall ${name}. Globally installed packages will remain in\
-${prefix}/lib/node_modules/ until you manually delete them.
-"
-
-livecheck.type      regex
-livecheck.url       https://registry.npmjs.org/npm
-livecheck.regex     {"latest-6":"(.*?)"}

--- a/devel/npm7/Portfile
+++ b/devel/npm7/Portfile
@@ -1,29 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           npm 1.0
 
-name                npm7
-version             7.20.1
+npm.setup           7.20.1
 revision            0
-categories          devel
-platforms           darwin
-supported_archs     noarch
-license             MIT
 maintainers         {ciserlohn @ci42} openmaintainer
-description         node package manager
-long_description    npm is a package manager for node. \
-                    You can use it to install and publish your node programs. \
-                    It manages dependencies and does other cool stuff.
-
-conflicts           npm3 npm4 npm5 npm6
-
-homepage            https://www.npmjs.com/
-
-master_sites        https://registry.npmjs.org/npm/-/
-
-distname            npm-${version}
-
-extract.suffix      .tgz
 
 # Please keep the sha1 - users can use it to validate sha values
 # published on npmjs.org for the package
@@ -31,18 +13,6 @@ checksums           rmd160  600ef152c4492793dc7a33cafd7af77d683403f8 \
                     sha1    31215a343c05611988190cedefe35a754db3c770 \
                     sha256  ed1857384642ca868eb1bea424e40086cff4a6c1f142b7d3a978fdc1b1e9902a \
                     size    3147829
-
-worksrcdir          "package"
-
-depends_lib         path:bin/node:nodejs16
-
-platform darwin {
-    if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs16 path:bin/node:nodejs8
-    }
-}
-
-use_configure       no
 
 patchfiles          patch-lib-update.js.diff
 
@@ -69,27 +39,3 @@ post-patch {
     }
 }
 
-build {
-    system -W ${worksrcpath} "NPM_CONFIG_UNSAFE_PERM=false ${prefix}/bin/node bin/npm-cli.js pack"
-}
-
-destroot.cmd        ${prefix}/bin/node ./bin/npm-cli.js
-destroot.args       --global ${distname}.tgz
-destroot.destdir    --prefix=${destroot}${prefix}
-
-post-destroot {
-    set completions_path ${destroot}${prefix}/share/bash-completion/completions/
-    xinstall -d ${completions_path}
-    xinstall -m 644 ${worksrcpath}/lib/utils/completion.sh ${completions_path}/npm
-}
-
-notes "
-It is not recommended to install packages globally. But if you do so\
-please be aware that they won't get cleaned up when you deactivate\
-or uninstall ${name}. Globally installed packages will remain in\
-${prefix}/lib/node_modules/ until you manually delete them.
-"
-
-livecheck.type      regex
-livecheck.url       https://registry.npmjs.org/npm
-livecheck.regex     {"latest":"(.*?)"}

--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           npm 1.0
 
 github.setup        yarnpkg yarn 1.22.10 v
 revision            2
@@ -32,15 +33,8 @@ checksums           rmd160  93f551f2f987a454a7f5295eb62bcc26a0e01eb2 \
                     sha256  7e433d4a77e2c79e6a7ae4866782608a8e8bcad3ec6783580577c59538381a6e \
                     size    1244965
 
-depends_run         path:bin/node:nodejs16
+depends_run         path:bin/node:nodejs[node_version yarn]
 
-platform darwin {
-    if {${os.major} < 13} {
-        depends_run-replace path:bin/node:nodejs16 path:bin/node:nodejs8
-    }
-}
-
-use_configure       no
 build {
     reinplace "s|Darwin|# Darwin|g" ${worksrcpath}/bin/yarn
 }


### PR DESCRIPTION
#### Description

As a first step in creating a javascript portgroup, this npm portgroup aims to make openly available which node versions each npm/yarn depends on.

This follows from the discussion on the [mailing list](https://lists.macports.org/pipermail/macports-dev/2021-July/043636.html). As part of this, I've also tried to refactor the npm ports by creating an `npm.setup` procedure.

I've tested this against npm6 and npm7. If errors appear in the CI for the other ports, I'll aim to correct them.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
