### PR TITLE
py-hdf5plugin: new port, version 3.1.1

### DIFF
--- a/python/py-hdf5plugin/Portfile
+++ b/python/py-hdf5plugin/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-hdf5plugin
+version             3.1.1
+revision            0
+
+platforms           darwin
+license             MIT
+maintainers         {nist.gov:joe.fowler @joefowler} openmaintainer
+
+description         A set of compression filters for h5py
+long_description    \
+    hdf5plugin provides HDF5 compression filters--namely: blosc, bitshuffle, lz4, \
+    FCIDECOMP, ZFP, zstd--and makes them usable from h5py.
+
+homepage            https://www.silx.org/doc/hdf5plugin/latest/
+
+checksums           rmd160  3c1b023c69a27f3ba72e08043a8737fd8ed6d479 \
+                    sha256  4600dbdbed8b5f8afe81f086b0ee256ca1aea47a17e5431ddd2f136510a9e02f \
+                    size    11276438
+
+compiler.cxx_standard 2011
+
+python.versions     37 38 39
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+        port:py${python.version}-cython \
+        port:py${python.version}-setuptools
+    
+    depends_run-append \
+        port:py${python.version}-h5py
+    
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

Add Python package hdf5plugin as new port.

See: https://trac.macports.org/ticket/63555
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
