### PR TITLE
glib2: fix build with latest Mason

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -12,7 +12,7 @@ name                        glib2
 conflicts                   glib2-devel
 set my_name                 glib
 version                     2.62.6
-revision                    1
+revision                    2
 checksums                   rmd160  24b9b58216a9d413b0bdb62f85c5b7d816cd133e \
                             sha256  104fa26fbefae8024ff898330c671ec23ad075c1c0bce45c325c6d5657d58b9c \
                             size    4703424
@@ -38,6 +38,7 @@ master_sites                gnome:sources/${my_name}/${branch}/
 
 patchfiles                  libintl.patch \
                             implicit.patch \
+                            patch-meson_build-c-version.diff \
                             patch-gio-tests-meson.build.diff \
                             patch-glib-gmain.c.diff \
                             patch-glib_gunicollate.c.diff \

--- a/devel/glib2/files/patch-meson_build-c-version.diff
+++ b/devel/glib2/files/patch-meson_build-c-version.diff
@@ -1,0 +1,25 @@
+From 5b8ee178b30df3e6b1ec9a8d3a43d060976a8f0f Mon Sep 17 00:00:00 2001
+From: Emmanuel Fleury <emmanuel.fleury@u-bordeaux.fr>
+Date: Tue, 22 Jan 2019 19:58:17 +0100
+Subject: [PATCH] Bump default build standard to gnu99
+
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 04ca8c2b0..b25df998e 100644
+--- meson.build
++++ meson.build
+@@ -4,7 +4,7 @@ project('glib', 'c', 'cpp',
+   default_options : [
+     'buildtype=debugoptimized',
+     'warning_level=1',
+-    'c_std=gnu89'
++    'c_std=gnu99'
+   ]
+ )
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
I'm not entirely sure why, but the glib2 build started failing; possibly due to a Mason upgrade.

Upstream has a fairly old bug[1] reporting this, so I just applied the fix directly.[2]

[1] https://gitlab.gnome.org/GNOME/glib/-/issues/1662
[2] https://gitlab.gnome.org/GNOME/glib/-/merge_requests/606

Fixes: https://trac.macports.org/ticket/63462

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
