### PR TITLE
wireshark3: update to 3.4.9

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -30,13 +30,13 @@ long_description    A network analyzer that lets you capture and \
 #   https://gitlab.com/wireshark/wireshark/-/merge_requests/1404
 
 if {${os.major} >= 16} {
-    version         3.4.8
+    version         3.4.9
     revision        0
 
-    checksums       sha256  58a7fa8dfe2010a8c8b7dcf66438c653e6493d47eb936ba48ef49d4aa4dbd725 \
-                    rmd160  573fd48c88c514de5000835c849d88c7df89e39a \
-                    sha1    b8ee02e6c708d74befafe48f80f294313345f90b \
-                    size    32314976
+    checksums       sha256  c6525e829bd24525ee699aa207ecd27c50646d64263a669671badfb71cd99620 \
+                    rmd160  7fd30ef3b906fa2301b6a77bd4623633d0b46f23 \
+                    sha1    0ed390387d9d6201cdd6364e782cb58c8ad4d9ce \
+                    size    32335284
 
     livecheck.type  regex
     livecheck.url   ${homepage}download.html
@@ -65,7 +65,7 @@ distfiles           wireshark-${version}${extract.suffix}
 
 worksrcdir          wireshark-${version}
 
-conflicts           wireshark-devel wireshark wireshark2 wireshark22 wireshark24 wireshark30
+conflicts           wireshark2 wireshark22 wireshark30
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

Updating wireshark3 to v3.4.9 and removing conflicts that no longer exist.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

