### PR TITLE
zvbi: fix build on 10.6-i386

### DIFF
--- a/multimedia/zvbi/Portfile
+++ b/multimedia/zvbi/Portfile
@@ -29,6 +29,8 @@ checksums           rmd160  36749d9f11994e0ff726ac3e9d11c790c7494455 \
                     sha256  fc883c34111a487c4a783f91b1b2bb5610d8d8e58dcba80c7ab31e67e4765318 \
                     size    1047761
 
+patchfiles          patch-i386.diff
+
 depends_lib         port:gettext \
                     port:libiconv \
                     port:libpng

--- a/multimedia/zvbi/files/patch-i386.diff
+++ b/multimedia/zvbi/files/patch-i386.diff
@@ -1,0 +1,29 @@
+--- src/misc.h	2013-07-02 04:32:31.000000000 +0200
++++ src/misc.h	2021-10-29 19:17:25.000000000 +0200
+@@ -52,17 +52,6 @@
+ #  define unlikely(expr) __builtin_expect(expr, 0)
+ #endif
+ 
+-#undef __i386__
+-#undef __i686__
+-/* FIXME #cpu is deprecated
+-#if #cpu (i386)
+-#  define __i386__ 1
+-#endif
+-#if #cpu (i686)
+-#  define __i686__ 1
+-#endif
+-*/
+-
+ /* &x == PARENT (&x.tm_min, struct tm, tm_min),
+    safer than &x == (struct tm *) &x.tm_min. A NULL _ptr is safe and
+    will return NULL, not -offsetof(_member). */
+@@ -156,8 +145,6 @@
+ 
+ #define likely(expr) (expr)
+ #define unlikely(expr) (expr)
+-#undef __i386__
+-#undef __i686__
+ 
+ static char *
+ PARENT_HELPER (char *p, unsigned int offset)


### PR DESCRIPTION
#### Description

I added the new zvbi port in #12707 and fixed 10.6-x86_64 in #12713. As reported in https://trac.macports.org/ticket/63718, it still didn't work on 10.6-i386. I think this is because zvbi undefines the `__i386__` macro, which the setjmp.h system header, which is included by the libpng header, depends on. The present pull request adds a patch to remove that undefine. The patch is purely speculative because I don't have access to a 10.6-i386 machine, but it seems reasonable.

Notifying @mascguy.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.1 20G224 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
