### PR TITLE
python3*: add dtrace variant

### DIFF
--- a/lang/python310-devel/Portfile
+++ b/lang/python310-devel/Portfile
@@ -232,6 +232,10 @@ variant optimizations description {Compile with LTO and PGO. Build time greatly 
     configure.args-append   --enable-optimizations
 }
 
+variant dtrace description {enable DTrace support} {
+    configure.args-append   --with-dtrace
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}downloads/source/
 #livecheck.regex     Python (${branch}\[.0-9\]+) -

--- a/lang/python36/Portfile
+++ b/lang/python36/Portfile
@@ -229,6 +229,10 @@ variant optimizations description {Compile with LTO and PGO. Build time greatly 
     configure.args-append   --enable-optimizations
 }
 
+variant dtrace description {enable DTrace support} {
+    configure.args-append   --with-dtrace
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}downloads/source/
 livecheck.regex     Python (${branch}(?:\\.\\d+)*)

--- a/lang/python38/Portfile
+++ b/lang/python38/Portfile
@@ -235,6 +235,10 @@ variant optimizations description {Compile with LTO and PGO. Build time greatly 
     configure.args-append   --enable-optimizations
 }
 
+variant dtrace description {enable DTrace support} {
+    configure.args-append   --with-dtrace
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}downloads/source/
 livecheck.regex     Python (${branch}\[.0-9\]+) -

--- a/lang/python39/Portfile
+++ b/lang/python39/Portfile
@@ -230,6 +230,10 @@ variant optimizations description {Compile with LTO and PGO. Build time greatly 
     configure.args-append   --enable-optimizations
 }
 
+variant dtrace description {enable DTrace support} {
+    configure.args-append   --with-dtrace
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}downloads/source/
 livecheck.regex     Python (${branch}\[.0-9\]+) -


### PR DESCRIPTION
#### Description

Adds a variant to use dtrace as described in
https://docs.python.org/3/howto/instrumentation.html

Also see https://github.com/macports/macports-ports/pull/6308

Fixes https://trac.macports.org/ticket/54443

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
