### PR TITLE
cmake: fix build with older clangs

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -78,7 +78,8 @@ if {${subport} eq ${name}} {
         patch-fix-system-prefix-path.diff \
         patch-cmake-leopard-tiger.diff \
         patch-fix-clock_gettime-test.diff \
-        patch-qt5gui.diff
+        patch-qt5gui.diff \
+        patch-cmake-cmInstallRuntime-initializer-fix.diff
 
     depends_lib-append \
         port:curl \

--- a/devel/cmake/files/patch-cmake-cmInstallRuntime-initializer-fix.diff
+++ b/devel/cmake/files/patch-cmake-cmInstallRuntime-initializer-fix.diff
@@ -1,0 +1,13 @@
+diff --git Source/cmInstallRuntimeDependencySet.cxx Source/cmInstallRuntimeDependencySet.cxx
+index 0cef49a..5f826f3 100644
+--- Source/cmInstallRuntimeDependencySet.cxx
++++ Source/cmInstallRuntimeDependencySet.cxx
+@@ -57,7 +57,7 @@ const std::set<const cmGeneratorTarget*>& GetTargetDependsClosure(
+     targetDepends,
+   const cmGeneratorTarget* tgt)
+ {
+-  auto it = targetDepends.insert({ tgt, {} });
++  auto it = targetDepends.insert({ tgt, std::set<const cmGeneratorTarget*>{} });
+   auto& retval = it.first->second;
+   if (it.second) {
+     auto const& deps = tgt->GetGlobalGenerator()->GetTargetDirectDepends(tgt);


### PR DESCRIPTION
use a specified constructor
closes: https://trac.macports.org/ticket/63460
see: https://gitlab.kitware.com/cmake/cmake/-/issues/22609

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
