### PR TITLE
gtk-doc: Fix scanning on Tiger

### DIFF
--- a/gnome/gtk-doc/Portfile
+++ b/gnome/gtk-doc/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                gtk-doc
 version             1.32
-revision            1
+revision            2
 categories          gnome devel
 license             GPL-2+
 platforms           darwin freebsd linux
@@ -36,6 +36,10 @@ depends_lib         port:libxml2 \
                     port:docbook-xml \
                     port:docbook-xsl-nons \
                     port:itstool
+
+platform darwin 8 {
+    patchfiles-append gtkdoc-tiger.diff
+}
 
 variant pdf description {Build with PDF output support} {
     depends_lib-append \

--- a/gnome/gtk-doc/files/gtkdoc-tiger.diff
+++ b/gnome/gtk-doc/files/gtkdoc-tiger.diff
@@ -1,0 +1,15 @@
+Without this patch, projects on Tiger will have an error like this
+during the destroot stage:
+
+dyld: Library not loaded: @loader_path/libgeocode-glib.0.dylib
+
+--- gtkdoc/scangobj.py.orig	2021-09-11 13:08:06.000000000 -0400
++++ gtkdoc/scangobj.py	2021-09-11 13:09:52.000000000 -0400
+@@ -1307,6 +1307,7 @@
+         return res
+ 
+     run_env = os.environ.copy()
++    run_env['DYLD_LIBRARY_PATH'] = options.module
+     run_env['LC_MESSAGES'] = 'C'
+     run_env.pop('LC_ALL', None)
+     res = execute_command(options, 'Running',


### PR DESCRIPTION
#### Description

Supersedes #12201. Projects including `libgweather` and `geocode-glib` fail during the destroot stage on Tiger with the error:

```
dyld: Library not loaded: @loader_path/libgeocode-glib.0.dylib
```

Tiger lacks `@rpath` and so each project's dynamic library can't be found before installation has occurred. Work around the issue by supplying the dylib location in `DYLD_LIBRARY_PATH` during symbol scanning.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
