### PR TITLE
chrome-cli: new port

### DIFF
--- a/www/chrome-cli/Portfile
+++ b/www/chrome-cli/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+PortGroup           xcode   1.0
+
+github.setup        prasmussen chrome-cli 1.7.1
+revision            0
+
+description         Control Google Chrome from the command line
+
+long_description    ${name} is a command line utility for controlling Google \
+                    Chrome compatible browsers on OS X. It is a native binary \
+                    that uses the Scripting Bridge to communicate with Chrome.
+
+categories          www
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+platforms           darwin
+
+checksums           rmd160  8e762674f554d7e6e34dbaaa4efb1ab85149a78d \
+                    sha256  27ee5ab9a9d60fbd829f069074fe592f2aafd129df0df4aedbbc12b8df11ac32 \
+                    size    11379
+
+github.tarball_from archive
+
+xcode.target        ${name}
+xcode.configuration Release
+
+destroot {
+    xinstall ${worksrcpath}/build/Release/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
