### PR TITLE
scrcpy: update to 1.19

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           meson 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        Genymobile scrcpy 1.18 v
+github.setup        Genymobile scrcpy 1.19 v
 revision            0
 
 categories          multimedia
@@ -24,12 +24,12 @@ extract.only        ${distfiles}
 distfiles-append    ${name}-server-v${version}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6f93f6b2dfa50c5e1bcce43ec14d777bfb9574e3 \
-                    sha256  a857724aac428853e24c870a7fc3dad43ae1d4bf7c35c470eae3e00fb3db5c46 \
-                    size    299534 \
+                    rmd160  3749eb770bd0d19723f18ceb6c4633d90dc0de03 \
+                    sha256  72d6578eda2b191ecb5a020f03325b123b95aa0bfd0b1217dd3fd53b6840cd85 \
+                    size    314862 \
                     ${name}-server-v${version} \
-                    rmd160  a0a96d90f96f2c747204db2f7df087b5eb2ca91b \
-                    sha256  641c5c6beda9399dfae72d116f5ff43b5ed1059d871c9ebc3f47610fd33c51a3 \
+                    rmd160  d4e7aeb896b768aa52afec55886d348afe39e146 \
+                    sha256  876f9322182e6aac6a58db1334f4225855ef3a17eaebc80aab6601d9d1ecb867 \
                     size    37330
 
 depends_build-append \


### PR DESCRIPTION
#### Description

Changelog: https://github.com/Genymobile/scrcpy/releases/tag/v1.19

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
