### PR TITLE
py-pyqtgraph: pin to latest supported version for Python < 3.7

### DIFF
--- a/python/py-pyqtgraph/Portfile
+++ b/python/py-pyqtgraph/Portfile
@@ -26,12 +26,18 @@ checksums           rmd160  e7edab8113b767f4d044d2fa2ba60ddffeeb62db \
                     size    961420
 revision            0
 
-homepage            http://pyqtgraph.org/
-distname            ${python.rootname}-${version}
+homepage            https://pyqtgraph.org/
 
 python.versions     27 35 36 37 38 39
 
-if {$subport ne $name} {
+if {${subport} ne ${name}} {
+    if {${python.version} < 37 || [variant_isset pyqt4] || [variant_isset pyside]} {
+        version     0.11.1
+        checksums   rmd160  dd120edb7b6199222713dd67d01387edc52277b0 \
+                    sha256  7d1417f36b5b92d1365671633a91711513e5afbcc82f32475d0690317607714e \
+                    size    789229
+    }
+
     depends_lib-append      port:py${python.version}-scipy
 
     variant pyqt4 conflicts pyqt5 pyside description "Qt interface via PyQt4" {
@@ -50,16 +56,11 @@ if {$subport ne $name} {
         depends_lib-append  port:py${python.version}-opengl
     }
 
-    if {${python.version} >= 36 && ![variant_isset pyside] && ![variant_isset pyqt4]} {
+    if {![variant_isset pyside] && ![variant_isset pyqt4]} {
         default_variants +pyqt5
-    } elseif {![variant_isset pyside] && ![variant_isset pyqt5]} {
-        default_variants +pyqt4
     }
 
     default_variants-append +opengl
 
     livecheck.type      none
-
-} else {
-    livecheck.name      ${python.rootname}
 }

--- a/python/py-pyqtgraph/Portfile
+++ b/python/py-pyqtgraph/Portfile
@@ -1,38 +1,37 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem        1.0
-PortGroup         python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name              py-pyqtgraph
+name                py-pyqtgraph
 
-categories-append graphics math
-platforms         darwin
-maintainers       {michaelld @michaelld} openmaintainer
-license           MIT
-supported_archs   noarch
+categories-append   graphics math
+platforms           darwin
+maintainers         {michaelld @michaelld} openmaintainer
+license             MIT
+supported_archs     noarch
 
-description       Scientific Graphics and Qt GUI library for Python
+description         Scientific Graphics and Qt GUI library for Python
 
-long_description  PyQtGraph is a pure-python graphics and GUI library \
-                  built on PyQt4/PyQt5 and numpy. It is intended for use in \
-                  mathematics / scientific / engineering applications. \
-                  It is very fast due to its heavy leverage of numpy \
-                  for number crunching and Qt’s GraphicsView framework \
-                  for fast display.
+long_description    PyQtGraph is a pure-python graphics and GUI library \
+                    built on PyQt4/PyQt5 and numpy. It is intended for use in \
+                    mathematics / scientific / engineering applications. \
+                    It is very fast due to its heavy leverage of numpy \
+                    for number crunching and Qt’s GraphicsView framework \
+                    for fast display.
 
-version           0.12.2
-checksums         rmd160  e7edab8113b767f4d044d2fa2ba60ddffeeb62db \
-                  sha256  fd0cf0678267b65ec28fb4908a7393424978a8c4b369e5749daf8861478fa4ca \
-                  size    961420
-revision          0
+version             0.12.2
+checksums           rmd160  e7edab8113b767f4d044d2fa2ba60ddffeeb62db \
+                    sha256  fd0cf0678267b65ec28fb4908a7393424978a8c4b369e5749daf8861478fa4ca \
+                    size    961420
+revision            0
 
-homepage          http://pyqtgraph.org/
-distname          ${python.rootname}-${version}
+homepage            http://pyqtgraph.org/
+distname            ${python.rootname}-${version}
 
-python.versions   27 35 36 37 38 39
+python.versions     27 35 36 37 38 39
 
 if {$subport ne $name} {
-
     depends_lib-append      port:py${python.version}-scipy
 
     variant pyqt4 conflicts pyqt5 pyside description "Qt interface via PyQt4" {


### PR DESCRIPTION
#### Description
- pin to latest supported version for Python < 3.7 (shouldn't require an increase of `epoch` as it presumably didn't build due to the `python_requires=">=3.7"` in the `setup.py`)
- conform to modeline
- use `https` for homepage
- set Qt5 as default variant for all Python versions

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1417 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
