### PR TITLE
stern: update to 1.19.0

### DIFF
--- a/sysutils/stern/Portfile
+++ b/sysutils/stern/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/wercker/stern 1.11.0
+go.setup            github.com/stern/stern 1.19.0 v
 maintainers         {breun.nl:nils @breun} openmaintainer
 platforms           darwin
 categories          sysutils
@@ -16,15 +16,17 @@ long_description    Stern allows you to tail multiple pods on Kubernetes and \
                     multiple containers within the pod. Each result is color \
                     coded for quicker debugging.
 
-homepage            https://github.com/wercker/stern
+checksums           rmd160  32298f4ee835c906883fa0e9d5df6b053617980f \
+                    sha256  d7d0349f37aab5158bf667317a2b843c2244eec4dc6e39053d0a6faf5312af25 \
+                    size    97275
 
-checksums           rmd160  655f16bb2c359778e396fae746df0ad89ed159d7 \
-                    sha256  e42e343052f4de3c050d2c856139841ead24afdf08d40e4e2cdda1fcac687c77 \
-                    size    24394
+set go_ldflags      "-s -w -X ${go.package}/cmd.version=${version}"
+build.args          -ldflags \"${go_ldflags}\" -o bin/${name}
 
-depends_build-append port:govendor
-
-build.cmd           govendor sync && go build -o bin/${name}
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies during the build phase. See
+# https://trac.macports.org/ticket/61192
+build.env-delete    GOPROXY=off GO111MODULE=off
 
 destroot {
     xinstall -m 755 ${worksrcpath}/bin/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
#### Description

Update to Stern 1.19.0. Switched from unmaintained https://github.com/wercker/stern to https://github.com/stern/stern.

###### Tested on

macOS 11.5 20G71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?