### PR TITLE
sn-demangler: fixed on macOS 10.10 and below

### DIFF
--- a/devel/sn-demangler/Portfile
+++ b/devel/sn-demangler/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 PortGroup           legacysupport 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        indoorvivants sn-demangler 0.0.3 v
 revision            0
@@ -29,7 +30,8 @@ java.fallback       openjdk11
 
 use_configure       no
 
-compiler.blacklist  *gcc*
+# Scala-Native requires clang 6+ or apple's clang 8+
+compiler.blacklist  *gcc* {clang < 800} {macports-clang-3.[0-9]} {macports-clang-[4-5].0}
 
 # needs MAP_ANONYMOUS
 legacysupport.newest_darwin_requires_legacy 14


### PR DESCRIPTION
-------

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->