### PR TITLE
s6: submission

### DIFF
--- a/devel/skalibs/Portfile
+++ b/devel/skalibs/Portfile
@@ -1,0 +1,62 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                skalibs
+version             2.11.0.0
+revision            0
+categories          devel
+platforms           darwin
+license             ISC
+maintainers         nomaintainer
+description         general-purpose libraries for C system programming
+
+long_description \
+    skalibs is a package centralizing the free software / open source \
+    C development files used for building all software at skarnet.org: \
+    it contains essentially general-purpose libraries. skalibs can \
+    also be used as a sound basic start for C development. There are a \
+    lot of general-purpose libraries out there\; but if your main goal \
+    is to produce small and secure C code with a focus on system \
+    programming, skalibs might be for you.
+
+homepage            https://skarnet.org/software/skalibs/
+master_sites        ${homepage}
+
+checksums           rmd160  f033bb3054865561f86edc93c0d2f265e6a72829 \
+                    sha256  98dfc8a02a333f5b12d069d84471c0d51ab5a421c4292963048b3652563d34d9 \
+                    size    216201
+
+configure.args      --disable-shared
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        AUTHORS \
+        COPYING \
+        NEWS \
+        README \
+        README.macos \
+        ${destroot}${docdir}
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/*.html] \
+        ${destroot}${docdir}
+    xinstall -d ${destroot}${docdir}/libdatastruct
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/libdatastruct/*.html] \
+        ${destroot}${docdir}/libdatastruct
+    xinstall -d ${destroot}${docdir}/libposixplz
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/libposixplz/*.html] \
+        ${destroot}${docdir}/libposixplz
+    xinstall -d ${destroot}${docdir}/librandom
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/librandom/*.html] \
+        ${destroot}${docdir}/librandom
+    xinstall -d ${destroot}${docdir}/libstdcrypto
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/libstdcrypto/*.html] \
+        ${destroot}${docdir}/libstdcrypto
+    xinstall -d ${destroot}${docdir}/libstddjb
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/libstddjb/*.html] \
+        ${destroot}${docdir}/libstddjb
+    xinstall -d ${destroot}${docdir}/libunixonacid
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/libunixonacid/*.html] \
+        ${destroot}${docdir}/libunixonacid
+}

--- a/lang/execline/Portfile
+++ b/lang/execline/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                execline
+version             2.8.1.0
+revision            0
+categories          lang
+platforms           darwin
+license             ISC
+maintainers         nomaintainer
+description         non-interactive scripting language
+
+long_description \
+    execline is a (non-interactive) scripting language, like sh - but \
+    its syntax is quite different from a traditional shell syntax. The \
+    execlineb program is meant to be used as an interpreter for a text \
+    file\; the other commands are essentially useful inside an \
+    execlineb script. execline is as powerful as a shell: it features \
+    conditional loops, getopt-style option handling, filename \
+    globbing, and more. Meanwhile, its syntax is far more logic and \
+    predictable than the shell's syntax, and has no security issues.
+
+homepage            https://skarnet.org/software/execline/
+master_sites        ${homepage}
+
+depends_build       port:skalibs
+
+checksums           rmd160  bebc7ab9fee8821926bfbd29c3f8fddc37d7c40c \
+                    sha256  5b55c9f9641e36d4238811ed3ab5586d3a1045cb48e0bda97c9a49fe8bfb5557 \
+                    size    97627
+
+configure.args      --disable-shared \
+                    --with-lib=${prefix}/lib/skalibs
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        AUTHORS \
+        COPYING \
+        NEWS \
+        README \
+        README.macos \
+        ${destroot}${docdir}
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/*.html] \
+        ${destroot}${docdir}
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/*.txt] \
+        ${destroot}${docdir}
+}

--- a/sysutils/s6/Portfile
+++ b/sysutils/s6/Portfile
@@ -1,0 +1,68 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                s6
+version             2.11.0.0
+revision            0
+categories          sysutils
+platforms           darwin
+license             ISC
+maintainers         nomaintainer
+description         toolbox for low-level process and service administration
+
+long_description \
+    s6 is a small suite of programs for UNIX, designed to allow \
+    process supervision (a.k.a service supervision), in the line of \
+    daemontools and runit, as well as various operations on processes \
+    and daemons. It is meant to be a toolbox for low-level process and \
+    service administration, providing different sets of independent \
+    tools that can be used within or without the framework, and that \
+    can be assembled together to achieve powerful functionality with \
+    a very small amount of code.
+
+homepage            https://skarnet.org/software/s6/
+master_sites        ${homepage}
+
+depends_build       port:execline \
+                    port:skalibs
+depends_run         port:execline
+
+checksums           rmd160  3a26359b062b1040cadb1e3408cf779057fee7a1 \
+                    sha256  c545e4e18cd98e7fdbef84566e212276e44630f25de3e7891a3c58e83a9074a8 \
+                    size    227693
+
+configure.args      --disable-shared \
+                    --with-lib=${prefix}/lib/execline \
+                    --with-lib=${prefix}/lib/skalibs
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        AUTHORS \
+        COPYING \
+        NEWS \
+        README \
+        README.macos \
+        ${destroot}${docdir}
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/*.html] \
+        ${destroot}${docdir}
+    xinstall -d ${destroot}${docdir}/libs6
+    xinstall -m 0644 {*}[glob ${worksrcpath}/doc/libs6/*.html] \
+        ${destroot}${docdir}/libs6
+
+    xinstall -m 755 -d ${destroot}${prefix}/var/s6-svscan/service
+}
+
+destroot.keepdirs   ${destroot}${prefix}/var/s6-svscan/service
+
+post-activate {
+    ui_msg "A startupitem for s6-svscan has been created."
+    ui_msg "The startupitem assumes a scandir of"
+    ui_msg "${prefix}/var/s6-svscan/service"
+}
+
+startupitem.create       yes
+startupitem.name         s6-svscan
+startupitem.executable   ${prefix}/bin/s6-svscan ${prefix}/var/s6-svscan/service


### PR DESCRIPTION
#### Description

[s6](https://skarnet.org/software/s6/) is an actively maintained spiritual descendant of djb's [daemontools](https://cr.yp.to/daemontools.html).

This pull includes s6, [execline](https://skarnet.org/software/execline/), and [skalibs](https://skarnet.org/software/skalibs/).  The former depend on the latter.  All are from the same upstream author.  For the sake of simplicity, this s6 port is delivered with all features enabled (namely execline support) without variants.  execline is technically optional, though working to exclude it would probably only benefit people on space constrained embedded devices.

`--disable-shared` is an [upstream directive](https://git.skarnet.org/cgi-bin/cgit.cgi/s6/tree/README.macos) for the Mac platform.

I have been testing this port, albeit with an older upstream release, since mid August.  No problems so far.

Closes: https://trac.macports.org/ticket/58116

Thank you for MacPorts!

###### Type(s)

- [x] enhancement

###### Tested on

macOS 11.6 20G165 x86_64
Xcode CLT 12.5.1.0.1.1623191612

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

s6 and execline include dozens of small programs (by design).  I have not had a reason to use all of them.  I have tested the most significant programs used for service supervision, including `s6-svscan`, `s6-supervise`, `s6-svscanctl`, `s6-svc`, `s6-log`, `s6-tai64nlocal`, `s6-envdir`, and possibly a few others.