### PR TITLE
exa: Fix build for arm64, add doc for macOS 10.12

### DIFF
--- a/sysutils/exa/Portfile
+++ b/sysutils/exa/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        ogham exa 0.10.1 v
-revision            0
+revision            1
 categories          sysutils
 platforms           darwin
 maintainers         {catlett.info:chad @chadcatlett} \
@@ -40,20 +40,32 @@ build.pre_args-replace   --frozen --offline
 variant git description {Build with git functionality} {}
 
 variant doc description {Build man pages} {
-    depends_build-append port:pandoc
-    post-build {
-        system -W ${worksrcpath} "${prefix}/bin/pandoc --standalone -f markdown -t man man/exa.1.md > man/exa.1"
-        system -W ${worksrcpath} "${prefix}/bin/pandoc --standalone -f markdown -t man man/exa_colors.5.md > man/exa_colors.5"
+    if {${os.platform} eq "darwin" && ${os.major} < 17 || \
+    ${configure.build_arch} eq "arm64"} {
+        depends_build-append port:go-md2man
+        post-build {
+            system -W ${worksrcpath}/man "${prefix}/bin/go-md2man \
+                -in=${name}.1.md -out=${name}.1"
+            system -W ${worksrcpath}/man "${prefix}/bin/go-md2man \
+                -in=${name}_colors.5.md -out=${name}_colors.5"
+        }
+        notes "
+            The man pages for macOS 10.12 and below or Apple Silicon have \
+            minor formatting errors as they were built with go-md2man instead \
+            of pandoc.
+        "
+    } else {
+        depends_build-append port:pandoc
+        post-build {
+            system -W ${worksrcpath}/man "${prefix}/bin/pandoc --standalone \
+                -f markdown -t man exa.1.md > exa.1"
+            system -W ${worksrcpath}/man "${prefix}/bin/pandoc --standalone \
+                -f markdown -t man exa_colors.5.md > exa_colors.5"
+        }
     }
 }
 
-# pandoc / stack fails to build on macOS 10.12 and older
-# see: https://trac.macports.org/ticket/60477
-if {${os.platform} eq "darwin" && ${os.major} < 17} {
-    default_variants +git
-} else {
-    default_variants +git +doc
-}
+default_variants +git +doc
 
 if {![variant_isset git]} {
     build.args          --no-default-features

--- a/sysutils/exa/Portfile
+++ b/sysutils/exa/Portfile
@@ -50,8 +50,8 @@ variant doc description {Build man pages} {
                 -in=${name}_colors.5.md -out=${name}_colors.5"
         }
         notes "
-            The man pages for macOS 10.12 and below or Apple Silicon have \
-            minor formatting errors as they were built with go-md2man instead \
+            The man pages for macOS 10.12 and below or Apple Silicon have\
+            minor formatting errors as they were built with go-md2man instead\
             of pandoc.
         "
     } else {


### PR DESCRIPTION
Changes:
* Replace `pandoc` by `go-md2man`. `pandoc` cannot be build because it dependency stack only support the arch x86_64. It's maybe fix build for arm64.
* Man-pages now be available on macOS 10.12 and below.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
