### PR TITLE
cosign: update to 1.1.0

### DIFF
--- a/security/cosign/Portfile
+++ b/security/cosign/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/sigstore/cosign 1.0.1 v
+go.setup            github.com/sigstore/cosign 1.1.0 v
 revision            0
 
 categories          security
@@ -16,19 +16,23 @@ long_description    \
     Container Signing, Verification and Storage in an OCI registry. Cosign \
     aims to make signatures invisible infrastructure.
 
-checksums           rmd160  4fa96db66e7f64367052743aad700179efb66cd8 \
-                    sha256  389a34dc04837eabf1d229031a78d9c07d52d6a53ec430135167bf1d7afd81f5 \
-                    size    6396480
+checksums           rmd160  333b87978cee87a647c59fbf82986b53fa564737 \
+                    sha256  5a849f8373733c8514fb120137f1c629478a777fd00c5ec44f76ba547003b999 \
+                    size    6423038
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 build.env-delete    GOPROXY=off GO111MODULE=off
 
-build.pre_args-append \
-    -ldflags '-X github.com/sigstore/cosign/cmd/cosign/cli.gitVersion=${version}'
-build.args          -o build/ ./...
+# build.pre_args-append \
+#     -ldflags '-X github.com/sigstore/cosign/cmd/cosign/cli.gitVersion=${version}'
+# build.args          -o build/ ./...
+build.cmd           make
+build.pre_args      GIT_VERSION="${version}" \
+                    GIT_TAG="build from tarball" GIT_HASH="" GIT_TREESTATE=""
+build.target        cosign
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/build/cosign ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${worksrcpath}/cosign ${destroot}${prefix}/bin/
 
     xinstall -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 0644 -W ${worksrcpath} \
@@ -38,16 +42,22 @@ destroot {
 }
 
 variant sget description {sget command for safer, automatic verification of signatures and integration with transparency log Rekor} {
+    post-build {
+        system -W ${worksrcpath} "${build.env} ${go.bin} build ./cmd/sget"
+    }
     post-destroot {
-        xinstall -m 0755 ${worksrcpath}/build/sget \
+        xinstall -m 0755 ${worksrcpath}/sget \
             ${destroot}${prefix}/bin/
     }
 }
 
 variant copasetic \
     description {experimental OPA plugin (embedded OPA interpreter)} {
+    post-build {
+        system -W ${worksrcpath} "${build.env} ${go.bin} build ./copasetic/main.go"
+    }
     post-destroot {
-        xinstall -m 0755 ${worksrcpath}/build/copasetic \
-            ${destroot}${prefix}/bin/
+        xinstall -m 0755 ${worksrcpath}/main \
+            ${destroot}${prefix}/bin/copasetic
     }
 }


### PR DESCRIPTION
CHANGES:
* Update to 1.1.0
* Use Makefile to display the correct version in `cosign version`
* Build a binary file for each variant separately.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
