### PR TITLE
py-gpilab-{framework,core}: use current py-sip, update to latest upstream version

### DIFF
--- a/python/py-gpilab-core/Portfile
+++ b/python/py-gpilab-core/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
 
-github.setup            gpilab core-nodes 2.2.0 v
+github.setup            gpilab core-nodes 2.3.0 v
 name                    py-gpilab-core
 # Bump to rebuild with latest py-gpilab-framework
 revision                0
@@ -20,10 +20,9 @@ long_description        The core nodes are a collection of basic data \
 
 homepage                http://gpilab.com
 
-checksums \
-    rmd160  3f779a36a2c07263617243431d6ec9fed7177bee \
-    sha256  f43c9bc01ed9d7d96ea35f6afbb3c8b4d65f0c16bb1779f70066e4e7569ae099 \
-    size    183510
+checksums               rmd160  8f434a59fb9241c6a44b12d8a963ac2def92d58b \
+                        sha256  6600cbf2b7a1c856d7414069f7dca29b4dd56d7d480e6ed3b8c7b5920cdd0c8b \
+                        size    195371
 
 if {${name} ne ${subport} } {
     depends_lib-append      port:py${python.version}-gpilab-framework \

--- a/python/py-gpilab-framework/Portfile
+++ b/python/py-gpilab-framework/Portfile
@@ -5,9 +5,9 @@ PortGroup               python 1.0
 PortGroup               github 1.0
 PortGroup               select 1.0
 
-github.setup            gpilab framework 1.3.0 v
+github.setup            gpilab framework 1.3.2 v
 name                    py-gpilab-framework
-revision                1
+revision                0
 python.versions         37 38 39
 supported_archs         noarch
 platforms               darwin
@@ -27,10 +27,9 @@ homepage                http://gpilab.com
 
 supported_archs         noarch
 
-checksums \
-    rmd160  2948565372091864aa7696194474840a5b759f11 \
-    sha256  8d1df7db71f0550d83c004789c8749a90f2d29f09812a6ef468a77b8e40d786c \
-    size    3991809
+checksums               rmd160  0ef8cc6ef1580af8e6ee7d617159dfa0edc71251 \
+                        sha256  514c7470d518f2873cb2fdc3898caad13dccbb136563490ecd075784b0e77d12 \
+                        size    3992096
 
 patchfiles                  mainWindow.py.diff \
                             canvasGraph.py.diff \
@@ -53,7 +52,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-pyflakes \
                             port:py${python.version}-qimage2ndarray \
                             port:py${python.version}-scipy \
-                            port:py${python.version}-sip4 \
+                            port:py${python.version}-sip \
                             port:gpilab_select
 
     livecheck.type          none


### PR DESCRIPTION
#### Description
The `py-gpilab-framework` port depends uses SIP; currently this port depends on the legacy `pyXY-sip4`, this PR changes that to the most recent `pyXY-sip` port. Since the port needs to be rebuild for this change anyway, I also updated it (and the `py-gpilab-core` port) to their latest upstream versions. They both install but I haven't done any testing to make sure it all works. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1417 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
