### PR TITLE
meson: Fix dylib install paths for typelib files

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -57,6 +57,9 @@ patchfiles-append   patch-meson-32bit-apple.diff
 # https://github.com/mesonbuild/meson/pull/9211
 patchfiles-append   patch-meson-gcc-appleframeworks.diff
 
+# Compiled typelib files need their dylibs' full install path
+patchfiles-append   patch-meson-gnome.diff
+
 # disable warning not accepted by older clang versions
 # this manifests currently on systems up to 10.9
 # https://github.com/mesonbuild/meson/issues/8307
@@ -74,16 +77,18 @@ platform darwin 8 {
 
     github.setup        mesonbuild meson 0.57.2
     github.tarball_from releases
-    revision            0
+    revision            1
     checksums           rmd160  8cf66e2b6cd4214cf6166d67fd4820de1f7776fb \
                         sha256  3a83e7b1c5de94fa991ec34d9b198d94f38ed699d3524cb0fdf3b99fd23d4cc5 \
                         size    1853721
 
     patchfiles-delete   patch-meson-clang-unknown-optimization-error.diff \
                         patch-meson-objc-accept-gnu89.diff \
-                        patch-meson-32bit-apple.diff
+                        patch-meson-32bit-apple.diff \
+                        patch-meson-gnome.diff
     patchfiles-append   patch-meson57-tiger-no-rpath-fix.diff \
-                        patch-meson-32bit-apple-tiger.diff
+                        patch-meson-32bit-apple-tiger.diff \
+                        patch-meson57-gnome.diff
 }
 
 # add a search path for crossfiles in our prefix

--- a/devel/meson/files/patch-meson-gnome.diff
+++ b/devel/meson/files/patch-meson-gnome.diff
@@ -1,0 +1,34 @@
+Due to a presumed bug in MP's g-ir-scanner[1], generated typelib files often
+point to the dylib's relative build path. E.g. running
+
+    g-ir-inspect --print-shlibs Pango
+
+Will print something like
+
+    shlib: ./pango/libpango-1.0.0.dylib
+
+At run-time, the GObject Introspection infrastructure won't be able to find the
+libpango dylib, and panic ensues. This patch ensures that the full install
+paths are specified in the typelib file. You can ensure correct operation with
+the above command, which should print something like
+
+    shlib: /opt/local/lib/libpango-1.0.0.dylib
+
+[1] https://trac.macports.org/ticket/62391
+
+--- mesonbuild/modules/gnome.py.orig
++++ mesonbuild/modules/gnome.py
+@@ -816,6 +816,13 @@
+         for incdir in typelib_includes:
+             typelib_cmd += ["--includedir=" + incdir]
+ 
++        for target in girtargets:
++            if isinstance(target, build.SharedLibrary):
++                typelib_cmd += ["--shared-library=" +
++                        os.path.join(state.environment.get_prefix(),
++                                     state.environment.get_shared_lib_dir(),
++                                     target.filename)]
++
+         typelib_target = self._make_typelib_target(state, typelib_output, typelib_cmd, generated_files, kwargs)
+ 
+         self._devenv_append('GI_TYPELIB_PATH', os.path.join(state.environment.get_build_dir(), state.subdir))

--- a/devel/meson/files/patch-meson57-gnome.diff
+++ b/devel/meson/files/patch-meson57-gnome.diff
@@ -1,0 +1,16 @@
+--- mesonbuild/modules/gnome.py.orig
++++ mesonbuild/modules/gnome.py
+@@ -816,6 +816,13 @@
+         for incdir in typelib_includes:
+             typelib_cmd += ["--includedir=" + incdir]
+ 
++        for target in girtargets:
++            if isinstance(target, build.SharedLibrary):
++                typelib_cmd += ["--shared-library=" +
++                        os.path.join(state.environment.get_prefix(),
++                                     state.environment.get_shared_lib_dir(),
++                                     target.filename)]
++
+         typelib_target = self._make_typelib_target(state, typelib_output, typelib_cmd, kwargs)
+ 
+         rv = [scan_target, typelib_target]


### PR DESCRIPTION
#### Description

This is designed to work around the "zillion tickets" issue of typelib files having the wrong paths to dylibs, and GObject Introspection being broken for a large number of ports. A small sampling:

* https://trac.macports.org/ticket/62391
* https://trac.macports.org/ticket/61792
* https://trac.macports.org/ticket/61934

This patch ignores the presumed bug in `g-ir-scanner` and supplies the install path explicitly to `g-ir-compiler` in Meson projects. It ensures that for any Meson project that uses `gnome.generate_gir`, the Meson-supplied install location will be used in the final typelib file.

Note that this is intended as a workaround – the installed plain-text `gir` files will still have the incorrect location, as the underlying bug in `g-ir-scanner` will still need to be addressed. Still, using the explicit install location is likely a reliable approach, and this patch won't necessarily need to be reverted in the future.

A few ports that this fixes locally in my testing:

* libgweather
* geocode-glib
* appstream-glib
* pango-devel (👋 @mascguy)

If merged, these and any port that invokes Meson's [`gnome.generate_gir`](https://mesonbuild.com/Gnome-module.html#gnomegenerate_gir) function will need a revbump.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
