### PR TITLE
openjdk: update to Azul Zulu OpenJDK 16.0.2

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -476,14 +476,10 @@ subport openjdk16-openj9 {
 }
 
 subport openjdk16-zulu {
-    if {${configure.build_arch} eq "x86_64"} {
-        version      16.30.15
-    } elseif {${configure.build_arch} eq "arm64"} {
-        version      16.30.19
-    }
+    version      16.32.15
     revision     0
 
-    set openjdk_version 16.0.1
+    set openjdk_version 16.0.2
 
     description  Azul Zulu Community OpenJDK 16 (Short Term Support)
     long_description ${long_description_zulu}
@@ -492,14 +488,14 @@ subport openjdk16-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  8cadf828e853a739b3860dc4e2066c6713e3baac \
-                     sha256  1f403942ce9f0ba7bfd3f5e0b2f9cae68fcafd4f08cb048b4fb9d75644b030ca \
-                     size    206494507
+        checksums    rmd160  c3d712e53d18bf01d764da601b8afdf3376c38e9 \
+                     sha256  3578018ff2a2c5392768261ba3707eacea35d4d2261f90835085342e14c2b4ca \
+                     size    206557323
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  c8302a50ead48af69b715f5b74ba242c9012b05e \
-                     sha256  9c50ea8a1bbe5045164cbc6f244efab99a66595b8a1947356c653135ba640bc4 \
-                     size    195103125
+        checksums    rmd160  87bf44f3809a19911c2b013cb44c0d92d083314e \
+                     sha256  ddb51f0dc2cbc9a84b7944450202c055aa41647beab5a9bc1876d64c0e8c4288 \
+                     size    195130848
     }
 
     worksrcdir   ${distname}/zulu-16.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 16.0.2 (Zulu 16.32.15).

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?