### PR TITLE
py-soco: new port

### DIFF
--- a/python/py-soco/Portfile
+++ b/python/py-soco/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-soco
+version             0.24.0
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+description         SoCo (Sonos Controller) is a simple library to control Sonos speakers.
+long_description    ${description}
+
+homepage            https://github.com/SoCo/SoCo
+
+checksums           rmd160  0f0408ff0f2a30108e033138ca54c68bd5bcb988 \
+                    sha256  b5e8e28f55a79f212920d4dfe5f41456bb0ef181e23f2f26d46fd1bfa21af910 \
+                    size    712221
+
+python.versions     37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-ifaddr \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-xmltodict
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

This port depends on:
 - #12127 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
