### PR TITLE
openjdk: update openjdk11-temurin to 11.0.13

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -281,10 +281,10 @@ subport openjdk11-openj9-large-heap {
 subport openjdk11-temurin {
     # https://adoptium.net/releases.html?variant=openjdk11&jvmVariant=hotspot
 
-    version      11.0.12
+    version      11.0.13
     revision     0
 
-    set build    7
+    set build    8
 
     description  Eclipse Temurin, based on OpenJDK 11
     long_description ${long_description_temurin}
@@ -294,9 +294,9 @@ subport openjdk11-temurin {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  bee29d914047e0954929bfc1643619773f448332 \
-                 sha256  13d056ee9a57bf2d5b3af4504c8f8cf7a246c4dff78f96b70dd05dad98075855 \
-                 size    191257594
+    checksums    rmd160  9cff976450233dd6f402ceace17b9586302e6011 \
+                 sha256  2b862f97b872e37f8c7ad6d3d30f7d0fcb3f0b951740c8fa142dea702945973c \
+                 size    190666788
 }
 
 subport openjdk11-zulu {


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.13.

###### Tested on

macOS 11.6.1 20G224 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?