### PR TITLE
google-cloud-sdk: update to 350.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             349.0.0
+version             350.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1cf167b86aa656015a5ac7a8c3e66b6c04fab4b7 \
-                    sha256  6b4d9b8aa91f0c647f97967e21daa71fc8a7c843f36e1832d5562f2cce0667da \
-                    size    90625752
+    checksums       rmd160  c02e4d83d560c9b504d90e55fc90bdc8a44efe51 \
+                    sha256  a20157ac9974b02b329d53fb1de0d79b6a5fc97844e71f47e22b59aa5fb652d5 \
+                    size    90655783
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  50f46754a95ff2b986375974e80431131fd1c6a7 \
-                    sha256  94f4a277921a6942f337b0db15c5ae1c44949822af41a8a8ce9746ca8f6a6138 \
-                    size    86873422
+    checksums       rmd160  807dfb666e4b294dad8d227a310341fb65906f9a \
+                    sha256  d3b995a4b8d0d5a2181d98298ca31020f406c323bc51889a4e3a7aefc346963e \
+                    size    86905628
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  1672e80c30048d54f7dab5bf298cc1e9ed888286 \
-                    sha256  ab834e7cc081ebf4acf271951defcb9e7d8db9a1fd910bdce332489b1c999c43 \
-                    size    86795240
+    checksums       rmd160  4561b35f836af5a8f05338e8005baf7d66f572fd \
+                    sha256  8af64643437114658c58d2fa75c58ee830737e04268a650f2992972b5440f1f3 \
+                    size    86826922
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 350.0.0.

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?