### PR TITLE
Update lang/php: backport fixes to php53 and php56

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -224,7 +224,7 @@ if {[vercmp ${branch} 8.0] >= 0} {
 if {[is_sapi_subport]} {
 
     platform darwin {
-        if {[vercmp ${branch} 7.0] < 0 && [vercmp ${xcodeversion} 12.0] >= 0} {
+        if {[vercmp ${branch} 5.6] < 0 && [vercmp ${xcodeversion} 12.0] >= 0} {
             # Implicit function declarations. Need to backport upstream fixes from php73+.
             # https://bugs.php.net/80176
             # https://trac.macports.org/ticket/60988
@@ -259,13 +259,18 @@ if {[is_sapi_subport]} {
     patch.pre_args      -p1
     patchfiles-append   patch-${php}-scripts-php-config.in.diff
 
-    if {[vercmp ${branch} 7.0] >= 0 && [vercmp ${branch} 7.2] <= 0} {
+    if {[vercmp ${branch} 5.6] >= 0 && [vercmp ${branch} 7.2] <= 0} {
         patchfiles-append \
                         patch-${php}-implicit.diff
     }
     if {[vercmp ${branch} 5.3] <= 0} {
         patchfiles-append \
                         patch-${php}-configure.diff
+    }
+    if {[vercmp ${branch} 5.3] == 0} {
+        # Only for 5.3. 5.4 and 5.5 are similar enough to 5.6 to not warrant this work.
+        patchfiles-append \
+                        patch-${php}-implicit.diff
     }
     if {[vercmp ${branch} 5.2] <= 0} {
         patchfiles-append \
@@ -419,10 +424,10 @@ subport ${php} {
 
     switch -- ${version} {
         5.2.17              {revision 15}
-        5.3.29              {revision 6}
+        5.3.29              {revision 7}
         5.4.45              {revision 5}
         5.5.38              {revision 6}
-        5.6.40              {revision 4}
+        5.6.40              {revision 5}
         7.0.33              {revision 4}
         7.1.33              {revision 2}
         7.2.34              {revision 3}
@@ -794,7 +799,12 @@ subport ${php}-curl {
     depends_lib-append      port:curl
 
     if {[vercmp ${branch} 7.4] < 0} {
-        if {[vercmp ${branch} 7.0] >= 0 && [vercmp ${branch} 7.1] <= 0} {
+        if {[vercmp ${branch} 5.6] >= 0 && [vercmp ${branch} 7.1] <= 0} {
+            patchfiles-append \
+                                patch-${php}-ext-curl-config.m4.diff
+        }
+        if {[vercmp ${branch} 5.3] == 0} {
+            # Only for 5.3. 5.4 and 5.5 are similar enough to 5.6 to not warrant this work.
             patchfiles-append \
                                 patch-${php}-ext-curl-config.m4.diff
         }
@@ -954,7 +964,7 @@ subport ${php}-ftp {
 subport ${php}-gd {
     switch -- ${version} {
         5.2.17              {revision 1}
-        5.3.29              {revision 1}
+        5.3.29              {revision 2}
         5.4.45              {revision 1}
         5.5.38              {revision 1}
         5.6.40              {revision 1}
@@ -1012,6 +1022,10 @@ subport ${php}-gd {
         depends_lib-append      port:t1lib
         configure.args-append   --with-t1lib=${prefix}
     }
+    }
+
+    if {[vercmp ${branch} 5.3] == 0} {
+        patchfiles-append   patch-${php}-ext-gd-implicit.diff
     }
 }
 
@@ -1256,7 +1270,7 @@ subport ${php}-mbstring {
         5.3.29              {revision 0}
         5.4.45              {revision 0}
         5.5.38              {revision 0}
-        5.6.40              {revision 0}
+        5.6.40              {revision 1}
         7.0.33              {revision 0}
         7.1.33              {revision 0}
         7.2.34              {revision 0}
@@ -1277,6 +1291,10 @@ subport ${php}-mbstring {
         depends_build-append    port:pkgconfig
 
         depends_lib-append      port:oniguruma6
+    }
+
+    if {[vercmp ${branch} 5.6] == 0} {
+        patchfiles-append   patch-${php}-ext-mbstring-implicit.diff
     }
 }
 

--- a/lang/php/files/patch-php53-ext-curl-config.m4.diff
+++ b/lang/php/files/patch-php53-ext-curl-config.m4.diff
@@ -1,0 +1,18 @@
+--- ext/curl/config.m4.orig	2014-08-13 20:22:50.000000000 +0100
++++ ext/curl/config.m4	2021-07-23 02:41:22.000000000 +0100
+@@ -65,6 +65,7 @@
+     AC_PROG_CPP
+     AC_MSG_CHECKING([for openssl support in libcurl])
+     AC_TRY_RUN([
++#include <strings.h>
+ #include <curl/curl.h>
+ 
+ int main(int argc, char *argv[])
+@@ -92,6 +93,7 @@
+    
+     AC_MSG_CHECKING([for gnutls support in libcurl])
+     AC_TRY_RUN([
++#include <strings.h>
+ #include <curl/curl.h>
+ 
+ int main(int argc, char *argv[])

--- a/lang/php/files/patch-php53-ext-gd-implicit.diff
+++ b/lang/php/files/patch-php53-ext-gd-implicit.diff
@@ -1,0 +1,32 @@
+commit 4e6d54f5a7003b73f12d86d7f5cba0a37ce40930
+Author: Pierre Joye <pierre.php@gmail.com>
+Date:   Fri Mar 22 08:28:11 2013 +0100
+
+    - fix regression (imagerotate_overflow.phpt)
+
+diff --git a/ext/gd/gd.c b/ext/gd/gd.c
+index caf84e304e..e291793fd7 100644
+--- ext/gd/gd.c.orig
++++ ext/gd/gd.c
+@@ -84,6 +84,10 @@
+ # endif
+ #endif
+ 
++#if defined(HAVE_GD_XPM) && defined(HAVE_GD_BUNDLED)
++# include "X11/xpm.h"
++#endif
++
+ #ifndef M_PI
+ #define M_PI 3.14159265358979323846
+ #endif
+@@ -125,6 +129,10 @@
+ #define gdNewDynamicCtxEx(len, data, val) gdNewDynamicCtx(len, data)
+ #endif
+ 
++/* as it is not really public, duplicate declaration here to avoid 
++   pointless warnings */
++int overflow2(int a, int b);
++
+ /* Section Filters Declarations */
+ /* IMPORTANT NOTE FOR NEW FILTER
+  * Do not forget to update:

--- a/lang/php/files/patch-php53-implicit.diff
+++ b/lang/php/files/patch-php53-implicit.diff
@@ -1,0 +1,1071 @@
+--- a/acinclude.m4.orig	2021-07-23 02:37:06.000000000 +0100
++++ b/acinclude.m4	2021-07-23 02:44:05.000000000 +0100
+@@ -1213,14 +1213,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ $1
+-    main() {
++    int main() {
+     int fd = open("conftest_in", O_WRONLY|O_CREAT, 0600);
+ 
+-    if (fd < 0) exit(1);
+-    if (pwrite(fd, "text", 4, 0) != 4) exit(1);
++    if (fd < 0) return 1;
++    if (pwrite(fd, "text", 4, 0) != 4) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+ 
+   ],[
+@@ -1243,14 +1243,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ $1
+-    main() {
++    int main() {
+     char buf[3]; 
+     int fd = open("conftest_in", O_RDONLY);
+-    if (fd < 0) exit(1);
+-    if (pread(fd, buf, 2, 0) != 2) exit(1);
++    if (fd < 0) return 1;
++    if (pread(fd, buf, 2, 0) != 2) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+   ],[
+     ac_cv_pread=yes
+@@ -1356,17 +1356,20 @@
+ #define PATH_MAX 1024
+ #endif
+ 
+-main() {
++int main() {
+   DIR *dir;
+   char entry[sizeof(struct dirent)+PATH_MAX];
+   struct dirent *pentry = (struct dirent *) &entry;
+ 
+   dir = opendir("/");
+   if (!dir) 
+-    exit(1);
+-  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0)
+-    exit(0);
+-  exit(1);
++    return 1;
++  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0) {
++    close(dir);
++    return 0;
++  }
++  close(dir);
++  return 1;
+ }
+     ],[
+       ac_cv_what_readdir_r=POSIX
+@@ -1696,6 +1699,7 @@
+   AC_CACHE_VAL(_cv_have_broken_glibc_fopen_append,[
+   AC_TRY_RUN([
+ #include <stdio.h>
++#include <unistd.h>
+ int main(int argc, char *argv[])
+ {
+   FILE *fp;
+@@ -1705,7 +1709,7 @@
+   fp = fopen(filename, "w");
+   if (fp == NULL) {
+     perror("fopen");
+-    exit(2);
++    return 2;
+   }
+   fputs("foobar", fp);
+   fclose(fp);
+@@ -1779,13 +1783,13 @@
+ 
+ cookie_io_functions_t funcs = {reader, writer, seeker, closer};
+ 
+-main() {
++int main() {
+   struct cookiedata g = { 0 };
+   FILE *fp = fopencookie(&g, "r", funcs);
+ 
+   if (fp && fseek(fp, 8192, SEEK_SET) == 0 && g.pos == 8192)
+-    exit(0);
+-  exit(1);
++    return 0;
++  return 1;
+ }
+ 
+ ], [
+--- a/configure.orig	2021-07-23 02:37:06.000000000 +0100
++++ b/configure	2021-07-23 03:08:12.000000000 +0100
+@@ -8631,7 +8631,7 @@
+   else
+     { echo "configure: error: Could not find a pike in $PHP_CAUDIUM/bin/" 1>&2; exit 1; }
+   fi
+-  if $PIKE -e 'float v; int rel;sscanf(version(), "Pike v%f release %d", v, rel);v += rel/10000.0; if(v < 7.0268) exit(1); exit(0);'; then
++  if $PIKE -e 'float v; int rel;sscanf(version(), "Pike v%f release %d", v, rel);v += rel/10000.0; if(v < 7.0268) return 1; return 0;'; then
+     PIKE_MODULE_DIR=`$PIKE --show-paths 2>&1| grep '^Module' | sed -e 's/.*: //'`
+     PIKE_INCLUDE_DIR=`echo $PIKE_MODULE_DIR | sed -e 's,lib/pike/modules,include/pike,' -e 's,lib/modules,include/pike,' `
+     if test -z "$PIKE_INCLUDE_DIR" || test -z "$PIKE_MODULE_DIR"; then
+@@ -12983,7 +12983,7 @@
+     { echo "configure: error: Could not find a pike in $PHP_ROXEN/bin/" 1>&2; exit 1; }
+   fi
+ 
+-  if $PIKE -e 'float v; catch(v = __VERSION__ + (__BUILD__/10000.0)); if(v < 0.7079) exit(1); exit(0);'; then
++  if $PIKE -e 'float v; catch(v = __VERSION__ + (__BUILD__/10000.0)); if(v < 0.7079) return 1; return 0;'; then
+     PIKE_MODULE_DIR=`$PIKE --show-paths 2>&1| grep '^Module' | sed -e 's/.*: //'`
+     PIKE_INCLUDE_DIR=`echo $PIKE_MODULE_DIR | sed -e 's,lib/pike/modules,include/pike,' -e 's,lib/modules,include/pike,'`
+     if test -z "$PIKE_INCLUDE_DIR" || test -z "$PIKE_MODULE_DIR"; then
+@@ -16954,8 +16954,8 @@
+ #define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
+ #define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+ int main () { int i; for (i = 0; i < 256; i++)
+-if (XOR (islower (i), ISLOWER (i)) || toupper (i) != TOUPPER (i)) exit(2);
+-exit (0); }
++if (XOR (islower (i), ISLOWER (i)) || toupper (i) != TOUPPER (i)) return 2;
++return 0; }
+ 
+ EOF
+ if { (eval echo configure:16962: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -17305,13 +17305,13 @@
+ 
+ cookie_io_functions_t funcs = {reader, writer, seeker, closer};
+ 
+-main() {
++int main() {
+   struct cookiedata g = { 0 };
+   FILE *fp = fopencookie(&g, "r", funcs);
+ 
+   if (fp && fseek(fp, 8192, SEEK_SET) == 0 && g.pos == 8192)
+-    exit(0);
+-  exit(1);
++    return 0;
++  return 1;
+ }
+ 
+ 
+@@ -17432,6 +17432,7 @@
+ #include "confdefs.h"
+ 
+ #include <stdio.h>
++#include <unistd.h>
+ int main(int argc, char *argv[])
+ {
+   FILE *fp;
+@@ -17441,7 +17442,7 @@
+   fp = fopen(filename, "w");
+   if (fp == NULL) {
+     perror("fopen");
+-    exit(2);
++    return 2;
+   }
+   fputs("foobar", fp);
+   fclose(fp);
+@@ -17887,12 +17888,12 @@
+ #line 17888 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(size_t));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:17899: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -17926,12 +17927,12 @@
+ #line 17927 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long long));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:17938: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -17965,12 +17966,12 @@
+ #line 17966 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long long int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:17977: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -18004,12 +18005,12 @@
+ #line 18005 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:18016: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -18043,12 +18044,12 @@
+ #line 18044 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:18055: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -19000,6 +19001,7 @@
+ #line 19001 "configure"
+ #include "confdefs.h"
+ 
++#include <string.h>
+ #include <netdb.h>
+ #include <sys/types.h>
+ #ifndef AF_INET
+@@ -19012,11 +19014,11 @@
+   hints.ai_flags = AI_NUMERICHOST;
+ 
+   if (getaddrinfo("127.0.0.1", 0, &hints, &ai) < 0) {
+-    exit(1);
++    return 1;
+   }
+ 
+   if (ai == 0) {
+-    exit(1);
++    return 1;
+   }
+ 
+   pai = ai;
+@@ -19024,16 +19026,16 @@
+   while (pai) {
+     if (pai->ai_family != AF_INET) {
+       /* 127.0.0.1/NUMERICHOST should only resolve ONE way */
+-      exit(1);
++      return 1;
+     }
+     if (pai->ai_addr->sa_family != AF_INET) {
+       /* 127.0.0.1/NUMERICHOST should only resolve ONE way */
+-      exit(1);
++      return 1;
+     }
+     pai = pai->ai_next;
+   }
+   freeaddrinfo(ai);
+-  exit(0);
++  return 0;
+ }
+   
+ EOF
+@@ -19171,9 +19173,9 @@
+ #include "confdefs.h"
+ #include <sys/types.h>
+ #include <sys/stat.h>
+-main() {
++int main() {
+ struct stat s, t;
+-exit(!(stat ("conftestdata", &s) == 0 && utime("conftestdata", (long *)0) == 0
++return (int)(!(stat ("conftestdata", &s) == 0 && utime("conftestdata", (long *)0) == 0
+ && stat("conftestdata", &t) == 0 && t.st_mtime >= s.st_mtime
+ && t.st_mtime - s.st_mtime < 120));
+ }
+@@ -19409,9 +19411,9 @@
+   else
+     return (&dummy > addr) ? 1 : -1;
+ }
+-main ()
++int main ()
+ {
+-  exit (find_stack_direction() < 0);
++  return (int)(find_stack_direction() < 0);
+ }
+ EOF
+ if { (eval echo configure:19418: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -19655,17 +19657,18 @@
+ #define PATH_MAX 1024
+ #endif
+ 
+-main() {
++int main() {
+   DIR *dir;
+   char entry[sizeof(struct dirent)+PATH_MAX];
+   struct dirent *pentry = (struct dirent *) &entry;
+ 
+   dir = opendir("/");
+   if (!dir) 
+-    exit(1);
+-  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0)
+-    exit(0);
+-  exit(1);
++    return 1;
++  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0) {
++    return 0;
++  }
++  return 1;
+ }
+     
+ EOF
+@@ -20706,12 +20709,12 @@
+ #line 20707 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:20718: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -20745,12 +20748,12 @@
+ #line 20746 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:20757: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -47074,12 +47077,12 @@
+ #line 47075 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(short));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:47086: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -47113,12 +47116,12 @@
+ #line 47114 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:47125: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -47152,12 +47155,12 @@
+ #line 47153 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:47164: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -47191,12 +47194,12 @@
+ #line 47192 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long long));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:47203: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -53536,8 +53539,8 @@
+ #define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
+ #define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+ int main () { int i; for (i = 0; i < 256; i++)
+-if (XOR (islower (i), ISLOWER (i)) || toupper (i) != TOUPPER (i)) exit(2);
+-exit (0); }
++if (XOR (islower (i), ISLOWER (i)) || toupper (i) != TOUPPER (i)) return 2;
++return 0; }
+ 
+ EOF
+ if { (eval echo configure:53544: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -57026,12 +57029,12 @@
+ #line 57027 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:57038: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -57065,12 +57068,12 @@
+ #line 57066 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(short));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:57077: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -57104,12 +57107,12 @@
+ #line 57105 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:57116: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -57451,7 +57454,7 @@
+ }
+ main ()
+ {
+-  exit (find_stack_direction() < 0);
++  return (int)(find_stack_direction() < 0);
+ }
+ EOF
+ if { (eval echo configure:57458: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -57487,10 +57490,10 @@
+ #line 57488 "configure"
+ #include "confdefs.h"
+ 
+-main()
++int main()
+ {
+   char c0 = 0x40, c1 = 0x80, c2 = 0x81;
+-  exit(memcmp(&c0, &c2, 1) < 0 && memcmp(&c1, &c2, 1) < 0 ? 0 : 1);
++  return (int)(memcmp(&c0, &c2, 1) < 0 && memcmp(&c1, &c2, 1) < 0 ? 0 : 1);
+ }
+ 
+ EOF
+@@ -62881,12 +62884,12 @@
+ #line 62882 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:62893: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -70715,12 +70718,12 @@
+ #line 70716 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:70727: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -70917,12 +70920,12 @@
+ #line 70918 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:70929: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -82472,14 +82475,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ 
+-    main() {
++    int main() {
+     int fd = open("conftest_in", O_WRONLY|O_CREAT, 0600);
+ 
+-    if (fd < 0) exit(1);
+-    if (pwrite(fd, "text", 4, 0) != 4) exit(1);
++    if (fd < 0) return 1;
++    if (pwrite(fd, "text", 4, 0) != 4) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+ 
+   
+@@ -82518,14 +82521,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ ssize_t pwrite(int, void *, size_t, off64_t);
+-    main() {
++    int main() {
+     int fd = open("conftest_in", O_WRONLY|O_CREAT, 0600);
+ 
+-    if (fd < 0) exit(1);
+-    if (pwrite(fd, "text", 4, 0) != 4) exit(1);
++    if (fd < 0) return 1;
++    if (pwrite(fd, "text", 4, 0) != 4) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+ 
+   
+@@ -82593,14 +82596,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ 
+-    main() {
++    int main() {
+     char buf[3]; 
+     int fd = open("conftest_in", O_RDONLY);
+-    if (fd < 0) exit(1);
+-    if (pread(fd, buf, 2, 0) != 2) exit(1);
++    if (fd < 0) return 1;
++    if (pread(fd, buf, 2, 0) != 2) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+   
+ EOF
+@@ -82640,14 +82643,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ ssize_t pread(int, void *, size_t, off64_t);
+-    main() {
++    int main() {
+     char buf[3]; 
+     int fd = open("conftest_in", O_RDONLY);
+-    if (fd < 0) exit(1);
+-    if (pread(fd, buf, 2, 0) != 2) exit(1);
++    if (fd < 0) return 1;
++    if (pread(fd, buf, 2, 0) != 2) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+   
+ EOF
+@@ -88473,12 +88476,12 @@
+ #line 88474 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(char *));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:88485: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -88656,6 +88659,8 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
+ 
+ int main(int argc, char **argv)
+ {
+@@ -88685,7 +88690,7 @@
+ 	fclose(fp);
+ 	unlink(filename);
+ 
+-	exit(result);
++	return result;
+ }
+ 
+ EOF
+@@ -88779,6 +88784,8 @@
+ #line 88780 "configure"
+ #include "confdefs.h"
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -88787,11 +88794,11 @@
+ #include <crypt.h>
+ #endif
+ 
+-main() {
++int main() {
+ #if HAVE_CRYPT
+-    exit (strcmp((char *)crypt("rasmuslerdorf","rl"),"rl.3StKT.4T8M"));
++    return strcmp((char *)crypt("rasmuslerdorf","rl"),"rl.3StKT.4T8M");
+ #else
+-	exit(0);
++	return 0;
+ #endif
+ }
+ EOF
+@@ -88830,6 +88837,8 @@
+ #line 88831 "configure"
+ #include "confdefs.h"
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -88838,11 +88847,11 @@
+ #include <crypt.h>
+ #endif
+ 
+-main() {
++int main() {
+ #if HAVE_CRYPT
+-  exit (strcmp((char *)crypt("rasmuslerdorf","_J9..rasm"),"_J9..rasmBYk8r9AiWNc"));
++  return strcmp((char *)crypt("rasmuslerdorf","_J9..rasm"),"_J9..rasmBYk8r9AiWNc");
+ #else
+-  exit(0);
++  return 0;
+ #endif
+ }
+ EOF
+@@ -88881,6 +88890,8 @@
+ #line 88882 "configure"
+ #include "confdefs.h"
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -88889,7 +88900,7 @@
+ #include <crypt.h>
+ #endif
+ 
+-main() {
++int main() {
+ #if HAVE_CRYPT
+     char salt[15], answer[40];
+ 
+@@ -88900,9 +88911,9 @@
+     salt[12]='\0';
+     strcpy(answer,salt);
+     strcat(answer,"rISCgZzpwk3UhDidwXvin0");
+-    exit (strcmp((char *)crypt("rasmuslerdorf",salt),answer));
++    return strcmp((char *)crypt("rasmuslerdorf",salt),answer);
+ #else
+-	exit(0);
++	return 0;
+ #endif
+ }
+ EOF
+@@ -88941,6 +88952,8 @@
+ #line 88942 "configure"
+ #include "confdefs.h"
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -88949,7 +88962,7 @@
+ #include <crypt.h>
+ #endif
+ 
+-main() {
++int main() {
+ #if HAVE_CRYPT
+     char salt[30], answer[70];
+     
+@@ -88957,9 +88970,9 @@
+     strcat(salt,"rasmuslerd............");
+     strcpy(answer,salt);
+     strcpy(&answer[29],"nIdrcHdxcUxWomQX9j6kvERCFjTg7Ra");
+-    exit (strcmp((char *)crypt("rasmuslerdorf",salt),answer));
++    return strcmp((char *)crypt("rasmuslerdorf",salt),answer);
+ #else
+-	exit(0);
++	return 0;
+ #endif
+ }
+ EOF
+@@ -88998,6 +89011,8 @@
+ #line 88999 "configure"
+ #include "confdefs.h"
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -89006,16 +89021,16 @@
+ #include <crypt.h>
+ #endif
+ 
+-main() {
++int main() {
+ #if HAVE_CRYPT
+     char salt[30], answer[80];
+     
+     salt[0]='$'; salt[1]='6'; salt[2]='$'; salt[3]='$'; salt[4]='b'; salt[5]='a'; salt[6]='r'; salt[7]='\0';
+     strcpy(answer, salt);
+     strcpy(&answer[29],"$6$$QMXjqd7rHQZPQ1yHsXkQqC1FBzDiVfTHXL.LaeDAeVV.IzMaV9VU4MQ8kPuZa2SOP1A0RPm772EaFYjpEJtdu.");
+-    exit (strcmp((char *)crypt("foo",salt),answer));
++    return strcmp((char *)crypt("foo",salt),answer);
+ #else
+-	exit(0);
++	return 0;
+ #endif
+ }
+ EOF
+@@ -89054,6 +89069,8 @@
+ #line 89055 "configure"
+ #include "confdefs.h"
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -89062,16 +89079,16 @@
+ #include <crypt.h>
+ #endif
+ 
+-main() {
++int main() {
+ #if HAVE_CRYPT
+     char salt[30], answer[80];
+     salt[0]='$'; salt[1]='5'; salt[2]='$'; salt[3]='$'; salt[4]='s'; salt[5]='a'; salt[6]='l'; salt[7]='t';  salt[8]='s'; salt[9]='t'; salt[10]='r'; salt[11]='i'; salt[12]='n'; salt[13]='g'; salt[14]='\0';    
+     strcat(salt,"");
+     strcpy(answer, salt);
+     strcpy(&answer[29], "$5$saltstring$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5");
+-    exit (strcmp((char *)crypt("foo",salt),answer));
++    return strcmp((char *)crypt("foo",salt),answer);
+ #else
+-	exit(0);
++	return 0;
+ #endif
+ }
+ EOF
+@@ -89401,7 +89418,7 @@
+   cat > conftest.$ac_ext <<EOF
+ #line 89403 "configure"
+ #include "confdefs.h"
+-main() { exit (fnmatch ("a*", "abc", 0) != 0); }
++main() { return (int)(fnmatch ("a*", "abc", 0) != 0); }
+ EOF
+ if { (eval echo configure:89407: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+ then
+@@ -93438,12 +93455,12 @@
+ #line 93439 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:93450: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -101264,8 +101281,8 @@
+ #define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
+ #define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+ int main () { int i; for (i = 0; i < 256; i++)
+-if (XOR (islower (i), ISLOWER (i)) || toupper (i) != TOUPPER (i)) exit(2);
+-exit (0); }
++if (XOR (islower (i), ISLOWER (i)) || toupper (i) != TOUPPER (i)) return 2;
++return 0; }
+ 
+ EOF
+ if { (eval echo configure:101272: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -101348,12 +101365,12 @@
+ #line 101349 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(char));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:101360: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -101388,12 +101405,12 @@
+ #line 101389 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(int));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:101400: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -101427,12 +101444,12 @@
+ #line 101428 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:101439: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -101466,12 +101483,12 @@
+ #line 101467 "configure"
+ #include "confdefs.h"
+ #include <stdio.h>
+-main()
++int main()
+ {
+   FILE *f=fopen("conftestval", "w");
+-  if (!f) exit(1);
++  if (!f) return 1;
+   fprintf(f, "%d\n", sizeof(long long));
+-  exit(0);
++  return 0;
+ }
+ EOF
+ if { (eval echo configure:101478: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -105642,10 +105659,10 @@
+ #line 105643 "configure"
+ #include "confdefs.h"
+ 
+-main()
++int main()
+ {
+   char c0 = 0x40, c1 = 0x80, c2 = 0x81;
+-  exit(memcmp(&c0, &c2, 1) < 0 && memcmp(&c1, &c2, 1) < 0 ? 0 : 1);
++  return (int)(memcmp(&c0, &c2, 1) < 0 && memcmp(&c1, &c2, 1) < 0 ? 0 : 1);
+ }
+ 
+ EOF
+@@ -105876,7 +105893,7 @@
+ }
+ main ()
+ {
+-  exit (find_stack_direction() < 0);
++  return (int)(find_stack_direction() < 0);
+ }
+ EOF
+ if { (eval echo configure:105883: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+@@ -105970,7 +105987,8 @@
+   cat > conftest.$ac_ext <<EOF
+ #line 105972 "configure"
+ #include "confdefs.h"
+-main() {char buf[20];exit(sprintf(buf,"testing 123")!=11); }
++#include <stdio.h>
++int main() {char buf[20]; return sprintf(buf,"testing 123")!=11; }
+ EOF
+ if { (eval echo configure:105976: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} && (./conftest; exit) 2>/dev/null
+ then
+@@ -106340,16 +106358,16 @@
+ 		double d = (double) LONG_MIN * LONG_MIN + 2e9;
+ 
+ 		if ((long) d == 2e9 && (long) -d == -2e9) {
+-			exit(0);
++			return 0;
+ 		}
+ 	} else if (sizeof(long) == 8) {
+ 		double correct = 18e18 - ((double) LONG_MIN * -2); /* Subtract ULONG_MAX + 1 */
+ 
+ 		if ((long) 18e18 == correct) { /* On 64-bit, only check between LONG_MAX and ULONG_MAX */
+-			exit(0);
++			return 0;
+ 		}
+ 	}
+-	exit(1);
++	return 1;
+ }
+ 
+ EOF
+@@ -106465,10 +106483,6 @@
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -106484,7 +106498,7 @@
+   else
+     puts (dlerror ());
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo configure:106491: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} 2>/dev/null; then
+@@ -106754,7 +106768,7 @@
+   fprintf(fp, "%d %d\n", ZEND_MM_ALIGNMENT, zeros);  
+   fclose(fp);
+ 
+-  exit(0);
++  return 0;
+ }
+ 
+ EOF
+@@ -106866,6 +106880,7 @@
+ #include <sys/mman.h>
+ #include <stdlib.h>
+ #include <stdio.h>
++#include <unistd.h>
+ #ifndef MAP_ANON
+ # ifdef MAP_ANONYMOUS
+ #  define MAP_ANON MAP_ANONYMOUS
+@@ -112370,10 +112385,6 @@
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -112389,7 +112400,7 @@
+   else
+     puts (dlerror ());
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo configure:112396: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} 2>/dev/null; then
+@@ -112466,10 +112477,6 @@
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -112485,7 +112492,7 @@
+   else
+     puts (dlerror ());
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { (eval echo configure:112492: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext} 2>/dev/null; then

--- a/lang/php/files/patch-php56-ext-curl-config.m4.diff
+++ b/lang/php/files/patch-php56-ext-curl-config.m4.diff
@@ -1,0 +1,24 @@
+Fix:
+
+error: implicitly declaring library function 'strncasecmp' with type 'int (const char *, const char *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
+Copied from the php70 ports
+
+https://github.com/php/php-src/commit/1a8df11364292dd3cac2c406a26e4aafaca62d36
+--- ext/curl/config.m4.orig	2019-01-09 09:54:13.000000000 +0000
++++ ext/curl/config.m4	2021-07-22 18:17:39.000000000 +0100
+@@ -61,6 +61,7 @@
+     AC_PROG_CPP
+     AC_MSG_CHECKING([for openssl support in libcurl])
+     AC_TRY_RUN([
++#include <strings.h>
+ #include <curl/curl.h>
+ 
+ int main(int argc, char *argv[])
+@@ -88,6 +89,7 @@
+    
+     AC_MSG_CHECKING([for gnutls support in libcurl])
+     AC_TRY_RUN([
++#include <strings.h>
+ #include <curl/curl.h>
+ 
+ int main(int argc, char *argv[])

--- a/lang/php/files/patch-php56-ext-mbstring-implicit.diff
+++ b/lang/php/files/patch-php56-ext-mbstring-implicit.diff
@@ -1,0 +1,180 @@
+PHP Upstream
+
+commit f809f2811964f216018f2ff7623d779991854252
+Author: Nikita Popov <nikic@php.net>
+Date:   Sat Jul 18 21:24:28 2015 +0200
+
+    Check mbfl_filt_put_invalid_char return value
+    
+    And fix some libmbfl warnings
+
+diff --git ext/mbstring/libmbfl/filters/mbfilter_iso2022jp_mobile.c ext/mbstring/libmbfl/filters/mbfilter_iso2022jp_mobile.c
+index a5260807d4..e0d5543882 100644
+--- ext/mbstring/libmbfl/filters/mbfilter_iso2022jp_mobile.c
++++ ext/mbstring/libmbfl/filters/mbfilter_iso2022jp_mobile.c
+@@ -48,7 +48,7 @@ const mbfl_encoding mbfl_encoding_2022jp_kddi = {
+ 	mbfl_no_encoding_2022jp_kddi,
+ 	"ISO-2022-JP-MOBILE#KDDI",
+ 	"ISO-2022-JP",
+-	mbfl_encoding_2022jp_kddi_aliases,
++	&mbfl_encoding_2022jp_kddi_aliases,
+ 	NULL,
+ 	MBFL_ENCTYPE_MBCS | MBFL_ENCTYPE_SHFTCODE | MBFL_ENCTYPE_GL_UNSAFE
+ };
+diff --git ext/mbstring/libmbfl/filters/mbfilter_utf8.c ext/mbstring/libmbfl/filters/mbfilter_utf8.c
+index a9c141bbfe..e81e0860d2 100644
+--- ext/mbstring/libmbfl/filters/mbfilter_utf8.c
++++ ext/mbstring/libmbfl/filters/mbfilter_utf8.c
+@@ -101,6 +101,7 @@
+ 	filter->status = 0;
+ 	filter->cache = 0;
+ 	CK((*filter->output_function)(w, filter->data));
++	return 0;
+ }
+ 
+ 
+@@ -109,7 +110,7 @@
+  */
+ int mbfl_filt_conv_utf8_wchar(int c, mbfl_convert_filter *filter)
+ {
+-	int s, c1, w = 0, flag = 0;
++	int s, c1;
+ 
+ retry:
+ 	switch (filter->status & 0xff) {
+@@ -126,7 +127,7 @@
+ 			filter->status = 0x30;
+ 			filter->cache = c & 0x7;
+ 		} else {
+-			mbfl_filt_put_invalid_char(c, filter);
++			CK(mbfl_filt_put_invalid_char(c, filter));
+ 		}
+ 		break;
+ 	case 0x10: /* 2byte code 2nd char: 0x80-0xbf */
+@@ -138,8 +139,8 @@
+ 			filter->cache = 0;
+ 			CK((*filter->output_function)(s, filter->data));			
+ 		} else {
+-			mbfl_filt_put_invalid_char(filter->cache, filter);
+-			goto retry;			
++			CK(mbfl_filt_put_invalid_char(filter->cache, filter));
++			goto retry;
+ 		}
+ 		break;
+ 	case 0x20: /* 3byte code 2nd char: 0:0xa0-0xbf,D:0x80-9F,1-C,E-F:0x80-0x9f */
+@@ -153,8 +154,8 @@
+ 			filter->cache = s;
+ 			filter->status++;
+ 		} else {
+-			mbfl_filt_put_invalid_char(filter->cache, filter);
+-			goto retry;						
++			CK(mbfl_filt_put_invalid_char(filter->cache, filter));
++			goto retry;
+ 		}
+ 		break;
+ 	case 0x30: /* 4byte code 2nd char: 0:0x90-0xbf,1-3:0x80-0xbf,4:0x80-0x8f */
+@@ -168,8 +169,8 @@
+ 			filter->cache = s;
+ 			filter->status++;
+ 		} else {
+-			mbfl_filt_put_invalid_char(filter->cache, filter);
+-			goto retry;						
++			CK(mbfl_filt_put_invalid_char(filter->cache, filter));
++			goto retry;
+ 		}
+ 		break;
+ 	case 0x31: /* 4byte code 3rd char: 0x80-0xbf */
+@@ -177,8 +178,8 @@
+ 			filter->cache = (filter->cache<<6) | (c & 0x3f);
+ 			filter->status++;
+ 		} else {
+-			mbfl_filt_put_invalid_char(filter->cache, filter);
+-			goto retry;						
++			CK(mbfl_filt_put_invalid_char(filter->cache, filter));
++			goto retry;
+ 		}
+ 		break;
+ 	default:
+@@ -200,7 +201,7 @@
+ 	filter->cache = 0;
+ 
+ 	if (status != 0) {
+-		mbfl_filt_put_invalid_char(cache, filter);
++		CK(mbfl_filt_put_invalid_char(cache, filter));
+ 	}
+ 
+ 	if (filter->flush_function != NULL) {
+diff --git ext/mbstring/libmbfl/filters/mbfilter_utf8_mobile.c ext/mbstring/libmbfl/filters/mbfilter_utf8_mobile.c
+index c449d3132a..41e02bf314 100644
+--- ext/mbstring/libmbfl/filters/mbfilter_utf8_mobile.c
++++ ext/mbstring/libmbfl/filters/mbfilter_utf8_mobile.c
+@@ -183,14 +183,14 @@
+ };
+ 
+ #define CK(statement)	do { if ((statement) < 0) return (-1); } while (0)
++int mbfl_filt_put_invalid_char(int c, mbfl_convert_filter *filter);
+ 
+ /*
+  * UTF-8 => wchar
+  */
+ int mbfl_filt_conv_utf8_mobile_wchar(int c, mbfl_convert_filter *filter)
+ {
+-	int s, w = 0, flag = 0;
+-	int s1 = 0, c1 = 0, snd = 0;
++	int s, s1 = 0, c1 = 0, snd = 0;
+ 
+ retry:
+ 	switch (filter->status & 0xff) {
+@@ -207,7 +207,7 @@
+ 			filter->status = 0x30;
+ 			filter->cache = c & 0x7;
+ 		} else {
+-			mbfl_filt_put_invalid_char(c, filter);
++			CK(mbfl_filt_put_invalid_char(c, filter));
+ 		}
+ 		break;
+ 	case 0x10: /* 2byte code 2nd char: 0x80-0xbf */
+@@ -237,8 +237,8 @@
+ 			}
+ 			CK((*filter->output_function)(s, filter->data));
+ 		} else {
+-			mbfl_filt_put_invalid_char(filter->cache, filter);
+-			goto retry;			
++			CK(mbfl_filt_put_invalid_char(filter->cache, filter));
++			goto retry;
+ 		}
+ 		break;
+ 	case 0x20: /* 3byte code 2nd char: 0:0xa0-0xbf,D:0x80-9F,1-C,E-F:0x80-0x9f */
+@@ -252,8 +252,8 @@
+ 			filter->cache = s;
+ 			filter->status++;
+ 		} else {
+-			mbfl_filt_put_invalid_char(filter->cache, filter);
+-			goto retry;						
++			CK(mbfl_filt_put_invalid_char(filter->cache, filter));
++			goto retry;
+ 		}
+ 		break;
+ 	case 0x30: /* 4byte code 2nd char: 0:0x90-0xbf,1-3:0x80-0xbf,4:0x80-0x8f */
+@@ -267,8 +267,8 @@
+ 			filter->cache = s;
+ 			filter->status++;
+ 		} else {
+-			mbfl_filt_put_invalid_char(filter->cache, filter);
+-			goto retry;						
++			CK(mbfl_filt_put_invalid_char(filter->cache, filter));
++			goto retry;
+ 		}
+ 		break;
+ 	case 0x31: /* 4byte code 3rd char: 0x80-0xbf */
+@@ -276,8 +276,8 @@
+ 			filter->cache = (filter->cache<<6) | (c & 0x3f);
+ 			filter->status++;
+ 		} else {
+-			mbfl_filt_put_invalid_char(filter->cache, filter);
+-			goto retry;						
++			CK(mbfl_filt_put_invalid_char(filter->cache, filter));
++			goto retry;
+ 		}
+ 		break;
+ 	default:

--- a/lang/php/files/patch-php56-implicit.diff
+++ b/lang/php/files/patch-php56-implicit.diff
@@ -1,0 +1,540 @@
+Fix implicit declaration of functions.
+https://bugs.php.net/bug.php?id=80171
+https://github.com/php/php-src/commit/aa405b7da270595d349d0596ad31305a41d4b1c0
+https://github.com/php/php-src/commit/00ba784a2ce95e009f98e0e6d263634673a3f2e1
+--- a/acinclude.m4.orig	2019-01-09 09:54:13.000000000 +0000
++++ b/acinclude.m4	2021-07-23 02:14:20.000000000 +0100
+@@ -1224,14 +1224,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ $1
+-    main() {
++    int main() {
+     int fd = open("conftest_in", O_WRONLY|O_CREAT, 0600);
+ 
+-    if (fd < 0) exit(1);
+-    if (pwrite(fd, "text", 4, 0) != 4) exit(1);
++    if (fd < 0) return 1;
++    if (pwrite(fd, "text", 4, 0) != 4) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+ 
+   ],[
+@@ -1254,14 +1254,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ $1
+-    main() {
++    int main() {
+     char buf[3]; 
+     int fd = open("conftest_in", O_RDONLY);
+-    if (fd < 0) exit(1);
+-    if (pread(fd, buf, 2, 0) != 2) exit(1);
++    if (fd < 0) return 1;
++    if (pread(fd, buf, 2, 0) != 2) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+   ],[
+     ac_cv_pread=yes
+@@ -1367,17 +1367,20 @@
+ #define PATH_MAX 1024
+ #endif
+ 
+-main() {
++int main() {
+   DIR *dir;
+   char entry[sizeof(struct dirent)+PATH_MAX];
+   struct dirent *pentry = (struct dirent *) &entry;
+ 
+   dir = opendir("/");
+   if (!dir) 
+-    exit(1);
+-  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0)
+-    exit(0);
+-  exit(1);
++    return 1;
++  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0) {
++    close(dir);
++    return 0;
++  }
++  close(dir);
++  return 1;
+ }
+     ],[
+       ac_cv_what_readdir_r=POSIX
+@@ -1707,6 +1710,7 @@
+   AC_CACHE_VAL(_cv_have_broken_glibc_fopen_append,[
+   AC_TRY_RUN([
+ #include <stdio.h>
++#include <unistd.h>
+ int main(int argc, char *argv[])
+ {
+   FILE *fp;
+@@ -1716,7 +1720,7 @@
+   fp = fopen(filename, "w");
+   if (fp == NULL) {
+     perror("fopen");
+-    exit(2);
++    return 2;
+   }
+   fputs("foobar", fp);
+   fclose(fp);
+@@ -1790,13 +1794,13 @@
+ 
+ cookie_io_functions_t funcs = {reader, writer, seeker, closer};
+ 
+-main() {
++int main() {
+   struct cookiedata g = { 0 };
+   FILE *fp = fopencookie(&g, "r", funcs);
+ 
+   if (fp && fseek(fp, 8192, SEEK_SET) == 0 && g.pos == 8192)
+-    exit(0);
+-  exit(1);
++    return 0;
++  return 1;
+ }
+ 
+ ], [
+--- a/configure.orig	2019-01-09 10:25:58.000000000 +0000
++++ b/configure	2021-07-23 02:01:37.000000000 +0100
+@@ -18498,13 +18498,13 @@
+ 
+ cookie_io_functions_t funcs = {reader, writer, seeker, closer};
+ 
+-main() {
++int main() {
+   struct cookiedata g = { 0 };
+   FILE *fp = fopencookie(&g, "r", funcs);
+ 
+   if (fp && fseek(fp, 8192, SEEK_SET) == 0 && g.pos == 8192)
+-    exit(0);
+-  exit(1);
++    return 0;
++  return 1;
+ }
+ 
+ 
+@@ -18619,6 +18619,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <stdio.h>
++#include <unistd.h>
+ int main(int argc, char *argv[])
+ {
+   FILE *fp;
+@@ -18628,7 +18629,7 @@
+   fp = fopen(filename, "w");
+   if (fp == NULL) {
+     perror("fopen");
+-    exit(2);
++    return 2;
+   }
+   fputs("foobar", fp);
+   fclose(fp);
+@@ -20394,6 +20395,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <string.h>
+ #include <netdb.h>
+ #include <sys/types.h>
+ #ifndef AF_INET
+@@ -20406,11 +20408,11 @@
+   hints.ai_flags = AI_NUMERICHOST;
+ 
+   if (getaddrinfo("127.0.0.1", 0, &hints, &ai) < 0) {
+-    exit(1);
++    return 1;
+   }
+ 
+   if (ai == 0) {
+-    exit(1);
++    return 1;
+   }
+ 
+   pai = ai;
+@@ -20418,16 +20420,16 @@
+   while (pai) {
+     if (pai->ai_family != AF_INET) {
+       /* 127.0.0.1/NUMERICHOST should only resolve ONE way */
+-      exit(1);
++      return 1;
+     }
+     if (pai->ai_addr->sa_family != AF_INET) {
+       /* 127.0.0.1/NUMERICHOST should only resolve ONE way */
+-      exit(1);
++      return 1;
+     }
+     pai = pai->ai_next;
+   }
+   freeaddrinfo(ai);
+-  exit(0);
++  return 0;
+ }
+ 
+ _ACEOF
+@@ -20944,22 +20946,26 @@
+ #define _REENTRANT
+ #include <sys/types.h>
+ #include <dirent.h>
++#include <unistd.h>
+ 
+ #ifndef PATH_MAX
+ #define PATH_MAX 1024
+ #endif
+ 
+-main() {
++int main() {
+   DIR *dir;
+   char entry[sizeof(struct dirent)+PATH_MAX];
+   struct dirent *pentry = (struct dirent *) &entry;
+ 
+   dir = opendir("/");
+   if (!dir)
+-    exit(1);
+-  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0)
+-    exit(0);
+-  exit(1);
++    return 1;
++  if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0) {
++    close(dir);
++    return 0;
++  }
++  close(dir);
++  return 1;
+ }
+ 
+ _ACEOF
+@@ -83209,14 +83215,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ 
+-    main() {
++    int main() {
+     int fd = open("conftest_in", O_WRONLY|O_CREAT, 0600);
+ 
+-    if (fd < 0) exit(1);
+-    if (pwrite(fd, "text", 4, 0) != 4) exit(1);
++    if (fd < 0) return 1;
++    if (pwrite(fd, "text", 4, 0) != 4) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+ 
+ 
+@@ -83251,14 +83257,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ ssize_t pwrite(int, void *, size_t, off64_t);
+-    main() {
++    int main() {
+     int fd = open("conftest_in", O_WRONLY|O_CREAT, 0600);
+ 
+-    if (fd < 0) exit(1);
+-    if (pwrite(fd, "text", 4, 0) != 4) exit(1);
++    if (fd < 0) return 1;
++    if (pwrite(fd, "text", 4, 0) != 4) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pwrite(fd, "text", 4, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+ 
+ 
+@@ -83320,14 +83326,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ 
+-    main() {
++    int main() {
+     char buf[3];
+     int fd = open("conftest_in", O_RDONLY);
+-    if (fd < 0) exit(1);
+-    if (pread(fd, buf, 2, 0) != 2) exit(1);
++    if (fd < 0) return 1;
++    if (pread(fd, buf, 2, 0) != 2) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+ 
+ _ACEOF
+@@ -83363,14 +83369,14 @@
+ #include <unistd.h>
+ #include <errno.h>
+ ssize_t pread(int, void *, size_t, off64_t);
+-    main() {
++    int main() {
+     char buf[3];
+     int fd = open("conftest_in", O_RDONLY);
+-    if (fd < 0) exit(1);
+-    if (pread(fd, buf, 2, 0) != 2) exit(1);
++    if (fd < 0) return 1;
++    if (pread(fd, buf, 2, 0) != 2) return 1;
+     /* Linux glibc breakage until 2.2.5 */
+-    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) exit(1);
+-    exit(0);
++    if (pread(fd, buf, 2, -1) != -1 || errno != EINVAL) return 1;
++    return 0;
+     }
+ 
+ _ACEOF
+@@ -87328,6 +87334,8 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
+ 
+ int main(int argc, char **argv)
+ {
+@@ -87445,6 +87453,8 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -87456,9 +87466,9 @@
+ int main() {
+ #if HAVE_CRYPT
+ 	char *encrypted = crypt("rasmuslerdorf","rl");
+-	exit(!encrypted || strcmp(encrypted,"rl.3StKT.4T8M"));
++	return !encrypted || strcmp(encrypted,"rl.3StKT.4T8M");
+ #else
+-	exit(1);
++	return 1;
+ #endif
+ }
+ _ACEOF
+@@ -87493,6 +87503,8 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -87504,9 +87516,9 @@
+ int main() {
+ #if HAVE_CRYPT
+ 	char *encrypted = crypt("rasmuslerdorf","_J9..rasm");
+-	exit(!encrypted || strcmp(encrypted,"_J9..rasmBYk8r9AiWNc"));
++	return !encrypted || strcmp(encrypted,"_J9..rasmBYk8r9AiWNc");
+ #else
+-	exit(1);
++	return 1;
+ #endif
+ }
+ _ACEOF
+@@ -87541,6 +87553,8 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -87562,9 +87576,9 @@
+ 	strcpy(answer,salt);
+ 	strcat(answer,"rISCgZzpwk3UhDidwXvin0");
+ 	encrypted = crypt("rasmuslerdorf",salt);
+-	exit(!encrypted || strcmp(encrypted,answer));
++	return !encrypted || strcmp(encrypted,answer);
+ #else
+-	exit(1);
++	return 1;
+ #endif
+ }
+ _ACEOF
+@@ -87599,6 +87613,8 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -87617,9 +87633,9 @@
+ 	strcpy(answer,salt);
+ 	strcpy(&answer[29],"nIdrcHdxcUxWomQX9j6kvERCFjTg7Ra");
+ 	encrypted = crypt("rasmuslerdorf",salt);
+-	exit(!encrypted || strcmp(encrypted,answer));
++	return !encrypted || strcmp(encrypted,answer);
+ #else
+-	exit(1);
++	return 1;
+ #endif
+ }
+ _ACEOF
+@@ -87654,6 +87670,8 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -87671,9 +87689,9 @@
+ 	strcpy(answer, salt);
+ 	strcat(answer, "EeHCRjm0bljalWuALHSTs1NB9ipEiLEXLhYeXdOpx22gmlmVejnVXFhd84cEKbYxCo.XuUTrW.RLraeEnsvWs/");
+ 	encrypted = crypt("rasmuslerdorf",salt);
+-	exit(!encrypted || strcmp(encrypted,answer));
++	return !encrypted || strcmp(encrypted,answer);
+ #else
+-	exit(1);
++	return 1;
+ #endif
+ }
+ _ACEOF
+@@ -87708,6 +87726,8 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <string.h>
++
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+@@ -87725,9 +87745,9 @@
+ 	strcpy(answer, salt);
+ 	strcat(answer, "cFAm2puLCujQ9t.0CxiFIIvFi4JyQx5UncCt/xRIX23");
+ 	encrypted = crypt("rasmuslerdorf",salt);
+-	exit(!encrypted || strcmp(encrypted,answer));
++	return !encrypted || strcmp(encrypted,answer);
+ #else
+-	exit(1);
++	return 1;
+ #endif
+ }
+ _ACEOF
+@@ -105354,7 +105374,10 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-main() {char buf[20];exit(sprintf(buf,"testing 123")!=11); }
++
++#include <stdio.h>
++int main() {char buf[20]; return sprintf(buf,"testing 123")!=11; }
++
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+ 
+@@ -105682,16 +105705,16 @@
+ 		double d = (double) LONG_MIN * LONG_MIN + 2e9;
+ 
+ 		if ((long) d == 2e9 && (long) -d == -2e9) {
+-			exit(0);
++			return 0;
+ 		}
+ 	} else if (sizeof(long) == 8) {
+ 		double correct = 18e18 - ((double) LONG_MIN * -2); /* Subtract ULONG_MAX + 1 */
+ 
+ 		if ((long) 18e18 == correct) { /* On 64-bit, only check between LONG_MAX and ULONG_MAX */
+-			exit(0);
++			return 0;
+ 		}
+ 	}
+-	exit(1);
++	return 1;
+ }
+ 
+ _ACEOF
+@@ -105777,10 +105800,6 @@
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -105796,7 +105815,7 @@
+   else
+     puts (dlerror ());
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5
+@@ -106047,7 +106066,7 @@
+   fprintf(fp, "%d %d\n", ZEND_MM_ALIGNMENT, zeros);
+   fclose(fp);
+ 
+-  exit(0);
++  return 0;
+ }
+ 
+ _ACEOF
+@@ -106157,6 +106176,7 @@
+ #include <sys/mman.h>
+ #include <stdlib.h>
+ #include <stdio.h>
++#include <unistd.h>
+ #ifndef MAP_ANON
+ # ifdef MAP_ANONYMOUS
+ #  define MAP_ANON MAP_ANONYMOUS
+@@ -111670,10 +111690,6 @@
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -111689,7 +111705,7 @@
+   else
+     puts (dlerror ());
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5
+@@ -111770,10 +111786,6 @@
+ #  endif
+ #endif
+ 
+-#ifdef __cplusplus
+-extern "C" void exit (int);
+-#endif
+-
+ void fnord() { int i=42;}
+ int main ()
+ {
+@@ -111789,7 +111801,7 @@
+   else
+     puts (dlerror ());
+ 
+-    exit (status);
++    return status;
+ }
+ EOF
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5


### PR DESCRIPTION
#### Description

Without these patches, we are unable to build PHP 5.3 or PHP 5.6 on a machine running 
OSX11 Big Sur. While these are unmaintained end-of-life versions, there are cases where
old installations may need to be maintained or run.

This also addresses similar build problems mbstring and gd extensions by patching 
their m4 files to avoid implicit function references during configure

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 x86_64
CommandLineTools

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
