### PR TITLE
libusb: fix GCC build on 10.14 and earlier

### DIFF
--- a/devel/libusb/Portfile
+++ b/devel/libusb/Portfile
@@ -44,6 +44,11 @@ if {${subport} eq ${name}} {
     # see https://trac.macports.org/ticket/56156
     patchfiles-append patch-10.7-nospeedsuper.diff
 
+    # see https://trac.macports.org/ticket/61868#comment:46
+    if {${os.platform} eq "darwin" && ${os.major} < 19 && [string match *gcc* ${configure.compiler}]} {
+        patchfiles-append patch-gcc-pragma-options-align-reset.diff
+    }
+
     # overload the github livecheck regex to look for versions that
     # are just numbers and '.', no letters (e.g., "1.0.19rc1").
 

--- a/devel/libusb/files/patch-gcc-pragma-options-align-reset.diff
+++ b/devel/libusb/files/patch-gcc-pragma-options-align-reset.diff
@@ -1,0 +1,20 @@
+This patch looks insane but the logic is explained here:
+
+https://trac.macports.org/ticket/61868#comment:46
+
+The 10.4 SDK needs three such pragmas; 10.14 SDK needs five. Add more if you need them; it won't hurt anything.
+
+--- libusb/os/darwin_usb.h.orig
++++ libusb/os/darwin_usb.h
+@@ -27,6 +27,9 @@
+ 
+ #include <IOKit/IOTypes.h>
+ #include <IOKit/IOCFBundle.h>
++#pragma options align=power
++#pragma options align=power
++#pragma options align=power
++#pragma options align=power
++#pragma options align=power
+ #include <IOKit/usb/IOUSBLib.h>
+ #include <IOKit/IOCFPlugIn.h>
+ 


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/61868

Probably the strangest patch I've ever written, but here it is. See [comment 46](https://trac.macports.org/ticket/61868#comment:46) for an explanation. Lightly tested with GCC7.5. Since libusb is pretty popular other GCC version tests will be welcome.

Leaving as Draft until someone can confirm this actually works on anyone's machine besides mine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
