### PR TITLE
lagrange: update to 1.6.1

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.5.2 v
+github.setup        skyjake lagrange 1.6.1 v
 github.tarball_from releases
 categories          net gemini
 platforms           darwin
@@ -19,13 +19,15 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  ec6fc9ee4543b7f47b62dac101e16c6186554698 \
-                    sha256  3be4d5b383726f725301bf757e06dcd2d30de1aa50431943387c9aa0df8d0a3f \
-                    size    20409523
+checksums           rmd160  ba9182ae40dc6b877c8fb45fe1a672c4620a57d8 \
+                    sha256  890b213b4ff8af28fe2608506a88c86fa12184d182d906c56a8e44986e425753 \
+                    size    22698567
 
 depends_build-append \
                     port:pkgconfig
-depends_lib-append  port:libsdl2 \
+depends_lib-append  port:fribidi \
+                    port:harfbuzz \
+                    port:libsdl2 \
                     port:libunistring \
                     path:lib/libssl.dylib:openssl \
                     port:mpg123 \
@@ -34,6 +36,9 @@ depends_lib-append  port:libsdl2 \
 
 compiler.c_standard 2011
 compiler.blacklist-append {clang < 800}
+
+configure.args-append "-DENABLE_HARFBUZZ_MINIMAL:BOOL=OFF"
+configure.args-append "-DENABLE_FRIBIDI_BUILD:BOOL=OFF"
 
 destroot {
     copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
