### PR TITLE
luarocks-1.0: disable livecheck on subports

### DIFF
--- a/_resources/port1.0/group/luarocks-1.0.tcl
+++ b/_resources/port1.0/group/luarocks-1.0.tcl
@@ -127,6 +127,7 @@ proc luarocks.setup {module vers {type "src.rock"} {docs {}} {source "custom"} {
                     if {${luarocks.branch} eq "5.1"} {
                         depends_lib-replace port:lua${luarocks.suffix} path:lib/libluajit-5.1.2.dylib:luajit
                     }
+                    livecheck.type none
                 }
             }
             if {$subport eq $name} {


### PR DESCRIPTION
-------

#### Description

This trivial commit prevent to add livecheck for subports which is created for lua branches by luarocks group.

To reproduce an issues just run `port livecheck 'lua*-lpeg'`

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->