### PR TITLE
k9s: make build reproducible

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/derailed/k9s 0.24.14 v
-revision            0
+revision            1
 
 homepage            https://k9scli.io
 
@@ -30,12 +30,9 @@ checksums           rmd160  619491fcdd83f126ea9f795dfbad30cb684dc1f3 \
                     sha256  78e432824adb7ba6300784630f9cf371a379cc809b1cbb66aea0cc4fa07b3cf3 \
                     size    6207437
 
-set build_date      [exec date +%FT%T%z]
-# Reproduce the "build" target from the upstream Makefile
 set go_ldflags      "-w -s \
     -X ${go.package}/cmd.version=v${version} \
-    -X ${go.package}/cmd.commit=unknown \
-    -X ${go.package}/cmd.date=${build_date}"
+    -X ${go.package}/cmd.commit=unknown"
 build.args          -ldflags \"${go_ldflags}\" ${go.package}
 
 # FIXME: This port currently can't be built without allowing go mod to fetch


### PR DESCRIPTION
#### Description

Don't set build date to make build reproducible.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?