### PR TITLE
repo: Update to version 2.16.3

### DIFF
--- a/python/repo/Portfile
+++ b/python/repo/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
 name                repo
 epoch               20160202
-version             2.15
+github.setup        GerritCodeReview git-repo 2.16.3 v
+revision            0
 license             Apache-2
 categories          python
 platforms           darwin
@@ -20,21 +22,17 @@ long_description    \
             to make it easier to work with Git in the context of Android.
 
 homepage            https://source.android.com/source/developing.html
-master_sites        https://storage.googleapis.com/git-repo-downloads/
 
-checksums           sha256  b449697154231b531b2233272b6404316b48468b438318aa2a1943d24eba5df3 \
-                    rmd160  bd66b05256b6906b9035cfbf38b81f4e11a2c3cf \
-                    size    44704
+github.tarball_from archive
+
+checksums           rmd160  095c0c4667f664d98cd90d18fb7e60f609aee659 \
+                    sha256  27715d785c31908e150509ad5922b2b6d0f0a81abfe264df87b58656b32d81e0 \
+                    size    222810
 
 depends_run         port:git
-extract.suffix
-extract.only
+
 use_configure       no
 build               { }
 destroot            {
-        xinstall -m 755 ${distpath}/${distname} ${destroot}${prefix}/bin/${name}
+        xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
 }
-
-livecheck.type      regex
-livecheck.url       https://gerrit.googlesource.com/git-repo/
-livecheck.regex     {v(\d+(?:\.\d+)+)}


### PR DESCRIPTION
#### Description

Change fetch.type to git as the versioned script is no longer available
from storage.googleapis.com/git-repo-downloads.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
