### PR TITLE
dylibbundler: update to 1.0.0

### DIFF
--- a/devel/dylibbundler/Portfile
+++ b/devel/dylibbundler/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        auriamg macdylibbundler 0.4.5 {} -release
+github.setup        auriamg macdylibbundler 1.0.0 {}
 revision            0
-checksums           rmd160  e87ffd25d5405e78bf02cb3c57795b0d5502bfec \
-                    sha256  cd41e45115371721e0aa94e70c457134acf49f6d5f6d359b5bae060fd876d887 \
-                    size    11114
+checksums           rmd160  16df7b25d306f4b0560ee6c3888dba23ed4073e5 \
+                    sha256  9e2c892f0cfd7e10cef9af1127fee6c18a4c391463b9fc50574667eec4ec2c60 \
+                    size    11878
 
 name                dylibbundler
 categories          devel
@@ -42,8 +42,10 @@ use_configure       no
 
 variant universal {}
 
+compiler.cxx_standard  2011
+
 build.args          CXX="${configure.cxx}" \
-                    CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]"
+                    CXXFLAGS="${configure.cxxflags} -std=c++11 [get_canonical_archflags cxx]"
 
 destroot.args       PREFIX=${prefix}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9216 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Just one note, I added the `configure.cxx_standard` and it did nothing, not sure if it's because the port doesn't use configure or what, but that's the reason I *also* added the `-std=c++11` flag like that in the `CXXFLAGS`. 