### PR TITLE
openjdk: update openjdk16-openj9 to 16.0.2

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -20,21 +20,6 @@ if {[regexp {openjdk[0-9]*(-zulu)?$} ${subport}]} {
 # Latest Long Term Support (LTS) major version
 version          11
 
-set long_description_adoptopenjdk_intro \
-   "OpenJDK build provided by AdoptOpenJDK, built from a fully open-source set of build scripts and infrastructure."
-
-set long_description_adoptopenjdk_hotspot \
-    "${long_description_adoptopenjdk_intro} HotSpot is the VM from the OpenJDK community and the most widely used VM.\
-It is suitable for all workloads."
-
-set long_description_adoptopenjdk_openj9 \
-    "${long_description_adoptopenjdk_intro} OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade\
-VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is suitable for running all workloads."
-
-set long_description_adoptopenjdk_openj9xl \
-    "${long_description_adoptopenjdk_openj9} This version uses non-compressed references and should be used for\
-applications which require heaps that are over ~57 GB."
-
 set long_description_ibm_semeru \
     "The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications built with\
 the OpenJDK class libraries and the Eclipse OpenJ9 JVM."
@@ -515,24 +500,24 @@ subport openjdk16-graalvm {
 }
 
 subport openjdk16-openj9 {
-    version      16.0.1
+    version      16.0.2
     revision     0
 
-    set build    9
-    set openj9_version 0.26.0
+    set build    7
+    set openj9_version 0.27.0
 
-    homepage     https://adoptopenjdk.net
+    homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
-    description  Open Java Development Kit 16 (AdoptOpenJDK) with Eclipse OpenJ9 VM
-    long_description ${long_description_adoptopenjdk_openj9}
+    description  Open Java Development Kit 16 (IBM Semeru) with Eclipse OpenJ9 VM
+    long_description ${long_description_ibm_semeru}
 
-    master_sites https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     OpenJDK16U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    master_sites https://github.com/ibmruntimes/semeru16-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  a6b458d6652512f9df22f997ecb10b02ee7c7b92 \
-                 sha256  6d4241c6ede2167fb71bd57f7a770a74564ee007c06bcae98e1abc3c1de4756f \
-                 size    205958282
+    checksums    rmd160  f1b5fec76825301cc3c8aee0d53b43a64dfd0590 \
+                 sha256  89e807261145243a358a2a626f64340944c03622f34eaa35429053e2085d7aef \
+                 size    205816803
 }
 
 subport openjdk16-temurin {


### PR DESCRIPTION
#### Description

Update OpenJDK 16 with OpenJ9 VM to 16.0.2.

As announced [on the AdoptOpenJDK blog](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/), the AdoptOpenJDK project has been replaced by the Adoptium project at the Eclipse Foundation, and Adoptium will not provide any OpenJDK releases based on OpenJ9. IBM has stepped in to provide these OpenJ9 releases, so with this update MacPorts switches to the IBM Semeru release.

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?