### PR TITLE
gocryptfs: Update to 2.2.1

### DIFF
--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 PortGroup           fuse 1.0
 
-go.setup            github.com/rfjakob/gocryptfs 2.2.0 v
+go.setup            github.com/rfjakob/gocryptfs 2.2.1 v
 revision            0
 
 categories          fuse
@@ -17,9 +17,9 @@ long_description    ${description}
 homepage            https://nuetzlich.net/gocryptfs/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  fe96b161b616299c1133558a3b682ff24990fbb0 \
-                        sha256  5ac58b3deef134745c6dbdfaac8d31cf2d2ef4aac9104f56553e427ad36c97f3 \
-                        size    1363930
+                        rmd160  6367fedd7d6ef743df8c86285974680b5aa41201 \
+                        sha256  2ddd48014f7390d72cddafd2dc3658beb31500b25ae5ac8a5dd5a2f45f44c011 \
+                        size    1364893
 
 set gitversionfuse "3ab5d95a30ae"
 go.vendors          gopkg.in/yaml.v3 \


### PR DESCRIPTION
#### Description

Update to 2.2.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
