### PR TITLE
syncthing: update to 1.18.3

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.18.2 v
+go.setup            github.com/syncthing/syncthing 1.18.3 v
+revision            0
 categories          net
 platforms           darwin
 license             MPL-2
@@ -18,15 +19,15 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  c2557cc7378d48cad458dd212d5a39dc37996533 \
-                        sha256  4bda7b50a1a9307444f46fecedd65abb052bfc8aeec45614f0497a307e787395 \
-                        size    6152302
+                        rmd160  fa463500bd18a2319e7ada276447cd24620d7083 \
+                        sha256  1e2cc4613a8c58d563fb28ee947e886d482ffdc21ce4e790cb6c66b1711b6824 \
+                        size    6153389
 
 go.vendors          gopkg.in/yaml.v3 \
-                        lock    9f266ea9e77c \
-                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
-                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
-                        size    86890 \
+                        lock    496545a6307b \
+                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
+                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
+                        size    90145 \
                     gopkg.in/yaml.v2 \
                         lock    v2.4.0 \
                         rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
@@ -37,57 +38,52 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
                         sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
                         size    3636 \
-                    gopkg.in/check.v1 \
-                        lock    038fdea0a05b \
-                        rmd160  0f1896097db9d42b2fb5d62999bb52c77635f758 \
-                        sha256  a82bd5c6960aa523c4dd8b30d52c3a7e8a5382e91f25862ef277bedf5c107007 \
-                        size    31647 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.26.0 \
-                        rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
-                        sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
-                        size    1270531 \
+                        lock    v1.27.1 \
+                        rmd160  a4ac7b66fd88a34a9ea447476d19ff3c1f2b57dd \
+                        sha256  fe1055b9bf6b8792aed1771f56c31f836c24a18d69eaeb13c88990db3d9da7ce \
+                        size    1278850 \
                     golang.org/x/xerrors \
                         lock    5ec99f83aff1 \
                         rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
                     golang.org/x/tools \
-                        lock    v0.1.5 \
-                        rmd160  1bbd33096e15d2084ba543ddbfd86936e5dd09cb \
-                        sha256  66907da0a219e6a27e504acc4c1c58fd9521585de0d6729a43694c950aef1670 \
-                        size    2843627 \
+                        lock    v0.1.6 \
+                        rmd160  8c43ece78447a5373ceff28670a51006582c5495 \
+                        sha256  43766d41f9618058ee539bc4fa4fbb6ab1c18ac9f11244af4255bf05c3aabfbb \
+                        size    2874202 \
                     golang.org/x/time \
-                        lock    f8bda1e9f3ba \
-                        rmd160  f8d3e8f61490936cad49b715f1c36b40b1ece39d \
-                        sha256  99f4d738462c7e441e7fb349ed353e87616be780659f25f50a2a4fca5b7a2b0f \
-                        size    9662 \
+                        lock    1f47c861a9ac \
+                        rmd160  0a17206bb0a833c0eef311ae2d8c1366a857c2a5 \
+                        sha256  818ca173dfc5b91e0516a9a30c099403bebfebc81d5a9496ba1f44adfa4bd6ec \
+                        size    9528 \
                     golang.org/x/text \
-                        lock    v0.3.6 \
-                        rmd160  e3da48fcc60d98e202458228188bf6dac408e309 \
-                        sha256  6b2d69df22b5ba1634bc6730c3f03404db499536a96c48b8016da80ced804450 \
-                        size    8356058 \
+                        lock    v0.3.7 \
+                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
+                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
+                        size    8356115 \
                     golang.org/x/sys \
-                        lock    f52c844e1c1c \
-                        rmd160  8aaf39f353b93a6474b33d0de1a0ccde2a71d9d6 \
-                        sha256  18bd889f302f2111356cc28e86dadb43a2b2cf61a9e5df3d1a059fe9e99fc9e0 \
-                        size    1209437 \
+                        lock    92d5a993a665 \
+                        rmd160  58d0238901bb441bde38638b8fdf89e2f28c0047 \
+                        sha256  8195f80853b1ef083cb81dc8b9acd89233f57596d15a7c42454f5acc0cef76f6 \
+                        size    1211662 \
                     golang.org/x/net \
-                        lock    853a461950ff \
-                        rmd160  86c824613f7d6a33990fc15cd6914aba624cb3fa \
-                        sha256  9bfecf30fca72160bb1e93b76147e666313c4d829b1b7cdc43c9e8b19cf97596 \
-                        size    1252168 \
+                        lock    3ad01bbaa167 \
+                        rmd160  4a5f4721bd34a04db6298a198dee0cd5953221ef \
+                        sha256  ce9054f4db7e2afef53ee55a8752a6b700821a4d2f0f3cbba25420b617338561 \
+                        size    1259491 \
                     golang.org/x/mod \
-                        lock    v0.4.2 \
-                        rmd160  0f3ca57198b4de4eb89b2c1a2bdb01af040d1f36 \
-                        sha256  e2e4cba5719f804f2ec901b4ccdf6d3abf05521868ed54f271be7c1bf6c48549 \
-                        size    104573 \
+                        lock    v0.5.1 \
+                        rmd160  6aac73c99cc5111f9b4675fbfeee0871ecea71a7 \
+                        sha256  1c5e2438581c6755be6c984375c51f93cee56b00de0898cdd61ce3d64c938d38 \
+                        size    112675 \
                     golang.org/x/crypto \
-                        lock    a769d52b0f97 \
-                        rmd160  0599d63a740ae1bb45dec221f8c89bd173575806 \
-                        sha256  983562ae6552af3e350cde284c14bf33d4d3e54a5aec40527f3157e7fc4400ca \
-                        size    1732004 \
+                        lock    089bfa567519 \
+                        rmd160  5435f7d637f5b4390f7f27cf8e5b27d4e3b2441a \
+                        sha256  db7030a2b172461539ec4e963a30a13f87947e480e426b3986c91ef8c1260747 \
+                        size    1734725 \
                     github.com/vitrun/qart \
                         lock    bf64b92db6b0 \
                         rmd160  50ea47d1b1d0b60138845f21d57cad0ac7e5e632 \
@@ -109,30 +105,30 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  9fb936ce779314cfa755bd208b8a5ba7e4f41c23bd7a1d61bda6facb5d13052b \
                         size    151087 \
                     github.com/syncthing/notify \
-                        lock    f45149b04939 \
-                        rmd160  e2f2f392b355ec28fa8cb3237fb051097e6a46af \
-                        sha256  5c1ed415aa68c8cf7e369c49e50922a446def96b652a67b1b0fec5e8cb28fd59 \
-                        size    58257 \
+                        lock    c6b7342338d2 \
+                        rmd160  09be7e59f0313249a76077bca2df25717718440d \
+                        sha256  7021da0bbe91cffecdd7621cfe8b6d918aee5d8e678987b7d593e443690c486e \
+                        size    58258 \
                     github.com/stretchr/testify \
                         lock    v1.7.0 \
                         rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
                         sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
                         size    91096 \
                     github.com/shirou/gopsutil \
-                        lock    v3.21.4 \
-                        rmd160  9a9ebaa7f4e3ad8b33e643f2ec5f320704697056 \
-                        sha256  4ef011dda9dabe9cee7db167d30616cf2034293c755090c6973dab88b68b426c \
-                        size    283931 \
+                        lock    v3.21.8 \
+                        rmd160  4de017111c3090a81d18fbd43fbbb968415940e4 \
+                        sha256  51d02b43c9e774944f8f05acadcdf946821776dd9feb0cc2bd4e2137a147a849 \
+                        size    296677 \
                     github.com/sclevine/spec \
                         lock    v1.4.0 \
                         rmd160  9e0712b9319670603040a683b0d1d96c87462c53 \
                         sha256  c253580600294f2cb6ef134816cdca7327b93ae67bc3d01ee903cbf57fac100c \
                         size    13501 \
                     github.com/sasha-s/go-deadlock \
-                        lock    v0.2.0 \
-                        rmd160  e9a7e7a4994c375c6fbf1a2773e37e1cd3bf2325 \
-                        sha256  5ff9df5b6d65603320a4839fe4ba24ce00284291032f035f17c2ea9ce3fe8676 \
-                        size    9959 \
+                        lock    v0.3.1 \
+                        rmd160  af046774d17cb529a416c91139e918bf7d438229 \
+                        sha256  62f2cc20771586afb808d048bf6637934af5e491f502cdfdc1e8976afe2e1f05 \
+                        size    11586 \
                     github.com/russross/blackfriday \
                         lock    v2.1.0 \
                         rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
@@ -144,25 +140,25 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  ca8446ddf4e9c684b76ab8216220b700e6e9fc1ae69b5ba59c845b09c87c787f \
                         size    37582 \
                     github.com/prometheus/procfs \
-                        lock    v0.6.0 \
-                        rmd160  ae0e0bcf1c664eacc18c03ec77973f0212dce472 \
-                        sha256  4ffc099c6f2ce85a7681e09462e465b140556743a248f4b3bdc665498f3380b1 \
-                        size    169970 \
+                        lock    v0.7.3 \
+                        rmd160  22af59de47369bf8ac95300e14ef8b1d370712a5 \
+                        sha256  40015c2a7a52b34e6502d2fc17458c30c3ee23f9c2246269d878ab0f96ca3177 \
+                        size    179014 \
                     github.com/prometheus/common \
-                        lock    v0.18.0 \
-                        rmd160  4a65e9893ce9836d491af99dcb86475849cb095b \
-                        sha256  d6f4463151f2c4eaa183512668382f6d40120f6905cc5cc7a254163efa5c10c3 \
-                        size    123706 \
+                        lock    v0.30.0 \
+                        rmd160  c986a7fb731135b026887be2738968cefe25f134 \
+                        sha256  81edbf79ed09d3cbd484f8c965e6c9ec7c0d6177acc3cf5641925c89cb20c105 \
+                        size    145575 \
                     github.com/prometheus/client_model \
                         lock    v0.2.0 \
                         rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
                         sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
                         size    10985 \
                     github.com/prometheus/client_golang \
-                        lock    v1.10.0 \
-                        rmd160  7f4395fec6846f595f0625c6288f4b520c805e62 \
-                        sha256  4ca1349fc8fac34193f250e66cef415465a85f5d32f69360fa43962a73252ca6 \
-                        size    176332 \
+                        lock    v1.11.0 \
+                        rmd160  96f9efe7bff3d325ea9f2a3a2caecf1dbebc77c2 \
+                        sha256  fcad11001028f3cecfc6e7f5221a361f0f5ea49cf6ab29a2baf70cf5e005d5a5 \
+                        size    168768 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -203,11 +199,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  bb6c5515804a1d141478074ba9a4f836fa51fb71 \
                         sha256  a4e98c422980433e9a9830f16b4155836baba4c3e3aa387f03840e5cb608c84d \
                         size    1256274 \
-                    github.com/niemeyer/pretty \
-                        lock    a10e7caefd8e \
-                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
-                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
-                        size    9405 \
                     github.com/miscreant/miscreant.go \
                         lock    26d376326b75 \
                         rmd160  cd64e010e3f36e163e269369dc7fb0c710ca41a9 \
@@ -234,40 +225,30 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  2ae2b9dc73270d6a0222347bf290b44b45d80a82c181c19183165c9952de0c6b \
                         size    169712 \
                     github.com/marten-seemann/qtls-go1-17 \
-                        lock    v0.1.0-rc.1 \
-                        rmd160  5f5bcb47b85e9cbffeab69189cff5dd3bd587770 \
-                        sha256  53a447b1a2518642e7c1d807b74caaf6638037bb5d63d6bd612e34ee87cc9b30 \
-                        size    421746 \
+                        lock    v0.1.0 \
+                        rmd160  53d4d3eb6609de0c808934f977288c9bf06b3633 \
+                        sha256  c764f1cc401e4e9b61c5e344d9916246962dfc0739b32a66882c6f372758c29a \
+                        size    421717 \
                     github.com/marten-seemann/qtls-go1-16 \
                         lock    v0.1.4 \
                         rmd160  1cadd0881456cc0d4dd653b432c06be1e1a1e43e \
                         sha256  6e750d55689b9eeff04ddadd5fd37f57c794f0eb0897622ea318b4b73990261a \
                         size    415570 \
-                    github.com/marten-seemann/qtls-go1-15 \
-                        lock    v0.1.5 \
-                        rmd160  935629c05cf01066de57f62599e6b60122f7cc6d \
-                        sha256  942e3d2166894e4cdfd21af9313021e8f90b5ff42792456671d6eb1a5cfd90c6 \
-                        size    413667 \
                     github.com/lucas-clemente/quic-go \
-                        lock    v0.22.0 \
-                        rmd160  672b422da53164156e47620fd32e9d78640b3707 \
-                        sha256  12e9ef4d4bb327af4a735dc01a9f22fda12ca9808860ccda44952b1b1126615b \
-                        size    519202 \
+                        lock    v0.23.0 \
+                        rmd160  4e16aafd86ca032239bec74e86fd2939fb5380ef \
+                        sha256  611f76ca6915ce2d10ff9e139ab00aa3cdaee69ac084550d3baa63726d6f285c \
+                        size    520139 \
                     github.com/lib/pq \
-                        lock    v1.10.1 \
-                        rmd160  8b194b5ee4d2e5b01c7c6fdb3223313cd1f248b1 \
-                        sha256  6667ba0c01e7dfd9df0b02fe602ce02fe08be86a4dec983cc25c42bd03f388e7 \
-                        size    103819 \
-                    github.com/kr/text \
-                        lock    v0.1.0 \
-                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
-                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
-                        size    8691 \
+                        lock    v1.10.3 \
+                        rmd160  4a75fc04a939940919ce70b35c24fb9af18d235f \
+                        sha256  6a46de02b805ef6d9c048354c6e78020f9f15c567408025ccb6031d994d49df5 \
+                        size    108034 \
                     github.com/klauspost/cpuid \
-                        lock    v2.0.6 \
-                        rmd160  d6973fc3d7158db97407b1456195822b8e84008a \
-                        sha256  3a8fe2a0c4424273a5fa76c9eb437e53e8dd9c506a1b0ee48669f02c20d58d1b \
-                        size    341436 \
+                        lock    v2.0.9 \
+                        rmd160  74b904a37421c1553ab642a54bf2f4c5eee76be0 \
+                        sha256  4e7fa18aac1517dfe13b3973210bbc995cb1571506258fc1a667b09f6c5cd383 \
+                        size    342181 \
                     github.com/kballard/go-shellquote \
                         lock    95032a82bc51 \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
@@ -304,10 +285,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  be284023d91976ef03d13cb5670e338c09a0a0da9925d7de457f44e33aebb724 \
                         size    102365 \
                     github.com/golang/snappy \
-                        lock    v0.0.1 \
-                        rmd160  a10055b1a93ad290e600742c23156dbd55afe046 \
-                        sha256  5ca0dcca007398f298a6386af5d4696faba962b6a625e3aa3961d212078722b8 \
-                        size    62627 \
+                        lock    v0.0.4 \
+                        rmd160  23c095b7e2bc6f5a978d771e4ecc9f7b0f204491 \
+                        sha256  6a2d69e63124670c8b8105fb34d32f3f34f6816f93bf5a6e28f85c428c5b40ae \
+                        size    66136 \
                     github.com/golang/protobuf \
                         lock    v1.5.2 \
                         rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
@@ -339,15 +320,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  94d84e08cdff9c92c5cf526f0ec803f46593247f8e0d4b19b30c9df1819c933d \
                         size    40027 \
                     github.com/go-ole/go-ole \
-                        lock    v1.2.4 \
-                        rmd160  ff816f1835d4311c60fbed68b0d01838c4265bb6 \
-                        sha256  55590e7d9e56e30094fd487a2dcf4926aa4bb82471f21f33131b606a6ce41294 \
-                        size    51683 \
+                        lock    8b1f7f90f6b1 \
+                        rmd160  70350a72faa92597facb55379e481ea049bb57da \
+                        sha256  d818d3dab064c4f8f2be9460353318207f58d562f874d06c0bff91cd423dc2af \
+                        size    52614 \
                     github.com/go-ldap/ldap \
-                        lock    v3.3.0 \
-                        rmd160  9bda09ecd67007658ded7fe00362f5b2a1c2ccc7 \
-                        sha256  87b05f1c1b77604027279bd57975561c0df8afecd44fe5a07d7684132e8e3d05 \
-                        size    88572 \
+                        lock    v3.4.1 \
+                        rmd160  80f39776487a723d9c270d3b77f518cdfdeb9b57 \
+                        sha256  7aebfa3d777cc10b537cb1084a34d2eceae70c56e52bc02d84ead8dcac612483 \
+                        size    90597 \
                     github.com/go-asn1-ber/asn1-ber \
                         lock    v1.5.3 \
                         rmd160  6bc758f34bd2021f3040c6c822e17cc92bf8c41e \
@@ -359,20 +340,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  690d7813db5510d0dc739335dc950519c6664cc47ce49029e9c817f4a0c896c1 \
                         size    19245 \
                     github.com/fsnotify/fsnotify \
-                        lock    v1.4.9 \
-                        rmd160  4660b5721da8aea4c890786e49d7cec39c2e04d3 \
-                        sha256  7920cf1e5ccf268962fcff0b501398ed6c28ed75b1e1281fb17b19a8b0e4db5c \
-                        size    31910 \
+                        lock    v1.5.1 \
+                        rmd160  c99fbad44a371ce38eb2bd5c6ef70fb4537952e3 \
+                        sha256  699405dfda2fe02a305bee66f58046adb43f426ac905f85d80710e36846b3768 \
+                        size    32714 \
                     github.com/flynn-archive/go-shlex \
                         lock    3f9db97f8568 \
                         rmd160  ec42eaffe2cf17a46e12c7c2a7d436c0f68ba655 \
                         sha256  b4205ec400df652238f7ed287c4b77b5f17a17d5793cd5371b7cc5e0f07dfeed \
                         size    7690 \
-                    github.com/dchest/siphash \
-                        lock    v1.2.2 \
-                        rmd160  2bd73ba3ee5e184fa5dfb3c05f1d09677cf40d01 \
-                        sha256  f54e1c29a8f84902be054c9c4c7593532fc8448b9de68d38e16b46499b546911 \
-                        size    10713 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
@@ -384,10 +360,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  da946f9c267dc73f01fb14126655c6f5dfe16b84ee91a1e0646f0d88a140cc8d \
                         size    8066 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.0 \
-                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
-                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
-                        size    52040 \
+                        lock    v2.0.1 \
+                        rmd160  74c013e19d22e56a27d9a3ad61b4bd86975036d1 \
+                        sha256  d23365bceea7382b59ca41ad868a80e34f8066785fb371b85b51ee0b65be6a21 \
+                        size    64243 \
                     github.com/chmduquesne/rollinghash \
                         lock    a60f8e7142b5 \
                         rmd160  e84dbc6401f822d165bef6c9e158e5676931c739 \
@@ -399,15 +375,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  528d149522e053aed14048608751da8ace5b44466038b1a8d47d04a050d81bdc \
                         size    15585 \
                     github.com/cespare/xxhash \
-                        lock    v2.1.1 \
-                        rmd160  0c0da0840864215209db2afcd2ee92a52ca2d4d1 \
-                        sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
-                        size    9300 \
+                        lock    v2.1.2 \
+                        rmd160  aa8f44c877aeb7a980aba19d9d84e6b20e52560d \
+                        sha256  4bc66a9c435d9fa48cc9f8cb72c402a863943d594c1b1f8b5f421541c58150d2 \
+                        size    11252 \
                     github.com/certifi/gocertifi \
-                        lock    83314bf6d27c \
-                        rmd160  ff0f7caa0af747a712a14978c9a73e7e83522e2c \
-                        sha256  189f8fae6a73c216f5a9db697ca534d456dd423bc0a18ab1c0f82e68b4d96ca2 \
-                        size    147057 \
+                        lock    431795d63e8d \
+                        rmd160  2abdbe7f2c77cbf012637de9cb3a5ea42173b6ae \
+                        sha256  a06bb1869b1ef9fa2253eaaffc738deed98535e65c04b5fea6e03cbfb5879ec0 \
+                        size    121737 \
                     github.com/ccding/go-stun \
                         lock    v0.1.3 \
                         rmd160  0f44206289f1515e2022efb959b830e839b0627f \
@@ -429,15 +405,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
                         size    10874 \
                     github.com/alecthomas/kong \
-                        lock    v0.2.16 \
-                        rmd160  65b1addf71c0dfbe97e41c732c9b80ed84af0d07 \
-                        sha256  b4d96a83d95fb0012206360f16dd020dd51bb30e5c8e6cd50e28b62a3073d92f \
-                        size    287153 \
+                        lock    v0.2.17 \
+                        rmd160  68590528301436f816362d36f7d1cfb6e7db2445 \
+                        sha256  b11a4b88cfc21a7333e87307993011e3d509b66c0d7d699af15d740bcfb91c89 \
+                        size    289756 \
                     github.com/StackExchange/wmi \
-                        lock    cbe66965904d \
-                        rmd160  1c28ff3f595532ab67c85f5232c9228cf97d65d9 \
-                        sha256  01b78146552b0c7d6126b64cdf4f7c40fe1e1e15a9f822d4a1bc6db5df1f48ca \
-                        size    11289 \
+                        lock    v1.2.1 \
+                        rmd160  f02f859c7021ddd8422f78793d3e3001c85565d2 \
+                        sha256  e1d463fd14dd07f40914b7ce14cfa4d453fec5292601fea27af24e2bb8bb470c \
+                        size    12455 \
                     github.com/Azure/go-ntlmssp \
                         lock    66371956d46c \
                         rmd160  74dcc3f7e70c2dbdf032390bd8734e0fc514ce65 \


### PR DESCRIPTION
#### Description

Updates syncthing to 1.18.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
