### PR TITLE
OpenBLAS: update to 0.3.18, update minimal architectures

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -27,22 +27,12 @@ compiler.thread_local_storage yes
 if {${os.major} >= 11 && ${os.major} <= 17} { 
     set blas_arch "CORE2"
 } 
+#OS 10.14 supports down to Mac Pro 5,1 that has Nehalem architecture
 if {${os.major} >= 18} {
     if {${os.arch} eq "arm"} {
         set blas_arch "ARMV8"
     } else {
-        #OS 10.14 supports down to Mac Pro 5,1 that has Nehalem architecture
-        if {${os.major} == 18} {
-            set blas_arch "NEHALEM"
-        }
-        #OS 10.15 supports down to MacBook Pro mid 2012 that has Ivy Bridge architecture
-        if {${os.major} == 19} {
-            set blas_arch "SANDYBRIDGE"
-        }
-        #OS 11 supports down to MacBook Pro late 2013 that has Haswell architecture
-        if {${os.major} >= 20} {
-            set blas_arch "HASWELL"
-        }
+        set blas_arch "NEHALEM"
     }
 }
 if {![info exists blas_arch]} {

--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -247,7 +247,6 @@ pre-build {
     }
 }
 
-depends_build-append port:cctools
 build.args          "AR=${prefix}/bin/ar RANLIB=${prefix}/bin/ranlib"
 
 platform darwin 8 {

--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -27,12 +27,22 @@ compiler.thread_local_storage yes
 if {${os.major} >= 11 && ${os.major} <= 17} { 
     set blas_arch "CORE2"
 } 
-#OS 10.14 supports down to Mac Pro 5,1 that has Nehalem architecture
 if {${os.major} >= 18} {
     if {${os.arch} eq "arm"} {
         set blas_arch "ARMV8"
     } else {
-        set blas_arch "NEHALEM"
+        #OS 10.14 supports down to Mac Pro 5,1 that has Nehalem architecture
+        if {${os.major} == 18} {
+            set blas_arch "NEHALEM"
+        }
+        #OS 10.15 supports down to MacBook Pro mid 2012 that has Ivy Bridge architecture
+        if {${os.major} == 19} {
+            set blas_arch "SANDYBRIDGE"
+        }
+        #OS 11 supports down to MacBook Pro late 2013 that has Haswell architecture
+        if {${os.major} >= 20} {
+            set blas_arch "HASWELL"
+        }
     }
 }
 if {![info exists blas_arch]} {

--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -43,11 +43,11 @@ if {![info exists blas_arch]} {
 subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup    xianyi OpenBLAS 5edd88c919e8b0949f599dd8b7a2a81d111e2073
-    version         20210917-[string range ${github.version} 0 7]
-    checksums       rmd160  1d9fcd946900550f6558bd6a26a0206b19b85169 \
-                    sha256  ff20565b9025573bede75e88d13b570de463829aef563d232549014ede934482 \
-                    size    12623252
+    github.setup    xianyi OpenBLAS dcb005351e84ff4a37339868ea5817d7a8a29ddc
+    version         20211003-[string range ${github.version} 0 7]
+    checksums       rmd160  b2f5144af88ed6e1c3df1ec140f50888861f1ef2 \
+                    sha256  d09db3bd2a71e0b13b00f785772cd29c674a10c6fae4fdd90c7d872e410639db \
+                    size    12624196
     revision        0
 
     name            ${github.project}-devel
@@ -63,10 +63,10 @@ if {[string first "-devel" $subport] > 0} {
 
 } else {
 
-    github.setup    xianyi OpenBLAS 0.3.17 v
-    checksums       rmd160  cb4325fc34cd0849829e1180cfe38ba6b3f84fb9 \
-                    sha256  84547c2d9f4aec68acbd56e349362fdb2c6652b431c9eef1140dc419979d8fd6 \
-                    size    12516980
+    github.setup    xianyi OpenBLAS 0.3.18 v
+    checksums       rmd160  ff7326f99e76bd345a06028bc6ee13eb32a72bc0 \
+                    sha256  a422463a113e0fb1b946289dce05de2bca83e7acbc85628f8f42da3a8c0b4ecc \
+                    size    12623804
     revision        0
 
     conflicts       OpenBLAS-devel


### PR DESCRIPTION
#### Description

Update of OpenBLAS to the latest version 0.3.18, and update of *-devel port to latest commit.
The minimal architectures to build upon have been increased based on the machines supported by the different OS versions, and dependencies have been cleaned up.
The different steps are in different commits to ease comparison, they should be squashed upon merging.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
