### PR TITLE
yubico-authenticator: Add missing dependencies

### DIFF
--- a/aqua/yubico-authenticator/Portfile
+++ b/aqua/yubico-authenticator/Portfile
@@ -4,11 +4,15 @@ PortSystem          1.0
 PortGroup           qmake5 1.0
 PortGroup           github 1.0
 
-qt5.depends_component qtdeclarative qtquickcontrols2
+qt5.depends_component \
+                    qtdeclarative \
+                    qtmultimedia \
+                    qtquickcontrols \
+                    qtquickcontrols2
 
 name                yubico-authenticator
 github.setup        Yubico yubioath-desktop 5.1.0 yubioath-desktop-
-revision            0
+revision            1
 categories          aqua security
 platforms           darwin
 license             BSD


### PR DESCRIPTION
#### Description

The yubico-authenticator binary links against qt5-qtmultimedia, but does not declare this dependency:

```
$> for file in $(otool -L work/destroot/Applications/MacPorts/Yubico\ Authenticator.app/Contents/MacOS/yubioath-desktop | sed 1d | awk '{print $1}' | grep '/opt/local'); do port -q provides "$file"; done | sort -u
qt5-qtbase
qt5-qtdeclarative
qt5-qtmultimedia
qt5-qtquickcontrols2
```


Additionally, yubico-authenticator fails to start without qt5-qtquickcontrols installed:

```
QQmlApplicationEngine failed to load component
qrc:/qml/main.qml:454:5: Type Navigator unavailable
qrc:/qml/Navigator.qml:350:9: Type NewCredentialView unavailable
qrc:/qml/NewCredentialView.qml:6:1: module "QtQuick.Dialogs" is not installed
Segmentation fault: 11
```

Add these dependencies to fix the issues. Bump the revision so that the dependencies that are recorded in the registry are updated for everyone. Without this, people could uninstall qt5-qtmultimedia or qt5-qtquickcontrols and would end up with a broken yubico-authenticator.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1217 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
