### PR TITLE
openjdk: update openjdk8-openj9 to 8u302

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -35,6 +35,10 @@ set long_description_adoptopenjdk_openj9xl \
     "${long_description_adoptopenjdk_openj9} This version uses non-compressed references and should be used for\
 applications which require heaps that are over ~57 GB."
 
+set long_description_ibm_semeru \
+    "The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications built with\
+the OpenJDK class libraries and the Eclipse OpenJ9 JVM."
+
 set long_description_temurin \
     "Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes."
 
@@ -141,24 +145,24 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u292
+    version      8u302
     revision     0
 
-    set build    10
-    set openj9_version 0.26.0
+    set build    08
+    set openj9_version 0.27.0
 
-    homepage     https://adoptopenjdk.net
+    homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
-    description  Open Java Development Kit 8 (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description ${long_description_adoptopenjdk_openj9}
+    description  Open Java Development Kit 8 (IBM Semeru) with Eclipse OpenJ9 VM
+    long_description ${long_description_ibm_semeru}
 
-    master_sites https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
-    distname     OpenJDK8U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
+    master_sites https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+    distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  15c82bb986080025de06ddaab2e08a4a493fb389 \
-                 sha256  d262bc226895e80b7e80d61905e65fe043ca0a3e3b930f7b88ddfacb8835e939 \
-                 size    118492789
+    checksums    rmd160  61134e128be3c959ce828b992c36bf39dca702cc \
+                 sha256  0bc4972188b06c3276cf9225a6718b19a7866f7543808b0fe9612039320849b5 \
+                 size    128923297
 }
 
 subport openjdk8-temurin {


### PR DESCRIPTION
#### Description

Update OpenJDK 8 with OpenJ9 VM to 8u302.

As announced [on the AdoptOpenJDK blog](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/), the AdoptOpenJDK project has been replaced by the Adoptium project at the Eclipse Foundation, and Adoptium will not provide any OpenJDK releases based on OpenJ9. IBM has stepped in to provide these OpenJ9 releases, so with this update MacPorts switches to the IBM Semeru releases.

After this is merged I will also switch the OpenJ9-based versions of OpenJDK 11 and 16 to the latest IBM Semeru releases.

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?