### PR TITLE
scala2.12 + 2.13: fixed license

### DIFF
--- a/lang/scala2.12/Portfile
+++ b/lang/scala2.12/Portfile
@@ -7,7 +7,7 @@ name            scala2.12
 version         2.12.14
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      lang java
-license         BSD
+license         Apache-2
 maintainers     {@catap korins.ky:kirill} openmaintainer
 description     The Scala Programming Language
 long_description \

--- a/lang/scala2.13/Portfile
+++ b/lang/scala2.13/Portfile
@@ -7,7 +7,7 @@ name            scala2.13
 version         2.13.6
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      lang java
-license         BSD
+license         Apache-2
 maintainers     {@catap korins.ky:kirill} openmaintainer
 description     The Scala Programming Language
 long_description \


### PR DESCRIPTION
#### Description

Scala had changed it's license a while ago: https://www.scala-lang.org/news/license-change.html

This changes affected 2.12.x, 2.13.x and 3.x scala only.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
