### PR TITLE
valabind: update to 1.8.0

### DIFF
--- a/devel/valabind/Portfile
+++ b/devel/valabind/Portfile
@@ -1,25 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                valabind
-version             0.10.0
+github.setup        radare valabind 1.8.0
+revision            0
+
 categories          devel
 platforms           darwin
 license             GPL-3
-maintainers         {g5pw @g5pw} openmaintainer
+
+maintainers         {g5pw @g5pw} \
+                    openmaintainer
+
 description         This program converts vapi vala interface files into swig interfaces.
 long_description    {*}${description} Allow C and Vala libraries to be used from many scripting \
                     languages, like Python, Perl, LUA, Java, Go and others.
-homepage            http://radare.org
-master_sites        http://radare.org/get/
 
-checksums           rmd160  743ac6a7834dad24245daaca8bc4328371481ded \
-                    sha256  35517455b4869138328513aa24518b46debca67cf969f227336af264b8811c19
+checksums           rmd160  bc3a3a0c3d5107a1404249ca6ae4458929b60787 \
+                    sha256  419e7abb0d89eb502a0263a7239e64cd6d20dfeac4f2ff529338787d49235877 \
+                    size    65629
 
 depends_build       port:pkgconfig
 
-depends_lib         port:vala
+depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    port:gettext \
+                    port:vala
 
 depends_run         port:swig
 
@@ -32,7 +38,5 @@ variant universal {}
 build.args          V=1 \
                     CC="${configure.cc} [get_canonical_archflags]"
 
-destroot.post_args-append   PREFIX=${prefix}
-
-livecheck.url       [lindex ${master_sites} 0]
-livecheck.regex     ">${name}-((?!\${extract.suffix}).*)${extract.suffix}<"
+destroot.post_args-append \
+                    PREFIX=${prefix}


### PR DESCRIPTION
#### Description

In addition to version update, also:
* Switch to using GitHub site
* Add lib deps on glib2 and gettext, to avoid opportunistic linking

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.7 19H1217
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?