### PR TITLE
mscompress: new port

### DIFF
--- a/archivers/mscompress/Portfile
+++ b/archivers/mscompress/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        erikolofsson mscompress 48ed3989f71ddc389b80e65b42d11ee5cbcd5aee
+version             20180118
+revision            0
+categories          archivers
+maintainers         nomaintainer
+description         compress.exe/expand.exe compatible (de)compressor
+long_description    ${description}
+platforms           darwin
+license             GPL-2
+
+checksums           rmd160  d793dc87b2344edd9b44446befb9246bec660ff6 \
+                    sha256  c28b4c2039d5c23be5380c54a67093ed68b6b5eb1cdba92ecbae4d1fc1a95c8f \
+                    size    13474
+
+use_autoreconf      yes


### PR DESCRIPTION
#### Description

I've created a Portfile for this old tool to enable compressing/decompressing of things from old installers from Microsoft.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6
Xcode 12.1

macOS 12.0.1
Xcode 13.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Tested on x86-64. I can test it on PPC/G4 if it is necessary, but i don't have any ARM based machine yet.
