### PR TITLE
duckdb: enable httpfs extension by default

### DIFF
--- a/databases/duckdb/Portfile
+++ b/databases/duckdb/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
 
 github.setup        cwida duckdb 0.2.9 v
-revision            0
+revision            1
 
 homepage            https://www.duckdb.org
 
@@ -33,7 +33,8 @@ patch {
 }
 
 configure.args-append -DBUILD_PARQUET_EXTENSION=TRUE \
-                      -DBUILD_FTS_EXTENSION=TRUE
+                      -DBUILD_FTS_EXTENSION=TRUE \
+                      -DBUILD_HTTPFS_EXTENSION=TRUE
 
 fetch.type          git
 
@@ -41,4 +42,5 @@ compiler.cxx_standard 2011
 
 depends_build-append \
                     port:pkgconfig \
-                    port:zstd
+                    port:zstd  \
+                    port:openssl


### PR DESCRIPTION
#### Description

enables the httpfs extension by default which allows reading of file (e.g. parquet over http)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
macOS 10.15.7 19H2 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
