### PR TITLE
roswell: new port

### DIFF
--- a/devel/roswell/Portfile
+++ b/devel/roswell/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        roswell roswell 21.06.14.110 v
+revision            0
+
+categories          devel
+license             MIT
+maintainers         {@kakuhen} openmaintainer
+platforms           darwin
+supported_archs     x86_64 arm64
+description         A Lisp implementation manager, launcher, and much more!
+long_description    \
+    Roswell is a full-stack environment for Common Lisp development, and has \
+    many features that makes it easy to test, share, and distribute your Lisp\
+    applications.
+
+depends_build       port:autoconf port:automake port:curl
+depends_lib         port:curl
+
+checksums           rmd160  08b5b8dd998f2b016132ed1d73d62933bfb4929a \
+                    sha256  ae84150bf2b012dcca5ceced252bedded61ee14156686bbb3d1e38dea955fbd2 \
+                    size    168112
+
+pre-configure {
+    system "cd ${worksrcpath} && ./bootstrap"
+}


### PR DESCRIPTION
#### Description
Roswell is a tool for managing Common Lisp implementations on one's machine, among other things.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
