### PR TITLE
google-cloud-sdk: update to 358.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             357.0.0
+version             358.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  0311edbd4d1a44a7fab838fff77b5863a1bb8808 \
-                    sha256  d946dfbc0bcebbe428d47673fa01a382bac453aa304a1b76c72a440737c09cf2 \
-                    size    91915763
+    checksums       rmd160  2b95384ce832265f38f4532456d53ce6c4b88838 \
+                    sha256  3ce98184f4c21bebca88af9e6102eed8eac36ca45d2c1ebdeb9b4e90ba9f58f9 \
+                    size    96400794
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  33e4cafc646ce093d9b6459e594e0a7d38bbeef0 \
-                    sha256  6dfef80cf74b058edb1561e4a1aaed29af5b0dbbc2d1f4afe7f96a5fca7e6da4 \
-                    size    88165594
+    checksums       rmd160  361d5fb62d3ad50b4a4de8435c932ef213493f35 \
+                    sha256  7986b36e8457ca700d47739f9eb2731ca6c2b0cc91bc0fa0a4e4ab64692e82b0 \
+                    size    92653534
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  2e7da77716d2895a035fcd1f53931cdc0a4d8bc7 \
-                    sha256  af77b1bcc3476a1ed173b90dcc918a47cbc9eead3d8efdab6ff99dc8ae79b11e \
-                    size    88088863
+    checksums       rmd160  187d3b4fe33b319613c3c10686f9212878247be8 \
+                    sha256  5ba8c3502616849f190c552333e4abf71ff7f2581810b5911f6887bd900cead5 \
+                    size    92576191
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 358.0.0.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?