### PR TITLE
osmium-tool: new port

### DIFF
--- a/gis/osmium-tool/Portfile
+++ b/gis/osmium-tool/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           boost 1.0
+
+github.setup        osmcode osmium-tool 1.13.1 v
+github.tarball_from archive
+revision            0
+
+categories          gis
+platforms           darwin
+maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
+
+license             GPL-3+ MIT BSD Boost-1
+
+description         A command line tool for working with OpenStreetMap
+
+long_description    A multipurpose command line tool for working with \
+                    OpenStreetMap data based on the Osmium library
+
+checksums           rmd160  3b024c02f3a1ae1a31ab3ef7369579e3d13fe59e \
+                    sha256  d6273e2614d390d8444b767018b7023bdac3538cbe094d2799eee50b6f08cd03 \
+                    size    394224
+
+compiler.cxx_standard 2011
+
+depends_lib-append  port:bzip2 \
+                    port:expat \
+                    port:lz4 \
+                    port:zlib
+
+depends_build-append \
+                    port:libosmium \
+                    port:pandoc \
+                    port:protozero \
+                    port:rapidjson
+
+post-patch {
+    file delete -force ${worksrcpath}/include/rapidjson
+}
+
+test.run            yes
+test.cmd            ctest --output-on-failure


### PR DESCRIPTION
#### Description

This port is dependent on pull request #12022

They are dependencies of a new Portfile I will be submitting for an OpenStreetMap tile server.

https://lists.macports.org/pipermail/macports-dev/2021-August/043683.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.5.2 20G95 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
