### PR TITLE
lablgtk2: update to version 2.18.11

### DIFF
--- a/x11/lablgtk2/Portfile
+++ b/x11/lablgtk2/Portfile
@@ -5,11 +5,11 @@ PortGroup           ocaml 1.0
 PortGroup           active_variants 1.1
 PortGroup           github 1.0
 
-github.setup        garrigue lablgtk 2.18.9
+github.setup        garrigue lablgtk 2.18.11
 revision            0
-checksums           rmd160  27d482e4d1d0edd86e57001ac697c77662231a3b \
-                    sha256  c8968f24bfe3459823637d13ba12e70338cf88d3e602994763d593ce550db51f \
-                    size    1068410
+checksums           rmd160  f119068f330f0c481a5e9ea3ef4014d04e10141d \
+                    sha256  ff3c551df4e220b0c0fb9a3da6429413bff14f8fc93f4dd6807a35463982c863 \
+                    size    1068587
 
 name                lablgtk2
 categories          x11 ocaml


### PR DESCRIPTION
#### Description

Updating lablgtk2 to version 2.18.11 allows to compile it with the present version of ocaml, 4.12 (and then to compile unison 2.51.4).

https://trac.macports.org/ticket/62576 is a related ticket.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
