### PR TITLE
qcachegrind: update to 21.08.1

### DIFF
--- a/devel/qcachegrind/Portfile
+++ b/devel/qcachegrind/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           qmake5 1.0
 PortGroup           github 1.0
 
-github.setup        KDE kcachegrind 20.08.1 v
+github.setup        KDE kcachegrind 21.08.1 v
 name                qcachegrind
 categories          devel
 platforms           darwin
@@ -18,9 +18,9 @@ long_description    ${description}
 homepage            https://kcachegrind.github.io/html/Home.html
 
 checksums \
-    rmd160  af03f33b85957ea81c340c229dc0e08611013062 \
-    sha256  1510710e0d58bf9c87460d53539bb485d8fbfb4adf3ad0a824ae33c97c69ff46 \
-    size    353614
+    rmd160  554c527daacb533154b0f3992a55f6e08e9a7586 \
+    sha256  1862bbc99343e97476c6b447c0494892f490ce56a1f23dd1cd527d7c008e9c46 \
+    size    382599
 
 depends_run         path:bin/dot:graphviz
 
@@ -29,7 +29,6 @@ patch.args          -p1
 
 post-patch {
     reinplace -W ${worksrcpath} "s|@@PREFIX@@|${prefix}|g" \
-        qcachegrind/qcgtoplevel.cpp \
         libviews/callgraphview.cpp
 }
 

--- a/devel/qcachegrind/files/0001-Fix-shell-invocations-for-MacPorts.patch
+++ b/devel/qcachegrind/files/0001-Fix-shell-invocations-for-MacPorts.patch
@@ -3,16 +3,20 @@ From: Aaron Madlon-Kay <aaron@wovn.io>
 Date: Fri, 18 Sep 2020 09:16:48 +0900
 Subject: [PATCH] Fix shell invocations for MacPorts
 
----
- libviews/callgraphview.cpp  | 4 ++--
- qcachegrind/qcgtoplevel.cpp | 2 +-
- 2 files changed, 3 insertions(+), 3 deletions(-)
-
 diff --git a/libviews/callgraphview.cpp b/libviews/callgraphview.cpp
-index 2f3c25f..be6d683 100644
+index 16996d9..180a76f 100644
 --- a/libviews/callgraphview.cpp
 +++ b/libviews/callgraphview.cpp
-@@ -2069,9 +2069,9 @@ void CallGraphView::refresh()
+@@ -938,7 +938,7 @@ bool GraphExporter::savePrompt(QWidget *parent, TraceData *data,
+         if (wrote && mime != "text/vnd.graphviz") {
+             QProcess proc;
+             proc.setStandardOutputFile(intendedName, QFile::Truncate);
+-            proc.start("dot", { dotRenderType, dotName }, QProcess::ReadWrite);
++            proc.start("@@PREFIX@@/bin/dot", { dotRenderType, dotName }, QProcess::ReadWrite);
+             proc.waitForFinished();
+             wrote = proc.exitStatus() == QProcess::NormalExit;
+ 
+@@ -2118,9 +2118,9 @@ void CallGraphView::refresh()
      QString renderProgram;
      QStringList renderArgs;
      if (_layout == GraphOptions::Circular)
@@ -24,19 +28,6 @@ index 2f3c25f..be6d683 100644
      renderArgs << QStringLiteral("-Tplain");
  
      _unparsedOutput = QString();
-diff --git a/qcachegrind/qcgtoplevel.cpp b/qcachegrind/qcgtoplevel.cpp
-index 5c60ae7..1f61b37 100644
---- a/qcachegrind/qcgtoplevel.cpp
-+++ b/qcachegrind/qcgtoplevel.cpp
-@@ -904,7 +904,7 @@ void QCGTopLevel::exportGraph()
- 
- #ifdef Q_OS_UNIX
-     // shell commands only work in UNIX
--    QString cmd = QStringLiteral("(dot %1 -Tps > %2.ps; xdg-open %3.ps)&")
-+    QString cmd = QStringLiteral("(@@PREFIX@@/bin/dot %1 -Tps > %2.ps; open %3.ps)&")
-                   .arg(n).arg(n).arg(n);
-     if (::system(QFile::encodeName( cmd ))<0)
-         qDebug() << "QCGTopLevel::exportGraph: can not run " << cmd;
 -- 
 2.28.0
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
