### PR TITLE
gegl-0.3: require C++11

### DIFF
--- a/graphics/gegl-0.3/Portfile
+++ b/graphics/gegl-0.3/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           gobject_introspection 1.0
 
 name                gegl-0.3
@@ -10,7 +9,6 @@ set gname           gegl
 version             0.3.34
 revision            10
 set branch          [join [lrange [split ${version} .] 0 1] .]
-conflicts           gegl-devel
 license             {GPL-3+ LGPL-3+}
 categories          graphics
 maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
@@ -76,9 +74,8 @@ post-patch {
 
 gobject_introspection yes
 
-# blacklist compilers that do not support C11 (redefinition of typedef 'GeglDownscale2x2Fun' in gegl-algorithms.h at line 51)
-# tweak gcc blacklisting for 10.5 ppc
-compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 300}
+# https://trac.macports.org/ticket/63663
+compiler.cxx_standard 2011
 
 use_autoreconf      yes
 autoreconf.args     -fvi


### PR DESCRIPTION
#### Description

Fix build on pre-10.9 due to C++ library mismatches (missing symbols).

Also remove conflict with `gegl-devel` since all of the installed files have `-0.3` in the path or filename.

Builds here on 10.4 – however, there are run-time errors on 10.4/10.5 that are not addressed in this PR.

Closes: https://trac.macports.org/ticket/63663

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
