### PR TITLE
mvnd: new submission

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       github 1.0
+PortGroup       java 1.0
+
+github.setup    mvndaemon mvnd 0.6.0
+revision        0
+name            mvnd
+categories      java
+platforms       darwin
+maintainers     {breun.nl:nils @breun} openmaintainer
+license         Apache-2
+
+description     mvnd aims at providing faster Maven builds using techniques known from Gradle and Takari.
+
+long_description mvnd aims at providing faster Maven builds using techniques known from Gradle and Takari.\
+                \n\
+                \n* mvnd embeds Maven (so there is no need to install Maven separately).\
+                \n* The actual builds happen inside a long living background process, a.k.a. daemon.\
+                \n* One daemon instance can serve multiple consecutive requests from the mvnd client.\
+                \n* The mvnd client is a native executable built using GraalVM.\
+                It starts faster and uses less memory compared to starting a traditional JVM.\
+                \n* Multiple daemons can be spawned in parallel if there is no idle daemon to serve a build request.\
+                \n* The JVM for running the actual builds does not need to get started anew for each build.\
+                \n* The classloaders holding classes of Maven plugins are cached over multiple builds.\
+                The plugin jars are thus read and parsed just once. SNAPSHOT versions of Maven plugins are not cached.\
+                \n* The native code produced by the Just-In-Time (JIT) compiler inside the JVM is kept too.\
+                Compared to stock Maven, less time is spent by the JIT compilation.\
+                During the repeated builds the JIT-optimized code is available immediately.\
+                This applies not only to the code coming from Maven plugins and Maven Core,\
+                but also to all code coming from the JDK itself.
+
+github.tarball_from releases
+distname        ${name}-${version}-darwin-amd64
+
+checksums       rmd160  db88edf9e65012e79de6db5dfdf4bb0338247015 \
+                sha256  7547bc5e1eff17f38b818813723ee25ceef07fe868bbabafdcea9e8fe1513613 \
+                size    31840173
+
+use_zip         yes
+use_configure   no
+
+if {${configure.build_arch} eq "x86_64"} {
+    # mvnd native client is used on x86_64 systems, which doesn't need a separate JDK to run
+    # Only requires a JDK to compile Maven projects
+    java.version    1.7+
+    java.fallback   openjdk11
+} else {
+    # mvnd JVM client is used on non-x86_64 systems, which requires Java 11 to run
+    java.version    11+
+    java.fallback   openjdk11
+}
+
+build {}
+
+destroot {
+    set target ${prefix}/share/java/${name}
+    set dest_target ${destroot}${target}
+
+    # Create the target directory in the destroot
+    xinstall -m 755 -d ${dest_target}
+
+    # Copy files into destroot
+    foreach f [glob -directory ${worksrcpath} *] {
+        copy ${f} ${dest_target}
+    }
+
+    # Remove files that are not needed on macOS
+    delete ${dest_target}/bin/mvnd.cmd
+
+    # Create launch script
+    set launch_script [open ${destroot}${prefix}/bin/mvnd w 0755]
+    puts $launch_script "#!/usr/bin/env bash"
+    if {${configure.build_arch} eq "x86_64"} {
+        # Use mvnd native client
+        puts $launch_script "${target}/bin/mvnd $@"
+    } else {
+        # Use mvnd JVM client
+        puts $launch_script "${target}/bin/mvnd.sh $@"
+    }
+    close $launch_script
+}


### PR DESCRIPTION
#### Description

New port for mvnd (Maven daemon).

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?