### PR TITLE
trim_osc: new port

### DIFF
--- a/python/trim_osc/Portfile
+++ b/python/trim_osc/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           active_variants 1.1
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        Zverik regional 7d473e463e1570bdd3b846c3d2539092c63bd98a
+version             20210417
+revision            0
+github.tarball_from archive
+
+name                trim_osc
+
+platforms           darwin
+maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
+
+license             WTFPL
+
+description         Scripts for regional OSM extracts support
+
+long_description    It is hard to maintain OSM tile service with a small \
+                    server: you can't have a properly updated regional \
+                    extract or even run osm2pgsql on low memory. This \
+                    package constains some scripts that help.
+
+python.default_version  39
+
+depends_lib-append  port:py${python.version}-lxml \
+                    port:py${python.version}-psycopg2 \
+                    port:py${python.version}-shapely
+
+checksums           rmd160  6e387ad3d613b3848778dd92df60d3c6296ac1b3 \
+                    sha256  c0eee61c14ef462d85e779bb108dedcb2054cf5ee453b2ec6a61039c0eabc648 \
+                    size    7041
+
+variant postgresql12 conflicts postgresql13 description {Use with PostgreSQL 12} {
+    require_active_variants py${python.version}-psycopg2 postgresql12
+    depends_lib-append port:postgresql12
+}
+
+variant postgresql13 conflicts postgresql12 description {Use with PostgreSQL 13} {
+    require_active_variants py${python.version}-psycopg2 postgresql13
+    depends_lib-append port:postgresql13
+}
+
+post-patch {
+    reinplace "s#/usr/bin/python3#${python.bin}#g" \
+        ${worksrcpath}/trim_osc.py
+}
+
+build {}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/share/${name}
+    xinstall -m 0755 \
+        {*}[glob ${worksrcpath}/*.py] \
+        ${destroot}${prefix}/share/${name}
+}


### PR DESCRIPTION
#### Description

This is a dependency of a new Portfile I will be submitting for an OpenStreetMap tile server.

https://lists.macports.org/pipermail/macports-dev/2021-August/043683.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.6 20G165 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
