### PR TITLE
fzf: update to 0.27.3

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.27.2
-revision            2
+go.setup            github.com/junegunn/fzf 0.27.3
+revision            0
 
 categories          sysutils
 platforms           darwin
@@ -14,9 +14,9 @@ description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  577e575ab9b9104694dd8ec2ad914b2b86553d8c \
-                        sha256  68aef240eb89c59a6e699dcc7341833a9be48483c663c16e9a4650ea18d2de4c \
-                        size    191979
+                        rmd160  958a1925d32233f51fe9b271dd94863062b39de8 \
+                        sha256  7845d581e94497a529eb0626ef74f360833ae0bc1769e9a4bb44bbd762c066c1 \
+                        size    202800 \
 
 go.vendors          golang.org/x/text \
                         lock    v0.3.6 \
@@ -29,10 +29,10 @@ go.vendors          golang.org/x/text \
                         sha256  ea781a5a35d70ed6f86287db5296e3b438625120be22bd9e208432dca8fd8f18 \
                         size    15357 \
                     golang.org/x/sys \
-                        lock    5e06dd20ab57 \
-                        rmd160  0e29fa746c2128c6d39e6b6b846d79384c3e9cb8 \
-                        sha256  93b0de8ad37fc1f97bc1f0a782fcb666b5ec01a8bcd6f5bce9bbc673c7f7d16b \
-                        size    1218990 \
+                        lock    0f9fa26af87c \
+                        rmd160  b5e5b546cddec0ad97bccbc3a19fe3630792097b \
+                        sha256  e9ff4a07a3cc01341990da0d8ecd1cfa05643a2db423bb1efcf62f577901ea77 \
+                        size    1202158 \
                     golang.org/x/sync \
                         lock    036812b2e83c \
                         rmd160  f42be6eb3565d2ed3d1066ea1a7f69437c8bb1e6 \
@@ -49,20 +49,20 @@ go.vendors          golang.org/x/text \
                         sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
                         size    44037 \
                     github.com/mattn/go-shellwords \
-                        lock    v1.0.11 \
-                        rmd160  6f262db0fb01afc26566a52cfe350c02218d056b \
-                        sha256  480c08a3a6d24008e0fac687a75f318f095a5108578605f9d7e560581c02eb4a \
-                        size    6112 \
+                        lock    v1.0.12 \
+                        rmd160  966c28bc678d710bb7f052842378462c800f24d7 \
+                        sha256  317db0f9d20370e4dc274495c7ecd409f8cefc84d4629df65f62ecd558c417ed \
+                        size    6326 \
                     github.com/mattn/go-runewidth \
-                        lock    v0.0.12 \
-                        rmd160  56fc1bfe9eb51e2c283d005ac369b3757ecae355 \
-                        sha256  63f20c04796f9f991a67f7ccf0e09c418b8e454d5cbd424943a5ade2f0065e6e \
-                        size    17358 \
+                        lock    v0.0.13 \
+                        rmd160  e177edb4dc4702ae2b23704934ff31cc6561bbd0 \
+                        sha256  dcd3ccbd956a6f53bc106b79489d0303a237c21d858d23250e3e1d7284b72b86 \
+                        size    17363 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
+                        lock    v0.0.14 \
+                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
+                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
+                        size    4705 \
                     github.com/lucasb-eyer/go-colorful \
                         lock    v1.2.0 \
                         rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \


### PR DESCRIPTION
#### Description

See: https://github.com/junegunn/fzf/releases/tag/0.27.3


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
