### PR TITLE
py-pandas: enable parallel build for latest release

### DIFF
--- a/python/py-pandas/Portfile
+++ b/python/py-pandas/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pandas
 version             1.3.4
-revision            0
+revision            1
 categories-append   science
 license             BSD
 platforms           darwin
@@ -25,6 +25,9 @@ checksums           rmd160  407fdee641566b335dfc58ff24e635fe157c242f \
                     size    4734599
 
 if {${name} ne ${subport}} {
+    # Disable parallel builds for older releases; only enabled for latest
+    use_parallel_build no
+
     if {${python.version} eq 27} {
         version             0.24.2
         revision            1
@@ -55,9 +58,10 @@ if {${name} ne ${subport}} {
         checksums           rmd160  593ee2c082df6b4edc85670cd0221dfec5b51b30 \
                             sha256  f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b \
                             size    5229894
+    } else {
+        # Latest release; enable parallel builds
+        use_parallel_build yes
     }
-
-    use_parallel_build  no
 
     depends_build-append \
                         port:py${python.version}-setuptools \


### PR DESCRIPTION
#### Description

Enable parallel build for `py-pandas`. Note that we're only enabling for the latest release; keep disabled for older versions, to avoid issues.

Based on the Git blame, it was disabled way back for v1.0.2, on 3/16/2020: https://github.com/macports/macports-ports/commit/cb7ee2787abef02a17e742c4225dd9eb3a9353f9

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?