### PR TITLE
py-netifaces: update to 0.11.0, deprecate port

### DIFF
--- a/python/py-netifaces/Portfile
+++ b/python/py-netifaces/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           deprecated 1.0
 
 name                py-netifaces
-version             0.10.9
+version             0.11.0
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             MIT
@@ -15,9 +16,12 @@ long_description    ${description}
 
 homepage            https://alastairs-place.net/projects/netifaces/
 
-checksums           rmd160  777b974353281b8e3b70549cabb77a6b1f0ee379 \
-                    sha256  2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3 \
-                    size    28844
+checksums           rmd160  40b7990e7ea06f6c03d5626519c4164de60da92e \
+                    sha256  043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32 \
+                    size    30106
+
+# See https://github.com/al45tair/netifaces/issues/78
+deprecated.upstream_support no
 
 python.versions     27 36 37 38 39
 


### PR DESCRIPTION
#### Description

The changelog can be found [here](https://github.com/al45tair/netifaces/blob/master/CHANGELOG). The project is no longer maintained upstream.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
