### PR TITLE
shellcheck: Update to version 0.7.2 on all architectures

### DIFF
--- a/devel/shellcheck/Portfile
+++ b/devel/shellcheck/Portfile
@@ -2,8 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           haskell_stack 1.0
 
 github.setup        koalaman shellcheck 0.7.2 v
+revision            1
 categories          devel haskell
 
 license             GPL-3+
@@ -17,38 +19,6 @@ long_description    \
     \n - To point out and clarify typical intermediate level semantic problems, that causes a shell to behave strangely and counter-intuitively. \
     \n - To point out subtle caveats, corner cases and pitfalls, that may cause an advanced user's otherwise working script to fail under future circumstances.
 
-# use a downloaded binary for systems that can't build pandoc through MacPorts at present
-if { ${os.platform} eq "darwin" && ${os.major} >= 20 } {
-
-    # BigSur can't presently build ghc/stack/cabal ports so use Catalina binary on
-    # both Intel and arm64
-    supported_archs x86_64
-    github.tarball_from releases
-    distname        ${name}-v${version}.darwin.x86_64
-    use_xz          yes
-    checksums           rmd160  f5801caf87d6523f5f820f07b6b854e20c79aa0c \
-                        sha256  969bd7ef668e8167cfbba569fb9f4a0b2fc1c4021f87032b6a0b0e525fb77369 \
-                        size    3988092
-    use_configure   no
-    build {}
-    destroot {
-        move ${worksrcpath}/${name} ${destroot}${prefix}/bin
-    }
-
-    notes-append {
-    This port installs a Catalina Intel binary for use on BigSur, both Intel and arm64.
-
-    once ghc / stack / cabal all properly function on these systems then a full building \
-    version of this port can be re-enabled.
-
-    }
-} else {
-
-    # these systems can build a working pandoc using MacPorts standard mechanisms
-
-    PortGroup           haskell_stack 1.0
-
-    checksums           rmd160  d7a5ac158bbb125bffa5758a5fbaba627be95434 \
-                        sha256  0474e71e8ef64862dbb5909964e97c5c32b6137b53983058773b1038df8525e4 \
-                        size    225245
-}
+checksums           rmd160  d7a5ac158bbb125bffa5758a5fbaba627be95434 \
+                    sha256  0474e71e8ef64862dbb5909964e97c5c32b6137b53983058773b1038df8525e4 \
+                    size    225245


### PR DESCRIPTION
#### Description

The original reason for this workaround version pinning is no longer valid:
> `BigSur can't presently build ghc/stack/cabal ports so use Catalina binary`

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
