### PR TITLE
fluidsynth: Fix build on Tiger/Leopard

### DIFF
--- a/multimedia/fluidsynth/Portfile
+++ b/multimedia/fluidsynth/Portfile
@@ -42,6 +42,10 @@ depends_lib         port:flac \
 
 depends_run-append  port:generaluser-soundfont
 
+# Remove with fluidsynth 2.2.3 or later
+# https://trac.macports.org/ticket/63230
+patchfiles-append   patch-pre-snow-leopard.diff
+
 # https://trac.macports.org/ticket/36962
 platform darwin 8 {
     patchfiles-append \

--- a/multimedia/fluidsynth/files/patch-pre-snow-leopard.diff
+++ b/multimedia/fluidsynth/files/patch-pre-snow-leopard.diff
@@ -1,0 +1,49 @@
+--- src/drivers/fluid_coreaudio.c.orig
++++ src/drivers/fluid_coreaudio.c
+@@ -187,14 +187,22 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func
+     dev->data = data;
+ 
+     // Open the default output unit
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    ComponentDescription desc;
++#else
+     AudioComponentDescription desc;
++#endif
+     desc.componentType = kAudioUnitType_Output;
+     desc.componentSubType = kAudioUnitSubType_HALOutput; //kAudioUnitSubType_DefaultOutput;
+     desc.componentManufacturer = kAudioUnitManufacturer_Apple;
+     desc.componentFlags = 0;
+     desc.componentFlagsMask = 0;
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    Component comp = FindNextComponent(NULL, &desc);
++#else
+     AudioComponent comp = AudioComponentFindNext(NULL, &desc);
++#endif
+ 
+     if(comp == NULL)
+     {
+@@ -202,7 +210,11 @@ new_fluid_core_audio_driver2(fluid_settings_t *settings, fluid_audio_func_t func
+         goto error_recovery;
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    status = OpenAComponent(comp, &dev->outputUnit);
++#else
+     status = AudioComponentInstanceNew(comp, &dev->outputUnit);
++#endif
+ 
+     if(status != noErr)
+     {
+@@ -372,7 +384,11 @@ delete_fluid_core_audio_driver(fluid_audio_driver_t *p)
+     fluid_core_audio_driver_t *dev = (fluid_core_audio_driver_t *) p;
+     fluid_return_if_fail(dev != NULL);
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    CloseComponent(dev->outputUnit);
++#else
+     AudioComponentInstanceDispose(dev->outputUnit);
++#endif
+ 
+     if(dev->buffers[0])
+     {


### PR DESCRIPTION
#### Description

A number of Core Audio symbols were renamed in 10.6, with the old names dropped in macOS 11.0.

See: https://trac.macports.org/ticket/63230

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
