### PR TITLE
libusb ports: move to path-style dependency

### DIFF
--- a/comms/libnfc/Portfile
+++ b/comms/libnfc/Portfile
@@ -26,5 +26,5 @@ checksums               rmd160  e0d7a3ce57fd57281145d3c78042b9fbccf85009 \
                         size    484309
 
 depends_build           port:pkgconfig
-depends_lib             port:libusb \
+depends_lib             path:lib/pkgconfig/libusb-1.0.pc:libusb \
                         port:libusb-compat

--- a/cross/avrdude/Portfile
+++ b/cross/avrdude/Portfile
@@ -21,7 +21,7 @@ master_sites      https://download.savannah.gnu.org/releases/avrdude/
 checksums         rmd160  245c20fa6f6be274093f43fa4932295ea47dafaa \
                   sha256  0f9f731b6394ca7795b88359689a7fa1fba818c6e1d962513eb28da670e0a196
 
-depends_lib       port:libusb \
+depends_lib       path:lib/pkgconfig/libusb-1.0.pc:libusb \
                   port:ncurses \
                   port:libftdi1 \
                   port:libelf \

--- a/cross/dfu-programmer/Portfile
+++ b/cross/dfu-programmer/Portfile
@@ -28,7 +28,7 @@ depends_build-append \
     port:pkgconfig
 
 depends_lib-append \
-    path:lib/libusb.dylib:libusb
+    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 patchfiles          implicit.patch
 

--- a/cross/dfu-util/Portfile
+++ b/cross/dfu-util/Portfile
@@ -21,4 +21,4 @@ checksums           rmd160  44d39b0fdcca5b675a61be56bcccd85881c1244a \
 
 depends_build       port:pkgconfig
 
-depends_lib         port:libusb
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb

--- a/cross/micronucleus/Portfile
+++ b/cross/micronucleus/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  199987dc2879ca197c62902cd7e430b578af0b8d \
                     sha256  b233895d26d522672b6bf7e0604adf6231a0e6b35f442a5d2c5a4859a019f9bc \
                     size    2213199
 
-depends_lib-append  port:libusb \
+depends_lib-append  path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:libusb-compat
 
 worksrcdir          ${distname}/commandline

--- a/cross/openocd/Portfile
+++ b/cross/openocd/Portfile
@@ -43,7 +43,7 @@ variant parport description {Enable building the pc parallel port driver. WARNIN
 
 variant ftdi conflicts ft2232_ftd2xx description {Enable building OpenOCD's built-in FTDI driver.} {
     configure.args-append --enable-ftdi
-	depends_lib-append port:libusb
+	depends_lib-append path:lib/pkgconfig/libusb-1.0.pc:libusb
 }
 
 # The ft2232 variant is deprecated, the ftdi variant is its replacement
@@ -152,12 +152,12 @@ variant minidriver_dummy conflicts zy1000 description {Enable the dummy minidriv
 
 variant stlink description {Enable building support for the STM ST-link} {
     configure.args-append --enable-stlink
-    depends_lib-append  port:libusb
+    depends_lib-append  path:lib/pkgconfig/libusb-1.0.pc:libusb
 }
 
 variant ti description {TI-ICDI interface on Stellaris Launchpad} {
     configure.args-append --enable-ti-icdi
-    depends_lib-append  port:libusb
+    depends_lib-append  path:lib/pkgconfig/libusb-1.0.pc:libusb
 }
 
 variant cmsis description {Enable building support for the cmsis-dap} {

--- a/cross/stlink/Portfile
+++ b/cross/stlink/Portfile
@@ -19,7 +19,7 @@ checksums               rmd160  3fdbf5e856aadcbe92a34266481682bd013a0941 \
                         sha256  3979a165612aa2ad7ef98b5f429c101e8b2a38fba1bc1bda311f5550e2d49892 \
                         size    295987
                     
-depends_lib-append      path:lib/libusb-1.0.a:libusb \
+depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb \
                         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                         port:pkgconfig
 

--- a/devel/libcaer/Portfile
+++ b/devel/libcaer/Portfile
@@ -20,7 +20,7 @@ long_description    Minimal C library to access, configure and get/send AER data
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:libusb
+depends_lib-append  path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 checksums           rmd160  67b5c16b8da39a193249dcdd055d90a9930cd9e4 \
                     sha256  431b606934b40de498a7d0f50876745b92b95d64b5ea81da0a52d055a2b89cd7

--- a/devel/libfreespace/Portfile
+++ b/devel/libfreespace/Portfile
@@ -26,7 +26,7 @@ checksums           md5 96a081e3b7fe2337344b8adc61259eb4 \
                     sha1 5b5d676bf00c3a30eee927496d1d0de65ce6fa7a \
                     rmd160 9fdb099c66f814c3e7f4101f6b61d602cb0ad60d
 
-depends_lib         port:libusb
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 destroot.violate_mtree  yes
 

--- a/devel/libftdi/Portfile
+++ b/devel/libftdi/Portfile
@@ -56,7 +56,7 @@ subport             libftdi1 {
 
     depends_lib-append  port:gettext \
                         port:libconfuse \
-                        port:libusb \
+                        path:lib/pkgconfig/libusb-1.0.pc:libusb \
                         port:python27 \
                         port:swig-python
 

--- a/devel/libnifalcon/Portfile
+++ b/devel/libnifalcon/Portfile
@@ -22,7 +22,7 @@ license             BSD
 homepage            https://libnifalcon.github.io/libnifalcon/
 github.tarball_from archive
 
-depends_lib         port:libusb
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 patchfiles          CMakeLists.txt.patch
 

--- a/devel/libusb-compat/Portfile
+++ b/devel/libusb-compat/Portfile
@@ -29,7 +29,7 @@ depends_build-append \
     port:libtool \
     port:pkgconfig
 
-depends_lib     path:lib/libusb-1.0.dylib:libusb
+depends_lib     path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 # use autotools to get ready to configure
 

--- a/devel/minipro/Portfile
+++ b/devel/minipro/Portfile
@@ -22,7 +22,7 @@ long_description    Opensource tool that aims to create a complete cross-platfor
 
 depends_build       port:pkgconfig
 
-depends_lib         port:libusb
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 depends_run         port:srecord
 

--- a/devel/mos-devel/Portfile
+++ b/devel/mos-devel/Portfile
@@ -32,7 +32,7 @@ depends_build-append \
 
 depends_lib-append  port:libftdi0 \
                     port:libftdi1 \
-                    port:libusb
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 # Makefile tries to run `go mod download` with GO111MODULE=off
 # Removes -mod=vendor

--- a/devel/mos/Portfile
+++ b/devel/mos/Portfile
@@ -28,7 +28,7 @@ depends_build-append \
 
 depends_lib-append  port:libftdi0 \
                     port:libftdi1 \
-                    port:libusb
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 # Makefile tries to run `go mod download` with GO111MODULE=off
 # Removes -mod=vendor

--- a/devel/usbredir/Portfile
+++ b/devel/usbredir/Portfile
@@ -22,7 +22,7 @@ use_xz              yes
 
 depends_build       port:pkgconfig
 
-depends_lib         port:libusb
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 # No configure script in tarball.
 # 0.10.0 and later use meson instead of autotools.

--- a/finance/cgminer/Portfile
+++ b/finance/cgminer/Portfile
@@ -21,7 +21,7 @@ depends_build-append port:pkgconfig \
                  port:gawk
 
 depends_lib      port:ncurses \
-                 port:libusb \
+                 path:lib/pkgconfig/libusb-1.0.pc:libusb \
                  port:curl
 
 use_autoreconf   yes

--- a/gis/libpcl/Portfile
+++ b/gis/libpcl/Portfile
@@ -29,7 +29,7 @@ depends_lib         port:eigen3 \
                     port:libpng \
                     port:openni \
                     port:qhull \
-                    port:libusb \
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:vtk \
                     port:zlib
 

--- a/gnome/spice-gtk/Portfile
+++ b/gnome/spice-gtk/Portfile
@@ -58,7 +58,7 @@ depends_lib-append  port:spice-protocol \
                     port:gstreamer1 \
                     port:gstreamer1-gst-plugins-base \
                     port:libepoxy \
-                    port:libusb \
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:libopus
 
 # for ucontext

--- a/graphics/darktable/Portfile
+++ b/graphics/darktable/Portfile
@@ -71,7 +71,7 @@ depends_lib-append      port:atk \
                         port:librsvg \
                         port:libsecret \
                         port:libsoup \
-                        port:libusb \
+                        path:lib/pkgconfig/libusb-1.0.pc:libusb \
                         port:lua \
                         port:libxml2 \
                         port:openexr \

--- a/graphics/openni/Portfile
+++ b/graphics/openni/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  2d78c4fce0908b1e4801649b6390c0d6a8afc68f \
 depends_build       port:doxygen \
                     path:bin/dot:graphviz
 
-depends_lib         port:libusb
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 pre-fetch {
     if {${os.platform} eq "darwin" && ${os.major} < 10} {

--- a/graphics/sane-backends/Portfile
+++ b/graphics/sane-backends/Portfile
@@ -28,7 +28,7 @@ checksums                   rmd160  a8b74418afc44513ec5e75e4f240448ad48ac59a \
 depends_build               port:pkgconfig
 
 depends_lib                 path:include/turbojpeg.h:libjpeg-turbo \
-                            port:libusb \
+                            path:lib/pkgconfig/libusb-1.0.pc:libusb \
                             port:net-snmp \
                             port:tiff \
                             port:zlib \

--- a/kde/digikam/Portfile
+++ b/kde/digikam/Portfile
@@ -63,7 +63,7 @@ depends_lib-append  port:gettext \
                     port:lensfun \
                     port:libgphoto2 \
                     port:liblqr \
-                    port:libusb \
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:jasper \
                     port:shared-desktop-ontologies
 

--- a/kde/kde4-workspace/Portfile
+++ b/kde/kde4-workspace/Portfile
@@ -32,7 +32,7 @@ patchfiles          patch-CMakeLists-for-OSX.patch \
 boost.depends_type  build
 
 depends_build-append port:freetype \
-                    port:libusb
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 depends_lib-append  port:kdelibs4 \
                     port:kdepimlibs4 \

--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -128,7 +128,7 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
                         port:libssh2 \
                         port:libtheora \
                         port:libupnp \
-                        port:libusb \
+                        path:lib/pkgconfig/libusb-1.0.pc:libusb \
                         port:libvorbis \
                         port:libvpx \
                         port:libxml2 \

--- a/multimedia/libmtp/Portfile
+++ b/multimedia/libmtp/Portfile
@@ -15,7 +15,7 @@ master_sites        sourceforge:project/${name}/${name}/${version}
 
 platforms           darwin
 depends_build       port:pkgconfig
-depends_lib         port:libiconv port:libusb
+depends_lib         port:libiconv path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 checksums           rmd160  a6ee084464d610a307388701f56f014c9669c8bb \
                     sha256  f8a34cf52d9f9b9cb8c7f26b12da347d4af7eb904c13189602e4c6b62d1a79dc \

--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -33,7 +33,7 @@ qt5.min_version         5.10.0
 depends_lib-append      port:faad2 \
                         port:fftw-3-single \
                         port:lame \
-                        port:libusb \
+                        path:lib/pkgconfig/libusb-1.0.pc:libusb \
                         port:mpg123
 
 default_variants        +rtlsdr +soapysdr +airspy

--- a/net/FreeRDP/Portfile
+++ b/net/FreeRDP/Portfile
@@ -36,7 +36,7 @@ depends_lib-append  port:xorg-libX11 \
                     port:zlib \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     path:lib/libssl.dylib:openssl \
-                    path:lib/libusb.dylib:libusb \
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     path:lib/pkgconfig/cairo.pc:cairo
 
 # Mac has 64bit filesystem too

--- a/net/bettercap/Portfile
+++ b/net/bettercap/Portfile
@@ -30,7 +30,7 @@ depends_build-append \
                     port:python39
 
 depends_lib-append  port:libpcap \
-                    port:libusb
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 build.cmd           make
 build.target        build

--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -166,7 +166,7 @@ variant qt description {Build Qt4 bindings} {
 
 variant libusb \
 description {Include support for better USB device discovery} {
-    depends_lib-append      path:lib/libusb-1.0.dylib:libusb
+    depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb
 
     build.args-replace      usb=no          usb=yes
     test.args-replace       usb=no          usb=yes

--- a/net/ola/Portfile
+++ b/net/ola/Portfile
@@ -75,7 +75,7 @@ variant libftdi1 conflicts libftdi0 description {Build with libftdi1 support} {
 }
 
 variant libusb description {Build with libusb support} {
-    depends_lib-append      port:libusb
+    depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb
     configure.args-delete   --disable-libusb
 }
 

--- a/science/SDRPlusPlus/Portfile
+++ b/science/SDRPlusPlus/Portfile
@@ -38,7 +38,7 @@ depends_lib-append \
     path:lib/pkgconfig/glfw3.pc:glfw \
     port:volk \
     port:rtaudio \
-    path:lib/libusb.dylib:libusb
+    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 configure.args-append \
     -DINSTALL_PREFIX=${prefix} \

--- a/science/SDRangel/Portfile
+++ b/science/SDRangel/Portfile
@@ -52,7 +52,7 @@ depends_lib-append \
     port:dsdcc \
     port:ffmpeg \
     port:fftw-3-single \
-    path:lib/libusb.dylib:libusb \
+    path:lib/pkgconfig/libusb-1.0.pc:libusb \
     port:libiconv \
     port:libopus \
     port:opencv${opencv_ver} \

--- a/science/SDRplay3/Portfile
+++ b/science/SDRplay3/Portfile
@@ -31,7 +31,7 @@ use_dmg             yes
 
 # libusb is required by sdrplay_apiService
 depends_lib-append \
-    path:lib/libusb-1.0.dylib:libusb
+    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 global I_N_T
 set I_N_T "/usr/bin/install_name_tool"

--- a/science/airspy/Portfile
+++ b/science/airspy/Portfile
@@ -23,7 +23,7 @@ license             MIT
 platforms           darwin
 
 depends_build-append port:pkgconfig
-depends_lib-append	path:lib/libusb-1.0.dylib:libusb
+depends_lib-append	path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 # remove top-level library and includes paths, such that internal
 # libraries and headers are used instead of any already-installed ones.

--- a/science/airspyhf/Portfile
+++ b/science/airspyhf/Portfile
@@ -24,4 +24,4 @@ depends_build-append \
     port:pkgconfig
 
 depends_lib-append \
-    path:lib/libusb.dylib:libusb
+    path:lib/pkgconfig/libusb-1.0.pc:libusb

--- a/science/bladeRF/Portfile
+++ b/science/bladeRF/Portfile
@@ -95,7 +95,7 @@ depends_build-append \
     port:pkgconfig \
 
 depends_lib-append \
-    path:lib/libusb-1.0.dylib:libusb \
+    path:lib/pkgconfig/libusb-1.0.pc:libusb \
     port:libedit \
     port:tecla
 

--- a/science/exodriver/Portfile
+++ b/science/exodriver/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  2d5b5b7c0204d6f779c26c88188b6f3f1eff3ead \
 
 worksrcdir          labjack-exodriver-${git_tag}/liblabjackusb
 
-depends_lib         port:libusb
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 patchfiles          patch-Makefile.diff
 

--- a/science/gr-baz/Portfile
+++ b/science/gr-baz/Portfile
@@ -138,7 +138,7 @@ variant uhd description "Install ${name} with support for UHD" {
 
 
 variant rtl description "Install ${name} with support for RTL SDR hardware (via libusb)" {
-    depends_lib-append path:lib/libusb-1.0.dylib:libusb
+    depends_lib-append path:lib/pkgconfig/libusb-1.0.pc:libusb
 
     configure.args-replace \
         -DLIBUSB_INCLUDE_DIR= \

--- a/science/gr-fcdproplus/Portfile
+++ b/science/gr-fcdproplus/Portfile
@@ -56,7 +56,7 @@ subport gr37-fcdproplus {
 
     depends_lib-append \
         port:gnuradio37 \
-        path:lib/libusb-1.0.dylib:libusb
+        path:lib/pkgconfig/libusb-1.0.pc:libusb
 
     set python_versions { 2.7 }
     set default_python_variant +python27

--- a/science/hackrf/Portfile
+++ b/science/hackrf/Portfile
@@ -46,7 +46,7 @@ if {${subport} eq ${name}} {
 }
 
 depends_build-append port:pkgconfig
-depends_lib-append   path:lib/libusb-1.0.dylib:libusb \
+depends_lib-append   path:lib/pkgconfig/libusb-1.0.pc:libusb \
                      port:fftw-3-single
 
 # Many compilers do not recognize "-std=gnu90", so remove it.

--- a/science/indi/Portfile
+++ b/science/indi/Portfile
@@ -33,7 +33,7 @@ checksums           rmd160  aec032a5a131a67439fca36dc3a1bb71f0979dd5 \
 
 depends_lib         port:libnova \
                     port:zlib \
-                    port:libusb \
+                    path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:libusb-compat \
                     port:cfitsio
 

--- a/science/libiio/Portfile
+++ b/science/libiio/Portfile
@@ -51,7 +51,7 @@ if {${subport} eq ${name}} {
 
     depends_lib-append \
         port:libxml2 \
-        path:lib/libusb.dylib:libusb \
+        path:lib/pkgconfig/libusb-1.0.pc:libusb \
         port:avahi \
         port:xz \
         port:zlib \

--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -55,7 +55,7 @@ depends_build-append \
     port:pkgconfig
 
 depends_lib-append \
-    path:lib/libusb.dylib:libusb \
+    path:lib/pkgconfig/libusb-1.0.pc:libusb \
     port:sqlite3
 
 configure.args-append \

--- a/science/linrad/Portfile
+++ b/science/linrad/Portfile
@@ -46,7 +46,7 @@ depends_lib-append \
     port:xorg-libXext \
     port:portaudio \
     port:libusb-compat \
-    path:lib/libusb-1.0.dylib:libusb
+    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 use_autoreconf yes
 

--- a/science/openhantek/Portfile
+++ b/science/openhantek/Portfile
@@ -23,7 +23,7 @@ long_description    OpenHantek is a free software for Hantek and compatible \
     (Voltcraft/Darkwire/Protek/Acetech) USB digital signal oscilloscopes
 
 depends_lib-append \
-    path:lib/libusb.dylib:libusb \
+    path:lib/pkgconfig/libusb-1.0.pc:libusb \
     port:fftw-3
 
 qt5.depends_component \

--- a/science/osmocore/Portfile
+++ b/science/osmocore/Portfile
@@ -76,7 +76,7 @@ depends_build-append \
     port:pkgconfig
 
 depends_lib-append \
-    path:lib/libusb-1.0.dylib:libusb \
+    path:lib/pkgconfig/libusb-1.0.pc:libusb \
     port:gnutls \
     port:python27 \
     port:talloc

--- a/science/perseus-sdr/Portfile
+++ b/science/perseus-sdr/Portfile
@@ -30,7 +30,7 @@ depends_build-append \
     port:libtool
 
 depends_lib-append \
-    path:lib/libusb.dylib:libusb
+    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 post-extract {
     # remove ssse3 on ppc

--- a/science/qdmr/Portfile
+++ b/science/qdmr/Portfile
@@ -37,7 +37,7 @@ qt5.depends_component \
     qtlocation
  
 depends_lib \
-    port:libusb
+    path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 configure.args-append \
     -DBUILD_TESTS=OFF \

--- a/science/rtl-sdr/Portfile
+++ b/science/rtl-sdr/Portfile
@@ -22,7 +22,7 @@ long_description    ${description}
 homepage            http://sdr.osmocom.org/trac/wiki/rtl-sdr
 
 depends_build-append port:pkgconfig port:doxygen
-depends_lib-append   path:lib/libusb-1.0.dylib:libusb
+depends_lib-append   path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 # remove top-level library and includes paths, such that internal
 # libraries and headers are used instead of any already-installed ones.

--- a/science/rtl_433/Portfile
+++ b/science/rtl_433/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  d10ab6c0fb91225bf41a75faa47b500f922b3391 \
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:libusb \
+depends_lib-append  path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:rtl-sdr \
                     port:SoapySDR
 

--- a/science/uhd/Portfile
+++ b/science/uhd/Portfile
@@ -363,7 +363,7 @@ if {![variant_isset examples]} {
 }
 
 variant libusb description {enable USB support via libusb version 1.0} {
-    depends_lib-append path:lib/libusb-1.0.dylib:libusb
+    depends_lib-append path:lib/pkgconfig/libusb-1.0.pc:libusb
     configure.args-append \
         -DENABLE_USB=ON \
         -DLIBUSB_INCLUDE_DIRS=${prefix}/include/libusb-1.0

--- a/sysutils/iguanaIR/Portfile
+++ b/sysutils/iguanaIR/Portfile
@@ -54,7 +54,7 @@ patchfiles      patch-compat.h.diff \
 configure.args  --disable-python    
            
 depends_lib     port:popt \
-                port:libusb \
+                path:lib/pkgconfig/libusb-1.0.pc:libusb \
                 port:libusb-compat
 
 post-destroot {

--- a/sysutils/lirc/Portfile
+++ b/sysutils/lirc/Portfile
@@ -46,7 +46,7 @@ depends_build-append \
                     port:man \
                     port:${pymodver}-yaml
 
-depends_lib         port:libusb \
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:libusb-compat \
                     port:libftdi1 \
                     port:portaudio

--- a/sysutils/uhubctl/Portfile
+++ b/sysutils/uhubctl/Portfile
@@ -21,7 +21,7 @@ long_description \
                 Smart hub is defined as one that implements per-port power switching.
 
 depends_lib-append \
-                path:lib/libusb-1.0.0.dylib:libusb
+                path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 build.target    uhubctl
 makefile.prefix_name \

--- a/sysutils/usbutils/Portfile
+++ b/sysutils/usbutils/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  b3b509ec7f9153402da4519aaedc141ecf064adf \
                     sha256  7593a01724bbc0fd9fe48e62bc721ceb61c76654f1d7b231b3c65f6dfbbaefa4
 
 depends_build       port:pkgconfig
-depends_lib         port:libusb \
+depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:usbids \
                     port:zlib
 

--- a/sysutils/xserve-frontpanel/Portfile
+++ b/sysutils/xserve-frontpanel/Portfile
@@ -27,7 +27,7 @@ long_description        ${name} provides a new open-source implementation of \
                         front panel of the Xserve but which stopped working \
                         after Lion.
 
-depends_lib-append      port:libusb
+depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 patchfiles              FindLibUSB.cmake.patch
 


### PR DESCRIPTION
#### Description

Allows `libusb-devel` to satisfy `libusb` dependencies.

Closes: https://trac.macports.org/ticket/60689

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
