### PR TITLE
openjdk: add subport for Eclipse Temurin 11, make openjdk11 a meta port

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -226,23 +226,25 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.11
+    version      11.0.12
     revision     0
 
-    set build    9
+    set meta true
 
-    homepage     https://adoptopenjdk.net
+    description  Open Java Development Kit 11 meta port
+    long_description Open Java Development Kit 11 meta port
 
-    description  Open Java Development Kit 11 (AdoptOpenJDK) with HotSpot VM
-    long_description ${long_description_adoptopenjdk_hotspot}
+    distfiles
+    destroot {
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
+    }
 
-    master_sites https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  5cd7c7ac1fa84fcaeab677076d80b4970cbf9334 \
-                 sha256  d851a220e77473a4b483d8bd6b6570e04fd83fdd48d6584b58b041f5997186c2 \
-                 size    186275966
+    if {${configure.build_arch} eq "x86_64"} {
+        depends_run-append port:openjdk11-temurin
+    } elseif {${configure.build_arch} eq "arm64"} {
+        depends_run-append port:openjdk11-zulu
+    }
 }
 
 subport openjdk11-graalvm {
@@ -287,6 +289,25 @@ subport openjdk11-openj9-large-heap {
     version      11.0.10
     revision     2
     replaced_by  openjdk11-openj9
+}
+
+subport openjdk11-temurin {
+    version      11.0.12
+    revision     0
+
+    set build    7
+
+    description  Eclipse Temurin, based on OpenJDK 11
+    long_description ${long_description_temurin}
+
+    master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${version}%2B${build}/
+
+    distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
+
+    checksums    rmd160  bee29d914047e0954929bfc1643619773f448332 \
+                 sha256  13d056ee9a57bf2d5b3af4504c8f8cf7a246c4dff78f96b70dd05dad98075855 \
+                 size    191257594
 }
 
 subport openjdk11-zulu {


### PR DESCRIPTION
#### Description

AdoptOpenJDK is rebranding as [Eclipse Temurin](https://adoptium.net). This pull request adds `openjdk11-temurin` as a new subport and changes `openjdk11` into a meta port that installs Eclipse Temurin on x86_64 systems and Azul Zulu on arm64 systems.

Also see https://trac.macports.org/ticket/63319

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?