### PR TITLE
syncthing: update to 1.18.1

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.17.0 v
+go.setup            github.com/syncthing/syncthing 1.18.1 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,9 +18,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  a8b3922fae38aaa9396c0a08aafec866e474ffa0 \
-                        sha256  eb6ed1718f677e38e7a02e22c06577914dd27a2aecde95ffa1f011905003b565 \
-                        size    6092970
+                        rmd160  9a6fe22a4c6a03d7b6e61a19b8056b001c986f13 \
+                        sha256  e4cda093b41ed60c5f34a0b8740978b609bc2f0d71d651d15fcc8f90212aca7e \
+                        size    6145312
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -48,18 +48,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
                         sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
                         size    1270531 \
-                    google.golang.org/grpc \
-                        repo    github.com/grpc/grpc-go \
-                        lock    v1.26.0 \
-                        rmd160  e831a775462a0399cb97ec0889174512f9d8bdc8 \
-                        sha256  494fb4767284855e46275a06d3a743068e62b2d0da903d824336ad94d6caf1f7 \
-                        size    765450 \
-                    google.golang.org/genproto \
-                        repo    github.com/googleapis/go-genproto \
-                        lock    24fa4b261c55 \
-                        rmd160  93f6926ff96d990032f4ef7cefa1d9744624799f \
-                        sha256  51c44148d4eb2ef9225af6a2a0308e0237619f582ba0d0a2b8a51b5a967afa1d \
-                        size    5332236 \
                     golang.org/x/xerrors \
                         lock    5ec99f83aff1 \
                         rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
@@ -240,11 +228,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
                         sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
                         size    37197 \
-                    github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
                     github.com/maruel/panicparse \
                         lock    v1.6.1 \
                         rmd160  6f7b6c1f0ea3b1d065dc8e8e1c0aa42d3db90434 \
@@ -305,11 +288,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
                         sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
                         size    13435 \
-                    github.com/grpc-ecosystem/grpc-gateway \
-                        lock    v1.9.5 \
-                        rmd160  f8386b54c5da2f6c3a0cf5b106ee4481ed42459b \
-                        sha256  266f0c8f49e8ab16b4dcfbd66b126e4e0d8c63ff8a6e0d8702e38734bb5650f7 \
-                        size    303364 \
                     github.com/greatroar/blobloom \
                         lock    v0.7.0 \
                         rmd160  2f7d414a0bd3e0d71ecc829ee6b94dcb49f60374 \
@@ -340,11 +318,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  dba4526dc11102f7cfc3ee7be23cb1416793e35b \
                         sha256  03b46be967afa501b74a1bf72211b08d6e8f6b2a3b42335105480b6df6e51980 \
                         size    26110 \
-                    github.com/golang/glog \
-                        lock    23def4e6c14b \
-                        rmd160  b5bd9166cd1e073a035b5bbd3c4d9febf2c917a7 \
-                        sha256  2826d20759090e909ba0f8771def236ad6433fc3e44bdc28374b309efe3e57cf \
-                        size    19662 \
                     github.com/gogo/protobuf \
                         lock    v1.3.2 \
                         rmd160  c16e6e6fb8f26d3d1ceef9e99fa4dfb5899878fd \


### PR DESCRIPTION
#### Description
Updates syncthing to 1.18.1
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
