### PR TITLE
libsdl2: Update to 2.0.16

### DIFF
--- a/devel/libsdl2/Portfile
+++ b/devel/libsdl2/Portfile
@@ -6,7 +6,7 @@ PortGroup       xcodeversion 1.0
 
 name            libsdl2
 set my_name     SDL2
-version         2.0.14
+version         2.0.16
 categories      devel multimedia
 platforms       macosx freebsd
 license         zlib
@@ -22,8 +22,9 @@ homepage        http://www.libsdl.org/
 master_sites    ${homepage}release/
 distname        ${my_name}-${version}
 
-checksums       rmd160 24ddf4bab53fae92fb0c96c7d3e6ceecca91c5df \
-                sha256 d8215b571a581be1332d2106f8036fcb03d12a70bae01e20f424976d275432bc
+checksums       rmd160  82315a0e9562755d9d7d6b958fc6fc478676efe9 \
+                sha256  65be9ff6004034b5b2ce9927b5a4db1814930f169c4b2dae0a1e4697075f287b \
+                size    7227262
 
 configure.args  --without-x
 build.args      V=1
@@ -69,8 +70,8 @@ if {${os.subplatform} ne "macosx"} {
 post-destroot {
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
-    xinstall -m 0644 -W ${worksrcpath} BUGS.txt COPYING.txt CREDITS.txt \
-        README.txt README-SDL.txt TODO.txt WhatsNew.txt \
+    xinstall -m 0644 -W ${worksrcpath} BUGS.txt CREDITS.txt \
+        README-SDL.txt TODO.txt WhatsNew.txt \
         {*}[glob ${worksrcpath}/docs/*.md] ${destroot}${docdir}
 }
 


### PR DESCRIPTION
#### Description
Update libsdl2 to 2.0.16


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9216 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
