### PR TITLE
Mercurial 5.9

### DIFF
--- a/devel/hg-evolve/Portfile
+++ b/devel/hg-evolve/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    hg-evolve
-version                 10.3.2
+version                 10.3.3
 revision                0
 
 categories              devel
@@ -25,9 +25,9 @@ long_description        Additional history rewriting commands for Mercurial \
                         developers to safely rewrite the same parts of history \
                         in a distributed way.
 
-checksums               rmd160  9c9a2f28eec8c2a9acc08168c62ab201f0bc97f9 \
-                        sha256  ba819732409d39ddd4ff2fc507dc921408bf30535d2d78313637b29eeac98860 \
-                        size    849975
+checksums               rmd160  fbb3141f6cbb919aa30ba5c5f69e4be3a9558cdb \
+                        sha256  ca3b0ae45a2c3a811c0dc39153b8a1ea8a5c8f786c56370a41dfd83a5bff2502 \
+                        size    850961
 
 python.default_version  39
 

--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-version             5.8.1
+version             5.9.1
 revision            0
 categories          devel python
 platforms           darwin
@@ -30,12 +30,11 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
                     Apples' FileMerge for merges.
 
 homepage            https://www.mercurial-scm.org
-master_sites        ${homepage}/release/
 
 checksums           ${distname}${extract.suffix}  \
-                    rmd160  0c6dde2ddcd08aeed00e422e04bed62bd3fd75f9 \
-                    sha256  81baa3fe2087bdda2dd119d7ea948f6badebaeb7b528a7d18b277e2ceb22b19b \
-                    size    7988000
+                    rmd160  d25686f9c34044b19c5dfac20a5f947d01786f06 \
+                    sha256  32eff9433c62d781dc93e5a6103327264d897ad2bbce3ecb5d2d78a93cf49f27 \
+                    size    8120006
 
 python.default_version 39
 
@@ -132,8 +131,9 @@ variant rust description {Enable experimental Rust optimizations} {
     autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     bitmaps                          2.1.0  031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2 \
+    block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
     byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
-    bytes-cast                       0.1.0  3196ba300c7bc9282a4331e878496cb3e9603a898a8f1446601317163e16ca52 \
+    bytes-cast                       0.2.0  0d434f9a4ecbe987e7ccfda7274b6f82ea52c9b63742565a65cb5e8ba0f2c452 \
     bytes-cast-derive                0.1.0  cb936af9de38476664d6b58e529aff30d482e4ce1c5e150293d00730b0d81fdb \
     cc                              1.0.66  4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
@@ -141,7 +141,8 @@ variant rust description {Enable experimental Rust optimizations} {
     chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
     clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
     const_fn                         0.4.4  cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826 \
-    cpython                          0.5.2  0f11357af68648b6a227e7e2384d439cec8595de65970f45e3f7f4b2600be472 \
+    cpufeatures                      0.1.4  ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8 \
+    cpython                          0.6.0  8094679a4e9bfc8035572162624bc800eda35b5f9eff2537b9cd9aacc3d9782e \
     crc32fast                        1.2.1  81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a \
     crossbeam-channel                0.4.4  b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87 \
     crossbeam-channel                0.5.0  dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775 \
@@ -152,13 +153,13 @@ variant rust description {Enable experimental Rust optimizations} {
     ctor                            0.1.16  7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484 \
     derive_more                    0.99.11  41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c \
     difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
     either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
     env_logger                       0.7.1  44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36 \
     flate2                          1.0.19  7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129 \
     format-bytes                     0.2.2  1c4e89040c7fd7b4e6ba2820ac705a45def8a0c098ec78d170ae88f1ef1d5762 \
     format-bytes-macros              0.3.0  b05089e341a0460449e2210c3bf7b61597860b07f0deae58da38dbed0a4c6b6d \
-    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-    gcc                             0.3.55  8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2 \
+    generic-array                   0.14.4  501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
     getrandom                       0.1.15  fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
     glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
     hermit-abi                      0.1.17  5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8 \
@@ -181,24 +182,20 @@ variant rust description {Enable experimental Rust optimizations} {
     num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
     num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
     num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
     output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
-    paste                           0.1.18  45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880 \
-    paste-impl                      0.1.18  d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6 \
+    paste                            1.0.5  acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58 \
     pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
     ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
     pretty_assertions                0.6.1  3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427 \
     proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
     proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
-    python27-sys                     0.5.2  f485897ed7048f5032317c4e427800ef9f2053355516524d73952b8b07032054 \
-    python3-sys                      0.5.2  5b29b99c6868eb02beb3bf6ed025c8bcdf02efc149b8e80347d3e5d059a806db \
+    python27-sys                     0.6.0  5826ddbc5366eb0b0492040fdc25bf50bb49092c192bd45e80fb7a24dc6832ab \
+    python3-sys                      0.6.0  b78af21b29594951a47fc3dac9b9eff0a3f077dec2f780ee943ae16a668f3b6a \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
-    rand                            0.3.23  64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c \
-    rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
     rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
-    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
-    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
     rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_distr                       0.2.2  96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2 \
     rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
@@ -206,15 +203,13 @@ variant rust description {Enable experimental Rust optimizations} {
     rand_xoshiro                     0.4.0  a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004 \
     rayon                            1.5.0  8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674 \
     rayon-core                       1.9.0  9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a \
-    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
     regex                            1.4.2  38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c \
     regex-syntax                    0.6.21  3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189 \
     remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
-    rust-crypto                     0.2.36  f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a \
-    rustc-serialize                 0.3.24  dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    sha-1                            0.9.6  8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16 \
     sized-chunks                     0.6.2  1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \

--- a/devel/tortoisehg/Portfile
+++ b/devel/tortoisehg/Portfile
@@ -6,7 +6,7 @@ PortGroup           app 1.0
 PortGroup           gitlab 1.0
 
 gitlab.instance     https://foss.heptapod.net
-gitlab.setup        mercurial/tortoisehg thg 5.8rc0
+gitlab.setup        mercurial/tortoisehg thg 5.9
 
 name                tortoisehg
 
@@ -21,9 +21,9 @@ description         A set of graphical tools for Mercurial
 long_description    A set of graphical tools for the Mercurial distributed \
                     source control management system.
 
-checksums           rmd160  d060b630a813c2ea98fdf845e8e74a551711e00a \
-                    sha256  a5ffe4bd6f43bee72199db9664650b4bc4c2afe431d51005a2ba3e1ce130979e \
-                    size    7512399
+checksums           rmd160  7ec861b069c919ef4678dcd0da2b14b7a7e4a382 \
+                    sha256  ff1d7a68c9fb7edc7cdcf674ccd6f0e1cd78f079202a00d7970e19460566de0c \
+                    size    7524522
 
 python.default_version 39
 
@@ -90,3 +90,7 @@ post-destroot {
 app.name            TortoiseHg
 app.executable      ${python.prefix}/bin/thg
 app.icon            icons/svg/thg_logo.svg
+
+# suppress release candidates
+gitlab.livecheck.regex \
+    (\[0-9.]+)


### PR DESCRIPTION
#### Description

This is an upgrade of Mercurial and its dependencies to version 5.9; it is currently draft until TortoiseHg also releases version 5.9.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Supercedes #11955