### PR TITLE
notcurses: update to 2.4.8

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        dankamongmen notcurses 2.4.5 v
+github.setup        dankamongmen notcurses 2.4.8 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ long_description    Notcurses facilitates the creation of modern TUI programs, m
 
 homepage            https://notcurses.com
 
-checksums           rmd160  c51b7ce97a1dcd6fbca5e9e9b8a08ffad1b4a310 \
-                    sha256  e006c8d0a19d148d1fa779803e19145a7d8c5f1bf1f8e9e5d2c14a5e0d860343 \
-                    size    10082686
+checksums           rmd160  f704becbc747786a2cb0c20b27278174c4ae2f54 \
+                    sha256  d06971005e4cf637cc90a694323c580791d1450a77b1700ae8deb453678d3243 \
+                    size    10091053
 
 compiler.c_standard 2011
 compiler.cxx_standard \


### PR DESCRIPTION
#### Description
Updates devel/notcurses from 2.4.5 to 2.4.8, bypassing 2.4.7. This adds complete Unicode 14.0 support on macOS, among other fixes.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
https://github.com/dankamongmen/notcurses/releases/tag/v2.4.8

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
