### PR TITLE
fluent-bit: fix build

### DIFF
--- a/sysutils/fluent-bit/Portfile
+++ b/sysutils/fluent-bit/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # Need clock_gettime()
 PortGroup           legacysupport 1.0
 
-legacysupport.newest_darwin_requires_legacy 15
+legacysupport.newest_darwin_requires_legacy 18
 
 name                fluent-bit
 version             1.8.5
@@ -37,6 +37,8 @@ master_sites        ${homepage}/releases/${branch}/
 checksums           rmd160  453c6ffdc245790f663e2b902b07fbf2ed0cfca0 \
                     sha256  2a9cb54b9cc86d4c1ed002f8969f94f85779b5dc5009be2890443163a01cd94b \
                     size    14783277
+
+patchfiles          patch-monkey-remove-malloc.h.diff
 
 # /usr/bin/ranlib: unknown option character `n' in: -no_warning_for_no_symbols
 compiler.blacklist-append   {clang < 700}

--- a/sysutils/fluent-bit/files/patch-monkey-remove-malloc.h.diff
+++ b/sysutils/fluent-bit/files/patch-monkey-remove-malloc.h.diff
@@ -1,0 +1,13 @@
+--- lib/monkey/deps/flb_libco/aarch64.c	2021-08-28 14:00:17.000000000 -0400
++++ lib/monkey/deps/flb_libco/aarch64.c	2021-08-28 14:00:35.000000000 -0400
+@@ -12,10 +12,6 @@
+ #include <string.h>
+ #include <stdint.h>
+ 
+-#ifndef IOS
+-#include <malloc.h>
+-#endif
+-
+ #ifdef __cplusplus
+ extern "C" {
+ #endif


### PR DESCRIPTION
- patch out attempted import of non-existent `malloc.h`

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
