### PR TITLE
openjdk: update openjdk8-temurin to 8u312

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -151,10 +151,10 @@ subport openjdk8-openj9 {
 subport openjdk8-temurin {
     # https://adoptium.net/releases.html?variant=openjdk8&jvmVariant=hotspot
 
-    version      8u302
+    version      8u312
     revision     0
 
-    set build    08
+    set build    07
 
     description  Eclipse Temurin, based on OpenJDK 8
     long_description ${long_description_temurin}
@@ -163,9 +163,9 @@ subport openjdk8-temurin {
     distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  69c845bcdea22bb8f5fb74a3fe1b248e0116c43a \
-                 sha256  6205fefca28342d99938b3933ed839784835ed1de6ed9ba034ce772377f74061 \
-                 size    107303398
+    checksums    rmd160  aa3258067243f32db66d0ab4c3f8154589837d57 \
+                 sha256  2428e7fbd0dfb7416783df89398c0ccc0fa883f4fabce0e9b83388bc2109268e \
+                 size    107991615
 }
 
 subport openjdk8-zulu {


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u312.

###### Tested on

macOS 11.6.1 20G224 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?