### PR TITLE
openjdk: update to GraalVM 21.3.0

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -115,20 +115,11 @@ subport openjdk8 {
     }
 }
 
+# Remove after 2022-10-19
 subport openjdk8-graalvm {
     version      21.0.0.2
-    revision     1
-
-    description  GraalVM Community Edition based on OpenJDK 8
-    long_description ${long_description_graalvm}
-
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-    distname     graalvm-ce-java8-darwin-amd64-${version}
-    worksrcdir   graalvm-ce-java8-${version}
-
-    checksums    rmd160  2fc5f23a1558b5e125ef91ad137270fe4f2b4d0c \
-                 sha256  25a653a44b3ad63479d7ae35d921c8d39282ff1849243f1afc0ffddd443e9079 \
-                 size    349277690
+    revision     2
+    replaced_by  openjdk11-graalvm
 }
 
 subport openjdk8-openj9 {
@@ -243,7 +234,7 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      21.2.0
+    version      21.3.0
     revision     0
 
     description  GraalVM Community Edition based on OpenJDK 11
@@ -253,9 +244,9 @@ subport openjdk11-graalvm {
     distname     graalvm-ce-java11-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java11-${version}
 
-    checksums    rmd160  7a1f0185f67022ad7f9ba5540a438580edd10792 \
-                 sha256  f62cdc44a031731aa221426724a55eb09c79d6b2e9275ae3ca7003da5884ca36 \
-                 size    399511612
+    checksums    rmd160  a3d4159e7a9fc118a6595b4aa36225530e9147b9 \
+                 sha256  6c2bf7f6e5fab901e8a2284a0dbec6ce214bde65aa80cfeb90bfef8eabb5f862 \
+                 size    403386940
 }
 
 subport openjdk11-openj9 {
@@ -481,20 +472,11 @@ subport openjdk16 {
     replaced_by  openjdk17
 }
 
+# Remove after 2022-10-19
 subport openjdk16-graalvm {
     version      21.2.0
-    revision     0
-
-    description  GraalVM Community Edition based on OpenJDK 16
-    long_description ${long_description_graalvm}
-
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-    distname     graalvm-ce-java16-darwin-amd64-${version}
-    worksrcdir   graalvm-ce-java16-${version}
-
-    checksums    rmd160  7dbae81c0113456544e08bda942f67c4ad13cd3b \
-                 sha256  833412a6e26c26ae3de37bd42e889f60d7a7651122c6d52741ed0d7f56a0460f \
-                 size    403397792
+    revision     1
+    replaced_by  openjdk17-graalvm
 }
 
 subport openjdk16-openj9 {
@@ -552,6 +534,22 @@ subport openjdk17 {
     } elseif {${configure.build_arch} eq "arm64"} {
         depends_run-append port:openjdk17-zulu
     }
+}
+
+subport openjdk17-graalvm {
+    version      21.3.0
+    revision     0
+
+    description  GraalVM Community Edition based on OpenJDK 17
+    long_description ${long_description_graalvm}
+
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+    distname     graalvm-ce-java17-darwin-amd64-${version}
+    worksrcdir   graalvm-ce-java17-${version}
+
+    checksums    rmd160  bdbe63ef185db265df38fae5666d0ea64d38d539 \
+                 sha256  60236506920cc84a07ea7602f4514d05da2c07c7176e0634652f8a9c5ad677aa \
+                 size    415089299
 }
 
 subport openjdk17-temurin {


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 21.3.0 builds.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?