### PR TITLE
texlive-bin: fixed building on clean system

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -414,7 +414,8 @@ post-activate {
     # Run mktexlsr if possible. Since mktexlsr is installed by
     # texlive-basic, it won't exist on a clean install, but we should
     # run it if upgrading.
-    catch {
+    if {[file exists ${prefix}/bin/mktexlsr]} {
+        ui_debug {Rebuilding TeX ls-R filename databases}
         system "${prefix}/bin/mktexlsr"
     }
 }


### PR DESCRIPTION
This issue was discovered by CI for https://github.com/macports/macports-ports/pull/12232

The log:
```
2021-09-17T19:14:14.0807510Z DEBUG: system: /opt/local/bin/mktexlsr
2021-09-17T19:14:14.0867250Z sh: /opt/local/bin/mktexlsr: No such file or directory
2021-09-17T19:14:14.0868170Z Command failed: /opt/local/bin/mktexlsr
2021-09-17T19:14:14.0868670Z Exit code: 127
```

-------

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->