### PR TITLE
gdb: update to 11.1

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            gdb
-version         10.2
+version         11.1
 revision        0
 categories      devel
 license         GPL-3+
@@ -33,9 +33,9 @@ supported_archs x86_64 i386
 
 master_sites    gnu
 
-checksums       rmd160  be6e1cea6f50a6a7cdaab925828524b278573ec4 \
-                sha256  b33ad58d687487a821ec8d878daab0f716be60d0936f2e3ac5cf08419ce70350 \
-                size    40267550
+checksums       rmd160  cdc4f037e9513d3502963ff51ed4ac1172aa47fe \
+                sha256  cc2903474e965a43d09c3b263952d48ced39dd22ce2d01968f3aa181335fcb9c \
+                size    37854893
 
 # these dependencies are listed under depends_lib rather than depends_build
 # because gdb will link with libraries they provide if installed.
@@ -44,6 +44,7 @@ checksums       rmd160  be6e1cea6f50a6a7cdaab925828524b278573ec4 \
 
 depends_lib     port:boehmgc \
                 port:expat \
+                port:gmp \
                 port:gettext \
                 port:libiconv \
                 port:ncurses \

--- a/devel/gdb/files/patch-python-config.py.diff
+++ b/devel/gdb/files/patch-python-config.py.diff
@@ -1,11 +1,10 @@
---- gdb/python/python-config.py.orig	2017-06-04 10:51:27.000000000 -0500
+--- gdb/python/python-config.py	2017-06-04 10:51:27.000000000 -0500
 +++ gdb/python/python-config.py	2017-11-17 10:14:07.000000000 -0600
-@@ -72,7 +72,7 @@
-                     libs.insert(0, '-L' + getvar('LIBPL'))
-                 elif os.name == 'nt':
-                     libs.insert(0, '-L' + sysconfig.PREFIX + '/libs')
--            if getvar('LINKFORSHARED') is not None:
-+            if not getvar('PYTHONFRAMEWORK'):
-                 libs.extend(getvar('LINKFORSHARED').split())
-         print (to_unix_path(' '.join(libs)))
- 
+@@ -77,7 +77,7 @@
+                     libs.insert(0, "-L" + getvar("LIBPL"))
+                 elif os.name == "nt":
+                     libs.insert(0, "-L" + sysconfig.PREFIX + "/libs")
+-            if getvar("LINKFORSHARED") is not None:
++            if not getvar("PYTHONFRAMEWORK"):
+                 libs.extend(getvar("LINKFORSHARED").split())
+         print(to_unix_path(" ".join(libs)))


### PR DESCRIPTION
#### Description

Upgrade gdb to 11.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
  `Failed to test gdb: gdb has no tests turned on. see 'test.run' in portfile(7)`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

gdb-add-index errors out because it can't find the `readelf` command, but I think that this was already an issue for gdb-10.2

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
