### PR TITLE
matterhorn: update to 50200.14.0

### DIFF
--- a/net/matterhorn/Portfile
+++ b/net/matterhorn/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           haskell_cabal 1.0
 
 name                matterhorn
-version             50200.13.0
+version             50200.14.0
 revision            0
-checksums           rmd160  d8fdb31d2d4ebdaf34e688498c7ed2ff5d91de58 \
-                    sha256  a2ebc8b1eec4e56e82e1ccd53c98ee6233e699a5a3c56b47bf24cd2d8fc4d0f3 \
-                    size    948356
+checksums           rmd160  35e759a2169b16ad7cd24bcc21d54b82edcf793b \
+                    sha256  adf4b752aa42f2ff338475a12b4809228a579d621ea38dde0eba817f893e0e74 \
+                    size    964220
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
 


### PR DESCRIPTION
#### Description
matterhorn: update to 50200.14.0

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?