### PR TITLE
baresip: update version to 1.1.0

### DIFF
--- a/net/baresip/Portfile
+++ b/net/baresip/Portfile
@@ -2,55 +2,58 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
+PortGroup           github 1.0
 
 name                baresip
-version             0.6.0
-revision            3
 categories          net
 platforms           darwin
 maintainers         {db.org:aeh @alfredh}
 license             BSD
-
 description         portable and modular SIP User-Agent \
                     with audio and video support
-
 long_description    ${name} is a ${description}.
 
-homepage            http://www.creytiv.com/
-master_sites        ${homepage}pub/
+github.setup        baresip baresip 1.1.0 v
+checksums           rmd160  f1f03ab052df92198f982d71932792dc4e31a110 \
+                    sha256  75ecc9037f55cb141658a5559c2ef84e12c721b7d69bb55f4640ffc82815eca2 \
+                    size    1105494
+revision            0
 
-checksums           rmd160  123f5e9e72f1c55481ee1b9079f834fee0a26ad3 \
-                    sha256  ab3dd329599e4df83eeeb5451b42811598e0171a45a90b34006c5628b61d0764 \
-                    size    599413
-
-depends_lib         port:libre \
-                    port:librem \
-                    port:libsdl2 \
-                    path:lib/libssl.dylib:openssl \
-                    port:spandsp-devel \
-                    port:x264 \
-                    path:lib/libavcodec.dylib:ffmpeg
+depends_lib \
+    port:libre \
+    port:librem \
+    port:libsdl2 \
+    path:lib/libssl.dylib:openssl \
+    port:spandsp-devel \
+    port:x264 \
+    path:lib/libavcodec.dylib:ffmpeg \
+    port:libgsm \
+    port:codec2
 
 use_configure       no
 
-build.args          CCACHE= \
-                    MOD_AUTODETECT= \
-                    PREFIX=${prefix} \
-                    SYSROOT="${configure.sdkroot}/usr" \
-                    SYSROOT_ALT=${prefix} \
-                    USE_CONS=1 \
-                    USE_COREAUDIO=1 \
-                    USE_AVCODEC=1 \
-                    USE_G711=1 \
-                    USE_G722=1 \
-                    USE_OPENGL=1 \
-                    USE_AVCAPTURE=1 \
-                    USE_STDIO=1 \
-                    USE_SDL2=1 \
-                    LIBRE_MK=${prefix}/share/re/re.mk \
-                    LIBRE_INC=${prefix}/include/re \
-                    LIBRE_SO=${prefix}/lib \
-                    EXTRA_CFLAGS=-I${prefix}/include/rem
+build.args \
+    CCACHE= \
+    MOD_AUTODETECT= \
+    PREFIX=${prefix} \
+    SYSROOT="${configure.sdkroot}/usr" \
+    SYSROOT_ALT=${prefix} \
+    USE_CONS=1 \
+    USE_COREAUDIO=1 \
+    USE_AVCODEC=1 \
+    USE_G711=1 \
+    USE_G722=1 \
+    USE_AVCAPTURE=1 \
+    USE_STDIO=1 \
+    USE_SDL2=1 \
+    USE_GSM=1 \
+    USE_CODEC2=1 \
+    LIBRE_MK=${prefix}/share/re/re.mk \
+    LIBRE_INC=${prefix}/include/re \
+    LIBRE_SO=${prefix}/lib \
+    LIBREM_INC=${prefix}/include/rem \
+    LIBREM_SO=${prefix}/lib
+
 destroot.args       ${build.args}
 
 if {[tbool configure.ccache]} {

--- a/net/libre/Portfile
+++ b/net/libre/Portfile
@@ -2,44 +2,43 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
+PortGroup           github 1.0
 
 name                libre
-version             0.6.0
-revision            1
 categories          net
 platforms           darwin
 maintainers         {db.org:aeh @alfredh}
 license             BSD
-
 description         Protocol library for real-time communications with async \
                     I/O support
-
 long_description    ${name} is a ${description}.
 
-homepage            http://www.creytiv.com/
-master_sites        ${homepage}pub/
+github.setup        baresip re 2.0.1 v
+checksums           rmd160  4f23053dd00938f9df6ffc91b08b54e3230f2872 \
+                    sha256  2fadb30911d09cd7f8a3faee0672f3d03c16de9d7dcafeabd8dce41133563da0 \
+                    size    342954
+revision            0
 
-distname            re-${version}
-
-checksums           rmd160  86d709afe8f5fcc1877cc2eda50dda7d4af45f0d \
-                    sha256  0e97bcb5cc8f84d6920aa78de24c7d4bf271c5ddefbb650848e0db50afe98131 \
-                    size    316224
-
-depends_lib         port:zlib \
-                    path:lib/libssl.dylib:openssl
+depends_lib \
+    port:zlib \
+    path:lib/libssl.dylib:openssl
 
 use_configure       no
 
-build.args          CCACHE= \
-                    PREFIX=${prefix} \
-                    SYSROOT="${configure.sdkroot}/usr" \
-                    SYSROOT_ALT=${prefix}
+build.args \
+    CCACHE= \
+    RELEASE=1 \
+    PREFIX=${prefix} \
+    SYSROOT="${configure.sdkroot}/usr" \
+    SYSROOT_ALT=${prefix}
 
-destroot.args       ${build.args}
+destroot.args \
+    ${build.args}
 
 if {[tbool configure.ccache]} {
     build.env-append CCACHE=ccache
 }
+
 if {![info exists universal_possible]} {
     set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
 }
@@ -56,5 +55,3 @@ if {${universal_possible} && [variant_isset universal]} {
 post-destroot {
     system "install_name_tool -id ${prefix}/lib/libre.dylib ${destroot}${prefix}/lib/libre.dylib"
 }
-
-livecheck.name      re

--- a/net/librem/Portfile
+++ b/net/librem/Portfile
@@ -2,40 +2,38 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
+PortGroup           github 1.0
 
 name                librem
-version             0.6.0
-revision            1
 categories          net
 platforms           darwin
 maintainers         {db.org:aeh @alfredh}
 license             BSD
-
 description         portable audio and video processing media library
-
 long_description    ${name} is a ${description}.
 
-homepage            http://www.creytiv.com/
-master_sites        ${homepage}pub/
+github.setup        baresip rem 1.0.0 v
+checksums           rmd160  6d122eb2c386cfc29aa8427ceb73e63e151ae2a7 \
+                    sha256  7adec440616377c268130f00ac9e0d4f338dd880c9747d96d7031046e6489a68 \
+                    size    47226
+revision            0
 
-distname            rem-${version}
 
-checksums           rmd160  88c0dba6716f448994141138daeb533a958b5b4f \
-                    sha256  417620da3986461598aef327c782db87ec3dd02c534701e68f4c255e54e5272c \
-                    size    41585
-
-depends_lib-append  port:libre \
-                    path:lib/libssl.dylib:openssl
+depends_lib-append  \
+    port:libre \
+    path:lib/libssl.dylib:openssl
 
 use_configure       no
 
-build.args          CCACHE= \
-                    PREFIX=${prefix} \
-                    SYSROOT="${configure.sdkroot}/usr" \
-                    SYSROOT_ALT=${prefix} \
-                    LIBRE_MK=${prefix}/share/re/re.mk \
-                    LIBRE_INC=${prefix}/include/re \
-                    LIBRE_SO=${prefix}/lib
+build.args \
+    CCACHE= \
+    PREFIX=${prefix} \
+    SYSROOT="${configure.sdkroot}/usr" \
+    SYSROOT_ALT=${prefix} \
+    LIBRE_MK=${prefix}/share/re/re.mk \
+    LIBRE_INC=${prefix}/include/re \
+    LIBRE_SO=${prefix}/lib
+
 destroot.args       ${build.args}
 
 if {[tbool configure.ccache]} {
@@ -57,5 +55,3 @@ if {${universal_possible} && [variant_isset universal]} {
 post-destroot {
     system "install_name_tool -id ${prefix}/lib/librem.dylib ${destroot}${prefix}/lib/librem.dylib"
 }
-
-livecheck.name      rem


### PR DESCRIPTION
#### Description

baresip: update version to 1.1.0
librem: update version to 1.0.0
libre: update version to 2.0.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
