### PR TITLE
minikube: update to 1.23.0

### DIFF
--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes/minikube 1.22.0 v
+go.setup            github.com/kubernetes/minikube 1.23.0 v
 go.package          k8s.io/minikube
 revision            0
 
@@ -26,14 +26,14 @@ maintainers         {lbschenkel @lbschenkel} \
 
 github.tarball_from archive
 
-checksums           rmd160  9f402d7ef36436046879b9241bae2b4b768b767b \
-                    sha256  5db3b43a36f477d5b41435b3aaeaf390f91b820f99df2a52b2f90938bd1753c2 \
-                    size    86231794
+checksums           rmd160  9f60346227bfb82d2c9e2edc9af964f3eeb5c0c4 \
+                    sha256  c40e43a4944cf434e03d2ce520c330bdca209fb08428601e1d453ea124a9c2b3 \
+                    size    86312792
 
 depends_build-append \
                     port:go-bindata
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.21
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.22
 
 default_variants    +hyperkit
 


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
