### PR TITLE
ffmpeg-devel: some tweaks

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               0
 version             4.4.1
-revision            2
+revision            3
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} {mascguy @mascguy} openmaintainer
@@ -68,7 +68,6 @@ checksums           rmd160  ebb1f042b2ba4f13be86339d30522cd73eb6da3e \
 
 depends_build       port:pkgconfig \
                     port:gmake \
-                    port:ld64 \
                     port:cctools \
                     port:texinfo
 
@@ -111,12 +110,8 @@ minimum_xcodeversions {9 3.1}
 # requires a C11 compiler
 compiler.c_standard 2011
 
-if {[lsearch [get_canonical_archs] i386] != -1} {
-    # clang-3.1 hits https://trac.macports.org/ticket/30137 (<rdar://problem/11542429>)
-    # clang-139 hits https://trac.macports.org/ticket/38141
-    compiler.blacklist-append {clang < 422.1.7}
-}
-
+# clang-3.1 hits https://trac.macports.org/ticket/30137 (<rdar://problem/11542429>)
+# clang-139 hits https://trac.macports.org/ticket/38141
 # warning: unknown warning option '-Werror=partial-availability'; did you mean '-Werror=availability'? [-Wunknown-warning-option]
 # warning: unknown warning option '-Wno-bool-operation'; did you mean '-Wno-bool-conversion'? [-Wunknown-warning-option]
 compiler.blacklist-append {clang < 800}


### PR DESCRIPTION
#### Description

- `ld64` was only required for Xcode11 bug (should be handled by `xcode_workaround`)

Removed;
```
if {[lsearch [get_canonical_archs] i386] != -1} {
    compiler.blacklist-append {clang < 422.1.7}
}
```
That would already be covered by;
```
compiler.blacklist-append {clang < 800}
```

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
