### PR TITLE
scummvm: Fix G3 build

### DIFF
--- a/emulators/scummvm/Portfile
+++ b/emulators/scummvm/Portfile
@@ -110,6 +110,14 @@ if {[string match *clang* ${configure.cxx}]} {
 # the plugins fail to link against libSDL2
 configure.ldflags-append -lSDL2
 
+# Fix build on G3
+platform powerpc {
+    if {[catch {sysctl hw.vectorunit} result] || $result == 0} {
+        configure.ldflags-append -force_cpusubtype_ALL
+        archive_sites
+    }
+}
+
 # Leopard build, at least, fails without c++11
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description

Another fix in the vein of #12585 and #11625. Tested and opens just fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
