### PR TITLE
nsh: new port

### DIFF
--- a/shells/nsh/Portfile
+++ b/shells/nsh/Portfile
@@ -1,0 +1,153 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        nuta nsh 0.4.2 v
+github.tarball_from archive
+revision            0
+
+description         A command-line shell like fish, but POSIX compatible.
+
+long_description    A command-line shell that focuses on productivity and \
+                    swiftness featuring a POSIX compliant interactive shell \
+                    with some Bash extensions, tab completions and syntax \
+                    highlighting, Bash completion support (by internally \
+                    invoking the genuine Bash), builtin zero configration \
+                    features, and written in Rust.
+
+categories          shells
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+platforms           darwin
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  70e6b954e2b06b40600dd2152a596cede5c0c2c5 \
+                    sha256  b0c656e194e2d3fe31dc1c6ee15fd5808db3b2428d79adf786c6900ebbba0849 \
+                    size    82006
+
+depends_run-append  port:bash
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 {*}[glob ${worksrcpath}/docs/*] \
+        ${destroot}${prefix}/share/doc/${name}/
+}
+
+cargo.crates \
+    addr2line                       0.15.2  e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    backtrace                       0.3.60  b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282 \
+    base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    blake2b_simd                    0.5.11  afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587 \
+    block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
+    block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
+    byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
+    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
+    cc                              1.0.69  e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    colored                          1.9.3  f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam-utils                  0.8.5  d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db \
+    crossterm                       0.18.2  4e86d73f2a0b407b5768d10a8c720cf5d2df49a9efc10ca09176d201ead4b7fb \
+    crossterm_winapi                 0.6.2  c2265c3f8e080075d9b6417aa72293fc71662f34b4af2612d8d1b074d29510db \
+    ctor                            0.1.20  5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d \
+    diff                            0.1.12  0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499 \
+    digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
+    dirs                             1.0.5  3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901 \
+    failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
+    failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
+    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    fern                             0.6.0  8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065 \
+    generic-array                   0.12.4  ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd \
+    getrandom                       0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
+    getrandom                        0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
+    gimli                           0.24.0  0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189 \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    instant                         0.1.10  bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.98  320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790 \
+    lock_api                         0.4.4  0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb \
+    log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
+    memchr                           2.4.0  b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc \
+    memoffset                        0.6.4  59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9 \
+    miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
+    mio                             0.7.13  8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16 \
+    miow                             0.3.7  b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21 \
+    nix                             0.22.0  cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187 \
+    ntapi                            0.3.6  3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44 \
+    object                          0.25.3  a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7 \
+    opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
+    output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
+    parking_lot                     0.11.1  6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb \
+    parking_lot_core                 0.8.3  fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018 \
+    pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
+    pest_derive                      2.1.0  833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0 \
+    pest_generator                   2.1.3  99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55 \
+    pest_meta                        2.1.3  54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d \
+    phf                              0.9.0  b2ac8b67553a7ca9457ce0e526948cad581819238f4a9d1ea74545851fa24f37 \
+    phf_generator                    0.9.0  0fc1437ada0f3a97d538f0bb608137bf53c53969028cab74c89893e1e9a12f0e \
+    phf_macros                       0.9.0  b706f5936eb50ed880ae3009395b43ed19db5bff2ebd459c95e7bf013a89ab86 \
+    phf_shared                       0.9.0  a68318426de33640f02be62b4ae8eb1261be2efbc337b60c54d845bf4484e0d9 \
+    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    pretty_assertions                0.7.2  1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
+    proc-macro2                     1.0.27  f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038 \
+    quote                            1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
+    rand                             0.8.4  2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8 \
+    rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_core                        0.6.3  d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7 \
+    rand_hc                          0.3.1  d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7 \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    redox_syscall                    0.2.9  5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee \
+    redox_users                      0.3.5  de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    rust-argon2                      0.8.3  4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb \
+    rustc-demangle                  0.1.20  dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    sha-1                            0.8.2  f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df \
+    signal-hook                     0.1.17  7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729 \
+    signal-hook                      0.2.3  844024c8913df6bfbfeee3061075ccc47216a897ac0b54a683dea3dfe16d19af \
+    signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
+    siphasher                        0.3.5  cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27 \
+    smallvec                         1.6.1  fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    structopt                       0.3.22  69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71 \
+    structopt-derive                0.4.15  7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10 \
+    syn                             1.0.73  f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7 \
+    synstructure                    0.12.5  474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa \
+    tempfile                         3.2.0  dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    typenum                         1.13.0  879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06 \
+    ucd-trie                         0.1.3  56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c \
+    unicode-segmentation             1.8.0  8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.3  5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi     0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
#### Description

New port for [`nsh` - a fish-like shell written in Rust](https://github.com/nuta/nsh)

![screenshot](https://gist.githubusercontent.com/nuta/5747db6c43978d9aa1941ce321cc1741/raw/405b7a1156292fd0456010b657f299b1daa367ff/nsh.png)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
