### PR TITLE
boost176: Fix build on Tiger

### DIFF
--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -105,6 +105,14 @@ patchfiles-append patch-export_serialization_explicit_template_instantiations.di
 # p64, p32).
 patchfiles-append patch-revert-lib-name-tagged.diff
 
+# Availability.h -> AvailabilityMacros.h on Tiger
+# A better fix was accepted upstream:
+# https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
+# So this patch can be removed for Boost 1.77 or later.
+platform darwin 8 {
+    patchfiles-append patch-tiger-availability.diff
+}
+
 # see https://trac.macports.org/wiki/UsingTheRightCompiler
 patchfiles-append patch-compiler.diff
 post-patch {
@@ -133,6 +141,12 @@ mpi.setup          -gcc
 # and requiring it does make such building easier for those ports.
 configure.cxxflags-append -std=gnu++11
 compiler.cxx_standard   2011
+
+# This flag fixes the return type of unsetenv(3)
+# See: https://trac.macports.org/ticket/63121
+platform darwin 8 {
+    configure.cxxflags-append -D__DARWIN_UNIX03=1
+}
 
 # It turns out that ccache and distcc can produce boost libraries that, although they
 # compile without warning, have all sorts of runtime errors especially with pointer corruption.

--- a/devel/boost176/files/patch-tiger-availability.diff
+++ b/devel/boost176/files/patch-tiger-availability.diff
@@ -1,0 +1,11 @@
+--- boost/core/uncaught_exceptions.hpp.orig	2021-07-24 00:30:05.000000000 -0400
++++ boost/core/uncaught_exceptions.hpp	2021-07-24 00:30:21.000000000 -0400
+@@ -27,7 +27,7 @@
+ #endif
+ 
+ #if defined(__APPLE__)
+-#include <Availability.h>
++#include <AvailabilityMacros.h>
+ // Apple systems only support std::uncaught_exceptions starting with specific versions:
+ // - Mac OS >= 10.12
+ // - iOS >= 10.0


### PR DESCRIPTION
#### Description

Tiger lacks `Availability.h` and has an outdated return type for `unsetenv(3)`.

See: https://trac.macports.org/ticket/63121

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
