### PR TITLE
Update patch-Makefile.mac.diff

### DIFF
--- a/sysutils/gptfdisk/files/patch-Makefile.mac.diff
+++ b/sysutils/gptfdisk/files/patch-Makefile.mac.diff
@@ -1,11 +1,11 @@
---- Makefile.mac.orig	2020-02-17 17:34:11.000000000 -0500
-+++ Makefile.mac	    2020-04-10 03:10:53.000000000 -0400
+--- Makefile.mac.orig	2021-06-10 02:27:00.000000000 +0300
++++ Makefile.mac		2021-08-03 18:44:23.000000000 +0300
 @@ -1,11 +1,12 @@
 +prefix=__PREFIX__
  CC=gcc
  CXX=c++
  # FATBINFLAGS=-arch x86_64 -arch i386 -mmacosx-version-min=10.9
- FATBINFLAGS=-arch x86_64 -mmacosx-version-min=10.9
+ FATBINFLAGS=-arch x86_64 -arch arm64 -mmacosx-version-min=10.9
  THINBINFLAGS=-arch x86_64 -mmacosx-version-min=10.9
 -CFLAGS=$(FATBINFLAGS) -O2 -D_FILE_OFFSET_BITS=64 -g
 +CFLAGS=$(FATBINFLAGS) -D_FILE_OFFSET_BITS=64 -g
@@ -15,18 +15,21 @@
  LIB_NAMES=crc32 support guid gptpart mbrpart basicmbr mbr gpt bsd parttypes attributes diskio diskio-unix
  MBR_LIBS=support diskio diskio-unix basicmbr mbrpart
  #LIB_SRCS=$(NAMES:=.cc)
-@@ -21,12 +22,12 @@
+@@ -21,13 +22,15 @@
  #	$(CXX) $(LIB_OBJS) -L/usr/lib -licucore gpttext.o gdisk.o -o gdisk
  
  cgdisk: $(LIB_OBJS) cgdisk.o gptcurses.o
--	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o /usr/lib/libncurses.dylib $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
+-	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o /usr/local/Cellar/ncurses/6.2/lib/libncurses.dylib $(LDFLAGS) -o cgdisk
 +	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o $(prefix)/lib/libncurses.dylib $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
++
+ #	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o /usr/lib/libncurses.dylib $(LDFLAGS) -o cgdisk
  #	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o $(LDFLAGS) -licucore -lncurses -o cgdisk
  
  sgdisk: $(LIB_OBJS) gptcl.o sgdisk.o
  #	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o /opt/local/lib/libiconv.a /opt/local/lib/libintl.a /opt/local/lib/libpopt.a $(FATBINFLAGS) -o sgdisk
 -	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/usr/local/lib -lpopt $(THINBINFLAGS) -o sgdisk
 +	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L$(prefix)/lib -lpopt $(FATBINFLAGS) -o sgdisk
++
  #	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/sw/lib -licucore -lpopt -o sgdisk
  
  fixparts: $(MBR_LIB_OBJS) fixparts.o


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [∎] enhancement


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61
mp-clang-10 @10.0.1_5
mp-clang-devel @20210401-d1828937_0 (clang version 13.0.0)

###### Verification <!-- (delete not applicable items) -->
Have you
port lin gptfdisk
--->  Verifying Portfile for gptfdisk
--->  0 errors and 0 warnings found. [checked your Portfile with `port lint`?]
gptfdisk has no tests turned on. [ tried existing tests with `sudo port test`?]
sudo port -vds install [tried a full install with `sudo port -vst install`?]
yes [ tested basic functionality of all binary files?]

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
