### PR TITLE
dupd: update to 1.7.1

### DIFF
--- a/sysutils/dupd/Portfile
+++ b/sysutils/dupd/Portfile
@@ -1,15 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem            1.0
+PortGroup             makefile 1.0
 
 name                  dupd
-version               1.6
+version               1.7.1
 description           Convenient and fast CLI to find duplicate files.
 homepage              http://www.virkki.com/dupd
 license               GPL-3
 categories            sysutils
 platforms             darwin
-use_configure         no
 build.target          dupd
 use_parallel_build    no
 test.run              yes
@@ -19,8 +19,12 @@ maintainers           {@jvirkki virkki.com:jyri}
 long_description      Convenient and fast CLI to find duplicate files. Supports an interactive style for exploring duplicates in the filesystem.
 
 master_sites          http://www.virkki.com/dupd
-checksums             rmd160 624afff8a1ecf1633a6fea0e49dc99cb37e4efc8 \
-                      sha256 68bce4d5ac0b8a00ac50da65634950eb46fb11a571e546fb543fc6c6bf6b79da
+checksums             rmd160  b406afc0490caad54f46225f9ca938faafc4b374 \
+                      sha256  70aaad030d88acd561f8f58bd5189964bc30f40d7027e6acff5c5b28df32ffc1 \
+                      size    983951
+
+depends_lib           port:sqlite3 \
+                      path:lib/libcrypto.dylib:openssl
 
 destroot.destdir      INSTALL_PREFIX=${destroot}${prefix} \
                       MAN_BASE=${destroot}${prefix}/share/man


### PR DESCRIPTION
#### Description

This PR is updating port to the last released version. It also fixed two issues:
 - switched to use `${configure.cc}` instead just `cc`;
 - added used dependency

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
