### PR TITLE
openjdk: update to Azul Zulu OpenJDK 2021 Q4 updates

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -73,10 +73,10 @@ if {${subport} eq "openjdk"} {
 subport openjdk7-zulu {
     # https://www.azul.com/downloads/?version=java-7-lts&os=macos&package=jdk
 
-    version      7.48.0.11
+    version      7.50.0.11
     revision     0
 
-    set openjdk_version 7.0.312
+    set openjdk_version 7.0.322
 
     description  Azul Zulu Community OpenJDK 7 (Long Term Support)
     long_description ${long_description_zulu}
@@ -84,9 +84,9 @@ subport openjdk7-zulu {
     master_sites https://cdn.azul.com/zulu/bin/
 
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  e67ace4cc674397e28700838101f7b200ac8a2a2 \
-                 sha256  303ccd606307ce37f48ffbaeccaaee72fa3445eb1503c99ae181b372b72701e3 \
-                 size    68501413
+    checksums    rmd160  6052a3fb3917e0dbf0bbeea711529cf39c5a670d \
+                 sha256  085af056bfa3cbba63992a388c4eadebb1e3ae6f88822bee17520488592d7726 \
+                 size    68505097
 
     worksrcdir   ${distname}/zulu-7.jdk
 
@@ -166,14 +166,10 @@ subport openjdk8-temurin {
 subport openjdk8-zulu {
     # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
 
-    if {${configure.build_arch} eq "x86_64"} {
-        version      8.56.0.21
-    } elseif {${configure.build_arch} eq "arm64"} {
-        version      8.56.0.23
-    }
+    version      8.58.0.13
     revision     0
 
-    set openjdk_version 8.0.302
+    set openjdk_version 8.0.312
 
     description  Azul Zulu Community OpenJDK 8 (Long Term Support)
     long_description ${long_description_zulu}
@@ -182,14 +178,14 @@ subport openjdk8-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  1dc569a8943abb351878b2e51ec3810904b34da7 \
-                     sha256  497c1d6eae5f3943a1c5f74be7bb8a650d6b0dc3bf069973d6d04f45c3daaf88 \
-                     size    108061992
+        checksums    rmd160  30a02522f89b4d454617b1a819a4b657f226fa14 \
+                     sha256  e8088937f8df77a4e18c690cfe3d602ff50af3446b1a5420438ec811b0cf50ea \
+                     size    108079078
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  74eaf41d309ec8a3c11968ad1766b1108ec540a9 \
-                     sha256  4482990c96e87519f52725b0bf3a6171510e3da268d55b793d1bf6eeb6485030 \
-                     size    105811540
+        checksums    rmd160  7d1629220e44a2e77ff4a7cc2bb0024692c49d62 \
+                     sha256  304251193046120487e6ee4b3172349118911f58e84fb8449e1ca14e03924db9 \
+                     size    105844180
     }
 
     worksrcdir   ${distname}/zulu-8.jdk
@@ -301,10 +297,10 @@ subport openjdk11-temurin {
 subport openjdk11-zulu {
     # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 
-    version      11.50.19
+    version      11.52.13
     revision     0
 
-    set openjdk_version 11.0.12
+    set openjdk_version 11.0.13
 
     description  Azul Zulu Community OpenJDK 11 (Long Term Support)
     long_description ${long_description_zulu}
@@ -313,14 +309,14 @@ subport openjdk11-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  2b136a6fbe8f0d9bcf52cf12a41099825f1fac07 \
-                     sha256  0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7 \
-                     size    195713033
+        checksums    rmd160  5e5eee2f151bcf166e0d4025b35a66d070160988 \
+                     sha256  e27a11a6e970ba6f597ecc957c0cdb502ff8990c243a6abd9df1e3413a0a3e44 \
+                     size    195746537
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  c482f2433c9aa6451b915bb5b56c748e7f153436 \
-                     sha256  e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17 \
-                     size    179357206
+        checksums    rmd160  d8184893aea25d7a5a6c0c6ff9ae18c837c7adab \
+                     sha256  eb8d593a61a9461a554e7bb1d67bca0f94242273f1d01a13f58c20c269b35fe5 \
+                     size    179324731
     }
 
     worksrcdir   ${distname}/zulu-11.jdk
@@ -371,10 +367,10 @@ subport openjdk13-openj9-large-heap {
 subport openjdk13-zulu {
     # https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
 
-    version      13.42.17
+    version      13.44.13
     revision     0
 
-    set openjdk_version 13.0.8
+    set openjdk_version 13.0.9
 
     description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
     long_description ${long_description_zulu}
@@ -383,14 +379,14 @@ subport openjdk13-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  6b815bc7964d1caf720032378b0767c1337a415a \
-                     sha256  89b4e117f3543e0135c4bfd97ff07425a656af5c15e8c30165f01b0dec86563c \
-                     size    200259765
+        checksums    rmd160  9ce25f37b5c2951c0669a1858f246e2095bb5191 \
+                     sha256  a8600f9a1c82c6ac60c8138a51ff1c60d055f59c78aa082b22ed711097ed56b1 \
+                     size    200299583
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  297c7baae1b4fc7dbb40f58ff561f3d20eafc5e5 \
-                     sha256  b5104d5b0857e475217a58f8b62bb9e0b118abc1e0aa06b4398da4598dd57f72 \
-                     size    179620444
+        checksums    rmd160  fb87f09ab81c1bc7de8c604bbbe116a295ef48bd \
+                     sha256  f600d120ae43cfe906c71eea10b26c7df01a0c343041cddfc1278f95f10cb4c3 \
+                     size    179657257
     }
 
     worksrcdir   ${distname}/zulu-13.jdk
@@ -440,10 +436,10 @@ subport openjdk15-openj9-large-heap {
 subport openjdk15-zulu {
     # https://www.azul.com/downloads/?version=java-15-mts&os=macos&package=jdk
 
-    version      15.34.17
+    version      15.36.13
     revision     0
 
-    set openjdk_version 15.0.4
+    set openjdk_version 15.0.5
 
     description  Azul Zulu Community OpenJDK 15 (Medium Term Support)
     long_description ${long_description_zulu}
@@ -452,14 +448,14 @@ subport openjdk15-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  b510fa41d6df9f92476248e9fd8a3333cc89e024 \
-                     sha256  73f284d1b5d150d6a286759c2d00ceafc4b50596399e9e9af0f1603c3dcb08de \
-                     size    201986189
+        checksums    rmd160  a4963a7f164be6b40e30c33105554de9d232d906 \
+                     sha256  e89e4b1ad499b59bfc74edef0975654a4033cdb9887a646c98cb35f41de72c06 \
+                     size    202001319
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  9b8cdb1bc888e01b0ee3e04efc00e0873c5ce852 \
-                     sha256  af9a181dbb38f8c7571b5d59359684b88a79ddda5b313adb2efab87221f53e2d \
-                     size    176383011
+        checksums    rmd160  d8878abda897736555a4c6265133ab2a7e1a6771 \
+                     sha256  b58b4385752c2439edd78f88b7206c5ff71880862e849e0700c7fc1e4bf91b60 \
+                     size    176400196
     }
 
     worksrcdir   ${distname}/zulu-15.jdk


### PR DESCRIPTION
#### Description

Update to:
* Azul Zulu 7.50.0.11 (OpenJDK 7.0.322)
* Azul Zulu 8.58.0.13 (OpenJDK 8.0.312)
* Azul Zulu 11.52.13 (OpenJDK 11.0.13)
* Azul Zulu 13.44.13 (OpenJDK 13.0.9)
* Azul Zulu 15.36.13 (OpenJDK 15.0.5)

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?