### PR TITLE
geocode-glib: Fix destroot stage on Tiger

### DIFF
--- a/gnome/geocode-glib/Portfile
+++ b/gnome/geocode-glib/Portfile
@@ -36,6 +36,12 @@ depends_lib         port:gettext \
                     port:json-glib \
                     port:libsoup
 
+# Work around lack of @rpath on Tiger, i.e. this error:
+# dyld: Library not loaded: @loader_path/libgeocode-glib.0.dylib
+platform darwin 8 {
+    destroot.env-append "DYLD_LIBRARY_PATH=geocode-glib"
+}
+
 if {![info exists universal_possible]} {
     set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
 }


### PR DESCRIPTION
#### Description

Similar to #12173, geocode-glib isn't happy when a binary is invoked after building but before installing on Tiger.

Perhaps this could be fixed in Meson, but this is an adequate workaround.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
