### PR TITLE
nmap: remove subversion variant

### DIFF
--- a/net/nmap/Portfile
+++ b/net/nmap/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		nmap
 version		7.91
+revision	1
 categories	net
 maintainers	darkart.com:opendarwin.org {geeklair.net:dluke @danielluke}
 description	Port scanning utility for large networks
@@ -56,7 +57,7 @@ configure.env ac_cv_header_lua_h=no
 use_parallel_build	no
 configure.ccache	no
 
-default_variants +subversion +ssl +pcre
+default_variants +ssl +pcre
 
 variant ssl description {build with ssl support} {
 			configure.args-append --with-openssl=${prefix}
@@ -66,11 +67,6 @@ variant ssl description {build with ssl support} {
 variant pcre description {build with pcre support} {
 			configure.args-append --with-pcre=${prefix}
 			depends_lib-append port:pcre
-		}
-
-variant subversion description {build with subversion (nmap-update) support} {
-			configure.args-delete --without-subversion
-			depends_lib-append port:subversion
 		}
 
 variant zenmap description {build zenmap in addition to nmap} {


### PR DESCRIPTION
Problem

the `nmap-update` command was removed in 7.90 and never had fully
functional infrastructure. Further, it causes a default dependency on
subversion.

Solution

Remove `subversion` variant

See Also

https://nmap.org/changelog.html
> Removed nmap-update. This program was intended to provide a way to
> update data files and NSE scripts, but the infrastructure was never
> fielded. It depended on Subversion version control and would have
> required maintaining separate versions of NSE scripts for compatibility.

Note that the upstream build system does not appear to have fully
removed references so `--without-subversion` still is required.


Tested on

macOS 10.14.6 18G9216 x86_64
Xcode 11.3.1 11C504
