### PR TITLE
python27: Move to openssl-1.0

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -53,7 +53,7 @@ depends_lib         port:bzip2 \
                     port:libedit \
                     port:libffi \
                     port:ncurses \
-                    path:lib/libssl.dylib:openssl \
+                    port:openssl10 \
                     port:sqlite3 \
                     port:zlib
 depends_run         port:python_select \
@@ -103,6 +103,8 @@ configure.cppflags-append -I${prefix}/include/db48
 configure.ldflags-append -L${prefix}/lib/db48
 
 configure.ccache    no
+configure.cppflags-prepend -I${prefix}/include/openssl-1.0
+configure.ldflags-prepend -L${prefix}/lib/openssl-1.0
 
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" \


### PR DESCRIPTION
This was done a while ago for some EOL Python3 versions, don’t know why it wasn’t for python2. As is in master, hashlib does not work properly on python27 (which bars me from building `qt5-qtwebengine`, for one)

I ran `port test python27` after this change and both `test_hashlib` and `test_ssl` pass.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
