### PR TITLE
netcdf: update to 4.8.1

### DIFF
--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -6,8 +6,8 @@ PortGroup                   github 1.0
 PortGroup                   cmake 1.0
 PortGroup                   muniversal 1.0
 
-github.setup                Unidata netcdf-c 4.8.0 v
-revision                    1
+github.setup                Unidata netcdf-c 4.8.1 v
+revision                    0
 epoch                       3
 name                        netcdf
 maintainers                 {takeshi @tenomoto} openmaintainer
@@ -23,9 +23,9 @@ long_description \
 
 homepage                    http://www.unidata.ucar.edu/software/netcdf/
 
-checksums           rmd160  cb223477d4ca4d488d907813ca643e4b7a24a379 \
-                    sha256  cbaecf7c7e554b79be28d898b878009d97a57d3007b069313c1fa8d950fd6c89 \
-                    size    18893602
+checksums           rmd160  d22da52d674c852d4a8126bdd12c86a4e8a111be \
+                    sha256  18836c8ceab3bf5f04c78dbd0f6ba2d957e51c97fd44955fa464b18b49022d21 \
+                    size    18959550
 
 compilers.choose            cc cpp
 mpi.setup


### PR DESCRIPTION
#### Description

Simple update to upstream version 4.8.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode Command Line Tools 12.5.1.0.1.1623191612

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
