### PR TITLE
nautilus: require +x11 variant for gtk3

### DIFF
--- a/gnome/nautilus/Portfile
+++ b/gnome/nautilus/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           active_variants 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           gobject_introspection 1.0
 
@@ -22,7 +23,8 @@ master_sites        gnome:sources/${name}/${branch}/
 use_xz              yes
 
 checksums           rmd160  f636f18f3af8e4bc87b3b0632255c051234e9116 \
-                    sha256  357d9d051fcc2c385ce9b3beb2db2ea1874b7cdf507ca10274a063023e1a61b3
+                    sha256  357d9d051fcc2c385ce9b3beb2db2ea1874b7cdf507ca10274a063023e1a61b3 \
+                    size    5143440
 
 depends_build       port:pkgconfig
 
@@ -38,6 +40,8 @@ depends_lib         port:desktop-file-utils \
                     port:xorg-libX11
 
 depends_run         port:adwaita-icon-theme
+
+require_active_variants gtk3 x11
 
 gobject_introspection yes
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/62947
(I'm also adding a size checksum while I'm at it)

#### Description
See linked Trac bug

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.5 20G71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Note that I have only tested that building fails properly when gtk3 is installed without the `+x11` variant; I haven't actually tested trying to do a successful install, since that would require reinstalling gtk3 and possibly breaking my entire setup.
