### PR TITLE
pywhat: remove `what` binary

### DIFF
--- a/security/pywhat/Portfile
+++ b/security/pywhat/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                pywhat
 version             3.2.0
-revision            0
+revision            1
 categories-prepend  security
 platforms           darwin
 license             GPL-3
@@ -26,6 +26,11 @@ homepage            https://github.com/bee-san/pyWhat
 checksums           rmd160 533e39ba38313f5de6d96470185a4073d5de7e9e \
                     sha256 48d15667949976e1f385dc1d96ce71e34c55997d51d45189f7770811f7ac11d1 \
                     size   45473
+
+# 'what' binary conflicts with developer_cmds
+# 'pywhat' binary does the same thing and is still available
+# See https://trac.macports.org/ticket/63286
+patchfiles          patch-pywhat-bin.diff
 
 depends_lib-append  port:py${python.version}-setuptools
 

--- a/security/pywhat/files/patch-pywhat-bin.diff
+++ b/security/pywhat/files/patch-pywhat-bin.diff
@@ -1,0 +1,11 @@
+--- setup.py.orig	2021-07-25 12:10:28.000000000 +0100
++++ setup.py	2021-07-25 12:11:12.000000000 +0100
+@@ -11,7 +11,7 @@
+ ['click>=7.1.2,<8.0.0', 'name_that_hash>=1.7.0,<2.0.0', 'rich>=9.9,<11.0']
+ 
+ entry_points = \
+-{'console_scripts': ['pywhat = pywhat.what:main', 'what = pywhat.what:main']}
++{'console_scripts': 'pywhat = pywhat.what:main'}
+ 
+ setup_kwargs = {
+     'name': 'pywhat',


### PR DESCRIPTION
`pywhat` binary still available, and does the same thing.

Closes: https://trac.macports.org/ticket/63286

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
