### PR TITLE
materialx: temporarily disable docs on macOS 10.11

### DIFF
--- a/graphics/materialx/Portfile
+++ b/graphics/materialx/Portfile
@@ -197,7 +197,16 @@ variant tests description {Build unit tests} {
     }
 }
 
-default_variants    +viewer +oiio +docs +tests
+if {${os.platform} eq "darwin" && ${os.major} == 15} {
+    # Temporarily remove building documentation for macOS 10.11.
+    # The doxygen port currently fails to build on macOS 10.11
+    # (https://trac.macports.org/ticket/63417), and as a result it will
+    # cause MaterialX to fail when attempting to build using +docs.
+    # (See also: https://trac.macports.org/ticket/63533)
+    default_variants    +viewer +oiio +tests
+} else {
+    default_variants    +viewer +oiio +docs +tests
+}
 
 ### The following code was adapted from the portfiles
 ### of ports such as openvdb and openimageio


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

I submitted a Trac ticket regarding this issue: https://trac.macports.org/ticket/63533

However, it turns out that there's already a Trac ticket regarding the `doxygen` problem: https://trac.macports.org/ticket/63417
so I'm submitting this PR to temporarily remove trying to build the docs in the default variants on macOS 10.11 until the doxygen issue can be fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
