### PR TITLE
exiv2: Remove obsolete compiler blacklist

### DIFF
--- a/graphics/exiv2/Portfile
+++ b/graphics/exiv2/Portfile
@@ -38,11 +38,6 @@ compiler.blacklist-append \
                     { clang < 426 } \
                     macports-clang-3.3
 
-# Remove this once upstream has their detection of the availability of
-# -fstack-protector-stong fixed.
-# https://github.com/Exiv2/exiv2/issues/1243
-compiler.blacklist-append {clang < 700}
-
 patchfiles-append   patch-remove-no-format-overflow.diff
 
 configure.args-append \


### PR DESCRIPTION
#### Description

The current version of exiv2 uses the new `-fstack-protector-strong` detection logic, so the blacklist that inspired it is no longer needed.

See: https://github.com/Exiv2/exiv2/issues/1243

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
