### PR TITLE
notcurses: update to 2.4.5

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        dankamongmen notcurses 2.4.2 v
+github.setup        dankamongmen notcurses 2.4.5 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ long_description    Notcurses facilitates the creation of modern TUI programs, m
 
 homepage            https://notcurses.com
 
-checksums           rmd160  7f6ff2acc187625bfbb6a49b14b061e7187c9b21 \
-                    sha256  f73bd2d3ec40d91729578b0a74c3228159bafcb09424cad85d9ba3fe18a2dca0 \
-                    size    10068031
+checksums           rmd160  c51b7ce97a1dcd6fbca5e9e9b8a08ffad1b4a310 \
+                    sha256  e006c8d0a19d148d1fa779803e19145a7d8c5f1bf1f8e9e5d2c14a5e0d860343 \
+                    size    10082686
 
 compiler.c_standard 2011
 compiler.cxx_standard \
@@ -38,7 +38,6 @@ depends_build-append \
 depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
                     port:libunistring \
                     port:ncurses \
-                    port:readline \
                     port:zlib
 
 test.run            yes


### PR DESCRIPTION
#### Description

Update Notcurses from 2.4.2 to 2.4.5, dropping readline dep (it is no longer used). 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
I have temporarily lost access to my macOS development environment =[. I'm reasonably confident that there won't be any macOS-specific problems, and indeed the release has been tested through Homebrew.

<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
