### PR TITLE
gjs: Fix build on 32-bit systems

### DIFF
--- a/gnome/gjs/Portfile
+++ b/gnome/gjs/Portfile
@@ -38,6 +38,9 @@ autoreconf.args     -fvi
 
 compiler.cxx_standard 2014
 
+# Fix gsize/size_t mismatch on 32-bit systems
+patchfiles          patch-gjs-gsize.diff
+
 # profiler currently only supported on Linux
 configure.args      --disable-profiler \
                     --disable-silent-rules

--- a/gnome/gjs/files/patch-gjs-gsize.diff
+++ b/gnome/gjs/files/patch-gjs-gsize.diff
@@ -1,0 +1,99 @@
+On 32-bit systems, gsize is an int but size_t is a (32-bit) long. This
+discrepancy results in compilation errors when attempting to interchange their
+pointers. The patch below changes gsize to size_t, and vice versa, depending
+on the surrounding context.
+
+For a complete discussion, see:
+
+https://gitlab.gnome.org/GNOME/gjs/-/merge_requests/680
+
+--- gi/arg.cpp.orig
++++ gi/arg.cpp
+@@ -1267,7 +1267,7 @@
+                                      GITransfer       transfer,
+                                      bool             may_be_null,
+                                      gpointer        *contents,
+-                                     gsize           *length_p)
++                                     size_t          *length_p)
+ {
+     bool ret = false;
+     GITypeInfo *param_info;
+@@ -1960,7 +1960,7 @@
+ 
+     case GI_TYPE_TAG_ARRAY: {
+         gpointer data;
+-        gsize length;
++        size_t length;
+         GIArrayType array_type = g_type_info_get_array_type(type_info);
+ 
+         /* First, let's handle the case where we're passed an instance
+--- gi/function.cpp.orig
++++ gi/function.cpp
+@@ -840,12 +840,12 @@
+         GjsAutoChar name = format_function_name(function, is_method);
+         JS_ReportWarningUTF8(context, "Too many arguments to %s: expected %d, "
+                              "got %" G_GSIZE_FORMAT, name.get(),
+-                             function->expected_js_argc, args.length());
++                             function->expected_js_argc, (gsize)args.length());
+     } else if (args.length() < function->expected_js_argc) {
+         GjsAutoChar name = format_function_name(function, is_method);
+         gjs_throw(context, "Too few arguments to %s: "
+                   "expected %d, got %" G_GSIZE_FORMAT,
+-                  name.get(), function->expected_js_argc, args.length());
++                  name.get(), function->expected_js_argc, (gsize)args.length());
+         return false;
+     }
+ 
+@@ -996,7 +996,7 @@
+                 GIArgInfo array_length_arg;
+ 
+                 gint array_length_pos = g_type_info_get_array_length(&ainfo);
+-                gsize length;
++                size_t length;
+ 
+                 if (!gjs_value_to_explicit_array(context, args[js_arg_pos],
+                                                  &arg_info, in_value, &length)) {
+--- gjs/byteArray.cpp.orig
++++ gjs/byteArray.cpp
+@@ -269,7 +269,7 @@
+ 
+     gbytes = (GBytes*) gjs_c_struct_from_boxed(context, bytes_obj);
+ 
+-    size_t len;
++    gsize len;
+     const void* data = g_bytes_get_data(gbytes, &len);
+     JS::RootedObject array_buffer(
+         context,
+--- gjs/context.cpp.orig
++++ gjs/context.cpp
+@@ -994,7 +994,7 @@
+                       GError       **error)
+ {
+     char *script;
+-    size_t script_len;
++    gsize script_len;
+     GjsAutoUnref<GFile> file = g_file_new_for_commandline_arg(filename);
+ 
+     if (!g_file_load_contents(file, nullptr, &script, &script_len, nullptr,
+--- gjs/global.cpp.orig
++++ gjs/global.cpp
+@@ -55,7 +55,7 @@
+            .setSourceIsLazy(true);
+ 
+     JS::RootedScript compiled_script(cx);
+-    size_t script_len;
++    gsize script_len;
+     auto script = static_cast<const char *>(g_bytes_get_data(script_bytes.get(),
+                                             &script_len));
+     if (!JS::Compile(cx, options, script, script_len, &compiled_script))
+--- gjs/module.cpp.orig
++++ gjs/module.cpp
+@@ -123,7 +123,7 @@
+         size_t script_len = 0;
+         int start_line_number = 1;
+ 
+-        if (!(g_file_load_contents(file, nullptr, &unowned_script, &script_len,
++        if (!(g_file_load_contents(file, nullptr, &unowned_script, nullptr,
+                                    nullptr, &error))) {
+             gjs_throw_g_error(cx, error);
+             return false;


### PR DESCRIPTION
#### Description

Originally part of #12192. For a thorough upstream discussion of the underlying issue, see [here](https://gitlab.gnome.org/GNOME/gjs/-/merge_requests/680). The gjs project has sent the issue further upstream to GLib; a fix there will not be available until 2.71. In the meantime, this patch allows for 32-bit builds of gjs 1.54.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
