### PR TITLE
xhyve: add missed dependencies

### DIFF
--- a/emulators/xhyve/Portfile
+++ b/emulators/xhyve/Portfile
@@ -6,7 +6,7 @@ PortGroup           xcode 1.0
 
 github.setup        machyve xhyve eab8ad838868205b872b93129e2ee91ca5328ea9
 version             20210922
-revision            0
+revision            1
 categories          emulators
 platforms           darwin
 supported_archs     x86_64
@@ -29,6 +29,8 @@ use_xcode           yes
 patch.pre_args      -p1
 patchfiles          cast-int.patch \
                     remove-walloca.patch
+
+depends_lib-append  port:zlib
 
 post-patch {
     foreach script [glob -- ${worksrcpath}/${name}run-*.sh] {


### PR DESCRIPTION
#### Description

`xhyve` is linked to `zlib`. Usually it is installed as side effect from another dependencies but it isn't trur for 10.11 and 10.10 builds. This builds are failed on linking phase
```
Undefined symbols for architecture x86_64:
  "_deflate", referenced from:
      _rfb_send_screen in xhyve_lto.o
      _rfb_send_all in xhyve_lto.o
  "_crc32", referenced from:
      _rfb_send_screen in xhyve_lto.o
  "_deflateEnd", referenced from:
      _rfb_thr in xhyve_lto.o
      _rfb_send_screen in xhyve_lto.o
      _rfb_send_all in xhyve_lto.o
  "_deflateInit_", referenced from:
      _rfb_thr in xhyve_lto.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Closes: https://trac.macports.org/ticket/57292


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->