### PR TITLE
emacs-mac-app: install emacs-module.h file

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -74,7 +74,7 @@ subport ${name}-devel {
     set emacs_version   27.2
 
     version         20210530
-    revision        0
+    revision        1
 
     long_description \
         ${name} is "Mac port" addition to GNU Emacs ${emacs_version}. \
@@ -134,7 +134,12 @@ post-destroot {
 
     # rename the app bundle to avoid a conflict with emacs-app.
     move ${destroot}${applications_dir}/Emacs.app \
-         ${destroot}${applications_dir}/EmacsMac.app
+        ${destroot}${applications_dir}/EmacsMac.app
+
+    # install emacs-module.h header file
+    xinstall -m 0755 -d ${destroot}${prefix}/include/emacs-mac
+    xinstall -m 0644 ${worksrcpath}/src/emacs-module.h \
+                    ${destroot}${prefix}/include/emacs-mac
 }
 
 variant multitty description {Enable Multi-TTY support} {


### PR DESCRIPTION
#### Description

Since some emacs packages require `emacs-module.h` file, such as [emacs-rime](https://github.com/DogLooksGood/emacs-rime).
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
