### PR TITLE
rlwrap: update to v0.45.2 and add maintainer

### DIFF
--- a/sysutils/rlwrap/Portfile
+++ b/sysutils/rlwrap/Portfile
@@ -3,12 +3,12 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            hanslub42 rlwrap 0.45 v
+github.setup            hanslub42 rlwrap 0.45.2 v
 revision                0
 categories              sysutils
 platforms               darwin
 license                 GPL-2+
-maintainers             nomaintainer
+maintainers             {@kakuhen} openmaintainer
 
 description             rlwrap is a readline wrapper.
 
@@ -16,9 +16,9 @@ long_description        rlwrap is a wrapper that enables any other command to \
                         support editing of keyboard input using the GNU \
                         readline library.
 
-checksums               rmd160  0b2530a2696b7f2da3e1b3f5317693b31b82bad4 \
-                        sha256  fb6ac7c8534ad52c709bdd88ec17c2de71c32d530c064f0c594fa1ecf377af1e \
-                        size    181271
+checksums               rmd160  057fdd4383774881d826bd63aab334c306bbebc9 \
+                        sha256  b776f12c05f15c321ae5fd838cc014b3e391cfd690b78906071e1069bc10112e \
+                        size    182055
 
 depends_build-append    port:autoconf \
                         port:automake \


### PR DESCRIPTION
#### Description
* Update from version 0.45 to 0.45.2
* Add myself as maintainer of the port

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
