### PR TITLE
qrencode: update to 4.1.1

### DIFF
--- a/graphics/qrencode/Portfile
+++ b/graphics/qrencode/Portfile
@@ -2,30 +2,38 @@
 
 PortSystem 1.0
 
+PortGroup               github  1.0
+PortGroup               cmake   1.1
+
+github.setup            fukuchi libqrencode 4.1.1 v
 name                    qrencode
-version                 4.0.2
-categories              graphics
-maintainers             nomaintainer
-license                 LGPL-2.1+
-description             QR Code generation
+revision                0
+
+homepage                https://fukuchi.org/works/qrencode
+
+description             A fast and compact library for QR Code generation
+
 long_description        Libqrencode is a C library for encoding data in a QR Code \
                         symbol, a kind of 2D symbology that can be scanned by handy \
                         terminals such as a mobile phone with CCD. The capacity of \
                         QR Code is up to 7000 digits or 4000 characters, and is highly robust.
-homepage                https://fukuchi.org/works/qrencode/index.html.en
-master_sites            https://fukuchi.org/works/qrencode/
+
+categories              graphics
+maintainers             nomaintainer
+license                 LGPL-2.1+
 platforms               darwin
-use_bzip2               yes
 
-checksums               rmd160  c8df9964d0d7f13f6e2708febd05c10d8d49607c \
-                        sha256  c9cb278d3b28dcc36b8d09e8cad51c0eca754eb004cb0247d4703cb4472b58b4 \
-                        size    430309
+checksums               rmd160  a663cc717b1f3b9899a96bfcefad49db928a6759 \
+                        sha256  5385bc1b8c2f20f3b91d258bf8ccc8cf62023935df2d2676b5b67049f31a049c \
+                        size    190419
 
-depends_build           port:pkgconfig
-depends_lib             port:libpng
+depends_build-append    port:pkgconfig
+depends_lib-append      port:libpng \
+                        port:zlib
+
+configure.args-append   -DBUILD_SHARED_LIBS=YES
 
 test.run                yes
 test.target             check
 
-livecheck.type          regex
-livecheck.regex         ${name}-(\[0-9.\]+)${extract.suffix}
+github.tarball_from     archive


### PR DESCRIPTION
- use source from Github
- switch to building using CMake

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
