### PR TITLE
libdazzle: Support for 10.4, 10.5, and PowerPC

### DIFF
--- a/gnome/libdazzle/Portfile
+++ b/gnome/libdazzle/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           meson 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
+
+# posix_memalign
+legacysupport.newest_darwin_requires_legacy 9
 
 name                libdazzle
 version             3.38.0
@@ -47,6 +51,18 @@ if {${universal_possible} && [variant_isset universal]} {
 } else {
     build.env-append       "CC=${configure.cc} ${configure.cc_archflags}"
     destroot.env-append    "CC=${configure.cc} ${configure.cc_archflags}"
+}
+
+# PowerPC support
+if {[string match *gcc* ${configure.compiler}] && ${os.arch} eq "powerpc" } {
+    # https://trac.macports.org/ticket/63490
+    patchfiles-append patch-libdazzle-gcc-powerpc-packed.diff
+
+    # Work around some fstack-protector-strong link errors. We could patch
+    # locally, but the same error affects the g-ir-scanner invocation, so it
+    # won't do any good until gnome.generate_gir is fixed in meson.
+    # See: https://gitlab.gnome.org/GNOME/libdazzle/-/merge_requests/56
+    configure.args-append --buildtype=plain
 }
 
 livecheck.type      gnome

--- a/gnome/libdazzle/files/patch-libdazzle-gcc-powerpc-packed.diff
+++ b/gnome/libdazzle/files/patch-libdazzle-gcc-powerpc-packed.diff
@@ -1,0 +1,23 @@
+For some reason with GCC7 compiling on PPC, the "pack" pragmas still add
+alignment padding at the end of the struct. This is not true of gcc-apple-4.2
+and earlier, nor is it true of __attribute__((packed)).
+
+See: https://trac.macports.org/ticket/63490
+
+--- src/search/dzl-fuzzy-mutable-index.c.orig
++++ src/search/dzl-fuzzy-mutable-index.c
+@@ -59,13 +59,11 @@
+   guint           case_sensitive : 1;
+ };
+ 
+-#pragma pack(push, 1)
+-typedef struct
++typedef struct __attribute__((packed))
+ {
+   guint64 id : 32;
+   guint64 pos : 16;
+ } DzlFuzzyMutableIndexItem;
+-#pragma pack(pop)
+ 
+ G_STATIC_ASSERT (sizeof(DzlFuzzyMutableIndexItem) == 6);
+ 


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/63490

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
