### PR TITLE
usd: mark port as conflicting with spidermonkey

### DIFF
--- a/graphics/usd/Portfile
+++ b/graphics/usd/Portfile
@@ -39,6 +39,14 @@ set py_ver_nodot    [string map {. {}} ${py_ver}]
 set py_ver_major    [lindex [split $py_ver .] 0]
 set py_ver_minor    [lindex [split $py_ver .] 1]
 
+# Both usd and spidermonkey attempt to create a library file called
+# ${prefix}/lib/libjs.dylib. Unfortunately, these are not the same
+# library, they just happen to be named the same.
+# (See: https://trac.macports.org/ticket/63258)
+# This issue has been reported upstream:
+# https://github.com/PixarAnimationStudios/USD/issues/1615
+conflicts           spidermonkey
+
 depends_lib-append  port:tbb
 
 compiler.cxx_standard 2014

--- a/lang/spidermonkey/Portfile
+++ b/lang/spidermonkey/Portfile
@@ -21,6 +21,14 @@ checksums           md5 5571134c3863686b623ebe4e6b1f6fe6 \
                     sha1 1a99e8e10cb6600a03ea98895583a8ed42136d1f \
                     rmd160 6eadf1ac7c10a13b3db3d499856c9e18ddbcdfdb
 
+# Both usd and spidermonkey attempt to create a library file called
+# ${prefix}/lib/libjs.dylib. Unfortunately, these are not the same
+# library, they just happen to be named the same.
+# (https://trac.macports.org/ticket/63258)
+# This issue has been reported upstream:
+# https://github.com/PixarAnimationStudios/USD/issues/1615
+conflicts           usd
+
 depends_lib         port:nspr \
                     port:readline
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/63258

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
