### PR TITLE
GPXSee: update to 9.5

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 9.4
+github.setup        tumic0 GPXSee 9.5
 revision            0
 categories          gis graphics
 platforms           darwin
@@ -17,9 +17,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  288fe5fd9ca587cbbe32fe24cb1e0a328b0ca0b3 \
-                    sha256  39189499bc5db33c3f915716242357445af3f6411db0ef4d531e63ce3ed55ab6 \
-                    size    4439043
+checksums           rmd160  c992a150a3bb63a6eef6e2b65f1d68c87b89661f \
+                    sha256  1cf851aa6302add928b4825fa7b962f6284075e0ee9a006f1180dd18aaeaf675 \
+                    size    4708395
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
