### PR TITLE
ninja: Move bash compl to ../share/bash-completion

### DIFF
--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 epoch               1
 github.setup        ninja-build ninja 1.10.2 v
-revision            1
+revision            2
 
 checksums           rmd160  1346989347fbb47b7211c1a49d5f9236f3027488 \
                     sha256  ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed \
@@ -60,8 +60,8 @@ build.args          -v
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
-    xinstall -d ${destroot}${prefix}/etc/bash_completion.d
-    xinstall -m 0644 ${worksrcpath}/misc/bash-completion ${destroot}${prefix}/etc/bash_completion.d/ninja
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0644 ${worksrcpath}/misc/bash-completion ${destroot}${prefix}/share/bash-completion/completions/ninja
 
     xinstall -d ${destroot}${prefix}/share/zsh/site-functions
     xinstall -m 0644 ${worksrcpath}/misc/zsh-completion ${destroot}${prefix}/share/zsh/site-functions/_ninja


### PR DESCRIPTION
Usually ${prefix}/share/bash-completion/completions is used for bash completion files. Most ports in MacPorts use this path.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
