### PR TITLE
skaffold: update to 1.32.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.31.0 v
+github.setup        GoogleContainerTools skaffold 1.32.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  85c53c584080c864a3d115188f176a832b7a5a80 \
-                    sha256  93e1600f7efae450e6b5632a9d190fdbf28e0c0fb74a3513e3591688a82d20e7 \
-                    size    16614326
+checksums           rmd160  da30c593de9728c63a431309cb2edc6f7d00a0ea \
+                    sha256  ea33655b42aa6da98ad614042c1368bab802e2b1cc1b3c6b19b5abf41c341bf9 \
+                    size    21257966
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.32.0.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?