### PR TITLE
ruby26: Fix build issues on 10.4, 10.5.

### DIFF
--- a/lang/ruby26/Portfile
+++ b/lang/ruby26/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                ruby26
 version             2.6.8
-revision            1
+revision            2
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} openmaintainer
@@ -16,7 +16,7 @@ long_description    Ruby is the interpreted scripting language for quick \
                     and easy object-oriented programming. It has many \
                     features to process text files and to do system \
                     management tasks (as in Perl). It is simple, \
-                    straight-forward, extensible, and portable.
+                    straightforward, extensible, and portable.
 
 homepage            https://www.ruby-lang.org/
 license             {Ruby BSD}
@@ -29,7 +29,8 @@ dist_subdir         ruby26
 checksums           md5 c53761123d17e929cfe248f50429bcab \
                     rmd160 734337856050cb238e0b81280364b614ee02b56d \
                     sha1 7d38cacb6a0779f04b9f19f94406da97e95bbec4 \
-                    sha256 dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6
+                    sha256 dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6 \
+                    size 14131671
 
 use_parallel_build  no
 
@@ -59,12 +60,20 @@ configure.args      --enable-shared \
 # patch-configure_cxx11.diff: fix "invalid suffix on literal" with C++11
 #                             from RUBY_ARCH and RUBY_PLATFORM in config.h
 #                             https://trac.macports.org/ticket/58255
+# Note that this patches the output of autoconf, rather than the input, but
+# at present, rerunning autonconf produces a broken configure.
 patchfiles          patch-configure_cxx11.diff
 # Fix test failure at ext/fiddle
 patchfiles-append   patch-test-fiddle-helper.rb.diff
 # avoid build error with apple clang 12 (implicit declaration of function)
 # https://bugs.ruby-lang.org/issues/17777
 patchfiles-append   patch-ruby_issue_17777.diff
+# Fix build on 10.4
+patchfiles-append   patch-tiger.diff
+# Fix build on < 10.6
+patchfiles-append   patch-osversions.diff
+# Fix build with pre-C99 compilers and some locale settings
+patchfiles-append   patch-c99check.diff
 
 # [NOTE] workaround for mismatch of sdk versions on macOS 11.x,
 # such as MacOSX11.0.sdk (buildbot) <=> MacOSX11.1.sdk (user's Mac).
@@ -77,11 +86,11 @@ post-build {
         # rewrite MacOSX11.1.sdk -> MacOSX.sdk in rbconfig.rb
         file copy ${worksrcpath}/rbconfig.rb ${worksrcpath}/rbconfig.rb.orig
         reinplace -E -q {s|(/MacOSX)[0-9\.]+(\.sdk[\'\"]?[[:blank:]])|\1\2|g} \
-		    ${worksrcpath}/rbconfig.rb \
-		    ${worksrcpath}/ruby-2.6.pc
+            ${worksrcpath}/rbconfig.rb \
+            ${worksrcpath}/ruby-2.6.pc
         reinplace -E -q {s|(/MacOSX)[0-9\.]+(\.sdk[\'\"]?)$|\1\2|g} \
-		    ${worksrcpath}/rbconfig.rb \
-		    ${worksrcpath}/ruby-2.6.pc
+            ${worksrcpath}/rbconfig.rb \
+            ${worksrcpath}/ruby-2.6.pc
     }
 }
 
@@ -161,6 +170,21 @@ platform darwin {
         build.cmd               ${prefix}/bin/gmake
         configure.args-append   --disable-dtrace
         configure.cflags-append -std=c99
+    }
+
+    # Xcode gcc 4.2 building x86_64 assembler code passes "-arch i386" to the
+    # assembler, breaking x86_64 builds, unless we override it.
+    if {[string match *gcc-4.2 ${configure.compiler}]
+        && "x86_64" in [get_canonical_archs]} {
+        configure.env-append    ASFLAGS=[get_canonical_archflags]
+    }
+
+    # Building for 10.5 x86_64 fails if libunwind-headers is active.
+    # It's unknown why only this one case fails.
+    if {${os.major} == 9 && "x86_64" in [get_canonical_archs]} {
+        PortGroup    conflicts_build 1.0
+
+        conflicts_build-append libunwind-headers
     }
 
     if {${os.major} == 8} {

--- a/lang/ruby26/files/patch-c99check.diff
+++ b/lang/ruby26/files/patch-c99check.diff
@@ -1,0 +1,13 @@
+--- tool/transform_mjit_header.rb.orig	2021-07-07 03:38:58.000000000 -0700
++++ tool/transform_mjit_header.rb	2021-08-17 16:03:15.000000000 -0700
+@@ -176,7 +176,9 @@ module MJITHeader
+   def self.conflicting_types?(code, cc, cflags)
+     with_code(code) do |path|
+       cmd = "#{cc} #{cflags} #{path}"
+-      out = IO.popen(cmd, err: [:child, :out], &:read)
++      # As per gcc docs, set LC_ALL=C to avoid curly quotes in messages
++      cmd_env = {"LC_ALL" => "C"}
++      out = IO.popen(cmd_env, cmd, err: [:child, :out], &:read)
+       !$?.success? &&
+         (out.match?(/error: conflicting types for '[^']+'/) ||
+          out.match?(/error: redefinition of parameter '[^']+'/))

--- a/lang/ruby26/files/patch-osversions.diff
+++ b/lang/ruby26/files/patch-osversions.diff
@@ -1,0 +1,32 @@
+--- ./dln.c.orig	2021-07-07 03:38:58.000000000 -0700
++++ ./dln.c	2021-08-17 19:39:02.000000000 -0700
+@@ -1347,8 +1347,7 @@ dln_load(const char *file)
+ 	    if (dln_incompatible_library_p(handle)) {
+ 
+ #   if defined __APPLE__ && \
+-    defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
+-    (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_11)
++    __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101100
+ 		/* dlclose() segfaults */
+ 		rb_fatal("%s - %s", incompatible, file);
+ #   else
+--- ./error.c.orig	2021-07-07 03:38:58.000000000 -0700
++++ ./error.c	2021-08-17 19:39:02.000000000 -0700
+@@ -478,7 +478,7 @@ preface_dump(FILE *out)
+ 	"-- Crash Report log information "
+ 	"--------------------------------------------\n"
+ 	"   See Crash Report log file under the one of following:\n"
+-# if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
++# if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+ 	"     * ~/Library/Logs/CrashReporter\n"
+ 	"     * /Library/Logs/CrashReporter\n"
+ # endif
+@@ -503,7 +503,7 @@ postscript_dump(FILE *out)
+ 	"[IMPORTANT]"
+ 	/*" ------------------------------------------------"*/
+ 	"\n""Don't forget to include the Crash Report log file under\n"
+-# if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
++# if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+ 	"CrashReporter or "
+ # endif
+ 	"DiagnosticReports directory in bug reports.\n"

--- a/lang/ruby26/files/patch-tiger.diff
+++ b/lang/ruby26/files/patch-tiger.diff
@@ -1,0 +1,24 @@
+--- ./signal.c.orig	2021-07-07 03:38:58.000000000 -0700
++++ ./signal.c	2021-09-15 19:38:08.000000000 -0700
+@@ -862,7 +862,8 @@ check_stack_overflow(int sig, const uint
+     const greg_t bp = mctx->gregs[REG_EBP];
+ #   endif
+ # elif defined __APPLE__
+-#   if __DARWIN_UNIX03
++#   include <AvailabilityMacros.h>
++#   if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ #     define MCTX_SS_REG(reg) __ss.__##reg
+ #   else
+ #     define MCTX_SS_REG(reg) ss.reg
+--- ./vm_dump.c.orig	2021-07-07 03:38:58.000000000 -0700
++++ ./vm_dump.c	2021-09-15 19:38:08.000000000 -0700
+@@ -411,7 +411,8 @@ rb_vmdebug_thread_dump_state(VALUE self)
+ }
+ 
+ #if defined __APPLE__
+-# if __DARWIN_UNIX03
++# include <AvailabilityMacros.h>
++# if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ #   define MCTX_SS_REG(reg) __ss.__##reg
+ # else
+ #   define MCTX_SS_REG(reg) ss.reg


### PR DESCRIPTION
This includes a patch for some OS version issues common to earlier
Ruby versions:

The OS version conditional in dln.c is comparing an undefined macro to
a sometimes undefined (and essentially useless) macro.  However, the
relevant code doesn't seem to be built for any OS version, making the
bug irrelevant.  Nevertheless, it's now fixed, since another, similar
fix was needed, anyway, and it might become relevant if something else
changes.

The OS version conditionals in error.c were using another useless
macro for the comparison, this time with a real effect, though only in
a couple of messages related to crash reports on < 10.6.  This is now
fixed.

It also includes an updated patch for a 10.4 issue:

The context register naming issue on 10.4 was sort of fixed upstream
but tied to an inappropriate config flag.  The patched version uses an
SDK version macro to make the decision.

A newly discovered issue, common to some older Ruby versions, is:

The 10.5 x86_64 build fails if libunwind-headers is active.  Since
this is an unusual configuration, and the need for libunwind-headers
seems to be waning, it's not worth fixing "right".  This just adds the
usual failure for such cases.  It's unknown why this only affects 10.5
x86_64 (and perhaps 10.4 x86_64, though that's untested).

The remaining issues were new in ruby26:

The syntax-checking compiler invocations in transform_mjit_header.rb
require a C99 or later compiler, but don't include compiler flags from
the build.  There's code to detect the non-C99 case and add -std=c99
to the real uses, but it relies on matching the error message from the
test case.  Recent versions of gcc use locale-dependent quotes which
may break such comparisons, depending on the current locale settings.
The fix recommended by gcc documentation is to run it with LC_ALL=C to
get traditional ASCII quotes.  This adds code to apply that
environment to the compiler test invocation.

For some strange reason, using gcc-4.2 for Ruby's coroutine-related
assembler code on x86_64 passes "-arch i386" to the assembler, thereby
causing failures on x86_64 register references.  To fix that, cases
with gcc-4.2 and x86_64 targeted now pass the correct architecture in
ASFLAGS.

Also corrects a small typo in the description.

Also fixes some lint errors in the Portfile.

Since this affects the installed code for < 10.6, it includes a
revbump.

Universal builds still fail on 10.4 i386 due to a weird configure bug,
and 10.4 ppc has broken universal dependencies.

TESTED:
Built -universal on 10.4-10.5 ppc, 10.4-10.6 i386, and 10.6-10.15
x86_64.  Built +universal on 10.5-10.13.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
