### PR TITLE
ntfs-3g: do not overwrite PortGroup dependencies

### DIFF
--- a/fuse/ntfs-3g/Portfile
+++ b/fuse/ntfs-3g/Portfile
@@ -27,12 +27,13 @@ extract.suffix      .tgz
 master_sites        http://tuxera.com/opensource/
 
 checksums           rmd160  aae0cd7a2560ad87ba41832f1b34af5aaaa38739 \
-                    sha256  3e5a021d7b761261836dcb305370af299793eedbded731df3d6943802e1262d5
+                    sha256  3e5a021d7b761261836dcb305370af299793eedbded731df3d6943802e1262d5 \
+                    size    1259054
 
 livecheck.type      regex
 livecheck.regex     {stable version</span></b> is <a href="https://tuxera.com/opensource/ntfs-3g_ntfsprogs-(.+?)\.tgz"}
 
-depends_lib         port:ossp-uuid
+depends_lib-append  port:ossp-uuid
 
 # Use default PKG_CONFIG_PATH to avoid picking up a FUSE installation
 # in /usr/local (see #30537)


### PR DESCRIPTION
Also add size to solve lint warning.

See: https://trac.macports.org/ticket/62062
(I believe this PR solves the ticket, but there are too few details there for me to be sure.)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
