### PR TITLE
micronaut: update to 2.5.11

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 2.5.9 v
+github.setup    micronaut-projects micronaut-starter 2.5.11 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  093df5edd690e4faa1c3a96805a69945c67fbd59 \
-                sha256  976da995dbd3e0e29666b26eb8a579b4c4af7d1009592cce8b69e2352a5f772a \
-                size    20153076
+checksums       rmd160  9fb8a70549c7a5f57a3afeae42c14ac0eeb24351 \
+                sha256  21f64a0c05c38a7a01693202c48f013adac9ee2f0cce89c5a277fc7485964034 \
+                size    20160197
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 2.5.11.

###### Tested on

macOS 11.5 20G71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?