### PR TITLE
libfido2: Update to version 1.8.0

### DIFF
--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        Yubico libfido2 1.6.0
+github.setup        Yubico libfido2 1.8.0
 revision            0
 
 categories          security crypto
@@ -15,9 +15,9 @@ license             bsd
 description         library to communicate with a FIDO device over USB
 long_description    provides library functionality and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.
 
-checksums           rmd160  8f58ba379c26d550531a5fa5b949cbdd8370809f \
-                    sha256  5969bfbdd3f5c5e3252c927c15ab28b1c4c4f60a51d1408b3d15cc556ec78835 \
-                    size    413939
+checksums           rmd160  5981a87c5072dc1333bd985827df71795dde1f72 \
+                    sha256  3ce91640dcf1e81078ffa3d8eab7069b257633e2f538e83a736d860964142632 \
+                    size    535973
 
 depends_build-append \
                     port:mandoc \


### PR DESCRIPTION
#### Description
Update libfido2 from version 1.6.0 to version 1.8.0

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
