### PR TITLE
ninja: fix cross-arch universal build

### DIFF
--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -2,8 +2,6 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-# see https://trac.macports.org/ticket/56494
-PortGroup           muniversal 1.0
 
 epoch               1
 github.setup        ninja-build ninja 1.10.2 v
@@ -38,7 +36,10 @@ long_description    Ninja is yet another build system. It takes as input    \
 homepage            https://ninja-build.org
 github.tarball_from archive
 
-patchfiles          patch-configure.py-bootstrap-only.diff
+installs_libs       no
+
+patchfiles          patch-configure.py-bootstrap-only.diff \
+                    patch-ninja-configure.py-remove-mmd.diff
 
 depends_build-append \
                     port:re2c

--- a/devel/ninja/files/patch-ninja-configure.py-remove-mmd.diff
+++ b/devel/ninja/files/patch-ninja-configure.py-remove-mmd.diff
@@ -1,0 +1,11 @@
+--- configure.py.orig	2021-02-13 23:21:58.000000000 -0800
++++ configure.py	2021-02-13 23:22:17.000000000 -0800
+@@ -425,7 +425,7 @@
+     )
+ else:
+     n.rule('cxx',
+-        command='$cxx -MMD -MT $out -MF $out.d $cflags -c $in -o $out',
++        command='$cxx $cflags -c $in -o $out',
+         depfile='$out.d',
+         deps='gcc',
+         description='CXX $out')


### PR DESCRIPTION
Apple's gcc compilers do not allow dependency file generation
when multiple arch flags are used

This resulted in the muniversal portgroup being used to repair the
build of ninja several years ago, however this has it's own
issues by not allowing a cross-arch universal binary to be built,
due to the way the ninja bootstraps itself during compilation.

if we strip the (unnecessary) dependency file generation by removing
the dependency flags, then the muniversal PortGroup is no longer
needed and the cross-arch universal build can succeed without
using the muniversal portgroup.

see: https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html
see: https://github.com/macports/macports-base/commit/701e7b2597f2da954a390b1b63aa90d6f7aaba20
see: https://trac.macports.org/ticket/56494

closes: https://trac.macports.org/ticket/62259

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
