### PR TITLE
gocryptfs: update to 2.2.0

### DIFF
--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 PortGroup           fuse 1.0
 
-go.setup            github.com/rfjakob/gocryptfs 2.1 v
+go.setup            github.com/rfjakob/gocryptfs 2.2.0 v
 revision            0
 
 categories          fuse
@@ -17,11 +17,11 @@ long_description    ${description}
 homepage            https://nuetzlich.net/gocryptfs/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  098e77361a89e3a8783add7e1364a902979d2459 \
-                        sha256  630bd128943796312e007adb7dc6f303ffc1436cb28ba18e0ac9a1e9fa5a747f \
-                        size    1353538
+                        rmd160  fe96b161b616299c1133558a3b682ff24990fbb0 \
+                        sha256  5ac58b3deef134745c6dbdfaac8d31cf2d2ef4aac9104f56553e427ad36c97f3 \
+                        size    1363930
 
-set gitversionfuse "15a8bb029a4e"
+set gitversionfuse "3ab5d95a30ae"
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
                         rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
@@ -109,9 +109,9 @@ go.vendors          gopkg.in/yaml.v3 \
                         size    3653945 \
                     github.com/hanwen/go-fuse \
                         lock    ${gitversionfuse} \
-                        rmd160  8fd353891c756903ae3aa841e31561004d3d14b9 \
-                        sha256  28fbaa7c222f473222ce0f04850c65bdee625907419d253b116f7d425a87c2bd \
-                        size    205706 \
+                        rmd160  f67c7ce554e587c5943e4d9358b9af9e76962d2a \
+                        sha256  28b3ec13201845b6f7a593a5eb2a7ce755c30fb5d1229b9c3b5301b0de10ec77 \
+                        size    207290 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.0 \
                         rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \


### PR DESCRIPTION
#### Description

See: https://github.com/rfjakob/gocryptfs#changelog


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
