### PR TITLE
gocryptfs: update to 2.1

### DIFF
--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 PortGroup           fuse 1.0
 
-go.setup            github.com/rfjakob/gocryptfs 2.0.1 v
+go.setup            github.com/rfjakob/gocryptfs 2.1 v
 revision            0
 
 categories          fuse
@@ -17,61 +17,66 @@ long_description    ${description}
 homepage            https://nuetzlich.net/gocryptfs/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  9a14c4c28f1c5dc9870f8ac4fed689df085c01dd \
-                        sha256  081780386c64c52fa85c16f6b4b149e39a25b41d28e9c14aeff70c1a3a40e85a \
-                        size    1346999
+                        rmd160  098e77361a89e3a8783add7e1364a902979d2459 \
+                        sha256  630bd128943796312e007adb7dc6f303ffc1436cb28ba18e0ac9a1e9fa5a747f \
+                        size    1353538
 
-set gitversionfuse  "62c5aa1919a7"
-go.vendors          gopkg.in/yaml.v2 \
-                        lock    v2.2.2 \
-                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
-                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
-                        size    70676 \
-                    gopkg.in/check.v1 \
-                        lock    20d25e280405 \
-                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
-                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
-                        size    30360 \
+set gitversionfuse "15a8bb029a4e"
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    golang.org/x/term \
+                        lock    6886f2dfbf5b \
+                        rmd160  8688e7b350892399f2918c70c87435016c64c572 \
+                        sha256  e52745c19f7ebe30ab78db8af43216b6795928089a433925ef3ebef0eaad98f3 \
+                        size    14938 \
                     golang.org/x/sys \
-                        lock    bc7a7d42d5c3 \
-                        rmd160  4129d5e430533da9682b13d9c5d36ff1dca5e4d7 \
-                        sha256  a3ce9da1a5661d4d6dd758f7535c2a9454f8e092a771fbcb133d820a029b2651 \
-                        size    1053520 \
+                        lock    bfb29a6856f2 \
+                        rmd160  8532b0affbd8046f1ba8197e58d7074cf7c4dd66 \
+                        sha256  c84221f35a3f3cfea0e8895d5f347614e9f1f73ad62ae96f8f83fb6ea76e1b67 \
+                        size    1209170 \
                     golang.org/x/net \
-                        lock    d3edc9973b7e \
-                        rmd160  b08d361eb4650a79a1dfe28a7952f47c7c91be24 \
-                        sha256  d756ad97da46b0ac38910edc052b9cb7b26eb2ae44faa34f5bab2c379aae2ba8 \
-                        size    1174398 \
+                        lock    60bc85c4be6d \
+                        rmd160  6a1bf501fae3881bd457e46d247c367c7c2b2346 \
+                        sha256  f1afa9c0e0e64fb09daf3555848517d902a0612da836d04c49fa01b5960e5b2e \
+                        size    1253009 \
                     golang.org/x/crypto \
-                        lock    4b2356b1ed79 \
-                        rmd160  9626217915a27506de4cc7c3d57bf8cf25cd042f \
-                        sha256  cdc724a31e0ea3a638f365d667cb66c8ff49aaaac9f0e82fddde5ef267bba0af \
-                        size    1728714 \
+                        lock    32db794688a5 \
+                        rmd160  02ab581de5510ce94205e0fe5a58aacd2cd375b8 \
+                        sha256  2276178323ee1992d2e845e78ffb8fdce625ef24602b97719428fddaf9f2192f \
+                        size    1732601 \
                     github.com/stretchr/testify \
-                        lock    v1.5.1 \
-                        rmd160  db9d43c3c804950ce9650d830f7dea5434ed83c1 \
-                        sha256  e5f566d1c23fb2b987f8a9f139e32866c1eea8c72051da25bbf6880a4f8c541a \
-                        size    78702 \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
                     github.com/sabhiram/go-gitignore \
-                        lock    d3107576ba94 \
-                        rmd160  0ac0382d1570aa565b546ef0a0ac1e89779677ad \
-                        sha256  8d8a491e6a894f0cf1999e9003f36510d33b032ef7b5da4ad4fb2cf23e6554cd \
-                        size    7608 \
+                        lock    54b8a0bf510f \
+                        rmd160  a857fc463477e6b9f836e792a96a4685ae2e143f \
+                        sha256  8da1f8a688c9217bad55da1738e9178017f5a9bb1e5ca2210b158f73d010219e \
+                        size    8081 \
                     github.com/rfjakob/eme \
-                        lock    v1.1.1 \
-                        rmd160  6a0da855d02259b13b2a3c3eedb28684d77e5b7d \
-                        sha256  f078b25e14f5ccfd70fd3193bad07df2fc59f027f0a365933e47bdadefabb7e9 \
-                        size    23424 \
+                        lock    v1.1.2 \
+                        rmd160  27b6194560dbcdfdad845bbad4d1ed456486f8e4 \
+                        sha256  beb9d8c20398ee8bf71dfc69cd082fba1e79eac2d1ae7d031909a673ca003a45 \
+                        size    23188 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
                         sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
                         size    11409 \
                     github.com/pkg/xattr \
-                        lock    v0.4.1 \
-                        rmd160  5e94780d05150c19b5a97136811d8ffc1466f604 \
-                        sha256  86800e346c68162119293586010f32bcac20344293b97755ef4f11a1191b3c05 \
-                        size    8307 \
+                        lock    v0.4.3 \
+                        rmd160  fdba0ff090e7ef820728334392fb5667fcdefcc5 \
+                        sha256  e1623ed7d3f052c532f0f97fcbbc43ae7371a4016c182e591fff37b6f2df9c82 \
+                        size    9445 \
                     github.com/kylelemons/godebug \
                         lock    d65d576e9348 \
                         rmd160  929cd615eff16a0c5ba2145b809b10016587a387 \
@@ -104,9 +109,9 @@ go.vendors          gopkg.in/yaml.v2 \
                         size    3653945 \
                     github.com/hanwen/go-fuse \
                         lock    ${gitversionfuse} \
-                        rmd160  60efe988c58e58c307bf86e3271ea7c419cd19eb \
-                        sha256  6fd20e10d9b30020f1cdee312c2906f85904894858bcd9248cf36e5912f2022f \
-                        size    204291 \
+                        rmd160  8fd353891c756903ae3aa841e31561004d3d14b9 \
+                        sha256  28fbaa7c222f473222ce0f04850c65bdee625907419d253b116f7d425a87c2bd \
+                        size    205706 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.0 \
                         rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \


### PR DESCRIPTION
#### Description

For changelog see: https://github.com/rfjakob/gocryptfs#changelog

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
