### PR TITLE
traefik: run go generate and go build steps in a single script so that both run with environment variables from `build.env`

### DIFF
--- a/net/traefik/Portfile
+++ b/net/traefik/Portfile
@@ -26,16 +26,21 @@ checksums           rmd160  240a87cb7bc5299fd360ba7ca6e25b730b55485b \
 depends_build-append \
                     port:go-bindata
 
-pre-build {
-    system -W ${worksrcpath} "${go.bin} generate"
+set build_sh        ${worksrcpath}/build.sh
+
+post-extract {
+    set bfile [open ${build_sh} w]
+    puts ${bfile} "#!/bin/sh"
+    puts ${bfile} "${go.bin} generate && ${go.bin} build -ldflags '-X ${go.package}/v2/pkg/version.Version=${version}' ./cmd/${name}"
+    close ${bfile}
+
+    file attributes ${build_sh} -permissions 0755
 }
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 build.env-delete    GOPROXY=off GO111MODULE=off
 
-build.pre_args-append \
-    -ldflags '-X ${go.package}/v2/pkg/version.Version=${version}'
-build.args          ./cmd/traefik
+build.cmd           ${build_sh}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
`traefik`'s build is failing on legacy macOS because the `go generate` step is being run via `system`, and is not getting the compiler options exposed in `build.env` that are set by `legacysupport` and the compiler wrapper portgroup.

You can this happening here: https://build.macports.org/builders/ports-10.11_x86_64-builder/builds/151309/steps/install-port/logs/stdio

This PR puts both the `go generate` and `go build` steps together in a single build script so both run under the same build context.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
