### PR TITLE
policykit: PowerPC support

### DIFF
--- a/security/policykit/Portfile
+++ b/security/policykit/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           gobject_introspection 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
 
 # pin version at 0.116 for now
@@ -59,10 +58,8 @@ post-patch {
     xinstall -m 755 ${filespath}/autogen.sh ${worksrcpath}
 }
 
-# use same blacklisting as mozjs60
 # mozjs60 requires C++14
 compiler.cxx_standard 2014
-compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 700}
 
 configure.env-append \
                     INTLTOOL_PERL=${prefix}/bin/perl5.28
@@ -81,6 +78,17 @@ configure.args      --with-authfw=pam \
                     --disable-test \
                     --enable-man-pages \
                     ac_cv_prog_AWK=/usr/bin/awk
+
+if { ${os.platform} eq "darwin" && [string match *gcc* ${configure.compiler}] && ${os.arch} eq "powerpc" } {
+    # mozjs60 needs one byte bools to compile itself, but then the exposed ABI
+    # is broken unless clients do the same when consuming the mozjs API. So we
+    # need one-byte bools when consuming the mozjs60 headers.
+    #
+    # Note that the policykit API does not expose any bools (only gboolean,
+    # which is four bytes everywhere), so we do not (yet) need to worry about
+    # cascading breakage here.
+    configure.cxxflags-append -mone-byte-bool
+}
 
 destroot.keepdirs   ${destroot}${prefix}/etc/polkit-1/localauthority \
                     ${destroot}${prefix}/var/lib/polkit-1


### PR DESCRIPTION
#### Description

Along with #12186 and #12192, this is the third musketeer of mozjs on PowerPC. The only functional change is to compile policykit with the same `bool` size that the updated `mozjs60` port will be expecting. Policykit doesn't expose any `bool`s to the outside world (good boy, *pat pat*), so this should be the end of the necessary changes.

To avoid a rev-bump, this PR triplet should be merged on the same day. Leaving as draft until the primary PR #12186 is tested and approved.

Also remove outdated blacklist logic since it's made redundant by `compiler.cxx_standard`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
