### PR TITLE
osmosis: Fix BuildBot failures for macOS 10.10 and above

### DIFF
--- a/java/osmosis/Portfile
+++ b/java/osmosis/Portfile
@@ -36,7 +36,7 @@ set confdir         ${prefix}/etc/${name}
 set appdir          ${prefix}/share/${name}
 set docdir          ${prefix}/share/doc/${name}
 
-java.version        1.8*
+java.version        1.8+
 java.fallback       openjdk11
 
 depends_build       port:gradle


### PR DESCRIPTION
BuildBot doesn't appear to have a 1.8 JDK available, but also later
JDK's should be OK with this port.

#### Description

Hopefully, fixes the issue in the following commit:

https://github.com/macports/macports-ports/commit/ae39446cb58632564af85d7d5452a171c8ba1241#commitcomment-56724769

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
