### PR TITLE
OpenBLAS: use ARMV8 as default architecture for ARM

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -30,14 +30,13 @@ if {${os.major} >= 11 && ${os.major} <= 17} {
 #OS 10.14 supports down to Mac Pro 5,1 that has Nehalem architecture
 if {${os.major} >= 18} {
     if {${os.arch} eq "arm"} {
-        # FIXME use correct arch name
-        #set blas_arch "???"
+        set blas_arch "ARMV8"
     } else {
         set blas_arch "NEHALEM"
     }
 }
 if {![info exists blas_arch]} {
-    #For older versions, and currently arm, we force native variant as there is no PPCG3 target in OpenBLAS
+    #For older versions, we force native variant as there is no PPCG3 target in OpenBLAS
     default_variants-append +native
 }
 


### PR DESCRIPTION
#### Description

Set the base architecture for M1 Mac to allow the installation of Openblas with binaries. 

There are reports that NEOVERSEN1 provides slightly better performance (see https://github.com/danielchalef/openblas-benchmark-m1), but ARMV8 is the basic target for M1 chips.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

and

macOS 11.4 20F71 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
