### PR TITLE
ccache: new +doc variant

### DIFF
--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -41,16 +41,20 @@ compiler.cxx_standard \
 # CMake Error at CMakeLists.txt:31: The compiler you are using is too old, sorry.
 compiler.blacklist  {clang < 700}
 
-depends_build-append \
-                    port:asciidoc \
-                    port:asciidoctor
-
 depends_lib-append  port:hiredis \
                     port:zstd
 
 # Do not use ccache to build this port unless MacPorts tells it to.
 configure.args-append -DUSE_CCACHE=NO
 
-build.target-append doc
+configure.args-append -DENABLE_DOCUMENTATION=OFF
+
+variant doc description {Enable documentation} {
+    configure.args-replace -DENABLE_DOCUMENTATION=OFF -DENABLE_DOCUMENTATION=ON
+    depends_build-append \
+                    port:asciidoctor
+}
+
+default_variants +doc
 
 test.run            yes


### PR DESCRIPTION
#### Description

The `asciidoctor` dependency requires `ruby30`, which is not available on PowerPC. Adding a `+doc` variant will let PPC users install ccache (after #12654 is merged too).

`asciidoc` is no longer needed – remove it altogether.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
