### PR TITLE
easytag-devel: new subport

### DIFF
--- a/audio/easytag/Portfile
+++ b/audio/easytag/Portfile
@@ -19,7 +19,10 @@ long_description    EasyTAG is a GTK3 utility for viewing and editing tags \
 master_sites        gnome:sources/${name}/${branch}
 
 checksums           rmd160  fb5684d904efeb8902bf4ec212f75cbba5e77dd1 \
-                    sha256  fc51ee92a705e3c5979dff1655f7496effb68b98f1ada0547e8cbbc033b67dd5
+                    sha256  fc51ee92a705e3c5979dff1655f7496effb68b98f1ada0547e8cbbc033b67dd5 \
+                    size    1381084
+
+conflicts           easytag-devel
 
 use_xz              yes
 
@@ -62,10 +65,32 @@ variant nautilus description {Build nautilus context actions} {
     configure.args-delete   --disable-nautilus-actions
 }
 
+subport easytag-devel {
+    PortGroup       gitlab 1.0
+
+    conflicts       $name
+
+    gitlab.instance https://gitlab.gnome.org
+    gitlab.setup    GNOME easytag ed742959eb312355042ef0b5928b2bd5724298db
+    version         20210912
+    revision        0
+
+    master_sites    ${gitlab.master_sites}
+
+    checksums       rmd160  fb64f89bfc2fa33df4daf0dd763a7360d2d3a418 \
+                    sha256  874093ab15893d9ba531d545a86b86b96fc0c00908bd6c98a26690dcb58b580f \
+                    size    1483172
+
+    depends_lib-append \
+                    port:libsoup
+}
+
 post-activate {
     system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
     system "${prefix}/bin/gtk-update-icon-cache-3.0 -f -t ${prefix}/share/icons/hicolor"
     system "${prefix}/bin/glib-compile-schemas ${prefix}/share/glib-2.0/schemas"
 }
 
-livecheck.type      gnome
+if {${name} eq ${subport}} {
+    livecheck.type  gnome
+}


### PR DESCRIPTION
#### Description

Easytag wasn't released for a while and current git contains a few bugfixes.

This also added size to checksum for old port.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy

-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->