### PR TITLE
cups-ppdc: Fix build on 10.6/10.7

### DIFF
--- a/print/cups-ppdc/Portfile
+++ b/print/cups-ppdc/Portfile
@@ -50,6 +50,8 @@ configure.args  --disable-dnssd \
                 --disable-ssl \
                 --disable-shared \
                 --with-bundledir=""
+# code signing is broken on Snow Leopard - "sign" with /usr/bin/true
+configure.env-append CODE_SIGN=true
 configure.cflags-append -fno-stack-protector
 configure.cxxflags-append -fno-stack-protector
 if {${os.platform} eq "darwin" && ${os.major} < 10} {

--- a/print/cups-ppdc/files/patch-configure.diff
+++ b/print/cups-ppdc/files/patch-configure.diff
@@ -1,6 +1,14 @@
 --- configure.orig
 +++ configure
-@@ -6905,7 +6905,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+@@ -5981,7 +5981,6 @@ $as_echo "yes" >&6; }
+ 			else
+ 				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ $as_echo "no" >&6; }
+-				as_fn_error $? "Run 'sudo mkdir -p /usr/local/include/sandbox' and 'sudo touch /usr/local/include/sandbox/private.h' to build CUPS." "$LINENO" 5
+ 			fi
+ 		fi
+ 
+@@ -6905,7 +6904,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
  	fi
  
  	# Add useful warning options for tracking down problems...


### PR DESCRIPTION
#### Description

Attempt to fix build issues referenced from https://github.com/macports/macports-ports/pull/11961#issuecomment-908623979. I have not tested on the relevant OSes. Would appreciate running this on the 10.6/10.7 build bots before merging if that is possible.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
