### PR TITLE
openjdk: update openjdk17-zulu to 17.30.15

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -583,10 +583,10 @@ subport openjdk17-temurin {
 subport openjdk17-zulu {
     # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 
-    version      17.28.13
+    version      17.30.15
     revision     0
 
-    set openjdk_version 17.0.0
+    set openjdk_version 17.0.1
 
     description  Azul Zulu Community OpenJDK 17 (Long Term Support)
     long_description ${long_description_zulu}
@@ -595,14 +595,14 @@ subport openjdk17-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  e6be31dc4f5f1e00c34bf5350a48cc7ebabb3203 \
-                     sha256  6029b1fe6853cecad22ab99ac0b3bb4fb8c903dd2edefa91c3abc89755bbd47d \
-                     size    192981407
+        checksums    rmd160  cc97b9d3487261caa7ab7f6c38fad54ce41a4d72 \
+                     sha256  09d64fe576373b4314422811bc8402fbb7700176822b0e1e2bf2ff8a6cad10eb \
+                     size    193015661
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  5b4988a2f197059d88c78d5c7623dbf6770b8a55 \
-                     sha256  6b17f01f767ee7abf4704149ca4d86423aab9b16b68697b7d36e9b616846a8b0 \
-                     size    190744456
+        checksums    rmd160  92bb19ff065f2d9527e00a5e2de65bdd7be34d9f \
+                     sha256  ce10425ce9cefdfb23ebeabebc0944cfb41531114a2d5bd89e3c19cc5cfa9913 \
+                     size    190776969
     }
 
     worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.30.15 (OpenJDK 17.0.1).

###### Tested on

macOS 11.6.1 20G224 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?