### PR TITLE
cmake: restore no-default-rpath usage on Tiger

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -47,7 +47,7 @@ if {${subport} eq ${name}} {
     checksums       rmd160  f0f13ae525878d7929dcc95f322d224e7b47443d \
                     sha256  54dd3e0dcd64e27ff8442071aacc4f5a9605896b5701de46d76f22d686238eba \
                     size    7264123
-    revision        1
+    revision        2
 
     gitlab.livecheck.regex {([0-9.]+)}
     compiler.cxx_standard 2011
@@ -78,7 +78,8 @@ if {${subport} eq ${name}} {
         patch-fix-system-prefix-path.diff \
         patch-cmake-leopard-tiger.diff \
         patch-fix-clock_gettime-test.diff \
-        patch-qt5gui.diff
+        patch-qt5gui.diff \
+        patch-restore-no-default-rpath-added-on-Tiger.diff
 
     depends_lib-append \
         port:curl \

--- a/devel/cmake/files/patch-restore-no-default-rpath-added-on-Tiger.diff
+++ b/devel/cmake/files/patch-restore-no-default-rpath-added-on-Tiger.diff
@@ -1,0 +1,20 @@
+reverts https://gitlab.kitware.com/cmake/cmake/-/commit/4aed96e2309e64571aabfda263b3ca4c4f62d619
+
+see discussion: https://trac.macports.org/ticket/63261
+
+
+--- ./Modules/Platform/Darwin.cmake.orig	2021-07-29 21:11:46.000000000 -0400
++++ ./Modules/Platform/Darwin.cmake	2021-07-29 21:12:56.000000000 -0400
+@@ -47,7 +47,11 @@
+ set(CMAKE_SHARED_MODULE_SUFFIX ".so")
+ set(CMAKE_MODULE_EXISTS 1)
+ set(CMAKE_DL_LIBS "")
+-set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
++
++# Enable rpath support for 10.5 and greater where it is known to work.
++if("${DARWIN_MAJOR_VERSION}" GREATER 8)
++  set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
++endif()
+ 
+ foreach(lang C CXX OBJC OBJCXX)
+   set(CMAKE_${lang}_OSX_COMPATIBILITY_VERSION_FLAG "-compatibility_version ")


### PR DESCRIPTION
cmake is gradually removing support for Tiger
at present, only the default adding of an -rpath
to all library and executables is troublesome however

this reverts:
https://gitlab.kitware.com/cmake/cmake/-/commit/4aed96e2309e64571aabfda263b3ca4c4f62d619

closes: https://trac.macports.org/ticket/63261

this needs someone to actually test it on Tiger to be 100% certain that it does the needed changes, but it looks to be correct.

What changes newer and future versions of cmake might make that make supporting Tiger difficult remain to be seen.