### PR TITLE
openjdk: update macOS compatibility checks

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -605,16 +605,25 @@ subport openjdk17-zulu {
 
 if {${os.platform} eq "darwin"} {
     # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-    if {[string match *-zulu ${subport}] && ${os.major} < 17} {
-        known_fail yes
-        pre-fetch {
-            ui_error "${name} ${version} is only supported on Mac OS X 10.13 High Sierra or later."
-            return -code error
-        }
-    } elseif {${os.major} < 14} {
+    if {[string match *-openj9 ${subport}] && ${os.major} < 14} {
+        # See https://www.ibm.com/support/pages/semeru-runtimes-support
         known_fail yes
         pre-fetch {
             ui_error "${name} ${version} is only supported on Mac OS X 10.10 Yosemite or later."
+            return -code error
+        }
+    } elseif {[string match *-temurin ${subport}] && ${os.major} < 16} {
+        # See https://adoptium.net/supported_platforms.html
+        known_fail yes
+        pre-fetch {
+            ui_error "${name} ${version} is only supported on Mac OS X 10.12 Sierra or later."
+            return -code error
+        }
+    } elseif {[string match *-zulu ${subport}] && ${os.major} < 18} {
+        # See https://www.azul.com/downloads/?os=macos&package=jdk
+        known_fail yes
+        pre-fetch {
+            ui_error "${name} ${version} is only supported on Mac OS X 10.14 Mojave or later."
             return -code error
         }
     }


### PR DESCRIPTION
#### Description

Updated macOS compatibility checks according to vendor information.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?