### PR TITLE
GROMACS: update to 2021.3

### DIFF
--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -1,22 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           muniversal 1.0
-PortGroup           cmake 1.0
-# this line is needed to allow use of gcc
-configure.cxx_stdlib   libstdc++
-PortGroup           cxx11 1.1
+PortGroup           cmake 1.1
 PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
-
 name                gromacs
-# not all versions have patches available for plumed; subport's patch will fail if not there
-# find list at https://www.plumed.org/doc-v2.5/user-doc/html/_code_specific_notes.html
-version             2019.2
+version             2021.3
+revision            0
 categories          science math
+platforms           darwin
 license             LGPL-2.1
 maintainers         {dstrubbe @dstrubbe} openmaintainer
-description         The World's fastest Molecular Dynamics package
+description         Molecular dynamics package designed for simulations of proteins, lipids, and nucleic acids. 
+
 long_description    GROMACS is a versatile package to perform molecular \
                     dynamics, i.e. simulate the Newtonian equations of motion for \
                     systems with hundreds to millions of particles. It is primarily \
@@ -25,111 +21,24 @@ long_description    GROMACS is a versatile package to perform molecular \
                     extremely fast at calculating the nonbonded interactions (that \
                     usually dominate simulations) many groups are also using it for \
                     research on non-biological systems, e.g. polymers.
-platforms           darwin
 
 homepage            http://www.gromacs.org/
 master_sites        http://ftp.gromacs.org/pub/gromacs
+checksums           md5     1850870fbbfb228051ee0afc1c5ddeff \
+                    size    37987972 \
+                    rmd160  74adb5fc9e2fa461d4d7ff603d0fe7e08476da20 \
+                    sha256  e109856ec444768dfbde41f3059e3123abdb8fe56ca33b1a83f31ed4575a1cc6
 
-# md5 as on http://manual.gromacs.org/documentation/2019.2/download.html
-checksums           rmd160  e59309b1a9d0de14a547f7727d4f4915aa3a6df7 \
-                    sha256  bcbf5cc071926bc67baa5be6fb04f0986a2b107e1573e15fadcb7d7fc4fb9f7e \
-                    md5     9978498d904ec81f50796b3cdaa9c5df \
-                    size    33437869
-
-depends_build-append \
-                    port:pkgconfig
-
-depends_lib-append  port:fftw-3-single port:libxml2 port:zlib
-
-# FIXME: enable use of avx when appropriate, instead of just SSE
-configure.args-append  -DGMX_SIMD:STRING="SSE4.1" -DBUILD_TESTING:BOOL=ON -DGMX_X11:BOOL=OFF -DGMX_HWLOC:BOOL=OFF -DGMX_OPENMP:BOOL=OFF
-# boost?
-
-variant x11 description {Enable GMX view via X11} {
-    configure.args-replace  -DGMX_X11:BOOL=OFF -DGMX_X11:BOOL=ON
-    depends_lib-append      port:xorg-libX11 port:xorg-libXext
-}
-
-variant hwloc description {Enable usage of HWLOC for hardware locality} {
-    configure.args-replace  -DGMX_HWLOC:BOOL=OFF -DGMX_HWLOC:BOOL=ON
-}
-
-variant threads description {Enable usage of OpenMP} {
-    configure.args-replace  -DGMX_OPENMP:BOOL=OFF -DGMX_OPENMP:BOOL=ON
-}
-
-compilers.choose    cc cxx
-mpi.setup
-
+depends_lib-append  port:fftw-3 port:zlib
+configure.args-append  -DGMX_SIMD=SSE4.1 -DGMX_FFT_LIBRARY=fftw3 -DREGRESSIONTEST_DOWNLOAD=ON
 test.run     yes
 test.target  check
 
-if {[mpi_variant_isset]} {
-    set suffix _mpi
-} else {
-    set suffix ""
-}
 
-pre-test {
-    system -W ${worksrcpath} "install_name_tool -change ${prefix}/lib/libgromacs${suffix}.dylib @executable_path/../lib/libgromacs${suffix}.dylib bin/gmx${suffix}"
-    # reset name for new executables that will be built in this phase
-    system -W ${worksrcpath} "install_name_tool -id @executable_path/../lib/libgromacs${suffix}.dylib lib/libgromacs${suffix}.dylib"
-}
-post-test {
-    # undo changes, in case 'install' is done afterward
-    system -W ${worksrcpath} "install_name_tool -change @executable_path/../lib/libgromacs${suffix}.dylib ${prefix}/lib/libgromacs.dylib bin/gmx${suffix}"
-    system -W ${worksrcpath} "install_name_tool -id ${prefix}/lib/libgromacs${suffix}.dylib lib/libgromacs${suffix}.dylib"
-}
-# look into this:
-#NOTE: Regression tests have not been run. If you want to run them from the build system, get the correct version of the regression tests package and set REGRESSIONTEST_PATH in CMake to point to it, or set REGRESSIONTEST_DOWNLOAD=ON.
-
-subport gromacs-plumed {
-    description    ${description}: \
-      (THIS PORT INSTALLS A VERSION OF GROMACS PATCHED WITH PLUMED)
-    long_description    ${long_description}: \
-      (THIS PORT INSTALLS A VERSION OF GROMACS PATCHED WITH PLUMED)
-    conflicts gromacs
-
-# in case gromacs is compiled with MPI, also enforce that plumed is compiled with the same MPI variant:
-    if {[mpi_variant_isset]} {
-        mpi.enforce_variant path:${prefix}/lib/libplumedKernel.dylib:plumed
-    }
-# make sure that thread MPI is disabled, since it does not work with plumed
-    configure.args-append -DGMX_THREAD_MPI=OFF
-
-    depends_build-append   path:${prefix}/bin/plumed:plumed
-    depends_lib-append     path:${prefix}/lib/libplumedKernel.dylib:plumed
-    post-patch {
-# I need to execute with full path since PATH variable is not properly set here
-# Also notice that I am patching with runtime. Notice that 
-# plumed compiled for MacPorts has the hardcoded path also in the runtime patch.
-# This allows the user to work with MacPorts plumed and possibly
-# override the choice setting the PLUMED_KERNEL environment variable.
-# Also notice that gromacs version is hardcoded here. Plumed patch is not always
-# updated when gromacs is.
-        exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-2019.2 --runtime -p
-    }
-    notes "
-PLUMED is linked with runtime binding. By setting the environment variable PLUMED_KERNEL\
-to the path of libplumedKernel.dylib you can replace your own PLUMED library at runtime.\
-By default, ${prefix}/lib/libplumedKernel.dylib is linked.
-"
-}
-
-linalg.setup  noveclibfort
-pre-configure {
-    if {[mpi_variant_isset]} {
-        configure.args-append  -DGMX_MPI:BOOL=ON -DMPIEXEC:STRING="${mpi.exec}"
-    }
-    configure.args-append      -DGMX_BLAS_USER="${linalglib}" -DGMX_LAPACK_USER="${linalglib}"
-}
-
-variant double description "Build in double precision (much slower, use only if you really need it)" {
-    depends_lib-delete      port:fftw-3-single
-    depends_lib-append      port:fftw-3
+variant double description "build GROMACS in double precision (slower, and not normally useful)" {
     configure.args-append   -DGMX_DOUBLE:BOOL=ON
 }
 
-livecheck.type          regex
-livecheck.url           http://ftp.gromacs.org/pub/gromacs/
-livecheck.regex         ${name}-(\[0-9.\]+)${extract.suffix}
+livecheck.type      regex
+livecheck.url       http://ftp.gromacs.org/pub/gromacs/
+livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -29,7 +29,7 @@ checksums           md5     1850870fbbfb228051ee0afc1c5ddeff \
                     rmd160  74adb5fc9e2fa461d4d7ff603d0fe7e08476da20 \
                     sha256  e109856ec444768dfbde41f3059e3123abdb8fe56ca33b1a83f31ed4575a1cc6
 
-depends_lib-append  port:fftw-3 port:zlib
+depends_lib-append  port:fftw-3-single port:zlib
 configure.args-append  -DGMX_SIMD=SSE4.1 -DGMX_FFT_LIBRARY=fftw3 -DREGRESSIONTEST_DOWNLOAD=ON
 test.run     yes
 test.target  check

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
+
 name                gromacs
 version             2021.3
 revision            0
@@ -11,8 +12,7 @@ categories          science math
 platforms           darwin
 license             LGPL-2.1
 maintainers         {dstrubbe @dstrubbe} openmaintainer
-description         Molecular dynamics package designed for simulations of proteins, lipids, and nucleic acids. 
-
+description         Molecular dynamics package designed for simulations of proteins, lipids, and nucleic acids.
 long_description    GROMACS is a versatile package to perform molecular \
                     dynamics, i.e. simulate the Newtonian equations of motion for \
                     systems with hundreds to millions of particles. It is primarily \
@@ -21,7 +21,6 @@ long_description    GROMACS is a versatile package to perform molecular \
                     extremely fast at calculating the nonbonded interactions (that \
                     usually dominate simulations) many groups are also using it for \
                     research on non-biological systems, e.g. polymers.
-
 homepage            http://www.gromacs.org/
 master_sites        http://ftp.gromacs.org/pub/gromacs
 checksums           md5     1850870fbbfb228051ee0afc1c5ddeff \
@@ -33,7 +32,6 @@ depends_lib-append  port:fftw-3-single port:zlib
 configure.args-append  -DGMX_SIMD=SSE4.1 -DGMX_FFT_LIBRARY=fftw3 -DREGRESSIONTEST_DOWNLOAD=ON
 test.run     yes
 test.target  check
-
 
 variant double description "build GROMACS in double precision (slower, and not normally useful)" {
     configure.args-append   -DGMX_DOUBLE:BOOL=ON


### PR DESCRIPTION
#### Description

This PR is updating the GROMACS port to the last released version (2021.3). 
It also fixing:

- Compilation errors due to outdated dependencies.
- Removed selecting clang 5.0 as the default compiler. 
- Removed some variants that seem to be no longer relevant on macOS


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
