### PR TITLE
osmosis: new port

### DIFF
--- a/java/osmosis/Portfile
+++ b/java/osmosis/Portfile
@@ -1,0 +1,109 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           java 1.0
+PortGroup           github 1.0
+
+github.setup        openstreetmap osmosis 0.48.3
+github.tarball_from archive
+revision            0
+
+categories          java gis
+platforms           darwin
+supported_archs     noarch
+maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
+
+license             public-domain LGPL-3+ ODbL Permissive
+
+description         A command line Java application for processing OSM data
+
+long_description    The tool consists of a series of pluggable \
+                    components that can be chained together to perform \
+                    a larger operation. For example, it has components \
+                    for reading from database and from file, \
+                    components for writing to database and to file, \
+                    components for deriving and applying change sets \
+                    to data sources, components for sorting data, \
+                    etc. It has been written so that it is easy to add \
+                    new features without re-writing common tasks such \
+                    as file or database handling.
+
+checksums           rmd160  a1920323b49aaabe15357630191aa364cc2fb9b2 \
+                    sha256  3bf84e32ed4ff9525b1901b71ac4ddf63fc60892ce522ca1926a82eeafc107cc \
+                    size    638032
+
+set confdir         ${prefix}/etc/${name}
+set appdir          ${prefix}/share/${name}
+set docdir          ${prefix}/share/doc/${name}
+
+java.version        1.8*
+java.fallback       openjdk11
+
+depends_build       port:gradle
+
+use_configure       no
+
+build.env-append    GRADLE_USER_HOME=${worksrcpath}/.gradle
+build.cmd           ${worksrcpath}/gradlew
+build.target        assemble
+
+test.run            yes
+test.env-append     GRADLE_USER_HOME=${worksrcpath}/.gradle
+test.cmd            ${worksrcpath}/gradlew
+test.target         build
+
+patchfiles          package-bin-osmosis.diff \
+                    build-gradle.diff
+
+post-patch {
+    reinplace "s|/etc/osmosis|${confdir}/${name}.conf|g" \
+        ${worksrcpath}/package/bin/osmosis
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/package/bin/osmosis
+    reinplace "s|@VERSION@|${version}|g" \
+        ${worksrcpath}/build.gradle
+    reinplace "s|/usr/share|${prefix}/share|g" \
+        ${worksrcpath}/package/script/munin/README
+    reinplace "s|/etc|${prefix}/etc|g" \
+        ${worksrcpath}/package/script/munin/README
+    reinplace "s|#user osm|#user nobody|g" \
+        ${worksrcpath}/package/script/munin/osm_replication.conf
+    reinplace "s|#env.osmosis /opt/osmosis/bin|env.osmosis ${appdir}/bin|g" \
+        ${worksrcpath}/package/script/munin/osm_replication.conf
+    reinplace "s|#env.workingDirectory /path/to/state.txt|#env.workingDirectory ${prefix}/var/lib/mod_tile/.osmosis/state.txt|g" \
+        ${worksrcpath}/package/script/munin/osm_replication.conf
+}
+
+pre-test {
+    # Tests that fail, which are effectively integration tests
+    # requiring databases that have been created and configured for
+    # testing.
+    file delete -force ${worksrcpath}/osmosis-apidb/src/test
+    file delete -force ${worksrcpath}/osmosis-extract/src/test
+    file delete -force ${worksrcpath}/osmosis-pgsimple/src/test
+    file delete -force ${worksrcpath}/osmosis-pgsnapshot/src/test
+}
+
+destroot {
+    xinstall -m 0755 -d ${destroot}/${appdir}
+    xinstall -m 0755 -d ${destroot}/${confdir}
+    xinstall -m 0755 -d ${destroot}/${docdir}
+    file copy ${worksrcpath}/README.md \
+        ${destroot}${docdir}
+    foreach d [glob -nocomplain ${worksrcpath}/package/*] {
+        file copy ${d} ${destroot}${appdir}
+    }
+}
+
+post-destroot {
+    file rename \
+        {*}[glob ${destroot}${appdir}/*.txt] \
+        ${destroot}${docdir}
+    file delete ${destroot}${appdir}/build.gradle \
+        ${destroot}${appdir}/bin/osmosis-extract-apidb-0.6 \
+        ${destroot}${appdir}/bin/osmosis-extract-mysql-0.6 \
+        ${destroot}${appdir}/bin/osmosis.bat
+    file delete -force ${destroot}${appdir}/build
+    ln -s ${appdir}/bin/${name} ${destroot}${prefix}/bin/${name}
+    destroot.keepdirs ${destroot}${confdir}
+}

--- a/java/osmosis/files/build-gradle.diff
+++ b/java/osmosis/files/build-gradle.diff
@@ -1,0 +1,11 @@
+--- build.gradle.orig	2021-08-18 12:52:48.000000000 +0100
++++ build.gradle	2021-08-18 12:54:57.000000000 +0100
+@@ -28,7 +28,7 @@
+ 
+ 	// Load the project version dynamically from Git.  For release builds, don't add a suffix.
+ 	def versionSuffix = "RELEASE".equals(osmosisBuildType) ? '' : '-' + osmosisBuildType
+-	version = 'git describe --always --dirty'.execute().in.text.trim() + versionSuffix
++	version = '@VERSION@'
+ 
+ 	// Enable access to artefact dependency repositories.
+ 	repositories {

--- a/java/osmosis/files/package-bin-osmosis.diff
+++ b/java/osmosis/files/package-bin-osmosis.diff
@@ -1,0 +1,14 @@
+--- package/bin/osmosis.orig	2021-08-27 15:57:04.000000000 +0100
++++ package/bin/osmosis	2021-08-27 15:58:59.000000000 +0100
+@@ -80,10 +80,7 @@
+ fi
+ 
+ # make it fully qualified
+-saveddir=`pwd`
+-MYAPP_HOME=`dirname "$PRG"`/..
+-MYAPP_HOME=`cd "$MYAPP_HOME" && pwd`
+-cd "$saveddir"
++MYAPP_HOME="@PREFIX@/share/osmosis"
+ 
+ # Build up the classpath of required jar files via classworlds launcher.
+ MYAPP_CLASSPATH=$MYAPP_HOME/lib/default/plexus-classworlds-*.jar


### PR DESCRIPTION
#### Description

This is a dependency of a new Portfile I will be submitting for an OpenStreetMap tile server.

https://lists.macports.org/pipermail/macports-dev/2021-August/043683.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.6 20G165 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
