### PR TITLE
vips: update to 8.11.4

### DIFF
--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
-github.setup        libvips libvips 8.11.2 v
-revision            1
+github.setup        libvips libvips 8.11.4 v
+revision            0
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.
@@ -18,9 +18,9 @@ license             LGPL-2.1+
 homepage            https://libvips.github.io/libvips/
 github.tarball_from releases
 
-checksums           rmd160  bb68cabc5465237d581697519f3b379b8fab27d7 \
-                    sha256  bb5ab776ee4c61ae94b4496c63ef523ca7367ebceabcba78ceb1bf97b1d36e06 \
-                    size    17780526
+checksums           rmd160  e9e77c96075923755108a80456cfc2c7d88bc42b \
+                    sha256  5043f38828a0ff9f2275f9252f69e14f701ef11f55786cda8aa6ce2c4fbed2f7 \
+                    size    17779472
 
 # minor tweak to allow build with older compilers
 # StandaloneFuzzTargetMain.c:31: error: 'for' loop initial declaration used outside C99 mode


### PR DESCRIPTION
#### Description

vips: update to 8.11.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> N/A
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
