### PR TITLE
logisim-evolution: update to Java 17 as fallback version

### DIFF
--- a/cad/logisim-evolution/Portfile
+++ b/cad/logisim-evolution/Portfile
@@ -5,7 +5,7 @@ PortGroup           java 1.0
 PortGroup           github 1.0
 
 github.setup        reds-heig logisim-evolution 3.5.0 v
-revision            1
+revision            2
 
 categories          cad education java
 platforms           darwin
@@ -22,10 +22,8 @@ checksums           rmd160  87b24defcabd6ab81333bc1c52c76928a64bdab1 \
                     sha256  8b52f1ce57205f68c396d12637ccb1d6955f631987c2e6b4247acce31116cbe4 \
                     size    40050282
 
-# non-LTS Java required for jpackage
-# Set to LTS Java 17 when released
 java.version        14+
-java.fallback       openjdk16
+java.fallback       openjdk17
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Java fallback version updated to latest long term support version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?