### PR TITLE
MacPass: updated to newest commit

### DIFF
--- a/security/MacPass/Portfile
+++ b/security/MacPass/Portfile
@@ -8,15 +8,15 @@ PortGroup           github 1.0
 # There is currently no MacPass release building on XCode 12 due to the introduction of arm64 architecture.
 # This has been fixed only on master yet, therefore I am using the latest commit on master as of today (01/02/21).
 # As soon as MacPass 0.8 is released, the release tarball will be used again.
-set macpass_hash    4addd907d4710ecbfc69e0224efc031b1bbaa2ad
+set macpass_hash    3cfbbb1f16437b2e1ae01ecde303ca1266960f8c
 set ddhotkey_hash   a996a0a3980de926168df7c2f8b02a1231760561
 
 github.setup        MacPass MacPass ${macpass_hash}
-version             0.8-RC2
+version             0.8-RC3
 categories          security
 platforms           darwin
 license             GPL-3
-maintainers         @janosch mailbox.org:janosch1 openmaintainer
+maintainers         {@janosch mailbox.org:janosch1} openmaintainer
 description         KeePass client for macOS
 long_description    ${name} is a native macOS port of KeePass. Key features are automatic \
                     form filling and regex matching of window titles to detect the correct target application. \
@@ -31,15 +31,16 @@ distfiles           ${macpass_hash}.tar.gz:macpass \
                     ${ddhotkey_hash}.tar.gz:ddhotkey
 
 checksums           ${macpass_hash}.tar.gz \
-                    rmd160  4002695949f0c846421e3dfd83443e6a33327495 \
-                    sha256  8757fe329a06d1798e40db2b617249bf2fcf66e112291e83867b329a2fd78e60 \
-                    size    11002547 \
+                    rmd160  61549b619d1dd0b4c0441004478594971ddfd4d8 \
+                    sha256  b70559e9b20316bf74cf6ea6bd2a13bf19d8c4abfac79e3056bda0264f97973f \
+                    size    11002723 \
                     ${ddhotkey_hash}.tar.gz \
                     rmd160  12ce0935b45c9b8a1e258f267ff8d18f0429eed0 \
                     sha256  656d090cca863b236b7d319df4a5853b55ebf9af39a31a08cb471122c9bfbf56 \
                     size    27575
 
 if {${os.platform} eq "darwin" && ${os.major} < 20} {
+    known_fail yes
     pre-fetch {
         ui_error "${name} @${version} requires macOS 11 or greater"
         return -code error "incompatible OS X version"

--- a/security/MacPass/Portfile
+++ b/security/MacPass/Portfile
@@ -1,43 +1,43 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem            1.0
-PortGroup             xcode 1.0
-PortGroup             github 1.0
+PortSystem          1.0
+PortGroup           xcode 1.0
+PortGroup           github 1.0
 
 # REMARK
 # There is currently no MacPass release building on XCode 12 due to the introduction of arm64 architecture.
 # This has been fixed only on master yet, therefore I am using the latest commit on master as of today (01/02/21).
 # As soon as MacPass 0.8 is released, the release tarball will be used again.
-set macpass_hash        4addd907d4710ecbfc69e0224efc031b1bbaa2ad
-set ddhotkey_hash       a996a0a3980de926168df7c2f8b02a1231760561
+set macpass_hash    4addd907d4710ecbfc69e0224efc031b1bbaa2ad
+set ddhotkey_hash   a996a0a3980de926168df7c2f8b02a1231760561
 
-github.setup            MacPass MacPass ${macpass_hash}
-version                 0.8-RC2
-categories              security
-platforms               darwin
-license                 GPL-3
-maintainers             @janosch mailbox.org:janosch1 openmaintainer
-description             KeePass client for macOS
-long_description        ${name} is a native macOS port of KeePass. Key features are automatic \
-                        form filling and regex matching of window titles to detect the correct target application. \
-                        Through the plugin MacPassHTTP, ${name} can also be used together with \
-                        keepass browser extensions to integrate ${name} as a password database the browser can use.
-homepage                https://macpassapp.org/
+github.setup        MacPass MacPass ${macpass_hash}
+version             0.8-RC2
+categories          security
+platforms           darwin
+license             GPL-3
+maintainers         @janosch mailbox.org:janosch1 openmaintainer
+description         KeePass client for macOS
+long_description    ${name} is a native macOS port of KeePass. Key features are automatic \
+                    form filling and regex matching of window titles to detect the correct target application. \
+                    Through the plugin MacPassHTTP, ${name} can also be used together with \
+                    keepass browser extensions to integrate ${name} as a password database the browser can use.
+homepage            https://macpassapp.org/
 
-master_sites            ${github.homepage}/archive:macpass \
-                        https://github.com/mstarke/DDHotKey/archive:ddhotkey
+master_sites        ${github.homepage}/archive:macpass \
+                    https://github.com/mstarke/DDHotKey/archive:ddhotkey
 
-distfiles               ${macpass_hash}.tar.gz:macpass \
-                        ${ddhotkey_hash}.tar.gz:ddhotkey
+distfiles           ${macpass_hash}.tar.gz:macpass \
+                    ${ddhotkey_hash}.tar.gz:ddhotkey
 
-checksums               ${macpass_hash}.tar.gz \
-                        rmd160  4002695949f0c846421e3dfd83443e6a33327495 \
-                        sha256  8757fe329a06d1798e40db2b617249bf2fcf66e112291e83867b329a2fd78e60 \
-                        size    11002547 \
-                        ${ddhotkey_hash}.tar.gz \
-                        rmd160  12ce0935b45c9b8a1e258f267ff8d18f0429eed0 \
-                        sha256  656d090cca863b236b7d319df4a5853b55ebf9af39a31a08cb471122c9bfbf56 \
-                        size    27575
+checksums           ${macpass_hash}.tar.gz \
+                    rmd160  4002695949f0c846421e3dfd83443e6a33327495 \
+                    sha256  8757fe329a06d1798e40db2b617249bf2fcf66e112291e83867b329a2fd78e60 \
+                    size    11002547 \
+                    ${ddhotkey_hash}.tar.gz \
+                    rmd160  12ce0935b45c9b8a1e258f267ff8d18f0429eed0 \
+                    sha256  656d090cca863b236b7d319df4a5853b55ebf9af39a31a08cb471122c9bfbf56 \
+                    size    27575
 
 if {${os.platform} eq "darwin" && ${os.major} < 20} {
     pre-fetch {


### PR DESCRIPTION
#### Description
<!-- Note: it is best to make pull requests from a branch rather than from master -->
Macpass does not get new releases since two years but gets new commits on master regularly so I am updating to the latest commit which fixes some bugs.

I also fixed the maintainer line and reduced an unneccesary large indent.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.1
Xcode 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
