### PR TITLE
ffmpeg: Add a patch for an upstream bug

### DIFF
--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -18,7 +18,7 @@ conflicts           ffmpeg-devel
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               1
 version             4.4
-revision            1
+revision            2
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer
@@ -92,6 +92,12 @@ depends_lib         port:lame \
                     port:zlib
 
 patchfiles          patch-libavcodec-audiotoolboxenc.c.diff
+
+# fix an upstream bug that overrides the max_b_frames setting
+# https://trac.ffmpeg.org/ticket/9231
+# this bug is fixed upstream in commit 55d9d6767967794edcdd6e1bbd8840fc6f4e9315
+# and should therefore be available in the next release version.
+patchfiles-append   patch-libavcodec-videotoolboxenc.c.diff
 
 # enable auto configure of asm optimizations
 # requires Xcode 3.1 or better on Leopard

--- a/multimedia/ffmpeg/files/patch-libavcodec-videotoolboxenc.c.diff
+++ b/multimedia/ffmpeg/files/patch-libavcodec-videotoolboxenc.c.diff
@@ -1,0 +1,10 @@
+--- libavcodec/videotoolboxenc.c
++++ libavcodec/videotoolboxenc.c
+@@ -1398,7 +1398,6 @@ static int vtenc_configure_encoder(AVCodecContext *avctx)
+     }
+ 
+     vtctx->codec_id = avctx->codec_id;
+-    avctx->max_b_frames = 16;
+ 
+     if (vtctx->codec_id == AV_CODEC_ID_H264) {
+         vtctx->get_param_set_func = CMVideoFormatDescriptionGetH264ParameterSetAtIndex;


### PR DESCRIPTION
#### Description

There is a bug in the VideoToolbox encoder of ffmpeg that overrides the max_b_frame settings (http://trac.ffmpeg.org/ticket/9231). This commit introduces a patch files that fixes the bug until there is a functioning release with this fix.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
