### PR TITLE
new port: micronucleus

### DIFF
--- a/cross/micronucleus/Portfile
+++ b/cross/micronucleus/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+
+github.setup        micronucleus micronucleus 2.5 v
+revision            0
+
+categories          cross
+platforms           darwin
+maintainers         {@mholling gmail.com:mdholling} openmaintainer
+description         Micronucleus is a bootloader designed for AVR ATtiny microcontrollers
+long_description    Micronucleus is a bootloader designed for AVR ATtiny microcontrollers \
+                    with a minimal usb interface, cross platform libusb-based program \
+                    upload tool, and a strong emphasis on bootloader compactness.
+license             GPL-2
+
+checksums           rmd160  199987dc2879ca197c62902cd7e430b578af0b8d \
+                    sha256  b233895d26d522672b6bf7e0604adf6231a0e6b35f442a5d2c5a4859a019f9bc \
+                    size    2213199
+
+depends_lib-append  port:libusb \
+                    port:libusb-compat
+
+worksrcdir          ${distname}/commandline
+use_configure       no
+build.target        micronucleus
+
+patch {
+    reinplace "s|/usr/local/opt/libusb-compat|${prefix}|g" ${worksrcpath}/Makefile
+    reinplace "s|/usr/local/opt/libusb|${prefix}|g" ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/micronucleus ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
#### Description

New port for micronucleus bootloader for AVR ATTiny microcontrollers, providing the command-line uploading tool.

###### Tested on

macOS 11.0
Xcode 12.3

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
