### PR TITLE
qt4-mac: fixes for macOS 12 Monterey

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -71,7 +71,7 @@ if {${macosx_deployment_target} ne ""} {
         set MINOR [expr [lindex [split ${os.version} "."] 0] - 20]
     }
 }
-ui_debug "Deduced OS MAJOR.MINOR = ${MAJOR}.${MINOR}"
+# ui_debug "Deduced OS MAJOR.MINOR = ${MAJOR}.${MINOR}"
 
 ###############################################
 # Patches are used to both fix compiling on various OS versions, and
@@ -392,6 +392,11 @@ if {${os.arch} == "arm"} {
     patchfiles-append patch-fix-ARM64-cross-build-as-X86_64.diff
 }
 
+# newer Clang (e.g., on macOS Monterey 12.0+) doesn't allow "volative"
+# ASM keyword; removing it should not hurt other compilers; if it does
+# we'll add an "if" to narrow the scope of application
+patchfiles-append patch-src_3rdparty_javascriptcore_JavaScriptCore_jit_JITStubs.cpp_remove_volatile.diff
+
 # the version header file is part of C++20
 # newer versions of Clang find VERSION instead
 post-extract {
@@ -403,7 +408,7 @@ post-extract {
 # error out if trying to build on a new OSX version (> 11.0).
 
 platform darwin {
-    if { ( ${MAJOR} == 10 && ${MINOR} > 15 ) || ${MAJOR} > 11 } {
+    if { ( ${MAJOR} == 10 && ${MINOR} > 15 ) || ${MAJOR} > 12 } {
         # This project needs to be updated to build with clang++ against libc++
         depends_lib
         depends_run

--- a/aqua/qt4-mac/files/patch-src_3rdparty_javascriptcore_JavaScriptCore_jit_JITStubs.cpp_remove_volatile.diff
+++ b/aqua/qt4-mac/files/patch-src_3rdparty_javascriptcore_JavaScriptCore_jit_JITStubs.cpp_remove_volatile.diff
@@ -1,0 +1,218 @@
+--- src/3rdparty/javascriptcore/JavaScriptCore/jit/JITStubs.cpp.orig
++++ src/3rdparty/javascriptcore/JavaScriptCore/jit/JITStubs.cpp
+@@ -116,7 +116,7 @@
+ COMPILE_ASSERT(offsetof(struct JITStackFrame, callFrame) == 0x58, JITStackFrame_callFrame_offset_matches_ctiTrampoline);
+ COMPILE_ASSERT(offsetof(struct JITStackFrame, code) == 0x50, JITStackFrame_code_offset_matches_ctiTrampoline);
+ 
+-asm volatile (
++asm (
+ ".text\n"
+ ".globl " SYMBOL_STRING(ctiTrampoline) "\n"
+ HIDE_SYMBOL(ctiTrampoline) "\n"
+@@ -138,7 +138,7 @@
+     "ret" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiVMThrowTrampoline) "\n"
+ HIDE_SYMBOL(ctiVMThrowTrampoline) "\n"
+ SYMBOL_STRING(ctiVMThrowTrampoline) ":" "\n"
+@@ -154,7 +154,7 @@
+     "ret" "\n"
+ );
+     
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiOpThrowNotCaught) "\n"
+ HIDE_SYMBOL(ctiOpThrowNotCaught) "\n"
+ SYMBOL_STRING(ctiOpThrowNotCaught) ":" "\n"
+@@ -179,7 +179,7 @@
+ COMPILE_ASSERT(offsetof(struct JITStackFrame, callFrame) == 0x90, JITStackFrame_callFrame_offset_matches_ctiTrampoline);
+ COMPILE_ASSERT(offsetof(struct JITStackFrame, code) == 0x80, JITStackFrame_code_offset_matches_ctiTrampoline);
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiTrampoline) "\n"
+ HIDE_SYMBOL(ctiTrampoline) "\n"
+ SYMBOL_STRING(ctiTrampoline) ":" "\n"
+@@ -206,7 +206,7 @@
+     "ret" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiVMThrowTrampoline) "\n"
+ HIDE_SYMBOL(ctiVMThrowTrampoline) "\n"
+ SYMBOL_STRING(ctiVMThrowTrampoline) ":" "\n"
+@@ -222,7 +222,7 @@
+     "ret" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiOpThrowNotCaught) "\n"
+ HIDE_SYMBOL(ctiOpThrowNotCaught) "\n"
+ SYMBOL_STRING(ctiOpThrowNotCaught) ":" "\n"
+@@ -242,7 +242,7 @@
+ #error "JIT_STUB_ARGUMENT_VA_LIST not supported on ARMv7."
+ #endif
+ 
+-asm volatile (
++asm (
+ ".text" "\n"
+ ".align 2" "\n"
+ ".globl " SYMBOL_STRING(ctiTrampoline) "\n"
+@@ -269,7 +269,7 @@
+     "bx lr" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".text" "\n"
+ ".align 2" "\n"
+ ".globl " SYMBOL_STRING(ctiVMThrowTrampoline) "\n"
+@@ -287,7 +287,7 @@
+     "bx lr" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".text" "\n"
+ ".align 2" "\n"
+ ".globl " SYMBOL_STRING(ctiOpThrowNotCaught) "\n"
+@@ -305,7 +305,7 @@
+ 
+ #elif COMPILER(GCC) && CPU(ARM_TRADITIONAL)
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiTrampoline) "\n"
+ HIDE_SYMBOL(ctiTrampoline) "\n"
+ SYMBOL_STRING(ctiTrampoline) ":" "\n"
+@@ -323,7 +323,7 @@
+     "mov pc, lr" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiVMThrowTrampoline) "\n"
+ HIDE_SYMBOL(ctiVMThrowTrampoline) "\n"
+ SYMBOL_STRING(ctiVMThrowTrampoline) ":" "\n"
+@@ -418,7 +418,7 @@
+ COMPILE_ASSERT(offsetof(struct JITStackFrame, code) == 0x30, JITStackFrame_code_offset_matches_ctiTrampoline);
+ COMPILE_ASSERT(offsetof(struct JITStackFrame, savedEBX) == 0x1c, JITStackFrame_stub_argument_space_matches_ctiTrampoline);
+ 
+-asm volatile (
++asm (
+ ".text\n"
+ ".globl " SYMBOL_STRING(ctiTrampoline) "\n"
+ HIDE_SYMBOL(ctiTrampoline) "\n"
+@@ -440,7 +440,7 @@
+     "ret" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiVMThrowTrampoline) "\n"
+ HIDE_SYMBOL(ctiVMThrowTrampoline) "\n"
+ SYMBOL_STRING(ctiVMThrowTrampoline) ":" "\n"
+@@ -456,7 +456,7 @@
+     "ret" "\n"
+ );
+     
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiOpThrowNotCaught) "\n"
+ HIDE_SYMBOL(ctiOpThrowNotCaught) "\n"
+ SYMBOL_STRING(ctiOpThrowNotCaught) ":" "\n"
+@@ -480,7 +480,7 @@
+ COMPILE_ASSERT(offsetof(struct JITStackFrame, code) == 0x48, JITStackFrame_code_offset_matches_ctiTrampoline);
+ COMPILE_ASSERT(offsetof(struct JITStackFrame, savedRBX) == 0x78, JITStackFrame_stub_argument_space_matches_ctiTrampoline);
+ 
+-asm volatile (
++asm (
+ ".text\n"
+ ".globl " SYMBOL_STRING(ctiTrampoline) "\n"
+ HIDE_SYMBOL(ctiTrampoline) "\n"
+@@ -515,7 +515,7 @@
+     "ret" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiVMThrowTrampoline) "\n"
+ HIDE_SYMBOL(ctiVMThrowTrampoline) "\n"
+ SYMBOL_STRING(ctiVMThrowTrampoline) ":" "\n"
+@@ -531,7 +531,7 @@
+     "ret" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiOpThrowNotCaught) "\n"
+ HIDE_SYMBOL(ctiOpThrowNotCaught) "\n"
+ SYMBOL_STRING(ctiOpThrowNotCaught) ":" "\n"
+@@ -551,7 +551,7 @@
+ #error "JIT_STUB_ARGUMENT_VA_LIST not supported on ARMv7."
+ #endif
+ 
+-asm volatile (
++asm (
+ ".text" "\n"
+ ".align 2" "\n"
+ ".globl " SYMBOL_STRING(ctiTrampoline) "\n"
+@@ -578,7 +578,7 @@
+     "bx lr" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".text" "\n"
+ ".align 2" "\n"
+ ".globl " SYMBOL_STRING(ctiVMThrowTrampoline) "\n"
+@@ -596,7 +596,7 @@
+     "bx lr" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".text" "\n"
+ ".align 2" "\n"
+ ".globl " SYMBOL_STRING(ctiOpThrowNotCaught) "\n"
+@@ -614,7 +614,7 @@
+ 
+ #elif COMPILER(GCC) && CPU(ARM_TRADITIONAL)
+ 
+-asm volatile (
++asm (
+ ".text\n"
+ ".globl " SYMBOL_STRING(ctiTrampoline) "\n"
+ HIDE_SYMBOL(ctiTrampoline) "\n"
+@@ -632,7 +632,7 @@
+     "mov pc, lr" "\n"
+ );
+ 
+-asm volatile (
++asm (
+ ".globl " SYMBOL_STRING(ctiVMThrowTrampoline) "\n"
+ HIDE_SYMBOL(ctiVMThrowTrampoline) "\n"
+ SYMBOL_STRING(ctiVMThrowTrampoline) ":" "\n"
+@@ -1024,7 +1024,7 @@
+     extern "C" { \
+         rtype JITStubThunked_##op(STUB_ARGS_DECLARATION); \
+     }; \
+-    asm volatile ( \
++    asm ( \
+         ".text" "\n" \
+         ".align 2" "\n" \
+         ".globl " SYMBOL_STRING(cti_##op) "\n" \
+@@ -1053,7 +1053,7 @@
+     extern "C" { \
+         rtype JITStubThunked_##op(STUB_ARGS_DECLARATION); \
+     }; \
+-    asm volatile ( \
++    asm ( \
+         ".globl " SYMBOL_STRING(cti_##op) "\n" \
+         HIDE_SYMBOL(cti_##op) "\n"             \
+         SYMBOL_STRING(cti_##op) ":" "\n" \

--- a/aqua/qt4-mac/files/patch-src_gui_kernel_qmime_mac.cpp.diff
+++ b/aqua/qt4-mac/files/patch-src_gui_kernel_qmime_mac.cpp.diff
@@ -1,5 +1,5 @@
---- .//src/gui/kernel/qmime_mac.cpp.orig
-+++ .//src/gui/kernel/qmime_mac.cpp
+--- src/gui/kernel/qmime_mac.cpp.orig
++++ src/gui/kernel/qmime_mac.cpp
 @@ -68,12 +68,6 @@
  #include "qmap.h"
  #include <private/qt_mac_p.h>


### PR DESCRIPTION
#### Description

Amazingly qt4-mac builds and executes on the macOS 12 Monterey beta! Just a small tweak / patchfile to fix the build with the latest Clang. I added a few other minor tweaks that technically aren't related.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.0 21A5294g x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
