### PR TITLE
vim: update to 8.2.2683

### DIFF
--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 set vim_version     8.2
-set vim_patchlevel  2681
+set vim_patchlevel  2683
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v
-revision            3
+revision            0
 
 categories          editors
 platforms           darwin freebsd
@@ -20,9 +20,9 @@ long_description    Vim is an advanced text editor that seeks to provide the\
 
 homepage            https://www.vim.org/
 
-checksums           rmd160  6635aee5718a31c6b692b3529fb4ea96a217eb20 \
-                    sha256  f0b8b7f013097adc9b3a40d199f4c5bc58cba9774b08bb1427ce51bd7dbf50d8 \
-                    size    15458967
+checksums           rmd160  117ecc6a7932b76ecfe53948172f5056b6ffb028 \
+                    sha256  15f869b640a50d0a3552c2b120536892bd5626c6c1bc25d8bb24af24f81e9b66 \
+                    size    15459857
 
 depends_lib         port:ncurses \
                     port:gettext \


### PR DESCRIPTION
#### Description

This updates brings vim up to patch 2683 (2 patches ahead of current master). One of these changes allows the `+tiny` and `+small` variants to be built successfully.

Closes: https://trac.macports.org/ticket/63600

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
