### PR TITLE
grep: Fix +libsigsegv variant

### DIFF
--- a/sysutils/grep/Portfile
+++ b/sysutils/grep/Portfile
@@ -5,7 +5,7 @@ PortGroup       compiler_blacklist_versions 1.0
 
 name            grep
 version         3.7
-revision        0
+revision        1
 platforms       darwin
 categories      sysutils
 license         GPL-3+
@@ -41,8 +41,7 @@ compiler.blacklist {clang < 500}
 configure.env   PATH=/usr/bin:$env(PATH)
 
 configure.args  --disable-silent-rules \
-                --program-prefix=g \
-                ac_cv_libsigsegv=no
+                --program-prefix=g
 
 depends_lib     port:gettext \
                 port:pcre
@@ -70,8 +69,10 @@ variant libsigsegv description {Use libsigsegv} {
     depends_lib-append \
                 port:libsigsegv
 
-    configure.args-delete \
-                ac_cv_libsigsegv=no
+    configure.args-append   --with-libsigsegv
+    # grep 3.7 has a link error unless -lsigsegv is supplied manually
+    # https://lists.gnu.org/archive/html/bug-grep/2021-08/msg00033.html
+    configure.libs-append   -lsigsegv
 }
 
 notes "


### PR DESCRIPTION
#### Description

New versions of grep link against `libsigsegv` using the `--with-libsigsegv` configure option, rather than auto-detection. grep 3.7 has a bug where this linking fails unless `-lsigsegv` is supplied manually. This PR addresses both of these issues.

Bump the revision number so that any installation with the `+libsigsegv` variant is now linked as expected.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
