### PR TITLE
gcc-devel: add basic support for macOS 12 Monterey for Intel only for now

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -73,6 +73,12 @@ if { ${build_arch} eq "arm64" } {
     distname        gcc-${version}
     use_xz          yes
 
+    # temporary patch to allow build on macOS 12 Monterey; this patch
+    # is the minimum required for basic functionality; it does not
+    # provide for optimizations for the specific OS.
+    patchfiles-append patch-min-fixes-for-macOS-12-Monterey.x86.diff
+    patch.pre_args -p1
+
 }
 
 depends_build-append \

--- a/lang/gcc-devel/files/patch-min-fixes-for-macOS-12-Monterey.x86.diff
+++ b/lang/gcc-devel/files/patch-min-fixes-for-macOS-12-Monterey.x86.diff
@@ -1,0 +1,56 @@
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 93e2b3219..ad3d1c30a 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -674,6 +674,11 @@ case ${target} in
+         macos_maj=11
+         def_ld64=609.0
+         ;;
++      *-*-darwin21*)
++        # Darwin 21 corresponds to macOS 12.
++        macos_maj=12
++        def_ld64=650.9
++        ;;
+       *-*-darwin)
+         case ${cpu_type} in
+           aarch64) macos_maj=11 ;;
+diff --git a/gcc/config/darwin-c.c b/gcc/config/darwin-c.c
+index 951a99877..62d28fcea 100644
+--- a/gcc/config/darwin-c.c
++++ b/gcc/config/darwin-c.c
+@@ -691,7 +691,7 @@ macosx_version_as_macro (void)
+   if (!version_array)
+     goto fail;
+ 
+-  if (version_array[MAJOR] < 10 || version_array[MAJOR] > 11)
++  if (version_array[MAJOR] < 10 || version_array[MAJOR] > 12)
+     goto fail;
+ 
+   if (version_array[MAJOR] == 10 && version_array[MINOR] < 10)
+diff --git a/gcc/config/darwin-driver.c b/gcc/config/darwin-driver.c
+index 3d7768f05..39bae2ff3 100644
+--- a/gcc/config/darwin-driver.c
++++ b/gcc/config/darwin-driver.c
+@@ -64,13 +64,20 @@ validate_macosx_version_min (const char *version_str)
+ 
+   major = strtoul (version_str, &end, 10);
+ 
+-  if (major < 10 || major > 11 ) /* MacOS 10 and 11 are known. */
++  if (major < 10 || major > 12 ) /* MacOS 10, 11, and 12 are known. */
+     return NULL;
+ 
+   /* Skip a separating period, if there's one.  */
+   version_str = end + ((*end == '.') ? 1 : 0);
+ 
+-  if (major == 11 && *end != '\0' && !ISDIGIT (version_str[0]))
++  if (major == 12 && *end != '\0' && !ISDIGIT (version_str[0]))
++     /* For MacOS 12, we allow just the major number, but if the minor is
++	there it must be numeric.  */
++    return NULL;
++  else if (major == 12 && *end == '\0')
++    /* We will rewrite 12 =>  12.0.0.  */
++    need_rewrite = true;
++  else if (major == 11 && *end != '\0' && !ISDIGIT (version_str[0]))
+      /* For MacOS 11, we allow just the major number, but if the minor is
+ 	there it must be numeric.  */
+     return NULL;


### PR DESCRIPTION
#### Description

add basic support for macOS 12 Monterey to the `gcc-devel` ports for Intel only for now. This patch is the minimum to allow building the current codebase on Monterey. This port then allows for NumPy and others to be built, and those are successful (thus far).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.0 21A5294g x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
