### PR TITLE
gcc11: add macOS 12 support

### DIFF
--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -79,12 +79,20 @@ if { ${os.platform} eq "darwin" && ${os.major} >= 17 } {
     # However, given that SIP is enabled by default in macOS, including on our
     # build bots, we already have to assume that ignoring DYLD_LIBRARY_PATH will
     # still produce a valid toolchain.
-    # 
+    #
     # Given that, we go ahead and disable DYLD_LIBRARY_PATH explicitly, avoiding
     # otherwise unworkably long build-times for hosts with SIP disabled.
-    # 
+    #
     # See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84257
     patchfiles-append patch-disable-dyld_library_path.diff
+}
+
+if { ${os.platform} eq "darwin" && ${os.major} == 21 } {
+    # Add preliminary Darwin 21 support to GCC 11.
+    # This should be removed, when GCC 11 supports Darwin 21 officially and the
+    # respective version is used by macports.
+    # See also: https://github.com/iains/gcc-darwin-arm64/commit/20f61faaed3b335d792e38892d826054d2ac9f15
+    patchfiles-append patch-darwin21-support.diff
 }
 
 if { ${configure.build_arch} eq "i386" } {

--- a/lang/gcc11/files/patch-darwin21-support.diff
+++ b/lang/gcc11/files/patch-darwin21-support.diff
@@ -1,0 +1,92 @@
+As seen in commit https://github.com/iains/gcc-darwin-arm64/commit/20f61faaed3b335d792e38892d826054d2ac9f15
+this patch adds Darwin 21 support to GCC 11
+
+diff --git gcc/config.gcc gcc/config.gcc
+index fb1f06f3da8..b447ec4c8e2 100644
+--- gcc/config.gcc
++++ gcc/config.gcc
+@@ -686,6 +686,11 @@ case ${target} in
+         macos_maj=11
+         def_ld64=609.0
+         ;;
++      *-*-darwin21*)
++        # Darwin 21 corresponds to macOS 12.
++        macos_maj=12
++        def_ld64=609.0
++        ;;
+       *-*-darwin)
+         case ${cpu_type} in
+           aarch64) macos_maj=11 ;;
+diff --git gcc/config/darwin-c.c gcc/config/darwin-c.c
+index 951a998775f..62d28fcea50 100644
+--- gcc/config/darwin-c.c
++++ gcc/config/darwin-c.c
+@@ -691,7 +691,7 @@ macosx_version_as_macro (void)
+   if (!version_array)
+     goto fail;
+ 
+-  if (version_array[MAJOR] < 10 || version_array[MAJOR] > 11)
++  if (version_array[MAJOR] < 10 || version_array[MAJOR] > 12)
+     goto fail;
+ 
+   if (version_array[MAJOR] == 10 && version_array[MINOR] < 10)
+diff --git gcc/config/darwin-driver.c gcc/config/darwin-driver.c
+index a036e091c48..bca71983674 100644
+--- gcc/config/darwin-driver.c
++++ gcc/config/darwin-driver.c
+@@ -64,17 +64,17 @@ validate_macosx_version_min (const char *version_str)
+ 
+   major = strtoul (version_str, &end, 10);
+ 
+-  if (major < 10 || major > 11 ) /* MacOS 10 and 11 are known. */
++  if (major < 10 || major > 12 ) /* MacOS 10, 11 and 12 are known. */
+     return NULL;
+ 
+   /* Skip a separating period, if there's one.  */
+   version_str = end + ((*end == '.') ? 1 : 0);
+ 
+-  if (major == 11 && *end != '\0' && !ISDIGIT (version_str[0]))
+-     /* For MacOS 11, we allow just the major number, but if the minor is
++  if (major >= 11 && *end != '\0' && !ISDIGIT (version_str[0]))
++     /* For MacOS 11 and newer, we allow just the major number, but if the minor is
+ 	there it must be numeric.  */
+     return NULL;
+-  else if (major == 11 && *end == '\0')
++  else if (major >= 11 && *end == '\0')
+     /* We will rewrite 11 =>  11.0.0.  */
+     need_rewrite = true;
+   else if (major == 10 && (*end == '\0' || !ISDIGIT (version_str[0])))
+@@ -160,10 +160,10 @@ darwin_find_version_from_kernel (void)
+ 
+   /* Darwin20 sees a transition to macOS 11.  In this, it seems that the
+      mapping to macOS minor version is now shifted to the kernel minor
+-     version - 1 (at least for the initial releases).  At this stage, we
+-     don't know what macOS version will correspond to Darwin21.  */
++     version - 1 (at least for the initial releases).  */
+   if (major_vers >= 20)
+     {
++      int macos_vers = major_vers - 9;
+       int minor_vers = *version_p++ - '0';
+       if (ISDIGIT (*version_p))
+ 	minor_vers = minor_vers * 10 + (*version_p++ - '0');
+@@ -172,7 +172,7 @@ darwin_find_version_from_kernel (void)
+       if (minor_vers > 0)
+ 	minor_vers -= 1; /* Kernel 20.3 => macOS 11.2.  */
+       /* It's not yet clear whether patch level will be considered.  */
+-      asprintf (&new_flag, "11.%02d.00", minor_vers);
++      asprintf (&new_flag, "%d.%02d.00", macos_vers, minor_vers);
+     }
+   else if (major_vers - 4 <= 4)
+     /* On 10.4 and earlier, the old linker is used which does not
+diff --git gcc/testsuite/gcc.dg/darwin-minversion-link.c gcc/testsuite/gcc.dg/darwin-minversion-link.c
+index 765fb799a91..e142a5830a4 100644
+--- gcc/testsuite/gcc.dg/darwin-minversion-link.c
++++ gcc/testsuite/gcc.dg/darwin-minversion-link.c
+@@ -16,6 +16,7 @@
+ /* { dg-additional-options "-mmacosx-version-min=010.014.05 -DCHECK=101405" { target *-*-darwin18* } } */
+ /* { dg-additional-options "-mmacosx-version-min=010.015.06 -DCHECK=101506" { target *-*-darwin19* } } */
+ /* { dg-additional-options "-mmacosx-version-min=011.000.00 -DCHECK=110000" { target *-*-darwin20 } } */
++/* { dg-additional-options "-mmacosx-version-min=012.000.00 -DCHECK=120000" { target *-*-darwin21 } } */
+ 
+ int
+ main ()


### PR DESCRIPTION
#### Description

Enables GCC 11 to compile under macOS 12 (monterey)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
