### PR TITLE
retdec: new port

### DIFF
--- a/devel/retdec/Portfile
+++ b/devel/retdec/Portfile
@@ -1,0 +1,81 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        avast retdec 4.0 v
+revision            0
+conflicts           ${name}-devel
+
+categories          devel
+license             MIT
+platforms           darwin
+maintainers         nomaintainer
+
+description         RetDec is a retargetable machine-code decompiler based on LLVM.
+long_description    ${description}. The decompiler is not limited to any particular \
+                    target architecture, operating system, or executable file format.
+
+checksums           rmd160  305e901b37441337d5c0dada1ccc5e737831ef1e \
+                    sha256  b0e3172d9d232899b71dac41446592c03abe089b8e9c7c1a9c8e8bfe92cf8b49 \
+                    size    8732003
+
+patch.pre_args      -p1
+patchfiles          patch-python3.diff \
+                    patch-yara-syntax-error.diff
+
+post-patch {
+    reinplace "s|\${CMAKE_INSTALL_PREFIX}|${destroot}\${CMAKE_INSTALL_PREFIX}|" ${worksrcpath}/CMakeLists.txt
+    reinplace "s|\${CMAKE_INSTALL_PREFIX}|${destroot}\${CMAKE_INSTALL_PREFIX}|" ${worksrcpath}/support/CMakeLists.txt
+    reinplace "s|DESTINATION \${SUPPORT_TARGET_DIR}/|DESTINATION \${RETDEC_INSTALL_SUPPORT_DIR}|" ${worksrcpath}/support/CMakeLists.txt
+}
+
+compiler.cxx_standard   2017
+
+# clang consumes up to 2Gb RAM, using parallel building may consume all memory.
+use_parallel_build  no
+
+build.args-append   CC=${configure.cc} \
+                    CXX=${configure.cxx}
+
+build.env-append    CC=${configure.cc} \
+                    CXX=${configure.cxx}
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:git \
+                    port:libtool \
+                    port:openssl \
+                    port:pkgconfig
+
+depends_lib-append  port:python39 \
+                    port:zlib
+
+depends_run-append  path:bin/dot:graphviz \
+                    port:upx
+
+subport retdec-devel {
+    conflicts       $name
+
+    version         20210812
+    github.setup    avast retdec 18b434f02b64bfb85232525ca10a6026b5d1f54f
+    revision        0
+
+    checksums       rmd160  bdbfe70797f15f8fab648b99eba288e126186a60 \
+                    sha256  7c0cb951e1cd3c37aa95241a1d554f9c4e7e234d388c97865d9b4cb4737537fe \
+                    size    12129751
+
+    # Before Catalina it also requires macports-libcxx
+    if {${os.platform} eq "darwin" && ${os.major} < 19} {
+        depends_lib-append          port:macports-libcxx
+        configure.cxxflags-append   -nostdinc++ -I${prefix}/include/libcxx/v1
+        configure.ldflags-append    -L${prefix}/lib/libcxx
+
+        notes-append    "This build of ${name} will use an external libc++ as your system\
+                        libc++ is not new enough to support ${name}. Issues may arise."
+    }
+}
+
+github.livecheck.regex  {([^"v]+)}

--- a/devel/retdec/files/patch-python3.diff
+++ b/devel/retdec/files/patch-python3.diff
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c692f65df..cee9928c8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,7 +37,8 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake)
+ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/options.cmake)
+ 
+ # RetDec, and some dependencies (e.g. LLVM, Keystone), require Python 3.
+-find_package(PythonInterp 3.4 REQUIRED)
++find_package(Python3 3.4 REQUIRED)
++set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+ 
+ ### Variables.
+ 

--- a/devel/retdec/files/patch-yara-syntax-error.diff
+++ b/devel/retdec/files/patch-yara-syntax-error.diff
@@ -1,0 +1,35 @@
+diff --git a/deps/yara/patch.cmake b/deps/yara/patch.cmake
+index 30257dce..ff8500e0 100644
+--- a/deps/yara/patch.cmake
++++ b/deps/yara/patch.cmake
+@@ -1,3 +1,30 @@
++# https://github.com/VirusTotal/yara/pull/1540
++function(patch_configure_ac file)
++    file(READ "${file}" content)
++    set(new_content "${content}")
++
++    string(REPLACE
++        "PKG_CHECK_MODULES(PROTOBUF_C, libprotobuf-c >= 1.0.0)"
++        "PKG_CHECK_MODULES([PROTOBUF_C], [libprotobuf-c >= 1.0.0])"
++        new_content
++        "${new_content}"
++    )
++
++    string(REPLACE
++        "AC_CHECK_LIB(protobuf-c, protobuf_c_message_unpack,,"
++        "AC_CHECK_LIB([protobuf-c], protobuf_c_message_unpack,,"
++        new_content
++        "${new_content}"
++    )
++
++    if("${new_content}" STREQUAL "${content}")
++        message(STATUS "-- Patching: ${file} skipped")
++    else()
++        message(STATUS "-- Patching: ${file} patched")
++        file(WRITE "${file}" "${new_content}")
++    endif()
++endfunction()
++patch_configure_ac("${yara_path}/configure.ac")
+ 
+ function(patch_vcxproj file)
+ 


### PR DESCRIPTION
#### Description

Added a new port for https://github.com/avast/retdec. The port contains also `-devel` version which is used current master.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
