### PR TITLE
go: use binary release as a bootstrap toolchain

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -33,6 +33,7 @@ long_description    \
 
 set go_src_dist     ${name}${version}.src${extract.suffix}
 set go_armbin_dist  ${name}${version}.darwin-arm64${extract.suffix}
+set go_amdbin_dist  ${name}${version}.darwin-amd64${extract.suffix}
 
 checksums           ${go_src_dist} \
                     rmd160  746baea495791be0e9f4ed6a162cc4466d4ce4cd \
@@ -41,7 +42,11 @@ checksums           ${go_src_dist} \
                     ${go_armbin_dist} \
                     rmd160  fee842e0a9f3e35c5f092e4a3a00baa3a187e0fb \
                     sha256  ce8771bd3edfb5b28104084b56bbb532eeb47fbb7769c3e664c6223712c30904 \
-                    size    129424944
+                    size    129424944 \
+                    ${go_amdbin_dist} \
+                    rmd160  200f1d297946dcffcf144c40b68f0a258e7ace25 \
+                    sha256  7914497a302a132a465d33f5ee044ce05568bacdb390ab805cb75a3435a23f94 \
+                    size    135966384
 
 master_sites        https://storage.googleapis.com/golang/
 distfiles           ${go_src_dist}
@@ -150,6 +155,22 @@ if {${configure.build_arch} eq "arm64"} {
         xinstall -d ${go_bin_path}
         system -W ${go_bin_path} \
             "${extract.cmd} ${extract.pre_args} ${distpath}/${go_armbin_dist} ${extract.post_args}"
+    }
+
+} elseif {${configure.build_arch} eq "x86_64" && ${os.major} >= 21} {
+
+    # Use a temporary installation of the binary AMD64 Go distribution to
+    # build Go for AMD64 on macOS 12 since go-1.4 fails to build
+    set go_bin_path         ${workpath}/go_prebuilt
+
+    build.env-append        GOROOT_BOOTSTRAP=${go_bin_path}/go
+
+    distfiles-append        ${go_amdbin_dist}
+
+    post-extract {
+        xinstall -d ${go_bin_path}
+        system -W ${go_bin_path} \
+            "${extract.cmd} ${extract.pre_args} ${distpath}/${go_amdbin_dist} ${extract.post_args}"
     }
 
 } else {


### PR DESCRIPTION
#### Description

[Since Go 1.4 does not support current versions of macOS](https://golang.org/doc/install/source#bootstrapFromSource) and compiling it fails on macOS 12, source compilation should use a binary release as a bootstrap toolchain.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
