### PR TITLE
libzzip: Update to 0.13.72

### DIFF
--- a/archivers/libzzip/Portfile
+++ b/archivers/libzzip/Portfile
@@ -2,10 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cmake 1.1
 
-github.setup        gdraheim zziplib 0.13.69 v
+github.setup        gdraheim zziplib 0.13.72 v
 name                libzzip
-version             0.13.71
 categories          archivers devel
 platforms           darwin
 license             LGPL
@@ -18,26 +18,24 @@ long_description    The ZZIPlib provides read access on ZIP-archives. The \
                     access files being either real files or zipped files, \
                     both with the same filepath.
 
-checksums           rmd160  d401fc327138d5b997c0cd318f808f95cea1f937 \
-                    sha256  c5cf1c11a6019862e5b6daea4d7c72124affe687b9637effc7ad3caf2b7b1d96 \
-                    size    1132209
+checksums           rmd160  20b12141e49c6332d8fd8b610d1fa4a868d9072b \
+                    sha256  61a14917400dbef5eafb482ddc862f3edad86c888a73f445f82e1ab856d24b46 \
+                    size    1162325
 
-depends_build       port:pkgconfig \
-                    port:python27
+patchfiles          patch_manPython.diff
 
-depends_lib         port:zlib
+depends_build-append \
+                    port:pkgconfig \
+                    port:python39
+
+depends_lib-append  port:zlib
 
 set docdir ${prefix}/share/doc/${name}
 
-configure.python    ${prefix}/bin/python2.7
-configure.env       ac_cv_path_PAX=:
-
-post-configure {
-    set builddir [glob -dir ${worksrcpath} "*apple-darwin*"]
-    reinplace -E {s|-arch [a-z0-9_]+||g} \
-        ${builddir}/zzip/zziplib-uninstalled.pc \
-        ${builddir}/zzip/zziplib.pc
-}
+configure.args-append \
+                    -DPYTHON_EXECUTABLE=${prefix}/bin/python3.9 \
+                    -DZZIPTEST=OFF \
+                    -DZZIPSDL=OFF
 
 post-destroot {
     xinstall -d ${destroot}${docdir}/html
@@ -64,14 +62,10 @@ post-destroot {
 }
 
 variant sdl description {Enable SDL support} {
-    depends_lib-append      port:libsdl
-
-    configure.args-append   --enable-sdl
+    depends_lib-append      port:libsdl2
+    configure.args-replace  -DZZIPSDL=OFF -DZZIPSDL=ON
 
     post-destroot {
         xinstall -m 0644 ${worksrcpath}/docs/README.SDL ${destroot}${docdir}
     }
 }
-
-test.run        yes
-test.target     check

--- a/archivers/libzzip/files/patch_manPython.diff
+++ b/archivers/libzzip/files/patch_manPython.diff
@@ -1,0 +1,87 @@
+diff --git docs/CMakeLists.txt.orig docs/CMakeLists.txt
+index 9271dd9..62795cf 100644
+--- docs/CMakeLists.txt.orig
++++ docs/CMakeLists.txt
+@@ -11,6 +11,7 @@ option(BUILD_TESTS "Build test programs" OFF)
+ option(MSVC_STATIC_RUNTIME "Build with static runtime libs (/MT)" ON)
+ option(ZZIP_HTMLSITE "Generate site html pages from docs" OFF)
+ option(ZZIP_HTMPAGES "Generate html manpages from sources" OFF)
++set(PYTHON_EXECUTABLE "" CACHE FILEPATH "Path to Python executable")
+ 
+ if(UNIX)
+ option(ZZIP_MANPAGES "Generate man3 manpages from sources" ON)
+@@ -21,7 +22,6 @@ endif()
+ # Zlib library needed
+ find_package ( ZLIB REQUIRED )
+ # pkg_search_module ( ZZIP zzip )
+-find_package(PythonInterp 3.5 REQUIRED)
+ find_package(UnixCommands REQUIRED) # bash cp mv rm gzip tar
+ find_program(XMLTO xmlto)
+ 
+@@ -31,7 +31,6 @@ set(README ${CMAKE_SOURCE_DIR}/README)
+ set(topdir ${CMAKE_SOURCE_DIR})
+ set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
+ set(outdir ${CMAKE_CURRENT_BINARY_DIR})
+-set(PY ${PYTHON_EXECUTABLE})
+ 
+ set(mandir ${CMAKE_INSTALL_FULL_MANDIR})
+ set(docdir ${CMAKE_INSTALL_FULL_DOCDIR})
+@@ -80,7 +79,7 @@ add_custom_command(OUTPUT site.html
+ add_custom_target(site DEPENDS site.html)
+ 
+ add_custom_command(OUTPUT zzip.xml
+-    COMMAND ${PY} ${srcdir}/zzipdoc/htm2dbk.py ${htm_FILES} zziplib.xml -o ${outdir}/zzip.xml
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/zzipdoc/htm2dbk.py ${htm_FILES} zziplib.xml -o ${outdir}/zzip.xml
+     DEPENDS zziplib.xml ${htm_FILES}
+     WORKING_DIRECTORY ${srcdir}
+     VERBATIM)
+@@ -101,28 +100,28 @@ endif()
+ set(docinfo --package=zziplib --version=${PROJECT_VERSION})
+ file(GLOB zzip_sources "${topdir}/zzip/*.c")
+ add_custom_command(OUTPUT zziplib.xml
+-    COMMAND ${PY} ${srcdir}/makedocs.py ${zzip_sources} ${docinfo} --onlymainheader=zzip/lib.h --output=zziplib
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/makedocs.py ${zzip_sources} ${docinfo} --onlymainheader=zzip/lib.h --output=zziplib
+     COMMAND ${MV} zziplib.docbook zziplib.xml
+     DEPENDS libzzip
+     BYPRODUCTS zziplib.html
+     VERBATIM)
+ add_custom_command(OUTPUT zzipmmapped.xml
+-    COMMAND ${PY} ${srcdir}/makedocs.py ${zzip_sources} ${docinfo} --onlymainheader=zzip/mmapped.h --output=zzipmmapped
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/makedocs.py ${zzip_sources} ${docinfo} --onlymainheader=zzip/mmapped.h --output=zzipmmapped
+     COMMAND ${MV} zzipmmapped.docbook zzipmmapped.xml
+     DEPENDS libzzipmmapped
+     BYPRODUCTS zzipmmapped.html
+     VERBATIM)
+ add_custom_command(OUTPUT zzipfseeko.xml
+-    COMMAND ${PY} ${srcdir}/makedocs.py ${zzip_sources} ${docinfo} --onlymainheader=zzip/fseeko.h --output=zzipfseeko
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/makedocs.py ${zzip_sources} ${docinfo} --onlymainheader=zzip/fseeko.h --output=zzipfseeko
+     COMMAND ${MV} zzipfseeko.docbook zzipfseeko.xml
+     DEPENDS libzzipfseeko
+     BYPRODUCTS zzipfseeko.html
+     VERBATIM)
+ add_custom_command(OUTPUT manpages.tar
+     COMMAND ${BASH} -c "test -d man3 && rm -rf man3; mkdir man3"
+-    COMMAND ${PY} ${srcdir}/dbk2man.py -o man3 man zziplib.xml
+-    COMMAND ${PY} ${srcdir}/dbk2man.py -o man3 man zzipmmapped.xml
+-    COMMAND ${PY} ${srcdir}/dbk2man.py -o man3 man zzipfseeko.xml
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/dbk2man.py -o man3 man zziplib.xml
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/dbk2man.py -o man3 man zzipmmapped.xml
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/dbk2man.py -o man3 man zzipfseeko.xml
+     COMMAND ${BASH} -c "test -d man3/man3 && mv man3 man3_; test -d man3_/man3 && mv man3_/man3 .; rm -rf man3_"
+     COMMAND ${BASH} -c "chmod 664 man3/*.3"
+     COMMAND ${BASH} -c "tar cf manpages.tar man3"
+@@ -131,10 +130,10 @@ add_custom_command(OUTPUT manpages.tar
+     VERBATIM)
+ add_custom_command(OUTPUT htmpages.tar
+     COMMAND ${BASH} -c "test -d html && rm -rf html; mkdir html"
+-    COMMAND ${PY} ${srcdir}/dbk2man.py -o html html zziplib.xml
+-    COMMAND ${PY} ${srcdir}/dbk2man.py -o html html zzipmmapped.xml
+-    COMMAND ${PY} ${srcdir}/dbk2man.py -o html html zzipfseeko.xml
+-    COMMAND ${PY} ${srcdir}/dir2index.py -o html html
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/dbk2man.py -o html html zziplib.xml
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/dbk2man.py -o html html zzipmmapped.xml
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/dbk2man.py -o html html zzipfseeko.xml
++    COMMAND ${PYTHON_EXECUTABLE} ${srcdir}/dir2index.py -o html html
+     COMMAND ${BASH} -c "tar cf htmpages.tar html/*.*"
+     COMMAND ${BASH} -c "ls -l `pwd`/htmpages.tar || true"
+     DEPENDS zziplib.xml zzipmmapped.xml zzipfseeko.xml

--- a/audio/mpd/Portfile
+++ b/audio/mpd/Portfile
@@ -9,7 +9,7 @@ PortGroup           boost 1.0
 name                mpd
 
 version             0.22.9
-revision            0
+revision            1
 checksums           rmd160  603af5318b4814003f97f4e5b8bce05bb007d6d3 \
                     sha256  f937403297c2240bd4a569f4b937ee7ab17398a5284ba9df4d6d4c3a0512bc64 \
                     size    738432

--- a/devel/lua-luazip/Portfile
+++ b/devel/lua-luazip/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name                lua-luazip
 version             1.2.3
+revision            1
 categories          devel
 license             MIT
 platforms           darwin

--- a/graphics/ogre/Portfile
+++ b/graphics/ogre/Portfile
@@ -6,7 +6,7 @@ PortGroup boost 1.0
 
 name                ogre
 version             1.7.3
-revision            7
+revision            8
 set branch          [join [lrange [split ${version} .] 0 1] .]
 license             MIT
 categories          graphics

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -15,6 +15,7 @@ PortGroup       muniversal 1.0
 
 name            texlive-bin
 version         2021.58693
+revision        1
 
 categories      tex
 maintainers     {dports @drkp}


### PR DESCRIPTION
#### Description

I was having issues building this from source; it was failing at the post-destroot stage due to a grep command failing, so I decided to check the portfile and realized version in master was reported as `0.13.71`, but when you actually look at the last commit (https://github.com/macports/macports-ports/commit/237e1401f88a43fe40b39c1ae774fe0b6157e25d#diff-42e8e9d789afaaee19e371f2c5a62df00c626a8ee6530d70ad99ba87bd1fe1d5), you will notice the maintainer bumped the version without actually changing it on the `github.setup`

So I went upstream and updated the port to the latest release, changing the build system to CMake in the process.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9216 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
