### PR TITLE
wireshark-chmodbpf: update to 1.1

### DIFF
--- a/net/wireshark-chmodbpf/Portfile
+++ b/net/wireshark-chmodbpf/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                wireshark-chmodbpf
-version             1.0
-revision            2
+version             1.1
+revision            0
 platforms           darwin macosx
 categories          net
 license             {GPL-2 GPL-3}

--- a/net/wireshark-chmodbpf/files/patch-wireshark-chmodbpf.diff
+++ b/net/wireshark-chmodbpf/files/patch-wireshark-chmodbpf.diff
@@ -3,8 +3,9 @@ new file mode 100755
 index 0000000..8564790
 --- /dev/null
 +++ sbin/wireshark-chmodbpf
-@@ -0,0 +1,40 @@
-+#!/bin/bash
+@@ -0,0 +1,41 @@
++#! /bin/zsh
++# shellcheck shell=bash
 +
 +#
 +# Unfortunately, macOS's devfs is based on the old FreeBSD
@@ -26,20 +27,20 @@ index 0000000..8564790
 +#
 +
 +# Pre-create BPF devices. Set to 0 to disable.
-+FORCE_CREATE_BPF_MAX=10
++FORCE_CREATE_BPF_MAX=256
 +
 +SYSCTL_MAX=$( sysctl -n debug.bpf_maxdevices )
 +if [ "$FORCE_CREATE_BPF_MAX" -gt "$SYSCTL_MAX" ] ; then
 +	FORCE_CREATE_BPF_MAX=$SYSCTL_MAX
 +fi
 +
-+syslog -s -l notice "ChmodBPF: Forcing creation and setting permissions for /dev/bpf*"
++syslog -s -l notice "ChmodBPF: Forcing creation and setting permissions for /dev/bpf0-$(( FORCE_CREATE_BPF_MAX - 1))"
 +
 +CUR_DEV=0
 +while [ "$CUR_DEV" -lt "$FORCE_CREATE_BPF_MAX" ] ; do
 +	# Try to do the minimum necessary to trigger the next device.
-+	read -n 0 < /dev/bpf$CUR_DEV > /dev/null 2>&1
-+	CUR_DEV=$(( $CUR_DEV + 1 ))
++	read -r -n 0 < /dev/bpf$CUR_DEV > /dev/null 2>&1
++	CUR_DEV=$(( CUR_DEV + 1 ))
 +done
 +
 +chgrp @BPF_GROUP@ /dev/bpf*


### PR DESCRIPTION
#### Description

Updating wireshark-chmodbpf to version 1.1.

1.1 defaults to a higher amount of bpf devices to create and alter permissions on, which on Catalina fixes an issue with wireshark complaining about not being able to access some bpf devices.  It also uses zsh now.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

