### PR TITLE
hcloud, py-hcloud: Update to 1.28.0 and 1.16.0

### DIFF
--- a/devel/hcloud/Portfile
+++ b/devel/hcloud/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/hetznercloud/cli 1.27.0 v
+go.setup            github.com/hetznercloud/cli 1.28.0 v
 revision            0
 
 name                hcloud
@@ -15,9 +15,9 @@ description         ${name} is a command-line interface for Hetzner Cloud.
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  709f3b6e13e773756ca99c0b2ce9ca01bc255f8d \
-                        sha256  e8c42b95629672db6b0c2c7c2b60db76605bad9d766ffaeac53485147c798795 \
-                        size    114104
+                        rmd160  b50e2324949fd865c2f8210d15b92b15a10fd0a9 \
+                        sha256  e6e84ab5899b3ab8289f93b2b55ea5c494fc18c2ba1c0625b05a8c8581cf4b7b \
+                        size    113095
 
 build.pre_args-append   -ldflags \
     '-X ${go.package}/internal/version.Version=${version}'
@@ -144,10 +144,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
                         size    2291 \
                     github.com/hetznercloud/hcloud-go \
-                        lock    v1.30.0 \
-                        rmd160  b1c2beae774f7053aedcba9522d9a160bc5b6074 \
-                        sha256  854dce1e669e7e996b5c4cda808433aa7477fa6b8d8ff71aba93364d9ba9c379 \
-                        size    92977 \
+                        lock    v1.31.0 \
+                        rmd160  4b064288132b50f0f808dae80eb1fc3f69c7dffb \
+                        sha256  7dd8c7b06da4489297c057ee6b1213698f76a5dd4b829ec24cb173eddee71b16 \
+                        size    93219 \
                     github.com/guptarohit/asciigraph \
                         lock    v0.5.1 \
                         rmd160  affbf05e3343a594f5a7c62a92c07bcc6ae34fd5 \

--- a/python/py-hcloud/Portfile
+++ b/python/py-hcloud/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-hcloud
-version             1.15.0
+version             1.16.0
 revision            0
 
 platforms           darwin
@@ -16,9 +16,9 @@ description         ${name} is a library for the Hetzner Cloud API.
 long_description    {*}${description}
 homepage            https://github.com/hetznercloud/hcloud-python
 
-checksums           rmd160  3526807c149984228c8c02e4a7485661d6fbbd96 \
-                    sha256  5fdf3d2d13b358b6964dc8d798f270148aa09bdd1d276fd836accafe6e4c10aa \
-                    size    93293
+checksums           rmd160  0128a9763400240f311f167c0850caa88a6893f5 \
+                    sha256  c8b94557d93bcfe437f20a8176693ea4f54358b74986cc19d94ebc23f48e40cc \
+                    size    93682
 
 python.versions     27 37 38 39
 


### PR DESCRIPTION
- hcloud: update to 1.28.0
- py-hcloud: update to 1.16.0

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
