### PR TITLE
curves: new port

### DIFF
--- a/math/curves/Portfile
+++ b/math/curves/Portfile
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           java 1.0
+PortGroup           legacysupport 1.1
+PortGroup           compiler_blacklist_versions 1.0
+
+github.setup        teodimoff curves 12d23e6a5b79267321d171d7220061e3a2a82565
+version             20210919
+revision            0
+
+checksums           rmd160  b7966ccb4e6117ef7475f0d94d37816f67de22ab \
+                    sha256  26ad39b0e8e0b195b5b21b6eb0871a60b1c4a6d6787fcf1e513467a28437112c \
+                    size    7775650
+
+categories          math graphics
+platforms           darwin
+supported_archs     noarch
+license             Apache-2
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+description         Curves provide mapping a point from 1D to 2D hilbert space.
+long_description    Curves provide Hilbert mapping of a point from 1D to 2D hilbert space. \
+                    This means that points closer together from one dimentional space are closer in the other. \
+                    In other words it preserves locality.
+
+# Required java version
+java.version        1.8+
+# LTS JDK port to install if required java not found
+java.fallback       openjdk11
+
+patch.pre_args      -p1
+patchfiles          fix-build.patch
+
+use_configure       no
+
+# Scala-Native requires clang 6+ or apple's clang 8+
+compiler.blacklist  *gcc* {clang < 800} {macports-clang-3.[0-9]} {macports-clang-[4-5].0}
+
+# needs MAP_ANONYMOUS, linkat and symlinkat
+legacysupport.newest_darwin_requires_legacy 14
+
+build.env-append    SBT_OPTS=-Duser.home=${workpath}/.home \
+                    CLANG_PATH=${configure.cc} \
+                    CLANGPP_PATH=${configure.cxx}
+
+build.cmd           ${prefix}/bin/sbt
+build.target        hashdrawNative/nativeLink
+
+build.pre_args-prepend \
+                    "'set (hashdraw.native / nativeCompileOptions) := \"${configure.cppflags}\".split(\" \").toSeq'" \
+                    "'set (hashdraw.native / nativeLinkingOptions) := \"${configure.ldflags}\".split(\" \").toSeq'"
+
+depends_build-append \
+                    port:sbt
+
+depends_lib-append  port:libsdl2
+
+destroot {
+    set bindir ${destroot}${prefix}/bin
+    xinstall -m 0755 -d ${bindir}
+    xinstall -m 0755 ${worksrcpath}/example/hashdraw/native/target/scala-2.13/hashdraw-out ${bindir}/${name}
+}

--- a/math/curves/files/fix-build.patch
+++ b/math/curves/files/fix-build.patch
@@ -1,0 +1,41 @@
+From 0e068f53b0e120192667c25fadf663253038aae1 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Sun, 19 Sep 2021 14:51:51 +0200
+Subject: [PATCH] Fixed build on macOS 11
+
+Here a fix for a few typos that prevents to build it.
+---
+ draw/native/src/main/resources/scala-native/HilbertWindow.c | 2 +-
+ draw/native/src/main/scala/curves/draw/SDL2.scala           | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/draw/native/src/main/resources/scala-native/HilbertWindow.c b/draw/native/src/main/resources/scala-native/HilbertWindow.c
+index f63bc87..e68ccfa 100644
+--- a/draw/native/src/main/resources/scala-native/HilbertWindow.c
++++ b/draw/native/src/main/resources/scala-native/HilbertWindow.c
+@@ -85,7 +85,7 @@ void drawGradientAndPointsInternal(int points,int order,int startFrom,int dotCol
+ 
+ }
+ 
+-void drawFileInternal(const char* fileName,int order,int height, int width, int color, long (*hilbertMapping)(int,int))
++void drawFile(const char* fileName,int order,int height, int width, int color, long (*hilbertMapping)(int,int))
+ {
+ init();
+ 
+diff --git a/draw/native/src/main/scala/curves/draw/SDL2.scala b/draw/native/src/main/scala/curves/draw/SDL2.scala
+index 0146b89..d16e5d3 100644
+--- a/draw/native/src/main/scala/curves/draw/SDL2.scala
++++ b/draw/native/src/main/scala/curves/draw/SDL2.scala
+@@ -26,10 +26,10 @@ def drawFile(fileName: CString, order: Int, height: Int, width: Int, color: Int,
+ }
+ 
+ def drawFile(fileName: String,order: Int, height: Int, width: Int, blackDot: Boolean, hilbertMapping: CFuncPtr2[Int,Int,Long]): Unit =  Zone { implicit z =>
+-  SDL2.drawTest(toCString(fileName),order,height,width,if(blackDot) 0 else 1,hilbertMapping)
++  SDL2.drawFile(toCString(fileName),order,height,width,if(blackDot) 0 else 1,hilbertMapping)
+ }
+ def drawFile(fileName: String, order: Int, blackDot: Boolean): Unit =  Zone { implicit z =>
+-  SDL2.drawTest(toCString(fileName),order,1 << order,1 << order,if(blackDot) 0 else 1,(points: Int,order: Int) => HilbertCurve(points,order).asLong)
++  SDL2.drawFile(toCString(fileName),order,1 << order,1 << order,if(blackDot) 0 else 1,(points: Int,order: Int) => HilbertCurve(points,order).asLong)
+ }
+ def draw(points: Int,order: Int,blackDot: Boolean,hashFunction: CFuncPtr1[Int,Int]): Unit = 
+         SDL2.drawGradientAndPoints(points,order,0,1 << order,1 << order,if(blackDot) 0 else 1 ,hashFunction,(points: Int,order: Int) => HilbertCurve(points,order).asLong)


### PR DESCRIPTION
-------

#### Description

Here a small utilits that is used to visualize entropy of file.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->