### PR TITLE
aria2: add bash-completion

### DIFF
--- a/net/aria2/Portfile
+++ b/net/aria2/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 github.setup        aria2 aria2 1.36.0 release-
-revision            0
+revision            1
 github.tarball_from releases
 categories          net
 platforms           darwin
@@ -14,7 +14,7 @@ license             {GPL-2+ OpenSSLException}
 description         download utility with resuming and segmented downloading
 long_description    aria2 is a download utility with resuming and segmented \
                     downloading. Supported protocols are HTTP/HTTPS/FTP/BitTorrent.
-                    
+
 use_xz              yes
 
 checksums           rmd160  dcde8da73d2300528d9cef8cc7bcbbbfb101e811 \
@@ -40,6 +40,13 @@ configure.args      --with-libiconv-prefix=${prefix} \
                     --with-xml-prefix=${prefix} \
                     --without-libcares \
                     --without-sqlite3
+
+post-destroot {
+    xinstall -d -m 0755 "${destroot}${prefix}/share/bash-completion/completions"
+    xinstall -m 0644 "${destroot}${prefix}/share/doc/aria2/bash_completion/aria2c" \
+        "${destroot}${prefix}/share/bash-completion/completions/aria2c"
+    file delete -force "${destroot}${prefix}/share/doc/aria2/bash_completion"
+}
 
 if {![variant_isset gnutls]} {
     # C++14


### PR DESCRIPTION
#### Description

Install bash completion file `aria2c` to the correct place.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14
Xcode xcode-select version 2354.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
