### PR TITLE
gemget: new port

### DIFF
--- a/net/gemget/Portfile
+++ b/net/gemget/Portfile
@@ -1,0 +1,85 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/makeworld-the-better-one/gemget 1.8.0 v
+revision            0
+categories          net gemini
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+license             MIT
+
+description         Command line downloader for the Gemini protocol
+long_description    ${description}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  c43dfd2307c6c3ad4da37671438266313efa864e \
+                        sha256  ce0dcc04c220aee8faf692d08d43627ea3fd40c3d56fd7ea889f7fb7aaea35e2 \
+                        size    10457
+
+go.vendors          golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    golang.org/x/net \
+                        lock    986b41b23924 \
+                        rmd160  83029228f5946c63337ea000b5123ccd20245004 \
+                        sha256  384b8c1e750469fe62d9280126a8218bf1f4eb13734ebaf4f856ae6dc18060a3 \
+                        size    1251258 \
+                    github.com/stretchr/testify \
+                        lock    v1.3.0 \
+                        rmd160  80582370443047a1d7020211865d85d54c036eea \
+                        sha256  ac782171992e3af1c8ac8384cbf4a39706ec5f9e3c6eed57a246e02dce571762 \
+                        size    102899 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/schollz/progressbar \
+                        lock    v3.6.0 \
+                        rmd160  f29fc1fcf32f76726e46b136ffdd805b895681e5 \
+                        sha256  35cfdfbfbe29162f42d5dea127774a22c14967133f99992f5e023df2f1f3918d \
+                        size    601968 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/mitchellh/colorstring \
+                        lock    d06e56a500db \
+                        rmd160  79e1fb92818b77a56b274c3bb7880891af3f7829 \
+                        sha256  0a3c9097c65cf50b9dfe8150adf2f096f9e62b36200759459969d3b9ee3a20fe \
+                        size    4679 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.9 \
+                        rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
+                        sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
+                        size    16716 \
+                    github.com/makeworld-the-better-one/go-gemini \
+                        lock    v0.11.0 \
+                        rmd160  8b52426f5ed2718c7e1d637de4e2dd2da0053dc3 \
+                        sha256  297368c8e482401448132cc6b04b41b87ff213111119861653aa7cd77f0e4391 \
+                        size    11863 \
+                    github.com/google/go-cmp \
+                        lock    v0.3.1 \
+                        rmd160  66e42f672a5a40561c388b78b3644abd926e7bef \
+                        sha256  86ee7c90714e7eb5c60d1a8a515235daef806df454c767043b593540e958167f \
+                        size    76416 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171
+
+build.args          -ldflags '-X main.version=${version}'
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
[**gemget**](https://github.com/makeworld-the-better-one/gemget/) - a command line downloader for the [Gemini protocol](https://gemini.circumlunar.space/).

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
