### PR TITLE
openjdk: replace openjdk16 with openjdk17

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -339,7 +339,7 @@ subport openjdk11-zulu {
 subport openjdk12 {
     version      12.0.2
     revision     1
-    replaced_by  openjdk16
+    replaced_by  openjdk17
 }
 
 # Remove after 2022-02-15
@@ -360,7 +360,7 @@ subport openjdk12-openj9-large-heap {
 subport openjdk13 {
     version      13.0.2
     revision     1
-    replaced_by  openjdk16
+    replaced_by  openjdk17
 }
 
 # Remove after 2022-02-15
@@ -409,7 +409,7 @@ subport openjdk13-zulu {
 subport openjdk14 {
     version      14.0.2
     revision     1
-    replaced_by  openjdk16
+    replaced_by  openjdk17
 }
 
 # Remove after 2022-02-15


### PR DESCRIPTION
#### Description

Replace the end of life `openjdk16` with `openjdk17`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?