### PR TITLE
meson: Fix error building pango-devel with GCC

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.58.1
-revision            0
+revision            1
 
 github.tarball_from releases
 license             Apache-2
@@ -59,6 +59,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
 # https://github.com/mesonbuild/meson/issues/6187
 patchfiles-append   patch-meson-32bit-apple.diff
 
+# https://github.com/mesonbuild/meson/pull/9211
+patchfiles-append   patch-meson-gcc-appleframeworks.diff
+
 # disable warning not accepted by older clang versions
 # this manifests currently on systems up to 10.9
 # https://github.com/mesonbuild/meson/issues/8307
@@ -72,7 +75,7 @@ platform darwin 8 {
     # and is therefore fragile. Keep pegged, and update occasionally
 
     github.setup        mesonbuild meson 0.55.3
-    revision            1
+    revision            2
     checksums           rmd160  b1e7f12184a7a61ae8bfa7ed210af8020d531009 \
                         sha256  6bed2a25a128bbabe97cf40f63165ebe800e4fcb46db8ab7ef5c2b5789f092a5 \
                         size    1740465
@@ -81,6 +84,8 @@ platform darwin 8 {
     patchfiles-append   patch-meson-powermacintosh.diff
     patchfiles-delete   patch-meson-clang-unknown-optimization-error.diff
     patchfiles-append patch-meson55-tiger-no-rpath-fix.diff
+    patchfiles-replace  patch-meson-gcc-appleframeworks.diff \
+                        patch-meson55-gcc-appleframeworks.diff
 }
 
 # add a search path for crossfiles in our prefix

--- a/devel/meson/files/patch-meson-gcc-appleframeworks.diff
+++ b/devel/meson/files/patch-meson-gcc-appleframeworks.diff
@@ -1,0 +1,18 @@
+Upstream: https://github.com/mesonbuild/meson/pull/9211
+
+Fix the following error when configuring pango (or any project with
+appleframeworks listed as a dependency) using GCC:
+
+ERROR: Dependency "appleframeworks" not found, tried framework
+--- mesonbuild/compilers/mixins/clike.py.orig	2021-09-02 16:07:01.000000000 -0400
++++ mesonbuild/compilers/mixins/clike.py	2021-09-02 16:07:36.000000000 -0400
+@@ -1199,9 +1199,6 @@
+         Finds the framework with the specified name, and returns link args for
+         the same or returns None when the framework is not found.
+         '''
+-        # TODO: maybe this belongs in clang? also, should probably check for macOS?
+-        if self.id != 'clang':
+-            raise mesonlib.MesonException('Cannot find frameworks with non-clang compiler')
+         return self._find_framework_impl(name, env, extra_dirs, allow_system)
+ 
+     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:

--- a/devel/meson/files/patch-meson55-gcc-appleframeworks.diff
+++ b/devel/meson/files/patch-meson55-gcc-appleframeworks.diff
@@ -1,0 +1,11 @@
+--- mesonbuild/compilers/mixins/clike.py.orig	2021-09-02 15:59:15.000000000 -0400
++++ mesonbuild/compilers/mixins/clike.py	2021-09-02 15:59:32.000000000 -0400
+@@ -1142,8 +1142,6 @@
+         Finds the framework with the specified name, and returns link args for
+         the same or returns None when the framework is not found.
+         '''
+-        if self.id != 'clang':
+-            raise mesonlib.MesonException('Cannot find frameworks with non-clang compiler')
+         return self.find_framework_impl(name, env, extra_dirs, allow_system)
+ 
+     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:


### PR DESCRIPTION
#### Description

Per https://github.com/macports/macports-ports/pull/11948#issuecomment-911550755, Meson projects that use the `appleframeworks` dependency fail to configure with GCC. Currently Meson assumes that only Clang supports the `-framework` flag but this flag is supported by modern GCC (plus Apple GCC 4+).

Submitted patch upstream as https://github.com/mesonbuild/meson/pull/9211. I suggest incorporating into MacPorts before the new `pango` goes live. This PR includes a revbump so that pango 1.49 will build properly for all users when the time comes.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? [ Tests are passing on upstream PR ]
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
