### PR TITLE
gromacs: update to 2021.3

### DIFF
--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -2,21 +2,20 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
-PortGroup           cmake 1.0
-# this line is needed to allow use of gcc
-configure.cxx_stdlib   libstdc++
-PortGroup           cxx11 1.1
+PortGroup           cmake 1.1
 PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 
 name                gromacs
 # not all versions have patches available for plumed; subport's patch will fail if not there
 # find list at https://www.plumed.org/doc-v2.5/user-doc/html/_code_specific_notes.html
-version             2019.2
+version             2021.3
+revision            0
 categories          science math
+platforms           darwin
 license             LGPL-2.1
 maintainers         {dstrubbe @dstrubbe} openmaintainer
-description         The World's fastest Molecular Dynamics package
+description         Molecular dynamics package designed for simulations of proteins, lipids, and nucleic acids.
 long_description    GROMACS is a versatile package to perform molecular \
                     dynamics, i.e. simulate the Newtonian equations of motion for \
                     systems with hundreds to millions of particles. It is primarily \
@@ -27,31 +26,33 @@ long_description    GROMACS is a versatile package to perform molecular \
                     research on non-biological systems, e.g. polymers.
 platforms           darwin
 
-homepage            http://www.gromacs.org/
-master_sites        http://ftp.gromacs.org/pub/gromacs
+homepage            https://www.gromacs.org/
+master_sites        https://ftp.gromacs.org/pub/gromacs
 
-# md5 as on http://manual.gromacs.org/documentation/2019.2/download.html
-checksums           rmd160  e59309b1a9d0de14a547f7727d4f4915aa3a6df7 \
-                    sha256  bcbf5cc071926bc67baa5be6fb04f0986a2b107e1573e15fadcb7d7fc4fb9f7e \
-                    md5     9978498d904ec81f50796b3cdaa9c5df \
-                    size    33437869
+# md5 as on http://manual.gromacs.org/documentation/2021.3/download.html
+checksums           rmd160  74adb5fc9e2fa461d4d7ff603d0fe7e08476da20 \
+                    sha256  e109856ec444768dfbde41f3059e3123abdb8fe56ca33b1a83f31ed4575a1cc6 \
+                    md5     1850870fbbfb228051ee0afc1c5ddeff \
+                    size    37987972
 
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:fftw-3-single port:libxml2 port:zlib
+depends_lib-append  port:fftw-3-single port:hwloc port:zlib
+
+compiler.cxx_standard 2017
 
 # FIXME: enable use of avx when appropriate, instead of just SSE
-configure.args-append  -DGMX_SIMD:STRING="SSE4.1" -DBUILD_TESTING:BOOL=ON -DGMX_X11:BOOL=OFF -DGMX_HWLOC:BOOL=OFF -DGMX_OPENMP:BOOL=OFF
-# boost?
+configure.args-append  -DGMX_SIMD:STRING="SSE4.1" -DBUILD_TESTING:BOOL=ON -DGMX_X11:BOOL=OFF -DGMX_HWLOC:BOOL=ON -DGMX_OPENMP:BOOL=OFF
+# Ensure that GROMACS log files reflect that the build was
+# done via macports, to help users troubleshoot issues
+configure.args-append  -DGMX_VERSION_STRING_OF_FORK="macports"
+# Always use libc++
+configure.args-append  -DGMX_STDLIB_CXX_FLAGS=-stdlib=libc++ -DGMX_STDLIB_LIBRARIES='-lc++abi -lc++'
 
 variant x11 description {Enable GMX view via X11} {
     configure.args-replace  -DGMX_X11:BOOL=OFF -DGMX_X11:BOOL=ON
     depends_lib-append      port:xorg-libX11 port:xorg-libXext
-}
-
-variant hwloc description {Enable usage of HWLOC for hardware locality} {
-    configure.args-replace  -DGMX_HWLOC:BOOL=OFF -DGMX_HWLOC:BOOL=ON
 }
 
 variant threads description {Enable usage of OpenMP} {
@@ -101,13 +102,13 @@ subport gromacs-plumed {
     depends_lib-append     path:${prefix}/lib/libplumedKernel.dylib:plumed
     post-patch {
 # I need to execute with full path since PATH variable is not properly set here
-# Also notice that I am patching with runtime. Notice that 
+# Also notice that I am patching with runtime. Notice that
 # plumed compiled for MacPorts has the hardcoded path also in the runtime patch.
 # This allows the user to work with MacPorts plumed and possibly
 # override the choice setting the PLUMED_KERNEL environment variable.
 # Also notice that gromacs version is hardcoded here. Plumed patch is not always
 # updated when gromacs is.
-        exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-2019.2 --runtime -p
+        exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-${version} --runtime -p
     }
     notes "
 PLUMED is linked with runtime binding. By setting the environment variable PLUMED_KERNEL\
@@ -131,5 +132,5 @@ variant double description "Build in double precision (much slower, use only if 
 }
 
 livecheck.type          regex
-livecheck.url           http://ftp.gromacs.org/pub/gromacs/
+livecheck.url           https://ftp.gromacs.org/pub/gromacs/
 livecheck.regex         ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

Updated to latest release, including for PLUMED support.

Updated to use compiler toolchains via non-deprecated mechanisms.

Required hwloc, as this will be wanted whenever arm support is worked out.

Customized version string so that reading the GROMACS log file will show that macports organized the build. That is potentially valuable information for GROMACS users and developers troubleshooting their runs.

Removed comment about boost, which is unused.

Removed libxml2 requirement, which is unused.

Updated to use HTTPS in links

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
