### PR TITLE
k6: update to 0.34.1

### DIFF
--- a/net/k6/Portfile
+++ b/net/k6/Portfile
@@ -3,13 +3,15 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/k6io/k6 0.33.0 v
+go.setup            github.com/k6io/k6 0.34.1 v
 revision            0
 
 categories          net
 platforms           darwin
 license             AGPL-3+
-maintainers         {l2dy @l2dy} openmaintainer
+maintainers         {l2dy @l2dy} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 description         A modern load testing tool, using Go and JavaScript
 long_description    k6 is a modern load testing tool, building on Load Impact's \
                     years of experience in the load and performance testing \
@@ -19,9 +21,9 @@ long_description    k6 is a modern load testing tool, building on Load Impact's 
 homepage            https://k6.io/
 github.tarball_from archive
 
-checksums           rmd160  8b4a570c64da9ab9031542317672b756953b51e7 \
-                    sha256  c532013f302996e409ac4e4c73b053320f7581b101351fd3053ebcf2fc2a3e07 \
-                    size    6908189
+checksums           rmd160  1f04dbb72955fa3f6f2ffa7e22b8d94105dbfdb4 \
+                    sha256  64225494aff029dd10f434fd5cb6ab232446c97208bdf9127e195e4d8615d83d \
+                    size    6770259
 
 build.env-delete    GO111MODULE=off
 


### PR DESCRIPTION
- add self as co-maintainer

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
