### PR TITLE
skaffold: update to 1.29.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.28.1 v
+github.setup        GoogleContainerTools skaffold 1.29.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  7813f27433048b86cebe8f0f7c220d57eb5aeb12 \
-                    sha256  4d96d820d48934b3c12415697146ec30318e235f3a35d4fc68024cda30b655ef \
-                    size    23969916
+checksums           rmd160  76c00bb822eecd5ce6e3256805737cba575fe360 \
+                    sha256  f12b1f608e8f7095bc5976c40c0c80417ee0a24ae7752012f51074539f311046 \
+                    size    18078858
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.29.0.

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?