### PR TITLE
zvbi: fix build on 10.6

### DIFF
--- a/multimedia/zvbi/Portfile
+++ b/multimedia/zvbi/Portfile
@@ -23,7 +23,7 @@ long_description    \
 
 homepage            http://zapping.sourceforge.net/ZVBI/
 master_sites        sourceforge:project/zapping/${name}/${version}
-distfiles           ${name}-${version}.tar.bz2
+use_bzip2           yes
 
 checksums           rmd160  36749d9f11994e0ff726ac3e9d11c790c7494455 \
                     sha256  fc883c34111a487c4a783f91b1b2bb5610d8d8e58dcba80c7ab31e67e4765318 \


### PR DESCRIPTION
#### Description

I added the new _zvbi_ port in #12707. As I just saw on https://ports.macports.org/port/zvbi/builds/, it didn't work on 10.6 (and possibly others) because the archive format was not correctly specified, which the present pull request fixes.

Notifying @mascguy.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.1 20G224 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
