### PR TITLE
openjdk: deprecate openjdk16*

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -18,7 +18,7 @@ if {[regexp {openjdk[0-9]*(-zulu)?$} ${subport}]} {
 }
 
 # Latest Long Term Support (LTS) major version
-version          11
+version          17
 
 set long_description_ibm_semeru \
     "The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications built with\
@@ -71,6 +71,8 @@ if {${subport} eq "openjdk"} {
 }
 
 subport openjdk7-zulu {
+    # https://www.azul.com/downloads/?version=java-7-lts&os=macos&package=jdk
+
     version      7.48.0.11
     revision     0
 
@@ -151,6 +153,8 @@ subport openjdk8-openj9 {
 }
 
 subport openjdk8-temurin {
+    # https://adoptium.net/releases.html?variant=openjdk8&jvmVariant=hotspot
+
     version      8u302
     revision     0
 
@@ -169,6 +173,8 @@ subport openjdk8-temurin {
 }
 
 subport openjdk8-zulu {
+    # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
+
     if {${configure.build_arch} eq "x86_64"} {
         version      8.56.0.21
     } elseif {${configure.build_arch} eq "arm64"} {
@@ -281,6 +287,8 @@ subport openjdk11-openj9-large-heap {
 }
 
 subport openjdk11-temurin {
+    # https://adoptium.net/releases.html?variant=openjdk11&jvmVariant=hotspot
+
     version      11.0.12
     revision     0
 
@@ -300,6 +308,8 @@ subport openjdk11-temurin {
 }
 
 subport openjdk11-zulu {
+    # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
+
     version      11.50.19
     revision     0
 
@@ -368,6 +378,8 @@ subport openjdk13-openj9-large-heap {
 }
 
 subport openjdk13-zulu {
+    # https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
+
     version      13.42.17
     revision     0
 
@@ -414,11 +426,10 @@ subport openjdk14-openj9-large-heap {
     replaced_by  openjdk16-openj9
 }
 
-# Remove after 2022-03-22
 subport openjdk15 {
-    version      15.0.2
-    revision     1
-    replaced_by  openjdk16
+    version      15.0.4
+    revision     0
+    replaced_by  openjdk15-zulu
 }
 
 # Remove after 2022-03-22
@@ -436,6 +447,8 @@ subport openjdk15-openj9-large-heap {
 }
 
 subport openjdk15-zulu {
+    # https://www.azul.com/downloads/?version=java-15-mts&os=macos&package=jdk
+
     version      15.34.17
     revision     0
 
@@ -461,26 +474,11 @@ subport openjdk15-zulu {
     worksrcdir   ${distname}/zulu-15.jdk
 }
 
+# Remove after 2022-09-14
 subport openjdk16 {
     version      16.0.2
-    revision     0
-
-    set meta true
-
-    description  Open Java Development Kit 16 meta port
-    long_description Open Java Development Kit 16 meta port
-
-    distfiles
-    destroot {
-        file mkdir ${destroot}${prefix}/share/doc
-        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
-    }
-
-    if {${configure.build_arch} eq "x86_64"} {
-        depends_run-append port:openjdk16-temurin
-    } elseif {${configure.build_arch} eq "arm64"} {
-        depends_run-append port:openjdk16-zulu
-    }
+    revision     1
+    replaced_by  openjdk17
 }
 
 subport openjdk16-graalvm {
@@ -520,49 +518,18 @@ subport openjdk16-openj9 {
                  size    205816803
 }
 
+# Remove after 2022-09-14
 subport openjdk16-temurin {
     version      16.0.2
-    revision     0
-
-    set build    7
-
-    description  Eclipse Temurin, based on OpenJDK 16
-    long_description ${long_description_temurin}
-
-    master_sites https://github.com/adoptium/temurin16-binaries/releases/download/jdk-${version}%2B${build}/
-
-    distname     OpenJDK16U-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  cd0c259c0f73c3c0ab5e2d936a413e121817d53d \
-                 sha256  27975d9e695cfbb93861540926f9f7bcac973a254ceecbee549706a99cbbdf95 \
-                 size    206621395
+    revision     1
+    replaced_by  openjdk17-temurin
 }
 
+# Remove after 2022-09-14
 subport openjdk16-zulu {
     version      16.32.15
-    revision     0
-
-    set openjdk_version 16.0.2
-
-    description  Azul Zulu Community OpenJDK 16 (Short Term Support)
-    long_description ${long_description_zulu}
-
-    master_sites https://cdn.azul.com/zulu/bin/
-
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  c3d712e53d18bf01d764da601b8afdf3376c38e9 \
-                     sha256  3578018ff2a2c5392768261ba3707eacea35d4d2261f90835085342e14c2b4ca \
-                     size    206557323
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  87bf44f3809a19911c2b013cb44c0d92d083314e \
-                     sha256  ddb51f0dc2cbc9a84b7944450202c055aa41647beab5a9bc1876d64c0e8c4288 \
-                     size    195130848
-    }
-
-    worksrcdir   ${distname}/zulu-16.jdk
+    revision     1
+    replaced_by  openjdk17-zulu
 }
 
 subport openjdk17 {


### PR DESCRIPTION
#### Description

Support for Java 16 ended when Java 17 was released.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?