### PR TITLE
openjdk: add openjdk17-zulu subport

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -565,6 +565,34 @@ subport openjdk16-zulu {
     worksrcdir   ${distname}/zulu-16.jdk
 }
 
+subport openjdk17-zulu {
+    # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
+
+    version      17.28.13
+    revision     0
+
+    set openjdk_version 17.0.0
+
+    description  Azul Zulu Community OpenJDK 17 (Long Term Support)
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+        checksums    rmd160  e6be31dc4f5f1e00c34bf5350a48cc7ebabb3203 \
+                     sha256  6029b1fe6853cecad22ab99ac0b3bb4fb8c903dd2edefa91c3abc89755bbd47d \
+                     size    192981407
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+        checksums    rmd160  5b4988a2f197059d88c78d5c7623dbf6770b8a55 \
+                     sha256  6b17f01f767ee7abf4704149ca4d86423aab9b16b68697b7d36e9b616846a8b0 \
+                     size    190744456
+    }
+
+    worksrcdir   ${distname}/zulu-17.jdk
+}
+
 if {${os.platform} eq "darwin"} {
     # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
     if {[string match *-zulu ${subport}] && ${os.major} < 17} {


### PR DESCRIPTION
#### Description

Add subport for Azul Zulu OpenJDK 17.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?