### PR TITLE
ccache: fix build on Tiger and PowerPC

### DIFF
--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -33,6 +33,13 @@ homepage            https://ccache.dev
 github.tarball_from releases
 use_xz              yes
 
+platform darwin powerpc {
+    patchfiles-append  patch-ccache-powerpc-darwin.diff
+}
+platform darwin 8 {
+    patchfiles-append  patch-ccache-no-posix-tiger.diff
+}
+
 compiler.c_standard 1999
 
 compiler.cxx_standard \

--- a/devel/ccache/files/patch-ccache-no-posix-tiger.diff
+++ b/devel/ccache/files/patch-ccache-no-posix-tiger.diff
@@ -1,0 +1,22 @@
+--- cmake/config.h.in.orig
++++ cmake/config.h.in
+@@ -28,7 +28,7 @@
+ #cmakedefine _DARWIN_C_SOURCE
+ 
+ // Define to activate features from IEEE Stds 1003.1-2008.
+-#define _POSIX_C_SOURCE 200809L
++//#define _POSIX_C_SOURCE 200809L
+ 
+ #if defined(__SunOS_5_8) || defined(__SunOS_5_9) || defined(__SunOS_5_10)
+ #  define _XOPEN_SOURCE 500
+--- test/run.orig
++++ test/run
+@@ -514,7 +514,7 @@ if [[ $OSTYPE = msys* ]]; then
+ fi
+ 
+ if $HOST_OS_APPLE; then
+-    SDKROOT=$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)
++    SDKROOT=/
+     if [ "$SDKROOT" = "" ]; then
+         echo "Error: xcrun --show-sdk-path failure"
+         exit 1

--- a/devel/ccache/files/patch-ccache-powerpc-darwin.diff
+++ b/devel/ccache/files/patch-ccache-powerpc-darwin.diff
@@ -1,0 +1,12 @@
+--- src/third_party/doctest.h.orig
++++ src/third_party/doctest.h
+@@ -370,6 +370,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
+ #elif defined(DOCTEST_PLATFORM_MAC)
+ #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
+ #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT (hicpp-no-assembler)
++#elif defined(__ppc__) || defined(__ppc64__)
++// https://www.cocoawithlove.com/2008/03/break-into-debugger.html
++#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n": : : "memory","r0","r3","r4")
+ #else
+ #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT (hicpp-no-assembler)
+ #endif


### PR DESCRIPTION
#### Description

Patches adapted from @kencu's TigerPorts. Tested locally through the build phase.

Closes: https://trac.macports.org/ticket/62516

Note that if you are trying to build this on Tiger at home, the `ruby30` dependency (included via `asciidoctor`) will fail. This will be addressed in a separate PR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
