### PR TITLE
notcurses: 2.3.18 submission

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        dankamongmen notcurses 2.3.18 v
+github.tarball_from archive
+revision            0
+
+categories          devel
+platforms           darwin
+license             Apache-2
+maintainers         {linux.com:nickblack @dankamongmen} openmaintainer
+
+description         blingful tuis and character graphics
+long_description    Notcurses facilitates the creation of modern TUI programs, making \
+                    full use of Unicode and 24-bit TrueColor. Its API is similar \
+                    to that of NCURSES, but extends that with z-buffering, rendering \
+                    of images and video using ffmpeg, alpha blending, widgets, palette \
+                    fades, resize awareness, and multithreading support.
+
+homepage            https://notcurses.com
+
+checksums           rmd160  48b1ee3ccea8ce2748cdbe1a0d0f884633c6d7dd \
+                    sha256  3748e095893e6f4f9c5d84cb66a5950ac65b11236789ebe1bc21a459beab4d72 \
+                    size    12146295
+
+compiler.c_standard 2011
+compiler.cxx_standard \
+                    2017
+
+depends_build-append \
+                    port:doctest \
+                    port:pandoc \
+                    port:pkgconfig
+
+depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
+                    port:libunistring \
+                    port:ncurses \
+                    port:readline \
+                    port:zlib
+
+test.run            yes


### PR DESCRIPTION
#### Description

Initial import of [Notcurses](https://notcurses.com), a blingful TUI/character graphics library.

###### Type(s)

- [X] new submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

I need to either package up doctest or disable `notcurses-tester` before this is going to fly.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Nope, haven't yet done most of this, just getting it up for comment while I look into packaging onqtam/doctest.