### PR TITLE
hiredis: move to cmake PG and support Tiger

### DIFF
--- a/databases/hiredis/Portfile
+++ b/databases/hiredis/Portfile
@@ -2,8 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           compiler_blacklist_versions 1.0
-PortGroup           makefile 1.0
+PortGroup           cmake 1.1
 
 github.setup        redis hiredis 1.0.2 v
 categories          databases
@@ -21,15 +20,15 @@ checksums           rmd160  3d539949eca1f3213585a03d7112cb8c28582644 \
 
 compiler.c_standard 1999
 
-use_configure       no
+configure.cflags-append -std=c99
 
-# The Makefile misuses LIBRARY_PATH
-# https://github.com/redis/hiredis/issues/382
-compiler.library_path
+configure.args-append -DDISABLE_TESTS=ON
 
 variant universal {}
 
-build.args-append   OPTIMIZATION="${configure.optflags}"
+platform darwin 8 {
+    patchfiles-append patch-hiredis-tiger.diff
+}
 
 # exclude pre-release versions
 github.livecheck.regex  {([0-9.]+)}

--- a/databases/hiredis/files/patch-hiredis-tiger.diff
+++ b/databases/hiredis/files/patch-hiredis-tiger.diff
@@ -1,0 +1,16 @@
+On Tiger, TCP_KEEPALIVE only appears if neither _XOPEN_SOURCE nor
+_POSIX_C_SOURCE is defined. Instead of dealing with other possible
+ramifications of undefining those, just pop in the TCP_KEEPALIVE
+definition from <netinet/tcp.h>.
+
+--- fmacros.h.orig
++++ fmacros.h
+@@ -6,7 +6,7 @@
+ 
+ #if defined(__APPLE__) && defined(__MACH__)
+ /* Enable TCP_KEEPALIVE */
+-#define _DARWIN_C_SOURCE
++#define TCP_KEEPALIVE 0x10
+ #endif
+ 
+ #endif


### PR DESCRIPTION
#### Description

hiredis ships with both a Makefile and CMakeLists.txt. The CMake build offers additional build options, so move to that. In particular, it allows disabling building the tests with `-DDISABLE_TESTS=ON`, which seems to be necessary on Tiger due to some conflicting function definition errors.

Enabling the tests post-Tiger can be done later – they have never been set up to run so there is no real loss here.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
