### PR TITLE
lagrange: update to 1.6.4

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.6.3 v
+github.setup        skyjake lagrange 1.6.4 v
 github.tarball_from releases
 categories          net gemini
 platforms           darwin
@@ -19,9 +19,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  128b2a0ea2057f791d537decbb12c69f9e652ffc \
-                    sha256  7c251a309888579416fe1e15cb4a8ed438d5d7989465b804199089ddb5c9faa5 \
-                    size    22715497
+checksums           rmd160  f7f0a623e0fe5c5791174d29ffbda6259a515431 \
+                    sha256  28f31507eeef91150067799d930f3b86fd45a956e0eb7d4f569218fca82f6488 \
+                    size    22716222
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
