### PR TITLE
gdb: support +python39 variant

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -89,7 +89,7 @@ post-destroot {
     }
 }
 
-set pythons_suffixes {27 35 36 37 38}
+set pythons_suffixes {27 35 36 37 38 39}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {


### PR DESCRIPTION
Add gdb support for Python 3.9:
```
$ gdb
(gdb) python-interactive
>>> import sys
>>> print(sys.version)
3.9.7 (default, Sep  1 2021, 12:35:15)
[Clang 12.0.5 (clang-1205.0.22.9)]
```

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
