### PR TITLE
allows aften to compile on apple silicon

### DIFF
--- a/audio/aften/Portfile
+++ b/audio/aften/Portfile
@@ -24,9 +24,10 @@ long_description    \
 master_sites        sourceforge:project/aften/aften/${version}
 use_bzip2           yes
 
-# two patches to fix build on PPC
+# two patches to fix build on PPC, one for apple silicon
 patchfiles          patch-aften-ppc-missingheader.diff \
-                    patch-ppc-altivec-flag.diff
+                    patch-ppc-altivec-flag.diff \
+                    patch-fix-apple-silicon.diff
 
 configure.args-append \
                     -DSHARED=On \

--- a/audio/aften/files/patch-fix-apple-silicon.diff
+++ b/audio/aften/files/patch-fix-apple-silicon.diff
@@ -1,0 +1,10 @@
+--- a/libaften/cpu_caps.h
++++ b/libaften/cpu_caps.h
+@@ -26,6 +26,7 @@
+ #include "ppc_cpu_caps.h"
+ #else
+ static inline void cpu_caps_detect(void){}
++static inline void apply_simd_restrictions(AftenSimdInstructions *simd_instructions){}
+ #endif
+
+ #endif /* CPU_CAPS_H */

--- a/audio/aften/files/patch-fix-apple-silicon.diff
+++ b/audio/aften/files/patch-fix-apple-silicon.diff
@@ -1,5 +1,5 @@
---- a/libaften/cpu_caps.h
-+++ b/libaften/cpu_caps.h
+--- libaften/cpu_caps.h
++++ libaften/cpu_caps.h
 @@ -26,6 +26,7 @@
  #include "ppc_cpu_caps.h"
  #else


### PR DESCRIPTION
#### Description
Fixes http://mac-os-forge.2317878.n4.nabble.com/62196-aften-0-0-8-error-implicit-declaration-of-function-apply-simd-restrictions-is-invalid-in-C99-td412202.html#a412204

Adds the fix for compilation on apple silicon implemented by @robertchin at https://github.com/robertchin/homebrew-core/blob/1ca70f36d0959306ba6ab9904269d8854055b2da/Formula/aften.rb

###### Type(s)
Update to after port

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 arm64
Xcode 12.5.1 12E507

###### Verification 
Have you

- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?