### PR TITLE
google-cloud-sdk: update to 362.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             361.0.0
+version             362.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  9d27368024ca49f0f8732a451cc1c776eddff561 \
-                    sha256  7ddb0eedab0d213f883a850ac6d838df3a02fdb155f71deeea452f06363af203 \
-                    size    96434250
+    checksums       rmd160  4b35be0689415e66a61f2cc80df6f97b835840e4 \
+                    sha256  85cc2e84cce038f9b36a7e7334afa56d63481e3e9e8ab9bb933348173a4cd229 \
+                    size    96501233
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1a6823e55a0f250c0891b0e160bac622396027a2 \
-                    sha256  ae86d17383db991bc32c1aae228ea5f08f8186086d95b84366b8f637730991bf \
-                    size    92705663
+    checksums       rmd160  32781b633339c5136e5648c69c4dec2bfaa8bb76 \
+                    sha256  ac85bbd5db9da19d5ac6cff2a3dd495edc122314a9f3788ffe67ff677db643a7 \
+                    size    92773093
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  dd19da1705d976b7902a57a610fd302625fdf6f5 \
-                    sha256  9101f91dc8853424538547344e8fedb2a6d350d32b608de9399ca1d01b67825f \
-                    size    92633386
+    checksums       rmd160  22fd604bdd57144810482bec315964b75b5b77b8 \
+                    sha256  7f9436df532b55b1bd9b9c51eb82665fdd363d5c72cd78ac6a0fdc9cfbbcf0c6 \
+                    size    92697158
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 362.0.0.

###### Tested on

macOS 11.6.1 20G224 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?