### PR TITLE
ghostscript: Fix build with GCC 4.2

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -39,6 +39,10 @@ patchfiles          patch-base_unix-dll.mak.diff \
 # https://bugs.ghostscript.com/show_bug.cgi?id=703880
 patchfiles-append   patch-configure.ac.diff
 
+# Fix issue with GCC pragmas inside function bodies
+# https://trac.macports.org/ticket/63105
+patchfiles-append   patch-base_scommon.h.diff
+
 checksums           ghostpdl-9.54.0.tar.gz \
                     rmd160  a48ecd441c761a9401a5e4a34ea90afd6936d419 \
                     sha256  63e54cddcdf48ea296b6315353f86b8a622d4e46959b10d536297e006b85687b \

--- a/print/ghostscript/files/patch-base_scommon.h.diff
+++ b/print/ghostscript/files/patch-base_scommon.h.diff
@@ -1,0 +1,36 @@
+--- base/scommon.h.orig
++++ base/scommon.h
+@@ -118,14 +118,14 @@
+ static inline void
+ stream_cursor_read_init(stream_cursor_read *r, const byte *buf, size_t length)
+ {
+-#ifdef __GNUC__
++#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || defined(__clang__))
+ #  pragma GCC diagnostic push
+ #  pragma GCC diagnostic ignored "-Warray-bounds"
+ #endif
+     /* starting pos for pointer is always one position back */
+     r->ptr = buf - 1;
+     r->limit = r->ptr + length;
+-#ifdef __GNUC__
++#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || defined(__clang__))
+ #  pragma GCC diagnostic pop
+ #endif
+ }
+@@ -133,14 +133,14 @@
+ static inline void
+ stream_cursor_write_init(stream_cursor_write *w, const byte *buf, size_t length)
+ {
+-#ifdef __GNUC__
++#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || defined(__clang__))
+ #  pragma GCC diagnostic push
+ #  pragma GCC diagnostic ignored "-Warray-bounds"
+ #endif
+     /* starting pos for pointer is always one position back */
+     w->ptr = (byte *)buf - 1;
+     w->limit = (byte *)w->ptr + length;
+-#ifdef __GNUC__
++#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || defined(__clang__))
+ #  pragma GCC diagnostic pop
+ #endif
+ }


### PR DESCRIPTION
#### Description

GCC 4.2 and earlier do not support `#pragma`s inside of function bodies. Furthermore, GCC 4.5 and earlier do not support the `push` and `pop` pragmas.

Closes: https://trac.macports.org/ticket/63105
Supersedes: https://github.com/macports/macports-ports/pull/11628

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
