### PR TITLE
osm2pgsql: add variant enabling building with Lua support

### DIFF
--- a/gis/osm2pgsql/Portfile
+++ b/gis/osm2pgsql/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants             1.1
 PortGroup           boost                       1.0
 
 github.setup        openstreetmap osm2pgsql 1.4.1
-revision            1
+revision            2
 
 categories          gis
 maintainers         {vince @Veence} openmaintainer
@@ -58,8 +58,8 @@ foreach suffix ${postgresql_suffixes} {
             if {!$result} {
                 ui_msg "Error: postgis3 isn't installed on the required postgresql version!"
                 return -code error "Variant mismatch."
-            }   
-        } 
+            }
+        }
     }
 }
 
@@ -75,7 +75,13 @@ set pgdefault "${pgdefault}} { default_variants +postgresql${suffix} }"
 
 eval ${pgdefault}
 
+variant lua description {Build with support for Lua} {
+    depends_lib-append port:lua
+}
 
 configure.args-append   "-DPROJ6_INCLUDE_DIR=${prefix}/lib/proj8/include"
 configure.args-append   "-DPROJ_LIBRARY=${prefix}/lib/proj8/lib/libproj.dylib"
-configure.args-append   "-DWITH_LUA=OFF"
+
+if {(![variant_isset lua])} {
+    configure.args-append   "-DWITH_LUA=OFF"
+}


### PR DESCRIPTION
#### Description

By default, the port builds without Lua support.  This change allows
the port to be built with the Lua option.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
