### PR TITLE
ntpsec: update to 1.2.1

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -5,7 +5,7 @@ PortGroup           waf 1.0
 PortGroup           python 1.0
 
 name                ntpsec
-version             1.2.0
+version             1.2.1
 revision            0
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
@@ -19,9 +19,19 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  c9b30c514feca77d9c65ea7bea9f0e22ca80a767 \
-                    sha256  6a7c7561a750519fe3441cbbaf1f684b379b97b655da4bf9cf0dd2052a4a02c8 \
-                    size    2625968
+checksums           rmd160  ca5d758bf6572b460ba8e8c8e70f09b8a7417fd0 \
+                    sha256  f2684835116c80b8f21782a5959a805ba3c44e3a681dd6c17c7cb00cc242c27a \
+                    size    2681237
+
+# 10.5 x86_64 builds successfully and passes all build tests, but doesn't
+# actually work.  This has apparently been true forever, but until recently,
+# dependency issues prevented building it at all.  Since this is a rare case
+# and not really a regression, we simply disallow it for now.  It's unknown
+# whether 10.4 x86_64 has the same issue, but we also disallow that out of
+# conservatism.  This should be removed once the code is fixed.
+if { ${os.platform} eq "darwin" && ${os.major} < 10 } {
+    supported_archs     i386 ppc
+}
 
 # To avoid breaking any code that uses our Python package, keep the Python
 # version at 2.7 until we add variants for Python versions.  The upstream

--- a/sysutils/ntpsec/files/patch-PreHighSierra.diff
+++ b/sysutils/ntpsec/files/patch-PreHighSierra.diff
@@ -1,5 +1,5 @@
---- ./attic/backwards.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./attic/backwards.c	2020-10-08 17:43:39.000000000 -0700
+--- ./attic/backwards.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./attic/backwards.c	2021-07-28 18:53:02.000000000 -0700
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -9,19 +9,19 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- ./attic/clocks.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./attic/clocks.c	2020-10-08 17:43:39.000000000 -0700
-@@ -5,6 +5,8 @@
- #include <stdio.h>
- #include <time.h>
+--- ./attic/clocks.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./attic/clocks.c	2021-07-28 18:53:02.000000000 -0700
+@@ -9,6 +9,8 @@
+ #include <unistd.h>
+ 
  
 +#include "ntp_machine.h"	/* For clock_gettime fallback */
 +
  struct table {
    const int type;
    const char* name;
---- ./attic/cmac-timing.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./attic/cmac-timing.c	2020-10-08 17:43:39.000000000 -0700
+--- ./attic/cmac-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./attic/cmac-timing.c	2021-07-28 18:53:02.000000000 -0700
 @@ -35,6 +35,8 @@
  #include <openssl/params.h> 
  #endif
@@ -31,8 +31,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  
---- ./attic/digest-timing.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./attic/digest-timing.c	2020-10-08 17:43:39.000000000 -0700
+--- ./attic/digest-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./attic/digest-timing.c	2021-07-28 18:53:02.000000000 -0700
 @@ -33,6 +33,8 @@
  #include <openssl/ssl.h>
  #endif
@@ -42,8 +42,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
---- ./attic/random.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./attic/random.c	2020-10-08 17:43:39.000000000 -0700
+--- ./attic/random.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./attic/random.c	2021-07-28 18:53:02.000000000 -0700
 @@ -10,6 +10,8 @@
  #include <openssl/opensslv.h>    /* for OPENSSL_VERSION_NUMBER */
  #include <openssl/rand.h>
@@ -53,8 +53,8 @@
  #define BATCHSIZE 1000000
  #define BILLION 1000000000
  #define HISTSIZE 2500
---- ./include/ntp_machine.h.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./include/ntp_machine.h	2020-10-08 17:43:39.000000000 -0700
+--- ./include/ntp_machine.h.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./include/ntp_machine.h	2021-07-28 18:53:02.000000000 -0700
 @@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
@@ -207,8 +207,8 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- ./include/ntp_stdlib.h.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./include/ntp_stdlib.h	2020-10-08 17:43:39.000000000 -0700
+--- ./include/ntp_stdlib.h.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./include/ntp_stdlib.h	2021-07-28 18:53:02.000000000 -0700
 @@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -219,8 +219,8 @@
  extern	char *	statustoa	(int, int);
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
---- ./include/ntp_syscall.h.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./include/ntp_syscall.h	2020-10-08 17:43:39.000000000 -0700
+--- ./include/ntp_syscall.h.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./include/ntp_syscall.h	2021-07-28 18:53:02.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -233,8 +233,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- ./libntp/clockwork.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./libntp/clockwork.c	2020-10-08 17:43:39.000000000 -0700
+--- ./libntp/clockwork.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./libntp/clockwork.c	2021-07-28 18:53:02.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -248,8 +248,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- ./libntp/statestr.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./libntp/statestr.c	2020-10-08 17:43:39.000000000 -0700
+--- ./libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./libntp/statestr.c	2021-07-28 18:53:02.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -350,9 +350,9 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ./ntpd/ntp_control.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./ntpd/ntp_control.c	2020-10-08 17:43:39.000000000 -0700
-@@ -1368,6 +1368,7 @@ ctl_putsys(
+--- ./ntpd/ntp_control.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./ntpd/ntp_control.c	2021-07-28 18:53:02.000000000 -0700
+@@ -1361,6 +1361,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
  	const char *ss;
@@ -360,7 +360,7 @@
  	static struct timex ntx;
  	static unsigned long ntp_adjtime_time;
  
-@@ -1383,6 +1384,7 @@ ctl_putsys(
+@@ -1376,6 +1377,7 @@ ctl_putsys(
  		else
                      ntp_adjtime_time = current_time;
  	}
@@ -368,8 +368,8 @@
  
  	switch (varid) {
  
-@@ -1782,50 +1784,93 @@ ctl_putsys(
- 		break;
+@@ -1666,45 +1668,94 @@ ctl_putsys(
+ 	CASE_UINT(CS_AUTHRESET, current_time - auth_timereset);
  
  		/*
 -		 * CTL_IF_KERNPPS() puts a zero if kernel hard PPS is not
@@ -410,13 +410,13 @@
 +		);
  		break;
  
- 	case CS_K_FREQ:
--		ctl_putsfp(sys_var[varid].text, ntx.freq);
+-	CASE_SFP(CS_K_FREQ, ntx.freq);
++	case CS_K_FREQ:
 +		CTL_IF_KERNLOOP(
 +			ctl_putsfp,
-+			(sys_var[varid].text, ntx.freq)
++			(CV_NAME, ntx.freq)
 +		);
- 		break;
++		break;
  
  	case CS_K_MAXERR:
 -		ctl_putdblf(sys_var[varid].text, false, 6,
@@ -447,13 +447,13 @@
  		ctl_putstr(sys_var[varid].text, ss, strlen(ss));
  		break;
  
- 	case CS_K_TIMECONST:
--		ctl_putint(sys_var[varid].text, ntx.constant);
+-	CASE_INT(CS_K_TIMECONST, ntx.constant);
++	case CS_K_TIMECONST:
 +		CTL_IF_KERNLOOP(
 +			ctl_putint,
-+			(sys_var[varid].text, ntx.constant)
++			(CV_NAME, ntx.constant)
 +		);
- 		break;
++		break;
  
  	case CS_K_PRECISION:
 -		ctl_putdblf(sys_var[varid].text, false, 6,
@@ -465,17 +465,18 @@
 +		);
  		break;
  
- 	case CS_K_FREQTOL:
--	        ctl_putsfp(sys_var[varid].text, ntx.tolerance);
+-	CASE_SFP(CS_K_FREQTOL, ntx.tolerance);
++	case CS_K_FREQTOL:
 +		CTL_IF_KERNLOOP(
 +			ctl_putsfp,
-+			(sys_var[varid].text, ntx.tolerance)
++			(CV_NAME, ntx.tolerance)
 +		);
- 		break;
++		break;
  
  	case CS_K_PPS_FREQ:
---- ./ntpd/ntp_loopfilter.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2020-10-08 17:43:39.000000000 -0700
+ 		CTL_IF_KERNPPS(
+--- ./ntpd/ntp_loopfilter.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./ntpd/ntp_loopfilter.c	2021-07-28 18:53:02.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -697,8 +698,8 @@
  	}
  }
 -
---- ./ntpd/ntp_timer.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2020-10-08 17:43:39.000000000 -0700
+--- ./ntpd/ntp_timer.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./ntpd/ntp_timer.c	2021-07-28 18:53:02.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -721,8 +722,8 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ./ntpd/refclock_local.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./ntpd/refclock_local.c	2020-10-08 17:43:39.000000000 -0700
+--- ./ntpd/refclock_local.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./ntpd/refclock_local.c	2021-07-28 18:53:02.000000000 -0700
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -745,8 +746,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ./ntpfrob/precision.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./ntpfrob/precision.c	2020-10-08 17:43:39.000000000 -0700
+--- ./ntpfrob/precision.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./ntpfrob/precision.c	2021-07-28 18:53:02.000000000 -0700
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -755,8 +756,8 @@
  
  #define	DEFAULT_SYS_PRECISION	-99
  
---- ./tests/libntp/statestr.c.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./tests/libntp/statestr.c	2020-10-08 17:43:39.000000000 -0700
+--- ./tests/libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./tests/libntp/statestr.c	2021-07-28 18:53:02.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -777,9 +778,9 @@
  }
  
  // statustoa
---- ./wafhelpers/bin_test.py.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./wafhelpers/bin_test.py	2020-10-08 17:43:39.000000000 -0700
-@@ -95,6 +95,12 @@ def cmd_bin_test(ctx, config):
+--- ./wafhelpers/bin_test.py.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./wafhelpers/bin_test.py	2021-07-28 18:53:02.000000000 -0700
+@@ -103,6 +103,12 @@ def cmd_bin_test(ctx):
      if ctx.env['PYTHON_CURSES']:
          cmd_map_python.update(cmd_map_python_curses)
  
@@ -790,10 +791,10 @@
 +                del cmd_map[cmd]
 +
      for cmd in sorted(cmd_map):
-         if not run(cmd, cmd_map[cmd], False):
+         if not run(cmd, cmd_map[cmd] % version):
              fails += 1
---- ./wafhelpers/options.py.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./wafhelpers/options.py	2020-10-08 17:43:39.000000000 -0700
+--- ./wafhelpers/options.py.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./wafhelpers/options.py	2021-07-28 18:53:02.000000000 -0700
 @@ -21,6 +21,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -803,9 +804,9 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- ./wscript.orig	2020-10-05 21:16:52.000000000 -0700
-+++ ./wscript	2020-10-08 17:43:39.000000000 -0700
-@@ -563,7 +563,7 @@ int main(int argc, char **argv) {
+--- ./wscript.orig	2021-06-06 21:03:11.000000000 -0700
++++ ./wscript	2021-07-28 18:53:02.000000000 -0700
+@@ -562,7 +562,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
          ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
@@ -814,7 +815,7 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -774,6 +774,21 @@ int main(int argc, char **argv) {
+@@ -776,6 +776,21 @@ int main(int argc, char **argv) {
          ctx.define("ENABLE_FUZZ", 1,
                     comment="Enable fuzzing low bits of time")
  


### PR DESCRIPTION
This includes the patches for compatibility with macOS<10.13,
which can also be seen (more readably) at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports_1_2_1

Up until recently, 10.5 x86_64 wasn't possible due to broken
dependencies.  That case now builds and passes its tests, but doesn't
actually work.  Pending resolution of this issue, x86_64 is excluded
from supported_archs for 10.5, as well as for 10.4 since it might have
the same issue and hasn't been tested.  At present (on 10.5 x86_64),
this results in at least one broken universal dependency, so it's back
to not being buildable at all.  This is no worse than previous
versions.

TESTED:
Tested (including building the usual set of variant combinations)
on 10.4-10.5 ppc, 10.4-10.6 i386, and 10.6-10.15 x86_64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
