### PR TITLE
grass7: remove unused variant and fix livecheck url

### DIFF
--- a/gis/grass7/Portfile
+++ b/gis/grass7/Portfile
@@ -8,7 +8,7 @@ PortGroup           debug 1.0
 github.setup        OSGeo grass 7.8.6
 name                grass7
 set main_version    [join [lrange [split ${version} "."] 0 1] ""]
-revision            0
+revision            1
 set realVersion     ${version}
 #distname           grass-${version}
 distname            grass-${realVersion}
@@ -266,15 +266,6 @@ variant sqlite description {Add SQLite 3 support} {
     configure.args-append --with-sqlite
     configure.args-append --with-sqlite-includes=${prefix}/include
     configure.args-append --with-sqlite-libs=${prefix}/lib
-}
-
-variant ffmpeg description {Add ffmpeg support} {
-    depends_lib-append    path:lib/libavcodec.dylib:ffmpeg
-    configure.args-append --with-ffmpeg \
-                          --with-ffmpeg-includes=\"${prefix}/include/libavcodec  \
-                                                   ${prefix}/include/libavformat \
-                                                   ${prefix}/include/libswscale\" \
-                          --with-ffmpeglibs=${prefix}/lib
 }
 
 variant openblas description {Use OpenBLAS for BLAS/LAPACK} {


### PR DESCRIPTION
#### Description

Removes the variant `ffmpeg`. The dependency of ffmpeg was dropped with GRASS GIS 7.0, so this variant was an unused remnant from version 6.
https://github.com/OSGeo/grass/commit/9b0c99051263e04f8a48b6f27cf58f0e6228662b#diff-bb21aa33a3f69ccb36c68b220f40ad08f29b9cd2c05dfedae7b9e3d5d4d08f6b

Also corrects the livecheck url.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
