### PR TITLE
google-cloud-sdk: update to 351.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             350.0.0
+version             351.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  c02e4d83d560c9b504d90e55fc90bdc8a44efe51 \
-                    sha256  a20157ac9974b02b329d53fb1de0d79b6a5fc97844e71f47e22b59aa5fb652d5 \
-                    size    90655783
+    checksums       rmd160  8c7e3b6d6c7eab1c39bb5fc9dc7973a40fee89e1 \
+                    sha256  3c6f244e60b7b721f0fccd4d84a63a09290f3f17749d56953b3b8809663e42d7 \
+                    size    91280923
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  807dfb666e4b294dad8d227a310341fb65906f9a \
-                    sha256  d3b995a4b8d0d5a2181d98298ca31020f406c323bc51889a4e3a7aefc346963e \
-                    size    86905628
+    checksums       rmd160  cee646bcbc699513929508bd43189beec6f5829e \
+                    sha256  193fb96eb33512058770f2c3621a64eed281599a385f5ac42418b71af75a27a8 \
+                    size    87526856
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  4561b35f836af5a8f05338e8005baf7d66f572fd \
-                    sha256  8af64643437114658c58d2fa75c58ee830737e04268a650f2992972b5440f1f3 \
-                    size    86826922
+    checksums       rmd160  5bb668f536c33c4bb7e1caff368efe9cf5916618 \
+                    sha256  f087165d91c1553160593380d602f8b03b57de9eeaf2fafaff9f3c10f60c93a0 \
+                    size    87445932
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 351.0.0.

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?