### PR TITLE
php modules: Add php81 support to php-uuid, php-zip, php-zstd

### DIFF
--- a/php/php-uuid/Portfile
+++ b/php/php-uuid/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 LGPL-2.1+
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1
 php.pecl                yes
 
 description             A wrapper around libuuid from the ext2utils project.

--- a/php/php-zip/Portfile
+++ b/php/php-zip/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
-php.branches        5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0
+php.branches        5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1
 php.pecl            yes
 
 if {[vercmp ${php.branch} 5.4] >= 0} {

--- a/php/php-zstd/Portfile
+++ b/php/php-zstd/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             MIT
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1
 
 description         Zstandard compression
 


### PR DESCRIPTION
#### Description

Just add support for php81 to the uuid, zip and zstd modules. I needed them so tried locally and they built without problem, so sharing.

Feel free to close this if you've some scheduled plan to incorporate all the missing php81 modules altogether.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (yes but there aren't test for the modules)
- [X] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
