### PR TITLE
lean: new port

### DIFF
--- a/math/lean/Portfile
+++ b/math/lean/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        leanprover-community lean 3.32.1 v
+revision            0
+
+categories          math
+license             Apache-2
+maintainers         {@kakuhen} openmaintainer
+platforms           darwin
+supported_archs     x86_64 arm64
+description         The Lean theorem prover.
+long_description    A fork of Lean 3 maintained and updated by the Lean \
+    community. Lean is a functional programming language that makes it easy to \
+    write correct and maintainable code. You can also use Lean as an \
+    interactive theorem prover.
+
+depends_lib         port:gmp
+
+checksums \
+    rmd160    6b1b8a1134c40ab772e8a3795ae0b29e13a24a22 \
+    sha256    50c49a426024fa35ee2547f7e82803deecb81fbdc187734da9b0fb56ff54e99f \
+    size      1873303
+
+cmake.build_type    Release
+cmake.generator     Ninja
+
+set worksrcdir ${worksrcdir}/src


### PR DESCRIPTION
#### Description
[leanprover-community/lean](https://github.com/leanprover-community/lean ) is the canonical upstream for the Lean theorem prover. Lean 3.x was discontinued by the official Lean developers in order to work on Lean 4.x, which does not have a stable release yet (as it is still in development). The official developers [defer to the community-maintained fork](https://github.com/leanprover/lean/blob/master/README.md) for anything involving Lean 3. Moreover, mathlib and related communities centered around Lean use the community-maintained fork. Lastly, other package repositories (such as FreeBSD ports) use the community branch's releases for math/lean.

For these reasons, I named the port lean and chose the community branch.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
