### PR TITLE
gnome-internet-radio-locator: update to 12.0.1

### DIFF
--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             3.0.0
-revision            1
+version             12.0.1
+revision            0
 set branch          [join [lrange [split $version .] 0 1] .]
 
 categories          gnome
@@ -19,9 +19,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  81702284088bf149d29a2f6baa4d9fd36d35b708 \
-                    sha256  1a84118e48b5b6cca6f5d409c45e8eba25891811b5a1861390dff7a039e296c6 \
-                    size    561696
+checksums           rmd160  60dbeb334386ccb2252158017ee83cdd3474922f \
+                    sha256  59a8dddba130a4b622899939545a225b498cc275c2ea4758bcb5648593c3b3d8 \
+                    size    651352
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
#### Description

Update gnome-internet-radio-locator 12.0.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.1 20G80 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
