### PR TITLE
graphviz-devel: add build dep 'autoconf-archive'

### DIFF
--- a/graphics/graphviz-devel/Portfile
+++ b/graphics/graphviz-devel/Portfile
@@ -58,7 +58,8 @@ revision                        0
 
 conflicts                       graphviz${otherbranch}
 
-depends_build                   port:pkgconfig
+depends_build                   port:pkgconfig \
+                                port:autoconf-archive
 
 depends_lib                     path:include/turbojpeg.h:libjpeg-turbo \
                                 port:libpng \


### PR DESCRIPTION
Building graphviz 2.49.1 failed for me [10.15.7] without these changes.

Wondering if anyone else is running into this or just me; or if others can confirm that this at least doesn't break it for them.