### PR TITLE
catgirl: new port

### DIFF
--- a/net/catgirl/Portfile
+++ b/net/catgirl/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                catgirl
+version             1.8
+revision            0
+categories          net
+license             GPL-3+
+platforms           darwin
+maintainers         {@ryanakca debian.org:rak} openmaintainer
+
+description         a TLS-only terminal IRC client
+
+long_description    catgirl is a TLS-only terminal IRC client. Its features \
+                    include tab completion, split scrolling, URL detection, nick \
+                    colouring topic diffing, and message filtering.
+
+homepage            https://git.causal.agency/catgirl/
+master_sites        ${homepage}snapshot/
+
+checksums           rmd160  a2c1da6d88e9cfd4ef039a0b68b991b6100fed05 \
+                    sha256  2ef69606640f25ca695bc65d0dd9e16f5fa36184feb38d1253a5648dad68776b \
+                    size    60915
+
+patchfiles          patch-0001-install-sandman.diff
+
+depends_build       port:pkgconfig
+
+depends_lib         lib:libtls.dylib:libressl \
+                    port:ncurses
+
+configure.post_args --prefix=${prefix} \
+                    --mandir=${prefix}/share/man
+
+livecheck.type      regex
+livecheck.regex     ${name}-(\\d+\.\\d+p\\d+).tar.gz

--- a/net/catgirl/files/patch-0001-install-sandman.diff
+++ b/net/catgirl/files/patch-0001-install-sandman.diff
@@ -1,0 +1,34 @@
+From e339056c2591476b180d5e7c3f5992a3ce3d5b69 Mon Sep 17 00:00:00 2001
+From: Ryan Kavanagh <rak@rak.ac>
+Date: Thu, 29 Jul 2021 18:43:55 -0400
+Subject: [PATCH] Install sandman
+
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git Makefile Makefile
+index 373e7d5..00e4efb 100644
+--- Makefile
++++ Makefile
+@@ -27,7 +27,7 @@ OBJS += xdg.o
+ 
+ dev: tags all
+ 
+-all: catgirl
++all: catgirl scripts/sandman
+ 
+ catgirl: ${OBJS}
+ 	${CC} ${LDFLAGS} ${OBJS} ${LDLIBS} -o $@
+@@ -40,7 +40,7 @@ tags: *.[ch]
+ clean:
+ 	rm -f catgirl ${OBJS} tags
+ 
+-install: catgirl catgirl.1
++install: catgirl catgirl.1 install-sandman
+ 	install -d ${DESTDIR}${BINDIR} ${DESTDIR}${MANDIR}/man1
+ 	install catgirl ${DESTDIR}${BINDIR}
+ 	install -m 644 catgirl.1 ${DESTDIR}${MANDIR}/man1
+-- 
+2.32.0
+


### PR DESCRIPTION
#### Description

new port:

```
description         a TLS-only terminal IRC client

long_description    catgirl is a TLS-only terminal IRC client. Its features \
                    include tab completion, split scrolling, URL detection, nick \
                    colouring topic diffing, and message filtering.
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
