### PR TITLE
google-cloud-sdk: update to 355.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             354.0.0
+version             355.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  24d2e647923e803db685b4b39429ad7934311de4 \
-                    sha256  2f411b1f09c46d6228746a23372689cf8d87e8b3cfd48b493efd2b37716006b2 \
-                    size    91577829
+    checksums       rmd160  794137cfdbc2d0d73677f946068999e747ca6dae \
+                    sha256  92caeb54c41d446e716bbb6107a56d71b48a66f0a2cca4a6423f4cbfa379611b \
+                    size    91724043
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4cf1714cd447076064126d02bfcb23d0f65e25b1 \
-                    sha256  cbf10388a9dd7bb51126a0a26a670bbb7b047e5da5a43f2b1469f6f67af6ea3c \
-                    size    87830040
+    checksums       rmd160  e498190355929435a56f6aa7a41ba74e8d01c535 \
+                    sha256  2d465f98d30f3bc59a047c7f9e38b733bf8d705e9bc7391817dc918cec91c665 \
+                    size    87972571
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  cd19aa2f1be7ef58fb7734c827d163f9fdaec023 \
-                    sha256  ef163979d36a85277ec1fe117598c3a8d11cce09495a22a7ace17e87ba169594 \
-                    size    87745214
+    checksums       rmd160  af078823f84c83fdf080c410937b3dafffed4995 \
+                    sha256  c2de8931711108f6542f291c140b806a93570315ab461ec0f903518ff817bbf7 \
+                    size    87887650
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 355.0.0.

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?