### PR TITLE
[WIP] godot: patch macOS version detection

### DIFF
--- a/games/godot/Portfile
+++ b/games/godot/Portfile
@@ -24,6 +24,7 @@ long_description    Godot Engine is a cross-platform game engine for \
 
 if {$subport eq ${name}} {
     github.setup    godotengine ${name} 3.3.1 "" -stable
+    revision        1
 
     checksums       rmd160  7b64622072972ff7d5e2fda3bd55980d7add2049 \
                     sha256  ee3bdd6355854957041cdc293d1d58431edfb9b80d6a96c5008b937cd86104e3 \
@@ -67,6 +68,11 @@ post-patch {
 \\      \"${prefix}/bin/yasm\",\\
 " \
         ${worksrcpath}/modules/webm/libvpx/SCsub
+
+    if {${os.platform} eq "darwin" && ${os.major} <= 14} {
+        reinplace {s/MAC_OS_X_VERSION_MAX_ALLOWED/__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__/} \
+            ${worksrcpath}/platform/osx/os_osx.mm
+    }
 }
 
 use_configure       no


### PR DESCRIPTION
#### Description

I just noticed that the Godot source code is using `MAC_OS_X_VERSION_MAX_ALLOWED` in a few places. MacPorts uses `__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__` to tell source codes what version of macOS is being used, and `MAC_OS_X_VERSION_MAX_ALLOWED` may not get reliably set by MacPorts, and should not be used.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
