### PR TITLE
mackup: update to 0.8.33, use python39

### DIFF
--- a/sysutils/mackup/Portfile
+++ b/sysutils/mackup/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                mackup
-version             0.8.32
+version             0.8.33
 
 categories-prepend  sysutils
 license             GPL-3
@@ -21,11 +21,11 @@ long_description    Mackup backs ups your application settings in a safe \
 
 homepage            https://github.com/lra/mackup
 
-checksums           rmd160  f60cf5a5bb1813010901d6fb8219b24e8a2e4185 \
-                    sha256  154c5d78951e20da2ed0ed226b0684d2bc7f5553dd7b465f217fd6caad6e7fef \
-                    size    54542
+checksums           rmd160  7be1ce1d4df0ae3450a8a8b0e6a1de5b795d7c55 \
+                    sha256  41a45b336f99d7cc2ec4b6a9099efcf03d2cd891ff78f24cb65fe2376e8c8f20 \
+                    size    57946
 
-python.default_version 38
+python.default_version 39
 
 depends_lib-append \
     port:py${python.version}-docopt \


### PR DESCRIPTION
#### Description

- new version 0.8.33
- switch to python39, defined in python port group

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6
xcode-select version 2354

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (No test included)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
