### PR TITLE
tippecanoe: new port

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               makefile 1.0
+PortGroup               legacysupport 1.0
+
+github.setup            mapbox tippecanoe 1.36.0
+revision                0
+categories              gis
+license                 BSD
+maintainers             {@sikmir gmail.com:sikmir} openmaintainer
+platforms               darwin
+description             Build vector tilesets from large collections of GeoJSON features
+long_description        ${description}
+
+checksums               rmd160  685878a57d9170d9bdb86e8253a6faa126419b0d \
+                        sha256  274ef274808ed847d3612e8906fbaf16d0b17516b9d7b3b342389f8c0a659d2e \
+                        size    16240869
+
+depends_lib-append      port:sqlite3 \
+                        port:zlib
+
+destroot.args-append    PREFIX=${destroot}${prefix}


### PR DESCRIPTION
#### Description
[**tippecanoe**](https://github.com/mapbox/tippecanoe) - Build vector tilesets from large collections of GeoJSON features.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
