### PR TITLE
libquicktime-devel: Update to 1.2.4-20210720

### DIFF
--- a/multimedia/libquicktime-devel/Portfile
+++ b/multimedia/libquicktime-devel/Portfile
@@ -1,11 +1,17 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 name                libquicktime-devel
 set my_name         libquicktime
 conflicts           libquicktime
-version             1.2.4
-revision            20180812
-set git_commit_hash 666c35cd0351ebcf7ee968c8014f2373f6ff423a
+version             1.2.4-20210720
+git.branch          27295919b3a1036ba8bc06cec414dcc501f72d89
+revision            0
+checksums           rmd160  e815c290bad27200c8a44ffeded444013136bf10 \
+                    sha256  7335c99c5a5872c8c4193d5eb7f846a843c5cac7a24995bd03ea6a23b3446c24 \
+                    size    819687
+
 categories          multimedia
 platforms           darwin
 maintainers         {jeremyhu @jeremyhu}
@@ -16,12 +22,8 @@ long_description    ${description}
 homepage            http://libquicktime.sourceforge.net/
 
 master_sites        https://sourceforge.net/code-snapshots/git/l/li/libquicktime/git.git
-distname            libquicktime-git-${git_commit_hash}
+distname            libquicktime-git-${git.branch}
 use_zip             yes
-
-checksums           rmd160  8f31d460dde8c5f933c75c26bdbbe4162aa9dc70 \
-                    sha256  bd0f6d2363b00c0ec9cf5e1c93de598935ec4e16f4d22826df46143b7736e0ca \
-                    size    820698
 
 depends_build       port:pkgconfig
 
@@ -38,11 +40,12 @@ configure.args      --without-gtk --without-alsa --without-libdv --without-openg
                     --without-doxygen \
                     --enable-gpl
 
-post-patch {
-    system "cd ${worksrcpath} && ./make_potfiles"
-}
-
 use_autoreconf      yes
-autoreconf.args     -fvi
+autoreconf.cmd      ./autogen.sh
+autoreconf.args
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
 
 livecheck.type      none


### PR DESCRIPTION
#### Description

libquicktime-devel: Update to 1.2.4-20210720

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
