### PR TITLE
dbeaver-community: Update to 21.2.3 and fix libjli.dylib

### DIFF
--- a/databases/dbeaver-community/Portfile
+++ b/databases/dbeaver-community/Portfile
@@ -2,9 +2,8 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           java 1.0
 
-github.setup        dbeaver dbeaver 21.2.1
+github.setup        dbeaver dbeaver 21.2.3
 github.tarball_from releases
 revision            0
 name                dbeaver-community
@@ -45,23 +44,49 @@ if {${build_arch} eq "arm64"} {
 distname            dbeaver-ce-${version}-macosx.cocoa.${arch}
 
 checksums           dbeaver-ce-${version}-macosx.cocoa.x86_64${extract.suffix} \
-                        rmd160  24fac79ac048e5d09623be148bdd4ec97d88046e \
-                        sha256  5570f73139cdaf740b166c81f33746a7be3441adad60e7f09cee93d32252ef01 \
-                        size    101474923 \
+                        rmd160  ca49335a1a37cd016d3c0a854523001f929100dd \
+                        sha256  940eb52988c4645847b7460f9e0b0d924b543cf30fe87c45f967ef4e15326179 \
+                        size    104293007 \
                     dbeaver-ce-${version}-macosx.cocoa.aarch64${extract.suffix} \
-                        rmd160  819ebfa7e170692b71effee88c36a2a582eb708a \
-                        sha256  d4e1deed746aec2e67c63fb5e20f85b22d7b20ba8dbf32eeb6dd39b0cef390f7 \
-                        size    103700103
+                        rmd160  ec4ce934b779cbf927a0e47e896d85bf14134b1c \
+                        sha256  58dd81b64fbad074087948801c2c8f843f58439da60d8f8765301f371e964fd6 \
+                        size    104946765
 
 extract.mkdir       yes
-
-java.version        11+
-java.fallback       openjdk11
-
 use_configure       no
 
 build {}
 
 destroot {
     copy ${worksrcpath}/DBeaver.app ${destroot}${applications_dir}
+}
+
+# Fix broken libjli.dylib using the openjdk11-zulu
+#
+# See https://github.com/dbeaver/dbeaver/issues/14141#issuecomment-945218003
+master_sites-append https://cdn.azul.com/zulu/bin/
+set openjdk_distname zulu11.50.19-ca-jdk11.0.12-macosx
+if {${build_arch} eq "x86_64"} {
+    distfiles-append    ${openjdk_distname}_x64${extract.suffix}
+    checksums-append    ${openjdk_distname}_x64${extract.suffix} \
+                        rmd160  2b136a6fbe8f0d9bcf52cf12a41099825f1fac07 \
+                        sha256  0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7 \
+                        size    195713033
+} elseif {${build_arch} eq "arm64"} {
+    distfiles-append    ${openjdk_distname}_aarch64${extract.suffix}
+    checksums-append    ${openjdk_distname}_aarch64${extract.suffix} \
+                        rmd160  c482f2433c9aa6451b915bb5b56c748e7f153436 \
+                        sha256  e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17 \
+                        size    179357206
+}
+pre-destroot {
+    delete ${worksrcpath}/DBeaver.app/Contents/Eclipse/jre/Contents/MacOS/libjli.dylib
+
+    if {${build_arch} eq "x86_64"} {
+        move ${worksrcpath}/${openjdk_distname}_x64/lib/jli/libjli.dylib \
+            ${worksrcpath}/DBeaver.app/Contents/Eclipse/jre/Contents/MacOS
+    } elseif {${build_arch} eq "arm64"} {
+        move ${worksrcpath}/${openjdk_distname}_aarch64/lib/jli/libjli.dylib \
+            ${worksrcpath}/DBeaver.app/Contents/Eclipse/jre/Contents/MacOS
+    }
 }


### PR DESCRIPTION
CHANGES:
* Remove Java PG, because Java is embedded in the app
* Update to 21.2.3
* Fix broken libjli.dylib using the openjdk11-zulu

See https://github.com/dbeaver/dbeaver/issues/14141

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
