### PR TITLE
robodoc: patches to Portfile and source

### DIFF
--- a/devel/robodoc/Portfile
+++ b/devel/robodoc/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                robodoc
 version             4.99.41
+revision            1
 categories          devel
 license             GPL-3+
 platforms           darwin
@@ -21,15 +22,13 @@ homepage            http://www.xs4all.nl/~rfsber/Robo/${name}.html
 master_sites        http://www.xs4all.nl/~rfsber/Robo/
 
 checksums           rmd160  5bf25607da0598de726c76dd8f32cb2b884bb295 \
-                    sha256  6a35993bcb7df46143149c46eb500d62a4fb0f0dcab3700a42b7d38656abd2b9
+                    sha256  6a35993bcb7df46143149c46eb500d62a4fb0f0dcab3700a42b7d38656abd2b9 \
+                    size    299656
+
+patchfiles          troff_generator.c.diff
 
 configure.args      --mandir="${prefix}/share/man"
 
 destroot.destdir    prefix="${destroot}${prefix}" \
                     docdir="${destroot}${prefix}/share/doc/${name}" \
                     mandir="${destroot}${prefix}/share/man"
-
-post-destroot {
-    reinplace "s|/usr/share|${prefix}/share/doc|" \
-              "${destroot}${prefix}/share/man/man1/robodoc.1"
-}

--- a/devel/robodoc/files/troff_generator.c.diff
+++ b/devel/robodoc/files/troff_generator.c.diff
@@ -1,0 +1,11 @@
+--- Source/troff_generator.c.orig	2011-02-02 23:45:37.000000000 +0100
++++ Source/troff_generator.c    2021-07-27 17:48:02.000000000 +0200
+@@ -30,7 +30,7 @@
+ #include <ctype.h>
+ 
+ #include <sys/param.h>
+-#include <sys/unistd.h>
++#include <unistd.h>
+ 
+ #include "troff_generator.h"
+ #include "util.h"


### PR DESCRIPTION
#### Description

* Source/troff_generator.c: replace <sys/unistd.h> with <unistd.h>
* Added recommended "size" to checksums section
* Removed post-destroot section as it was not doing anything

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5 20G71 x86_64
Xcode Command Line Tools 12.5.1.0.1.1623191612


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
