### PR TITLE
gitlab-runner: update to 14.3.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 14.1.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 14.3.1 v
 
 categories          devel
 platforms           darwin
@@ -22,16 +22,15 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  b1f552ca495149b73106815743afaeb38e6dddbd \
-                    sha256  71858b2f9a12eca02e50a975ab8b35fe3e3bcc62e48898a6e4427b993f57d760 \
-                    size    9026301
+checksums           rmd160  a76b8fca3290d9a673c30f99584c2e98eaec8a23 \
+                    sha256  da2f7f420f105282e43b98d961433d09aa1dfa407836919e7c06823cc44c3e16 \
+                    size    9089340
 
-set build_date      [exec date +%FT%T%z]
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \
     -X ${go.package}/common.VERSION=${version} \
     -X ${go.package}/common.REVISION=unknown \
-    -X ${go.package}/common.BUILT=${build_date} \
+    -X ${go.package}/common.BUILT=unknown \
     -X ${go.package}/common.BRANCH=unknown \
     -s -w"
 build.args          -ldflags \"${go_ldflags}\" -o out/binaries/${name} ${go.package}


### PR DESCRIPTION
#### Description

Update to GitLab Runner 14.3.1.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?