### PR TITLE
grep: Fix build on Tiger

### DIFF
--- a/sysutils/grep/Portfile
+++ b/sysutils/grep/Portfile
@@ -24,6 +24,14 @@ checksums       rmd160  07849ea26faade7d3204b78379acb345eb252a71 \
                 sha256  5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c \
                 size    1641196
 
+post-patch {
+    # https://trac.macports.org/ticket/63381
+    platform darwin 8 {
+        reinplace "s|__ss.__r1|ss.r1|" lib/sigsegv.c
+        reinplace "s|__ss.__esp|ss.esp|" lib/sigsegv.c
+    }
+}
+
 # error: type name requires a specifier or qualifier
 # error: expected member name or ';' after declaration specifiers
 # error: expected ';' at end of declaration list


### PR DESCRIPTION
#### Description

Some thread and register struct members on Tiger are not prefixed with double underscores, resulting in a compile error. Tested on PowerPC, but fix is also applicable to Intel.

Closes: https://trac.macports.org/ticket/63381

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
