### PR TITLE
openssh: Fix build on 10.4/10.5

### DIFF
--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -111,7 +111,10 @@ if {${name} eq ${subport}} {
     use_parallel_build  yes
 
     platform macosx {
-        if {${os.major} <= 11} {
+        if {${os.major} < 10} {
+            # See: https://trac.macports.org/ticket/60385
+            configure.args-delete   --with-keychain=apple
+        } elseif {${os.major} <= 11} {
             # clang is required to build the new Apple Keychain integration due
             # to it using the Object Subscripting feature, c.f. #59397.
             # We'll keep it simple and just blacklist any gcc version, cc


### PR DESCRIPTION
#### Description

Disable Keychain integration (and GCC blacklist) on older systems.

Closes: https://trac.macports.org/ticket/60385
Closes: https://trac.macports.org/ticket/60879

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
