### PR TITLE
openssl11: Fix commit IDs in Portfile comments

### DIFF
--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -45,8 +45,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     configure.cxx_stdlib
 }
 
-#   https://github.com/openssl/openssl/commit/c023d98dcf2ba1cc30f545ae54d0e037e80a8794
-#   https://github.com/openssl/openssl/commit/24cdb1bfecbd765e829b9932a5a60ff63a7dff4b
+#   https://github.com/openssl/openssl/commit/96ac8f13f4d0ee96baf5724d9f96c44c34b8606c
+#   https://github.com/openssl/openssl/commit/2f3b120401533db82e99ed28de5fc8aab1b76b33
 #   Patches updated to fix 10.4 build
 patchfiles-append   patch-pre-Sierra.diff
 


### PR DESCRIPTION
The upstream commit IDs referenced in relation to the pre-Sierra patch
were for the master branch.  This replaces them with the versions for
the OpenSSL_1_1_1-stable branch, matching the correct versions of the
code.

This potentially affects the openssl port, but currently ignores it
due to the other pending change.  The upstream code may be different
in the 3.0.0 case, anyway.

TESTED:
Passes port lint.  Comment-only change.

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
