### PR TITLE
py-tensorflow-macos: Update to version 2.6.0, py-tensorflow-metal: Submission

### DIFF
--- a/python/py-tensorflow-addons/Portfile
+++ b/python/py-tensorflow-addons/Portfile
@@ -32,9 +32,11 @@ if {${name} ne ${subport}} {
     # Should match the version required by main tensorflow port
     bazel.version   3.1
 
-    # Conflicts with tensorflow_macos
-    if {${python.version} eq 38} {
-        conflicts   py${python.version}-tensorflow_macos
+    # Conflicts with tensorflow-macos
+    if { (${build_arch} eq {arm64} && (${python.version} eq 38 || ${python.version} eq 39))
+        || (${build_arch} eq {x86_64} && ${python.version} eq 38) } {
+        conflicts   py${python.version}-tensorflow-macos \
+                    py${python.version}-tensorflow_macos
     }
 
     depends_build-append \

--- a/python/py-tensorflow-macos/Portfile
+++ b/python/py-tensorflow-macos/Portfile
@@ -1,0 +1,129 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-tensorflow-macos
+version             2.6.0
+revision            0
+
+platforms           darwin
+categories-append   lang
+license             Apache-2.0
+maintainers         nomaintainer
+
+description         Mac-optimized TensorFlow to be used with py-tensorflow-metal.
+
+long_description    Hardware-accelerated TensorFlow and TensorFlow \
+                    Addons for macOS 11.0+. Native hardware \
+                    acceleration is supported on M1 Macs and \
+                    Intel-based Macs through Apple’s ML Compute \
+                    framework.
+
+homepage            https://developer.apple.com/metal/tensorflow-plugin/
+
+extract.suffix      .whl
+extract.only
+
+# set build_arch by hand on arm64/x86_64 systems to get x86_64/arm64 checksums
+# run `port clean --all py*-tensorflow-macos` before commenting out this line
+# set build_arch arm64
+
+if {${build_arch} eq {arm64}} {
+    python.versions 38 39
+} elseif {${build_arch} eq {x86_64}} {
+    python.versions 38
+}
+
+if {${os.platform} eq {darwin} && ${os.major} < 20} {
+    known_fail      yes
+    pre-fetch {
+        ui_error "TensorFlow with ML Compute acceleration is only available \
+            on macOS 11.0 and later."
+        error {unsupported platform}
+    }
+}
+
+if {${name} ne ${subport}} {
+    conflicts       py${python.version}-tensorflow \
+                    py${python.version}-tensorflow_macos \
+                    py${python.version}-tensorflow1 \
+                    py${python.version}-tensorflow-addons
+
+    supported_archs ${build_arch}
+
+    # https://pypi.org/project/tensorflow-macos/#files
+    if {${build_arch} eq {arm64}} {
+        if {${python.version} eq {38}} {
+            master_sites \
+                https://files.pythonhosted.org/packages/12/ee/6f882b0f7579042b87741eab4d0a80d3e2e13851c942534060063ec84899/
+            checksums \
+                    rmd160  6dc7c90a0d4b8ee1b5cef542adba5f5b925d9de2 \
+                    sha256  b05e38ea6c4751e78d863e4bf3abb84ca8c4f5e6965592b2004db8f89b2067a0 \
+                    size    168547196
+        } elseif {${python.version} eq {39}} {
+            master_sites \
+                https://files.pythonhosted.org/packages/15/f4/5c4f7fbe04a6a25e0feaf8e0803fd5afbfe221e28b54b79302bd1f2b57f3/
+            checksums \
+                    rmd160  369f48cb7d535b855baa2736a65c21e1b46fe14e \
+                    sha256  5e0994f049443a65ade6e465b79f954a9dc23256d805d8adf6be602bf2181cff \
+                    size    168572013
+        }
+    } elseif {${build_arch} eq {x86_64}} {
+        if {${python.version} eq {38}} {
+            master_sites \
+                https://files.pythonhosted.org/packages/61/77/b09dcfceb4c81893bcf842c7fb001d08ad51d9291927e7324b02e33612d9/
+            checksums \
+                    rmd160  b550fcbe01c938423c4c9e5180860444aeb1e282 \
+                    sha256  447ed714b2305df7f26e2dcbef85f405a0461f860a4289e1e39069c660e9eded \
+                    size    199804393
+        }
+    }
+    distname tensorflow_macos-${version}-cp${python.version}-cp${python.version}-macosx_11_0_${build_arch}
+
+    depends_build-append \
+                    port:py${python.version}-pip \
+                    port:py${python.version}-wheel
+
+    depends_run-append \
+                    port:py${python.version}-absl \
+                    port:py${python.version}-astunparse \
+                    port:py${python.version}-flatbuffers \
+                    port:py${python.version}-gast \
+                    port:py${python.version}-grpcio \
+                    port:py${python.version}-h5py \
+                    port:py${python.version}-keras_preprocessing \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-opt_einsum \
+                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-tensorflow_estimator \
+                    port:py${python.version}-scipy \
+                    port:py${python.version}-tensorboard \
+                    port:py${python.version}-termcolor \
+                    port:py${python.version}-typing_extensions \
+                    port:py${python.version}-wrapt \
+                    port:py${python.version}-typeguard
+    
+    use_configure   no
+
+    build {}
+
+    destroot.cmd    pip-${python.branch}
+    destroot.args   --ignore-installed \
+                    --no-cache-dir \
+                    --no-dependencies \
+                    --root ${destroot}
+    destroot.post_args
+
+    destroot {
+        system "${destroot.cmd} ${destroot.target} ${destroot.args} ${distpath}/${distname}${extract.suffix}"
+    }
+
+    post-destroot {
+        # avoid conflict with py${python.version}-tensorboard
+        delete      ${destroot}${python.prefix}/bin/tensorboard \
+                    ${destroot}${prefix}/bin/tensorboard-${python.branch}
+    }
+
+    livecheck.type  none
+}

--- a/python/py-tensorflow-metal/Portfile
+++ b/python/py-tensorflow-metal/Portfile
@@ -1,0 +1,103 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-tensorflow-metal
+version             0.2.0
+revision            0
+
+platforms           darwin
+categories-append   lang
+license             MIT
+maintainers         nomaintainer
+
+description         TensorFlow acceleration for Mac GPUs.
+
+long_description    Hardware-accelerated TensorFlow and TensorFlow \
+                    Addons for macOS 11.0+. Native hardware \
+                    acceleration is supported on M1 Macs and \
+                    Intel-based Macs through Apple’s ML Compute \
+                    framework.
+
+homepage            https://developer.apple.com/metal/tensorflow-plugin/
+
+extract.suffix      .whl
+extract.only
+
+# set build_arch by hand on arm64/x86_64 systems to get x86_64/arm64 checksums
+# run `port clean --all py*-tensorflow-metal` before commenting out this line
+# set build_arch arm64
+
+if {${build_arch} eq {arm64}} {
+    python.versions 38 39
+} elseif {${build_arch} eq {x86_64}} {
+    python.versions 38
+}
+
+if {${os.platform} eq {darwin} && ${os.major} < 20} {
+    known_fail      yes
+    pre-fetch {
+        ui_error "TensorFlow with ML Compute acceleration is only available \
+            on macOS 11.0 and later."
+        error {unsupported platform}
+    }
+}
+
+if {${name} ne ${subport}} {
+    supported_archs ${build_arch}
+
+    # https://pypi.org/project/tensorflow-metal/#files
+    if {${build_arch} eq {arm64}} {
+        if {${python.version} eq {38}} {
+            master_sites \
+                https://files.pythonhosted.org/packages/81/58/d2ef783ee1252d310f7115b5b31d3e11a9a9d699b002626c0c6c69ae7df1/
+            
+            checksums \
+                    rmd160  22c7cbf14c4d87fd059f7c0412ae9948c8c9b10b \
+                    sha256  44beccffce522fffc2aca2b1bd8fb377d208412547aada59079501d1206e9403 \
+                    size    1216341
+        } elseif {${python.version} eq {39}} {
+            master_sites \
+                https://files.pythonhosted.org/packages/a0/77/05782164e93b01b46848eca95c98be70c0f3c4b112a171d69b304f467fb6/
+            checksums \
+                    rmd160  97a4644761161fd369a3e4b7ef80b874f2abdd58 \
+                    sha256  97b0d395bf63473a3b053e7124d27eab6211dc1c36c083b0e97c910664fe060f \
+                    size    1216340
+        }
+    } elseif {${build_arch} eq {x86_64}} {
+        if {${python.version} eq {38}} {
+            master_sites \
+                https://files.pythonhosted.org/packages/70/79/0441e197f01916036c9d9392158b4f23cba84a89e520da6f89f59e1deaa3/
+            checksums \
+                    rmd160  dfde28c46ada18d77df1b07546c968bc77547430 \
+                    sha256  6493b1a9099da200fe789ac5c001a9cd08eb4da1c7b434531a0decdb4c570200 \
+                    size    1345572
+        }
+    }
+    distname tensorflow_metal-${version}-cp${python.version}-cp${python.version}-macosx_11_0_${build_arch}
+
+    depends_build-append \
+                    port:py${python.version}-pip \
+                    port:py${python.version}-wheel
+
+    depends_run-append \
+                    port:py${python.version}-tensorflow-macos
+    
+    use_configure   no
+
+    build {}
+
+    destroot.cmd    pip-${python.branch}
+    destroot.args   --ignore-installed \
+                    --no-cache-dir \
+                    --no-dependencies \
+                    --root ${destroot}
+    destroot.post_args
+
+    destroot {
+        system "${destroot.cmd} ${destroot.target} ${destroot.args} ${distpath}/${distname}${extract.suffix}"
+    }
+
+    livecheck.type  none
+}

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -54,15 +54,19 @@ python.versions  37 38 39
 if {${name} ne ${subport}} {
 
     PortGroup bazel 1.0
+
     # See https://www.tensorflow.org/install/source#macos for tested bazel versions.
     bazel.version   3.7
 
     # TF versions 1 and 2 cannot be installed at once
     conflicts py${python.version}-tensorflow1
 
-    # Conflicts with tensorflow_macos
-    if {${python.version} eq 38} {
-        conflicts-append py${python.version}-tensorflow_macos
+    # Conflicts with tensorflow-macos
+    if { (${build_arch} eq {arm64} && (${python.version} eq 38 || ${python.version} eq 39))
+        || (${build_arch} eq {x86_64} && ${python.version} eq 38) } {
+        conflicts-append \
+                    py${python.version}-tensorflow-macos \
+                    py${python.version}-tensorflow_macos
     }
 
     variant mkl description {Enable Intel Math Kernel Library support} {
@@ -129,13 +133,13 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none
 
-    # If tensorflow_macos is available for this OS + python version advertise it
+    # If tensorflow-macos is available for this OS + python version advertise it
     if { ${os.major} > 19 && ${python.branch} == 3.8 } {
         notes "
-A hardware accelerated MacOS optimised port of tensorflow from Apple 
+A hardware accelerated MacOS optimised port of tensorflow from Apple
 is available as an alternative to ${subport}. To use run :-
     sudo port uninstall -f ${subport} ${subport}-addons
-    sudo port install ${subport}_macos
+    sudo port install ${subport}-macos
 "
     }
 

--- a/python/py-tensorflow1/Portfile
+++ b/python/py-tensorflow1/Portfile
@@ -63,14 +63,18 @@ python.versions  37 38 39
 if {${name} ne ${subport}} {
 
     PortGroup bazel 1.0
+
     bazel.version   "0.25"
 
     # TF versions 1 and 2 cannot be installed at once
     conflicts py${python.version}-tensorflow
 
-    # Conflicts with tensorflow_macos
-    if {${python.version} eq 38} {
-        conflicts-append py${python.version}-tensorflow_macos
+    # Conflicts with tensorflow-macos
+    if { (${build_arch} eq {arm64} && (${python.version} eq 38 || ${python.version} eq 39))
+        || (${build_arch} eq {x86_64} && ${python.version} eq 38) } {
+        conflicts-append \
+                    py${python.version}-tensorflow-macos \
+                    py${python.version}-tensorflow_macos
     }
 
     depends_build-append \

--- a/python/py-tensorflow_macos/Portfile
+++ b/python/py-tensorflow_macos/Portfile
@@ -1,114 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           python 1.0
+PortGroup           obsolete 1.0
 
-github.setup        apple tensorflow_macos 0.1 v alpha3
-name                py-${github.project}
-version             ${github.version}.${github.tag_suffix}
-revision            0
-
-platforms           darwin
-categories-append   lang
+name                py-tensorflow_macos
+version             0.1
+revision            1
+homepage            https://github.com/apple/tensorflow_macos/
+categories          python lang
 license             restrictive/distributable
-maintainers         nomaintainer
 
-description         Mac-optimized TensorFlow and TensorFlow Addons
+replaced_by         py-tensorflow-macos
 
-long_description    Hardware-accelerated TensorFlow and TensorFlow \
-                    Addons for macOS 11.0+. Native hardware \
-                    acceleration is supported on M1 Macs and \
-                    Intel-based Macs through Apple’s ML Compute \
-                    framework.
-
-# https://github.com/apple/tensorflow_macos/blob/master/scripts/download_and_install.sh
-distfiles           ${github.project}-${github.version}${extract.suffix}:tarball \
-                    ${github.project}-${github.version}${github.tag_suffix}${extract.suffix}:releases
-
-master_sites        ${github.homepage}/tarball/${git.branch}:tarball \
-                    github.master_sites ${github.homepage}/releases/download/${git.branch}:releases
-
-checksums           [lindex [split [lindex ${distfiles} 0] :] 0] \
-                    rmd160  975a2ee2508df2fe801b841d3f6f8a0172854292 \
-                    sha256  623237c06941d26f52280535c0139c9d58fc214e0378b4513803a65bfda48ff6 \
-                    size    8095 \
-                    [lindex [split [lindex ${distfiles} 1] :] 0] \
-                    rmd160  812afc151dd87abb657df6d8e66ad8681c91a3bd \
-                    sha256  80807f8b0fc4a98ffa0b7395304fa61239f246a84f1eedbca70a5a1847d4dead \
-                    size    376699291
-
-extract.cmd         ${portutil::autoconf::tar_command}
-extract.pre_args    -xzf
-extract.post_args
-
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    known_fail      yes
-    pre-fetch {
-        ui_error "TensorFlow with ML Compute acceleration is only available \
-            on macOS 11.0 and later."
-        error {unsupported platform}
+set python_rootname [regsub ^py- [option name] ""]
+set python_versions 38
+foreach pv ${python_versions} {
+    subport "py${pv}-${python_rootname}" {
+        replaced_by py${pv}-tensorflow-macos
     }
-}
-
-python.versions 38
-
-if {${name} ne ${subport}} {
-    conflicts       py${python.version}-tensorflow \
-                    py${python.version}-tensorflow1 \
-                    py${python.version}-tensorflow-addons
-
-    depends_build-append \
-                    port:py${python.version}-pip \
-                    port:py${python.version}-wheel
-
-    depends_run-append \
-                    port:py${python.version}-absl \
-                    port:py${python.version}-astunparse \
-                    port:py${python.version}-flatbuffers \
-                    port:py${python.version}-gast \
-                    port:py${python.version}-grpcio \
-                    port:py${python.version}-h5py \
-                    port:py${python.version}-keras_preprocessing \
-                    port:py${python.version}-numpy \
-                    port:py${python.version}-opt_einsum \
-                    port:py${python.version}-protobuf3 \
-                    port:py${python.version}-tensorflow_estimator \
-                    port:py${python.version}-scipy \
-                    port:py${python.version}-tensorboard \
-                    port:py${python.version}-termcolor \
-                    port:py${python.version}-typing_extensions \
-                    port:py${python.version}-wrapt \
-                    port:py${python.version}-typeguard
-    
-    use_configure   no
-
-    build {}
-
-    destroot.cmd    pip-${python.branch}
-    destroot.args   --ignore-installed \
-                    --no-cache-dir \
-                    --no-dependencies \
-                    --root ${destroot}
-    destroot.post_args
-
-    destroot {
-        foreach whl [glob -type f ${workpath}/${github.project}/${build_arch}/tensorflow*cp${python.version}*.whl] {
-            system "${destroot.cmd} ${destroot.target} ${destroot.args} ${whl}"
-        }
-    }
-
-    post-destroot {
-        # avoid conflict with py${python.version}-tensorboard
-        delete      ${destroot}${python.prefix}/bin/tensorboard \
-                    ${destroot}${prefix}/bin/tensorboard-${python.branch}
-
-        set github_project_path [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]
-        set docdir ${prefix}/share/doc/${subport}
-        xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${github_project_path} LICENSE.txt README.md \
-            ${destroot}${docdir}        
-    }
-
-    livecheck.type  none
 }


### PR DESCRIPTION
#### Description

* Update to version 2.6.0
* Rename as `py-tensorflow-macos` per pypi
* Obsolete old github version `tensorflow_macos`
* Submit `py-tensorflow-metal`

cc: @cjones051073

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

# TensorFlow Metal CNN Benchmark
```python
import numpy as np, os, pandas as pd, platform, time, warnings

import tensorflow as tf
print(tf.__version__)

from tensorflow.python.framework.ops import disable_eager_execution, enable_eager_execution
from tensorflow.python.keras import backend

from numpy import unique
from numpy import argmax
from tensorflow.keras.datasets.mnist import load_data
from tensorflow.keras import Sequential
from tensorflow.keras.layers import Dense, Conv2D, MaxPool2D, Flatten, Dropout

from IPython.display import Image
from IPython.core.display import HTML 

print(tf.config.list_physical_devices('GPU'))
if tf.test.gpu_device_name():
    print('Default GPU Device: {}'.format(tf.test.gpu_device_name()))
else:
    print("Please install GPU version of TF")

import matplotlib as mpl, matplotlib.pyplot as plt
from matplotlib import cm
from matplotlib.colors import LightSource
from mpl_toolkits.mplot3d import Axes3D

# boldify
# Legible plot style defaults
# http://matplotlib.org/api/matplotlib_configuration_api.html
# http://matplotlib.org/users/customizing.html
mpl.rcParams['figure.figsize'] = (12.0, 8)
mpl.rc('font',**{'family': 'sans-serif', 'weight': 'bold', 'size': 14})
mpl.rc('axes',**{'titlesize': 20, 'titleweight': 'bold', 'labelsize': 16, 'labelweight': 'bold'})
mpl.rc('legend',**{'fontsize': 14})
mpl.rc('figure',**{'titlesize': 16, 'titleweight': 'bold'})
mpl.rc('lines',**{'linewidth': 2.5, 'markersize': 18, 'markeredgewidth': 0})
mpl.rc('mathtext',**{'fontset': 'custom', 'rm': 'sans:bold', 'bf': 'sans:bold', 'it': 'sans:italic', 'sf': 'sans:bold', 'default': 'it'})
# plt.rc('text',usetex=False) # [default] usetex should be False
mpl.rcParams['text.latex.preamble'] = r'\usepackage{amsmath,sfmath} \boldmath'

prop_cycle = plt.rcParams['axes.prop_cycle']
colors_default = prop_cycle.by_key()['color']

(trainX, trainy), (testX, testy) = tf.keras.datasets.mnist.load_data()
print('Train: X=%s, y=%s' % (trainX.shape, trainy.shape))
print('Test: X=%s, y=%s' % (testX.shape, testy.shape))

# a single grayscale channel
trainX = trainX[…, np.newaxis]
testX = testX[…, np.newaxis]

in_shape = trainX.shape[1:]
print(in_shape)

n_classes = len(unique(trainy))
print(n_classes)

# Normalize
trainX = trainX.astype('float32') / 255.0
testX = testX.astype('float32') / 255.0

# Create CNN Model
model = Sequential()
model.add(Conv2D(32, (3, 3), activation='relu', kernel_initializer='he_uniform', input_shape=in_shape))
model.add(MaxPool2D((2, 2), strides=(2,2)))
model.add(Conv2D(32, (2, 2), activation='relu', kernel_initializer='he_uniform'))
model.add(MaxPool2D((2, 2), strides=(2,2)))
model.add(Flatten())
model.add(Dense(500, activation='relu', kernel_initializer='he_uniform'))
# model.add(Dropout(0.5))
model.add(Dense(n_classes, activation='softmax'))
model.summary()

model.compile(optimizer='adam', loss='sparse_categorical_crossentropy', metrics=['accuracy'])

start_time = time.time()
model.fit(trainX, trainy, epochs=10, batch_size=2**12, verbose=1)
elapsed_time = time.time() - start_time

print(f"Time: {elapsed_time}")

# Evaluate
loss, acc = model.evaluate(testX, testy, verbose=0)
print('Accuracy: %.3f' % acc)


# Numpy comparison tests

# edges of all the image data
images_numpy = np.vstack([trainX, testX])

start_time = time.time()

images = tf.convert_to_tensor(images_numpy, dtype=np.float32)
grad_images = tf.image.sobel_edges(images)
grad_images_numpy = grad_images.numpy()

elapsed_time = time.time() - start_time

print(f"Time: {elapsed_time}")
print(grad_images_numpy.shape)

# Compare to `opencv`

import cv2

KERNEL_SIZE = 3

start_time = time.time()
gradx = np.array([gx for gx in map(lambda x: cv2.Sobel(x, cv2.CV_64F, 1, 0, ksize=KERNEL_SIZE), images_numpy)])
grady = np.array([gx for gx in map(lambda x: cv2.Sobel(x, cv2.CV_64F, 0, 1, ksize=KERNEL_SIZE), images_numpy)])
grad_images_numpy = np.stack([gradx, grady], axis=3)
elapsed_time = time.time() - start_time

print(f"Time: {elapsed_time}")
print(grad_images_numpy.shape)
```
