### PR TITLE
libbluray: fix build on Tiger

### DIFF
--- a/multimedia/libbluray/Portfile
+++ b/multimedia/libbluray/Portfile
@@ -29,6 +29,10 @@ depends_lib         port:libxml2 \
                     port:fontconfig \
                     port:freetype
 
+platform darwin 8 {
+    patchfiles-append patch-libbluray-disable-POSIX-Tiger.diff
+}
+
 configure.perl      ${prefix}/bin/perl5
 
 configure.args      --disable-doxygen-doc \

--- a/multimedia/libbluray/files/patch-libbluray-disable-POSIX-Tiger.diff
+++ b/multimedia/libbluray/files/patch-libbluray-disable-POSIX-Tiger.diff
@@ -1,0 +1,18 @@
+--- Makefile.in.old
++++ Makefile.in
+@@ -743,7 +743,6 @@
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ MOSTLYCLEANFILES = $(DX_CLEANFILES)
+-POSIX_C_SOURCE = 200809L
+ EXTRA_DIST = \
+ 	bootstrap \
+ 	ChangeLog \
+@@ -762,7 +761,6 @@
+ 
+ AM_CPPFLAGS = \
+ 	-D_ISOC99_SOURCE \
+-	-D_POSIX_C_SOURCE=$(POSIX_C_SOURCE) \
+ 	-D_REENTRANT \
+ 	\
+ 	-I$(top_srcdir)/src \


### PR DESCRIPTION
#### Description

Patch from @kencu's TigerPorts. Tested locally through destroot stage.

See: https://trac.macports.org/ticket/39442

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
