### PR TITLE
bitwarden-cli: update to 1.18.1

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        bitwarden cli 1.18.0 v
+github.setup        bitwarden cli 1.18.1 v
 revision            0
 
 name                bitwarden-cli
@@ -16,9 +16,9 @@ description         Bitwarden password manager CLI
 long_description    CLI implementation of the Bitwarden password manager.
 homepage            https://bitwarden.com
 
-checksums           rmd160  c2304e98e5c7f744cb651e63c950c87c45ae8bb4 \
-                    sha256  57b21ff53a9a83b1d7fecfc9120156db256881eafa3e009fc5fa14a315ada1fd \
-                    size    19611629
+checksums           rmd160  fb35af00304fa16b94906e858fc4135f6f393917 \
+                    sha256  b0726ccac9ed90ffbfef0c5acaef4f6bb85982860ea87e448f7f2c711632787a \
+                    size    19615266
 
 github.tarball_from releases
 distname            bw-macos-${version}


### PR DESCRIPTION
#### Description

See: https://github.com/bitwarden/cli/releases/tag/v1.18.1.


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
