### PR TITLE
zulu-jdk: update to Java 17

### DIFF
--- a/java/zulu-jdk/Portfile
+++ b/java/zulu-jdk/Portfile
@@ -80,13 +80,13 @@ subport zulu-jdk15 {
 # Remove after 2022-05-07
 subport zulu-jdk16 {
     version     16.0.83
-    revision    1
-    replaced_by openjdk16-zulu
+    revision    2
+    replaced_by openjdk17-zulu
 }
 
 # Remove after 2022-05-07
 subport zulu-jdk17 {
     version     17.0.21
-    revision    1
-    replaced_by openjdk16-zulu
+    revision    2
+    replaced_by openjdk17-zulu
 }


### PR DESCRIPTION
#### Description

Replace the end of life Java 16 with 17.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?