### PR TITLE
mysql8: pre-C++17 compiler restriction cleanup

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -82,9 +82,6 @@ if {$subport eq $name} {
 
     compiler.cxx_standard 2017
 
-    # TODO: explain why these compilers are blacklisted
-    compiler.blacklist-append *gcc-5 {clang < 900}
-
     # /usr/include/c++/v1/optional:960:34: note: candidate function not viable: no known conversion from 'optional<...>' to 'const optional<...>' for object argument
     compiler.blacklist-append {clang < 1100}
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/60894

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
