### PR TITLE
mysql8: use MacPorts' libc++ on macOS ≤10.12

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -93,6 +93,10 @@ if {$subport eq $name} {
     # MYSQL_VERSION_MAJOR=8
     compiler.blacklist-append {macports-clang-[8-9].0}
 
+    # Requires std::shared_timed_mutex, std::bad_optional_access
+    legacysupport.newest_darwin_requires_legacy 16
+    legacysupport.use_mp_libcxx yes
+
     # Use default CMake build_types
     if {[variant_isset debug]} {
         cmake.build_type    Debug


### PR DESCRIPTION
…for `std::shared_timed_mutex` and `std::bad_optional_access`
See: https://trac.macports.org/ticket/60853

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
