### PR TITLE
google-cloud-sdk: update to 359.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             358.0.0
+version             359.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  2b95384ce832265f38f4532456d53ce6c4b88838 \
-                    sha256  3ce98184f4c21bebca88af9e6102eed8eac36ca45d2c1ebdeb9b4e90ba9f58f9 \
-                    size    96400794
+    checksums       rmd160  34e9fa04cd49f8b2b71e1ab44ca772d29d54bb14 \
+                    sha256  4d086077c18ba8a1fe4a3d79357c284c07c6567fbb5973d00ae66b205beb22c5 \
+                    size    96472015
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  361d5fb62d3ad50b4a4de8435c932ef213493f35 \
-                    sha256  7986b36e8457ca700d47739f9eb2731ca6c2b0cc91bc0fa0a4e4ab64692e82b0 \
-                    size    92653534
+    checksums       rmd160  ca4c3fa365c041cdf0e9c961b4018bb00344b506 \
+                    sha256  f79438933a40b893b8997f1e1351d8dd1f99faaf2925a4aa6ae2f118452e8825 \
+                    size    92716858
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  187d3b4fe33b319613c3c10686f9212878247be8 \
-                    sha256  5ba8c3502616849f190c552333e4abf71ff7f2581810b5911f6887bd900cead5 \
-                    size    92576191
+    checksums       rmd160  fd6c3c15562ae0f18dd5034a240ecf6c2968bbbe \
+                    sha256  0c5d415382a5b9bb5bf31bdf471394e4bbe5fc9a0793c759eea1e3a6becb33b5 \
+                    size    92640619
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 359.0.0.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?