### PR TITLE
nektarpp: update to 5.0.3

### DIFF
--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -7,7 +7,7 @@ PortGroup               gitlab 1.0
 PortGroup               boost 1.0
 
 gitlab.instance         https://gitlab.nektar.info
-gitlab.setup            nektar nektar 5.0.2 v
+gitlab.setup            nektar nektar 5.0.3 v
 
 boost.version           1.71
 
@@ -35,10 +35,10 @@ distfiles               ${main_distfile}:main \
                         tetgen-1.5.zip:thirdparty \
                         triangle-1.6.zip:thirdparty
 
-checksums               nektar-5.0.2.tar.bz2 \
-                        rmd160  1b093fc9616a1b522198d55323da2bbb35315f36 \
-                        sha256  956ad44e400cf50b0aa01955c9568a6c5fa9d1ac5438039a3f1f3d8b88ba4c8b \
-                        size    51514235 \
+checksums               nektar-5.0.3.tar.bz2 \
+                        rmd160  352e69fb1d7fc56c59ea344c3772f6b03e5e57e7 \
+                        sha256  2786525ec46884c726c1ab3518846b639b1995d761b66031b7e3d55441c6364f \
+                        size    51949715 \
                         tetgen-1.5.zip \
                         rmd160  d8785f4ca6b26608ec9423f7574a0e736380370a \
                         sha256  52207793198746de14abcb30a0aeed617d7348ff37544e7d7e65aaaa76d7fa70 \
@@ -69,6 +69,7 @@ depends_lib-append      port:arpack \
 
 # Don't build demos and tests by default.
 configure.args-append   -DNEKTAR_BUILD_DEMOS=OFF \
+                        -DNEKTAR_ERROR_ON_WARNINGS=OFF \
                         -DNEKTAR_BUILD_TESTS=OFF \
                         -DNEKTAR_BUILD_UNIT_TESTS=OFF \
                         -DNEKTAR_SOLVER_DIFFUSION=OFF \


### PR DESCRIPTION
#### Description

Update to 5.0.3, disable errors on warnings due to compiler warnings from boost multi_array.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.2 20G95 x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
