### PR TITLE
Winetricks: remove zenity variant

### DIFF
--- a/x11/winetricks/Portfile
+++ b/x11/winetricks/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            Winetricks winetricks 20210825
-revision                0
+revision                1
 checksums               rmd160  f324815fad1b8641270368e64f90a9e8d307cba5 \
                         sha256  da3f6d39d1a4280d66d77704bbe1119be8fc4ae3a28396f386d96f4cdb079fbf \
                         size    689734
@@ -39,9 +39,3 @@ post-destroot {
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} COPYING README.md ${destroot}${docdir}
 }
-
-variant zenity description {Use zenity for GUI dialog boxes} {
-    depends_run-append  port:zenity
-}
-
-default_variants +zenity


### PR DESCRIPTION
See https://github.com/Winetricks/winetricks/issues/1687

Nobody has sent a PR to fix the zenity gui and it was broken prior to even that open issue keeping the zenity variant around doesn’t make sense.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
