### PR TITLE
fsdb: update to 2.73-2

### DIFF
--- a/perl/fsdb/Portfile
+++ b/perl/fsdb/Portfile
@@ -11,11 +11,11 @@ perl5.default_branch    5.28
 perl5.create_variants   ${perl5.branches}
 
 name                fsdb
-perl5.setup         Fsdb 2.71 ../../authors/id/J/JO/JOHNH
+perl5.setup         Fsdb 2.73-2 ../../authors/id/J/JO/JOHNH
 revision            0
-checksums           rmd160  a0ffb2c177788fb86fa0f7f080c91d211ad9be42 \
-                    sha256  135d22cc65efa395d4ddbfbc7e087e04dd011a73353970ea61cfe8cee3a69098 \
-                    size    498482
+checksums           rmd160  4cc26129a8bff4ded9da667fe9e33c272e449a12 \
+                    sha256  22c7d269d1804bfe562b2e373328cba37721b27d3c5a903a751ef0a70c07e9dc \
+                    size    501746
 
 categories-append   textproc
 
@@ -51,7 +51,7 @@ select.file         ${filespath}/fsdb-${perl5.major}
 notes               "
 To make the Perl ${perl5.major} version of fsdb the one that is run\
 when you execute the commands without a version suffix, e.g.\
-'dbcolselect', run:
+'dbcol', run:
 
 port select --set ${select.group} [file tail ${select.file}]
 "


### PR DESCRIPTION
#### Description
fsdb: update to 2.73-2
* update example command in notes from "dbcolselect", which doesn't exist, to "dbcol"

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?