### PR TITLE
qdmr: update to version 0.9.0-alpha

### DIFF
--- a/science/qdmr/Portfile
+++ b/science/qdmr/Portfile
@@ -8,7 +8,7 @@ PortGroup           qt5 1.0
 
 name                qdmr
 maintainers         @hmatuschek {ra1nb0w @ra1nb0w} openmaintainer
-version             0.8.1
+version             0.9.0-alpha
 
 categories          science
 license             GPL-3
@@ -25,9 +25,9 @@ homepage            https://dm3mat.darc.de/qdmr/
 
 github.setup        hmatuschek qdmr ${version} v
 
-checksums           rmd160  0fce8a5b5f1270c61ff5e3cfd32f713269375a05 \
-                    sha256  5f7b9175896cb9950af188dbcbbc4bf0c6f96e7c84c0996d984e3550dc8eddc0 \
-                    size    3870691
+checksums           rmd160  0ff15e31997e49d6be9a8b6e3578f90e4203c7a1 \
+                    sha256  61d82e063d1b3a7a65bc763c4366283d9a7635255e4fc2c136e5c2e872ba0561 \
+                    size    5540085
 
 qt5.depends_build_component \
     qttools
@@ -37,7 +37,8 @@ qt5.depends_component \
     qtlocation
  
 depends_lib \
-    port:libusb
+    port:libusb \
+    port:yaml-cpp
 
 configure.args-append \
     -DBUILD_TESTS=OFF \


### PR DESCRIPTION
#### Description

Update to version 0.9.0-alpha. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
