### PR TITLE
podman: update to 3.4.1

### DIFF
--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/containers/podman 3.4.0 v
-revision            1
+go.setup            github.com/containers/podman 3.4.1 v
+revision            0
 
 categories          sysutils
 license             Apache-2
@@ -20,9 +20,9 @@ long_description    Podman is a tool for running Linux containers. \
 maintainers         {judaew @judaew} openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  affef5f3f8cf3d6174f19cea0d0dc8032749ea15 \
-                        sha256  5ebf7c7dfb10c84eb15263a8776a53b58357c60318c373e33e65bcf99c087679 \
-                        size    10951433
+                        rmd160  1ecd57c81cc56f6ac6101c293162be1223ef4bee \
+                        sha256  7b851db9dde1f7c9243c8bc9b879858b4d400ba282c9195c223549bc84506e67 \
+                        size    10954255
 
 post-extract {
     reinplace "s|-mod=vendor||g" ${worksrcpath}/Makefile


### PR DESCRIPTION
#### Description

Updating podman to version 3.4.1

This release contains more podman-machine fixes.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
