### PR TITLE
nushell: update to 0.38.0

### DIFF
--- a/shells/nushell/Portfile
+++ b/shells/nushell/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        nushell nushell 0.36.0
+github.setup        nushell nushell 0.38.0
 revision            0
 categories          shells
 platforms           darwin
@@ -18,10 +18,10 @@ homepage            https://www.nushell.sh
 
 build.args          --features extra
 
-checksums           nushell-${version}.tar.gz \
-                    rmd160  2767fa81c9b3719727fb09d6888d065ce2a12ab2 \
-                    sha256  f1349c37f28bed75a79a1a2e54080a02d9a55561d0950fa33ff209c95f0d2945 \
-                    size    6289388
+checksums           ${distname}${extract.suffix} \
+                    rmd160  3e5e5baea6f744ba1e90c9d2bf5b272e86450ac3 \
+                    sha256  308d5b2074a93c620009d7cd1c0d9d2588916943b9ac1af4fa115baffb34f945 \
+                    size    6297324
 
 destroot {
     delete {*}[glob ${worksrcpath}/target/[cargo.rust_platform]/release/*.d]
@@ -49,82 +49,65 @@ After a logout, on your next login you should be greeted with a shiny Nu prompt.
 
 For further informations, please read the Nu Book at https://www.nushell.sh/book/
 "
+
 cargo.crates \
     Inflector                       0.11.4  fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3 \
-    addr2line                       0.15.2  e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a \
+    addr2line                       0.16.0  3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
     adler32                          1.2.0  aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234 \
-    aead                             0.3.2  7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331 \
-    aes                              0.6.0  884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561 \
-    aes-gcm                          0.8.0  5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da \
-    aes-soft                         0.6.4  be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072 \
-    aesni                           0.10.0  ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce \
     ahash                            0.7.4  43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98 \
     aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
-    alloc-no-stdlib                  2.0.1  5192ec435945d87bc2f70992b4d818154b5feede43c09fb7592146374eac90a6 \
+    alloc-no-stdlib                  2.0.3  35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3 \
     alloc-stdlib                     0.2.1  697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2 \
-    ansi_colours                     1.0.2  52cb663b84aea8670b4a40368360e29485c11b03d14ff6283261aeccd69d5ce1 \
+    ansi_colours                     1.0.4  60e2fb6138a49ad9f1cb3c6d8f8ccbdd5e62b4dab317c1b435a47ecd7da1d28f \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
-    anyhow                          1.0.41  15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61 \
+    anyhow                          1.0.43  28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf \
     arboard                          1.2.1  47044a1809e2953fe6d084312b81dcb7d9ffc24fee45aa39e5b938f66f75b8a8 \
     arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
     arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
-    arrow                            5.1.0  ddf189dff0c7e0f40588fc25adbe5bb6837b82fc61bb7cadf5d76de030f710bb \
+    arrow2                           0.5.3  bd13b40184904cea33bbc7388c394a995ae5e74d21314c5084d6392753415510 \
     as-slice                         0.1.5  45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0 \
-    async-channel                    1.6.1  2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319 \
-    async-executor                   1.4.1  871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965 \
-    async-global-executor            2.0.2  9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6 \
-    async-io                         1.4.1  4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b \
-    async-lock                       2.4.0  e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b \
-    async-mutex                      1.4.0  479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e \
-    async-recursion                  0.3.2  d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2 \
-    async-std                        1.9.0  d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341 \
-    async-task                       4.0.3  e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0 \
-    async-trait                     0.1.50  0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722 \
-    atomic-waker                     1.0.0  065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a \
+    async-stream                     0.3.2  171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625 \
+    async-stream-impl                0.3.2  648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308 \
+    async-trait                     0.1.51  44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
-    backtrace                       0.3.60  b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282 \
-    base-x                           0.2.8  a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b \
+    backtrace                       0.3.61  e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01 \
     base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
-    bat                             0.18.1  cc7224a2b5bdebb4762c36c25841694ab90328fe0c59fc8e685577795b9b785b \
+    bat                             0.18.3  5a069bad29696ecaa51ac79d3eb87abe3b65c7808ab2b3836afd9bd6c4009362 \
     bigdecimal-rs                    0.2.1  85375a908d633fa70ab5b8a217d3d0b6e5c4a9b03786f0c3c969e77f4016b10c \
     bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
     bit-set                          0.5.2  6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de \
     bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bitpacking                       0.8.4  a8c7d2ac73c167c06af4a5f37e6e59d84148d57ccbe4480b76f0273eefea82d7 \
     blake2b_simd                    0.5.11  afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587 \
     block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
-    block-buffer                     0.2.0  1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814 \
     block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
-    blocking                         1.0.2  c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9 \
-    brotli                           3.3.0  7f29919120f08613aadcd4383764e00526fc9f18b6c0895814faeed0dd78613e \
-    brotli-decompressor              2.3.1  1052e1c3b8d4d80eb84a8b94f0a1498797b5fb96314c001156a1c761940ef4ec \
+    brotli                           3.3.2  71cb90ade945043d3d53597b2fc359bb063db8ade2bcffe7997351d0756e9d50 \
+    brotli-decompressor              2.3.2  59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80 \
     bson                            0.14.1  3c177ed0122f24ce5e0f05bf9b29e79f3ac1a359bc504e0e14c3b34896c71c00 \
     bstr                            0.2.16  90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279 \
-    bugreport                        0.4.0  a0e97e538864a7c95d33accbf64c8d354018ba3b6e032502fd0fe7259cf1aa3d \
+    bugreport                        0.4.1  0014b4b2b4f63bfe69c3838470121290cc437fdc79785d408a761a21e8b2404c \
     bumpalo                          3.7.0  9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631 \
-    byte-tools                       0.2.0  560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40 \
     byte-unit                       4.0.12  063197e6eb4b775b64160dedde7a0986bb2836cce140e9492e9e96f28e18bcd8 \
-    bytemuck                         1.7.0  9966d2ab714d0f785dbac0a0396251a35280aeb42413281617d0209ab4898435 \
+    bytemuck                         1.7.2  72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b \
     byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
     bytes                           0.4.12  206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
     bytes                            0.5.6  0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38 \
-    bytes                            1.0.1  b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040 \
+    bytes                            1.1.0  c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8 \
     bzip2                            0.4.3  6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0 \
-    bzip2-sys                     0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
-    cache-padded                     1.1.1  631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba \
+    bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     calamine                        0.18.0  b86ca78da4bdce5ac0f0bdbc0218ad14232f1e668376e044233f64c527cf5abb \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
-    cc                              1.0.68  4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787 \
+    cc                              1.0.69  e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2 \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
     chrono-humanize                  0.2.1  2eddc119501d583fd930cb92144e605f44e0252c38dd89d9247fffa1993375cb \
     chrono-tz                        0.5.3  2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120 \
-    cipher                           0.2.5  12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801 \
     clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
     clipboard-win                    4.2.1  4e4ea1881992efc993e4dc50a324cdbd03216e41bdc8385720ff47efc9bd2ca8 \
     clircle                          0.3.0  e68bbd985a63de680ab4d1ad77b6306611a8f961b282c8b5ab513e6de934e396 \
@@ -132,72 +115,58 @@ cargo.crates \
     codespan-reporting              0.11.1  3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     common-path                      1.0.0  2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101 \
-    concurrent-queue                 1.2.2  30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3 \
-    config                          0.10.1  19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3 \
     console                         0.14.1  3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45 \
-    const_fn                         0.4.8  f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7 \
     constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
     content_inspector                0.2.4  b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38 \
     convert_case                     0.4.0  6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e \
-    cookie                          0.14.4  03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951 \
     core-foundation                  0.9.1  0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62 \
     core-foundation-sys              0.8.2  ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b \
     core-graphics                   0.21.0  52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978 \
-    cpufeatures                      0.1.4  ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8 \
-    cpuid-bool                       0.2.0  dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba \
+    cpufeatures                      0.2.1  95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469 \
     crc32fast                        1.2.1  81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a \
     crossbeam-channel                0.5.1  06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4 \
-    crossbeam-deque                  0.8.0  94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9 \
+    crossbeam-deque                  0.8.1  6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e \
     crossbeam-epoch                  0.9.5  4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd \
     crossbeam-utils                  0.8.5  d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db \
     crossterm                       0.19.0  7c36c10130df424b2f3552fcc2ddcd9b28a27b1e54b358b45874f88d1ca6888c \
     crossterm_winapi                 0.7.0  0da8964ace4d3e4a044fd027919b2237000b24315a37c916f61809f1ff2140b9 \
-    crypto-mac                       0.4.0  779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198 \
-    crypto-mac                      0.10.0  4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6 \
+    crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
+    crypto-mac                      0.11.1  b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714 \
     cssparser                       0.27.2  754b69d351cdc2d8ee09ae203db831e005560fc6030da058f86ad60c92a9cb0a \
     cssparser-macros                 0.6.0  dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e \
-    cstr_core                        0.2.3  2807c5e92588b6bf1c8c0354af2a4f079d0586c683df322aea719d5dc9b8d5bb \
+    cstr_core                        0.2.4  917ba9efe9e1e736671d5a03f006afc4e7e3f32503e2077e0bcaf519c0c8c1d3 \
     csv                              1.1.6  22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1 \
     csv-core                        0.1.10  2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
-    ctor                            0.1.20  5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d \
-    ctr                              0.6.0  fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f \
-    ctrlc                            3.1.9  232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a \
+    ctrlc                            3.2.0  377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1 \
     cty                              0.2.1  7313c0d620d0cb4dbd9d019e461a4beb501071ff46ec0ab933efb4daa76d73e3 \
-    curl                            0.4.38  003cb79c1c6d1c93344c7e1201bb51c2148f24ec2bd9c253709d6b2efb796515 \
-    curl-sys                      0.4.44+curl-7.77.0  4b6d85e9322b193f117c966e79c2d6929ec08c02f339f950044aba12e20bbaf1 \
-    dashmap                          4.0.2  e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c \
-    data-encoding                    2.3.2  3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57 \
     decimal                          2.1.0  5a8ab77e91baeb15034c3be91e87bff4665c9036216148e4996d9a9f5792114d \
     deflate                         0.7.20  707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4 \
     deflate                          0.8.6  73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174 \
     derive-new                       0.5.9  3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535 \
-    derive_is_enum_variant           0.1.1  d0ac8859845146979953797f03cc5b282fb4396891807cdb3d04929a88418197 \
-    derive_more                    0.99.14  5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320 \
-    digest                           0.6.2  e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a \
+    derive_more                    0.99.16  40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df \
     digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
-    directories                      3.0.2  e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7 \
     directories-next                 2.0.0  339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc \
     dirs                             1.0.5  3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901 \
     dirs                             3.0.2  30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309 \
     dirs-next                        2.0.0  b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1 \
     dirs-sys                         0.3.6  03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780 \
     dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
-    discard                          1.0.4  212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0 \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     dtoa                             0.4.8  56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0 \
     dtoa-short                       0.3.3  bde03329ae10e79ede66c9ce4dc930aa8599043b0743008548680f25b91502d6 \
     dtparse                          1.2.0  13276c5dbd7f365e00efe6631242772fe6615e1899df84d1f6ce3ae7b48209f6 \
     dunce                            1.0.2  453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541 \
     dyn-clone                        1.0.4  ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf \
+    ego-tree                         0.6.2  3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591 \
     either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
     eml-parser                       0.1.2  031fe36712cec8b81c5b76b555666ce855a4dfc2dcc35bb907046bf2ef545578 \
     encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
     encoding                        0.2.33  6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec \
-    encoding-index-japanese       1.20141219.5  04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91 \
-    encoding-index-korean         1.20141219.5  4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81 \
-    encoding-index-simpchinese    1.20141219.5  d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7 \
-    encoding-index-singlebyte     1.20141219.5  3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a \
-    encoding-index-tradchinese    1.20141219.5  fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18 \
+    encoding-index-japanese   1.20141219.5  04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91 \
+    encoding-index-korean     1.20141219.5  4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81 \
+    encoding-index-simpchinese 1.20141219.5 d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7 \
+    encoding-index-singlebyte 1.20141219.5  3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a \
+    encoding-index-tradchinese 1.20141219.5 fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18 \
     encoding_index_tests             0.1.4  a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569 \
     encoding_rs                     0.8.28  80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065 \
     endian-type                      0.1.2  c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d \
@@ -205,139 +174,116 @@ cargo.crates \
     env_logger                       0.8.4  a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3 \
     error-chain                     0.12.4  2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc \
     error-code                       2.3.0  b5115567ac25674e0043e472be13d14e537f37ea8aa4bdc4aef0c89add1db1ff \
-    event-listener                   2.5.1  f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59 \
     failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
     failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
-    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
     fallible-iterator                0.2.0  4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7 \
     fallible-streaming-iterator      0.1.9  7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a \
-    fancy-regex                      0.3.5  ae91abf6555234338687bb47913978d275539235fcb77ba9863b779090b42b14 \
-    fast-float                       0.2.0  95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c \
-    fastrand                         1.4.1  77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb \
+    fancy-regex                      0.7.1  9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf \
     fd-lock                          3.0.0  b8806dd91a06a7a403a8e596f9bfbfb34e469efbc363fc9c9713e79e26472e36 \
     filesize                         0.2.0  12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43 \
-    fixedbitset                      0.2.0  37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d \
     flatbuffers                      2.0.0  ef4c5738bcd7fad10315029c50026f83c9da5e4a21f8ed66826f43e0e2bde5f6 \
     flate2                          1.0.20  cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0 \
-    flume                            0.9.2  1bebadab126f8120d410b677ed95eee4ba6eb7c6dd8e34a5ec88a08050e26132 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     form_urlencoded                  1.0.1  5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
     fs_extra                         1.2.0  2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394 \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
-    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
     futf                             0.1.4  7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b \
     futures                         0.1.31  3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678 \
-    futures                         0.3.15  0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27 \
-    futures-channel                 0.3.15  e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2 \
-    futures-core                    0.3.15  0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1 \
-    futures-executor                0.3.15  badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79 \
-    futures-io                      0.3.15  acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1 \
-    futures-lite                    1.12.0  7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48 \
-    futures-macro                   0.3.15  a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121 \
-    futures-sink                    0.3.15  a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282 \
-    futures-task                    0.3.15  8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae \
-    futures-timer                    3.0.2  e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c \
-    futures-util                    0.3.15  feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967 \
-    futures_codec                    0.4.1  ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b \
+    futures                         0.3.16  1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b \
+    futures-channel                 0.3.16  74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9 \
+    futures-core                    0.3.16  af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99 \
+    futures-executor                0.3.16  4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c \
+    futures-io                      0.3.16  0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582 \
+    futures-macro                   0.3.16  c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57 \
+    futures-sink                    0.3.16  c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53 \
+    futures-task                    0.3.16  bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2 \
+    futures-util                    0.3.16  67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78 \
     fxhash                           0.2.1  c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c \
     gcc                             0.3.55  8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2 \
-    generic-array                    0.8.4  b2297fb0e3ea512e380da24b52dca3924028f59df5e3a17a18f81d8349ca7ebe \
     generic-array                   0.12.4  ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd \
     generic-array                   0.13.3  f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309 \
     generic-array                   0.14.4  501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
     gethostname                      0.2.1  e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028 \
+    getopts                         0.2.21  14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5 \
     getrandom                       0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
     getrandom                        0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
     getset                           0.1.1  24b328c01a4d71d2d8173daa93562a73ab0fe85616876f02500f53d82948c504 \
-    ghash                            0.3.1  97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375 \
-    gimli                           0.24.0  0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189 \
-    git-version                      0.3.4  94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2 \
-    git-version-macro                0.3.4  34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657 \
-    git2                           0.13.20  d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba \
+    gimli                           0.25.0  f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7 \
+    git-version                      0.3.5  f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899 \
+    git-version-macro                0.3.5  fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f \
+    git2                           0.13.21  659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490 \
     gjson                            0.7.5  205c41cae258334004939aa09ae377372968c2b6241bae6266fa1c0589cf0a6e \
     glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
-    globset                          0.4.7  f0fc1b9fa0e64ffb1aa5b95daa0f0f167734fd528b7c02eabc581d9d843649b1 \
-    gloo-timers                      0.2.1  47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f \
-    h2                               0.2.7  5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535 \
-    h2                               0.3.3  825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726 \
+    globset                          0.4.8  10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd \
+    grep-cli                         0.1.6  2dd110c34bb4460d0de5062413b773e385cbf8a85a63fc535590110a09e79e8a \
+    h2                               0.3.4  d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472 \
     hamcrest2                        0.3.0  49f837c62de05dc9cc71ff6486cd85de8856a330395ae338a04bfcefe5e91075 \
     hash32                           0.1.1  d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc \
+    hash_hasher                      2.0.3  74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c \
     hashbrown                       0.11.2  ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e \
     hashlink                         0.7.0  7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf \
     heapless                         0.6.1  634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422 \
-    heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
-    hermit-abi                      0.1.18  322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
     hex                              0.3.2  805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77 \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    hkdf                            0.10.0  51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f \
-    hmac                             0.4.2  7a13f4163aa0c5ca1be584aace0e2212b2e41be5478218d4f657f5f778b2ae2a \
-    hmac                            0.10.1  c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15 \
+    hmac                            0.11.0  2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b \
     hmac-sha1                        0.1.3  e1333fad8d94b82cab989da428b0b36a3435db3870d85e971a1d6dc0a8576722 \
     html5ever                       0.25.1  aafcf38a1a36118242d29b92e1b08ef84e67e4a5ed06e0a80be20e6a32bfed6b \
     htmlescape                       0.3.1  e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163 \
     http                             0.2.4  527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11 \
-    http-body                        0.3.1  13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b \
-    http-body                        0.4.2  60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9 \
-    http-client                      6.4.1  ce318d86a47d18d1db645c979214f809a6cd625202ad334ef75ca813b30dac80 \
-    http-types                      2.11.1  ad077d89137cd3debdce53c66714dc536525ef43fe075d41ddc0a8ac11f85957 \
-    httparse                         1.4.1  f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68 \
-    httpdate                         0.3.2  494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47 \
+    http-body                        0.4.3  399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5 \
+    httparse                         1.5.1  acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503 \
     httpdate                         1.0.1  6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440 \
     humantime                        1.3.0  df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f \
-    hyper                          0.13.10  8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb \
-    hyper                          0.14.10  7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03 \
-    hyper-tls                        0.4.3  d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed \
+    hyper                          0.14.12  13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd \
     hyper-tls                        0.5.0  d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905 \
     ical                             0.7.0  4a9f7215ad0d77e69644570dee000c7678a47ba7441062c1b5f918adde0d73cf \
     idna                             0.2.3  418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
     image                           0.22.5  08ed2ada878397b045454ac7cfb011d73132c59f31a955d230bd1f1c2e68eb4a \
     image                          0.23.14  24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1 \
     indexmap                         1.7.0  bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5 \
-    infer                            0.2.3  64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac \
     inflate                          0.4.5  1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff \
-    insta                            1.7.1  c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244 \
-    instant                          0.1.9  61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec \
-    integer-encoding                 1.1.7  48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f \
+    insta                            1.7.2  58019516c1403ac45b106c9fc4e8fcbd77a78e98b014c619d1506338902ccfa4 \
+    instant                         0.1.10  bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d \
+    integer-encoding                 3.0.2  90c11140ffea82edce8dcd74137ce9324ec24b3cf0175fc9d7e29164da9915b8 \
     iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
     ipnet                            2.3.1  68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9 \
     is_executable                    1.0.1  fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8 \
-    isahc                           0.9.14  e2948a0ce43e2c2ef11d7edf6816508998d99e13badd1150be0914205df9388a \
     itertools                       0.10.1  69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf \
-    itoa                             0.4.7  dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736 \
-    jobserver                       0.1.22  972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd \
+    itoa                             0.4.8  b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4 \
+    jobserver                       0.1.24  af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa \
     jpeg-decoder                    0.1.22  229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2 \
-    js-sys                          0.3.51  83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062 \
-    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
-    kv-log-macro                     1.0.7  0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f \
-    lazy_static                     0.2.11  76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73 \
+    js-sys                          0.3.53  e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    lexical                          5.2.2  f404a90a744e32e8be729034fc33b90cf2a56418fbf594d69aa3c0214ad414e5 \
-    lexical-core                     0.7.6  6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe \
-    libc                            0.2.99  a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765 \
-    libgit2-sys                   0.12.21+1.1.0  86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825 \
+    lexical                          6.0.0  23f26223deed22acc21a8aea097679f86af968272e29c4157696cdd8c983bf91 \
+    lexical-core                     0.8.0  d32c80337884d5044fe54e9c1b8d64b92de67e10d9312e472a8ff6d6ea849daf \
+    lexical-parse-float              0.8.0  673a01c82cb851a33bb46cacc44c3ad5e7b39ea3b8d22ade21646221df58e45f \
+    lexical-parse-integer            0.8.0  f2c92badda8cc0fc4f3d3cc1c30aaefafb830510c8781ce4e8669881f3ed53ac \
+    lexical-util                     0.8.1  6ff669ccaae16ee33af90dc51125755efed17f1309626ba5c12052512b11e291 \
+    lexical-write-float              0.8.0  f93601479eae2b41ad465e1f813ea98780069ef1d69063145e76c1bd108ab769 \
+    lexical-write-integer            0.8.0  ece956492e0e40fd95ef8658a34d53a3b8c2015762fdcaaff2167b28de1f56ef \
+    libc                           0.2.101  3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21 \
+    libgit2-sys              0.12.22+1.1.0  89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3 \
     libm                             0.2.1  c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a \
-    libnghttp2-sys                0.1.6+1.43.0  0af55541a8827e138d59ec9e5877fb6095ece63fb6f4da45e7491b4fbd262855 \
     libsqlite3-sys                  0.22.2  290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d \
     libz-sys                         1.1.3  de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66 \
     line-wrap                        0.1.1  f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9 \
-    linked-hash-map                  0.3.0  6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd \
     linked-hash-map                  0.5.4  7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3 \
-    lock_api                         0.4.4  0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb \
+    lock_api                         0.4.5  712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109 \
     log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
     lz4                             1.23.2  aac20ed6991e01bf6a2e68cc73df2b389707403662a8ba89f68511fb340f724c \
     lz4-sys                          1.9.2  dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae \
     mac                              0.1.1  c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
     markup5ever                     0.10.1  a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd \
-    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    matches                          0.1.9  a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f \
     md-5                             0.9.1  7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15 \
     md5                              0.6.1  7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d \
     md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
-    memchr                           2.4.0  b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc \
+    memchr                           2.4.1  308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a \
     memmap2                          0.2.3  723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4 \
     memoffset                        0.6.4  59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9 \
     meval                            0.2.0  f79496a5651c8d57cd033c5add8ca7ee4e3d5f7587a4777484640d9cb60392d9 \
@@ -345,31 +291,26 @@ cargo.crates \
     mime_guess                       2.0.3  2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212 \
     miniz_oxide                      0.3.7  791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435 \
     miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
-    minus                            3.4.0  a4157dc2cce665432eeb14110669961b4746d5fbd04b399b9af3a0edee37104c \
-    mio                             0.6.23  4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4 \
     mio                             0.7.13  8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16 \
-    miow                             0.2.2  ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d \
     miow                             0.3.7  b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21 \
-    mp4                              0.8.2  369762a9ab26451c57e0860102029db0f5c6b142baf6f373e759f311a828b50e \
+    mp4                              0.8.3  51eb18a88129198ca1e8e92f26038ed6814cd0e608fa43215bf57368604bf093 \
     multiversion                     0.6.1  025c962a3dd3cc5e0e520aa9c612201d127dcdf28616974961a649dca64f5373 \
     multiversion-macros              0.6.1  a8a3e2bde382ebf960c1f3e79689fa5941625fe9bf694a1cb64af3e85faff3af \
-    native-tls                       0.2.7  b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4 \
+    native-tls                       0.2.8  48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d \
     neso                             0.5.0  6b3c31defbcb081163db18437fd88c2a267cb3e26f7bd5e4b186e4b1b38fe8c8 \
-    net2                            0.2.37  391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae \
     new_debug_unreachable            1.0.4  e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54 \
     nibble_vec                       0.1.0  77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
     nipper                           0.1.9  761382864693f4bb171abf9e8de181a320b00464a83a9a5071059057b1fe0116 \
-    nix                             0.20.0  fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a \
+    nix                             0.20.1  df8e5e343312e7fbeb2a52139114e9e702991ef9c2aea6817ff2440b35647d56 \
     nix                             0.22.1  e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     nom                              1.2.4  a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce \
-    nom                              5.1.2  ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af \
     ntapi                            0.3.6  3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44 \
     num                              0.2.1  b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36 \
     num                              0.4.0  43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606 \
     num-bigint                       0.2.6  090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304 \
-    num-bigint                       0.3.2  7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba \
-    num-bigint                       0.4.0  4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512 \
+    num-bigint                       0.3.3  5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3 \
+    num-bigint                       0.4.2  74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535 \
     num-complex                      0.2.4  b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95 \
     num-complex                      0.4.0  26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085 \
     num-format                       0.4.0  bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465 \
@@ -378,57 +319,48 @@ cargo.crates \
     num-rational                     0.2.4  5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
     num-rational                     0.3.2  12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07 \
     num-rational                     0.4.0  d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a \
-    num-traits                      0.1.43  92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31 \
     num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
     num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
     objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
     objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
     objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
-    object                          0.25.3  a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7 \
+    object                          0.26.2  39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2 \
     once_cell                        1.8.0  692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56 \
     onig                             6.2.0  b16fd3c0e73b516af509c13c4ba76ec0c987ce20d78b38cff356b8d01fc6a6c0 \
     onig_sys                        69.7.0  9fd9442a09e4fbd08d196ddf419b2c79a43c3a46c800320cc841d45c2449a240 \
     opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
-    open                             1.7.0  1711eb4b31ce4ad35b0f316d8dfba4fe5c7ad601c448446d84aae7a896627b20 \
-    openssl                        0.10.34  6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8 \
+    open                             1.7.1  dcea7a30d6b81a2423cc59c43554880feff7b57d12916f231a79f8d6d9470201 \
+    openssl                        0.10.36  8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a \
     openssl-probe                    0.1.4  28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a \
-    openssl-sys                     0.9.63  b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98 \
+    openssl-sys                     0.9.66  1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82 \
     ordered-float                    1.1.1  3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
-    parking                          2.0.0  427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72 \
-    parking_lot                     0.11.1  6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb \
-    parking_lot_core                 0.8.3  fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018 \
-    parquet                          5.1.0  db54d10313f64ea22e1fe0332864abefb19aa1c322bfbc67999ff743aebf868d \
-    parquet-format                   2.6.1  a5bc6b23543b5dedc8f6cce50758a35e5582e148e0cfa26bd0cacd569cda5b71 \
+    parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
+    parking_lot_core                 0.8.4  467fce6df07c66afb48b6284f13c724a1d5a13cbfcfdf5d5ce572c8313e0c722 \
+    parquet-format-async-temp        0.2.0  03abc2f9c83fe9ceec83f47c76cc071bfd56caba33794340330f35623ab1f544 \
+    parquet2                         0.4.0  73758f76c8c842dfd846dfbc6ee05779aff626908531fffc3305a30cbccc55e7 \
     parse-zoneinfo                   0.3.0  c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41 \
     path_abs                         0.5.1  05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3 \
+    pathdiff                         0.2.0  877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34 \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
     peresil                          0.3.0  f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57 \
     pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
-    petgraph                         0.5.1  467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7 \
     phf                              0.8.0  3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12 \
     phf_codegen                      0.8.0  cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815 \
     phf_generator                    0.8.0  17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
     phf_macros                       0.8.0  7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c \
     phf_shared                       0.8.0  c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
-    pin-project                     0.4.28  918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f \
-    pin-project                      1.0.7  c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4 \
-    pin-project-internal            0.4.28  3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e \
-    pin-project-internal             1.0.7  48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f \
-    pin-project-lite                0.1.12  257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777 \
-    pin-project-lite                 0.2.6  dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905 \
+    pin-project-lite                 0.2.7  8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
-    plist                            1.1.0  679104537029ed2287c216bfb942bbf723f48ee98f0aef15611634173a74ef21 \
+    plist                            1.2.1  a38d026d73eeaf2ade76309d0c65db5a35ecf649e3cec428db316243ea9d6711 \
     png                             0.15.3  ef859a23054bbfee7811284275ae522f0434a3c8e7f4b74bd4a35ae7e1c4a283 \
     png                             0.16.8  3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6 \
-    polars                          0.15.1  080a75a211a2b0feb01c85efbdb3906593150629679f2b1147ae80c98cde87ea \
-    polars-arrow                    0.15.1  5ff08a43b4d19710717e35d91b036bb636fdf7daa794c9ccc38e7ba95aca1135 \
-    polars-core                     0.15.1  4929a06fa295e6f702a7d516a84f5cf65cfb72c675daf3cf99031a0d1ef6fe6f \
-    polars-io                       0.15.1  422d2405b409defef53de50d2eaf3ab77080c95505d191722c6236d9f3a022a7 \
-    polars-lazy                     0.15.1  50a6302df2cf8f261823fefc032b5fc7c6f8d2eb5c55c9bf305d472d1f500376 \
-    polling                          2.1.0  92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25 \
-    polyval                          0.4.5  eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd \
+    polars                          0.16.0  e3545b707f5dc6ac936540da732dbeb51f7f3a1c52bba7561be75fba07c38ee8 \
+    polars-arrow                    0.16.0  4bebe1310113f2330e92faf7c67634b69a3c30fede04fe5236a258afb43d9d5f \
+    polars-core                     0.16.0  8da53d641dcaebe2a3b6cc442f657fd83709cb22a67677eabeb24cb004ebd04e \
+    polars-io                       0.16.0  708e3bf4d8866e4c8a2defe36d7a5359d69e3884a9da0a9cc1f2e2eac194177b \
+    polars-lazy                     0.16.0  9d1ffc1bb44a8ddd0607448f49027d69debe3f7243aad3b17f713780d0d47205 \
     ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
     precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
     pretty                           0.5.2  f60c0d9f6fc88ecdd245d90c1920ff76a430ab34303fc778d33b1d0a4c3bf6d3 \
@@ -438,15 +370,13 @@ cargo.crates \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
     proc-macro-nested                0.1.7  bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086 \
-    proc-macro2                     1.0.27  f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038 \
+    proc-macro2                     1.0.28  5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612 \
     ptree                            0.3.2  beb17280503804146233f15c98385d3c65f0330663ce0b602a1e4c9379e96b4d \
-    query_interface                  0.3.5  78c0f0046284eebb86b68f93f9677d499034f88e15ca01021ceea32c4d3c3693 \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quick-xml                       0.19.0  b3d72d5477478f85bd00b6521780dfba1ec6cdaadcf90b8b181c36d7de561f9b \
     quick-xml                       0.22.0  8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b \
     quickcheck                       1.0.3  588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6 \
     quickcheck_macros                1.0.0  b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9 \
-    quote                           0.3.15  7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a \
     quote                            1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
     radix_trie                       0.2.1  c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd \
     rand                            0.3.23  64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c \
@@ -469,7 +399,7 @@ cargo.crates \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
     readkey                          0.1.7  86d401b6d6a1725a59f1b4e813275d289dff3ad09c72b373a10a7a8217ba3146 \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
-    redox_syscall                    0.2.9  5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee \
+    redox_syscall                   0.2.10  8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff \
     redox_users                      0.3.5  de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d \
     redox_users                      0.4.0  528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64 \
     regex                            1.5.4  d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461 \
@@ -486,89 +416,68 @@ cargo.crates \
     rust-embed                       5.9.0  2fe1fe6aac5d6bb9e1ffd81002340363272a7648234ec7bdfac5ee202cb65523 \
     rust-embed-impl                  5.9.0  3ed91c41c42ef7bf687384439c312e75e0da9c149b0390889b94de3c7d9d9e66 \
     rust-embed-utils                 5.1.0  2a512219132473ab0a77b52077059f1c47ce4af7fbdc94503e9862a34422876d \
-    rust-ini                        0.13.0  3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2 \
     rust_decimal                    0.10.2  a93c95e3d5c1d997e6e4ba9bda898f4e1d73934cd05510c972f10087d0ef00c1 \
-    rustc-demangle                  0.1.19  410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce \
+    rustc-demangle                  0.1.21  7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342 \
     rustc-serialize                 0.3.24  dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda \
-    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
     rustc_version                    0.3.3  f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee \
     rustversion                      1.0.5  61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088 \
     rustyline                        9.0.0  790487c3881a63489ae77126f57048b42d62d3b2bafbf37453ea19eedb6340d6 \
     ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
-    s3handler                        0.7.3  0adbccfcc46d65a60db3af38aa60cc3569fa905f1a6bf537afb306456aa2a28e \
+    s3handler                        0.7.4  6b7327334dd66eab764647b4df9331a46487e933812351baf8fffdeb8a022711 \
     safemem                          0.3.3  ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.19  8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    scraper                         0.12.0  48e02aa790c80c2e494130dec6a522033b6a23603ffc06360e9fe6c611ea2c12 \
     security-framework               2.3.1  23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467 \
-    security-framework-sys           2.3.0  7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284 \
+    security-framework-sys           2.4.0  19133a286e494cc3311c165c4676ccb1fd47bed45b55f9d71fbd784ad4cea6f8 \
     selectors                       0.22.0  df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe \
-    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver                          0.11.0  f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6 \
-    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
     semver-parser                   0.10.2  00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7 \
-    serde                           0.8.23  9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8 \
-    serde                          1.0.126  ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03 \
-    serde-hjson                      0.9.1  6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8 \
-    serde-value                      0.6.0  5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb \
+    serde                          1.0.129  d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1 \
     serde_bytes                     0.11.5  16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9 \
-    serde_derive                   1.0.126  963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43 \
+    serde_derive                   1.0.129  e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3 \
     serde_ini                        0.2.0  eb236687e2bb073a7521c021949be944641e671b8505a94069ca37b656c81139 \
-    serde_json                      1.0.64  799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79 \
-    serde_qs                         0.7.2  5af82de3c6549b001bec34961ff2d6a54339a87bab37ce901b693401f27de6cb \
-    serde_test                      0.8.23  110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5 \
-    serde_test                     1.0.127  de9e52f2f83e2608a121618b6d3885b514613aac702306232c4f035ff60fdb56 \
+    serde_json                      1.0.66  336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127 \
+    serde_test                     1.0.129  ca4ebf9d3eff2c70e4092a70a9d759e01b675f8daf1442703a18e57898847830 \
     serde_urlencoded                 0.7.0  edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9 \
-    serde_yaml                      0.8.17  15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23 \
+    serde_yaml                      0.8.20  ad104641f3c958dab30eb3010e834c2622d1f3f4c530fef1dee20ad9485f3c09 \
     serial_test                      0.5.1  e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d \
     serial_test_derive               0.5.1  b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5 \
     servo_arc                        0.1.1  d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432 \
     sha1                             0.2.0  cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c \
-    sha1                             0.6.0  2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d \
-    sha2                             0.6.0  7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a \
-    sha2                             0.9.5  b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12 \
-    shadow-rs                        0.6.8  442a33cdfd55c916c7c9a3aff44a2612a7da95652dd9d09b0dca0571748af49e \
+    sha2                             0.9.6  9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3 \
+    shadow-rs                       0.6.13  34aa4acee547e80ee27be89308f61409058e0b4e9396f59461ed2de11c71e5b6 \
     shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
     shell-words                      1.0.0  b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074 \
     signal-hook                     0.1.17  7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729 \
     signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
-    simdutf8                         0.1.3  c970da16e7c682fa90a261cf0724dee241c9f7831635ecc4e988ae8f3b505559 \
     similar                          1.3.0  1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec \
-    siphasher                        0.3.5  cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27 \
-    slab                             0.4.3  f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527 \
-    sluice                           0.5.4  8fa0333a60ff2e3474a6775cc611840c2a55610c831dd366503474c02f1a28f5 \
+    siphasher                        0.3.6  729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1 \
+    slab                             0.4.4  c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590 \
     smallvec                         1.6.1  fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e \
     smart-default                    0.6.0  133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6 \
     snap                             1.0.5  45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451 \
-    socket2                         0.3.19  122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e \
-    socket2                          0.4.0  9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2 \
-    spinning_top                     0.2.4  75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c \
+    socket2                          0.4.1  765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
-    standback                       0.2.17  e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     std_prelude                     0.2.12  8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe \
-    stdweb                          0.4.20  d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5 \
-    stdweb-derive                    0.5.3  c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef \
-    stdweb-internal-macros           0.2.9  58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11 \
-    stdweb-internal-runtime          0.1.5  213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0 \
     str-buf                          1.0.5  d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a \
+    streaming-iterator               0.1.5  303235c177994a476226b80d076bd333b7b560fb05bd242a10609d11b07f81f5 \
+    strength_reduce                  0.2.3  a3ff2f71c82567c565ba4b3009a9350a96a7269eaa4001ebedae926230bc2254 \
     string_cache                     0.8.1  8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a \
     string_cache_codegen             0.5.1  f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97 \
-    strip-ansi-escapes               0.1.0  9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee \
+    strip-ansi-escapes               0.1.1  011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    subtle                           2.4.0  1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2 \
-    surf                             2.2.0  2a154d33ca6b5e1fe6fd1c760e5a5cc1202425f6cca2e13229f16a69009f6328 \
+    subtle                           2.4.1  6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601 \
     sxd-document                     0.3.2  94d82f37be9faf1b10a82c4bd492b74f698e40082f0f40de38ab275f31d42078 \
     sxd-xpath                        0.4.2  36e39da5d30887b5690e29de4c5ebb8ddff64ebd9933f98a01daaa4fd11b36ea \
-    syn                            0.11.11  d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad \
-    syn                             1.0.73  f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7 \
-    synom                           0.11.3  a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6 \
-    synstructure                    0.12.4  b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701 \
-    syntect                          4.5.0  2bfac2b23b4d049dc9a89353b4e06bbc85a8f42020cccbe5409a115cf19031e5 \
+    syn                             1.0.75  b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7 \
+    synstructure                    0.12.5  474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa \
+    syntect                          4.6.0  8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031 \
     sys-info                         0.9.0  33fcecee49339531cf6bd84ecf3ed94f9c8ef4a7e700f2a1cac9cc1ca485383a \
     sys-locale                       0.1.0  91f89ebb59fa30d4f65fafc2d68e94f6975256fd87e812dd99cb6e020c8563df \
-    sysinfo                         0.16.5  567e910ef0207be81a4e1bb0491e9a8d9866cf45b20fe1a52c03d347da9ea51b \
-    sysinfo                         0.18.2  d404aefa651a24a7f2a1190fec9fb6380ba84ac511a6fefad79eb0e63d39a97d \
+    sysinfo                         0.20.2  42ef9905d4f98c059046037078f070e66de0f5ac69e5bb63f6bf805b570b3b51 \
     tempfile                         3.2.0  dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22 \
     tendril                          0.4.2  a9ef557cb397a4f0a5a3a628f06515f78563f2209e64d47055d9dc6052bf5e33 \
     term                             0.5.2  edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42 \
@@ -580,31 +489,20 @@ cargo.crates \
     thin-slice                       0.1.1  8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c \
     thiserror                       1.0.26  93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2 \
     thiserror-impl                  1.0.26  060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745 \
-    threadpool                       1.8.1  d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa \
-    thrift                          0.13.0  0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b \
     tiff                             0.6.1  9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437 \
     time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
-    time                            0.2.27  4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242 \
-    time-macros                      0.1.1  957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1 \
-    time-macros-impl                 0.1.2  fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f \
-    tint                             1.0.1  7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896 \
-    tinyvec                          1.2.0  5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342 \
+    tinyvec                          1.3.1  848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338 \
     tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
     titlecase                        1.1.0  f565e410cfc24c2f2a89960b023ca192689d7f77d3f8d4f4af50c2d8affe1117 \
-    tokio                           0.2.25  6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092 \
-    tokio                            1.8.1  98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985 \
+    tokio                           1.10.1  92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5 \
     tokio-io                        0.1.13  57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674 \
     tokio-macros                     1.3.0  54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110 \
     tokio-native-tls                 0.3.0  f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b \
-    tokio-tls                        0.3.1  9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343 \
-    tokio-util                       0.3.1  be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499 \
     tokio-util                       0.6.7  1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592 \
     toml                             0.5.8  a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa \
     tower-service                    0.3.1  360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6 \
     tracing                         0.1.26  09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d \
-    tracing-attributes              0.1.15  c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2 \
-    tracing-core                    0.1.18  a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052 \
-    tracing-futures                  0.2.5  97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2 \
+    tracing-core                    0.1.19  2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8 \
     trash                            1.3.0  90df96afb154814e214f37eac04920c66886fd95962f22febb4d537b0dacd512 \
     try-lock                         0.2.3  59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642 \
     tui                             0.15.0  861d8f3ad314ede6219bcb2ab844054b1de279ee37a9bc38e3d606f9d3fb2a71 \
@@ -613,44 +511,39 @@ cargo.crates \
     ucd-trie                         0.1.3  56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c \
     umask                            1.0.0  982efbf70ec4d28f7862062c03dd1a4def601a5079e0faf1edc55f2ad0f6fe46 \
     unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
-    unicode-bidi                     0.3.5  eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0 \
+    unicode-bidi                     0.3.6  246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085 \
     unicode-normalization           0.1.19  d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9 \
     unicode-segmentation             1.8.0  8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b \
     unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
-    unicode-xid                      0.0.4  8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc \
     unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
-    universal-hash                   0.4.0  8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402 \
     unsafe_unwrap                    0.1.0  1230ec65f13e0f9b28d789da20d2d419511893ea9dac2c1f4ef67b8b14e5da80 \
     url                              2.2.2  a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c \
     user32-sys                       0.2.0  4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47 \
     users                           0.11.0  24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032 \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     utf8-width                       0.1.5  7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b \
-    utf8parse                        0.1.1  8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d \
     utf8parse                        0.2.0  936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372 \
     uuid                             0.8.2  bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7 \
-    value-bag                     1.0.0-alpha.7  dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae \
-    vcpkg                           0.2.14  70455df2fdf4e9bf580a92e443f1eb0303c390d682e2ea817312c9e81f8c3399 \
+    vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
     version_check                    0.9.3  5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-    vte                              0.3.3  4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf \
-    waker-fn                         1.1.0  9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca \
+    vte                             0.10.1  6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983 \
+    vte_generate_state_changes       0.1.1  d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff \
     walkdir                          2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
     want                             0.3.0  1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
-    wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
-    wasi                          0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
-    wasm-bindgen                    0.2.74  d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd \
-    wasm-bindgen-backend            0.2.74  3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900 \
-    wasm-bindgen-futures            0.4.24  5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1 \
-    wasm-bindgen-macro              0.2.74  088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4 \
-    wasm-bindgen-macro-support      0.2.74  be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97 \
-    wasm-bindgen-shared             0.2.74  d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f \
-    web-sys                         0.3.51  e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi     0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
+    wasm-bindgen                    0.2.76  8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0 \
+    wasm-bindgen-backend            0.2.76  cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041 \
+    wasm-bindgen-futures            0.4.26  95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972 \
+    wasm-bindgen-macro              0.2.76  44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef \
+    wasm-bindgen-macro-support      0.2.76  0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad \
+    wasm-bindgen-shared             0.2.76  acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29 \
+    web-sys                         0.3.53  224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c \
     webbrowser                       0.5.5  ecad156490d6b620308ed411cfee90d280b3cbd13e189ea0d3fada8acc89158a \
     weezl                            0.1.5  d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e \
-    wepoll-ffi                       0.1.2  d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb \
-    which                            4.1.0  b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe \
+    which                            4.2.2  ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9 \
     widestring                       0.4.3  c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c \
     wild                             2.0.4  035793abb854745033f01a07647a79831eba29ec0be377205f2a25b0aa830020 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
@@ -661,13 +554,12 @@ cargo.crates \
     winapi-wsapoll                   0.1.1  44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     winreg                           0.7.0  0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69 \
-    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
     x11                             2.18.2  77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773 \
     x11rb                            0.8.1  6ffb080b3f2f616242a4eb8e7d325035312127901025b0052bc3154a282d0f19 \
-    xml-rs                           0.8.3  b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a \
+    xml-rs                           0.8.4  d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3 \
     xmlparser                       0.13.3  114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8 \
     yaml-rust                        0.4.5  56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85 \
     zip                             0.5.13  93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815 \
-    zstd                          0.9.0+zstd.1.5.0  07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd \
-    zstd-safe                     4.1.1+zstd.1.5.0  c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079 \
-    zstd-sys                      1.6.1+zstd.1.5.0  615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33
+    zstd                  0.9.0+zstd.1.5.0  07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd \
+    zstd-safe             4.1.1+zstd.1.5.0  c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079 \
+    zstd-sys              1.6.1+zstd.1.5.0  615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
