### PR TITLE
wireguard-tools: update to 1.0.20210914

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20210424
+version             1.0.20210914
 revision            0
-checksums           rmd160  b624edd5f96e7e004cee91e9278b5f38d5ffc3a2 \
-                    sha256  b288b0c43871d919629d7e77846ef0b47f8eeaa9ebc9cedeee8233fc6cc376ad \
-                    size    96816
+checksums           rmd160  a989471297b6713c59dc3e850aee59fef9e4cd2a \
+                    sha256  97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac \
+                    size    99744
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
