### PR TITLE
ruby-install: update to 0.8.3

### DIFF
--- a/ruby/ruby-install/Portfile
+++ b/ruby/ruby-install/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        postmodern ruby-install 0.8.1 v
+github.setup        postmodern ruby-install 0.8.3 v
 revision            0
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {catlett.info:chad @chadcatlett} \
 description         Installs Ruby, JRuby, Rubinius, TruffleRuby or mruby.
 long_description    ${description}
 
-checksums           rmd160  6495dc139c37f5426fa3dd15532faf2906647389 \
-                    sha256  e4fc28d7dd92795a3825e7102c3eb48bec20552adb56ffb031d809c57b974f44 \
-                    size    30953
+checksums           rmd160  7e134959cfbd72a140e9eff2e7162d90a9085898 \
+                    sha256  8f5791d974aa94f4c863d5855b28cdb20493e19e3b655136164575df1a3d76d4 \
+                    size    32387
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Updating ruby-install to v0.8.3.

[Changelog from v0.8.1 to v0.8.3](https://github.com/postmodern/ruby-install/compare/v0.8.1...v0.8.3)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?