### PR TITLE
asciidoctorj: New port

### DIFF
--- a/textproc/asciidoctorj/Portfile
+++ b/textproc/asciidoctorj/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           java 1.0
+
+name                asciidoctorj
+version             2.5.2
+revision            0
+
+categories          textproc java
+platforms           darwin
+license             Apache-2
+supported_archs     noarch
+maintainers         {outlook.de:judaew @judaew} openmaintainer
+
+description         \
+    AsciidoctorJ is the official library for running Asciidoctor on the JVM.
+long_description    {*}${description} Using AsciidoctorJ, you can convert \
+    AsciiDoc content or analyze the structure of a parsed AsciiDoc document \
+    from Java and other JVM languages.
+homepage            https://asciidoctor.org
+
+master_sites        https://repo1.maven.org/maven2/org/asciidoctor/asciidoctorj/${version}/
+distname            ${name}-${version}-bin
+worksrcdir          ${name}-${version}
+
+checksums           rmd160  ca537de047d7335b7475a6fb5392c3dda9c872c5 \
+                    sha256  889fd490a43e59e06c4f9d6692228e48ada2829acead7ea8c454a596c5cb2a96 \
+                    size    52364352
+
+java.version        1.8+
+java.fallback       openjdk11
+
+use_zip             yes
+use_configure       no
+build {}
+
+patchfiles          patch-prefix-for-app-libs.diff
+
+destroot {
+    delete ${worksrcpath}/bin/${name}.bat
+
+    reinplace "s,@@PREFIX@@,${prefix}/lib/${name},g" ${worksrcpath}/bin/${name}
+    xinstall -m 0755 ${worksrcpath}/bin/${name} ${destroot}${prefix}/bin
+
+    xinstall -m 0755 -d ${destroot}${prefix}/lib/asciidoctorj
+    xinstall -m 0644 {*}[glob ${worksrcpath}/lib/*.jar] \
+        ${destroot}${prefix}/lib/asciidoctorj
+}
+
+livecheck.type      regex
+livecheck.url       https://repo1.maven.org/maven2/org/asciidoctor/asciidoctorj/
+livecheck.regex     (\\d+(?:\\.\\d+)*)/

--- a/textproc/asciidoctorj/files/patch-prefix-for-app-libs.diff
+++ b/textproc/asciidoctorj/files/patch-prefix-for-app-libs.diff
@@ -1,0 +1,20 @@
+--- bin/asciidoctorj.orig	2021-08-08 12:44:00.000000000 +0300
++++ bin/asciidoctorj	2021-09-14 01:59:51.000000000 +0300
+@@ -21,7 +21,7 @@
+ done
+ SAVED="`pwd`"
+ cd "`dirname \"$PRG\"`/.." >/dev/null
+-APP_HOME="`pwd -P`"
++APP_HOME="@@PREFIX@@"
+ cd "$SAVED" >/dev/null
+ 
+ APP_NAME="asciidoctorj"
+@@ -64,7 +64,7 @@
+     ;;
+ esac
+ 
+-CLASSPATH=$APP_HOME/lib/asciidoctorj-2.5.2-bin.jar:$APP_HOME/lib/asciidoctorj-2.5.2.jar:$APP_HOME/lib/asciidoctorj-api-2.5.2.jar:$APP_HOME/lib/asciidoctorj-epub3-1.5.1.jar:$APP_HOME/lib/asciidoctorj-diagram-2.1.2.jar:$APP_HOME/lib/asciidoctorj-pdf-1.6.0.jar:$APP_HOME/lib/asciidoctorj-revealjs-4.1.0.jar:$APP_HOME/lib/jruby-complete-9.2.17.0.jar:$APP_HOME/lib/jcommander-1.72.jar
++CLASSPATH=$APP_HOME/asciidoctorj-2.5.2-bin.jar:$APP_HOME/asciidoctorj-2.5.2.jar:$APP_HOME/asciidoctorj-api-2.5.2.jar:$APP_HOME/asciidoctorj-epub3-1.5.1.jar:$APP_HOME/asciidoctorj-diagram-2.1.2.jar:$APP_HOME/asciidoctorj-pdf-1.6.0.jar:$APP_HOME/asciidoctorj-revealjs-4.1.0.jar:$APP_HOME/jruby-complete-9.2.17.0.jar:$APP_HOME/jcommander-1.72.jar
+ 
+ # Determine the Java command to use to start the JVM.
+ if [ -n "$JAVA_HOME" ] ; then


### PR DESCRIPTION
#### Description

`asciidoctorj` is official library for running Asciidoctor on the JVM. AsciidoctorJ can connvert AsciiDoc content or analyze the structure of a parsed AsciiDoc document from Java nad other JVM languages.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
