### PR TITLE
py-crypto conflicts with py-pycryptodome

### DIFF
--- a/python/py-crypto/Portfile
+++ b/python/py-crypto/Portfile
@@ -29,6 +29,9 @@ checksums           rmd160  ac0db079e5e4be9daf739e094c10e96291dbc009 \
 python.versions     27 35 36 37 38 39
 
 if {${name} ne ${subport}} {
+    # See: See: https://trac.macports.org/ticket/63481
+    conflicts           py${python.version}-pycryptodome
+
     depends_lib-append  port:gmp
 
     post-destroot {

--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -25,6 +25,9 @@ checksums           rmd160  c10290cefe964891fac78e8fd32e4d3e667bcdd0 \
                     size    3762120
 
 if {${name} ne ${subport}} {
+    # See: See: https://trac.macports.org/ticket/63481
+    conflicts           py${python.version}-crypto
+
     depends_build-append \
                         port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description

See details: https://trac.macports.org/ticket/63481

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->