### PR TITLE
nco: update to 5.0.3

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.0.2
+github.setup        nco nco 5.0.3
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto}
@@ -19,9 +19,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  1e183a2f96bbc204f71bb069259916394a67c101 \
-                    sha256  915d6ffa7ce14c937e8f904543949ebf8f4674278ffc94d3f3f665981eeb785b \
-                    size    5419731
+checksums           rmd160  b9e99cf6906bcfeafe7fe167f930db554d7a09a2 \
+                    sha256  84e6766b384e3825ee1430ab2fe164ec346d94dbe100eb6e937cd5df8facc0cf \
+                    size    5760295
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Simple update to upstream version 5.0.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.6 20G165 x86_64
Xcode Command Line Tools 13.0.0.0.1.1630607135

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
