### PR TITLE
posix-macos-addons: update to 20211005

### DIFF
--- a/devel/posix-macos-addons/Portfile
+++ b/devel/posix-macos-addons/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        stanislaw posix-macos-addons cecae59732ed3998440cbe8dc7dd931281166141
-version             20211002
+github.setup        stanislaw posix-macos-addons 8f50a927c81e3ce9f44686d6997ec3b0fbb97bb0
+version             20211005
 revision            0
 
-checksums           rmd160  1078e19a52f598452e13571e710641d848c09c84 \
-                    sha256  7a04f00b8d7b8b95fddeac6fa98ad39bf72ab2f21ed3bef864d8fc876cea7128 \
-                    size    275185
+checksums           rmd160  7f3cf1499ae41fd06b9cc1080b250059b3876808 \
+                    sha256  1df068ab67288c0686d21ae7106e8d966640c10fd3501c2cb6147aecc43b3a8c \
+                    size    275892
 
 categories          devel
 platforms           darwin


### PR DESCRIPTION
#### Description

Here mainly fixes for old macOS

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->