### PR TITLE
GPXSee: update to 9.4

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 9.3
+github.setup        tumic0 GPXSee 9.4
 revision            0
 categories          gis graphics
 platforms           darwin
@@ -17,9 +17,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  fc23ddfb5805e57c02b711ccac11c0cff8642122 \
-                    sha256  0b48aad520e9dfcfa51cb9826088ecf67d180ce94d46263eddb0f9a2648cf120 \
-                    size    4436278
+checksums           rmd160  288fe5fd9ca587cbbe32fe24cb1e0a328b0ca0b3 \
+                    sha256  39189499bc5db33c3f915716242357445af3f6411db0ef4d531e63ce3ed55ab6 \
+                    size    4439043
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
