### PR TITLE
macfuse: update to 4.2.1

### DIFF
--- a/fuse/macfuse/Portfile
+++ b/fuse/macfuse/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        osxfuse osxfuse 4.2.0 macfuse-
-revision            1
+github.setup        osxfuse osxfuse 4.2.1 macfuse-
+revision            0
 name                macfuse
 conflicts           osxfuse
 categories          fuse
@@ -24,9 +24,9 @@ github.tarball_from releases
 distname            ${name}-${version}
 use_dmg             yes
 
-checksums           rmd160  ba5890bccb55afc402b2d5c1a17c1e21056d8a58 \
-                    sha256  bf413e3aae887b6e8e8f8ad46152eb34575b7ff7f90d6cc55735ad00c5a4c7a6 \
-                    size    5975938
+checksums           rmd160  b8bfc9c5e61dff56ea9eba1cf0ffd0db7420320e \
+                    sha256  bd3abba91a8c16005eb3937ad492e49275e60db429bbecd30d54769c191e0699 \
+                    size    5974464
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     known_fail yes


### PR DESCRIPTION
#### Description

macfuse: update to 4.2.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
