### PR TITLE
boost: Try to fix cmake symlink creation.

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -47,12 +47,19 @@ destroot {
     }
     # Sym link libraries
     xinstall -d ${destroot}${prefix}/lib
-    foreach lib [glob [boost::lib_dir]/*] {
+    if [file exists [boost::lib_dir]/cmake] {
+        xinstall -d ${destroot}${prefix}/lib/cmake
+    }
+    fs-traverse -tails lib [list [boost::lib_dir]] {
         # Skip numpy lib if present for main boost port
         if { ${subport} ne ${name} || ![string match *numpy* $lib] } {
-            set plib ${prefix}/lib/[file tail ${lib}]
+            set plib ${prefix}/lib/${lib}
             if {![file exists ${plib}]} {
-                ln -s ${lib} ${destroot}${prefix}/lib/
+                if {![file isdirectory [boost::lib_dir]/${lib}]} {
+                    ln -s [boost::lib_dir]/${lib} ${destroot}${plib}
+                } else {
+                    xinstall -d ${destroot}${plib}
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/63273

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Note: I haven't tested this very extensively but I used a project I am part of that had no trouble finding Boost before, had been having issues since the new side-by-side boost scheme began (which is a great idea btw) and is now working again with this patch.