### PR TITLE
blender: fix Xcode minimum version requirement for macOS 10.13

### DIFF
--- a/graphics/blender/Portfile
+++ b/graphics/blender/Portfile
@@ -114,7 +114,7 @@ post-patch {
     set platform_apple_xcode.cmake \
         ${worksrcpath}/build_files/cmake/platform/platform_apple_xcode.cmake
 
-    if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    if {${os.platform} eq "darwin" && ${os.major} <= 17} {
         reinplace -E {s/(MACOSX_DEPLOYMENT_TARGET) 10.13/\1 10.11/} \
             ${platform_apple.cmake}
         reinplace {/VERSION_LESS 10.0/,/FATAL_ERROR/s/10.0/8.2/g} \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/63427

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Blender's devs have (unnecessarily) restricted the minimum required version of Xcode to version 10.0. I had put in a patch that lowers this requirement, but don't have a macOS 10.13 machine so I wasn't aware that it hadn't been covered in my patch. This PR fixes it so that the minimum required Xcode is also reduced on 10.13.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
