### PR TITLE
mycli: update to 1.2.4

### DIFF
--- a/databases/mycli/Portfile
+++ b/databases/mycli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli mycli 1.23.2 v
+github.setup        dbcli mycli 1.24.1 v
 revision            0
 
 categories          databases python
@@ -17,9 +17,9 @@ long_description    {*}${description}
 
 homepage            https://mycli.net
 
-checksums           rmd160  793a85110f8195bffa15db51440ed0be268e9211 \
-                    sha256  a6253546f0545e242dd6a6ab9763f791a12199a20a922c2cfea7d2c5c8f7191c \
-                    size    272326
+checksums           rmd160  b83e7f824d690716e31a7465a4ddea6be4f511e4 \
+                    sha256  4bac6b70b5c054819e3e5823427ebf7f1c4a6757feb15847e808d5280f5de61e \
+                    size    275983
 
 variant python27 conflicts python36 python37 python38 python39 description "Use Python 2.7" {}
 variant python36 conflicts python27 python37 python38 python39 description "Use Python 3.6" {}
@@ -60,7 +60,14 @@ depends_lib-append  port:py${python.version}-cli-helpers \
                     port:py${python.version}-pygments \
                     port:py${python.version}-pymysql \
                     port:py${python.version}-setuptools \
-                    port:py${python.version}-sqlparse
+                    port:py${python.version}-sqlparse \
+                    port:py${python.version}-pyaes
+
+test.run            yes
+test.env-append     PYTHONPATH=${worksrcpath}/build/lib
+test.cmd            ${python.bin}
+test.pre_args       -m ${name}.main
+test.args           --version
 
 post-destroot {
     set docdir ${prefix}/share/doc/${subport}
@@ -68,3 +75,5 @@ post-destroot {
     xinstall -m 0644 -W ${worksrcpath} changelog.md README.md \
         LICENSE.txt CONTRIBUTING.md AUTHORS.rst ${destroot}${docdir}
 }
+
+github.tarball_from archive


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
