### PR TITLE
lua-language-server: Use legacysupport

### DIFF
--- a/lua/lua-language-server/Portfile
+++ b/lua/lua-language-server/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        sumneko lua-language-server 2.4.7
 fetch.type          git
@@ -15,17 +16,6 @@ maintainers         {judaew @judaew} openmaintainer
 description         Lua Language Server coded by Lua
 long_description    {*}${description}
 
-if {${os.major} < 17} {
-    known_fail      yes
-    pre-fetch {
-        ui_error    "${name} do not build on macOS 10.12 or earlier (at least"
-        ui_error    "not with the versions of libc++ included on those system)"
-        ui_error    "because: The following features of the C++17 standard are"
-        ui_error    "are not supported by /use/bin/clang++:"
-        ui_error    "  * std::optional (C++17)"
-        return -code error "incompatible OS X version"
-    }
-}
 
 post-fetch {
     system -W ${worksrcpath} "git submodule update --init"
@@ -52,16 +42,11 @@ use_configure       no
 compiler.c_standard 2011
 compiler.cxx_standard 2017
 
-if {${os.major} == 17} {
-    # This fix adapted from @ryandesign for mkvtoolnix:
-    # https://github.com/macports/macports-ports/commit/3e534a7e32698dbf5f2ef68980aca9d50701c3da
-    #
-    # libc++ on 10.13 supports std::optional but the compilers that shipped
-    # with 10.13's Xcode incorrectly believed that it didn't.
-    # https://github.com/llvm/llvm-project/commit/7fb40e1569dd66292b647f4501b85517e9247953
-    # MacPorts clang 8 and later have applied this fix.
-    compiler.blacklist-append clang macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
-}
+# lua-language-server use std::optional, which is broken on macOS == 10.13 and
+# not available on macOS < 10.13 (with the version libc++ included on those
+# those system). Use MacPorts's libc++ instead to fix it.
+legacysupport.newest_darwin_requires_legacy 17
+legacysupport.use_mp_libcxx yes
 
 pre-build {
     system -W ${worksrcpath} "${prefix}/bin/ninja -C 3rd/luamake -f \


### PR DESCRIPTION
Enable legacysupport.use_mp_libcxx for std::optional

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
