### PR TITLE
py-pyshortcuts: new port, version 1.8.0

### DIFF
--- a/python/py-pyshortcuts/Portfile
+++ b/python/py-pyshortcuts/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pyshortcuts
+version             1.8.0
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {nist.gov:joe.fowler @joefowler} openmaintainer
+
+description         Helps users create shortcuts to run python scripts and other applications.
+long_description    \
+    Pyshortcuts helps Python developers and users create shortcuts that will run python \
+    scripts and other applications. The shortcuts created can go onto the user's desktop \
+    or into the Start Menu (for systems with Start Menus) or both.
+
+homepage            https://github.com/newville/pyshortcuts
+
+checksums           rmd160  aa5e642300259a5f736b5587a173a24edad0bc72 \
+                    sha256  1e66467a0b7c15f42e2d616abeb2d80aa81d9e0ccca50991dc79bdb99f39d8c1 \
+                    size    933679
+
+python.versions     37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description
New port of python package pyshortcuts. It "helps users create shortcuts to run python scripts and other applications." Needed for planned package `py-xraylarch`.

See: https://trac.macports.org/ticket/63555
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
