### PR TITLE
libfive: remove maintainer

### DIFF
--- a/graphics/libfive/Portfile
+++ b/graphics/libfive/Portfile
@@ -5,6 +5,12 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
+# Version 601730dc8181f12aeb0c6c66bbe3f4f9b4523134 below does not build
+# with Eigen 3.4, which is the current Eigen version in MacPorts. Newer
+# versions require macOS 10.15 or later to be able to build with
+# Eigen 3.4+, so the update should be done by someone with access 10.15+.
+# See https://trac.macports.org/ticket/63664
+
 # libfive does not have releases; the master branch is recommended.
 # See https://libfive.com/download/
 github.setup        libfive libfive 601730dc8181f12aeb0c6c66bbe3f4f9b4523134
@@ -14,7 +20,7 @@ revision            0
 categories          graphics math cad
 platforms           darwin
 license             MPL-2
-maintainers         {gmail.com:szhorvat @szhorvat} openmaintainer
+maintainers         nomaintainer
 
 homepage            https://libfive.com/
 


### PR DESCRIPTION
#### Description

Remove myself as maintainer. See https://trac.macports.org/ticket/63664

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
