### PR TITLE
Gocryptfs: Exclude pre-release versions from livecheck

### DIFF
--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -152,3 +152,7 @@ destroot {
     xinstall -m 0755 ${worksrcpath}/Documentation/gocryptfs-xray.1 ${destroot}${prefix}/share/man/man1
     xinstall -m 0755 ${worksrcpath}/Documentation/statfs.1 ${destroot}${prefix}/share/man/man1
 }
+
+# Exclude pre-release versions.
+github.livecheck.regex \
+                    {([0-9.]+)}


### PR DESCRIPTION
#### Description

The livecheck should not include beta versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
