### PR TITLE
openjdk: add subport for Eclipse Temurin, make openjdk8 a meta port

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -35,6 +35,9 @@ set long_description_adoptopenjdk_openj9xl \
     "${long_description_adoptopenjdk_openj9} This version uses non-compressed references and should be used for\
 applications which require heaps that are over ~57 GB."
 
+set long_description_temurin \
+    "Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes."
+
 set long_description_graalvm \
     "GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++."
@@ -100,23 +103,25 @@ subport openjdk7-zulu {
 }
 
 subport openjdk8 {
-    version      8u292
+    version      8u302
     revision     0
 
-    set build    10
+    set meta true
 
-    description  Open Java Development Kit 8 (AdoptOpenJDK) with HotSpot VM
-    long_description ${long_description_adoptopenjdk_hotspot}
+    description  Open Java Development Kit 8 meta port
+    long_description Open Java Development Kit 8 meta port
 
-    master_sites https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk${version}-b${build}/
-    distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
-    worksrcdir   jdk${version}-b${build}
+    distfiles
+    destroot    {
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
+    }
 
-    configure.cxx_stdlib libstdc++
-
-    checksums    rmd160  680c91c140f50774e20efabe58c9780a9a62b94a \
-                 sha256  5646fbe9e4138c902c910bb7014d41463976598097ad03919e4848634c7e8007 \
-                 size    103785976
+    if {${configure.build_arch} eq "x86_64"} {
+        depends_run-append port:openjdk8-temurin
+    } elseif {${configure.build_arch} eq "arm64"} {
+        depends_run-append port:openjdk8-zulu
+    }
 }
 
 subport openjdk8-graalvm {
@@ -129,7 +134,7 @@ subport openjdk8-graalvm {
     master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
     distname     graalvm-ce-java8-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java8-${version}
-    
+
     checksums    rmd160  2fc5f23a1558b5e125ef91ad137270fe4f2b4d0c \
                  sha256  25a653a44b3ad63479d7ae35d921c8d39282ff1849243f1afc0ffddd443e9079 \
                  size    349277690
@@ -142,6 +147,8 @@ subport openjdk8-openj9 {
     set build    10
     set openj9_version 0.26.0
 
+    homepage     https://adoptopenjdk.net
+
     description  Open Java Development Kit 8 (AdoptOpenJDK) with Eclipse OpenJ9 VM
     long_description ${long_description_adoptopenjdk_openj9}
 
@@ -152,6 +159,24 @@ subport openjdk8-openj9 {
     checksums    rmd160  15c82bb986080025de06ddaab2e08a4a493fb389 \
                  sha256  d262bc226895e80b7e80d61905e65fe043ca0a3e3b930f7b88ddfacb8835e939 \
                  size    118492789
+}
+
+subport openjdk8-temurin {
+    version      8u302
+    revision     0
+
+    set build    08
+
+    description  Eclipse Temurin, based on OpenJDK 8
+    long_description ${long_description_temurin}
+
+    master_sites https://github.com/adoptium/temurin8-binaries/releases/download/jdk${version}-b${build}/
+    distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
+    worksrcdir   jdk${version}-b${build}
+
+    checksums    rmd160  69c845bcdea22bb8f5fb74a3fe1b248e0116c43a \
+                 sha256  6205fefca28342d99938b3933ed839784835ed1de6ed9ba034ce772377f74061 \
+                 size    107303398
 }
 
 subport openjdk8-zulu {
@@ -206,6 +231,8 @@ subport openjdk11 {
 
     set build    9
 
+    homepage     https://adoptopenjdk.net
+
     description  Open Java Development Kit 11 (AdoptOpenJDK) with HotSpot VM
     long_description ${long_description_adoptopenjdk_hotspot}
 
@@ -228,7 +255,7 @@ subport openjdk11-graalvm {
     master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
     distname     graalvm-ce-java11-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java11-${version}
-    
+
     checksums    rmd160  7a1f0185f67022ad7f9ba5540a438580edd10792 \
                  sha256  f62cdc44a031731aa221426724a55eb09c79d6b2e9275ae3ca7003da5884ca36 \
                  size    399511612
@@ -240,6 +267,8 @@ subport openjdk11-openj9 {
 
     set build    9
     set openj9_version 0.26.0
+
+    homepage     https://adoptopenjdk.net
 
     description  Open Java Development Kit 11 (AdoptOpenJDK) with Eclipse OpenJ9 VM
     long_description ${long_description_adoptopenjdk_openj9}
@@ -428,6 +457,8 @@ subport openjdk16 {
 
     set build    9
 
+    homepage     https://adoptopenjdk.net
+
     description  Open Java Development Kit 16 (AdoptOpenJDK) with HotSpot VM
     long_description ${long_description_adoptopenjdk_hotspot}
 
@@ -462,6 +493,8 @@ subport openjdk16-openj9 {
 
     set build    9
     set openj9_version 0.26.0
+
+    homepage     https://adoptopenjdk.net
 
     description  Open Java Development Kit 16 (AdoptOpenJDK) with Eclipse OpenJ9 VM
     long_description ${long_description_adoptopenjdk_openj9}
@@ -522,60 +555,61 @@ if {[string match *-graalvm ${subport}]} {
     homepage     https://www.graalvm.org
 } elseif {[string match *-zulu ${subport}]} {
     homepage     https://www.azul.com/downloads/
-} else {
-    homepage     https://adoptopenjdk.net
+} elseif {[string match *-temurin ${subport}]} {
+    homepage     https://adoptium.net
 }
 
 livecheck.type  none
 
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
 use_configure    no
-
 build {}
 
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
+if {![info exists meta]} {
+    variant Applets \
+        description { Advertise the JVM capability "Applets".} {}
 
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
+    variant BundledApp \
+        description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
 
-set target /Library/Java/JavaVirtualMachines/${subport}
-set destroot_target ${destroot}${target}
+    variant JNI \
+        description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
 
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
+    variant WebStart \
+        description { Advertise the JVM capability "WebStart".} {}
 
-    if {${subport} eq "openjdk7-zulu"} {
-        # MacPorts reports this file as broken
-        delete ${destroot_target}/Contents/Home/jre/lib/xawt/libmawt.dylib
+    patch {
+        foreach var { Applets BundledApp JNI WebStart } {
+            if {[variant_isset ${var}]} {
+                reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+            }
+        }
     }
+
+    test.run    yes
+    test.cmd    Contents/Home/bin/java
+    test.target
+    test.args   -version
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+    destroot.violate_mtree yes
+
+    set target /Library/Java/JavaVirtualMachines/${subport}
+    set destroot_target ${destroot}${target}
+
+    destroot {
+        xinstall -m 755 -d ${destroot_target}
+        copy ${worksrcpath}/Contents ${destroot_target}
+
+        if {${subport} eq "openjdk7-zulu"} {
+            # MacPorts reports this file as broken
+            delete ${destroot_target}/Contents/Home/jre/lib/xawt/libmawt.dylib
+        }
+    }
+
+    notes "
+    If you have more than one JDK installed you can make ${subport} the default
+    by adding the following line to your shell profile:
+
+        export JAVA_HOME=${target}/Contents/Home
+    "
 }
-
-notes "
-If you have more than one JDK installed you can make ${subport} the default
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"


### PR DESCRIPTION
#### Description

AdoptOpenJDK is rebranding as [Eclipse Temurin](https://adoptium.net). This pull request adds `openjdk8-temurin` as a new subport and changes `openjdk8` into a meta port that installs Eclipse Temurin on x86_64 systems and Azul Zulu on arm64 systems.

Also see https://trac.macports.org/ticket/63319

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?