### PR TITLE
emacs{-app}-devel: update to 2021-10-20

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -96,14 +96,14 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     legacysupport.newest_darwin_requires_legacy 13
 
-    set date        2021-09-28
+    set date        2021-10-20
     epoch           4
     version         [string map {- {}} ${date}]
     revision        0
 
     fetch.type      git
     git.url         --shallow-since=${date}T00:00:00 https://github.com/emacs-mirror/emacs.git
-    git.branch      ccb35fb8fb9de5f069fd0103f24e3048d716febc
+    git.branch      5f5189e9be6c70c4db99e8057287d16955b9c620
 
     # --shallow-since needs a newer version of git than on some older systems
     # So use MacPorts version


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/63651


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->