### PR TITLE
clisp: build with ffcall

### DIFF
--- a/lang/clisp/Portfile
+++ b/lang/clisp/Portfile
@@ -5,7 +5,7 @@ PortGroup       compiler_blacklist_versions 1.0
 
 name            clisp
 version         2.49.92
-revision        0
+revision        1
 categories      lang
 maintainers     {easieste @easye} openmaintainer
 platforms       darwin
@@ -34,7 +34,8 @@ checksums       md5     edb0e61a66693bfb246d157b75df195a \
 
 depends_lib     port:readline   \
                 port:gettext    \
-                port:libsigsegv 
+                port:libsigsegv \
+                port:ffcall
          
 universal_variant     no
 use_bzip2             yes
@@ -56,9 +57,7 @@ if {${os.platform} eq "darwin" && ${os.major} >= 11} {
 configure.cc-append  ${configure.cc_archflags}
 configure.args      --with-libiconv-prefix=${prefix} \
                     --with-libreadline-prefix=${prefix} \
-                    --with-libsigsegv-prefix=${prefix} \
-    --without-ffcall
-# TODO update MacPorts devel/ffcall; use it
+                    --with-libsigsegv-prefix=${prefix}
 
 platform darwin {
     configure.args-append \


### PR DESCRIPTION
#### Description
Due to an outdated ffcall, clisp was unable to use it, so we would
configure without ffcall. Now that ffcall has been updated, keeping
this configuration flag is unnecessary.

Note there are some compiler warnings, but the FFI feature is provided as intended.
```
% clisp
  i i i i i i i       ooooo    o        ooooooo   ooooo   ooooo
  I I I I I I I      8     8   8           8     8     o  8    8
  I  \ `+' /  I      8         8           8     8        8    8
   \  `-+-'  /       8         8           8      ooooo   8oooo
    `-__|__-'        8         8           8           8  8
        |            8     o   8           8     o     8  8
  ------+------       ooooo    8oooooo  ooo8ooo   ooooo   8

Welcome to GNU CLISP 2.49.92 (2018-02-18) <http://clisp.org/>

Copyright (c) Bruno Haible, Michael Stoll 1992-1993
Copyright (c) Bruno Haible, Marcus Daniels 1994-1997
Copyright (c) Bruno Haible, Pierpaolo Bernardi, Sam Steingold 1998
Copyright (c) Bruno Haible, Sam Steingold 1999-2000
Copyright (c) Sam Steingold, Bruno Haible 2001-2018

Type :h and hit Enter for context help.

[1]> *features*
(:READLINE :REGEXP :WILDCARD :SYSCALLS :I18N :LOOP :COMPILER :CLOS :MOP :CLISP :ANSI-CL
 :COMMON-LISP :LISP=CL :INTERPRETER :LOGICAL-PATHNAMES :SOCKETS :GENERIC-STREAMS :SCREEN
 :FFI :GETTEXT :UNICODE :BASE-CHAR=CHARACTER :WORD-SIZE=64 :UNIX :MACOS)
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
