### PR TITLE
py-{botocore,boto3}: Drop Python 2.7 and 3.5 subports

### DIFF
--- a/python/py-boto3/Portfile
+++ b/python/py-boto3/Portfile
@@ -25,19 +25,9 @@ checksums           rmd160  654e50ea49a9cfe1604b828b9a4f1a99eefab63c \
                     sha256  9417d5dd88904cfded28e28ea174641b712659cc849bced9a46f796f5e85442f \
                     size    103191
 
-python.versions     27 36 37 38 39 310
+python.versions     36 37 38 39 310
 
 if {${name} ne ${subport}} {
-    # See https://github.com/boto/boto3/blob/develop/CHANGELOG.rst#1180
-    if {${python.version} eq 27} {
-        version             1.17.112
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  87f6a8ac4a0b8a4cc7f2945c182bf6af2dfe9594 \
-                            sha256  08b6dacbe7ebe57ae8acfb7106b2728d946ae1e0c3da270caee1deb79ccbd8af \
-                            size    98293
-    }
-
     depends_build-append    port:py${python.version}-setuptools
     depends_run-append      port:py${python.version}-botocore \
                             port:py${python.version}-jmespath \

--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -24,28 +24,9 @@ checksums           rmd160  53f7f66d67bee6d49b06c5b6655d796bf240925a \
                     sha256  d7c190ed4e1ddb24f9872a0641b28da4afc04b6b993f0ec3dd5224a847df5519 \
                     size    8306878
 
-python.versions     27 35 36 37 38 39 310
+python.versions     36 37 38 39 310
 
 if {${name} ne ${subport}} {
-    if {${python.version} == 27} {
-        # See https://github.com/boto/botocore/blob/develop/CHANGELOG.rst#1210
-        version             1.20.112
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  05e0f89dc685dacf5f7d935c5d8c6e65f0f3b8f0 \
-                            sha256  d0b9b70b6eb5b65bb7162da2aaf04b6b086b15cc7ea322ddc3ef2f5e07944dcf \
-                            size    7917776
-
-    } elseif {${python.version} == 35} {
-        # See https://github.com/boto/botocore/blob/develop/CHANGELOG.rst#11963
-        version             1.19.63
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  6d806f84076204176d87ff3b96fb91c5fea04ce9 \
-                            sha256  d3694f6ef918def8082513e5ef309cd6cd83b612e9984e3a66e8adc98c650a92 \
-                            size    7437996
-    }
-
     depends_build-append \
                     port:py${python.version}-setuptools
 

--- a/python/py-mrjob/Portfile
+++ b/python/py-mrjob/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  9aa30d419bca2917f8bd495f76e36ead0c123262 \
                     sha256  5fb72ad6f2f1bb13696dc97c918cb59c29d675d7afe5f84307d31856b545c144 \
                     size    1676800
 
-python.versions     27 35 36 37
+python.versions     36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-s3fs/Portfile
+++ b/python/py-s3fs/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39
+python.versions     36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -30,28 +30,7 @@ if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-aiobotocore \
                         port:py${python.version}-fsspec
 
-    if {${python.version} eq 27} {
-        version             0.3.5
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  4e4bcc9f772215455940d5b342d847ed76bb00cb \
-                            sha256  f1d8d80ae7789e6c95f8432e3ec12d1c28e624aecf8c84afed373fb182b505ab \
-                            size    46289
-        depends_lib-delete  port:py${python.version}-aiobotocore \
-                            port:py${python.version}-fsspec
-        depends_lib-append  port:py${python.version}-six \
-                            port:py${python.version}-boto3 \
-                            port:py${python.version}-botocore
-    } elseif {${python.version} eq 35} {
-        version             0.4.2
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  f93edfce066508c00b6df39efc1feae2c3bb3d4c \
-                            sha256  2ca5de8dc18ad7ad350c0bd01aef0406aa5d0fff78a561f0f710f9d9858abdd0 \
-                            size    57527
-        depends_lib-delete  port:py${python.version}-aiobotocore
-        depends_lib-append  port:py${python.version}-botocore
-    } elseif {${python.version} eq 36} {
+    if {${python.version} eq 36} {
         version             0.5.1
         revision            0
         distname            ${python.rootname}-${version}

--- a/python/py-s3transfer/Portfile
+++ b/python/py-s3transfer/Portfile
@@ -20,7 +20,7 @@ long_description    ${description}
 
 homepage            https://github.com/boto/${python.rootname}
 
-python.versions     27 36 37 38 39 310
+python.versions     36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -28,18 +28,6 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-botocore
-
-    if {${python.version} == 27} {
-        depends_lib-append \
-                    port:py${python.version}-futures
-
-        version     0.4.2
-        revision    0
-        distname    ${python.rootname}-${version}
-        checksums   rmd160  01c31ca8b8cfa216298cb57a4503bac001a0bc4d \
-                    sha256  cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2 \
-                    size    129664
-    }
 
     test.run        yes
 

--- a/python/py-smart_open/Portfile
+++ b/python/py-smart_open/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39
+python.versions     36 37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -27,22 +27,6 @@ checksums           rmd160  9a4b3c8876a20f653fbf075e96f0b7cbae4fc7de \
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
-
-    if {${python.version} <= 35} {
-        version             1.10.1
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  83609eda4fa2bac442ca87a7b3c3ffd08fd2324c \
-                            sha256  c1a65a9b59e2d76626d81c483180733feb763570224239e4ea9ffd836651b131 \
-                            size    92788
-
-        if {${python.version} eq 27} {
-            depends_lib-append  port:py${python.version}-bz2file
-        }
-
-        depends_lib-append  port:py${python.version}-boto3 \
-                            port:py${python.version}-requests
-    }
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description

The py-botocore and py-boto3 dependencies no longer support Python 2.7 and 3.5. These projects release new changes with the API every day. The best idea is to drop of these subports.

Drop Python 2.7 and 3.5:
- py-smart_open
- py-s3fs
- py-s3transfer
- py-mrjob
- py-botocore
- py-boto3

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
