### PR TITLE
google-cloud-sdk: update to 356.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             355.0.0
+version             356.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  794137cfdbc2d0d73677f946068999e747ca6dae \
-                    sha256  92caeb54c41d446e716bbb6107a56d71b48a66f0a2cca4a6423f4cbfa379611b \
-                    size    91724043
+    checksums       rmd160  0a25cd37e54c67709dcaf7f9ca52045d06684a05 \
+                    sha256  5ef09ff44bbaadb8f5c9bc705ba2e320bad87b860dc7e9a92437fbdbb80ad61b \
+                    size    91805585
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e498190355929435a56f6aa7a41ba74e8d01c535 \
-                    sha256  2d465f98d30f3bc59a047c7f9e38b733bf8d705e9bc7391817dc918cec91c665 \
-                    size    87972571
+    checksums       rmd160  d8e680e1f3f57eb03abf15b7344fbb097bb19fcd \
+                    sha256  98f9353538cca55fe43f4bc2d75237f827bca986661c0d8d46fc34852492b940 \
+                    size    88057258
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  af078823f84c83fdf080c410937b3dafffed4995 \
-                    sha256  c2de8931711108f6542f291c140b806a93570315ab461ec0f903518ff817bbf7 \
-                    size    87887650
+    checksums       rmd160  8d8f070d2a61cdf71f8699255c3d5fe364b39566 \
+                    sha256  9372bf69982f40aeb0ca91cc47a579e56f04381471ef32bd72c5936205ddf13b \
+                    size    87970570
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 356.0.0.

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?