### PR TITLE
fftw-3: fix G3 build

### DIFF
--- a/math/fftw-3/Portfile
+++ b/math/fftw-3/Portfile
@@ -254,6 +254,15 @@ pre-configure {
 
     if {![variant_exists universal] || ![variant_isset universal]} {
         configure.args-append $merger_configure_args(${configure.build_arch})
+
+        # Fix G3 build
+        platform powerpc {
+            if {[catch {sysctl hw.vectorunit} result] || $result == 0} {
+                # Added twice so delete twice
+                configure.args-delete "--enable-fma --enable-altivec"
+                configure.args-delete "--enable-fma --enable-altivec"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#### Description

Same general idea as https://github.com/macports/macports-ports/pull/11625. Built and confirmed `ppc` architecture instead of `ppc7400` on a G3.

The logic is a little fragile but I think it's the best I can do without changes to base.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
