### PR TITLE
godot: simplify clang version checking

### DIFF
--- a/games/godot/Portfile
+++ b/games/godot/Portfile
@@ -117,25 +117,11 @@ foreach v ${clang_versions} {
 # file that is part of the Godot source code
 set sconstruct_default_mp_clang 5
 
-# error: invalid value 'gnu++14' in '-std=gnu++14'
-# On older macOS versions use (latest) clang variant by default
-if {$subport eq ${name} && \
-    ${os.platform} eq "darwin" && ${os.major} <= 15 || \
-    $subport eq "${name}-3.2" && \
-    ${os.platform} eq "darwin" && ${os.major} <= 13} \
-{
-    set has_clang_variant no
-    foreach v ${clang_versions} {
-        if {[variant_isset clang[get_major ${v}]]} {
-            set has_clang_variant yes
-        }
-    }
-    if {!$has_clang_variant} {
-        # Use most recent clang by default
-        default_variants-append +clang[get_major [
-            lindex $clang_versions end
-        ]]
-    }
+# On older macOS versions, use clang variant by default
+if {[string match macports-clang-* ${configure.compiler}]} {
+    regexp {macports-clang-([0-9]+(?:\.[0-9]+)*)} \
+        ${configure.compiler} result clang_version
+    default_variants-append +clang[get_major $clang_version]
 }
 
 # Configure the variants


### PR DESCRIPTION
#### Description

As a result of rewriting the portfile in the previous PR, the block of code that does clang version checking can be simplified (this PR).

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
