### PR TITLE
gdb-apple: Fix `mig` not found error

### DIFF
--- a/devel/gdb-apple/Portfile
+++ b/devel/gdb-apple/Portfile
@@ -53,6 +53,11 @@ post-patch {
         ${worksrcpath}/gdb/config/i386/macosx.mh \
         ${worksrcpath}/libiberty/config/mh-macosx \
         ${worksrcpath}/bfd/configure.host
+
+    # https://trac.macports.org/ticket/63153
+     reinplace "s|\$(SDKROOT)/usr/bin/mig|/usr/bin/mig|" \
+        ${worksrcpath}/gdb/config/i386/macosx.mh \
+        ${worksrcpath}/gdb/config/powerpc/macosx.mh
 }
 
 configure.args \


### PR DESCRIPTION
#### Description

While working on #11690 I found it necessary to fix https://trac.macports.org/ticket/63153

A successful CI build will confirm the fix on modern platforms.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
