### PR TITLE
py-confuse: new port

### DIFF
--- a/python/py-confuse/Portfile
+++ b/python/py-confuse/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-confuse
+version             1.5.0
+revision            0
+
+categories-append   devel
+license             MIT
+platforms           darwin
+supported_archs     noarch
+
+description         painless YAML config files for Python
+long_description    Confuse is a configuration library for Python that uses YAML. \
+                    It takes care of defaults, overrides, type checking, command-line integration, \
+                    human-readable errors, and standard OS-specific locations.
+
+homepage            https://pypi.org/project/confuse/
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+checksums           rmd160  273168fcfd32562b9663c470f311128cfd773d41 \
+                    sha256  92fbca1c70611120ea722372e0c071c0d342a75f796b4bde4bf0348ea49f022e \
+                    size    45520
+python.versions     37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-yaml
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
