### PR TITLE
py-pymatgen: new port, version 2022.0.14

### DIFF
--- a/python/py-pymatgen/Portfile
+++ b/python/py-pymatgen/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pymatgen
+version             2022.0.14
+revision            0
+
+categories-append   science
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {nist.gov:joe.fowler @joefowler} openmaintainer
+
+description         Python Materials Genomics (pymatgen) is a robust materials analysis code
+long_description \
+    ${description} that defines core object representations for structures \
+    and molecules with support for many electronic structure codes. \
+    It is currently the core analysis code powering the Materials Project.
+
+homepage            https://pymatgen.org/
+
+checksums           rmd160  da02e284efbdd35b8af26d33afbb881849e80682 \
+                    sha256  03d24ebafc21becab376c26de09437dd5cfb7bda7099046194e95b4c9fa35209 \
+                    size    3336765
+
+python.versions     37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+        port:py${python.version}-cython \
+        port:py${python.version}-setuptools
+
+    depends_lib-append \
+        port:py${python.version}-numpy
+
+    depends_run-append \
+        port:py${python.version}-beautifulsoup4 \
+        port:py${python.version}-matplotlib \
+        port:py${python.version}-monty \
+        port:py${python.version}-networkx \
+        port:py${python.version}-palettable \
+        port:py${python.version}-pandas \
+        port:py${python.version}-plotly \
+        port:py${python.version}-requests \
+        port:py${python.version}-ruamel-yaml \
+        port:py${python.version}-scipy \
+        port:py${python.version}-spglib \
+        port:py${python.version}-sympy \
+        port:py${python.version}-tabulate \
+        port:py${python.version}-uncertainties
+
+    if {${python.version} < 38} {
+        depends_run-append port:py${python.version}-typing_extensions
+    }
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description
Add Python Materials Genomics, a materials analysis code.

Requires new port `py-spglib` (PR #12533) first.

See https://trac.macports.org/ticket/63555
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
