### PR TITLE
brlaser: new port

### DIFF
--- a/print/brlaser/Portfile
+++ b/print/brlaser/Portfile
@@ -1,0 +1,81 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       github 1.0
+PortGroup       cmake 1.1
+
+github.setup    pdewacht brlaser 6 v
+revision        0
+categories      print
+license         GPL-2+
+maintainers     nomaintainer
+description     Driver for Brother laser printers
+
+long_description \
+    brlaser is an open-source driver for Brother-branded monochrome laser \
+    printers, useful on systems where the proprietary driver is not \
+    available.
+
+notes "
+    **************************************************************************
+    brlaser has installed a collection of PostScript Printer Description (PPD)
+    files to the following directory:
+
+      ${prefix}/share/cups/model
+
+    Each file corresponds to a particular Brother laser printer model. (In many
+    cases, choosing an incorrect PPD file will still print correctly.)
+
+    To install a printer, plug in your printer and open the Print & Fax pane
+    in System Preferences. Click the + sign to add a printer, then locate the
+    Use (or Print Using) button and choose Other. Navigate to the PPD file
+    corresponding to your printer to install it.
+
+    For example, the PPD file for a Brother HL-L2300D can be found here:
+
+      ${prefix}/share/cups/model/brl2300d.ppd
+
+    The brlaser MacPorts package must remain installed on the system in order
+    to print to any printers added in this way.
+
+    *************************************************************************"
+
+checksums       rmd160 829cf057ed7e11abb42a79b2e6c631522539021c \
+                sha256 d1b180b5e15eeb3d7236abdaab665f3a3ac8fc27d192ab4ad4ad250cc0520aa3 \
+                size 22830
+
+# /usr/bin/ppdc exists on 10.6 and later
+if { ${os.platform} ne "darwin" || ${os.major} < 10 } {
+    depends_build-append \
+                port:cups-ppdc
+}
+
+patchfiles      patch-cups-1.1.diff \
+                patch-tumble.diff \
+                patch-absolute-filter-path.diff \
+                patch-no-stack-protector.diff
+
+if { ${os.platform} eq "darwin" && ${os.major} < 17 } {
+    patchfiles-append patch-no-open_memstream.diff
+}
+
+compiler.cxx_standard   2011
+
+configure.args-append -DCUPS_SERVER_BIN:FILEPATH=${prefix}/libexec/cups
+configure.args-append -DCUPS_DATA_DIR:FILEPATH=${prefix}/share/cups
+
+post-build {
+    system -W ${workpath} "ppdc build/brlaser.drv -d build/ppd"
+}
+
+test.run yes
+test.target check
+
+destroot {
+    xinstall -d ${destroot}${prefix}/libexec/cups/filter
+    xinstall -m 0755 ${workpath}/build/rastertobrlaser \
+        ${destroot}${prefix}/libexec/cups/filter
+
+    xinstall -d ${destroot}${prefix}/share/cups/model
+    xinstall -m 0644 {*}[glob ${workpath}/build/ppd/*.ppd] ${destroot}${prefix}/share/cups/model
+}

--- a/print/brlaser/files/patch-absolute-filter-path.diff
+++ b/print/brlaser/files/patch-absolute-filter-path.diff
@@ -1,0 +1,14 @@
+The default filter search path is /usr/libexec/cups/filter. MacPorts can't
+write to this location, so specify an absolute path instead.
+
+--- brlaser.drv.in.orig
++++ brlaser.drv.in
+@@ -29,7 +29,7 @@ Manufacturer "Brother"
+ Version "@BRLASER_VERSION@"
+ 
+ // Each filter provided by the driver...
+-Filter application/vnd.cups-raster 33 rastertobrlaser
++Filter application/vnd.cups-raster 33 @CUPS_SERVER_BIN@/filter/rastertobrlaser
+ 
+ // Supported resolutions.
+ // The 1200dpi mode is weird: we need to send 1200x1200dpi raster

--- a/print/brlaser/files/patch-cups-1.1.diff
+++ b/print/brlaser/files/patch-cups-1.1.diff
@@ -1,0 +1,157 @@
+Patch to allow compiling against CUPS 1.1 (Tiger)
+
+CUPS 1.2 introduced the cups_page_header2_t structure, which adds some fields
+to the older cups_page_header_t structure. The previous field names are
+unchanged, so we can swap in one for the other in the code with macros in
+src/compat.h.
+
+Three fields in particular (cupsInteger, cupsNumColors, and cupsPageSizeName)
+are not present in the 1.1 structure. So provide some workarounds in src/main.cc
+to store data and use fields that are present on 1.1.
+
+One hack worth noting is that because 1.1 lacks custom integer fields, the
+"Toner save mode" is stored in the "compression" field with this patch. The
+"compression" field isn't used elsewhere in the driver, so this should be safe.
+
+If this patch breaks, it might be easier to provide a libcups port (the cups-ppdc
+port already compiles libcups for its own use) and just compile against that.
+However, this will require verifying that filters compiled with a newer libcups
+will properly function when speaking to an older, system-provided cupsd.
+
+--- brlaser.drv.in.orig
++++ brlaser.drv.in
+@@ -75,8 +75,8 @@ MediaType 7 "ENV-THICK/Thick envelopes"
+ MediaType 8 "ENV-THIN/Thin envelopes"
+ 
+ Option "brlaserEconomode/Toner save mode" Boolean AnySetup 10
+-  *Choice False/Off "<</cupsInteger10 0>>setpagedevice"
+-  Choice True/On "<</cupsInteger10 1>>setpagedevice"
++  *Choice False/Off "<</cupsCompression 0>>setpagedevice"
++  Choice True/On "<</cupsCompression 1>>setpagedevice"
+ 
+ 
+ {
+--- /dev/null
++++ src/compat.h
+@@ -0,0 +1,29 @@
++// This file is part of the brlaser printer driver.
++//
++// Copyright 2021 Evan Miller
++//
++// brlaser is free software: you can redistribute it and/or modify
++// it under the terms of the GNU General Public License as published by
++// the Free Software Foundation, either version 2 of the License, or
++// (at your option) any later version.
++//
++// brlaser is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++//
++// You should have received a copy of the GNU General Public License
++// along with brlaser.  If not, see <http://www.gnu.org/licenses/>.
++
++#ifndef COMPAT_H
++#define COMPAT_H
++
++#include <cups/cups.h>
++
++#if CUPS_VERSION_MAJOR == 1 && CUPS_VERSION_MINOR < 2
++#define _BRLASER_CUPS_COMPAT_OLD
++#define cups_page_header2_t cups_page_header_t
++#define cupsRasterReadHeader2(r, h) cupsRasterReadHeader(r, h)
++#endif
++
++#endif
+--- src/debug.cc.orig
++++ src/debug.cc
+@@ -93,6 +93,7 @@ void dump_page_header(const cups_page_header2_t &h) {
+   d(cupsRowCount);
+   d(cupsRowFeed);
+   d(cupsRowStep);
++#ifndef _BRLASER_CUPS_COMPAT_OLD
+   d(cupsNumColors);
+   d(cupsBorderlessScalingFactor);
+   d(cupsPageSize);
+@@ -103,5 +104,6 @@ void dump_page_header(const cups_page_header2_t &h) {
+   d(cupsMarkerType);
+   d(cupsRenderingIntent);
+   d(cupsPageSizeName);
++#endif
+ #undef d
+ }
+--- src/debug.h.orig
++++ src/debug.h
+@@ -18,6 +18,7 @@
+ #ifndef DEBUG_H
+ #define DEBUG_H
+ 
++#include "compat.h"
+ #include <cups/raster.h>
+ 
+ void dump_page_header(const cups_page_header2_t &h);
+--- src/main.cc.orig
++++ src/main.cc
+@@ -90,25 +90,26 @@ page_params build_page_params(const cups_page_header2_t &header) {
+   static const std::array<std::string, 6> sources = {{
+     "AUTO", "T1", "T2", "T3", "MP", "MANUAL"
+   }};
+-  static const std::map<std::string, std::string> sizes = {
+-    { "A4", "A4" },
+-    { "A5", "A5" },
+-    { "A6", "A6" },
+-    { "B5", "B5" },
+-    { "B6", "B6" },
+-    { "EnvC5", "C5" },
+-    { "EnvMonarch", "MONARCH" },
+-    { "EnvPRC5", "DL" },
+-    { "EnvDL", "DL" },
+-    { "Executive", "EXECUTIVE" },
+-    { "Legal", "LEGAL" },
+-    { "Letter", "LETTER" }
++
++  static const std::map<std::tuple<int, int>, std::string> sizes = {
++      { {595, 842}, "A4" },
++      { {420, 595}, "A5" },
++      { {298, 420}, "A6" },
++      { {499, 709}, "B5" },
++      { {354, 499}, "B6" },
++      { {649, 459}, "C5" },
++      { {312, 624}, "DL" },
++      { {279, 540}, "MONARCH" },
++      { {522, 756}, "EXECUTIVE" },
++      { {612, 792}, "LETTER" },
++      { {612, 1008}, "LEGAL" },
+   };
+ 
+   page_params p = { };
++  p.papersize = "A4";
+   p.num_copies = header.NumCopies;
+   p.resolution = header.HWResolution[0];
+-  p.economode = header.cupsInteger[10];
++  p.economode = header.cupsCompression;
+   p.mediatype = header.MediaType;
+   p.duplex = header.Duplex;
+ 
+@@ -117,11 +118,9 @@ page_params build_page_params(const cups_page_header2_t &header) {
+   else
+     p.sourcetray = sources[0];
+ 
+-  auto size_it = sizes.find(header.cupsPageSizeName);
++  auto size_it = sizes.find(std::make_tuple(header.PageSize[0], header.PageSize[1]));
+   if (size_it != sizes.end())
+     p.papersize = size_it->second;
+-  else
+-    p.papersize = "A4";
+ 
+   return p;
+ }
+@@ -176,7 +175,7 @@ int main(int argc, char *argv[]) {
+     while (!interrupted && cupsRasterReadHeader2(ras, &header)) {
+       if (header.cupsBitsPerPixel != 1
+           || header.cupsBitsPerColor != 1
+-          || header.cupsNumColors != 1
++          || header.cupsColorSpace != 3
+           || header.cupsBytesPerLine > 10000) {
+         fprintf(stderr, "ERROR: " PACKAGE ": Page %d: Bogus raster data.\n", job.pages() + 1);
+         dump_page_header(header);

--- a/print/brlaser/files/patch-no-open_memstream.diff
+++ b/print/brlaser/files/patch-no-open_memstream.diff
@@ -1,0 +1,24 @@
+Comment out some tests that require open_memstream (function added in 10.13)
+
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -116,16 +116,16 @@ target_link_libraries(rastertobrlaser ${CUPS_LDFLAGS})
+ add_executable(brdecode EXCLUDE_FROM_ALL src/brdecode.cc)
+ add_executable(test_lest test/test_lest.cc)
+ add_executable(test_line test/test_line.cc src/line.cc)
+-add_executable(test_block test/test_block.cc)
++# add_executable(test_block test/test_block.cc)
+ 
+ enable_testing()
+ add_test(test_lest test_lest)
+ add_test(test_line test_line)
+-add_test(test_block test_block)
++# add_test(test_block test_block)
+ 
+ # Autotools-style "make check" command
+ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+-add_dependencies(check test_lest test_line test_block)
++add_dependencies(check test_lest test_line) # test_block
+ 
+ 
+ # Installation

--- a/print/brlaser/files/patch-no-stack-protector.diff
+++ b/print/brlaser/files/patch-no-stack-protector.diff
@@ -1,0 +1,13 @@
+The stack protector results in link errors on some older systems.
+
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -41,7 +41,7 @@ extra_cxx_compiler_flag("-Wall")
+ extra_cxx_compiler_flag("-Wno-missing-braces")
+ extra_cxx_compiler_flag("-Wdate-time")
+ # Some security flags
+-extra_cxx_compiler_flag("-fstack-protector-strong")
++# extra_cxx_compiler_flag("-fstack-protector-strong")
+ extra_cxx_compiler_flag("-Wformat")
+ extra_cxx_compiler_flag("-Wformat -Werror=format-security")
+ extra_cxx_compiler_flag("-D_FORTIFY_SOURCE=2")

--- a/print/brlaser/files/patch-tumble.diff
+++ b/print/brlaser/files/patch-tumble.diff
@@ -1,0 +1,53 @@
+Upstream explanation: https://github.com/pdewacht/brlaser/pull/124
+
+--- src/job.cc.orig
++++ src/job.cc
+@@ -73,14 +73,15 @@ void job::write_page_header() {
+           page_params_.papersize.c_str());
+   fprintf(out_, "@PJL SET PAGEPROTECT = AUTO\n");
+   fprintf(out_, "@PJL SET ORIENTATION = PORTRAIT\n");
++  fprintf(out_, "@PJL SET DUPLEX = %s\n",
++          page_params_.duplex ? "ON" : "OFF");
++  fprintf(out_, "@PJL SET BINDING = %s\n",
++          page_params_.tumble ? "SHORTEDGE" : "LONGEDGE");
++  fprintf(out_, "@PJL SET COPIES = %d\n",
++          std::max(1, page_params_.num_copies));
+   fprintf(out_, "@PJL ENTER LANGUAGE = PCL\n");
+ 
+   fputs("\033E", out_);
+-  fprintf(out_, "\033&l%dX", std::max(1, page_params_.num_copies));
+-
+-  if (page_params_.duplex) {
+-    fputs("\033&l2S", out_);
+-  }
+ }
+ 
+ void job::encode_page(const page_params &page_params,
+--- src/job.h.orig
++++ src/job.h
+@@ -27,6 +27,7 @@ struct page_params {
+   int num_copies;
+   int resolution;
+   bool duplex;
++  bool tumble;
+   bool economode;
+   std::string sourcetray;
+   std::string mediatype;
+@@ -36,6 +37,7 @@ struct page_params {
+     return num_copies == o.num_copies
+       && resolution == o.resolution
+       && duplex == o.duplex
++      && tumble == o.tumble
+       && economode == o.economode
+       && sourcetray == o.sourcetray
+       && mediatype == o.mediatype
+--- src/main.cc.orig
++++ src/main.cc
+@@ -111,6 +111,7 @@ page_params build_page_params(const cups_page_header2_t &header) {
+   p.economode = header.cupsInteger[10];
+   p.mediatype = header.MediaType;
+   p.duplex = header.Duplex;
++  p.tumble = header.Tumble;
+ 
+   if (header.MediaPosition < sources.size())
+     p.sourcetray = sources[header.MediaPosition];


### PR DESCRIPTION
#### Description

[`brlaser`](https://github.com/pdewacht/brlaser) is an open-source CUPS driver for Brother monochrome laser printers, useful on systems where the proprietary driver is not available. The driver is packaged on FreeBSD as [print/brlaser](https://www.freshports.org/print/brlaser) and on Debian as [printer-driver-brlaser](https://packages.debian.org/sid/text/printer-driver-brlaser).

This port differs from the above packages in that it compiles and installs the PPD files themselves (with help from [`cups-ppdc`](https://ports.macports.org/port/cups-ppdc/details/)) instead of leaving it as a task to the user. The PPD files are installed to the same location that `cups-pdf` uses.

The notes field instructs end users on setting up a printer for the first time. Patches are included to assist with compilation and to enhance duplex printing – submitted upstream but the project is not especially active.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
