### PR TITLE
libgit2: Fix build on Tiger

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -50,5 +50,17 @@ variant threadsafe description {Build with threadsafe option} {
 
 default_variants    +threadsafe
 
+platform darwin 8 {
+    # Fix unsetenv return value
+    configure.cflags-append -D__DARWIN_UNIX03
+
+    # Copy Apple's copyfile.h for use on Mac OS X 10.4 and higher.
+    # See APPLE_LICENSE.txt for license and copying information.
+    post-patch {
+        file copy ${filespath}/copyfile.h ${worksrcpath}
+    }
+    configure.cflags-append "-I${worksrcpath}"
+}
+
 # customize regex to avoid release candidates, alpha, beta, etc
 github.livecheck.regex (\\d+(?:\\.\\d+)*)

--- a/devel/libgit2/files/copyfile.h
+++ b/devel/libgit2/files/copyfile.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2004 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+#ifndef _COPYFILE_H_ /* version 0.1 */
+#define _COPYFILE_H_
+
+/*
+ * this is a proposed API to add to libSystem to faciliatate copying
+ * of files and their associated metadata.  There are several open
+ * source projects that need modifications to support preserving
+ * extended attributes and acls and this API collapses several hundred
+ * lines of modifications into one or two calls.
+ *
+ * This implementation is incomplete and the interface may change in a 
+ * future release.
+ */
+
+/* private */
+#include <stdint.h>
+struct _copyfile_state;
+typedef struct _copyfile_state * copyfile_state_t;
+typedef uint32_t copyfile_flags_t;
+
+/* public */
+
+/* receives:
+ *   from	path to source file system object
+ *   to		path to destination file system object
+ *   state	opaque blob for future extensibility
+ *		Must be NULL in current implementation
+ *   flags	(described below)
+ * returns:
+ *   int	negative for error
+ */
+
+int copyfile(const char *from, const char *to, copyfile_state_t state, copyfile_flags_t flags);
+int copyfile_free(copyfile_state_t);
+copyfile_state_t copyfile_init(void);
+
+/* Flag for clients to disable their use of copyfile() */
+#define COPYFILE_DISABLE_VAR	"COPY_EXTENDED_ATTRIBUTES_DISABLE"
+
+/* flags for copyfile */
+
+#define COPYFILE_ACL	    (1<<0)
+#define COPYFILE_STAT	    (1<<1)
+#define COPYFILE_XATTR	    (1<<2)
+#define COPYFILE_DATA	    (1<<3)
+
+#define COPYFILE_SECURITY   (COPYFILE_STAT | COPYFILE_ACL)
+#define COPYFILE_METADATA   (COPYFILE_SECURITY | COPYFILE_XATTR)
+#define COPYFILE_ALL	    (COPYFILE_METADATA | COPYFILE_DATA)
+
+#define COPYFILE_CHECK		(1<<16) /* return flags for xattr or acls if set */
+#define COPYFILE_EXCL		(1<<17) /* fail if destination exists */
+#define COPYFILE_NOFOLLOW_SRC	(1<<18) /* don't follow if source is a symlink */
+#define COPYFILE_NOFOLLOW_DST	(1<<19) /* don't follow if dst is a symlink */
+#define COPYFILE_MOVE		(1<<20) /* unlink src after copy */
+#define COPYFILE_UNLINK		(1<<21) /* unlink dst before copy */
+#define COPYFILE_NOFOLLOW	(COPYFILE_NOFOLLOW_SRC | COPYFILE_NOFOLLOW_DST)
+
+#define COPYFILE_PACK		(1<<22)
+#define COPYFILE_UNPACK		(1<<23)
+
+#define COPYFILE_VERBOSE	(1<<30)
+
+#endif /* _COPYFILE_H_ */


### PR DESCRIPTION
#### Description

Fix the `copyfile.h` absence with the solution found in net/rsync-lart. (Maybe a candidate for LegacySupport?)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
