### PR TITLE
py-parsing: restore 3.0.1 for Python 3.6+, keep 2.4.7 for earlier

### DIFF
--- a/python/py-parsing/Portfile
+++ b/python/py-parsing/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-parsing
 python.rootname     pyparsing
-version             2.4.7
+version             3.0.1
 revision            0
 epoch               1
 
@@ -25,15 +25,22 @@ long_description    The parsing module is an alternative approach to creating \
 
 homepage            https://github.com/pyparsing/pyparsing/
 
-checksums           rmd160  2dbbca645985bb7f4b4d7a36b6ba3958302adfb9 \
-                    sha256  c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
-                    size    649718
+checksums           rmd160  a753503d9042e9a32943504aa5e876178c2e6e60 \
+                    sha256  84196357aa3566d64ad123d7a3c67b0e597a115c4934b097580e5ce220b91531 \
+                    size    876312
 
 python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    if {${python.version} <= 35} {
+        version     2.4.7
+        checksums   rmd160  2dbbca645985bb7f4b4d7a36b6ba3958302adfb9 \
+                    sha256  c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
+                    size    649718
+    }
 
     test.run        yes
     test.cmd        ${python.bin} -m unittest


### PR DESCRIPTION
#### Description
https://github.com/macports/macports-ports/commit/2e874abdf9e411f1e341fa63975253c4c1807253 downgraded py-parsing to maintain compatibility with Python 3.5 and earlier, but there is no need to downgrade for later Pythons. In this PR I use the common "split version" idiom for using the latest compatible version for each Python.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->