### PR TITLE
libzzip: update to 0.13.72

### DIFF
--- a/archivers/libzzip/Portfile
+++ b/archivers/libzzip/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake  1.1
 PortGroup           github 1.0
 
-github.setup        gdraheim zziplib 0.13.69 v
+github.setup        gdraheim zziplib 0.13.72 v
 name                libzzip
-version             0.13.71
 categories          archivers devel
 platforms           darwin
 license             LGPL
@@ -18,28 +18,40 @@ long_description    The ZZIPlib provides read access on ZIP-archives. The \
                     access files being either real files or zipped files, \
                     both with the same filepath.
 
-checksums           rmd160  d401fc327138d5b997c0cd318f808f95cea1f937 \
-                    sha256  c5cf1c11a6019862e5b6daea4d7c72124affe687b9637effc7ad3caf2b7b1d96 \
-                    size    1132209
+checksums           rmd160  20b12141e49c6332d8fd8b610d1fa4a868d9072b \
+                    sha256  61a14917400dbef5eafb482ddc862f3edad86c888a73f445f82e1ab856d24b46 \
+                    size    1162325
 
-depends_build       port:pkgconfig \
-                    port:python27
+set python.branch   3.9
+set python.version  [join [split ${python.branch} "."] ""]
 
-depends_lib         port:zlib
+depends_build-append \
+                    port:pkgconfig \
+                    port:python${python.version}
 
-set docdir ${prefix}/share/doc/${name}
+depends_lib-append  port:zlib
 
-configure.python    ${prefix}/bin/python2.7
-configure.env       ac_cv_path_PAX=:
+depends_test-append port:unzip \
+                    port:zip
 
-post-configure {
-    set builddir [glob -dir ${worksrcpath} "*apple-darwin*"]
-    reinplace -E {s|-arch [a-z0-9_]+||g} \
-        ${builddir}/zzip/zziplib-uninstalled.pc \
-        ${builddir}/zzip/zziplib.pc
-}
+patch.pre_args      -p1
+patchfiles          fixed-tests.patch \
+                    fixed-macports-zip-unzip.patch
+
+# this build links its own library, so => Disable RPATH
+# See: https://github.com/gdraheim/zziplib/issues/121
+cmake.install_rpath
+configure.pre_args-delete \
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+    -DCMAKE_INSTALL_RPATH="[join [option cmake.install_rpath] \;]"
+
+configure.args-append \
+                    -DPYTHON_EXECUTABLE=${prefix}/bin/python${python.branch} \
+                    -DZZIPSDL=OFF
 
 post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+
     xinstall -d ${destroot}${docdir}/html
 
     xinstall -m 0644 -W ${worksrcpath} COPYING.LIB ChangeLog README TODO \
@@ -66,7 +78,7 @@ post-destroot {
 variant sdl description {Enable SDL support} {
     depends_lib-append      port:libsdl
 
-    configure.args-append   --enable-sdl
+    configure.args-replace  -DZZIPSDL=OFF -DZZIPSDL=ON
 
     post-destroot {
         xinstall -m 0644 ${worksrcpath}/docs/README.SDL ${destroot}${docdir}

--- a/archivers/libzzip/files/fixed-macports-zip-unzip.patch
+++ b/archivers/libzzip/files/fixed-macports-zip-unzip.patch
@@ -1,0 +1,110 @@
+commit 40a99a0af9c78aaf6d673dcd2086db0bd7f5f439
+Author: Kirill A. Korinsky <kirill@korins.ky>
+Date:   Mon Sep 20 20:22:38 2021 +0200
+
+    support of MacPorts' zip and unzip
+    
+    MacPorts ships different version of `unzip` and `zip`. This small
+    pull request adjusts tests to supporting them.
+    
+    Closes https://github.com/gdraheim/zziplib/issues/123
+
+diff --git a/test/zziptests.py b/test/zziptests.py
+index f315dc7..bfd406c 100644
+--- a/test/zziptests.py
++++ b/test/zziptests.py
+@@ -1848,10 +1848,10 @@ class ZZipTest(unittest.TestCase):
+     self.assertLess(len(errors(run.errors)), 430)
+     #
+     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
+-        returncodes = [2])
++        returncodes = [2,12])
+     self.assertLess(len(run.output), 90)
+     self.assertLess(len(errors(run.errors)), 900)
+-    self.assertIn('file #1:  bad zipfile offset (local header sig):  127', run.errors)
++    self.assertTrue(any(x in run.errors for x in ('file #1:  bad zipfile offset (local header sig):  127', 'error: invalid zip file with overlapped components (possible zip bomb)')))
+     #self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
+     self.assertFalse(os.path.exists(tmpdir+"/test"))
+     self.rm_testdir()
+@@ -2092,10 +2092,10 @@ class ZZipTest(unittest.TestCase):
+     self.assertLess(len(errors(run.errors)), 500)
+     #
+     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
+-        returncodes = [3])
++        returncodes = [3,12])
+     self.assertLess(len(run.output), 90)
+     self.assertLess(len(errors(run.errors)), 900)
+-    self.assertIn('file #1:  bad zipfile offset (lseek)', run.errors)
++    self.assertTrue(any(x in run.errors for x in ('file #1:  bad zipfile offset (lseek)', 'invalid zip file with overlapped components (possible zip bomb)')))
+     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
+     self.assertFalse(os.path.exists(tmpdir+"/test"))
+     self.rm_testdir()
+@@ -3189,11 +3189,11 @@ class ZZipTest(unittest.TestCase):
+     self.assertLess(len(errors(run.errors)), 800)
+     #
+     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
+-        returncodes = [3])
++        returncodes = [3,12])
+     self.assertLess(len(run.output), 200)
+     self.assertLess(len(errors(run.errors)), 800)
+     self.assertIn("missing 18 bytes in zipfile", run.errors)
+-    self.assertIn('expected central file header signature not found', run.errors)
++    self.assertTrue(any(x in run.errors for x in ('expected central file header signature not found', 'invalid zip file with overlapped components (possible zip bomb)')))
+     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
+     self.assertFalse(os.path.exists(tmpdir+"/test"))
+     self.rm_testdir()
+@@ -3232,13 +3232,13 @@ class ZZipTest(unittest.TestCase):
+     self.assertLess(len(errors(run.errors)), 800)
+     #
+     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
+-        returncodes = [3])
++        returncodes = [3,12])
+     self.assertGreater(len(run.output), 30)
+     self.assertGreater(len(errors(run.errors)), 1)
+     self.assertLess(len(run.output), 400)
+     self.assertLess(len(errors(run.errors)), 800)
+     self.assertIn("missing 18 bytes in zipfile", run.errors)
+-    self.assertIn('expected central file header signature not found', run.errors)
++    self.assertTrue(any(x in run.errors for x in ('expected central file header signature not found', 'invalid zip file with overlapped components (possible zip bomb)')))
+     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
+     self.assertFalse(os.path.exists(tmpdir+"/test"))
+     self.rm_testdir()
+@@ -3456,11 +3456,11 @@ class ZZipTest(unittest.TestCase):
+     self.assertLess(len(errors(run.errors)), 800)
+     #
+     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
+-        returncodes = [3])
++        returncodes = [3,12])
+     self.assertLess(len(run.output), 400)
+     self.assertLess(len(errors(run.errors)), 800)
+     self.assertIn("missing 5123 bytes in zipfile", run.errors)
+-    self.assertIn("expected central file header signature not found", run.errors)
++    self.assertTrue(any(x in run.errors for x in ('expected central file header signature not found', 'invalid zip file with overlapped components (possible zip bomb)')))
+     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
+     self.assertFalse(os.path.exists(tmpdir+"/test"))
+     self.rm_testdir()
+@@ -3583,13 +3583,13 @@ class ZZipTest(unittest.TestCase):
+     self.assertLess(len(errors(run.errors)), 800)
+     #
+     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
+-        returncodes = [3])
++        returncodes = [3,12])
+     self.assertGreater(len(run.output), 20)
+     self.assertGreater(len(errors(run.errors)), 1)
+     self.assertLess(len(run.output), 2500)
+     self.assertLess(len(errors(run.errors)), 800)
+     self.assertIn("missing 21 bytes in zipfile", run.errors)
+-    self.assertIn('expected central file header signature not found', run.errors)
++    self.assertTrue(any(x in run.errors for x in ('expected central file header signature not found', 'invalid zip file with overlapped components (possible zip bomb)')))
+     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
+     self.assertFalse(os.path.exists(tmpdir+"/test"))
+     self.rm_testdir()
+@@ -3792,7 +3792,7 @@ class ZZipTest(unittest.TestCase):
+     self.assertTrue(greps(run.errors, "missing 6 bytes in zipfile"))
+     #
+     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
+-        returncodes = [3])
++        returncodes = [3,12])
+     self.rm_testdir()
+   def test_65671(self):
+     """ unzzip-big -l $(CVE).zip  """

--- a/archivers/libzzip/files/fixed-tests.patch
+++ b/archivers/libzzip/files/fixed-tests.patch
@@ -1,0 +1,39 @@
+commit 732d0000306d3e7efb589c684e5b3be88425ec93
+Author: Kirill A. Korinsky <kirill@korins.ky>
+Date:   Mon Sep 20 18:27:40 2021 +0200
+
+    Fixed tests on macOS
+    
+    It fixes https://github.com/gdraheim/zziplib/issues/120 by adding `123`
+    exit code which is macOS's way to return `-8`.
+    
+    It also fixed minor differences in output.
+
+diff --git a/test/zziptests.py b/test/zziptests.py
+index f315dc7..10dc6d9 100644
+--- a/test/zziptests.py
++++ b/test/zziptests.py
+@@ -3662,7 +3662,7 @@ class ZZipTest(unittest.TestCase):
+     self.assertFalse(run.returncode)
+     # list the ZIPfile
+     exe=self.bins("unzip-mem");
+-    run = shell("{chdir} {tmpdir} && ../{exe} -v {zipname}.zip".format(**locals()), returncodes = [0,-8])
++    run = shell("{chdir} {tmpdir} && ../{exe} -v {zipname}.zip".format(**locals()), returncodes = [0,-8,136])
+     logg.error("FIXME: unzip-mem test_65485 is not solved")
+     self.skipTest("FIXME: not solved")
+     self.assertFalse(run.returncode)
+@@ -3841,12 +3841,12 @@ class ZZipTest(unittest.TestCase):
+     exe = self.bins("unzzip-mix")
+     run = shell("{exe} -l {tmpdir}/{filename} ".format(**locals()),
+         returncodes = [2])
+-    self.assertTrue(greps(run.errors, "Invalid or incomplete"))
++    self.assertTrue(greps(run.errors, "Invalid or incomplete") or greps(run.errors, "Illegal byte sequence"))
+     #
+     run = shell("cd {tmpdir} && ../{exe} {filename} ".format(**locals()),
+         returncodes = [2])
+     # self.assertLess(len(run.output), 30)
+-    self.assertTrue(greps(run.errors, "Invalid or incomplete"))
++    self.assertTrue(greps(run.errors, "Invalid or incomplete") or greps(run.errors, "Illegal byte sequence"))
+     self.rm_testdir()
+   def test_65674(self):
+     """ unzzip-zap -l $(CVE).zip  """

--- a/audio/mpd/Portfile
+++ b/audio/mpd/Portfile
@@ -9,7 +9,7 @@ PortGroup           boost 1.0
 name                mpd
 
 version             0.22.9
-revision            0
+revision            1
 checksums           rmd160  603af5318b4814003f97f4e5b8bce05bb007d6d3 \
                     sha256  f937403297c2240bd4a569f4b937ee7ab17398a5284ba9df4d6d4c3a0512bc64 \
                     size    738432

--- a/lua/lua-luazip/Portfile
+++ b/lua/lua-luazip/Portfile
@@ -5,7 +5,7 @@ PortGroup           luarocks 1.0
 
 luarocks.branches   5.1 5.2 5.3
 luarocks.setup      luazip 1.2.7-1
-revision            0
+revision            1
 license             MIT
 categories          lua archivers
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -15,6 +15,7 @@ PortGroup       muniversal 1.0
 
 name            texlive-bin
 version         2021.58693
+revision        1
 
 categories      tex
 maintainers     {dports @drkp}

--- a/textproc/cmconvert/Portfile
+++ b/textproc/cmconvert/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        catap cmconvert v1.9.6
-revision            0
+revision            1
 categories          textproc
 platforms           darwin
 license             GPL-2+


### PR DESCRIPTION
#### Description

This pull request really updated libzzip to the last version.

It also switched to using `cmake` build which allow to overstep an issue with caching `Cflags` and `Libs` from build and injects it to anyone who used it.

Just try to install `libzzip` before this PR and run:

```sh
cat /opt/local/lib/pkgconfig/zzip*
```

If your sdk haven't match with cached one and application used this lib, it injects two `-isysroot` which creates quite an issue.

Good example of such case is: https://github.com/macports/macports-ports/pull/12222

This pull request depends on:
 - https://github.com/macports/macports-ports/pull/12241
 - https://github.com/macports/macports-ports/pull/12270
 - https://github.com/macports/macports-ports/pull/12281
 - https://github.com/macports/macports-ports/pull/12320

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->