### PR TITLE
detekt-cli: update to 1.18.1

### DIFF
--- a/java/detekt-cli/Portfile
+++ b/java/detekt-cli/Portfile
@@ -6,11 +6,11 @@ PortGroup           github  1.0
 
 name                detekt-cli
 
-github.setup        detekt detekt 1.18.0 v
+github.setup        detekt detekt 1.18.1 v
 revision            0
 
-# The resulting .jar uses the version of the latest release candidate.
-set buildversion ${version}-RC3
+# Set the version of the resulting jar. This might be, but is not necessarily identical to ${version}.
+set buildversion    ${version}
 
 categories          java devel
 license             Apache-2
@@ -24,9 +24,9 @@ homepage            https://detekt.github.io
 github.tarball_from archive
 
 distname            v${version}
-checksums           sha256  98e868aa3b452922c3cc732b9f6f65754cf219a13854ebbd5de647cf594c72d9 \
-                    rmd160  7df121e869d6466d295163e67ad5a707c291bf95 \
-                    size    2615465
+checksums           sha256  56be42d9fe39f56a6874a0f21e5698ae5c4abbab7393c4c6e97225963bfe1194 \
+                    rmd160  14d71915f588ba26f18168de97e09a945012d9b2 \
+                    size    2616356
 
 java.fallback       openjdk11
 java.version        1.8+


### PR DESCRIPTION
#### Description

See: https://github.com/detekt/detekt/releases/tag/v1.18.1.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
