### PR TITLE
osm2pgsql: Specify lua as the default variant

### DIFF
--- a/gis/osm2pgsql/Portfile
+++ b/gis/osm2pgsql/Portfile
@@ -7,12 +7,11 @@ PortGroup           active_variants             1.1
 PortGroup           boost                       1.0
 
 github.setup        openstreetmap osm2pgsql 1.4.1
-revision            2
 
 categories          gis
 maintainers         {vince @Veence} openmaintainer
-description         osm2pgsql is an OSM data injector for PostGIS
-long_description    osm2pgsql is a command line tool to import\
+description         ${subport} is an OSM data injector for PostGIS
+long_description    ${subport} is a command line tool to import\
                     Open Street Map (a.k.a OSM) data\
                     into a PostGreSQL/PostGIS spatial database.
 
@@ -82,6 +81,29 @@ variant lua description {Build with support for Lua} {
 configure.args-append   "-DPROJ6_INCLUDE_DIR=${prefix}/lib/proj8/include"
 configure.args-append   "-DPROJ_LIBRARY=${prefix}/lib/proj8/lib/libproj.dylib"
 
-if {(![variant_isset lua])} {
-    configure.args-append   "-DWITH_LUA=OFF"
+if {${subport} eq ${name}} {
+    revision        3
+
+    if {(![variant_isset lua])} {
+        configure.args-append   "-DWITH_LUA=OFF"
+    }
+} else {
+    livecheck.type  none
+}
+
+subport ${name}-lua {
+    revision        3
+
+    depends_lib-append port:lua
+
+    description         ${description} with Lua support
+
+    long_description    ${long_description} \
+                        This sub-port includes support for Lua scripts.
+
+    post-destroot {
+        file rename ${destroot}${prefix}/bin/${name} ${destroot}${prefix}/bin/${subport}
+        file rename ${destroot}${prefix}/share/man/man1/${name}.1 ${destroot}${prefix}/share/man/man1/${subport}.1
+        file rename ${destroot}${prefix}/share/${name} ${destroot}${prefix}/share/${subport}
+    }
 }


### PR DESCRIPTION
#### Description

@Veence I've create a Portfile for `mod_tile` (PR #12391), a map tile server for OpenStreetMaps.  It requires `osm2pgsql` with the `lua` variant.  Without it as a default, the `mod_tile` port does not pass checks as it builds `osm2pgsql` without the `lua` variant.  It's also a poor user experience in the same scenario.

Ryan Schmidt has suggested some possible solutions [1]; either the variant being a default or alternatively being broken out into another port or sub-port.

Is it OK to have it as a default variant?  If not, what solution would you prefer?

[1]: https://lists.macports.org/pipermail/macports-dev/2021-October/043788.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
