### PR TITLE
jdupes: update to 1.20.1

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jbruchon jdupes 1.20.0 v
+github.setup        jbruchon jdupes 1.20.1 v
 revision            0
-checksums           rmd160  b3e93916a5edae077d9db4eeeba4526b0df6f2ec \
-                    sha256  beba8f843b24659764a6a747e3fd4b3343c4b3c8fa9fdd167977e98d433b5de6 \
-                    size    93845
+checksums           rmd160  244247bd07037629b36401c9aaca082923e4ed28 \
+                    sha256  e93568d1967518cace5bd26ab52328c05cb13bd3e95f225cba3c15d9c0c5fd35 \
+                    size    94108
 
 platforms           darwin
 categories          sysutils


### PR DESCRIPTION
#### Description
jdupes: update to 1.20.1

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
