### PR TITLE
unbound: ability to run multiple unbounds in parallel

### DIFF
--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -5,6 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
 version             1.13.2
+revision            1
 
 categories          net
 license             BSD
@@ -95,8 +96,14 @@ startupitem.create	yes
 startupitem.name	unbound
 startupitem.logfile	/Library/Logs/unbound-startupitem.log
 startupitem.logevents	yes
-startupitem.start	"(${prefix}/sbin/unbound-anchor -a ${prefix}/etc/${name}/root.key 2>&1) || : && (chown ${unbounduser}:${unboundgroup} ${prefix}/etc/${name}/root.key 2>&1) && (${prefix}/sbin/unbound 2>&1)"
-startupitem.stop	"(/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid) 2>&1)"
+# the following entries handle multiple instances running in parallel
+startupitem.start	"(\'${prefix}/sbin/unbound-anchor\' -a \'${prefix}/etc/${name}/root.key\' 2>&1) \\"\
+	"    || : && (chown ${unbounduser}:${unboundgroup} \'${prefix}/etc/${name}/root.key\' 2>&1) \\"\
+	"    && (for i in \'${prefix}/etc/${name}/${name}\'*conf; \\"\
+	"        do \'${prefix}/sbin/unbound\' -c \"\$i\" 2>&1; done)"
+startupitem.stop	"(for i in \'${prefix}/var/run/${name}/${name}\'*pid; \\"\
+	"    do /bin/kill -15 \$(cat \"\$i\") 2>&1; done)"
+# The following ignores any second process and pidfile
 startupitem.pidfile	clean ${prefix}/var/run/${name}/${name}.pid
 
 notes-append        "An example configuration is provided at ${prefix}/etc/${name}/${name}.conf-dist."


### PR DESCRIPTION
#### Description

The startup item will start/stop an unbound daemon for each
unbound*.conf file in the /opt/local/etc/unbound directory.
If there is only a single unbound*.conf file it behaves as before.
This is useful for being able to run rspamd properly. Without
this, the rspamd-initiated DNS qeuries might be blocked. Using
a second non-forwarding unbound solves the issue.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`? There are still tabs in the file that end up in the startup wrapper for readability
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
