### PR TITLE
notcurses: update to 2.4.1

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        dankamongmen notcurses 2.4.0 v
+github.setup        dankamongmen notcurses 2.4.1 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ long_description    Notcurses facilitates the creation of modern TUI programs, m
 
 homepage            https://notcurses.com
 
-checksums           rmd160  8efc3851757660fdb6cd3d840577fd5779ca52eb \
-                    sha256  9bc35bfaadfd51d45e3de6d3b5d6d484a3042773a10904cb1bf4c7562d834d77 \
-                    size    12149105
+checksums           rmd160  43c13b9e2d97963a7bb5930dbcdbe97ce01c2430 \
+                    sha256  982fc662f7239cff6713ce0f17f1db7c76a3de1644196438de6bb276bec65704 \
+                    size    12150755
 
 compiler.c_standard 2011
 compiler.cxx_standard \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.4
Xcode 11.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

```
--->  Computing dependencies for notcurses
--->  Fetching distfiles for notcurses
--->  Attempting to fetch notcurses-2.4.1.tar.gz from https://distfiles.macports.org/notcurses
--->  Attempting to fetch notcurses-2.4.1.tar.gz from https://ywg.ca.distfiles.macports.org/mirror/macports/distfiles/notcurses
--->  Attempting to fetch notcurses-2.4.1.tar.gz from http://ykf.ca.distfiles.macports.org/MacPorts/mpdistfiles/notcurses
--->  Attempting to fetch notcurses-2.4.1.tar.gz from https://github.com/dankamongmen/notcurses/archive/v2.4.1
--->  Verifying checksums for notcurses
--->  Extracting notcurses
--->  Configuring notcurses
--->  Building notcurses
--->  Testing notcurses
```