### PR TITLE
mapnik: Specify postgis as the default variant

### DIFF
--- a/gis/mapnik/Portfile
+++ b/gis/mapnik/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                mapnik
 version             3.0.23
-revision            3
+revision            4
 categories          gis devel
 platforms           darwin
 license             LGPL-2.1
@@ -86,6 +86,8 @@ variant libxml2 description {Enable libxml2 support for includes and entities} {
     configure.args-append   XML2_CONFIG=${prefix}/bin/xml2-config \
                             XMLPARSER=libxml2
 }
+
+default_variants +postgis
 
 compiler.cxx_standard  2011
 


### PR DESCRIPTION
#### Description

I've create a Portfile for mod_tile (PR #12391), a map tile server for OpenStreetMaps. It requires `mapnik` with the `postgis` variant. Without it as a default, the mod_tile port does not pass checks as it builds `mapnik` without the `postgis` variant. It's also a poor user experience in the same scenario.

Ryan Schmidt has suggested some possible solutions[1]; either the variant being a default or alternatively being broken out into another port or sub-port.

This PR simply adds `postgis` as a default variant.

[1] https://lists.macports.org/pipermail/macports-dev/2021-October/043788.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
