### PR TITLE
gopass: update to 1.12.8

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.12.7 v
+go.setup            github.com/gopasspw/gopass 1.12.8 v
 categories          security
 maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 license             MIT
@@ -15,9 +15,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  937843d97d4cd24492aef4ffbc695fb535c31757 \
-                        sha256  f3ca341db9f35b5c52e651358ff5292b99d38f4c0bb0ebb2a824f753cd56af48 \
-                        size    2175394
+                        rmd160  c7580b4638330fd81f1e3200a4f387282d22f2b1 \
+                        sha256  f6bee0adee2715d711c6f062015604f0f06a0b68597548e3869170f1e8011f1b \
+                        size    2180566
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -37,16 +37,16 @@ go.vendors          rsc.io/qr \
                         sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
                         size    90145 \
                     gopkg.in/check.v1 \
-                        lock    8fa46927fb4f \
-                        rmd160  c84f37dc900224c5e9e6e16ed5acc0d625583bc1 \
-                        sha256  c41439b343f3fc3c0b6f943b4aae642f10f19451e945c23dfb324c9c8f87d0b7 \
-                        size    31616 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.26.0 \
-                        rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
-                        sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
-                        size    1270531 \
+                        lock    v1.27.1 \
+                        rmd160  a4ac7b66fd88a34a9ea447476d19ff3c1f2b57dd \
+                        sha256  fe1055b9bf6b8792aed1771f56c31f836c24a18d69eaeb13c88990db3d9da7ce \
+                        size    1278850 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.7 \
@@ -59,30 +59,30 @@ go.vendors          rsc.io/qr \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
                     golang.org/x/term \
-                        lock    72f3dc4e9b72 \
-                        rmd160  1427b5158f35c3f52a9db9c627d0234c15883561 \
-                        sha256  4cd03aeed351110019c384f469fde517b7e506285bd82147611d9d461ba0b30b \
-                        size    15007 \
+                        lock    6886f2dfbf5b \
+                        rmd160  8688e7b350892399f2918c70c87435016c64c572 \
+                        sha256  e52745c19f7ebe30ab78db8af43216b6795928089a433925ef3ebef0eaad98f3 \
+                        size    14938 \
                     golang.org/x/sys \
-                        lock    37df388d1f33 \
-                        rmd160  8b8d8283c49539d82519ae2ab8a956f52dc4dc26 \
-                        sha256  755b9c1befa705fec85a4381faa474cb0435bb7b0a28f2e969d5a62c66339753 \
-                        size    1219510 \
+                        lock    63515b42dcdf \
+                        rmd160  c00cd97dd5a737ca9049130f84fffe1b40f379b1 \
+                        sha256  24526e1ff5494c59acf642bac86dff4ec0ca6074732c557cb22eab2bfbf84f76 \
+                        size    1210631 \
                     golang.org/x/oauth2 \
-                        lock    5e61552d6c78 \
-                        rmd160  83dc2e1f196d85fc3f81b0a419f9cfc6b99bd1f5 \
-                        sha256  5e2d7cec4d0de80a086551a8b1443ebd8caaa094388c64d01076454f5ce85aca \
-                        size    78978 \
+                        lock    2bc19b11175f \
+                        rmd160  c9df20100b53e8a7ecee251aa9c62292996e9e0e \
+                        sha256  8fe1df422742e2d1b07b36bd22c7eaeb8f8a9ae1c34aa464d364491e49660a89 \
+                        size    85656 \
                     golang.org/x/net \
-                        lock    e915ea6b2b7d \
-                        rmd160  c50582099618a5484b843bd9ec9951d7faa10016 \
-                        sha256  39758186bcf8fab55e659434e0b9e3a7c31445e4be0c6ad4de02044876d9ac57 \
-                        size    1249423 \
+                        lock    e898025ed96a \
+                        rmd160  6a4d90944957dfff46fd424e76f8bbd468fa83a5 \
+                        sha256  4d9f66d6821d5d2785f87c7656d7c4e18aec286e3dfc8d04c0950ef40ae9d398 \
+                        size    1253234 \
                     golang.org/x/crypto \
-                        lock    4f45737414dc \
-                        rmd160  bcb326a0dae5b4b3e09c9813124af96df85c7088 \
-                        sha256  415ceaf7f4f678acdf9eeab47f7faf96a501e98d9f3eebe263d7c532d32af3e7 \
-                        size    1726572 \
+                        lock    32db794688a5 \
+                        rmd160  02ab581de5510ce94205e0fe5a58aacd2cd375b8 \
+                        sha256  2276178323ee1992d2e845e78ffb8fdce625ef24602b97719428fddaf9f2192f \
+                        size    1732601 \
                     github.com/xrash/smetrics \
                         lock    039620a65673 \
                         rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
@@ -113,6 +113,11 @@ go.vendors          rsc.io/qr \
                         rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
                         sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
                         size    92950 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.8.0 \
+                        rmd160  22e8b4dadfbeefb32fd38f3ebab26c94d4b165c5 \
+                        sha256  c7ab367e516959a51525f8152a62df0acc9a32ca153a502da967f072ae69d899 \
+                        size    129032 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -123,11 +128,6 @@ go.vendors          rsc.io/qr \
                         rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
-                    github.com/niemeyer/pretty \
-                        lock    a10e7caefd8e \
-                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
-                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
-                        size    9405 \
                     github.com/nbutton23/zxcvbn-go \
                         lock    fa2cb2858354 \
                         rmd160  17c2ab9843836ee904acced65d6d22f13a4b614c \
@@ -168,6 +168,11 @@ go.vendors          rsc.io/qr \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
                         sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
                         size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.3.0 \
+                        rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
+                        sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
+                        size    10043 \
                     github.com/kballard/go-shellquote \
                         lock    95032a82bc51 \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
@@ -233,16 +238,21 @@ go.vendors          rsc.io/qr \
                         rmd160  71a007da8ad943b7e3b070ab9a272e576adad676 \
                         sha256  69e7bf877a72e225b3d9f424ca644a17f67209f5e311e910f1650cdb7f1b62a8 \
                         size    10712 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.0 \
-                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
-                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
-                        size    52040 \
+                        lock    v2.0.1 \
+                        rmd160  74c013e19d22e56a27d9a3ad61b4bd86975036d1 \
+                        sha256  d23365bceea7382b59ca41ad868a80e34f8066785fb371b85b51ee0b65be6a21 \
+                        size    64243 \
                     github.com/chzyer/test \
                         lock    a1ea475d72b1 \
                         rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
@@ -280,10 +290,10 @@ go.vendors          rsc.io/qr \
                         size    5023 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
-                        lock    v1.0.0-beta.3 \
-                        rmd160  50832cf6734e20eba82bc207307785e42e3f7887 \
-                        sha256  a5b1335f41d769caa2193aa1b176f0cc9cfb47f380afb8d308c51c0f7dc6a91e \
-                        size    78117 \
+                        lock    v1.0.0-rc.1 \
+                        rmd160  a83aba34025ad1df3a443deb358c11c1239e15ac \
+                        sha256  4bdeff6fc20d81c28a18df76cc982f1fcca03f385dfcc36cf3ddff73b5b2f5fe \
+                        size    39144 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
                         lock    v1.0.0-rc.3 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.12.8)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
