### PR TITLE
openjdk: update openjdk11-openj9 to 11.0.12

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -268,24 +268,24 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.11
+    version      11.0.12
     revision     0
 
-    set build    9
-    set openj9_version 0.26.0
+    set build    7
+    set openj9_version 0.27.0
 
-    homepage     https://adoptopenjdk.net
+    homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
-    description  Open Java Development Kit 11 (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description ${long_description_adoptopenjdk_openj9}
+    description  Open Java Development Kit 11 (IBM Semeru) with Eclipse OpenJ9 VM
+    long_description ${long_description_ibm_semeru}
 
-    master_sites https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK11U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  32a90e5a4a660b5e62a12c998a4ac4282334b2a3 \
-                 sha256  797cee6b9f6e18bcc026ee9dcebbce81d62ca897038402d247630b25d41efe15 \
-                 size    202089267
+    checksums    rmd160  3f5918ca71264b358cbb040eeb2f78fed329affc \
+                 sha256  5b0dea6c3ca46ad201e5854a7fdb8699490257c49134c9d55f3d8292bdb14ba9 \
+                 size    203006828
 }
 
 # Remove after 2022-04-30


### PR DESCRIPTION
#### Description

Update OpenJDK 11 with OpenJ9 VM to 11.0.12.

As announced [on the AdoptOpenJDK blog](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/), the AdoptOpenJDK project has been replaced by the Adoptium project at the Eclipse Foundation, and Adoptium will not provide any OpenJDK releases based on OpenJ9. IBM has stepped in to provide these OpenJ9 releases, so with this update MacPorts switches to the IBM Semeru releases.

After this is merged I will also switch the OpenJ9-based versions of OpenJDK 16 to the latest IBM Semeru release.

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?