### PR TITLE
openjdk: update OpenJ9 subports to 8u312 and 11.0.13

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -128,11 +128,11 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
-    version      8u302
+    version      8u312
     revision     0
 
-    set build    08
-    set openj9_version 0.27.0
+    set build    07
+    set openj9_version 0.29.0
 
     homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
@@ -143,9 +143,9 @@ subport openjdk8-openj9 {
     distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  61134e128be3c959ce828b992c36bf39dca702cc \
-                 sha256  0bc4972188b06c3276cf9225a6718b19a7866f7543808b0fe9612039320849b5 \
-                 size    128923297
+    checksums    rmd160  e81e1dd37185b4b7d2799124ccc25a8b81909a7e \
+                 sha256  71c7edbd7267aa1fd5c877d7454139f0f601d2364c8895f922e59c238dd66119 \
+                 size    129005651
 }
 
 subport openjdk8-temurin {
@@ -251,11 +251,11 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.12
+    version      11.0.13
     revision     0
 
-    set build    7
-    set openj9_version 0.27.0
+    set build    8
+    set openj9_version 0.29.0
 
     homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
@@ -266,9 +266,9 @@ subport openjdk11-openj9 {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  3f5918ca71264b358cbb040eeb2f78fed329affc \
-                 sha256  5b0dea6c3ca46ad201e5854a7fdb8699490257c49134c9d55f3d8292bdb14ba9 \
-                 size    203006828
+    checksums    rmd160  ec117d7540c0798e1e4fe33143629bfaaaca61cf \
+                 sha256  0f0a117666ead0b28e3b44a4f2cc56645f25a28ce67bd51b671c118ea6842774 \
+                 size    203173127
 }
 
 # Remove after 2022-04-30


### PR DESCRIPTION
#### Description

Update OpenJ9 subports to 8u312 and 11.0.13.

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?