### PR TITLE
checkssl: new port submission

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/szazeski/checkssl 0.2 v
+revision            0
+
+homepage            https://www.checkssl.org
+
+description         checkssl - simple command line tool to check or monitor your https certificate
+
+long_description    ${description}
+
+categories          sysutils devel
+platforms           darwin
+license             MIT
+installs_libs       no
+
+maintainers         {breun.nl:nils @breun} \
+                    openmaintainer
+
+checksums           rmd160  da8f7afd1cf684d329546ca2e69f38dda6791375 \
+                    sha256  270ae3b3ed60827aeafc89da54e00c066c5bd7daa2962bdc82e191ffd24c2fd1 \
+                    size    4071
+
+destroot {
+    set doc_dir ${destroot}${prefix}/share/doc/${name}
+
+    # Create the doc_dir directory
+    xinstall -m 755 -d ${doc_dir}
+
+    # Copy the docs
+    foreach f { LICENSE README.md } {
+        copy ${worksrcpath}/${f} ${doc_dir}
+    }
+
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

New port for [checkssl](https://www.checkssl.org).

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?