### PR TITLE
py-twisted: update to 21.7.0 (py36+), 21.2.0 (py35), fix fetch

### DIFF
--- a/python/py-twisted/Portfile
+++ b/python/py-twisted/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-twisted
-version             20.3.0
+version             21.7.0
 categories-append   devel net
 license             MIT
 platforms           darwin
@@ -18,14 +18,11 @@ long_description    Twisted is an event-driven networking framework \
 
 homepage            https://www.twistedmatrix.com/
 
-set dl_version      [join [lrange [split ${version} .] 0 1] .]
-master_sites        https://twistedmatrix.com/Releases/Twisted/${dl_version}
-distname            Twisted-${version}
-use_bzip2           yes
+python.rootname     Twisted
 
-checksums           rmd160  d30b3dd66222e4dd3ad4ce668f1c556690e8b554 \
-                    sha256  d72c55b5d56e176563b91d11952d13b01af8725c623e498db5507b6614fc1e10 \
-                    size    3127793
+checksums           rmd160  ae67d0d71834b6fcaead604c4cfc00f1b549aab1 \
+                    sha256  2cd652542463277378b0d349f47c62f20d9306e57d1247baabd6d1d38a109006 \
+                    size    3739740
 
 python.versions 27 35 36 37 38 39
 
@@ -37,9 +34,38 @@ if {${name} ne ${subport}} {
         port:py${python.version}-zopeinterface \
         port:py${python.version}-incremental \
         port:py${python.version}-hyperlink \
-        port:py${python.version}-constantly
+        port:py${python.version}-constantly \
+        port:py${python.version}-automat \
+        port:py${python.version}-attrs
     depends_run-append \
         port:py${python.version}-pyhamcrest
+
+    if {${python.version} == 27} {
+        version     20.3.0
+
+        checksums   rmd160  d30b3dd66222e4dd3ad4ce668f1c556690e8b554 \
+                    sha256  d72c55b5d56e176563b91d11952d13b01af8725c623e498db5507b6614fc1e10 \
+                    size    3127793
+
+        use_bzip2   yes
+
+        # Dependencies:
+        # https://github.com/twisted/twisted/blob/121c98e006a31750661107d390ec2dc4ffe28e8a/src/twisted/python/_setup.py#L270
+    } elseif {${python.version} == 35} {
+        version     21.2.0
+
+        checksums   rmd160  8ee4a98a79aecd9ff7eaf1570973dfda546cc3cb \
+                    sha256  77544a8945cf69b98d2946689bbe0c75de7d145cdf11f391dd487eae8fc95a12 \
+                    size    3727284
+
+        # Dependencies:
+        # https://github.com/twisted/twisted/blob/f1daeeee171b1cd9dae77833c66728023198b468/setup.cfg#L28
+    } elseif {${python.version} >= 36} {
+        # Dependencies:
+        # https://github.com/twisted/twisted/blob/4e3b22afe1f76b360733b65d6b835b7aaae6deb6/setup.cfg#L28
+        depends_lib-append \
+            port:py${python.version}-typing_extensions
+    }
 
     post-destroot {
         # update the plugin cache
@@ -52,13 +78,5 @@ if {${name} ne ${subport}} {
         }
     }
 
-    # see https://trac.macports.org/ticket/54627
-    depends_run-append \
-        port:py${python.version}-automat
-
     livecheck.type  none
-} else {
-    livecheck.type   regex
-    livecheck.url    https://twistedmatrix.com/Releases/
-    livecheck.regex  {Twisted-(\d+(?:.\d+)*)}
 }


### PR DESCRIPTION
#### Description

The homepage apparently no longer hosts distfiles, so I changed the port to fetch from PyPI.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
