### PR TITLE
ade: restore GCC support

### DIFF
--- a/devel/ade/Portfile
+++ b/devel/ade/Portfile
@@ -24,5 +24,8 @@ checksums           rmd160  7b0f61fbe8a791c2f8725e6039cdbd8b8193e59a \
 
 compiler.cxx_standard 2011
 
-compiler.blacklist-append *gcc* {clang < 900} {macports-clang-3.[0-9]} {macports-clang-[4-6].0}
+compiler.blacklist-append {clang < 900} {macports-clang-3.[0-9]} {macports-clang-[4-6].0}
 compiler.fallback-append  macports-clang-8.0 macports-clang-7.0
+
+# GCC error: '{anonymous}::HostBufferImpl::~HostBufferImpl()' defined but not used
+configure.cxxflags  -Wno-unused-function


### PR DESCRIPTION
#### Description

Tested with GCC7.5

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
