### PR TITLE
openjdk: update openjdk17-temurin x86_64 to 17.0.1

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -555,10 +555,14 @@ subport openjdk17-temurin {
     # Java 17 is the first Temurin release with arm64 support
     supported_archs  x86_64 arm64
 
-    version      17
+    if {${configure.build_arch} eq "x86_64"} {
+        version 17.0.1
+        set build    12
+    } elseif {${configure.build_arch} eq "arm64"} {
+        version 17
+        set build    35
+    }
     revision     0
-
-    set build    35
 
     description  Eclipse Temurin, based on OpenJDK 17
     long_description ${long_description_temurin}
@@ -566,10 +570,10 @@ subport openjdk17-temurin {
     master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${version}%2B${build}/
 
     if {${configure.build_arch} eq "x86_64"} {
-        distname     OpenJDK17-jdk_x64_mac_hotspot_${version}_${build}
-        checksums    rmd160  0d79be9e1e6cf50d939e839a53ba15c2f9209a77 \
-                     sha256  e9de8b1b62780fe99270a5b30f0645d7a91eded60438bcf836a05fa7b93c182f \
-                     size    192417649
+        distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
+        checksums    rmd160  1db5d0eacd33b7892f41d6579370ee5089a4a265 \
+                     sha256  98a759944a256dbdd4d1113459c7638501f4599a73d06549ac309e1982e2fa70 \
+                     size    192449459
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     OpenJDK17-jdk_aarch64_mac_hotspot_${version}_${build}
         checksums    rmd160  b879101e8175b93c30dcb33f8bc25440c8227853 \


### PR DESCRIPTION
#### Description

Update Eclipse Temurin for Java 17 on x86_64 to 17.0.1. (The 17.0.1 release isn't out yet for arm64.)

###### Tested on

macOS 11.6.1 20G224 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?