### PR TITLE
libtool: more robust xattr command

### DIFF
--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -80,12 +80,9 @@ post-destroot {
 
     # libtool 2.4.6 contains com.dropbox.attributes xattrs,
     # let's avoid spreading them further (#54459)
-    # xattr on leopard or earlier does not support -r so do the recursion manually
-    if {${os.platform} eq "darwin" && ${os.major} >= 10} {
-        system "xattr -r -d com.dropbox.attributes ${destroot}"
-    } else {
-        system -W ${destroot} "find . -type f -print0 | xargs -0 xattr -d com.dropbox.attributes"
-    }
+    # xattr on Leopard or earlier does not support -r so do the recursion manually
+    # xattr on Monterey supports -r but errors on directories, so do fully manual
+    system -W ${destroot} "xattr -d com.dropbox.attributes \$(find . -type f -print0 | xargs -0 xattr | grep com.dropbox.attributes | awk '{ print \$1 }' | sed -e 's@:\$@@g')"
 }
 
 test.run            yes


### PR DESCRIPTION
#### Description

xattr on macOS 12 Monterey beta supports -r but errors on directories, so do fully manual ... hoping for the same command here!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.0 21A5294g x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
