### PR TITLE
ruby: Fix configure.env quoting for MacPorts>=2.6

### DIFF
--- a/lang/ruby/Portfile
+++ b/lang/ruby/Portfile
@@ -154,15 +154,15 @@ if {${universal_possible} && [variant_isset universal]} {
 	#   pure ruby libraries
 	#     - lib/ruby/[1.8|site_ruby/1.8|vendor_ruby/1.8]/
 	foreach arch ${configure.universal_archs} {
-		append merger_configure_env(${arch}) "ARCH_FLAG=\"-arch ${arch}\" "
+		lappend merger_configure_env(${arch}) "ARCH_FLAG=-arch ${arch}"
 		# force environment "ac_cv_build" to specify locations of extension
 		# modules(*.bundle), headers(ruby.h, config.h, ..) and rbconfig.rb.
 		# like this:
 		#   i386   -> ${prefix}/lib/ruby/1.8/i386-apple-darwin10/
 		#   x86_64 ->                       /x86_64-apple-darwin10/
 		set cpu_type ${arch}
-		append merger_configure_env(${arch}) \
-			"ac_cv_build=\"${cpu_type}-apple-darwin${os.major}\" "
+		lappend merger_configure_env(${arch}) \
+			"ac_cv_build=${cpu_type}-apple-darwin${os.major}"
 	}
 } elseif {[info exists build_arch] && ${build_arch} ne ""} {
 	configure.env-append "ARCH_FLAG=-arch ${build_arch}"


### PR DESCRIPTION
#### Description

ruby: Fix configure.env quoting for MacPorts>=2.6. Fixes build failure with universal variant:

```
ccache /usr/bin/clang -pipe -Os -Werror=implicit-function-declaration -arch x86_64  -fno-common -pipe -fno-common    -DRUBY_EXPORT "-arch -I. -I. -I/opt/local/include -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE   -c array.c
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
make: *** [array.o] Error 2
```

(The way that `configure.env` etc. need to be quoted in MacPorts changed in 2.6.0.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
