### PR TITLE
saml2aws: update to 2.32.0

### DIFF
--- a/security/saml2aws/Portfile
+++ b/security/saml2aws/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/Versent/saml2aws 2.30.0 v
+go.setup            github.com/Versent/saml2aws 2.32.0 v
 go.package          github.com/versent/saml2aws
 revision            0
 categories          security
@@ -19,9 +19,9 @@ long_description    CLI tool which enables you to login and retrieve AWS \
 homepage            https://github.com/Versent/saml2aws
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  0cdd193229f49d1a0585f6fb71442baf41a9f7a3 \
-                        sha256  34de318eb3a725a392433d19da3991e30f67304b8db6340d061795661f703d76 \
-                        size    214434
+                        rmd160  8d89b10f2476a022c9bdd6ea2899f7a8e275dc89 \
+                        sha256  f865ec3ebb6f2da23c2e0b95c6841dcdd2124c3ed9be9ef59dc828a85ee8de58 \
+                        size    224377
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    496545a6307b \
@@ -59,30 +59,35 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  3bf7b61de210c621fb70e697c0020789bfbe426754d0f743978e77f84a7472f1 \
                         size    15286 \
                     golang.org/x/sys \
-                        lock    8ebf48af031b \
-                        rmd160  d661d5b39f4f15538e641a1eb2212f81febdf862 \
-                        sha256  48cc64e0c62e486d83fc3402f7a8e7fc274dc5076085770d2cbbced22e2b0c1f \
-                        size    1110262 \
+                        lock    9665404d3644 \
+                        rmd160  4c47bbbbf001306ebd2a83eabadf4e8d1c61b4a1 \
+                        sha256  ee42b3847e9d5cb93b8b5f40f3770e78f3b0a715c3104a68abbb6d4c9f4272da \
+                        size    1200443 \
                     golang.org/x/net \
-                        lock    5f4716e94777 \
-                        rmd160  895f92b5004f164eb6b391054a0539cae27edaa1 \
-                        sha256  36948241880ee379819f082f08eb171362d95d0f341c6d2dfcb2475ec18289e9 \
-                        size    1251410 \
+                        lock    a5a99cb37ef4 \
+                        rmd160  797f072d96e4dae35f374a47f3aeae6df6ecc15b \
+                        sha256  040b4c1ba1728fdac35bba3f4b89d823e1f8c4cf5e8716c969a684fa920ad6ab \
+                        size    1249385 \
                     golang.org/x/crypto \
                         lock    eec23a3978ad \
                         rmd160  098b29e5fb0c1a0fa7a118e433eb5d952053391b \
                         sha256  da658dad4a60a368edea1cbb28651cf44b46b06fdd726462c5696aa5283f12c2 \
                         size    1725759 \
+                    github.com/tidwall/pretty \
+                        lock    v1.1.0 \
+                        rmd160  97cd6d106c0a3f63f01a2950b6b18454fa96209f \
+                        sha256  329c65558ebea57a0c029abfd893fc3c827c7d2a2cb4b6142774c2fdeae4fd2c \
+                        size    10507 \
                     github.com/tidwall/match \
-                        lock    v1.0.0 \
-                        rmd160  2476b0ca44d73f07db77436555066cc0dfc6d768 \
-                        sha256  111ada47abfd8a45266f95330840ec7dd63adde18ba743bb00b3d840f9bf44d8 \
-                        size    4275 \
+                        lock    v1.0.3 \
+                        rmd160  cfb64a9e55e014e0b843547ca5791f2bf388c56d \
+                        sha256  7a88711ca2dae3e5b302cda376fd37ce36719acf538511496a3934d4cd7171eb \
+                        size    4829 \
                     github.com/tidwall/gjson \
-                        lock    v1.1.1 \
-                        rmd160  b684027f6a4a143eefb40d426ec8fd7be2462316 \
-                        sha256  28d12108599e2278ad3861cb846c27ccef6c65ce7a9f27007763f0dcb24ded90 \
-                        size    39971 \
+                        lock    v1.8.1 \
+                        rmd160  7d0eb12fb3fe0800d500038bd43e1f1112c0cdc8 \
+                        sha256  324deff99593469ef53292c5ebca1740ef6f60facfce678d50aae1a442d8c408 \
+                        size    50871 \
                     github.com/stretchr/testify \
                         lock    v1.7.0 \
                         rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \


### PR DESCRIPTION
#### Description

Update saml2aws to v2.32.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
