### PR TITLE
libretls: new port

### DIFF
--- a/devel/libretls/Portfile
+++ b/devel/libretls/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libretls
+version             3.3.3p1
+revision            0
+categories          devel
+platforms           darwin
+license             ISC
+maintainers         {causal.agency:june @causal-agent} openmaintainer
+
+description         libtls for OpenSSL
+long_description    LibreTLS is a port of libtls from LibreSSL to OpenSSL. \
+                    libtls is a new TLS library, designed to make it easier \
+                    to write foolproof applications.
+
+homepage            https://git.causal.agency/libretls/about/
+master_sites        https://causal.agency/libretls/
+
+checksums           rmd160  7a6bd3ecf5ae0385ad175a4cb97b02e3571a69c3 \
+                    sha256  8a5b38a76b778da8d6f4236f1ea89e680daea971be6ee3a57e4e7ae99a883aa2 \
+                    size    434666
+
+depends_lib         port:openssl
+
+configure.args      --with-openssl=${prefix}
+configure.checks.implicit_function_declaration.whitelist-append getpagesize
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     ${name}-(\[0-9.\]+(p\[0-9\]+)?)${extract.suffix}


### PR DESCRIPTION
Provides libtls through a dependency on openssl, rather than libressl.
libtls is required by the recently added catgirl port.

Re: https://github.com/macports/macports-ports/pull/11735

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
