### PR TITLE
task: update to 2.6.0

### DIFF
--- a/office/task/Portfile
+++ b/office/task/Portfile
@@ -2,11 +2,11 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           cmake 1.0
+PortGroup           cmake 1.1
 
-github.setup        GothenburgBitFactory taskwarrior 2.5.3 v
+github.setup        GothenburgBitFactory taskwarrior 2.6.0 v
 github.tarball_from releases
-revision            1
+revision            0
 name                task
 maintainers         nomaintainer
 
@@ -23,13 +23,11 @@ license             MIT
 homepage            https://taskwarrior.org/
 
 distname            task-${github.version}
-checksums           rmd160  d59dcb1644dccafb0ff35c5ea3e704e88b5d9f71\
-                    sha256  7243d75e0911d9e2c9119ad94a61a87f041e4053e197f7280c42410aa1ee963b\
-                    size    788760
+checksums           rmd160  18a89b9cbaeb0f8ac90bc96e8711bfc3021ad4c9\
+                    sha256  3d0b445d45ffc578c3fefadc82501e35de898d09e8cd7460709077751e55b9c5\
+                    size    832281
 
 depends_lib         port:gnutls
-
-cmake.out_of_source yes
 
 compiler.cxx_standard 2017
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
macOS 10.15.7 19H2 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
