### PR TITLE
hugo: update to 0.88.1

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.87.0 v
+go.setup            github.com/gohugoio/hugo 0.88.1 v
 revision            0
-checksums           rmd160  e600a79037ed7dce38c1603d3b5b9cbe836d17a4 \
-                    sha256  09d3bbc0f09c203c3172c255c5c252ff5a79e5152f75ac940d4edf0959f841c9 \
-                    size    37008949
+checksums           rmd160  4f9d17de222f7a77cf55a094f84846898134b7dc \
+                    sha256  c12fc18a0ed092c56981e261a352b106a90abae029a5d060cd0f4aa6427594da \
+                    size    37010247
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.88.1

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
