### PR TITLE
directory-studio: simplify Portfile

### DIFF
--- a/databases/directory-studio/Portfile
+++ b/databases/directory-studio/Portfile
@@ -23,32 +23,21 @@ homepage                    https://directory.apache.org/studio/
 master_sites                https://downloads.apache.org/directory/studio/${version}/
 
 distname                    ApacheDirectoryStudio-${version}-macosx.cocoa.x86_64
-extract.suffix              .dmg
+use_dmg                     yes
 
 checksums                   rmd160  d1379aec14bc326ca97eceba220379c8f25531cb \
                             sha256  1f024ed122256ec69cc148ff628ed3103f47e95d3cdd0b66ed806afcc68d29ec \
                             size    141019379
 
-extract                     {
-                            file mkdir /tmp/${distname}
-                            system "hdiutil attach ${distpath}/${distfiles} -private -nobrowse -mountpoint /tmp/${distname}"
-                            }
-
 java.version                1.8+
 java.fallback               openjdk11
 
 use_configure               no
-
 build                       {}
 
-destroot                    {
-                            copy /tmp/${distname}/ApacheDirectoryStudio.app ${destroot}${applications_dir}
-                            }
-
-post-destroot               {
-                            system "hdiutil detach /tmp/${distname}"
-                            delete /tmp/${distname}
-                            }
+destroot {
+    copy ${worksrcpath}/ApacheDirectoryStudio.app ${destroot}${applications_dir}
+}
 
 livecheck.type              regex
 livecheck.url               ${homepage}/update/product/compositeContent.xml


### PR DESCRIPTION
###### Tested on

macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?