### PR TITLE
p5-net-ssleay: Work around macOS 12 dyld misfeature

### DIFF
--- a/perl/p5-net-ssleay/Portfile
+++ b/perl/p5-net-ssleay/Portfile
@@ -25,6 +25,8 @@ if {${perl5.major} != ""} {
 
     configure.env   OPENSSL_PREFIX=[openssl::install_area]
 
+    patchfiles      patch-libdir.diff
+
 # clang: error: unknown argument: '-fstack-protector-strong'
     if {[string match *clang* ${configure.compiler}]} {
         post-configure {

--- a/perl/p5-net-ssleay/files/patch-libdir.diff
+++ b/perl/p5-net-ssleay/files/patch-libdir.diff
@@ -1,0 +1,11 @@
+--- Makefile.PL
++++ Makefile.PL
+@@ -154,7 +154,7 @@
+     for ("$prefix/include", "$prefix/inc32", '/usr/kerberos/include') {
+       push @{$opts->{inc_paths}}, $_ if -f "$_/openssl/ssl.h";
+     }
+-    for ($prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll") {
++    for ("$prefix/lib64", "$prefix/lib", "$prefix/out32dll") {
+       push @{$opts->{lib_paths}}, $_ if -d $_;
+     }
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Attempting to load a file that does not exist (here,
/opt/local/libcrypto.dylib) will search the dyld shared cache by
filename, and return /usr/lib/libcrypto.dylib from the dyld shared
cache. That module is poisoned and has a load-time initializer that
calls abort(). There is no reason to attempt to load from /opt/local as
opposed to /opt/local/lib.

```
mark@sweet16 zsh% sw_vers
ProductName:	macOS
ProductVersion:	12.0.1
BuildVersion:	21A559
mark@sweet16 zsh% /opt/local/bin/perl5.28 Makefile.PL
Do you want to run external tests?
These tests *will* *fail* if you do not have network connectivity. [n]
*** Found OpenSSL-1.1.1l installed in /opt/local
*** Be sure to use the same compiler and options to compile your OpenSSL, perl,
    and Net::SSLeay. Mixing and matching compilers is not supported.
Checking if your kit is complete...
Looks good
WARNING: /opt/local/bin/perl5.28 is loading libcrypto in an unsafe way
zsh: abort      /opt/local/bin/perl5.28 Makefile.PL
```

Closes: https://trac.macports.org/ticket/63415

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
