### PR TITLE
vte: Fix build on 32-bit platforms

### DIFF
--- a/gnome/vte/Portfile
+++ b/gnome/vte/Portfile
@@ -46,7 +46,8 @@ depends_run         port:adwaita-icon-theme
 gobject_introspection yes
 
 patchfiles          patch-src-pty.cc.diff \
-                    patch-src-vteutils.cc.diff
+                    patch-src-vteutils.cc.diff \
+                    patch-vte-gsize.diff
 
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 

--- a/gnome/vte/files/patch-vte-gsize.diff
+++ b/gnome/vte/files/patch-vte-gsize.diff
@@ -1,0 +1,53 @@
+gsize and size_t are not the same type on 32-bit platforms.
+
+See: https://gitlab.gnome.org/GNOME/glib/-/issues/2493
+
+--- src/vte.cc.orig
++++ src/vte.cc
+@@ -1189,7 +1189,7 @@
+                               match_context)) >= 0 || r == PCRE2_ERROR_PARTIAL)) {
+                 gsize ko = offset;
+                 gsize rm_so, rm_eo;
+-                gsize *ovector;
++                size_t *ovector;
+ 
+                 ovector = pcre2_get_ovector_pointer_8(match_data);
+                 rm_so = ovector[0];
+@@ -3412,7 +3412,7 @@
+ 
+         /* Convert the data to UTF-8 */
+         auto inbuf = (char*)buf->data;
+-        size_t inbytes = buf->len;
++        gsize inbytes = buf->len;
+ 
+         _VTE_DEBUG_IF(VTE_DEBUG_IO) {
+                 _vte_debug_hexdump("Incoming buffer before conversion to UTF-8",
+@@ -3422,7 +3422,7 @@
+         auto unibuf = _vte_byte_array_new();
+         _vte_byte_array_set_minimum_size(unibuf, VTE_UTF8_BPC * inbytes);
+         auto outbuf = (char*)unibuf->data;
+-        size_t outbytes = unibuf->len;
++        gsize outbytes = unibuf->len;
+ 
+         bool stop = false;
+         do {
+@@ -10653,7 +10653,7 @@
+         int (* match_fn) (const pcre2_code_8 *,
+                           PCRE2_SPTR8, PCRE2_SIZE, PCRE2_SIZE, uint32_t,
+                           pcre2_match_data_8 *, pcre2_match_context_8 *);
+-        gsize *ovector, so, eo;
++        size_t *ovector; gsize so, eo;
+         int r;
+ 
+         if (_vte_regex_get_jited(m_search_regex.regex))
+--- src/vteregex.cc.orig
++++ src/vteregex.cc
+@@ -213,7 +213,7 @@
+         if (code == nullptr) {
+                 set_gerror_from_pcre_error(errcode, error);
+                 g_prefix_error(error, "Failed to compile pattern to regex at offset %" G_GSIZE_FORMAT ":",
+-                               erroffset);
++                               (gsize)erroffset);
+                 return NULL;
+         }
+ 


### PR DESCRIPTION
#### Description

Same idea as #12295, retype `gsize`/`size_t` pointers that are interchangeable on 64-bit but not 32-bit.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
