### PR TITLE
librsvg-devel: Use fallback for universal builds

### DIFF
--- a/graphics/librsvg-devel/Portfile
+++ b/graphics/librsvg-devel/Portfile
@@ -51,6 +51,10 @@ license_noconflict  gobject-introspection \
 
 set max_darwin_for_rust 13
 
+if {![info exists universal_possible]} {
+    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
+}
+
 #----------------------------------------------------------------------------------------
 # Developer-only override, allowing easy testing of desired behavior:
 # - librsvg.override.fallback=yes - Force use of fallback release
@@ -69,6 +73,7 @@ if {[info exists librsvg.override.fallback]} {
             ${os.major} < ${max_darwin_for_rust}
             || ${build_arch} eq "arm64"
             || ${build_arch} eq "i386"
+            || ${universal_possible} && [variant_isset universal]
         )} {
         set librsvg_fallback yes
     } else {


### PR DESCRIPTION
#### Description
Build for +universal fails if the platform supports cargo/rust, this change forces the fallback version when +universal is called.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
