### PR TITLE
docbook-xsl: fix livecheck

### DIFF
--- a/textproc/docbook-xsl/Portfile
+++ b/textproc/docbook-xsl/Portfile
@@ -32,6 +32,8 @@ if {${subport} eq ${name}} {
     revision        4
     description     The DocBook XSL stylesheets
     livecheck.type  regex
+    livecheck.url   ${github.homepage}
+    livecheck.regex {/release/(\d+(?:\.\d+)+)}
 }
 
 subport ${name}-nons {


### PR DESCRIPTION
#### Description

The default livecheck URL https://github.com/docbook/xslt10-stylesheets/tags only contains snapshot versions. (The latest stable version is found after clicking <kbd>Next</kbd> a few times.)

Instead, let's check https://github.com/docbook/xslt10-stylesheets where the latest stable release is explicitly stated.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use [skip notification] (surrounded with []) to avoid notifying maintainers -->
