### PR TITLE
elasticsearch: Disable non-open-source plugin xpack.security

### DIFF
--- a/databases/elasticsearch/files/patch-elasticsearch-yml.diff
+++ b/databases/elasticsearch/files/patch-elasticsearch-yml.diff
@@ -1,5 +1,5 @@
---- config/elasticsearch.yml
-+++ config/elasticsearch.yml	2019-05-09 13:16:24.000000000 -0400
+--- config/elasticsearch.yml	2021-09-08 14:14:21.000000000 -0400
++++ config/elasticsearch.yml	2021-09-08 14:17:47.000000000 -0400
 @@ -14,7 +14,7 @@
  #
  # Use a descriptive name for your cluster:
@@ -34,12 +34,20 @@
  #
  # Make sure that the heap size is set to about half the memory available
  # on the system and that the owner of the process is allowed to use this
-@@ -53,6 +57,8 @@
- # Set the bind address to a specific IP (IPv4 or IPv6):
+@@ -54,6 +58,8 @@
+ # address here to expose this node on the network:
  #
  #network.host: 192.168.0.1
 +# Bind to localhost unless explicitly changed
 +network.host: 127.0.0.1
  #
- # Set a custom port for HTTP:
+ # By default Elasticsearch listens for HTTP traffic on the first free port it
+ # finds starting at 9200. Set a specific HTTP port here:
+@@ -80,3 +86,7 @@
+ # Require explicit names when deleting indices:
  #
+ #action.destructive_requires_name: true
++#
++# Disable xpack security
++#
++xpack.security.enabled: false


### PR DESCRIPTION
* See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html
* This is necessary to use a Kibana front-end with default settings

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
