### PR TITLE
integrit: new port

### DIFF
--- a/security/integrit/Portfile
+++ b/security/integrit/Portfile
@@ -1,0 +1,68 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                integrit
+version             4.1
+revision            0
+categories          security
+platforms           darwin
+maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
+license             GPL-2.0
+
+description         integrit is the most simple Tripwire alternative
+
+long_description    integrit is a more simple alternative to file \
+                    integrity verification programs like tripwire and \
+                    aide. It helps you determine whether an intruder \
+                    has modified a computer system. \
+                    \
+                    integrit works by creating a database that is a \
+                    snapshot of the most essential parts of your \
+                    computer system. You put the database somewhere \
+                    safe, and then later you can use it to make sure \
+                    that no one has made any illicit modifications to \
+                    the computer system. In the case of a break in, you \
+                    know exactly which files have been modified, added, \
+                    or removed. \
+                    \
+                    integrit is a robust, stable piece of software \
+                    designed for professional use.
+
+homepage            http://integrit.sourceforge.net
+master_sites        sourceforge:integrit
+distname            integrit-${version}
+
+checksums           rmd160  d56585c9c38c2e53f10d0ad6aef5ea9067ddd852 \
+                    sha256  2a09b670ee025d6fae756e044f780ccaca90688a97183a350927e3885174223e \
+                    size    271626
+
+depends_build       port:automake \
+                    port:autoconf
+
+set doc_dir         ${prefix}/share/doc/integrit
+
+patchfiles          Makefile-in.diff \
+                    doc-Makefile-in.diff
+
+# Recreate configure as it is old and causes -Wimplicit-function-declaration warnings
+use_autoreconf      yes
+
+configure.args      --mandir=${prefix}/share/man --infodir=${prefix}/share/info
+
+build.target        integrit
+
+post-destroot {
+    xinstall -d -m 755 ${destroot}/${doc_dir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/examples/*] \
+        ${destroot}${doc_dir}
+}
+
+# Future releases of the project are expected to be made on GitHub, as at
+# 2021-08-21 only a release candidate has been made available on GitHub.
+livecheck.type      regex
+livecheck.url       https://github.com/integrit/integrit/releases.atom
+# Following regex includes release candidates
+#livecheck.regex     {<id>tag:github.com,2008:Repository/24138673/v(\d+(\.\d+)+)(?:-rc.*)</id>}
+# Following regex excludes release candidates
+livecheck.regex     {<id>tag:github.com,2008:Repository/24138673/v(\d+(\.\d+)+)</id>}

--- a/security/integrit/files/Makefile-in.diff
+++ b/security/integrit/files/Makefile-in.diff
@@ -1,0 +1,11 @@
+--- Makefile.in~	2007-06-02 22:41:37.000000000 +0100
++++ Makefile.in	2021-08-12 17:42:13.000000000 +0100
+@@ -26,7 +26,7 @@
+ # VPATH		 = @srcdir@
+ CC	 = @CC@
+ PROG	 = integrit
+-SBINDIR	 = @sbindir@
++SBINDIR	 = $(DESTDIR)@sbindir@
+ INSTALL	 = @INSTALL@
+ OBJ	 = @OBJ@
+ ILIBOBJ	 = @ILIBOBJ@

--- a/security/integrit/files/doc-Makefile-in.diff
+++ b/security/integrit/files/doc-Makefile-in.diff
@@ -1,0 +1,16 @@
+--- doc/Makefile.in~	2007-06-02 22:41:36.000000000 +0100
++++ doc/Makefile.in	2021-08-12 17:43:28.000000000 +0100
+@@ -23,11 +23,11 @@
+ srcdir		 = @srcdir@
+ # we aren't using VPATH
+ # VPATH		 = @srcdir@
+-MANDIR		 = @mandir@
++MANDIR		 = $(DESTDIR)@mandir@
+ INSTALL	 = @INSTALL@
+ INSTALL_INFO	 = install-info
+ INFO_FILES	 = integrit.info
+-infodir	 = @infodir@
++infodir	 = $(DESTDIR)@infodir@
+ 
+ # target for developers puts info file in srcdir
+ # 


### PR DESCRIPTION
#### Description

integrit is a simple yet secure alternative to products like tripwire. It has a small memory footprint and uses up-to-date cryptographic algorithms.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.5.2 20G95 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
