### PR TITLE
links: implicit declaration of memrchr is expected

### DIFF
--- a/www/links/Portfile
+++ b/www/links/Portfile
@@ -44,6 +44,8 @@ configure.args  --disable-graphics \
                 --without-openmp \
                 --without-x
 
+configure.checks.implicit_function_declaration.whitelist-append memrchr
+
 post-patch {
     reinplace s|/etc/|${prefix}/etc/| ${worksrcpath}/os_dep.h
 }


### PR DESCRIPTION
configure script checks for `memrchr()`, which is unavailable on macOS

#### Description

Avoid warning:
```
Warning: Configuration logfiles contain indications of -Wimplicit-function-declaration; check that features were not accidentally disabled:
  memrchr: found in links-2.25/config.log
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 CLT

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
