### PR TITLE
kubectl: updates to latest patch versions and other fixes

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -29,6 +29,7 @@ set latestVersion       kubectl-1.22
 
 subport kubectl-1.22 {
     set source_build    yes
+    supported_archs     x86_64 arm64
 
     set patchNumber     0
     revision            0
@@ -40,48 +41,57 @@ subport kubectl-1.22 {
 
 subport kubectl-1.21 {
     set source_build    yes
+    supported_archs     x86_64 arm64
 
-    set patchNumber     3
-    revision            1
+    set patchNumber     4
+    revision            0
 
     # because source_build is yes, this is the checksum of the kubernetes
     # source tarball
-    checksums           rmd160  6de2b481bdf383dbba2094ed927c559de043a3fa \
-                        sha256  76efee33b02a85ea6e8e74dd7d95b9d5f78cdd29734c2d0f8a9bc0b20f20c755 \
-                        size    36090238
+    checksums           rmd160  058888662f6e7c3713608fc9af49c6838b35c3ce \
+                        sha256  e569ebfe1bb9430e3dd24b606416fe6cc5b7bdcbee900e79ef8e2a38ce784b35 \
+                        size    36099646
 }
 
 subport kubectl-1.20 {
     set source_build    yes
+    supported_archs     x86_64
 
-    set patchNumber     4
-    revision            1
+    set patchNumber     10
+    revision            0
 
-    checksums           rmd160  ace075d1556d3f990a415a694dcd7ba89568bf2d \
-                        sha256  79ee11e306d948afe18c3265023218470956f5434daf52340188339ec322a5db \
-                        size    34447748
+    # because source_build is yes, this is the checksum of the kubernetes
+    # source tarball
+    checksums           rmd160  b0dc9458176f895411fe817a5334c508631e5838 \
+                        sha256  fd8561f88b8423eba046cea74ecc06c897b211920733eaa2d6340f3f9b379b65 \
+                        size    34502666
 }
 
 subport kubectl-1.19 {
     set source_build    yes
+    supported_archs     x86_64
 
-    set patchNumber     8
-    revision            1
+    set patchNumber     14
+    revision            0
 
-    checksums           rmd160  6c388189031d21318206ab7e289459a0ed6b465b \
-                        sha256  b18e17fe404b3e004339ec686455b7db3feccf46a6077be49745101ea2e8fff3 \
-                        size    33500607
+    # because source_build is yes, this is the checksum of the kubernetes
+    # source tarball
+    checksums           rmd160  a3841f057780508e7ce0a61fd578587ecd52350e \
+                        sha256  be7417021623b11c4e72e31bf4b663f8b0fae2364c74c7633f8860bf98a347a1 \
+                        size    33547290
 }
 
 subport kubectl-1.18 {
-    set patchNumber     16
-    checksums           rmd160  bd898f840b462f87752be1c06ac10ffe0a690de8 \
-                        sha256  5c9657eb86bb02b0fb1c4eb3f7ee10093184b6a3d7df74bef9d9aa02a386b117 \
-                        size    50125040
+    set patchNumber     20
+    revision            0
+    checksums           rmd160  8f4313fecacbb6169305754538a06c61423227f7 \
+                        sha256  bc709378c27da458b31395787a74cd9ac58dce7dbe2a7ba92f8bc2221eeed0be \
+                        size    50095696
 }
 
 subport kubectl-1.17 {
     set patchNumber     17
+    revision            0
     checksums           rmd160  4710ba1c832cd9ac6917600bcd54c70eb2b46666 \
                         sha256  e76b57bbed823a8572f7ccbf9caae56855048434d818dc13559e89ead5f91578 \
                         size    49542736
@@ -95,10 +105,10 @@ subport kubectl-1.16 {
 }
 
 subport kubectl-1.15 {
-    set patchNumber     10
-    checksums           rmd160  22bfa8f33cc5edfcff86bccd6a45a051979799cc \
-                        sha256  ac14a937e3b8d70f86f635b08272813f2e00282d05c61c3087bbbd9333738d02 \
-                        size    48600048
+    set patchNumber     12
+    checksums           rmd160  879ef587b357fa4108ca239527e8dd51186ad65d \
+                        sha256  1b06cab9ee7988f8e71c48dd1d9379aa7c14123cbbc63e12ab5342c3e9130972 \
+                        size    48668112
 }
 
 subport kubectl-1.14 {
@@ -246,7 +256,7 @@ if {${subport} == ${name}} {
     set regexVersionPart [string map {. {\.}} $baseVersion]
     livecheck.type      regex
     livecheck.url       https://api.github.com/repos/kubernetes/kubernetes/releases?per_page=100
-    livecheck.regex     \"name\": \"v(${regexVersionPart}\\.\\d+)\"
+    livecheck.regex     \".+releases/tag/v(${regexVersionPart}\\.\\d+)\"
 
     # Generate select file
     select.group        kubectl


### PR DESCRIPTION
#### Description

- update kubectl 1.15, 1.18 to 1.21 to the latest patch versions

- set supported_archs for 1.19 and above

- kubectl 1.19 & 1.20 have source build enabled, but do not successfully build Darwin ARM64.  Set supported_archs as appropriate.

- fix livecheck regex

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
