### PR TITLE
openjdk: add subport for Eclipse Temurin 16, make openjdk16 a meta port

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -473,23 +473,25 @@ subport openjdk15-zulu {
 }
 
 subport openjdk16 {
-    version      16.0.1
+    version      16.0.2
     revision     0
 
-    set build    9
+    set meta true
 
-    homepage     https://adoptopenjdk.net
+    description  Open Java Development Kit 16 meta port
+    long_description Open Java Development Kit 16 meta port
 
-    description  Open Java Development Kit 16 (AdoptOpenJDK) with HotSpot VM
-    long_description ${long_description_adoptopenjdk_hotspot}
+    distfiles
+    destroot {
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
+    }
 
-    master_sites https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-${version}%2B${build}/
-    distname     OpenJDK16U-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  267a6b47ffc2edccb827acf01bca5fde6e029861 \
-                 sha256  3be78eb2b0bf0a6edef2a8f543958d6e249a70c71e4d7347f9edb831135a16b8 \
-                 size    199997543
+    if {${configure.build_arch} eq "x86_64"} {
+        depends_run-append port:openjdk16-temurin
+    } elseif {${configure.build_arch} eq "arm64"} {
+        depends_run-append port:openjdk16-zulu
+    }
 }
 
 subport openjdk16-graalvm {
@@ -527,6 +529,25 @@ subport openjdk16-openj9 {
     checksums    rmd160  a6b458d6652512f9df22f997ecb10b02ee7c7b92 \
                  sha256  6d4241c6ede2167fb71bd57f7a770a74564ee007c06bcae98e1abc3c1de4756f \
                  size    205958282
+}
+
+subport openjdk16-temurin {
+    version      16.0.2
+    revision     0
+
+    set build    7
+
+    description  Eclipse Temurin, based on OpenJDK 16
+    long_description ${long_description_temurin}
+
+    master_sites https://github.com/adoptium/temurin16-binaries/releases/download/jdk-${version}%2B${build}/
+
+    distname     OpenJDK16U-jdk_x64_mac_hotspot_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
+
+    checksums    rmd160  cd0c259c0f73c3c0ab5e2d936a413e121817d53d \
+                 sha256  27975d9e695cfbb93861540926f9f7bcac973a254ceecbee549706a99cbbdf95 \
+                 size    206621395
 }
 
 subport openjdk16-zulu {


### PR DESCRIPTION
#### Description

AdoptOpenJDK is rebranding as [Eclipse Temurin](https://adoptium.net). This pull request adds `openjdk16-temurin` as a new subport and changes `openjdk16` into a meta port that installs Eclipse Temurin on x86_64 systems and Azul Zulu on arm64 systems.

Also see https://trac.macports.org/ticket/63319

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?