### PR TITLE
py-gmusicapi: new port

### DIFF
--- a/python/py-gmusicapi/Portfile
+++ b/python/py-gmusicapi/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-gmusicapi
+version             13.0.0
+revision            0
+
+categories-append   devel audio
+license             BSD
+platforms           darwin
+supported_archs     noarch
+
+description         An unofficial client library for Google Music.
+long_description    ${description}
+
+homepage            https://unofficial-google-music-api.readthedocs.io/
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+checksums           rmd160  19ac2cefe6a824dd93660c4101d6cabe0bcf4579 \
+                    sha256  b3548a8aa9ac834de05248f1ad7f32a11e96a3aeb265efa76f04796889d1b891 \
+                    size    173038
+
+python.versions     37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-appdirs \
+                    port:py${python.version}-dateutil \
+                    port:py${python.version}-decorator \
+                    port:py${python.version}-gpsoauth \
+                    port:py${python.version}-mechanicalsoup \
+                    port:py${python.version}-mutagen \
+                    port:py${python.version}-oauth2client \
+                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-validictory
+
+    post-destroot {
+        set egg-info ${destroot}${python.pkgd}/gmusicapi-${version}-py${python.branch}.egg-info
+        foreach d [glob -dir ${egg-info} *] {
+            file attributes ${d} -permissions 0644
+        }
+    }
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

This PR depends on:
 - https://github.com/macports/macports-ports/pull/12117
 - https://github.com/macports/macports-ports/pull/12118
 - https://github.com/macports/macports-ports/pull/12119

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
