### PR TITLE
google-cloud-sdk: update to 354.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             353.0.0
+version             354.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  5274e49aee588bfcc294946ca4ef674e76b13ab4 \
-                    sha256  d463578c0d326a53a5dbd5953ef377f08d7000345340204f71b1d6326adea38e \
-                    size    91479351
+    checksums       rmd160  24d2e647923e803db685b4b39429ad7934311de4 \
+                    sha256  2f411b1f09c46d6228746a23372689cf8d87e8b3cfd48b493efd2b37716006b2 \
+                    size    91577829
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  6910f7de51009e40362f466770b5cd7c14a14f64 \
-                    sha256  8541defbe346e179cf4a1baacad1420e4245bc81eeedeb0a90cdf7b0b3b5ebcd \
-                    size    87725307
+    checksums       rmd160  4cf1714cd447076064126d02bfcb23d0f65e25b1 \
+                    sha256  cbf10388a9dd7bb51126a0a26a670bbb7b047e5da5a43f2b1469f6f67af6ea3c \
+                    size    87830040
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d5175aca8f8f1029f978a63954de1b4c9b34b02e \
-                    sha256  e5538562e364527dede0b5c1d39075c738ea73b141d0b20abb25cadc4e4e96a6 \
-                    size    87643283
+    checksums       rmd160  cd19aa2f1be7ef58fb7734c827d163f9fdaec023 \
+                    sha256  ef163979d36a85277ec1fe117598c3a8d11cce09495a22a7ace17e87ba169594 \
+                    size    87745214
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 354.0.0.

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?