### PR TITLE
openjdk: add opendj17-temurin and openjdk17 meta port

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -565,6 +565,49 @@ subport openjdk16-zulu {
     worksrcdir   ${distname}/zulu-16.jdk
 }
 
+subport openjdk17 {
+    version      17
+    revision     0
+
+    set meta true
+
+    description  Open Java Development Kit 17 meta port
+    long_description Open Java Development Kit 17 meta port
+
+    distfiles
+    destroot {
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
+    }
+
+    if {${configure.build_arch} eq "x86_64"} {
+        depends_run-append port:openjdk17-temurin
+    } elseif {${configure.build_arch} eq "arm64"} {
+        depends_run-append port:openjdk17-zulu
+    }
+}
+
+subport openjdk17-temurin {
+    # https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
+
+    version      17
+    revision     0
+
+    set build    35
+
+    description  Eclipse Temurin, based on OpenJDK 17
+    long_description ${long_description_temurin}
+
+    master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${version}%2B${build}/
+
+    distname     OpenJDK17-jdk_x64_mac_hotspot_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
+
+    checksums    rmd160  0d79be9e1e6cf50d939e839a53ba15c2f9209a77 \
+                 sha256  e9de8b1b62780fe99270a5b30f0645d7a91eded60438bcf836a05fa7b93c182f \
+                 size    192417649
+}
+
 subport openjdk17-zulu {
     # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 


### PR DESCRIPTION
#### Description

Add Eclipse Temurin OpenJDK 17 (`openjdk17-temurin`) and an `openjdk17` meta port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?