### PR TITLE
added beets-ydl

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -553,6 +553,30 @@ subport ${name}-xtractor {
                     port:py${python.version}-yaml
 }
 
+# Blocked by:
+#  - https://trac.macports.org/ticket/63478
+#  - https://trac.macports.org/ticket/63481
+subport beets-ydl {
+    name            beets-ydl
+    version         0.0.4
+    revision        0
+
+    license         MIT
+
+    description     Download audio from youtube-dl soures and import into beets
+    long_description ${description}
+
+    homepage        https://github.com/vmassuchetto/beets-ydl
+
+    checksums       rmd160  d9dd382e3d817fc950902b4a42945ceb8402579e \
+                    sha256  c9f12b201132bcb30c97f681c7c96c3a56a6d538532d5ed929c8a30b38d33fc2 \
+                    size    8499
+
+    depends_lib-append \
+                    port:py${python.version}-xdg \
+                    port:youtube-dl
+}
+
 subport ${name}-yearfixer {
     version         0.0.3
     revision        0
@@ -605,6 +629,7 @@ subport ${name}-full {
                     port:beets-summarize \
                     port:beets-usertag \
                     port:beets-xtractor \
+                    port:beets-ydl \
                     port:beets-yearfixer
 
     build           {}


### PR DESCRIPTION
#### Description

This is some proof of concept of missed beets plugin.

Anyway, this PR is blocked by:
 - https://trac.macports.org/ticket/63478
 - https://trac.macports.org/ticket/63481

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->