### PR TITLE
xhyve: bump version to support Big Sur

### DIFF
--- a/emulators/xhyve/Portfile
+++ b/emulators/xhyve/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        machyve xhyve 1f46a3d0bbeb6c90883f302425844fcc3800a776
-version             20191002
+github.setup        machyve xhyve eab8ad838868205b872b93129e2ee91ca5328ea9
+version             20210922
 categories          emulators
 platforms           darwin
 supported_archs     x86_64
@@ -19,9 +19,14 @@ long_description \
     It can run FreeBSD and vanilla Linux distributions and \
     may gain support for other guest operating systems in the future.
 
-checksums           rmd160  b1e803cad9b1577925bee4230efee8a1a198cea0 \
-                    sha256  8bc4198bea593f56676b17a36a2a2b1b6490f7aa26c0e06d70c501b79db3d77d \
-                    size    11718059
+checksums           rmd160  8371e4638d2caee3323338c735156f0a683c3277 \
+                    sha256  e16034a57ddf4409e7e3939f683820b03891232dffa522bff9e0bc0507c6cecb \
+                    size    11718776
+
+use_xcode           yes
+
+patch.pre_args      -p1
+patchfiles          cast-int.patch
 
 post-patch {
     foreach script [glob -- ${worksrcpath}/${name}run-*.sh] {
@@ -36,6 +41,16 @@ pre-fetch {
             return -code error "incompatible OS X version"
     }
 }
+
+platform macosx {
+    # Here a tricky part. xhyve needs xcode sdk and not CommandLineTools
+    # see: https://github.com/macports/macports-ports/pull/11911
+    set macosx_sdkpath ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+    if { [file exists ${macosx_sdkpath}] } {
+        configure.sdkroot ${macosx_sdkpath}
+    }
+}
+
 
 xcode.destroot.path ${prefix}/bin
 build.args-append INSTALL_PREFIX=${prefix}

--- a/emulators/xhyve/files/cast-int.patch
+++ b/emulators/xhyve/files/cast-int.patch
@@ -1,0 +1,44 @@
+commit 55e2b427882624157cbce08a211c5af83043bb2f
+Author: Kirill A. Korinsky <kirill@korins.ky>
+Date:   Wed Sep 22 12:30:21 2021 +0200
+
+    Explicitly cast to uint8_t
+    
+    Apple clang-1300.0.29.3 (ships with macOS 11.6) requires to use
+    `-Wno-shorten-64-to-32` and `-Wsnoign-conversion`, or explicitly cast to
+    smaller type or signed type.
+    
+    `immediate` is `int64_t` and `opsize` is 4 bits field which makes mask
+    clearly no more than 5 bits => cast to `uint8_t` is safe here and just
+    makes clang happy and code clean.
+    
+    `buf[]` is also `uint8_t` and cast happened before but implicitly.
+
+diff --git a/src/pci_ahci.c b/src/pci_ahci.c
+index ebd89a5..60619f3 100644
+--- a/src/pci_ahci.c
++++ b/src/pci_ahci.c
+@@ -220,8 +220,8 @@ static inline void lba_to_msf(uint8_t *buf, int lba)
+ {
+ 	lba += 150;
+ 	buf[0] = (uint8_t) ((lba / 75) / 60);
+-	buf[1] = (lba / 75) % 60;
+-	buf[2] = lba % 75;
++	buf[1] = (uint8_t) (lba / 75) % 60;
++	buf[2] = (uint8_t) (lba % 75);
+ }
+ 
+ /*
+diff --git a/src/vmm/vmm_instruction_emul.c b/src/vmm/vmm_instruction_emul.c
+index 41fc465..e289977 100644
+--- a/src/vmm/vmm_instruction_emul.c
++++ b/src/vmm/vmm_instruction_emul.c
+@@ -1467,7 +1467,7 @@ emulate_bittest(void *vm, int vcpuid, uint64_t gpa, struct vie *vie,
+ 	 * "Range of Bit Positions Specified by Bit Offset Operands"
+ 	 */
+ 	bitmask = vie->opsize * 8 - 1;
+-	bitoff = vie->immediate & bitmask;
++	bitoff = (uint8_t)(vie->immediate & bitmask);
+ 
+ 	/* Copy the bit into the Carry flag in %rflags */
+ 	if (val & (1UL << bitoff))


### PR DESCRIPTION
#### Description

This is moving to a few commits ahead mainly to include https://github.com/machyve/xhyve/pull/200 which introduced support of Big Sur

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
