### PR TITLE
wireguard-go: update to 0.0.20211016

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20210424
+version             0.0.20211016
 revision            0
-checksums           rmd160  10dcd710cad724ebaa008d3c0db7571c3f1291ee \
-                    sha256  0f9a7c0657e6119d317a0bab453aeb5140111b186ae10f62cfa081eecf2f03ba \
-                    size    105496
+checksums           rmd160  1920b4ac0ea2bff8df27f28cb8768f2ced319df9 \
+                    sha256  25c9ec596adc714fa456f88b61704bb069f17be3604d1c9cfae96579c924361d \
+                    size    97948
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-go: update to 0.0.20211016

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?