### PR TITLE
pango-devel: Fix man page building on Tiger

### DIFF
--- a/x11/pango-devel/Portfile
+++ b/x11/pango-devel/Portfile
@@ -62,6 +62,12 @@ configure.cxxflags-append \
 
 license_noconflict      gobject-introspection
 
+# Fix help2man invocation on Tiger
+platform darwin 8 {
+    # meson on Tiger cannot use rpaths, so we workaround with this to find dylib
+    destroot.env-append    "DYLD_LIBRARY_PATH=${build_dir}/pango"
+}
+
 if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx" && ${os.major} > 8} {
     variant quartz {
         # Although this variant does nothing, pango will automatically build


### PR DESCRIPTION
#### Description

`help2man` invokes `utils/pango-view` to generate the man page, but at least on Tiger the libpango dylib can't be found during build-time ("Library not loaded / Reason: image not found" error).

Leaving as a draft until #12171 is merged since this PR relies on features introduced in Meson 0.57.0.

Also added a note about an upstream pull request.

CC @mascguy and #11948

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
