### PR TITLE
hashcat: update to 6.2.4

### DIFF
--- a/security/hashcat/Portfile
+++ b/security/hashcat/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               makefile 1.0
 
-github.setup            hashcat hashcat 6.2.3 v
+github.setup            hashcat hashcat 6.2.4 v
 github.tarball_from     archive
 
 categories              security
@@ -25,6 +25,6 @@ homepage                https://hashcat.net/hashcat/
 
 build.target            {}
 
-checksums               rmd160  8bb501834a320aaac3de149c5ab39c2eb89ee968 \
-                        sha256  c0be1c6693ee1f35c7bef1f79bf9e30a954f717ef42d00e37787aaeff3271e51 \
-                        size    6222424
+checksums               rmd160  4ae3b29b580b8949458a6fb0e26f93a6238162a9 \
+                        sha256  9020396ff933693e310b479b641e86f1783d9819d60d1d907752ad8d24a60c31 \
+                        size    6269444


### PR DESCRIPTION
#### Description

- This release adds performance improvements, a new rule-engine function, several new hash-modes, and bug fixes.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
