### PR TITLE
hdf5: Enable legacysupport (needed for some variants.)

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           mpi 1.0
+PortGroup           legacysupport 1.1
 
 name                hdf5
 version             1.12.1


### PR DESCRIPTION
Maintainer update.

Not rev-bumping as standard variants do not require.

If anyone has a pre-Sierra system around to make sure this doesn't cause any issues, I'd appreciate it; we have at least one report of this change enabling a successful build with a number of variants set: https://trac.macports.org/ticket/63500