### PR TITLE
git: update to 2.33.0

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.32.0
-revision            1
+version             2.33.0
+revision            0
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -23,14 +23,14 @@ use_xz              yes
 distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
-checksums           git-2.32.0.tar.xz \
-                    rmd160  f09cbd4baea0051bc9f0364c4a75be476e37a86f \
-                    sha256  68a841da3c4389847ecd3301c25eb7e4a51d07edf5f0168615ad6179e3a83623 \
-                    size    6551348 \
-                    git-manpages-2.32.0.tar.xz \
-                    rmd160  3f1b7d3946961aa5d25e62674e73d3b681dc6b0e \
-                    sha256  19e3cb0425c94d4ad82984f41522e77c8e35093e15a891f8e7195617201f6ac1 \
-                    size    491868
+checksums           git-${version}${extract.suffix} \
+                    rmd160  c1aa086fc178020862b837ea5c0c81687126361e \
+                    sha256  bf3c6ab5f82e072aad4768f647cfb1ef60aece39855f83f080f9c0222dd20c4f \
+                    size    6548308 \
+                    git-manpages-${version}${extract.suffix} \
+                    rmd160  ed2306890b7505a1ca1a75b62e814eca0b25828e \
+                    sha256  d6d38abe3fe45b74359e65d53e51db3aa92d7f551240b7f7a779746f24c4bc31 \
+                    size    492900
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
@@ -143,10 +143,10 @@ variant pcre description {Use pcre} {
 
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
-    checksums-append        git-htmldocs-2.32.0.tar.xz \
-                            rmd160  77e0a51bb2ed0e4a2bc2550808ab367682d5c6ee \
-                            sha256  821bd3b5dfd31040bf9ed38ef02df3dcf063546127f07d59ec9669274e8b8818 \
-                            size    1381664
+    checksums-append        git-htmldocs-${version}${extract.suffix} \
+                            rmd160  da1afce9a7160466ea2dabf84a87bd3147eefe2a \
+                            sha256  309c5d3cdd9a115f693c0e035298cc867a3b8ba8ce235fa1ac950a48cb4b0447 \
+                            size    1393260
 
     patchfiles-append       patch-git-subtree.html.diff
 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
