### PR TITLE
go-tools: update to 0.1.6

### DIFF
--- a/devel/go-tools/Portfile
+++ b/devel/go-tools/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golang/tools 0.1.5 v
+go.setup            github.com/golang/tools 0.1.6 v
 epoch               7
 revision            0
 
@@ -16,9 +16,9 @@ maintainers         {ciserlohn @ci42} {@enckse voidedtech.com:enckse} openmainta
 description         Various packages and tools that support the Go programming language.
 long_description    $description
 
-checksums           rmd160  1bbd33096e15d2084ba543ddbfd86936e5dd09cb \
-                    sha256  66907da0a219e6a27e504acc4c1c58fd9521585de0d6729a43694c950aef1670 \
-                    size    2843627
+checksums           rmd160  8c43ece78447a5373ceff28670a51006582c5495 \
+                    sha256  43766d41f9618058ee539bc4fa4fbb6ab1c18ac9f11244af4255bf05c3aabfbb \
+                    size    2874202
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

update go-tools to latest version

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
