### PR TITLE
libgweather: Fix destroot stage on Tiger

### DIFF
--- a/net/libgweather/Portfile
+++ b/net/libgweather/Portfile
@@ -49,6 +49,11 @@ configure.args      -Dglade_catalog=false \
                     -Dgtk_doc=true \
                     -Dzoneinfo_dir=${prefix}/share/zoneinfo
 
+platform darwin 8 {
+    # Fix "Library not loaded" error caused by lack of Tiger @rpath
+    destroot.env-append "DYLD_LIBRARY_PATH=${build_dir}/${name}"
+}
+
 if {![info exists universal_possible]} {
     set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
 }


### PR DESCRIPTION
#### Description

Same problem and fix as several others, #12255, #12256, etc

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
