### PR TITLE
gtk-doc: Remove Perl dependency

### DIFF
--- a/gnome/gtk-doc/Portfile
+++ b/gnome/gtk-doc/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           perl5 1.0
 
 name                gtk-doc
 version             1.32
@@ -32,7 +31,6 @@ depends_build       port:pkgconfig \
 
 depends_lib         port:libxml2 \
                     port:libxslt \
-                    port:perl${perl5.major} \
                     port:docbook-xml \
                     port:docbook-xsl-nons \
                     port:itstool
@@ -46,9 +44,6 @@ if {![variant_isset pdf]} {
     patchfiles-append \
                     disable-pdf.patch
 }
-
-# use default MacPorts perl branch
-configure.perl      ${perl5.bin}
 
 configure.env-append XSLTPROC=${prefix}/bin/xsltproc
 configure.args      --with-xml-catalog=${prefix}/etc/xml/catalog \
@@ -107,11 +102,6 @@ if {![variant_isset python36] &&
     ![variant_isset python38] &&
     ![variant_isset python39] } {
     default_variants +python39
-}
-
-post-configure {
-    reinplace "s|^#!.*|#!${perl5.bin} -w|" \
-        ${worksrcpath}/tools/docpercentages.pl
 }
 
 # some tests are known to fail in gtk-doc 1.29+


### PR DESCRIPTION
#### Description

Perl is no longer needed except for a single utility script that is 1) Not installed 2) Not executed during build 3) Compatible with system Perl back to 10.4

Closes: https://trac.macports.org/ticket/63406

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
