### PR TITLE
postgis3: add port:pkgconfig to depends_build

### DIFF
--- a/databases/postgis3/Portfile
+++ b/databases/postgis3/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                postgis3
 categories          databases gis
 license             GPL-2+
-version             3.1.3
+version             3.1.4
 revision            0
 platforms           darwin
 maintainers         {vince @Veence} openmaintainer
@@ -22,14 +22,15 @@ homepage            http://postgis.net/
 master_sites        http://download.osgeo.org/postgis/source
 distname            postgis-${version}
 
-checksums           rmd160  01542d4351c39c67b88837d8ac6c98133d8a7bdc \
-                    sha256  71e929553bb73a0413206a0f92df5180ac6579c500d8ddce3a03559f1b349fcb \
-                    size    17273487
+checksums           rmd160  daa6339bda59ccf043ba48ea642a2bf079d41ece \
+                    sha256  dc8e3fe8bc532e422f5d724c5a7c437f6555511716f6410d4d2db9762e1a3796 \
+                    size    17269391
 
 depends_build       port:autoconf \
                     port:automake \
                     port:libtool \
-                    port:libxslt
+                    port:libxslt \
+                    port:pkgconfig
 
 depends_lib         port:geos\
                     port:libiconv\
@@ -43,7 +44,7 @@ conflicts           postgis postgis2
 
 # Neither is PostGIS 2.0 compatible with PostGreSQL 8
 # Database variants (from the GDAL port)
-set postgresql_suffixes {13 12 11 10}
+set postgresql_suffixes {13 12}
 
 set postgresql_variants {}
 
@@ -66,8 +67,8 @@ foreach suffix ${postgresql_suffixes} {
             --with-pgconfig=${prefix}/lib/${vrt}/bin/pg_config
         build.args-append       \
             PGSQL_DOCDIR=${destroot}${prefix}/share/doc/${vrt} \
-            PGSQL_MANDIR=${destroot}${prefix}/share/man 
-        " 
+            PGSQL_MANDIR=${destroot}${prefix}/share/man
+        "
 }
 
 # postgresql default
@@ -99,25 +100,25 @@ variant sfcgal              description {Uses SFCGAL for 3D queries} {
     configure.args-append   --with-sfcgal=${prefix}/bin/sfcgal-config
 }
 
-variant proj6 conflicts {proj7 proj8} {
+variant proj6 description {Build with Proj 6} conflicts proj7 proj8 {
     depends_lib-append      port:proj6
     configure.args-append   PROJ_CFLAGS=-I${prefix}/lib/proj6/include
     configure.args-append   PROJ_LIBS="-L${prefix}/lib/proj6/lib -lproj"
 }
 
-variant proj7 conflicts {proj6 proj8} {
+variant proj7 description {Build with Proj 7} conflicts proj6 proj8 {
     depends_lib-append      port:proj7
     configure.args-append   PROJ_CFLAGS=-I${prefix}/lib/proj7/include
     configure.args-append   PROJ_LIBS="-L${prefix}/lib/proj7/lib -lproj"
 }
 
-variant proj8 conflicts {proj6 proj7} {
+variant proj8 description {Build with Proj 8} conflicts proj6 proj7 {
     depends_lib-append      port:proj8
     configure.args-append   PROJ_CFLAGS=-I${prefix}/lib/proj8/include
     configure.args-append   PROJ_LIBS="-L${prefix}/lib/proj8/lib -lproj"
 }
 
-default_variants            +raster +topology 
+default_variants            +raster +topology
 
 if {![variant_isset proj6] && ![variant_isset proj7] && ![variant_isset proj8]} {
     default_variants        +proj8
@@ -126,7 +127,7 @@ if {![variant_isset proj6] && ![variant_isset proj7] && ![variant_isset proj8]} 
 # Port phases
 
 configure.cflags-append \
-    -Diconv=libiconv -Diconv_open=libiconv_open -Diconv_close=libiconv_close 
+    -Diconv=libiconv -Diconv_open=libiconv_open -Diconv_close=libiconv_close
 
 # see https://trac.macports.org/wiki/UsingTheRightCompiler
 configure.env-append    CPPBIN=${configure.cpp}


### PR DESCRIPTION
#### Description

Running port install with -vst occasionally fails to find proj.h.
configure.ac checks for pkg-config but only issues a warning when not
found.  Hopefully, this is all that is needed to fix the apparently
random build failures.

- Fix `port lint` warnings
- Upgrade to latest version

Build failure for macOS 10.15 for another portfile submission can be seen here:

https://github.com/macports/macports-ports/pull/12391/checks?check_run_id=3723204584

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.6 20G165 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
