### PR TITLE
babl ports: move to path-style dependency

### DIFF
--- a/graphics/gegl-0.3/Portfile
+++ b/graphics/gegl-0.3/Portfile
@@ -39,7 +39,7 @@ depends_build-append \
                     port:w3m \
                     port:python27
 
-depends_lib-append  port:babl \
+depends_lib-append  path:lib/pkgconfig/babl.pc:babl \
                     port:gdk-pixbuf2 \
                     path:lib/pkgconfig/gtk+-2.0.pc:gtk2 \
                     path:include/turbojpeg.h:libjpeg-turbo \

--- a/graphics/gegl/Portfile
+++ b/graphics/gegl/Portfile
@@ -35,7 +35,7 @@ depends_build-append \
                     port:pkgconfig \
                     port:python39
 
-depends_lib         port:babl \
+depends_lib         path:lib/pkgconfig/babl.pc:babl \
                     path:lib/pkgconfig/cairo.pc:cairo \
                     path:lib/pkgconfig/pango.pc:pango \
                     port:gdk-pixbuf2 \

--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -43,7 +43,7 @@ depends_build       port:pkgconfig \
 
 depends_lib         port:desktop-file-utils \
                     port:iso-codes \
-                    port:babl \
+                    path:lib/pkgconfig/babl.pc:babl \
                     port:gegl \
                     port:atk \
                     port:gdk-pixbuf2 \


### PR DESCRIPTION
#### Description

This change allows `babl-devel` to satisfy any `babl` dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
