### PR TITLE
openjdk: add openjdk17-temurin for arm64

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -547,15 +547,14 @@ subport openjdk17 {
         system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
     }
 
-    if {${configure.build_arch} eq "x86_64"} {
-        depends_run-append port:openjdk17-temurin
-    } elseif {${configure.build_arch} eq "arm64"} {
-        depends_run-append port:openjdk17-zulu
-    }
+    depends_run-append port:openjdk17-temurin
 }
 
 subport openjdk17-temurin {
     # https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
+
+    # Java 17 is the first Temurin release with arm64 support
+    supported_archs  x86_64 arm64
 
     version      17
     revision     0
@@ -567,12 +566,19 @@ subport openjdk17-temurin {
 
     master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${version}%2B${build}/
 
-    distname     OpenJDK17-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     OpenJDK17-jdk_x64_mac_hotspot_${version}_${build}
+        checksums    rmd160  0d79be9e1e6cf50d939e839a53ba15c2f9209a77 \
+                     sha256  e9de8b1b62780fe99270a5b30f0645d7a91eded60438bcf836a05fa7b93c182f \
+                     size    192417649
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     OpenJDK17-jdk_aarch64_mac_hotspot_${version}_${build}
+        checksums    rmd160  b879101e8175b93c30dcb33f8bc25440c8227853 \
+                     sha256  910bb88543211c63298e5b49f7144ac4463f1d903926e94a89bfbf10163bbba1 \
+                     size    182381849
+    }
 
-    checksums    rmd160  0d79be9e1e6cf50d939e839a53ba15c2f9209a77 \
-                 sha256  e9de8b1b62780fe99270a5b30f0645d7a91eded60438bcf836a05fa7b93c182f \
-                 size    192417649
+    worksrcdir   jdk-${version}+${build}
 }
 
 subport openjdk17-zulu {


### PR DESCRIPTION
#### Description

Add Eclipse Temurin build of OpenJDK 17 for arm64.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?