### PR TITLE
vim: Fix variants to select feature sets correctly

### DIFF
--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 set vim_version     8.2
 set vim_patchlevel  2681
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v
+revision            1
 
 categories          editors
 platforms           darwin freebsd
@@ -89,9 +90,9 @@ variant motif description {Build GUI version with Motif widgets} requires x11 co
 configure.args-append --with-features=normal
 set levels {tiny small big huge}
 foreach level ${levels} {
-    variant ${level} description "Build ${level} feature set" conflicts {*}[lsearch -inline -all -not -exact $levels $level] {
+    variant ${level} description "Build ${level} feature set" conflicts {*}[lsearch -inline -all -not -exact $levels $level] "
         configure.args-replace --with-features=normal --with-features=$level
-    }
+    "
 }
 
 variant xim description {Build with support for X Input Method} {


### PR DESCRIPTION
#### Description

Previously, the `+tiny`, `+small`, `+big`, and `+huge` variants *all* ran
```
configure --with-features=huge
```
because they were not expanding `$level` at definition time.

Fix that and revbump to rebuild Vim with the intended feature set.

(Unfortunately, `+tiny` [the variant I am interested in at the moment] doesn't build for me, but that's a separate problem.)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?