### PR TITLE
hamlib: add patch to use correct python*-config

### DIFF
--- a/science/hamlib/Portfile
+++ b/science/hamlib/Portfile
@@ -110,6 +110,12 @@ foreach py_ver ${python_versions} {
         configure.args-append \
             --with-python-binding
 
+        # fixup configure for the correct python3.X-config
+        post-patch {
+            reinplace "s@python3-config@python${active_python_version}-config@g" \
+                ${worksrcpath}/configure
+        }
+
         # specify the Python version to use
         set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
         configure.args-append \


### PR DESCRIPTION
#### Description

I don't `select` a Python3, so my setup does not provide `python3-config`, which is used by the `configure` script in HamLib ... and thus configuration fails. We should not rely on any `select` files inside MP -- those are for user's convenience; instead, we should use the port's files. That's what this patch does.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5 20G71
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
