### PR TITLE
syncthing: update to 1.18.2

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.18.1 v
+go.setup            github.com/syncthing/syncthing 1.18.2 v
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,9 +18,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  9a6fe22a4c6a03d7b6e61a19b8056b001c986f13 \
-                        sha256  e4cda093b41ed60c5f34a0b8740978b609bc2f0d71d651d15fcc8f90212aca7e \
-                        size    6145312
+                        rmd160  c2557cc7378d48cad458dd212d5a39dc37996533 \
+                        sha256  4bda7b50a1a9307444f46fecedd65abb052bfc8aeec45614f0497a307e787395 \
+                        size    6152302
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -28,10 +28,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
                         size    86890 \
                     gopkg.in/yaml.v2 \
-                        lock    v2.3.0 \
-                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
-                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
-                        size    72838 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
                     gopkg.in/tomb.v1 \
                         lock    dd632973f1e7 \
                         rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
@@ -54,10 +54,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
                     golang.org/x/tools \
-                        lock    v0.1.0 \
-                        rmd160  ed8549ff61216e862597412cca9a2f3cd3448147 \
-                        sha256  7ee4ceea7cc41925aa41c185d17886694bcd611cb9896be15e578a491c8594c0 \
-                        size    2683296 \
+                        lock    v0.1.5 \
+                        rmd160  1bbd33096e15d2084ba543ddbfd86936e5dd09cb \
+                        sha256  66907da0a219e6a27e504acc4c1c58fd9521585de0d6729a43694c950aef1670 \
+                        size    2843627 \
                     golang.org/x/time \
                         lock    f8bda1e9f3ba \
                         rmd160  f8d3e8f61490936cad49b715f1c36b40b1ece39d \
@@ -69,25 +69,25 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  6b2d69df22b5ba1634bc6730c3f03404db499536a96c48b8016da80ced804450 \
                         size    8356058 \
                     golang.org/x/sys \
-                        lock    d19ff857e887 \
-                        rmd160  2ed08c61c86e3546de28692ad78e8b0097c472ea \
-                        sha256  129834fa0c0c2139853fee97ffd7872d75f9398735db82e2f445595a7a1697e2 \
-                        size    1232340 \
+                        lock    f52c844e1c1c \
+                        rmd160  8aaf39f353b93a6474b33d0de1a0ccde2a71d9d6 \
+                        sha256  18bd889f302f2111356cc28e86dadb43a2b2cf61a9e5df3d1a059fe9e99fc9e0 \
+                        size    1209437 \
                     golang.org/x/net \
-                        lock    89ef3d95e781 \
-                        rmd160  d7ce678a4df908e249c02e1bd027cb36ca9f0919 \
-                        sha256  2bbf2441a2a203e2376baddb6c5de37bb63a3b46010b0c9bfdf631d0128e83dc \
-                        size    1247545 \
+                        lock    853a461950ff \
+                        rmd160  86c824613f7d6a33990fc15cd6914aba624cb3fa \
+                        sha256  9bfecf30fca72160bb1e93b76147e666313c4d829b1b7cdc43c9e8b19cf97596 \
+                        size    1252168 \
                     golang.org/x/mod \
-                        lock    v0.3.0 \
-                        rmd160  0f19d3d89a7745c9877e5095399e24bdb2a79908 \
-                        sha256  d4e740958a7d07574b73c6b6a5ab717cd0bc219416e47c5950fe3cefab414f92 \
-                        size    93933 \
+                        lock    v0.4.2 \
+                        rmd160  0f3ca57198b4de4eb89b2c1a2bdb01af040d1f36 \
+                        sha256  e2e4cba5719f804f2ec901b4ccdf6d3abf05521868ed54f271be7c1bf6c48549 \
+                        size    104573 \
                     golang.org/x/crypto \
-                        lock    83a5a9bb288b \
-                        rmd160  c7750005747d7fada41ca0933f9937f0f26f9034 \
-                        sha256  3ed5b0a92055b3010d0a40b71c331c6921e211ba6f03074308ab555a405e0d67 \
-                        size    1726599 \
+                        lock    a769d52b0f97 \
+                        rmd160  0599d63a740ae1bb45dec221f8c89bd173575806 \
+                        sha256  983562ae6552af3e350cde284c14bf33d4d3e54a5aec40527f3157e7fc4400ca \
+                        size    1732004 \
                     github.com/vitrun/qart \
                         lock    bf64b92db6b0 \
                         rmd160  50ea47d1b1d0b60138845f21d57cad0ac7e5e632 \
@@ -189,20 +189,20 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  4730f81213989b0c32c857b033f5dfe049f664d9959a3c1f8c534183eecd0874 \
                         size    9608 \
                     github.com/onsi/gomega \
-                        lock    v1.10.3 \
-                        rmd160  3ce67285e98fcf47d6ae18e2a50b6685c132e323 \
-                        sha256  ff8e349c8e3996170fdf809e659cca57284dfacd62545c39519df5820f7b9c14 \
-                        size    97892 \
+                        lock    v1.13.0 \
+                        rmd160  dc92bda8de121272ba08a6fd53d305f86af161fb \
+                        sha256  84bb470e2662d0243c708df882666f82aa735376b837fa3edecea02ede08efac \
+                        size    127847 \
                     github.com/onsi/ginkgo \
-                        lock    v1.14.0 \
-                        rmd160  a1ff8b445c4b593fc8c399993c90f8ff423260fa \
-                        sha256  5aec86ace19613b3976cdadf587d42461d47b89b9b02c5dabafa05a86f704fb2 \
-                        size    145828 \
+                        lock    v1.16.4 \
+                        rmd160  e0c7145b2a5a9fa39d1883b7ceb788af8a3dd4db \
+                        sha256  1cf29213663b89b7578f41a0185b814dab82d40fb5233bf0fe951591ce32ab10 \
+                        size    164059 \
                     github.com/nxadm/tail \
-                        lock    v1.4.4 \
-                        rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
-                        sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
-                        size    1238830 \
+                        lock    v1.4.8 \
+                        rmd160  bb6c5515804a1d141478074ba9a4f836fa51fb71 \
+                        sha256  a4e98c422980433e9a9830f16b4155836baba4c3e3aa387f03840e5cb608c84d \
+                        size    1256274 \
                     github.com/niemeyer/pretty \
                         lock    a10e7caefd8e \
                         rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
@@ -233,21 +233,26 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  6f7b6c1f0ea3b1d065dc8e8e1c0aa42d3db90434 \
                         sha256  2ae2b9dc73270d6a0222347bf290b44b45d80a82c181c19183165c9952de0c6b \
                         size    169712 \
-                    github.com/marten-seemann/qtls-go1-15 \
+                    github.com/marten-seemann/qtls-go1-17 \
+                        lock    v0.1.0-rc.1 \
+                        rmd160  5f5bcb47b85e9cbffeab69189cff5dd3bd587770 \
+                        sha256  53a447b1a2518642e7c1d807b74caaf6638037bb5d63d6bd612e34ee87cc9b30 \
+                        size    421746 \
+                    github.com/marten-seemann/qtls-go1-16 \
                         lock    v0.1.4 \
-                        rmd160  370ab7801f30cbfdf823274dc0ad68c6b492b969 \
-                        sha256  e0e690f3333659b7732af5ccab65044f09aa89dafa7158410c5f8ca5e451fe13 \
-                        size    413757 \
-                    github.com/marten-seemann/qtls \
-                        lock    v0.10.0 \
-                        rmd160  560c030e5cd2045dc65345b67ce0257ec709ac65 \
-                        sha256  9db255f013988eee87447b47a3510b56cfb3e0acb1e4f0af13215b971a82f6b4 \
-                        size    403908 \
+                        rmd160  1cadd0881456cc0d4dd653b432c06be1e1a1e43e \
+                        sha256  6e750d55689b9eeff04ddadd5fd37f57c794f0eb0897622ea318b4b73990261a \
+                        size    415570 \
+                    github.com/marten-seemann/qtls-go1-15 \
+                        lock    v0.1.5 \
+                        rmd160  935629c05cf01066de57f62599e6b60122f7cc6d \
+                        sha256  942e3d2166894e4cdfd21af9313021e8f90b5ff42792456671d6eb1a5cfd90c6 \
+                        size    413667 \
                     github.com/lucas-clemente/quic-go \
-                        lock    v0.19.3 \
-                        rmd160  d34abe8d7dc661b7deaf5e39fbbe88747314d662 \
-                        sha256  2589e82385f612cc4b45ab0bad5ae105d36d823a137245520d71e90009f4f17f \
-                        size    495534 \
+                        lock    v0.22.0 \
+                        rmd160  672b422da53164156e47620fd32e9d78640b3707 \
+                        sha256  12e9ef4d4bb327af4a735dc01a9f22fda12ca9808860ccda44952b1b1126615b \
+                        size    519202 \
                     github.com/lib/pq \
                         lock    v1.10.1 \
                         rmd160  8b194b5ee4d2e5b01c7c6fdb3223313cd1f248b1 \
@@ -309,10 +314,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
                         size    171736 \
                     github.com/golang/mock \
-                        lock    v1.5.0 \
-                        rmd160  d52e6bcf001864ba50f79333a8d5aa60aedb3d97 \
-                        sha256  9ab3a093ccfb9d18118ebf969153ea1a350a530be7cf647bbc73ac7a4e018cf8 \
-                        size    66435 \
+                        lock    v1.6.0 \
+                        rmd160  ed853462703f04ce365bb17b8c88a92994aa5006 \
+                        sha256  4b107f6d26db03f8a36ae38f7b017399ed56571cdbf7b7ebc7bff0006c7dffb5 \
+                        size    69263 \
                     github.com/golang/groupcache \
                         lock    41bb18bfe9da \
                         rmd160  dba4526dc11102f7cfc3ee7be23cb1416793e35b \
@@ -328,6 +333,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  1f472cf991498a8091446eb788fe85e0c5403185 \
                         sha256  2de3694ee0ff41a96b66f9aa3eec51048e620cdd09acc8685f18c3abcd6e14ae \
                         size    25971 \
+                    github.com/go-task/slim-sprig \
+                        lock    348f09dbbbc0 \
+                        rmd160  7cc4d26be51d6fdf2b54b1fd1506b58c58317303 \
+                        sha256  94d84e08cdff9c92c5cf526f0ec803f46593247f8e0d4b19b30c9df1819c933d \
+                        size    40027 \
                     github.com/go-ole/go-ole \
                         lock    v1.2.4 \
                         rmd160  ff816f1835d4311c60fbed68b0d01838c4265bb6 \
@@ -439,10 +449,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  543c0a8ad8a9f2f9dc33585a8cdd5b7c3f8d19907f9833dd0a978edc56679768 \
                         size    12410 \
                     github.com/AudriusButkevicius/pfilter \
-                        lock    e9aaf99ab213 \
-                        rmd160  f4cdd90365edfd44e6783c4f6f99e919102374ed \
-                        sha256  605f6d99454282ffc3b9c134075dd031e94075cf563276c02fc7513342f6342a \
-                        size    18636
+                        lock    v0.0.10 \
+                        rmd160  5809d7f65eef2f8ddc491c2e16c354bd9e68d498 \
+                        sha256  497206e2535f8f4ba068401aadddaecfd5ac12826d998ecc82e341a98cf85c66 \
+                        size    21083
 
 build.cmd           ${go.bin} run build.go
 build.target        install syncthing


### PR DESCRIPTION
#### Description

Updates syncthing to 1.18.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
