### PR TITLE
openjdk: update openjdk16-graalvm to 21.2.0

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -495,7 +495,7 @@ subport openjdk16 {
 }
 
 subport openjdk16-graalvm {
-    version      21.1.0
+    version      21.2.0
     revision     0
 
     description  GraalVM Community Edition based on OpenJDK 16
@@ -505,9 +505,9 @@ subport openjdk16-graalvm {
     distname     graalvm-ce-java16-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java16-${version}
 
-    checksums    rmd160  4bec36c128b42d324f6e7a513501e7c7c7b2fd4c \
-                 sha256  dafece9d03251304a6d9fc242862cfc08b85e2b8921d3b019a8a19b95af78e2c \
-                 size    404268013
+    checksums    rmd160  7dbae81c0113456544e08bda942f67c4ad13cd3b \
+                 sha256  833412a6e26c26ae3de37bd42e889f60d7a7651122c6d52741ed0d7f56a0460f \
+                 size    403397792
 }
 
 subport openjdk16-openj9 {


### PR DESCRIPTION
#### Description

Update to GraalVM 21.2.0 for OpenJDK 16.

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?