### PR TITLE
qt5-qtbase: macOS 12 SDK compatibility fix

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1002,6 +1002,11 @@ foreach {module module_info} [array get modules] {
 
             # find the Rez program
             patchfiles-append patch-find_rez.diff
+
+            # Backported upstream patch to build with the macOS 12 SDK.
+            # https://github.com/qt/qtbase/commit/dece6f5840463ae2ddf927d65eb1b3680e34a547
+            patchfiles-append patch-qiosurfacegraphicsbuffer.h.diff
+
             post-patch {
                 reinplace \
                     "s|__MACPORTS_Rez__|[exec xcrun --find Rez]|g" \

--- a/aqua/qt5/files/patch-qiosurfacegraphicsbuffer.h.diff
+++ b/aqua/qt5/files/patch-qiosurfacegraphicsbuffer.h.diff
@@ -1,0 +1,17 @@
+diff --git src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+index e070ba977d55..cc7193d8b71b 100644
+--- src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
++++ src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+@@ -43,6 +43,9 @@
+ #include <qpa/qplatformgraphicsbuffer.h>
+ #include <private/qcore_mac_p.h>
+ 
++#include <CoreGraphics/CGColorSpace.h>
++#include <IOSurface/IOSurface.h>
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QIOSurfaceGraphicsBuffer : public QPlatformGraphicsBuffer
+-- 
+2.33.1
+


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This backports the upstream patch at
https://github.com/qt/qtbase/commit/dece6f5840463ae2ddf927d65eb1b3680e34a547
to qt5 (5.15). There doesn’t seem to be maintenance of this version
upstream any longer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
