### PR TITLE
bitwarden-cli: Build from sources

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -16,23 +16,27 @@ description         Bitwarden password manager CLI
 long_description    CLI implementation of the Bitwarden password manager.
 homepage            https://bitwarden.com
 
-checksums           rmd160  fb35af00304fa16b94906e858fc4135f6f393917 \
-                    sha256  b0726ccac9ed90ffbfef0c5acaef4f6bb85982860ea87e448f7f2c711632787a \
-                    size    19615266
+checksums           rmd160  5eb1201c952bc4e4e6da8df7be4528773cbb97db \
+                    sha256  6de961d51e5605b29e73be616c7b071fe6464d4cf87af870ff18b043953b2eab \
+                    size    200634
 
-github.tarball_from releases
-distname            bw-macos-${version}
-use_zip             yes
+fetch.type          git
 
-extract.mkdir       yes
+depends_fetch-append \
+                    path:bin/npm:npm6
 
-# Port installs a binary.
-supported_archs     x86_64
+post-fetch {
+    system -W "${worksrcpath}" "npm run sub:init"
+}
 
-use_configure       no
+configure {
+    system -W "${worksrcpath}" "npm install"
+}
 
-build               {}
+build {
+    system -W "${worksrcpath}" "npm run dist:mac"
+}
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/bw ${destroot}${prefix}/bin
+    xinstall -m 755 ${worksrcpath}/dist/macos/bw ${destroot}${prefix}/bin
 }


### PR DESCRIPTION
#### Description

Build bw-cli from sources using NPM instead of downloading prebuild
binaries from Github.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
