### PR TITLE
libprotozero: new port

### DIFF
--- a/devel/protozero/Portfile
+++ b/devel/protozero/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        mapbox protozero 1.7.0 v
+github.tarball_from archive
+
+categories          devel
+platforms           darwin
+maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
+
+license             BSD Boost-1 Apache-2
+
+description         A minimalistic protocol buffer decoder and encoder in C++
+
+long_description    Low-level: this is designed to be a building block \
+                    for writing a very customized decoder for a stable \
+                    protobuf schema. If your protobuf schema is \
+                    changing frequently or lazy decoding is not \
+                    critical for your application then this approach \
+                    offers no value: just use the C++ API that can be \
+                    generated with the Google Protobufs protoc \
+                    program.
+
+checksums           rmd160  d1f420730e65008ec2c0f394e5a1383a0997dc16 \
+                    sha256  beffbdfab060854fd770178a8db9c028b5b6ee4a059a2fed82c46390a85f3f31 \
+                    size    1114856
+
+compiler.cxx_standard 2011
+
+test.run            yes
+test.cmd            ctest --output-on-failure


### PR DESCRIPTION
#### Description

libprotozero: new port

libprotozero is a dependency of a new Portfile I will be submitting for an OpenStreetMap tile server.

https://lists.macports.org/pipermail/macports-dev/2021-August/043683.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.5.2 20G95 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
