### PR TITLE
gzip: Correctly bypass 2038 check

### DIFF
--- a/archivers/gzip/Portfile
+++ b/archivers/gzip/Portfile
@@ -33,8 +33,9 @@ configure.args      --disable-silent-rules \
                     DEFS=NO_ASM
 
 # Bypass year 2038 awareness code that causes the universal variant to fail.
+# https://trac.macports.org/ticket/55643
 configure.args-append \
-                    TIME_T_32_BIT_OK=yes
+                    --disable-year2038
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

After the recent update a +universal build fails, changing `TIME_T_32_BIT_OK` to `gl_cv_type_time_t_y2038` resolves the issue.

The relevant section from main.log before the proposed change.
```
:info:configure configure: error: in `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_archivers_gzip/gzip/work/gzip-1.11':
:info:configure configure: error: The 'time_t' type stops working after January 2038,
:info:configure                    and your system appears to support a wider 'time_t'.
:info:configure                    Try configuring with 'CC="/usr/bin/clang -m64"'.
:info:configure                    To build with a 32-bit time_t anyway (not recommended),
:info:configure                    configure with '--disable-year2038'.
:info:configure See `config.log' for more details
:info:configure Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_archivers_gzip/gzip/work/gzip-1.11" && ./configure --prefix=/opt/local --disable-dependency-tracking --disable-silent-rules DEFS=NO_ASM TIME_T_32_BIT_OK=yes 
:info:configure Exit code: 1
:error:configure Failed to configure gzip: consult /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_archivers_gzip/gzip/work/gzip-1.11/config.log
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
