### PR TITLE
Update MoarVM, nqp and rakudo to 2021.07

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                MoarVM
-version             2021.05
+version             2021.07
 categories          lang devel
 platforms           darwin
 license             Artistic-2 MIT BSD ISC public-domain
@@ -16,9 +16,9 @@ long_description    MoarVM is a virtual machine built especially for \
 homepage            https://moarvm.org/
 master_sites        https://moarvm.org/releases/
 
-checksums           rmd160  32665b40603d03f79a1ab21969123c906aa3b515 \
-                    sha256  b14c8778664e3bcaed9cfde3c7b3a3b1898be5f839efee7464979e3954a6a897 \
-                    size    5448573
+checksums           rmd160  fab74335e4c4ab7c35d687030ed167a3f3817834 \
+                    sha256  8437ceefa5c132d0cf8328b22604e26f0a2a54c0377538aa9ae4bdfcf66d63fe \
+                    size    5451296
 
 # TODO: https://github.com/MoarVM/MoarVM/issues/321
 # conflicts         dyncall libtommath libuv

--- a/lang/nqp/Portfile
+++ b/lang/nqp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Raku nqp 2021.05
+github.setup        Raku nqp 2021.07
 description         A lightweight Perl-6 like language for virtual machines
 long_description    This is "Not Quite Perl" -- a lightweight Perl 6-like \
                     environment for virtual machines.  The key feature of \
@@ -21,9 +21,9 @@ platforms           darwin
 github.tarball_from \
                     releases
 
-checksums           rmd160  a9a4cb0ff5088574df53c2fe045244f09af4ccc4 \
-                    sha256  b43cf9d25a8b3187c7e132e1edda647d58bc353ca0fb534cc9aa0f8df7fff73f \
-                    size    5204115
+checksums           rmd160  ed6a00f94b484cefb98a810c5bbdb3f5f0115ad8 \
+                    sha256  dcaaf2a43ab3b752be6f4147a88abdc5b897e5ba85e536a0282bde8e4d363ea4 \
+                    size    5207096
 
 depends_build       port:perl5
 

--- a/lang/rakudo/Portfile
+++ b/lang/rakudo/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rakudo rakudo 2021.05
+github.setup        rakudo rakudo 2021.07
 description         Perl6 compiler
 long_description    Rakudo is a compiler for the Perl 6 language (version 6.d) \
                     Rakudo is built using NQP (Not Quite Perl 6), which in \
@@ -19,9 +19,9 @@ homepage            https://rakudo.org/
 github.tarball_from \
                     releases
 
-checksums           rmd160  e5d3e902062b1ff74c73c94a9966e4aba583fb13 \
-                    sha256  538633ed2eb742d15972742ffb5e9ccae1b238fca053565da48ee9bdc96a3341 \
-                    size    5726333
+checksums           rmd160  a36c9b7867be8c4d35d9eabcd1fca535695fb4a5 \
+                    sha256  178afe4dc8b2f32e155eb2f8482e1125409edfd8451c39d33a472047047fab52 \
+                    size    7728968
 
 depends_build       port:perl5
 


### PR DESCRIPTION
#### Description

Update MoarVM, nqp and rakudo to 2021.07

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.4 20F71 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
