### PR TITLE
libgweather: update to 40.0

### DIFF
--- a/net/libgweather/Portfile
+++ b/net/libgweather/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           meson 1.0
 
 name                libgweather
-version             3.36.1
-set branch          [join [lrange [split ${version} .] 0 1] .]
+version             40.0
+set branch          [lrange [split ${version} .] 0 0]
 maintainers         {devans @dbevans} openmaintainer
 categories          net gnome
 license             GPL-2+ LGPL-2.1+
@@ -21,9 +21,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  3add156fc57585e4b59c0be384f72f189f4b18fb \
-                    sha256  de2709f0ee233b20116d5fa9861d406071798c4aa37830ca25f5ef2c0083e450 \
-                    size    2702144
+checksums           rmd160  2aca846071b21a0fe916cc12cd8fed6eb87ef5ab \
+                    sha256  ca4e8f2a4baaa9fc6d75d8856adb57056ef1cd6e55c775ba878ae141b6276ee6 \
+                    size    2704404
 
 depends_build-append \
                     port:pkgconfig \
@@ -39,9 +39,7 @@ depends_lib         port:geocode-glib \
 
 post-patch {
     reinplace -W ${worksrcpath} "s|^#!.*python3|#!${prefix}/bin/python3.8|" \
-        data/update-locations.py \
-        data/check-observations.py \
-        data/locations_diff.py \
+        data/gen_locations_variant.py \
         meson/meson_post_install.py
 }
 


### PR DESCRIPTION
#### Description

With the new `libgweather` library version, some programs (e.g. `gnome-weather`) may emit an error like

```
GWeather-CRITICAL **: 09:39:32.216: gweather_info_update: assertion 'info->contact_info != NULL' failed.
```

This does not affect the library functionality, but the client programs will need to be updated at some point.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
