### PR TITLE
weechat: update to 3.3

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -10,11 +10,11 @@ legacysupport.newest_darwin_requires_legacy 10
 
 conflicts           weechat-devel
 name                weechat
-version             3.1
+version             3.3
 revision            0
-checksums           rmd160  de2cd7e33bda4d6c4092e9ac12afcaa28de02568 \
-                    sha256  a55a2975aa119f76983412507e3ddb3fe68d0744e08739681ddc17744e77a4f7 \
-                    size    2230316
+checksums           rmd160  f2c74ea964c1d6b09d5123ac8a9577ee3354188f \
+                    sha256  cafeab8af8be4582ccfd3e74fd40e5086a1efa158231f2c26b8b05c3950fcbdf \
+                    size    2564280
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
@@ -26,17 +26,18 @@ livecheck.url       https://weechat.org/dev/info/stable/
 homepage            https://weechat.org/
 license             GPL-3
 description         Fast, light & extensible IRC client
-long_description    \
-    WeeChat (Wee Enhanced Environment for Chat) is a fast and light IRC client \
-    for many operating systems. Everything can be done with a keyboard. It is \
-    customizable and extensible with plugins/scripts, and includes: \
-    \n - nicklist \
-    \n - smart hotlist \
-    \n - infobar with highlight notification \
-    \n - horizontal and vertical split \
-    \n - double charset support (decode/encode) \
-    \n - FIFO pipe for remote control \
-    \n - and much more!
+long_description    WeeChat (Wee Enhanced Environment for Chat) is \
+                    a fast and light IRC client for many operating \
+                    systems. Everything can be done with a keyboard. \
+                    It is customizable and extensible with \
+                    plugins/scripts, and includes: \
+                    \n - nicklist \
+                    \n - smart hotlist \
+                    \n - infobar with highlight notification \
+                    \n - horizontal and vertical split \
+                    \n - double charset support (decode/encode) \
+                    \n - FIFO pipe for remote control \
+                    \n - and much more!
 
 categories          irc
 maintainers         {isi.edu:calvin @cardi} openmaintainer
@@ -44,57 +45,61 @@ platforms           darwin
 
 depends_build-append \
                     port:asciidoctor \
-                    port:libxslt \
+                    port:docbook-xsl-nons \
                     port:pkgconfig \
-                    port:docbook-xsl-nons
+                    port:libxslt
 
-depends_lib-append  \
-                    port:curl \
+depends_lib-append  port:curl \
                     port:gettext \
+                    port:gnutls \
                     port:libgcrypt \
                     port:libiconv \
                     port:ncurses
 
+depends_run-append  path:etc/openssl/cert.pem:curl-ca-bundle
+
+depends_test-append port:cpputest
+
 license_noconflict  asciidoctor
 
 configure.args-append \
-                    -DENABLE_GNUTLS=OFF \
-                    -DENABLE_LUA=OFF \
                     -DENABLE_GUILE=OFF \
+                    -DENABLE_JAVASCRIPT=OFF \
+                    -DENABLE_LUA=OFF \
+                    -DENABLE_MAN=ON \
                     -DENABLE_PERL=OFF \
+                    -DENABLE_PHP=OFF \
                     -DENABLE_PYTHON=OFF \
                     -DENABLE_PYTHON2=OFF \
                     -DENABLE_RUBY=OFF \
                     -DENABLE_SPELL=OFF \
                     -DENABLE_TCL=OFF \
-                    -DENABLE_JAVASCRIPT=OFF \
-                    -DENABLE_PHP=OFF \
-                    -DENABLE_MAN=ON
+                    -DENABLE_TESTS=OFF
 
 variant python requires python27 description {Compatibility variant, requires +python27} {}
 
-variant python27 description "Bindings for python 2.7 plugins" conflicts python36 python37 python38 python39 {
+variant python27 description "Bindings for Python 2.7 plugins" conflicts python36 python37 python38 python39 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.args-replace  -DENABLE_PYTHON2=OFF -DENABLE_PYTHON2=ON
     depends_lib-append      port:python27
 }
 
-variant python36 description "Bindings for python 3.6 plugins" conflicts python27 python37 python38 python39 {
+variant python36 description "Bindings for Python 3.6 plugins" conflicts python27 python37 python38 python39 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python36
 }
 
-variant python37 description "Bindings for python 3.7 plugins" conflicts python27 python36 python38 python39 {
+variant python37 description "Bindings for Python 3.7 plugins" conflicts python27 python36 python38 python39 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python37
 }
 
-variant python38 description "Bindings for python 3.8 plugins" conflicts python27 python36 python37 python39 {
+variant python38 description "Bindings for Python 3.8 plugins" conflicts python27 python36 python37 python39 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python38
 }
 
-variant python39 description "Bindings for python 3.9 plugins" conflicts python27 python36 python37 python38 {
+variant python39 description "Bindings for Python 3.9 plugins" conflicts python27 python36 python37 python38 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python39
 }
@@ -115,22 +120,33 @@ post-patch {
     }
 }
 
-variant tcl description {Support for tcl} {
-    configure.args-delete   -DENABLE_TCL=OFF
-    configure.args-append   -DENABLE_TCL=ON
-    depends_lib-append      port:tcl
-}
-
-variant aspell description {Support for aspell} {
+variant aspell description {Support for Spellcheck (aspell)} {
     configure.args-delete   -DENABLE_SPELL=OFF
     configure.args-append   -DENABLE_SPELL=ON
     depends_lib-append      port:aspell
 }
 
-variant lua description {Bindings for lua plugins} {
+variant doc description {Build HTML Documentation and Plugin API} {
+    configure.args-append   -DENABLE_DOC=ON
+    depends_build-append    port:source-highlight
+}
+
+variant lua description {Bindings for Lua plugins} {
     configure.args-delete   -DENABLE_LUA=OFF
     configure.args-append   -DENABLE_LUA=ON
     depends_lib-append      port:lua
+}
+
+variant perl description {Bindings for Perl plugins} {
+    configure.args-delete   -DENABLE_PERL=OFF
+    configure.args-append   -DENABLE_PERL=ON
+    depends_lib-append      path:bin/perl:perl5
+}
+
+variant ruby description {Bindings for Ruby plugins} {
+    configure.args-delete   -DENABLE_RUBY=OFF
+    configure.args-append   -DENABLE_RUBY=ON
+    depends_lib-append      port:ruby
 }
 
 variant scheme description {Bindings for Scheme (guile) plugins} {
@@ -139,34 +155,11 @@ variant scheme description {Bindings for Scheme (guile) plugins} {
     depends_lib-append      port:guile
 }
 
-variant perl description {Bindings for perl plugins} {
-    configure.args-delete   -DENABLE_PERL=OFF
-    configure.args-append   -DENABLE_PERL=ON
-    depends_lib-append      path:bin/perl:perl5
+variant tcl description {Bindings for Tcl plugins} {
+    configure.args-delete   -DENABLE_TCL=OFF
+    configure.args-append   -DENABLE_TCL=ON
+    depends_lib-append      port:tcl
 }
-
-variant ruby description {Bindings for ruby plugins} {
-    configure.args-delete   -DENABLE_RUBY=OFF
-    configure.args-append   -DENABLE_RUBY=ON
-    depends_lib-append      port:ruby
-}
-
-variant tls description {Support for secure connecting} {
-    depends_run-append      path:etc/openssl/cert.pem:curl-ca-bundle
-
-    configure.args-delete   -DENABLE_GNUTLS=OFF
-    configure.args-append   -DENABLE_GNUTLS=ON \
-                            -DCA_FILE=${prefix}/etc/openssl/cert.pem
-    depends_lib-append      port:gnutls
-}
-
-variant doc description {Build Documentation and plugin API} {
-    depends_build-append    port:source-highlight
-
-    configure.args-append   -DENABLE_DOC=ON
-}
-
-default_variants    +tls
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/weechat


### PR DESCRIPTION
weechat: update to 3.3
* removed tls variant as `ENABLE_GNUTLS` is no longer an option and GnuTLS is always compiled and used (as of weechat v2.9)
* cleaned up Portfile:
  - sorted arguments and variants
  - updated descriptions of some variants

#### Description

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?