### PR TITLE
demeter-devel: obsolete the port

### DIFF
--- a/science/demeter/Portfile
+++ b/science/demeter/Portfile
@@ -13,8 +13,6 @@ checksums           rmd160  ffabee287fe397551f3b6fa2d57900c43d9dd07a \
                     sha256  001e6a18a9150b8edffa1c00c81701003d13a300121e498207ab370d48542b28 \
                     size    82922089
 
-conflicts           demeter-devel
-
 categories          science
 platforms           darwin
 license             Permissive
@@ -99,16 +97,12 @@ post-destroot   {
 
 test.run            yes
 
-# At the moment, demeter-devel will use the most recent full release
+# demeter-devel used to be the latest pre-release demeter; now it is obsolete.
 subport demeter-devel {
+    PortGroup           obsolete 1.0
+
+    replaced_by         demeter
     epoch               2
-    github.setup        bruceravel demeter 0.9.26
-    revision            0
-    checksums           rmd160  ffabee287fe397551f3b6fa2d57900c43d9dd07a \
-                        sha256  001e6a18a9150b8edffa1c00c81701003d13a300121e498207ab370d48542b28 \
-                        size    82922089
-
-    conflicts           demeter
-
-#    depends_lib-append  port:p${perl-version}-encoding-fixlatin-xs
+    version             0.9.26
+    revision            1
 }


### PR DESCRIPTION
port `demeter-devel` has been identical to `demeter` for many years, as the upstream package is not actively developed. I propose we remove it by obsoleting it and replace it with `demeter`.

I'm not sure my patch is the preferred method to accomplish this, but I'm giving it a try.

See: https://trac.macports.org/ticket/63555
See: https://trac.macports.org/ticket/60340
Closes: https://trac.macports.org/ticket/59630

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
