### PR TITLE
josm: update to 18118

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             17919
+version             18118
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java16
 
-checksums           rmd160  37bd3bbc34fabd8476849148f72347c9c7977efc \
-                    sha256  5beb3a0110399724704ee443f3dc26e070a16f6529e405d0c21e6e93453ba509 \
-                    size    39940194
+checksums           rmd160  72c35b5beda2bc66f3aef3a6ad0ac8c67636cf08 \
+                    sha256  278d087f601438d76a6835e732fcc81b12c945a20178bb041fcd25f2307d3b44 \
+                    size    40144262
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2021-08-02: Stable release 18118](https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.07)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
