### PR TITLE
mozjs52: deprecate

### DIFF
--- a/lang/mozjs52/Portfile
+++ b/lang/mozjs52/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           deprecated 1.0
+
+# Firefox 52 ESR hit EOL on 2018-09-05
+deprecated.eol_version yes
 
 name                mozjs52
 version             52.6.0
@@ -14,7 +18,8 @@ maintainers         {devans @dbevans} openmaintainer
 description         JavaScript-C Engine
 long_description    SpiderMonkey is Mozilla's JavaScript engine written in C/C++. \
                     It is used in various Mozilla products, including Firefox, \
-                    and is available under the MPL2.
+                    and is available under the MPL2. This port is now deprecated in favor \
+                    of mozjs60.
 
 homepage            https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
 # build from GNOME releng tarball


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/57032

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
