### PR TITLE
freetds: Fix build with GCC 4.2

### DIFF
--- a/databases/freetds/Portfile
+++ b/databases/freetds/Portfile
@@ -45,6 +45,11 @@ depends_lib         port:gnutls \
 # error: use of unknown builtin '__builtin_bswap16' [-Wimplicit-function-declaration]
 compiler.blacklist  {clang < 500}
 
+# Fix conflicting intptr_t definitions
+# https://trac.macports.org/ticket/63394
+compiler.c_standard 1999
+configure.cflags-append -std=c99
+
 configure.args      --disable-odbc \
                     --disable-silent-rules \
                     --enable-krb5 \


### PR DESCRIPTION
#### Description

FreeTDS pulls in stdint.h via nettle, but if c99 is not set it also provides its own conflicting definitions and the build fails.

Tested through the "build" phase.

Closes: https://trac.macports.org/ticket/63394

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
