### PR TITLE
posix-macos-addons: update to 20211014

### DIFF
--- a/devel/posix-macos-addons/Portfile
+++ b/devel/posix-macos-addons/Portfile
@@ -2,15 +2,16 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        stanislaw posix-macos-addons 8f50a927c81e3ce9f44686d6997ec3b0fbb97bb0
-version             20211005
+github.setup        stanislaw posix-macos-addons 60946dbd89b3620ae4aa119380f38658f391fd76
+version             20211014
 revision            0
 
-checksums           rmd160  7f3cf1499ae41fd06b9cc1080b250059b3876808 \
-                    sha256  1df068ab67288c0686d21ae7106e8d966640c10fd3501c2cb6147aecc43b3a8c \
-                    size    275892
+checksums           rmd160  f8567ec0c9db405a5a5ac26137b4359e044f5f54 \
+                    sha256  0b51d85a194feeec3c7199fb1f8c28540e8a6925c6b68a8a4966b09bdcf9c7d5 \
+                    size    275933
 
 categories          devel
 platforms           darwin
@@ -23,6 +24,7 @@ description         Some missing bits of POSIX for macOS.
 long_description    This is a collection of the POSIX functions which are not available on macOS.
 
 compiler.cxx_standard   2011
+compiler.blacklist      *gcc-3.* *gcc-4.* {clang < 700}
 
 post-destroot {
     xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Also blacklist unsupported compilers


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->