### PR TITLE
ocaml-lwt: depend on ocaml-dune-configurator

### DIFF
--- a/ocaml/ocaml-lwt/Portfile
+++ b/ocaml/ocaml-lwt/Portfile
@@ -12,7 +12,7 @@ maintainers         {landonf @landonf} openmaintainer
 license             MIT
 description         Promises and event-driven I/O for OCaml
 long_description    Lwt provides typed, composable promises for OCaml, with \
-					support for parallel resolution.
+                    support for parallel resolution.
 
 homepage            https://github.com/ocsigen/lwt
 platforms           darwin
@@ -38,7 +38,7 @@ post-patch {
         src/unix/dune
 }
 
-ocaml.build_type	dune
+ocaml.build_type    dune
 
 dune.build.env      LWT_DISCOVER_ARGUMENTS=--use-libev=true \
                     C_INCLUDE_PATH=${prefix}/include \

--- a/ocaml/ocaml-lwt/Portfile
+++ b/ocaml/ocaml-lwt/Portfile
@@ -18,7 +18,8 @@ homepage            https://github.com/ocsigen/lwt
 platforms           darwin
 
 depends_build       port:ocaml-cppo
-depends_lib         port:ocaml-result \
+depends_lib         port:ocaml-dune-configurator \
+                    port:ocaml-result \
                     port:ocaml-mmap \
                     port:ocaml-ocplib-endian \
                     port:libev


### PR DESCRIPTION
cf. src/unix/config/dune

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6
Xcode 13.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
