### PR TITLE
httpie: update to 2.5.0

### DIFF
--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        jakubroztocil httpie 2.4.0
+github.setup        httpie httpie 2.5.0
 
 maintainers         {g5pw @g5pw} openmaintainer
 categories          net
@@ -39,10 +39,11 @@ if {[variant_isset python36]} {
 depends_lib-append  port:py${python.version}-requests \
                     port:py${python.version}-requests-toolbelt \
                     port:py${python.version}-pygments \
-                    port:py${python.version}-socks
+                    port:py${python.version}-socks \
+                    port:py${python.version}-defusedxml
 
-checksums           rmd160  4c791ff11b153e3f6037cb42280b1dc20a05de77 \
-                    sha256  767290c062f944117fd42c41fcc751c82adff170f149622bf0cc3ab2587c41ca \
-                    size    1772552
+checksums           rmd160  88d227d52199c232c0ddf704a219d1781b1e77ee \
+                    sha256  00c4b7bbe7f65abe1473f37b39d9d9f8f53f44069a430ad143a404c01c2179fc \
+                    size    1105185
 
 python.link_binaries_suffix


### PR DESCRIPTION
#### Description

It is a first PR to check the process :)
Unfortunately I do not have a Mac to test.

I am wondering how checksums were fetched for previous releases? Because I cannot get to find matches.
For instance, with the old 2.4.0 version:
```shell
$ wget https://github.com/httpie/httpie/archive/refs/tags/2.4.0.tar.gz -O httpie-2.4.0.tar.gz
$ openssl dgst -rmd160 httpie-2.4.0.tar.gz       
RIPEMD160(httpie-2.4.0.tar.gz)= 6046e651328a16072921264deae78e373826051b
```
But the current checksum is `4c791ff11b153e3f6037cb42280b1dc20a05de77`. Maybe `port` is altering the file somehow?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
