### PR TITLE
libjpeg-turbo-devel: update to 2.1.1

### DIFF
--- a/graphics/libjpeg-turbo-devel/Portfile
+++ b/graphics/libjpeg-turbo-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 
 name                libjpeg-turbo-devel
 set my_name         libjpeg-turbo
-version             2.1.0
+version             2.1.1
 revision            0
 categories          graphics
 platforms           darwin
@@ -33,10 +33,10 @@ master_sites        sourceforge:project/${my_name}/${version}
 distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 
-checksums           sha1    6bf63c869105d341011cd4915816de888338231a \
-                    rmd160  cdb947d63425a8d17b1d83e478f4581ab090a74e \
-                    sha256  bef89803e506f27715c5627b1e3219c95b80fc31465d4452de2a909d382e4444 \
-                    size    2255497
+checksums           sha1    f9c3c17479f4fa2c76dba15125552fc9f6bfda80 \
+                    rmd160  61540f131dbfd5564fba7aee0cecfdd3bab164b9 \
+                    sha256  b76aaedefb71ba882cbad4e9275b30c2ae493e3195be0a099425b5c6b99bd510 \
+                    size    2256321
 
 configure.args      -DWITH_JPEG8=ON
 


### PR DESCRIPTION
#### Description

Release notes: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.1.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
