### PR TITLE
sn-demangler: fixed a way to setup linking flags

### DIFF
--- a/devel/sn-demangler/Portfile
+++ b/devel/sn-demangler/Portfile
@@ -44,8 +44,8 @@ build.cmd           ${prefix}/bin/sbt
 build.target        demanglerNative/nativeLink
 
 build.pre_args-prepend \
-                    "'set nativeCompileOptions := Seq(\"${configure.cppflags}\")'" \
-                    "'set nativeLinkingOptions := Seq(\"${configure.ldflags}\")'"
+                    "'set (demangler.native(true) / nativeCompileOptions) := \"${configure.cppflags}\".split(\" \").toSeq'" \
+                    "'set (demangler.native(true) / nativeLinkingOptions) := \"${configure.ldflags}\".split(\" \").toSeq'"
 
 depends_build-append \
                     port:sbt


### PR DESCRIPTION
#### Description

This should fix builds on all targets

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
