### PR TITLE
gjs: update to 1.54.3

### DIFF
--- a/gnome/gjs/Portfile
+++ b/gnome/gjs/Portfile
@@ -1,12 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           gobject_introspection 1.0
 
 name                gjs
-version             1.52.5
-revision            4
+version             1.54.3
+revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         GNOME JavaScript/Spidermonkey bindings
 long_description    ${description}
@@ -19,9 +18,9 @@ homepage            https://wiki.gnome.org/Projects/Gjs
 master_sites        gnome:sources/${name}/${branch}/
 use_xz              yes
 
-checksums           rmd160  3115c054fd9bd8b565bc904f4d8bd3c343297289 \
-                    sha256  f0b49acc6e3ae9c736753bbef50a7dbd6f6f500b05df1cb354721f9ff4509c7b \
-                    size    627796
+checksums           rmd160  6b6ef5e4812d393237be264dffc6f6ee4a87f8e6 \
+                    sha256  76b30dcc3ce9836c053aee531aa9f1d9d3f94b8503adf0a5a7bd176c492ba6b1 \
+                    size    647704
 
 depends_build       port:pkgconfig \
                     port:gettext
@@ -30,18 +29,14 @@ depends_lib         port:gtk3 \
                     port:gnome-js-common \
                     port:libffi \
                     path:lib/pkgconfig/cairo.pc:cairo \
-                    port:mozjs52 \
+                    port:mozjs60 \
                     port:readline
 
 # Teach glibtool about -stdlib=libc++
 use_autoreconf      yes
 autoreconf.args     -fvi
 
-compiler.cxx_standard \
-                    2011
-# Blacklist needs to match mozjs52:
-# mozjs52 requires clang-3.6 or equivalent
-compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 602} macports-clang-3.3 macports-clang-3.4
+compiler.cxx_standard 2014
 
 # profiler currently only supported on Linux
 configure.args      --disable-profiler \


### PR DESCRIPTION
#### Description

This update:

* Upgrades gjs version from 1.52.5 to 1.54.3
* Bumps the mozjs dependency to mozjs60
* Removes the obsolete compiler blacklist

Originally this PR included PowerPC support requiring #12186, but that change is still WIP and may not require alterations to this Portfile so I will keep it separate.

Debian's 1.52 -> 1.54 migration notes can be found here:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=906016

The conclusion of that discussion was that the included mozjs52 -> mozjs60 transition does not require a soname bump, so the reverse dependents should not require a rebuild.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
