### PR TITLE
emacs{-app}-devel: workarround for an issue

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -99,11 +99,15 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     set date        2021-09-10
     epoch           4
     version         [string map {- {}} ${date}]
-    revision        0
+    revision        1
 
     fetch.type      git
     git.url         --shallow-since=${date}T00:00:00 https://github.com/emacs-mirror/emacs.git
     git.branch      192a384408cc846d8e66e91a67cd9ad4e7f0be24
+
+    # Fix for bug 50534
+    patchfiles-append \
+                    Fix-incorrectly-appearing-toolbar-on-NS-bug-50534.patch
 
     # --shallow-since needs a newer version of git than on some older systems
     # So use MacPorts version

--- a/editors/emacs/files/Fix-incorrectly-appearing-toolbar-on-NS-bug-50534.patch
+++ b/editors/emacs/files/Fix-incorrectly-appearing-toolbar-on-NS-bug-50534.patch
@@ -1,0 +1,29 @@
+diff --git src/nsmenu.m src/nsmenu.m
+index 3493e4e131..f0c5bb24e6 100644
+--- src/nsmenu.m
++++ src/nsmenu.m
+@@ -1094,7 +1094,7 @@ - (void)menu:(NSMenu *)menu willHighlightItem:(NSMenuItem *)item
+ #undef TOOLPROP
+     }
+ 
+-  if ([toolbar isVisible] != FRAME_EXTERNAL_TOOL_BAR (f))
++  if (![toolbar isVisible] != !FRAME_EXTERNAL_TOOL_BAR (f))
+     {
+       f->output_data.ns->in_animation = 1;
+       [toolbar setVisible: FRAME_EXTERNAL_TOOL_BAR (f)];
+diff --git src/nsterm.m src/nsterm.m
+index 8d88f7bd3d..7c90bbd578 100644
+--- src/nsterm.m
++++ src/nsterm.m
+@@ -8323,10 +8323,9 @@ - (void)createToolbar: (struct frame *)f
+   EmacsToolbar *toolbar = [[EmacsToolbar alloc]
+                             initForView:view
+                             withIdentifier:[NSString stringWithLispString:f->name]];
++  [toolbar setVisible:NO];
+   [self setToolbar:toolbar];
+ 
+-  update_frame_tool_bar (f);
+-
+ #ifdef NS_IMPL_COCOA
+   {
+     NSButton *toggleButton;


### PR DESCRIPTION
#### Description

This commit introduced a workaround for an issue https://debbugs.gnu.org/cgi/bugreport.cgi?bug=50534

This issue was introduced at the last update by https://github.com/macports/macports-ports/pull/12190

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->