### PR TITLE
lnav: update to 0.10.0

### DIFF
--- a/sysutils/lnav/Portfile
+++ b/sysutils/lnav/Portfile
@@ -4,36 +4,44 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 
-github.setup        tstack lnav 0.9.0 v
+github.setup        tstack lnav 0.10.0 v
 revision            0
 
-maintainers         {g5pw @g5pw} openmaintainer
-categories          sysutils
+homepage            https://lnav.org
+
 description         An advanced log file viewer for the small-scale.
+
 long_description    Many logging tools, like Splunk, provide great features but \
                     are optimized for large-scale deployments.  They require \
                     installing and configuring servers before they can be \
                     effectively used.  There is still a need for a robust log \
                     file analyzer for the terminal.
+
+categories          sysutils
 platforms           darwin
 license             BSD
-homepage            http://lnav.org
+
+maintainers         {g5pw @g5pw} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 depends_lib         port:curl \
                     port:pcre \
                     port:sqlite3 \
                     port:ncurses \
+                    port:libarchive \
                     port:readline \
                     port:zlib \
                     port:bzip2 \
                     path:lib/libssl.dylib:openssl
 
-checksums           rmd160  88827fcfd89b726f36d1abd20f343f1bd22b3526 \
-                    sha256  03e15449a87fa511cd19c6bb5e95de4fffe17612520ff7683f2528d3b2a7238f \
-                    size    1094734
+checksums           rmd160  dac445ef89aee40b71ad7d1541bf6a01f36bd3b4 \
+                    sha256  05caf14d410a3912ef9093773aec321e0f4718a29476005c05dd53fcd6de1531 \
+                    size    1686358
 
 configure.args      --disable-silent-rules \
                     --disable-static \
+                    --with-libarchive \
                     --with-libcurl=${prefix} \
                     --with-ncurses \
                     --with-pcre \


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
