### PR TITLE
snooze: submission

### DIFF
--- a/sysutils/snooze/Portfile
+++ b/sysutils/snooze/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        leahneukirchen snooze 0.5 v
+github.tarball_from archive
+revision            0
+categories          sysutils
+platforms           darwin
+license             public-domain
+maintainers         nomaintainer
+description         run a command at a particular time
+
+long_description \
+    snooze is a tool for waiting until a particular time and then \
+    running a command. Together with a service supervision system such \
+    as runit, this can be used to replace cron(8).
+
+checksums           rmd160  e1113ffb0d056c2dc4dcfb100d33ee57fce484f0 \
+                    sha256  d63fde85d9333188bed5996baabd833eaa00842ce117443ffbf8719c094be414 \
+                    size    8008
+
+patchfiles          patch-Makefile.diff

--- a/sysutils/snooze/files/patch-Makefile.diff
+++ b/sysutils/snooze/files/patch-Makefile.diff
@@ -1,0 +1,14 @@
+--- Makefile
++++ Makefile
+@@ -1,9 +1,9 @@
+ ALL=snooze
+ 
+-CFLAGS=-g -O2 -Wall -Wextra -Wwrite-strings
++CFLAGS+=-g -Wall -Wextra -Wwrite-strings
+ 
+ DESTDIR=
+-PREFIX=/usr/local
++PREFIX?=/usr/local
+ BINDIR=$(PREFIX)/bin
+ MANDIR=$(PREFIX)/share/man
+ 


### PR DESCRIPTION
#### Description

> snooze is a tool for waiting until a particular time and then running a command. Together with a service supervision system such as runit, this can be used to replace cron(8).

This is my first port pull.  snooze is especially pleasant to use with the s6 supervisor.  I have also prepared a portfile for s6, which would resolve this [old Trac bug](https://trac.macports.org/ticket/58116), though it might help to seek review on something simpler first.

###### Type(s)

- [X] submission

###### Tested on

I have an Xcode CLT installation, not Xcode itself.  I used the [CLT receipt command snippet](https://trac.macports.org/wiki/ProblemHotlist#reinstall-clt) from the wiki.

macOS 11.6 20G165 x86_64
Xcode CLT 12.5.1.0.1.1623191612

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
