### PR TITLE
icdiff: Update to 2.0.3

### DIFF
--- a/textproc/icdiff/Portfile
+++ b/textproc/icdiff/Portfile
@@ -4,12 +4,18 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        jeffkaufman icdiff 2.0.0 release-
+github.setup        jeffkaufman icdiff 2.0.3 release-
+revision            0
+checksums           rmd160  d7dbabcdb27d128ea0796649a12530a428d44020 \
+                    sha256  23e9502895999a929e1d3559403205846742f7cf8a22c5d7f3c4db910ba12321 \
+                    size    32357
+
 categories          textproc sysutils devel
 platforms           darwin
 maintainers         {raimue @raimue} \
                     openmaintainer
 license             PSF
+supported_archs     noarch
 
 description         improved colored diff
 
@@ -18,11 +24,8 @@ long_description    \
     in the way. This is especially helpful for identifying and understanding \
     small changes within existing lines.
 
-homepage            http://www.jefftk.com/icdiff
-
-checksums           rmd160  a99e1323366789845e5d3cdc15f3bca986cc2e1c \
-                    sha256  5cf377f6064fbff75c39c6d4cde7926e013c420f832ec58226c585ca78b64fc0 \
-                    size    32145
+homepage            https://www.jefftk.com/icdiff
+github.tarball_from archive
 
 python.default_version 39
 


### PR DESCRIPTION
#### Description

icdiff: Update to 2.0.3; supported_archs noarch

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
