### PR TITLE
cue: build via goreleaser

### DIFF
--- a/devel/cue/Portfile
+++ b/devel/cue/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/cuelang/cue 0.4.0 v
 go.package          cuelang.org/go
-revision            0
+revision            1
 
 homepage            https://cuelang.org
 
@@ -21,165 +21,22 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 license             Apache-2
 installs_libs       no
 
-build.pre_args      -ldflags \
-                        \"-X ${go.package}/cmd/cue/cmd.version=v${version}\" \
-                    -o ${workpath}/
-build.args          ./cmd/${name}
+fetch.type          git
 
-github.livecheck.regex {([0-9.]+)}
+depends_build-append \
+                    port:goreleaser
+
+# Allow Go to download dependencies at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+build.cmd           goreleaser
+build.pre_args      build
+build.args          --single-target
+
+github.livecheck.regex  {([0-9.]+)}
 
 destroot {
-    xinstall -m 0755 ${workpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0755 \
+        ${worksrcpath}/dist/${name}_${goos}_${goarch}/${name} \
+        ${destroot}${prefix}/bin/
 }
-
-checksums           ${distname}${extract.suffix} \
-                        rmd160  85e08f21b6fa6329cc0b7f65a3ccb6f4118e5831 \
-                        sha256  1b3fcd3708ea16a2f51d88c193c6d69fa8785a9f29512bd1fa67b1d341cb5173 \
-                        size    1248285
-
-go.vendors          gopkg.in/yaml.v3 \
-                        lock    a6ecf24a6d71 \
-                        rmd160  ee20dd502c9d5dfc994048fd1569c75ac2b09276 \
-                        sha256  433b5d47a6ad2fef9a75f63c6ecb63e44cdc9dd2efbf70950b7f14512cf056e0 \
-                        size    86629 \
-                    gopkg.in/errgo.v2 \
-                        lock    v2.1.0 \
-                        rmd160  6629a8436aacbbf5e42c0211d591941bfd8ce34d \
-                        sha256  c14c14eba0928e6dfa4f89449bdbe2b6feafc76116b60bdc1b51956abf55c6bf \
-                        size    9938 \
-                    gopkg.in/check.v1 \
-                        lock    788fd7840127 \
-                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
-                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
-                        size    31597 \
-                    golang.org/x/xerrors \
-                        lock    9bdfabe68543 \
-                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
-                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
-                        size    13661 \
-                    golang.org/x/tools \
-                        lock    54c614fe050c \
-                        rmd160  982c2a4e1d8e0a5573367149a1276d3eeda90106 \
-                        sha256  33797a3b010bbb2ced5b8a1ffe817567d00271d0d168f943a3603e83c0125776 \
-                        size    2476102 \
-                    golang.org/x/text \
-                        lock    v0.3.2 \
-                        rmd160  3b9523084f6a8b2e6a6987e49c56f05e22ad69eb \
-                        sha256  d624899dfd390d9d4a77e5c8e5abd8c45f0b6163e0dc7176aee39f25c5f1bed0 \
-                        size    7168458 \
-                    golang.org/x/net \
-                        lock    0de0cce0169b \
-                        rmd160  fe0bcee1ff05a427fd403fb86505bb10549efedb \
-                        sha256  9a8baf6e727edbf6d13dcf4aeaa16fdb427e7e14d2a6cd1c111ca35b86dfd530 \
-                        size    1172422 \
-                    golang.org/x/mod \
-                        lock    ce943fd02449 \
-                        rmd160  7ec34e9999d863e8e510fda467c41f7d7d2feb4a \
-                        sha256  3435c8d1e975ed8b89ee43c76e9699c9bd811341aa362af95aae647e7b06a48f \
-                        size    102257 \
-                    golang.org/x/exp \
-                        lock    84987778548c \
-                        rmd160  a6a9c4073573162834b9fef25dfc1f28f6a2101e \
-                        sha256  3f2e9d4ebb325f1727945683ec1d2c3acf89b8410a8a885816f39e11bd5faa2c \
-                        size    1525746 \
-                    github.com/stretchr/testify \
-                        lock    v1.2.2 \
-                        rmd160  45703d5a082af570664fb80e99918077596349aa \
-                        sha256  ea0e76528dc47d7d84739cd8a8c7560e3f12d4ff490bdd2641a9990a168e6f2f \
-                        size    101747 \
-                    github.com/spf13/pflag \
-                        lock    v1.0.3 \
-                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
-                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
-                        size    46029 \
-                    github.com/spf13/cobra \
-                        lock    v1.0.0 \
-                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
-                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
-                        size    128931 \
-                    github.com/rogpeppe/go-internal \
-                        lock    v1.8.0 \
-                        rmd160  22e8b4dadfbeefb32fd38f3ebab26c94d4b165c5 \
-                        sha256  c7ab367e516959a51525f8152a62df0acc9a32ca153a502da967f072ae69d899 \
-                        size    129032 \
-                    github.com/protocolbuffers/txtpbfmt \
-                        lock    f6a6b3f636fc \
-                        rmd160  47dc13c7a8371798fb810109068477cc8c483d69 \
-                        sha256  5881fb1a56f3538cac9b3a58604a2ebbd9bf257aa8cd77675305a9900a6071a5 \
-                        size    149545 \
-                    github.com/pmezard/go-difflib \
-                        lock    v1.0.0 \
-                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
-                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
-                        size    11409 \
-                    github.com/pkg/errors \
-                        lock    v0.8.1 \
-                        rmd160  a33afa0fbe2e76b7a621d25bdb4bf0b964b18bb5 \
-                        sha256  1ec95b0705f5ac6ea502266b4e6bf177041b7832148a4bf090686243b0f9aa59 \
-                        size    11018 \
-                    github.com/pkg/diff \
-                        lock    20ebb0f2a09e \
-                        rmd160  f8336f7442e9394b64a6aad23a6ae1d6a230dfc4 \
-                        sha256  086dfcc0449ef79f412e6308fd2ace2207a8a88cde2c86f13f77635673e08890 \
-                        size    200592 \
-                    github.com/mpvl/unique \
-                        lock    cbe035fff7de \
-                        rmd160  1429a9af6b2c2f716ce585c67e80eb5dc92306a6 \
-                        sha256  1bf98248cd745c87fd1a7472744864dfa648690e448dce6e917a39f2710fb8ff \
-                        size    2588 \
-                    github.com/lib/pq \
-                        lock    v1.0.0 \
-                        rmd160  f402fa787270acb206c46b40e66c832303603b57 \
-                        sha256  a9e678ebe7837d12a84057db4c8ad6ab0f9f177d99c7057fc493383ae26f1987 \
-                        size    91448 \
-                    github.com/kylelemons/godebug \
-                        lock    v1.1.0 \
-                        rmd160  917ada648e70d2e339b8ff36d2f86882d0d2efa1 \
-                        sha256  6151c487936ab72cffbf804626228083c9b3abfc908a2bb41b1160e1e5780aaf \
-                        size    17641 \
-                    github.com/kr/text \
-                        lock    v0.1.0 \
-                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
-                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
-                        size    8691 \
-                    github.com/kr/pretty \
-                        lock    v0.1.0 \
-                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
-                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
-                        size    8553 \
-                    github.com/inconshreveable/mousetrap \
-                        lock    v1.0.0 \
-                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
-                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
-                        size    2291 \
-                    github.com/google/uuid \
-                        lock    v1.2.0 \
-                        rmd160  9717876312bfbe146a478d24bdb41bf8bb4a6ade \
-                        sha256  ddfae8a6ac3b56a02db288778b424a123c14efe44cdab70e4bab0b1e6dd13114 \
-                        size    14154 \
-                    github.com/google/go-cmp \
-                        lock    v0.4.0 \
-                        rmd160  2d73ccb9863b49adb03196aff7c41a7048e646fb \
-                        sha256  e7274fa6cc337c12123a02acc907524b7c3c234af59b2c924664300a57cb3ea0 \
-                        size    81597 \
-                    github.com/golang/glog \
-                        lock    23def4e6c14b \
-                        rmd160  b5bd9166cd1e073a035b5bbd3c4d9febf2c917a7 \
-                        sha256  2826d20759090e909ba0f8771def236ad6433fc3e44bdc28374b309efe3e57cf \
-                        size    19662 \
-                    github.com/emicklei/proto \
-                        lock    v1.6.15 \
-                        rmd160  bc90b1f75f5fd67418b675dc532ee11a32d4c8e8 \
-                        sha256  b04a1dcb6e2e2af6401a63ad8099ad33e24c708406649f0868f07d411649a1f8 \
-                        size    28597 \
-                    github.com/davecgh/go-spew \
-                        lock    v1.1.1 \
-                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
-                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
-                        size    42171 \
-                    github.com/cockroachdb/apd \
-                        lock    v2.0.1 \
-                        rmd160  83cc78ab5a7a5508a784bb04a2617618b2ac483c \
-                        sha256  5761f9fcf4c700b47ef3b14cd8f7448a4afb7805aaea0f3eb103a9a91327164a \
-                        size    304575
-


### PR DESCRIPTION
Switch `cue`'s build process to build with `goreleaser`, which is closer to the preference on how `cue` should be built:

https://github.com/cue-lang/cue/issues/1125

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
