### PR TITLE
fzf: add install helper, fix completion

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/junegunn/fzf 0.28.0
-revision            0
+revision            1
 
 categories          sysutils
 platforms           darwin
@@ -99,15 +99,11 @@ post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/man/man1
     xinstall -m 0644 {*}[glob ${worksrcpath}/man/man1/*.1] ${destroot}${prefix}/share/man/man1/
 
-    # install shell completion (bash, zsh)
-    xinstall -d ${destroot}${prefix}/share/bash-completion/completions/
-    xinstall -m 644 ${worksrcpath}/shell/completion.bash ${destroot}${prefix}/share/bash-completion/completions/${name}
-    xinstall -d ${destroot}${prefix}/share/zsh/site-functions/
-    xinstall -m 644 ${worksrcpath}/shell/completion.zsh ${destroot}${prefix}/share/zsh/site-functions/_${name}
-
-    # make other files available, but not enabled
+    # shell completion and key binding files
     xinstall -d ${destroot}${prefix}/share/fzf/shell/
-    xinstall -m 0644 {*}[glob ${worksrcpath}/shell/key-bindings.*] ${destroot}${prefix}/share/fzf/shell/
+    xinstall -m 0644 {*}[glob ${worksrcpath}/shell/*] ${destroot}${prefix}/share/fzf/shell/
+
+    # fzf.vim plugin
     xinstall -d ${destroot}${prefix}/share/fzf/vim/doc/
     xinstall -m 644 ${worksrcpath}/doc/${name}.txt ${destroot}${prefix}/share/fzf/vim/doc/${name}.txt
     xinstall -d ${destroot}${prefix}/share/fzf/vim/plugin/
@@ -115,9 +111,35 @@ post-destroot {
 }
 
 notes "
-Shell key bindings for bash and zsh are located in:
+Bash
+====
 
-    ${prefix}/share/fzf/shell
+Append this line to ~/.bashrc to enable fzf keybindings for Bash:
+
+ source ${prefix}/share/fzf/shell/key-bindings.bash
+
+Append this line to ~/.bashrc to enable fuzzy auto-completion for Bash:
+
+ source ${prefix}/share/fzf/shell/completion.bash
+
+Zsh
+===
+
+Append this line to ~/.zshrc to enable fzf keybindings for Zsh:
+
+ source ${prefix}/share/fzf/shell/key-bindings.zsh
+
+Append this line to ~/.zshrc to enable fuzzy auto-completion for Zsh:
+
+ source ${prefix}/share/fzf/shell/completion.zsh
+
+Fish
+===
+
+Append this line to ~/.config/fish/config.fish to enable fzf keybindings for Fish:
+
+ source ${prefix}/share/fzf/shell/key-bindings.fish
+
 
 The Vim plugin is located in:
 


### PR DESCRIPTION
#### Description

The completions in fzf package are not common bash, zsh completion
files to be put into `${prefix}/share/bash-completion` or
`${prefix}/share/zsh/site-functions`. They are designed to be sourced
directly.
The `install` script checks existence of `fzf` and help users setup
fzf keybidings, completions.

Changes

1. put completion, keybinding files under `${destroot}${prefix}/share/fzf/shell/`
2. put `install`, `uninstall` helpers into `${destroot}${prefix}/share/fzf`
3. the `install` helper requires executables like `fzf` is located relatively as `./bin/fzf`. Executables are firstly put into 
   `${destroot}${prefix}/share/fzf/bin/`, then linked as `${destroot}${prefix}/bin/fzf`.

file structure after this commit

```sh
❯ port contents fzf
Port fzf contains:
  /opt/local/bin/fzf
  /opt/local/bin/fzf-tmux
  /opt/local/share/doc/fzf/LICENSE
  /opt/local/share/doc/fzf/README-VIM.md
  /opt/local/share/doc/fzf/README.md
  /opt/local/share/fzf/bin/fzf
  /opt/local/share/fzf/bin/fzf-tmux
  /opt/local/share/fzf/install
  /opt/local/share/fzf/shell/completion.bash
  /opt/local/share/fzf/shell/completion.zsh
  /opt/local/share/fzf/shell/key-bindings.bash
  /opt/local/share/fzf/shell/key-bindings.fish
  /opt/local/share/fzf/shell/key-bindings.zsh
  /opt/local/share/fzf/uninstall
  /opt/local/share/fzf/vim/doc/fzf.txt
  /opt/local/share/fzf/vim/plugin/fzf.vim
  /opt/local/share/man/man1/fzf-tmux.1.gz
  /opt/local/share/man/man1/fzf.1.gz
```



<summary>executable existence check by `install` helper passed

<details>

```sh
❯ /opt/local/share/fzf/install --help
usage: /opt/local/share/fzf/install [OPTIONS]

    --help               Show this message
    --bin                Download fzf binary only; Do not generate ~/.fzf.{bash,zsh}
    --all                Download fzf binary and update configuration files
                         to enable key bindings and fuzzy completion
    --xdg                Generate files under $XDG_CONFIG_HOME/fzf
    --[no-]key-bindings  Enable/disable key bindings (CTRL-T, CTRL-R, ALT-C)
    --[no-]completion    Enable/disable fuzzy completion (bash & zsh)
    --[no-]update-rc     Whether or not to update shell configuration files

    --no-bash            Do not set up bash configuration
    --no-zsh             Do not set up zsh configuration
    --no-fish            Do not set up fish configuration

❯ /opt/local/share/fzf/install --completion
Downloading bin/fzf ...
  - Already exists
  - Checking fzf executable ... 0.27.3
Do you want to enable key bindings? ([y]/n) n

Generate /Users/laggardkernel/.fzf.bash ... OK
Generate /Users/laggardkernel/.fzf.zsh ... OK

Do you want to update your shell configuration files? ([y]/n) n

Update /Users/laggardkernel/.bashrc:
  - [ -f ~/.fzf.bash ] && source ~/.fzf.bash
    ~ Skipped

Update /Users/laggardkernel/.zshrc:
  - [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
    ~ Skipped

For more information, see: https://github.com/junegunn/fzf
```

</details>
</summary>

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6
xcode-select version 2354

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
