### PR TITLE
google-cloud-sdk: update to 357.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             356.0.0
+version             357.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  0a25cd37e54c67709dcaf7f9ca52045d06684a05 \
-                    sha256  5ef09ff44bbaadb8f5c9bc705ba2e320bad87b860dc7e9a92437fbdbb80ad61b \
-                    size    91805585
+    checksums       rmd160  0311edbd4d1a44a7fab838fff77b5863a1bb8808 \
+                    sha256  d946dfbc0bcebbe428d47673fa01a382bac453aa304a1b76c72a440737c09cf2 \
+                    size    91915763
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d8e680e1f3f57eb03abf15b7344fbb097bb19fcd \
-                    sha256  98f9353538cca55fe43f4bc2d75237f827bca986661c0d8d46fc34852492b940 \
-                    size    88057258
+    checksums       rmd160  33e4cafc646ce093d9b6459e594e0a7d38bbeef0 \
+                    sha256  6dfef80cf74b058edb1561e4a1aaed29af5b0dbbc2d1f4afe7f96a5fca7e6da4 \
+                    size    88165594
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  8d8f070d2a61cdf71f8699255c3d5fe364b39566 \
-                    sha256  9372bf69982f40aeb0ca91cc47a579e56f04381471ef32bd72c5936205ddf13b \
-                    size    87970570
+    checksums       rmd160  2e7da77716d2895a035fcd1f53931cdc0a4d8bc7 \
+                    sha256  af77b1bcc3476a1ed173b90dcc918a47cbc9eead3d8efdab6ff99dc8ae79b11e \
+                    size    88088863
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 357.0.0.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?