### PR TITLE
pango-devel: Fix Tiger build

### DIFF
--- a/x11/pango-devel/Portfile
+++ b/x11/pango-devel/Portfile
@@ -48,6 +48,8 @@ depends_lib \
     port:fribidi \
     port:harfbuzz-devel
 
+patchfiles              pango-tiger-no-coretext.diff
+
 configure.args-append   -Dxft=disabled \
                         -Dintrospection=enabled
 
@@ -60,12 +62,13 @@ configure.cxxflags-append \
 
 license_noconflict      gobject-introspection
 
-platform macosx {
+if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx" && ${os.major} > 8} {
     variant quartz {
         # Although this variant does nothing, pango will automatically build
-        # itself differently depending on whether or not cairo is installed with
-        # the quartz variant. Therefore this variant is necessary to be able to
-        # distinguish whether an installed pango has Quartz support or not.
+        # itself differently depending on whether or not cairo is installed
+        # with the quartz variant and whether CoreText is available. Therefore
+        # this variant is necessary to be able to distinguish whether an
+        # installed pango has Quartz support or not.
     }
 
     default_variants    +quartz
@@ -84,9 +87,9 @@ variant x11 {
 }
 
 default_variants        +x11
-if {${os.platform} ne "darwin" || ${os.subplatform} ne "macosx"} {
-    # When not on macOS, don't allow X11 support to be disabled, since it is the
-    # only available option.
+if {${os.platform} ne "darwin" || ${os.subplatform} ne "macosx" || ${os.major} <= 8} {
+    # When not on macOS 10.5+, don't allow X11 support to be disabled, since it
+    # is the only available option.
     variant_set         x11
 }
 

--- a/x11/pango-devel/files/pango-tiger-no-coretext.diff
+++ b/x11/pango-devel/files/pango-tiger-no-coretext.diff
@@ -1,0 +1,48 @@
+--- meson.build.orig	2021-09-07 18:23:09.000000000 -0400
++++ meson.build	2021-09-07 18:30:14.000000000 -0400
+@@ -370,7 +370,7 @@
+ endif
+ 
+ if host_system == 'darwin'
+-  has_core_text = cc.links('''#include <Carbon/Carbon.h>
++  has_core_text = cc.links('''#include <CoreText/CoreText.h>
+                               int main (void) {
+                                 CTGetCoreTextVersion ();
+                                 return 0;
+@@ -446,15 +446,14 @@
+       endforeach
+     endif
+     if dep.found()
+-      if b[0] == 'cairo-ft'
+-        if build_pangoft2
+-          pango_conf.set(b[2], 1)
+-          pango_font_backends += b[3]
+-        endif
+-      else
+-        pango_conf.set(b[2], 1)
+-        pango_font_backends += b[3]
++      if b[0] == 'cairo-ft' and not build_pangoft2
++        continue
+       endif
++      if b[0] == 'cairo-quartz' and not pango_conf.has('HAVE_CORE_TEXT')
++        continue
++      endif
++      pango_conf.set(b[2], 1)
++      pango_font_backends += b[3]
+     endif
+   endforeach
+ 
+@@ -503,8 +502,12 @@
+   foreach header : cairo_headers
+     if cc.has_header('cairo-@0@.h'.format(header))
+       pango_conf.set('HAVE_CAIRO_@0@'.format(header.underscorify().to_upper()), 1)
+-      if header == 'win32' or header == 'quartz'
++      if header == 'win32'
+         pango_font_backends += header
++      elif header == 'quartz'
++        if pango_conf.has('HAVE_CORE_TEXT')
++          pango_font_backends += header
++        endif
+       else
+         pango_cairo_backends += header
+       endif


### PR DESCRIPTION
#### Description

Tiger lacks CoreText (or rather has it as a private framework). Fix Pango's CoreText detection by using an `#include` and then condition Pango's "quartz" backend on the result. Then modify the Portfile logic so that the `+quartz` variant is no longer made available on Tiger.

Upstream pull request: https://gitlab.gnome.org/GNOME/pango/-/merge_requests/471

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
