### PR TITLE
hugo: update to 0.86.0

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.85.0 v
+go.setup            github.com/gohugoio/hugo 0.86.0 v
 revision            0
-checksums           rmd160  26c566f497a615736be590ec2121ce3358111b57 \
-                    sha256  a2eee56b6edf660fd7814041963e9e6f6fe9a59c19fddeb14694e9959a681fe9 \
-                    size    38969502
+checksums           rmd160  ce932bd78e2fa805a64c504c62f2ebcda6e00b1a \
+                    sha256  9cb27816c7744739819a118e670c2e3b3c818b8fd01bf8425b3f1c414aeded5f \
+                    size    39138767
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.86.0

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
