### PR TITLE
bat: add missing dependency (libgit2)

### DIFF
--- a/textproc/bat/Portfile
+++ b/textproc/bat/Portfile
@@ -5,7 +5,7 @@ PortGroup           github  1.0
 PortGroup           cargo   1.0
 
 github.setup        sharkdp bat 0.18.3 v
-revision            0
+revision            1
 
 description         A cat(1) clone with syntax highlighting and Git integration.
 
@@ -27,6 +27,9 @@ checksums           ${distname}${extract.suffix} \
 # For crate:onig_sys
 depends_build-append \
                     path:bin/cmake:cmake
+
+depends_run-append \
+                    port:libgit2
 
 github.tarball_from archive
 


### PR DESCRIPTION
#### Description

The `bat` has the following error when running. Maybe `bat` now depends on `libgit2`.

```console
$ bat file
dyld: Library not loaded: /opt/local/lib/libgit2.1.1.dylib
  Referenced from: /opt/local/bin/bat
  Reason: image not found
Abort trap: 6
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
