### PR TITLE
libreoffice: do not use system libcmis

### DIFF
--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -5,7 +5,7 @@ PortGroup           boost 1.0
 
 name                libreoffice
 version             7.2.0.2
-revision            0
+revision            1
 categories          office aqua
 license             {LGPL-3 MPL-1.1}
 platforms           macosx
@@ -35,12 +35,14 @@ master_sites        ${main_uri}:main \
                     ${extern_uri}:opens \
                     ${addons_uri}:dtoa \
                     ${main_uri}:dicts \
-                    ${main_uri}:translations
+                    ${main_uri}:translations \
+                    ${addons_uri}:libcmis
 distfiles           ${main_distfile}:main \
                     ${name}-dictionaries-${version}.tar.xz:dicts \
                     ${name}-translations-${version}.tar.xz:translations \
                     dtoa-20180411.tgz:dtoa \
-                    f543e6e2d7275557a839a164941c0a86e5f2c3f2a0042bfc434c88c6dde9e140-opens___.ttf:opens
+                    f543e6e2d7275557a839a164941c0a86e5f2c3f2a0042bfc434c88c6dde9e140-opens___.ttf:opens \
+                    libcmis-0.5.2.tar.xz:libcmis
 
 checksums           libreoffice-${version}.tar.xz \
                     rmd160  2de3ba21c8499d1eee856f459d8ac959917b225a \
@@ -61,7 +63,11 @@ checksums           libreoffice-${version}.tar.xz \
                     f543e6e2d7275557a839a164941c0a86e5f2c3f2a0042bfc434c88c6dde9e140-opens___.ttf \
                     rmd160  b9e2cc0c836faa59eca3bfc0f24e1b790646b112 \
                     sha256  f543e6e2d7275557a839a164941c0a86e5f2c3f2a0042bfc434c88c6dde9e140 \
-                    size    207992
+                    size    207992 \
+                    libcmis-0.5.2.tar.xz \
+                    rmd160  cb17ab0d699ab56faae46ebaaabca618f3cf8b28 \
+                    sha256  d7b18d9602190e10d437f8a964a32e983afd57e2db316a07d87477a79f5000a2 \
+                    size    484404
 
 depends_build-append \
     port:autoconf \
@@ -95,7 +101,6 @@ depends_lib-append  \
     port:lcms2 \
     port:libabw \
     port:libcdr-0.1 \
-    port:libcmis \
     port:libe-book \
     port:libepoxy \
     port:libepubgen \
@@ -217,7 +222,6 @@ configure.args-append  \
     --with-system-hunspell \
     --with-system-jars \
     --with-system-libabw \
-    --with-system-libcmis \
     --with-system-libebook \
     --with-system-libepubgen \
     --with-system-libexttextcat \
@@ -241,6 +245,7 @@ configure.args-append  \
     --without-java \
     --without-package-format \
     --without-system-dicts \
+    --without-system-libcmis \
     --without-system-sane \
     \"--with-lang=bg br ca ca-valencia cy cs da de el en-US en-GB es et eu fi fr ga gd gl hr hu id is it ja km lt lv nb nl nn pl pt pt-BR ro ru sk sl sv ta tr uk zh-CN zh-TW\"
 


### PR DESCRIPTION
LibreOffice uses a patched version of libcmis which is not compatible with
the original version.

https://gerrit.libreoffice.org/c/core/+/119572

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5 20G71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
