### PR TITLE
google-cloud-sdk: update to 352.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             351.0.0
+version             352.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  8c7e3b6d6c7eab1c39bb5fc9dc7973a40fee89e1 \
-                    sha256  3c6f244e60b7b721f0fccd4d84a63a09290f3f17749d56953b3b8809663e42d7 \
-                    size    91280923
+    checksums       rmd160  f0d0a9b9ffb694ce72c4682394edbe0bace80247 \
+                    sha256  59bfa9b45c183fd8918110dd0a68c97e652e562422713bb1226a6a0fa280f835 \
+                    size    91426616
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  cee646bcbc699513929508bd43189beec6f5829e \
-                    sha256  193fb96eb33512058770f2c3621a64eed281599a385f5ac42418b71af75a27a8 \
-                    size    87526856
+    checksums       rmd160  0bff88780f40da8b588749cd67684b227fb64cda \
+                    sha256  75bc1e499cbb0a2c204a7caf59869a16734a4d98396b2472f6ba29614b58f1e6 \
+                    size    87670898
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  5bb668f536c33c4bb7e1caff368efe9cf5916618 \
-                    sha256  f087165d91c1553160593380d602f8b03b57de9eeaf2fafaff9f3c10f60c93a0 \
-                    size    87445932
+    checksums       rmd160  4b91278fdc872cd1ff8772825a425fb17d915bee \
+                    sha256  18db968d11488e51184b213da54ae411327a8a44c82dfc604f12d341402822e2 \
+                    size    87590025
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -91,7 +91,8 @@ patch {
         --usage-reporting false \
         --command-completion false \
         --path-update false \
-        --quiet"
+        --quiet \
+        --install-python false"
 
     set additional_components {}
     foreach component_variant [dict keys ${variant_to_component}] {


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 352.0.0.

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?