### PR TITLE
pam-reattach: new port

### DIFF
--- a/security/pam-reattach/Portfile
+++ b/security/pam-reattach/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+name                pam-reattach
+github.setup        fabianishere pam_reattach 1.2 v
+github.tarball_from archive
+revision            0
+
+categories          security
+license             MIT
+maintainers         {@kakuhen} openmaintainer
+platforms           darwin
+description         PAM module to reattach to user's per-session bootstrap namespace
+long_description    \
+    A PAM module for reattaching to the authenticating user's per-session bootstrap \
+    namespace on macOS. This allows users to make use of the pam_tid module within \
+    programs like screen and tmux.
+
+checksums           sha256  60133388c400a924ca05ee0e5e6f9cc74c9f619bf97e545afe96f35544b0d011 \
+                    rmd160  5ffe80d19895d9985109071ab1d539c994303e85 \
+                    size    6209
+
+variant withcli description { Install CLI application that reattaches } {
+    configure.args-append   -DENABLE_CLI=ON
+}
+
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        ui_error "${name} makes use of XPC, which requires OS X v10.7 or later."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
+notes "
+When this module is not installed in /usr/local/lib/pam, you must specify the full path to the module in the PAM service file.
+"


### PR DESCRIPTION
#### Description
This is a PAM module that is used to allow things like Touch ID authentication when using sudo inside of a screen or tmux session.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
