### PR TITLE
github-1.0: github.setup_port_name option

### DIFF
--- a/_resources/port1.0/group/github-1.0.tcl
+++ b/_resources/port1.0/group/github-1.0.tcl
@@ -57,6 +57,11 @@ default github.livecheck.branch master
 options github.livecheck.regex
 default github.livecheck.regex {(\[^"]+)}
 
+# Do not touch port's name. Useful when this group is used with very complex subports
+# See: https://github.com/macports/macports-ports/pull/12132
+options github.setup_port_name
+default github.setup_port_name yes
+
 proc github.setup {gh_author gh_project gh_version {gh_tag_prefix ""} {gh_tag_suffix ""}} {
     global extract.suffix github.author github.project github.version github.tag_prefix github.tag_suffix
     global github.homepage github.master_sites github.livecheck.branch PortInfo
@@ -67,7 +72,7 @@ proc github.setup {gh_author gh_project gh_version {gh_tag_prefix ""} {gh_tag_su
     github.tag_prefix       ${gh_tag_prefix}
     github.tag_suffix       ${gh_tag_suffix}
 
-    if {!([info exists PortInfo(name)] && (${PortInfo(name)} ne ${github.project}))} {
+    if {!([info exists PortInfo(name)] && (${PortInfo(name)} ne ${github.project})) && [option github.setup_port_name]} {
         name                ${github.project}
     }
 

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -202,6 +202,8 @@ subport ${name}-autofix {
 }
 
 subport ${name}-barcode {
+    github.setup_port_name no
+
     github.setup    8h2a beets-barcode ad18cace04873157a96c34a48e714874825db724
     version         20210908
     revision        0
@@ -323,6 +325,8 @@ subport ${name}-describe {
 }
 
 subport ${name}-follow {
+    github.setup_port_name no
+
     github.setup    nolsto beets-follow eb504a0b3b457993d599530a66a54b11b740ecb5
     version         20210908
     revision        0
@@ -389,6 +393,8 @@ subport ${name}-ibroadcast {
 }
 
 subport ${name}-importreplace {
+    github.setup_port_name no
+
     github.setup    edgars-supe beets-importreplace 0.1.1 v
     revision        0
 
@@ -475,6 +481,8 @@ subport ${name}-noimport {
 }
 
 subport ${name}-originquery {
+    github.setup_port_name no
+
     github.setup    x1ppy beets-originquery 269e9e4cfc88128493b25ed814e34df2528dc1ef
     version         20210908
     revision        0
@@ -515,6 +523,8 @@ subport ${name}-summarize {
 }
 
 subport ${name}-usertag {
+    github.setup_port_name no
+
     github.setup    igordertigor beets-usertag 8e058361c9dfa335980048c0afb9274e5f077611
     version         20210908
     revision        0


### PR DESCRIPTION
#### Description

This option prevent portgroup to setup `name` from github repo when it doesn't required.

This PR is included the only case of when it requires to pass `port lint --nitpick beets*` without any errors.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->