### PR TITLE
xorgproto: Fix protocol mismatch

### DIFF
--- a/x11/xorg-xorgproto/Portfile
+++ b/x11/xorg-xorgproto/Portfile
@@ -4,12 +4,12 @@ PortSystem       1.0
 
 name             xorg-xorgproto
 epoch            1
-version          2021.4
+version          2021.4.99.2
 revision         0
 
-checksums        rmd160  7003602d02df7bda5da22412f6a35d4e144d4a11 \
-                 sha256  0f5157030162844b398e7ce69b8bb967c2edb8064b0a9c9bb5517eb621459fbf \
-                 size    885414
+checksums        rmd160  557cd714e87645e67b584e62f1b09aa952c6a2f6 \
+                 sha256  c38878053179c6f8bc2daeeeeb4710b5fbf0e46db5b3134aee4a1977ffb06e7a \
+                 size    875274
 
 categories       x11 devel
 license          X11


### PR DESCRIPTION
#### Description

I was getting an error I don't remember precisely related to a protocol mismatch between dependencies of Xorgproto. Bumping the version fixed it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5 20G71 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
