### PR TITLE
recutils: new submission

### DIFF
--- a/databases/recutils/Portfile
+++ b/databases/recutils/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                recutils
+version             1.8
+
+categories          databases
+maintainers         @zaid openmaintainer
+description         Tools to work with human-editable, plain text data files
+long_description    \
+    GNU Recutils is a set of tools and libraries to access human-editable, \
+    plain text databases called recfiles. The data is stored as a sequence \
+    of records, each record containing an arbitrary number of named fields.
+
+platforms           darwin
+license             GPL-3+
+
+homepage            https://www.gnu.org/software/recutils/
+master_sites        gnu
+checksums           sha256  df8eae69593fdba53e264cbf4b2307dfb82120c09b6fab23e2dad51a89a5b193 \
+                    rmd160  d3f0042a5898ad5630f1295d9fa2f87a08031a34 \
+                    size    2474024
+
+depends_build       port:flex
+depends_lib         port:curl \
+                    port:libgcrypt \
+                    port:ossp-uuid
+depends_test        port:check
+
+configure.args      --disable-dependency-tracking \
+                    --disable-silent-rules
+
+# This is needed to make the build work on newer versions of MacOS where warnings are treated as errors.
+# See thread at https://lists.gnu.org/archive/html/bug-recutils/2021-09/msg00001.html for details
+configure.cflags    -Wno-implicit-function-declaration
+
+test.target         check
+test.run            yes


### PR DESCRIPTION
#### Description

New port for GNU Recutils (https://www.gnu.org/software/recutils/) with support for encryption (via GnuPG) and UUID type.

###### Tested on

macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?