### PR TITLE
Revert "mdds: update to 2.0.0"

### DIFF
--- a/devel/mdds/Portfile
+++ b/devel/mdds/Portfile
@@ -4,8 +4,9 @@ PortSystem          1.0
 PortGroup           gitlab 1.0
 PortGroup           boost 1.0
 
-gitlab.setup        mdds mdds 2.0.0
-revision            0
+gitlab.setup        mdds mdds 1.7.0
+revision            1
+epoch               1
 
 categories          devel
 platforms           darwin
@@ -15,9 +16,9 @@ maintainers         {gmail.com:audvare @Tatsh} openmaintainer
 description         Collection of multi-dimensional data structure and indexing algorithms.
 long_description    {*}${description}
 
-checksums           rmd160  c0cf55c438209f540d065d0bb4b2a3b8cd261ca2 \
-                    sha256  0d48bc19c4bd4c76cce944e19c714c10d4e8a94cca5e96bbeca69161a189c320 \
-                    size    686417
+checksums           rmd160  26f16383abc1e9f70664810e60d453809986910c \
+                    sha256  4f1ab3127a1ae9c1e3b09c854566480f5192627f6ebb7f0984993931876b8d68 \
+                    size    644140
 
 use_autoreconf      yes
 configure.args      --disable-memory_tests \


### PR DESCRIPTION
This reverts commit 4f06f37601a66ba3e29cb438df01841f22a4d4d7.

This is needed for `libreoffice` to build. I tried patching LibreOffice's `configure.ac` to use mdds-2.0 and it fails to build.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
