### PR TITLE
cpputest: update to 4.0

### DIFF
--- a/devel/cpputest/Portfile
+++ b/devel/cpputest/Portfile
@@ -4,18 +4,28 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-categories          devel
-platforms           darwin macosx
-license             BSD
-maintainers         nomaintainer
-description         CppUTest unit testing and mocking framework for C/C++
-long_description    ${description}
-
-github.setup        cpputest cpputest 3.8 v
-checksums           rmd160  263e721051408362c2afebe26bbc7a57e3ed34ed \
-                    sha256  73ee4862117ebc93fd78c14647024641d9bf99af6a876924b7dd5ba2f9d3bb12 \
-                    size    2333395
+github.setup        cpputest cpputest 4.0 v
 revision            0
+checksums           rmd160  3f59d987202a38a18c6a749c5d5c8df9b0e99cb5 \
+                    sha256  0b66d20661f232d2a6af124c4455c8ccc9a4ce72d29f6ad4877eb385faaf5108 \
+                    size    762773
+
+github.tarball_from archive
+
+homepage            https://cpputest.github.io/
+license             BSD
+description         CppUTest unit testing and mocking framework for C/C++
+long_description    CppUTest is a C /C++ based unit xUnit test \
+                    framework for unit testing and for test-driving \
+                    your code. It is written in C++ but is used in C \
+                    and C++ projects and frequently used in embedded \
+                    systems but it works for any C/C++ project.
+
+categories          devel
+maintainers         nomaintainer
+platforms           darwin
 
 depends_build-append \
-    port:pkgconfig
+                    port:pkgconfig
+
+test.run            yes


### PR DESCRIPTION
#### Description
cpputest: update to 4.0
* enable tests
* Portfile: general cleanup and reformatting
  - add homepage
  - add long_description
  - remove `macosx` from platforms (already covered by `darwin`)

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?