### PR TITLE
dvbcut: new port

### DIFF
--- a/multimedia/dvbcut/Portfile
+++ b/multimedia/dvbcut/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           qt5 1.0
+
+github.setup        bernhardu dvbcut-deb 0.7.3 v
+github.tarball_from archive
+revision            0
+
+name                dvbcut
+categories          multimedia
+platforms           darwin
+license             GPL-2
+maintainers         nomaintainer
+description         Qt application for cutting parts out of DVB streams
+long_description    DVBcut is a Qt application that allows you to select certain parts of an \
+                    MPEG transport stream and save these parts into a single MPEG output file. \
+                    It follows a keyhole surgery approach where the input video and audio data \
+                    is mostly kept unchanged, and only very few frames at the beginning and/or \
+                    end of the selected range are re-encoded in order to obtain a valid MPEG \
+                    file.
+
+checksums           rmd160  7ae24ba9c72754effc92a88a694a092ad416e2f9 \
+                    sha256  c0397919e89bd3a77f488b8c25d3bad9a11f14cd30d16097c3bf666bc3f56d7b \
+                    size    186547
+
+patchfiles          pkgconfig.patch byteswap.patch
+
+depends_lib         port:a52dec \
+                    port:ffmpeg \
+                    port:libao \
+                    port:libmad
+depends_build       port:pkgconfig
+qt5.depends_build_component qttools
+
+use_autoreconf      yes
+
+compiler.cxx_standard 2011
+configure.cxxflags-append -std=c++11
+
+configure.env       PATH=$env(PATH):${prefix}/libexec/qt5/bin
+build.env           PATH=$env(PATH):${prefix}/libexec/qt5/bin
+
+post-destroot {
+    file mkdir "${destroot}${prefix}/share/dvbcut/icons"
+    file copy "${worksrcpath}/dvbcut.svg" "${destroot}${prefix}/share/dvbcut/icons/dvbcut.svg"
+}

--- a/multimedia/dvbcut/files/byteswap.patch
+++ b/multimedia/dvbcut/files/byteswap.patch
@@ -1,0 +1,100 @@
+From 34940b76018eed3ac3fe6f6db37637390880055b Mon Sep 17 00:00:00 2001
+From: Thomas Perl <m@thp.io>
+Date: Sat, 26 Sep 2020 17:12:19 +0200
+Subject: [PATCH] Remove byteswap.h dependency (not available on macOS/BSD)
+
+---
+ DISTFILES         |  1 -
+ import/byteswap.h | 41 -----------------------------------------
+ src/defines.h     |  4 ++--
+ src/index.h       |  1 -
+ 4 files changed, 2 insertions(+), 45 deletions(-)
+ delete mode 100644 import/byteswap.h
+
+diff --git a/DISTFILES b/DISTFILES
+index 0a7ff78..7379871 100644
+--- DISTFILES
++++ DISTFILES
+@@ -39,7 +39,6 @@ icons/play.png
+ icons/play.svgz
+ icons/stop.png
+ icons/stop.svgz
+-import/byteswap.h
+ import/stdlib.cpp
+ import/stdlib.h
+ import/sys/mman.h
+diff --git a/import/byteswap.h b/import/byteswap.h
+deleted file mode 100644
+index ac4b3ad..0000000
+--- import/byteswap.h
++++ /dev/null
+@@ -1,41 +0,0 @@
+-/* byteswap.h
+-
+-Copyright 2005 Red Hat, Inc.
+-
+-This file is part of Cygwin.
+-
+-This software is a copyrighted work licensed under the terms of the
+-Cygwin license.  Please consult the file "CYGWIN_LICENSE" for
+-details. */
+-
+-#ifndef _BYTESWAP_H
+-#define _BYTESWAP_H
+-
+-#ifdef __cplusplus
+-extern "C" {
+-#endif
+-#define __bswap_constant_16 __bswap_16
+-#define __bswap_constant_32 __bswap_32
+-#define __bswap_constant_64 __bswap_64
+-#define __bswap_16(x) \
+-     ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8))
+-
+-#define __bswap_32(x) \
+-      ((((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >>  8) |               \
+-       (((x) & 0x0000ff00) <<  8) | (((x) & 0x000000ff) << 24))
+-
+-
+-#define __bswap_64(x) \
+-     ((((x) & 0xff00000000000000ull) >> 56)				      \
+-      | (((x) & 0x00ff000000000000ull) >> 40)				      \
+-      | (((x) & 0x0000ff0000000000ull) >> 24)				      \
+-      | (((x) & 0x000000ff00000000ull) >> 8)				      \
+-      | (((x) & 0x00000000ff000000ull) << 8)				      \
+-      | (((x) & 0x0000000000ff0000ull) << 24)				      \
+-      | (((x) & 0x000000000000ff00ull) << 40)				      \
+-      | (((x) & 0x00000000000000ffull) << 56))
+-
+-#ifdef __cplusplus
+-}
+-#endif
+-#endif /* _BYTESWAP_H */
+diff --git a/src/defines.h b/src/defines.h
+index 253e7bb..b612950 100644
+--- src/defines.h
++++ src/defines.h
+@@ -46,9 +46,9 @@ static inline int videostream(int s=0)
+ #define mbo32(x) \
+       ((((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >>  8) | \
+        (((x) & 0x0000ff00) <<  8) | (((x) & 0x000000ff) << 24))
+-#define htom32(x) (__bswap_32(x))
++#define htom32(x) mbo32(x)
+ #define mbo16(x) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8))
+-#define htom16(x) (__bswap_16(x))
++#define htom16(x) mbo16(x)
+ #else
+ #define mbo32(x) (x)
+ #define htom32(x) (x)
+diff --git a/src/index.h b/src/index.h
+index 44999a9..c70ddea 100644
+--- src/index.h
++++ src/index.h
+@@ -22,7 +22,6 @@
+ #define _DVBCUT_INDEX_H
+ 
+ #include <stdint.h>
+-#include <byteswap.h>
+ #include <set>
+ #include <vector>
+ #include "types.h"

--- a/multimedia/dvbcut/files/pkgconfig.patch
+++ b/multimedia/dvbcut/files/pkgconfig.patch
@@ -1,0 +1,72 @@
+From 0d046ff510b31391c08bb6531587b0bbe533ba39 Mon Sep 17 00:00:00 2001
+From: Thomas Perl <m@thp.io>
+Date: Sat, 26 Sep 2020 17:02:36 +0200
+Subject: [PATCH] autotools: Use pkg-config to find Qt5 libs
+
+---
+ configure.ac | 45 ++++++++++++---------------------------------
+ 1 file changed, 12 insertions(+), 33 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 04ead90..8f7b161 100644
+--- configure.ac
++++ configure.ac
+@@ -94,21 +94,18 @@ dnl Checks for library functions.
+ AC_FUNC_MMAP
+ 
+ dnl external stuff
+-AC_CHECK_LIB(Qt5Core, main,
+-  [HAVE_QT5="yes"],
+-  [AC_MSG_ERROR([Qt5Core library not found])])
+-
+-AC_CHECK_LIB(Qt5Gui, main,
+-  [HAVE_QT5="yes"],
+-  [AC_MSG_ERROR([Qt5Gui library not found])])
+-
+-AC_CHECK_LIB(Qt5Xml, main,
+-  [HAVE_QT5="yes"],
+-  [AC_MSG_ERROR([Qt5Xml library not found])])
+-
+-AC_CHECK_LIB(Qt5Widgets, main,
+-  [HAVE_QT5="yes"],
+-  [AC_MSG_ERROR([Qt5Widgets library not found])])
++PKG_CHECK_MODULES([QT5], [Qt5Core >= 5.3 Qt5Gui >= 5.3 Qt5Xml >= 5.3 Qt5Widgets >= 5.3])
++AC_SUBST([QT5_CFLAGS])
++AC_SUBST([QT5_LIBS])
++
++#error "You must build your code with position independent code if Qt was built with -reduce-relocations. " \
++#      "Compile your code with -fPIC (-fPIE is not enough)."
++#
++# https://bugreports.qt.io/browse/QTBUG-50156
++# With Qt5 pkg-config reports no '-fPIC', but header file complains that it is needed.
++#
++CPPFLAGS="$CPPFLAGS -fPIC $QT5_CFLAGS"
++LIBS="$LIBS $QT5_LIBS"
+ 
+ AC_CHECK_PROGS(MOC, [moc-qt5 moc])
+ AC_CHECK_PROGS(UIC, [uic-qt5 uic])
+@@ -118,24 +115,6 @@ if test -z "$MOC" || test -z "$UIC" || test -z "$RCC" || test -z "$LRELEASE"; th
+    AC_MSG_ERROR([Qt utility programs moc, uic, rcc and lrelease are required.])
+ fi
+ 
+-if test "x$HAVE_QT5" = "xyes"; then
+-   QT_CXXFLAGS=`$PKG_CONFIG --cflags Qt5Core Qt5Gui Qt5Xml Qt5Widgets`
+-
+-      #error "You must build your code with position independent code if Qt was built with -reduce-relocations. " \
+-      #      "Compile your code with -fPIC (-fPIE is not enough)."
+-      #
+-      # https://bugreports.qt.io/browse/QTBUG-50156
+-      # With Qt5 pkg-config reports no '-fPIC', but header file complains that it is needed.
+-      #
+-   QT_CXXFLAGS="-fPIC $QT_CXXFLAGS"
+-
+-   QT_LIBS=`$PKG_CONFIG --libs Qt5Core Qt5Gui Qt5Xml Qt5Widgets`
+-   CPPFLAGS="$CPPFLAGS $QT_CXXFLAGS"
+-   LIBS="$LIBS $QT_LIBS"
+-else
+-   AC_MSG_ERROR([cannot find Qt5 library >= 5.3])
+-fi
+-
+ AC_DEFINE(__STDC_LIMIT_MACROS, 1, [Required for C++])
+ AC_DEFINE(__STDC_CONSTANT_MACROS, 1, [Required for C++])
+ AC_DEFINE(_FILE_OFFSET_BITS, 64, [We are always using large files])


### PR DESCRIPTION
#### Description

dvbcut enables cutting MPEG2 transport streams without re-encoding anything but the first and last few frames. It was originally available at http://dvbcut.sourceforge.net, but maintenance has long been taken over by the Debian package maintainer at https://github.com/bernhardu/dvbcut-deb.

The two patches included in this port have already been merged upstream, but no release has been made since.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
