### PR TITLE
google-cloud-sdk: update to 361.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             360.0.0
+version             361.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f301149f5d8f18748e1a7f0b7cf7b289b7ae805d \
-                    sha256  4159f7419b8abe7de7bddb88ced85bf547cbc49c488801b3f06ee9188474a33f \
-                    size    96550734
+    checksums       rmd160  9d27368024ca49f0f8732a451cc1c776eddff561 \
+                    sha256  7ddb0eedab0d213f883a850ac6d838df3a02fdb155f71deeea452f06363af203 \
+                    size    96434250
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4134952ca0d5355bbe87c187db4b61801353de72 \
-                    sha256  b900370f1c05f2dbf819aa257c545790ef087f858f0e438eac20ed0bed375e32 \
-                    size    92793164
+    checksums       rmd160  1a6823e55a0f250c0891b0e160bac622396027a2 \
+                    sha256  ae86d17383db991bc32c1aae228ea5f08f8186086d95b84366b8f637730991bf \
+                    size    92705663
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d6b4e6e3da982172a6dcaf3be109b8d1488afd1b \
-                    sha256  7d40e2282958d713ebb5ce8fa7c28ccb4787f2cd304c2ee1f5bf9c91f4f00b5e \
-                    size    92715538
+    checksums       rmd160  dd19da1705d976b7902a57a610fd302625fdf6f5 \
+                    sha256  9101f91dc8853424538547344e8fedb2a6d350d32b608de9399ca1d01b67825f \
+                    size    92633386
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 361.0.0.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?