### PR TITLE
dosbox-x: update to 0.83.18 and add arm as a supported arch

### DIFF
--- a/emulators/dosbox-x/Portfile
+++ b/emulators/dosbox-x/Portfile
@@ -5,13 +5,14 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 PortGroup           app 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           muniversal 1.0
 
-github.setup        joncampbell123 dosbox-x 0.83.7 dosbox-x-v
+github.setup        joncampbell123 dosbox-x 0.83.18 dosbox-x-v
 revision            0
 
-checksums           rmd160  cd4edafe72c77e00166151c1fcc7d2e772d99db7 \
-                    sha256  9cdfa3267c340a869255d8eb1c4ebf4adde47c22854e1d013da22190350bfbb3 \
-                    size    47403831
+checksums           rmd160  ea6b903cd2cec53139a575b20d0c9ea3311ebfb7 \
+                    sha256  e80d5ad8f79c28422207bba676bc3524c1f94c4df9587cb33d28eb2e8e3792df \
+                    size    62659195
 
 categories          emulators
 platforms           darwin
@@ -31,11 +32,9 @@ homepage            https://dosbox-x.com
 github.tarball_from archive
 
 patchfiles          patch-futimens.diff \
-                    patch-mactypes.diff \
-                    patch-convertbasetorect.diff \
-                    patch-menu-osx-cgpointfix.diff
+                    patch-mactypes.diff
 
-supported_archs     i386 x86_64
+supported_archs     i386 x86_64 arm64
 
 # build also looks for nasm, but doesn't use it even if it is found
 depends_build-append \

--- a/emulators/dosbox-x/files/patch-futimens.diff
+++ b/emulators/dosbox-x/files/patch-futimens.diff
@@ -1,6 +1,6 @@
---- ./src/dos/drive_local.cpp.orig	2020-08-28 17:21:06.000000000 -0700
-+++ ./src/dos/drive_local.cpp	2020-08-28 17:28:19.000000000 -0700
-@@ -59,6 +59,16 @@
+--- src/dos/drive_local.cpp.orig	2021-10-12 22:39:22.000000000 -0700
++++ src/dos/drive_local.cpp	2021-10-12 22:41:38.000000000 -0700
+@@ -107,6 +107,16 @@
  #define MAX_PATH PATH_MAX
  #endif
  

--- a/emulators/dosbox-x/files/patch-mactypes.diff
+++ b/emulators/dosbox-x/files/patch-mactypes.diff
@@ -1,6 +1,6 @@
---- src/gui/menu_osx.mm.orig	2020-08-28 22:30:31.000000000 -0700
-+++ src/gui/menu_osx.mm	2020-08-28 22:31:44.000000000 -0700
-@@ -9,7 +9,9 @@
+--- src/gui/menu_macos.mm.orig	2021-10-12 22:35:34.000000000 -0700
++++ src/gui/menu_macos.mm	2021-10-12 22:44:54.000000000 -0700
+@@ -10,7 +10,9 @@
  #include "SDL_syswm.h"
  
  #if DOSBOXMENU_TYPE == DOSBOXMENU_NSMENU /* Mac OS X NSMenu / NSMenuItem handle */
@@ -10,3 +10,12 @@
  # include <Cocoa/Cocoa.h>
  # include <Foundation/NSString.h>
  # include <ApplicationServices/ApplicationServices.h>
+@@ -587,7 +589,7 @@
+             pt.y = (prct.origin.y + prct.size.height) - pt.y;
+         }
+ 
+-        err = CGGetDisplaysWithPoint(pt,1,&did,&cnt);
++        err = CGGetDisplaysWithPoint(CGPointMake(pt.x,pt.y),1,&did,&cnt);
+ 
+         /* This might happen if our window is so far off the screen that the center point does not match any monitor */
+         if (err != kCGErrorSuccess) {


### PR DESCRIPTION
#### Description

Update dosbox-x to 0.83.18 and add arm/M1 as a supported arch

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X ] tried a full install with `sudo port -vst install`?
- [ X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
