### PR TITLE
kops: update to 1.21.1

### DIFF
--- a/devel/kops/Portfile
+++ b/devel/kops/Portfile
@@ -1,8 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
+
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes/kops 1.21.0 v
+go.setup            github.com/kubernetes/kops 1.21.1 v
 revision            0
 go.package          k8s.io/kops
 
@@ -17,9 +19,9 @@ installs_libs       no
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  761e28ecf17bb3c15e27e9b43d3a0a0290eb11ca \
-                    sha256  b6246cc58e5ad2c9566238bbe99ba8ba1e9593b016336ba5dd6320f66040ac40 \
-                    size    27394827
+checksums           rmd160  acbb914dd0da2a58caeadefbc19f0d17c5f461cd \
+                    sha256  4b1f5dcc5bc8909a7f68698c356144dc63264c4af723aecfa18a0e31ed521009 \
+                    size    27399968
 
 depends_run         port:kubectl-1.21
 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
