### PR TITLE
Poetry: update to 1.0.9

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    poetry
-version                 1.1.8
+version                 1.1.9
 revision                0
 categories-append       devel
 platforms               darwin
@@ -23,9 +23,9 @@ long_description        Poetry: Dependency Management for Python. \
 
 homepage                https://python-poetry.org/
 
-checksums               rmd160  1565f6fbe7a55a2dc3ca1f5d651fa1c10dc9a8e9 \
-                        sha256  6dc82e85d919ab99a0b18baea1933a00a40d85eedce24f80a6099909e387914e \
-                        size    134465
+checksums               rmd160  30029378654360536a6da559b21d6f282ce79a66 \
+                        sha256  481c6264cecf907c47e82216205e7f8486d70e4d54c721b8c3fc651364b0d0ca \
+                        size    135550
 
 variant python37 conflicts python38 python39 description {Use Python 3.7} {}
 variant python38 conflicts python37 python39 description {Use Python 3.8} {}

--- a/python/py-pkginfo/Portfile
+++ b/python/py-pkginfo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pkginfo
-version             1.7.0
+version             1.7.1
 platforms           darwin
 license             MIT
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
@@ -18,9 +18,9 @@ long_description \
 
 homepage            https://pypi.python.org/pypi/pkginfo
 
-checksums           rmd160  9065991656247be33e4e01478bcbd222e6261646 \
-                    sha256  029a70cb45c6171c329dfc890cde0879f8c52d6f3922794796e06f577bb03db4 \
-                    size    37209
+checksums           rmd160  7ab4420729f4b3ffdc55d282f086bef12ba0db65 \
+                    sha256  e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd \
+                    size    34280
 
 python.versions     27 36 37 38 39
 

--- a/python/py-poetry-core/Portfile
+++ b/python/py-poetry-core/Portfile
@@ -5,12 +5,12 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-poetry-core
-version             1.0.4
+version             1.0.5
 revision            0
 
-checksums           rmd160  475dbc774168dd5740f933bbd5d77192298c28c2 \
-                    sha256  4b3847ad3e7b5deb88a35b23fa19762b9cef26828770cef3a5b47ffb508119c1 \
-                    size    344968
+checksums           rmd160  04f3a7433ae02f7e33ada663cfea344832f85214 \
+                    sha256  8cad9893ea70e344b2ce1a75d3834ba3fb1bac8123f89aad758e59e2a5d67805 \
+                    size    346202
 
 categories-append   devel
 platforms           darwin


### PR DESCRIPTION
#### Description

Also update dependency py-pkginfo with minor update. Basic binary testing was done with a `poetry update` on a poetry repo.

###### Type(s)


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
