### PR TITLE
pspp-devel: fix build with gcc7

### DIFF
--- a/math/pspp-devel/Portfile
+++ b/math/pspp-devel/Portfile
@@ -66,8 +66,12 @@ post-patch {
     }
 }
 
-# error: type name requires a specifier or qualifier
-compiler.c_standard  2011
+# error: unknown field 'text' specified in initializer
+compiler.blacklist *gcc-3.* *gcc-4.*
+compiler.c_standard 1999
+
+# Code uses 'asm' instead of '__asm__', so we need a GNU standard
+configure.cflags-append -std=gnu99
 
 #configure.cflags-append -g
 configure.python    ${prefix}/bin/python3.9


### PR DESCRIPTION
#### Description

The latest betas use C99-style for loop initializers, but also need GNU extensions for its `asm` syntax, so GNU99 it is.

GCC 4.2 will still not build the code base, so don't change the value of `compiler.c_standard`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
