### PR TITLE
gdb-apple: PowerPC support

### DIFF
--- a/devel/gdb-apple/Portfile
+++ b/devel/gdb-apple/Portfile
@@ -28,7 +28,7 @@ can run on most popular UNIX and Microsoft Windows variants.
 
 homepage        http://opensource.apple.com/source/gdb
 platforms       darwin
-supported_archs x86_64 i386
+supported_archs x86_64 i386 ppc
 
 # xm.h can be created out of order
 use_parallel_build no
@@ -43,7 +43,21 @@ depends_build   port:gettext port:zlib port:flex port:texinfo
 
 depends_lib     port:libiconv port:ncurses port:sqlite3
 
-patchfiles	patch-macosx-nat.c.diff
+patchfiles      patch-macosx-nat.c.diff
+
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    patchfiles-append \
+                patch-macosx-tdep.c.diff \
+                patch-macosx-nat-threads.c.diff \
+                patch-gdb-availability.diff
+
+    if {${os.major} == 8} {
+        depends_build-append port:libmacho-headers
+        patchfiles-append \
+                patch-macosx-nat-info.c.diff \
+                patch-include-libiberty.h.diff
+    }
+}
 
 worksrcdir	${worksrcdir}/src
 
@@ -55,7 +69,7 @@ post-patch {
         ${worksrcpath}/bfd/configure.host
 
     # https://trac.macports.org/ticket/63153
-     reinplace "s|\$(SDKROOT)/usr/bin/mig|/usr/bin/mig|" \
+    reinplace "s|\$(SDKROOT)/usr/bin/mig|/usr/bin/mig|" \
         ${worksrcpath}/gdb/config/i386/macosx.mh \
         ${worksrcpath}/gdb/config/powerpc/macosx.mh
 }
@@ -76,8 +90,10 @@ destroot.args \
     LEXLIB="${prefix}/lib/libfl.a"
 
 post-destroot {
-    system "chgrp procmod ${destroot}${prefix}/bin/*-apple"
-    system "chmod g+s ${destroot}${prefix}/bin/*-apple"
+    if { ${os.arch} ne "powerpc" } {
+        system "chgrp procmod ${destroot}${prefix}/bin/*-apple"
+        system "chmod g+s ${destroot}${prefix}/bin/*-apple"
+    }
 
     foreach info [glob -tails -directory ${destroot}${prefix}/share/info g*] {
         move ${destroot}${prefix}/share/info/${info} ${destroot}${prefix}/share/info/apple-${info}

--- a/devel/gdb-apple/files/patch-gdb-availability.diff
+++ b/devel/gdb-apple/files/patch-gdb-availability.diff
@@ -1,0 +1,207 @@
+Check for spawn.h, execinfo.h, and libproc.h and block out sections of code
+where related system functions are not available. This enables compilation
+on 10.4 and 10.5.
+
+--- gdb/config.in.orig
++++ gdb/config.in
+@@ -124,6 +124,9 @@
+ /* Define to 1 if you have the <dlfcn.h> header file. */
+ #undef HAVE_DLFCN_H
+ 
++/* Define to 1 if you have the <execinfo.h> header file. */
++#undef HAVE_EXECINFO_H
++
+ /* Define to 1 if you have the `fork' function. */
+ #undef HAVE_FORK
+ 
+@@ -169,6 +172,9 @@
+ /* Define to 1 if you have the `m' library (-lm). */
+ #undef HAVE_LIBM
+ 
++/* Define to 1 if you have the <libproc.h> header file. */
++#undef HAVE_LIBPROC_H
++
+ /* Define if libunwind library is being used. */
+ #undef HAVE_LIBUNWIND
+ 
+@@ -337,6 +343,9 @@
+ /* Define to 1 if the system has the type `socklen_t'. */
+ #undef HAVE_SOCKLEN_T
+ 
++/* Define to 1 if you have the <spawn.h> header file. */
++#undef HAVE_SPAWN_H
++
+ /* Define to 1 if you have the <stddef.h> header file. */
+ #undef HAVE_STDDEF_H
+ 
+--- gdb/configure.ac.orig
++++ gdb/configure.ac
+@@ -524,7 +524,7 @@ AC_CHECK_HEADERS(sys/user.h, [], [],
+ ])
+ AC_CHECK_HEADERS(sys/wait.h wait.h)
+ AC_CHECK_HEADERS(termios.h termio.h sgtty.h)
+-AC_CHECK_HEADERS(unistd.h)
++AC_CHECK_HEADERS(unistd.h spawn.h execinfo.h libproc.h)
+ 
+ # On Solaris 2.[789], we need to define _MSE_INT_H to avoid a clash
+ # between <widec.h> and <wchar.h> that would cause AC_CHECK_HEADERS to
+--- gdb/configure.orig
++++ gdb/configure
+@@ -27720,7 +27720,7 @@ fi
+ done
+ 
+ 
+-for ac_header in unistd.h
++for ac_header in unistd.h spawn.h execinfo.h libproc.h
+ do
+ as_ac_Header=`echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ if { as_var=$as_ac_Header; eval "test \"\${$as_var+set}\" = set"; }; then
+--- gdb/macosx/macosx-nat-dyld.c.orig
++++ gdb/macosx/macosx-nat-dyld.c
+@@ -791,7 +791,7 @@ macosx_locate_dyld_via_taskinfo (macosx_dyld_thread_status *s)
+        }
+      else
+        {
+-#if defined (NM_NEXTSTEP)
++#if defined (NM_NEXTSTEP) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+           if (macosx_status->task == TASK_NULL)
+             return 0;
+ 
+--- gdb/macosx/macosx-nat-inferior.c.orig
++++ gdb/macosx/macosx-nat-inferior.c
+@@ -60,13 +60,18 @@
+ #include <sys/sysctl.h>
+ #include <sys/proc.h>
+ #include <mach/mach_error.h>
++#ifdef HAVE_SPAWN_H
+ #include <spawn.h>
++#endif
+ 
+ #include <semaphore.h>
+ 
+ #include <dlfcn.h>
++#ifdef HAVE_LIBPROC_H
+ #include <libproc.h>
+ #include <sys/proc_info.h>
++#endif
++#include <AvailabilityMacros.h>
+ 
+ #include "macosx-nat-dyld.h"
+ #include "macosx-nat-inferior.h"
+@@ -2701,6 +2706,7 @@ macosx_get_thread_name (ptid_t ptid)
+   if (tp->private == NULL || tp->private->app_thread_port == 0)
+     return NULL;
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+   thread_identifier_info_data_t tident;
+   unsigned int info_count;
+   kern_return_t kret;
+@@ -2728,6 +2734,7 @@ macosx_get_thread_name (ptid_t ptid)
+             }
+         }
+     }
++#endif /* MAC_OS_X_VERSION_MIN_REQUIRED >= 1050 */
+   return buf;
+ }
+ 
+--- gdb/macosx/macosx-nat-infthread.c
++++ gdb/macosx/macosx-nat-infthread.c
+@@ -36,8 +36,11 @@
+ #include <sys/dir.h>
+ #include <inttypes.h>
+ 
++#ifdef HAVE_LIBPROC_H
+ #include <libproc.h>
+ #include <sys/proc_info.h>
++#endif
++#include <AvailabilityMacros.h>
+ 
+ #include "macosx-nat-inferior.h"
+ #include "macosx-nat-inferior-util.h"
+@@ -810,6 +813,7 @@ print_thread_info (thread_t tid, int *gdb_thread_id)
+     print_stack_frame (get_selected_frame (NULL), 0, LOCATION);
+     switch_to_thread (current_ptid);
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+   thread_identifier_info_data_t tident;
+   info_count = THREAD_IDENTIFIER_INFO_COUNT;
+   kret = thread_info (tid, THREAD_IDENTIFIER_INFO, (thread_info_t) &tident, 
+@@ -879,6 +883,7 @@ print_thread_info (thread_t tid, int *gdb_thread_id)
+       printf_filtered ("\tcurrent priority: %d\n", pth.pth_priority);
+       printf_filtered ("\tmax priority: %d\n", pth.pth_maxpriority);
+     }
++#endif /* MAC_OS_X_VERSION_MIN_REQUIRED >= 1050 */
+ 
+   printf_filtered ("\tsuspend count: %d", info.suspend_count);
+ 
+@@ -1176,6 +1181,7 @@ macosx_print_thread_details (struct ui_out *uiout, ptid_t ptid)
+   ui_out_field_fmt (uiout, "mach-port-number", "0x%s", 
+                     paddr_nz (app_thread_name));
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+   thread_identifier_info_data_t tident;
+   info_count = THREAD_IDENTIFIER_INFO_COUNT;
+   kret = thread_info (tid, THREAD_IDENTIFIER_INFO, (thread_info_t) &tident, 
+@@ -1208,6 +1214,7 @@ macosx_print_thread_details (struct ui_out *uiout, ptid_t ptid)
+                               paddr_nz (struct_addr));
+         }
+     }
++#endif /* MAC_OS_X_VERSION_MIN_REQUIRED >= 1050 */
+ }
+ 
+ 
+--- gdb/remote.c
++++ gdb/remote.c
+@@ -64,7 +64,10 @@
+ #include "macosx-nat-dyld.h"
+ #include "macosx-nat-dyld-process.h"
+ #endif
++#ifdef HAVE_EXECINFO_H
+ #include <execinfo.h>
++#endif
++#include <AvailabilityMacros.h>
+ 
+ /* Prototypes for local functions.  */
+ static void cleanup_sigint_signal_handler (void *dummy);
+@@ -478,11 +481,13 @@ struct memory_packet_config
+ static void
+ remote_backtrace_self (const char *message)
+ {
++#if (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+   void *bt_buffer[100];
+   int count = backtrace (bt_buffer, 100);
+   if (message && message[0])
+     fprintf_filtered (gdb_stderr, "%s", message);
+   backtrace_symbols_fd (bt_buffer, count, STDERR_FILENO);
++#endif
+ }
+ 
+ static void
+--- gdb/utils.c
++++ gdb/utils.c
+@@ -28,7 +28,10 @@
+ #include "event-top.h"
+ #include "exceptions.h"
+ #include "bfd.h"
++#ifdef HAVE_EXECINFO_H
+ #include <execinfo.h>
++#endif
++#include <AvailabilityMacros.h>
+ #include <sys/resource.h>
+ #include <uuid/uuid.h>
+ #include <regex.h>
+@@ -882,12 +885,14 @@ internal_vproblem (struct internal_problem *problem,
+ 
+   /* APPLE LOCAL: Do a stack crawl of how we got here so we're more likely
+      to get useful bug reports.  */
++#if (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+   {
+     void *bt_buffer[15];
+     int count = backtrace (bt_buffer, 15);
+     fprintf (stderr, "gdb stack crawl at point of internal error:\n");
+     backtrace_symbols_fd (bt_buffer, count, STDERR_FILENO);
+   }
++#endif
+ 
+   /* Create a string containing the full error/warning message.  Need
+      to call query with this full string, as otherwize the reason

--- a/devel/gdb-apple/files/patch-include-libiberty.h.diff
+++ b/devel/gdb-apple/files/patch-include-libiberty.h.diff
@@ -1,0 +1,16 @@
+There's a bug in the configure script that thinks basename is not declared.
+Normally this isn't a problem, but on Tiger the argument is "const char *"
+which conflicts with the manually provided definition below. So this patch is
+needed on Tiger only.
+
+--- include/libiberty.h.orig
++++ include/libiberty.h
+@@ -96,7 +96,7 @@
+ #if !HAVE_DECL_BASENAME
+   /* APPLE LOCAL basename */
+ #if defined (__GNU_LIBRARY__ ) || defined (__linux__) || defined (__FreeBSD__) || defined (__OpenBSD__) || defined(__NetBSD__) || defined (__APPLE__) || defined (__CYGWIN__) || defined (__CYGWIN32__) || defined (__MINGW32__) || defined (HAVE_DECL_BASENAME)
+-extern char *basename (char *);
++extern char *basename (const char *);
+ #else
+ /* Do not allow basename to be used if there is no prototype seen.  We
+    either need to use the above prototype or have one from

--- a/devel/gdb-apple/files/patch-macosx-nat-info.c.diff
+++ b/devel/gdb-apple/files/patch-macosx-nat-info.c.diff
@@ -1,0 +1,40 @@
+Use the old underscore-free struct field names - patch should be applied only
+on Tiger.
+
+--- gdb/macosx/macosx-nat-info.c.orig
++++ gdb/macosx/macosx-nat-info.c
+@@ -268,8 +268,8 @@
+   {
+     union
+     {
+-      struct __darwin_ppc_thread_state thread;
+-      struct __darwin_ppc_exception_state exception;
++      ppc_thread_state_t thread;
++      ppc_exception_state_t exception;
+     } thread_state;
+     int register_count, i;
+     unsigned int *register_data;
+@@ -282,7 +282,7 @@
+     MACH_CHECK_ERROR (result);
+ 
+     printf_unfiltered ("\nPPC_THREAD_STATE \n");
+-    register_data = &thread_state.thread.__r0;
++    register_data = &thread_state.thread.r0;
+     register_count = 0;
+     for (i = 0; i < 8; ++i)
+       {
+@@ -297,11 +297,11 @@
+       }
+ 
+     printf_unfiltered ("srr0: 0x%08x    srr1: 0x%08x\n",
+-                       thread_state.thread.__srr0, thread_state.thread.__srr1);
++                       thread_state.thread.srr0, thread_state.thread.srr1);
+     printf_unfiltered ("cr:   0x%08x    xer:  0x%08x\n",
+-                       thread_state.thread.__cr, thread_state.thread.__xer);
++                       thread_state.thread.cr, thread_state.thread.xer);
+     printf_unfiltered ("lr:   0x%08x    ctr:  0x%08x\n",
+-                       thread_state.thread.__lr, thread_state.thread.__ctr);
++                       thread_state.thread.lr, thread_state.thread.ctr);
+   }
+ #endif
+ }

--- a/devel/gdb-apple/files/patch-macosx-nat-threads.c.diff
+++ b/devel/gdb-apple/files/patch-macosx-nat-threads.c.diff
@@ -1,0 +1,15 @@
+Fix a hang observed on a Tiger/PPC system when attempting to end a debugging
+session. pthread_detach is essentially an asynchronous pthread_join, so this
+shouldn't have any side effects, but apply at your own discretion.
+
+--- gdb/macosx/macosx-nat-threads.c.orig
++++ gdb/macosx/macosx-nat-threads.c
+@@ -46,7 +46,7 @@
+ 
+   ret = pthread_cancel (pthread);
+ 
+-  ret = pthread_join (pthread, NULL);
++  ret = pthread_detach (pthread);
+   if (ret != 0)
+     {
+       warning ("Unable to join to canceled thread: %s (%d)", strerror (errno),

--- a/devel/gdb-apple/files/patch-macosx-tdep.c.diff
+++ b/devel/gdb-apple/files/patch-macosx-tdep.c.diff
@@ -1,0 +1,16 @@
+Fixes compilation targeting 10.4 and 10.5
+
+--- gdb/macosx/macosx-tdep.c.orig
++++ gdb/macosx/macosx-tdep.c
+@@ -1558,7 +1558,11 @@
+   if (plist_data == NULL)
+     return NULL;
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++  CFPropertyListRef plist = CFPropertyListCreateFromXMLData (kCFAllocatorDefault, plist_data, kCFPropertyListImmutable, NULL);
++#else
+   CFPropertyListRef plist = CFPropertyListCreateWithData (kCFAllocatorDefault, plist_data, kCFPropertyListImmutable, NULL, NULL);
++#endif
+ 
+   if (plist == NULL || CFGetTypeID (plist) != CFDictionaryGetTypeID())
+     {


### PR DESCRIPTION
#### Description

Enable building on PowerPC (10.4+) with the supplied patches. PPC64 debugging is not supported.

To circumvent a hang witnessed on Tiger/PPC, replace a call to `pthread_join` with `pthread_detach`. It's possible that this change introduces a thread leak on 10.4/10.5, but the program appears to function normally.

Tiger's native GDB has Apple revision 696, so this port will make 1000+ commits available on that platform.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
