### PR TITLE
flyctl: update to 0.0.246

### DIFF
--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        superfly flyctl 0.0.216 v
+github.setup        superfly flyctl 0.0.246 v
 revision            0
 categories          devel
 platforms           darwin
@@ -21,13 +21,13 @@ github.tarball_from releases
 distname            ${name}_${version}_macOS_${build_arch}
 
 checksums           ${name}_${version}_macOS_x86_64${extract.suffix} \
-                    rmd160  58b5717c723b3252773e71e7850e4cded97c0250 \
-                    sha256  fdab337dcd61df20d5b8629cb7c6b1ace3a28db9307ba256fc33f137efbf1d67 \
-                    size    16696177 \
+                    rmd160  1451bcedc41d8abca79b276dcb06220167d42f79 \
+                    sha256  07ec4507beac246d2c1971215c709b4ceab5d23aaefa627e3039c0105f897b4f \
+                    size    18875569 \
                     ${name}_${version}_macOS_arm64${extract.suffix} \
-                    rmd160  8081609236c0bcd567ec48d9358a94671cc41350 \
-                    sha256  c4e28e7077cc39db255433d8d2a39805fed9b21b34896c594c1a24c45280b168 \
-                    size    16488109
+                    rmd160  a764a74f792045aebb41879fa31a04d951b9e515 \
+                    sha256  ff42e1d7e8d1c873daec8aad23ece855599b6f77cfa2ab03db18865e1b55f4a3 \
+                    size    18300962
 
 use_configure       no
 installs_libs       no


### PR DESCRIPTION
#### Description

Update flyctl to 0.0.246

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
