### PR TITLE
libosmium: new port

### DIFF
--- a/gis/libosmium/Portfile
+++ b/gis/libosmium/Portfile
@@ -1,0 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           boost 1.0
+
+github.setup        osmcode libosmium 2.17.0 v
+github.tarball_from archive
+revision            0
+
+categories          gis
+platforms           darwin
+maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
+
+license             Boost-1 public-domain
+
+description         A fast and flexible C++ library for working with OpenStreetMap data
+
+long_description    Low-level: this is designed to be a building block \
+                    for writing a very customized decoder for a stable \
+                    protobuf schema. If your protobuf schema is \
+                    changing frequently or lazy decoding is not \
+                    critical for your application then this approach \
+                    offers no value: just use the C++ API that can be \
+                    generated with the Google Protobufs protoc \
+                    program.
+
+checksums           rmd160  3923cb87ea091aa69a23ca2ee517ea438ac9fe56 \
+                    sha256  4a7672d7caf4da3bc68619912b298462370c423c697871a0be6273c6686e10d6 \
+                    size    513404
+
+installs_libs       no
+
+compiler.cxx_standard 2011
+
+configure.args-append \
+                    -DBUILD_TESTING=OFF \
+                    -DBUILD_EXAMPLES=OFF
+
+depends_build-append \
+                    port:protozero
+
+boost.depends_type  build
+
+variant tests description {Build and run unit tests} {
+
+    depends_build-append \
+                        port:bzip2 \
+                        port:expat \
+                        port:gdal \
+                        port:proj4 \
+                        port:sparsehash \
+                        port:zlib
+
+    configure.args-delete \
+                        -DBUILD_TESTING=OFF \
+                        -DBUILD_EXAMPLES=OFF
+
+    configure.args-append \
+                        -DPROJ_INCLUDE_DIR=${prefix}/lib/proj49/include \
+                        -DPROJ_LIBRARY=${prefix}/lib/proj49/lib/libproj.dylib \
+
+    test.run            yes
+    test.cmd            ctest --output-on-failure
+
+}


### PR DESCRIPTION
#### Description

This port is a dependency of a new Portfile I will be submitting for an OpenStreetMap tile server.

https://lists.macports.org/pipermail/macports-dev/2021-August/043683.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.5.2 20G95 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
