### PR TITLE
gitlab-runner: update to 14.3.2

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 14.3.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 14.3.2 v
 
 categories          devel
 platforms           darwin
@@ -22,9 +22,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  a76b8fca3290d9a673c30f99584c2e98eaec8a23 \
-                    sha256  da2f7f420f105282e43b98d961433d09aa1dfa407836919e7c06823cc44c3e16 \
-                    size    9089340
+checksums           rmd160  6df5d67db95f854ace645b0004d7ad2cc2628ad7 \
+                    sha256  f67aeae05349f5c612ea5d8772407237caf4da586c0365e3c7edceec6b853d8c \
+                    size    9088939
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 14.3.2.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?