### PR TITLE
catgirl: use libretls for libtls dependency by default

### DIFF
--- a/devel/libretls/Portfile
+++ b/devel/libretls/Portfile
@@ -25,7 +25,10 @@ checksums           rmd160  7a6bd3ecf5ae0385ad175a4cb97b02e3571a69c3 \
 depends_lib         port:openssl
 
 configure.args      --with-openssl=${prefix}
+
+if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append getpagesize
+}
 
 livecheck.type      regex
 livecheck.url       ${master_sites}

--- a/net/catgirl/Portfile
+++ b/net/catgirl/Portfile
@@ -4,11 +4,14 @@ PortSystem          1.0
 
 name                catgirl
 version             1.8
-revision            0
+revision            1
 categories          net
 license             GPL-3+
+license_noconflict  openssl libressl
 platforms           darwin
-maintainers         {@ryanakca debian.org:rak} openmaintainer
+maintainers         {@ryanakca debian.org:rak} \
+                    {causal.agency:june @causal-agent} \
+                    openmaintainer
 
 description         a TLS-only terminal IRC client
 
@@ -27,7 +30,7 @@ patchfiles          patch-0001-install-sandman.diff
 
 depends_build       port:pkgconfig
 
-depends_lib         lib:libtls.dylib:libressl \
+depends_lib         path:lib/libtls.dylib:libretls \
                     port:ncurses
 
 configure.post_args --prefix=${prefix} \


### PR DESCRIPTION
catgirl can build with libtls provided by either libretls when
openssl is installed, or by libressl when libressl is installed.
Since openssl is the default, use libretls to provide the missing
library. Also use a path: dependency since we always want to build
against a MacPorts libtls.

While here, add license_noconflict for both openssl and libressl,
since catgirl's license includes additional permission for
OpenSSL/LibreSSL.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
