### PR TITLE
openjdk: add obsolete subports

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -43,6 +43,7 @@ set openj9_version 0
 
 set obsoleted_ports {
     openjdk
+    openjdk8-graalvm
     openjdk8-openj9-large-heap
     openjdk10
     openjdk11-openj9-large-heap
@@ -58,6 +59,10 @@ set obsoleted_ports {
     openjdk15
     openjdk15-openj9
     openjdk15-openj9-large-heap
+    openjdk16
+    openjdk16-graalvm
+    openjdk16-temurin
+    openjdk16-zulu
 }
 
 if {${subport} in ${obsoleted_ports}} {


### PR DESCRIPTION
#### Description

List all obsolete subports.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?