### PR TITLE
nco: update to 5.0.1

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.0.0
+github.setup        nco nco 5.0.1
 revision            1
 platforms           darwin
 maintainers         {takeshi @tenomoto}
@@ -19,9 +19,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  9926c6725bfb9cfd3ca42204636649e609871e1f \
-                    sha256  1ab272a302a2b85380b71aa85ee4a2abb8381eb9a24066e224810ae7d2ca8b79 \
-                    size    5406941
+checksums           rmd160  759b84bdec4fe3e955681069a9ddf8904399b88d \
+                    sha256  0e4936c87c390adca2c6d9716b26104f463156afe72a7cc0c525adf0a85ae066 \
+                    size    5409256
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Update to upstream version 5.0.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5 20G71 x86_64
Xcode Command Line Tools 12.5.1.0.1.1623191612

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
