### PR TITLE
openjdk: remove redundant variants for openjdk*-temurin

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -607,14 +607,16 @@ use_configure    no
 build {}
 
 if {![info exists meta]} {
+    if {![string match *-temurin ${subport}]} {
+        variant BundledApp \
+            description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+        variant JNI \
+            description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+    }
+
     variant Applets \
         description { Advertise the JVM capability "Applets".} {}
-
-    variant BundledApp \
-        description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-    variant JNI \
-        description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
 
     variant WebStart \
         description { Advertise the JVM capability "WebStart".} {}


### PR DESCRIPTION
#### Description

Remove variants `BundledApp` and `JNI` for `openjdk*-temurin` subports, because those capabilities are enabled by default on those ports.

```
❯ grep -A 5 JVMCapabilities /Library/Java/JavaVirtualMachines/openjdk*-temurin/Contents/Info.plist
/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Info.plist:		<key>JVMCapabilities</key>
/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Info.plist-		<array>
/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Info.plist-			<string>CommandLine</string>
/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Info.plist-			<string>JNI</string>
/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Info.plist-			<string>BundledApp</string>
/Library/Java/JavaVirtualMachines/openjdk11-temurin/Contents/Info.plist-		</array>
--
/Library/Java/JavaVirtualMachines/openjdk16-temurin/Contents/Info.plist:		<key>JVMCapabilities</key>
/Library/Java/JavaVirtualMachines/openjdk16-temurin/Contents/Info.plist-		<array>
/Library/Java/JavaVirtualMachines/openjdk16-temurin/Contents/Info.plist-			<string>CommandLine</string>
/Library/Java/JavaVirtualMachines/openjdk16-temurin/Contents/Info.plist-			<string>JNI</string>
/Library/Java/JavaVirtualMachines/openjdk16-temurin/Contents/Info.plist-			<string>BundledApp</string>
/Library/Java/JavaVirtualMachines/openjdk16-temurin/Contents/Info.plist-		</array>
--
/Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Info.plist:		<key>JVMCapabilities</key>
/Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Info.plist-		<array>
/Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Info.plist-			<string>CommandLine</string>
/Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Info.plist-			<string>JNI</string>
/Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Info.plist-			<string>BundledApp</string>
/Library/Java/JavaVirtualMachines/openjdk8-temurin/Contents/Info.plist-		</array>
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?