### PR TITLE
josm: update to 18193

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18118
+version             18193
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java16
 
-checksums           rmd160  72c35b5beda2bc66f3aef3a6ad0ac8c67636cf08 \
-                    sha256  278d087f601438d76a6835e732fcc81b12c945a20178bb041fcd25f2307d3b44 \
-                    size    40144262
+checksums           rmd160  c1050eebef935c6ecfee22048a53588ad6186a27 \
+                    sha256  3a80d7e6d3d32eb52019f05ad757455727ae5d26a2f1024d7902d6c28b7692c9 \
+                    size    75340212
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2021-09-02: Stable release 18193](https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.08)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
