### PR TITLE
glib2-devel: Bump version to avoid problem with gnu89 standard flag

### DIFF
--- a/devel/glib2-devel/Portfile
+++ b/devel/glib2-devel/Portfile
@@ -10,11 +10,11 @@ PortGroup                   muniversal 1.0
 name                        glib2-devel
 conflicts                   glib2
 set my_name                 glib
-version                     2.62.6
+version                     2.68.4
 revision                    1
-checksums                   rmd160  24b9b58216a9d413b0bdb62f85c5b7d816cd133e \
-                            sha256  104fa26fbefae8024ff898330c671ec23ad075c1c0bce45c325c6d5657d58b9c \
-                            size    4703424
+checksums                   rmd160  cf4d834a0e8f5e77ba39d627290ac0263ba0f177 \
+                            sha256  62fd061d08a75492617e625a73e2c05e259f831acbb8e1f8b9c81f23f7993a3b \
+                            size    4945212
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  devel
@@ -35,23 +35,23 @@ long_description            Glib is a library which includes support routines \
 
 master_sites                gnome:sources/${my_name}/${branch}/
 
-patchfiles                  libintl.patch \
-                            implicit.patch \
-                            patch-gio-tests-meson.build.diff \
-                            patch-glib-gmain.c.diff \
-                            patch-glib_gunicollate.c.diff \
-                            patch-gio_xdgmime_xdgmime.c.diff \
-                            patch-gio_gdbusprivate.c.diff \
-                            patch-get-launchd-dbus-session-address.diff \
-                            patch-gmodule-gmodule-dl.c.diff \
-                            patch-meson_build-meson_options-appinfo.diff \
-                            patch-meson-build-python-path.diff \
-                            patch-meson_build-atomic-test-older-clang-versions.diff \
-                            universal.patch \
-                            patch-glib2-findfolders-before-SL.diff
-
-# this test fails (I believe wrongly) when configuring arm64 on Intel
-patchfiles-append           patch-glib2-allow-frexpl-test-to-pass.diff
+# patchfiles                  libintl.patch \
+#                             implicit.patch \
+#                             patch-gio-tests-meson.build.diff \
+#                             patch-glib-gmain.c.diff \
+#                             patch-glib_gunicollate.c.diff \
+#                             patch-gio_xdgmime_xdgmime.c.diff \
+#                             patch-gio_gdbusprivate.c.diff \
+#                             patch-get-launchd-dbus-session-address.diff \
+#                             patch-gmodule-gmodule-dl.c.diff \
+#                             patch-meson_build-meson_options-appinfo.diff \
+#                             patch-meson-build-python-path.diff \
+#                             patch-meson_build-atomic-test-older-clang-versions.diff \
+#                             universal.patch \
+#                             patch-glib2-findfolders-before-SL.diff
+# 
+# # this test fails (I believe wrongly) when configuring arm64 on Intel
+# patchfiles-append           patch-glib2-allow-frexpl-test-to-pass.diff
 
 depends_build-append        bin:xmllint:libxml2 \
                             port:pkgconfig


### PR DESCRIPTION
#### Description

Addresses this: https://trac.macports.org/ticket/63462

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
