### PR TITLE
libproxy: blacklist compilers

### DIFF
--- a/net/libproxy/Portfile
+++ b/net/libproxy/Portfile
@@ -35,6 +35,12 @@ depends_build-append \
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:vala
 
+# std::vector.data first appeared in mainline GCC 4.1, but was 
+# absent from Apple GCC 4.2, and not standardized until C++11.
+# See the complete discussion beginning with the message:
+# https://lists.isocpp.org/std-discussion/2021/08/1370.php
+compiler.blacklist-append *gcc-3.* *gcc-4.0 gcc-4.2 apple-gcc-4.2
+
 #
 # webkit and mozjs pacrunners disabled by default due to the
 # following issues


### PR DESCRIPTION
#### Description

I realize blacklisting is not ideal, but working around https://trac.macports.org/ticket/63267 will require a non-trivial code patch. I've tried to tailor the blacklist as narrowly as possible – more info in Portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
