### PR TITLE
jumpcut: Update to 0.75

### DIFF
--- a/aqua/jumpcut/Portfile
+++ b/aqua/jumpcut/Portfile
@@ -1,33 +1,65 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           xcode 1.0
 
 name                jumpcut
-version             0.63
 categories          aqua
-maintainers         nomaintainer
+maintainers         {judaew @judaew} openmaintainer
 license             MIT
-supported_archs     i386 ppc
 
 description         Jumpcut: Minimalist Clipboard Buffering for OS X
-
 long_description    Jumpcut is an application that provides “clipboard \
                     buffering” — that is, access to text that you’ve cut or \
                     copied, even if you’ve subsequently cut or copied \
                     something else. The goal of Jumpcut’s interface is to \
                     provide quick, natural, intuitive access to your \
                     clipboard’s history.
+homepage            https://snark.github.io/jumpcut/
 
-homepage            http://jumpcut.sourceforge.net/
-master_sites        sourceforge:project/jumpcut/jumpcut-source/${version}/
+variant universal {}
+default_variants    +universal
 
-distname            ${name}_${version}-src
-extract.suffix      .tgz
+if {![variant_isset universal]} {
+    pre-fetch {
+        ui_error "${name} port uses pre-built binary which contains several\
+            architectures. Please do not install this port without the\
+            +universal variant."
+        return -code error "Try running `port install ${name} +universal`"
+    }
+}
 
-checksums           md5     8ea757ff5723c397be557618592e49bc \
-                    rmd160  ddf4f7fee02d84de62cec037a286d5f9c8a704f1 \
-                    sha256  48a0d44673138a97a2e734cd991bb065437ec66e1653a44d0e2679aa1087c9d9 \
-                    size    486246
+if {${os.major} < 14 } {
+    version             0.63
+    revision            1
 
-patchfiles          patch-AppController.m.diff
+    supported_archs     i386 ppc
+    master_sites        sourceforge:project/jumpcut/jumpcut/${version}
+    distname            Jumpcut_${version}
+    extract.suffix      .tgz
+
+    checksums           rmd160  4812eddf7f6efd116a511192dae398682a68beba \
+                        sha256  19c84eefbc7f173af45affe3a9ca6fd9ec58d9bdf6bacef165085e63e82d54e1 \
+                        size    530939
+} else {
+    PortGroup           github 1.0
+
+    github.setup        snark jumpcut 0.75 v
+    github.tarball_from releases
+    revision            0
+
+    supported_archs     arm64 x86_64
+    distname            Jumpcut-${version}
+    use_bzip2           yes
+
+    checksums           rmd160  ef7e23249a314c092ac7ad8e70828c638d16891d \
+                        sha256  170c669ae3dffdf029434412eb6ec5d733905583ad7ad72120179b5af3615c1a \
+                        size    2148931
+}
+
+extract.mkdir       yes
+use_configure       no
+build {}
+
+destroot {
+    copy ${worksrcpath}/Jumpcut.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description

Closed: [trac#60092](https://trac.macports.org/ticket/60092)

Update to 0.75 and switch to use releases. The latest pre-build package supports arm64 and x86_64 architectures. For macOS below 10.10 (Yosemite), the author recommends using version 0.63. Pre-build package for 0.63 supports i386 and ppc architectures.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
