### PR TITLE
GitUp: update patch to remove sparkle

### DIFF
--- a/devel/GitUp/Portfile
+++ b/devel/GitUp/Portfile
@@ -18,11 +18,12 @@ if {[vercmp $xcodeversion 12.2] < 0 || ${os.major} < 20} {
 }
 
 github.setup            git-up GitUp ${version} v
+revision                1
 
 categories              devel
 platforms               darwin
 license                 GPL-3
-maintainers             {@knapoc knapoc} openmaintainer
+maintainers             @Knapoc openmaintainer
 description             GitUp is a native macOS git client
 long_description        GitUp provides features such as a live and interactive repo graph \
                         unlimited redo/undo, snapshots for 1-click rollbacks, visual commit \

--- a/devel/GitUp/files/patch-disable-sparkle.diff
+++ b/devel/GitUp/files/patch-disable-sparkle.diff
@@ -1,17 +1,160 @@
 diff --git GitUp/Application/AppDelegate.m GitUp/Application/AppDelegate.m
-index 2efe0c1..3a1908f 100644
+index 4ef4dcb..694fd63 100644
 --- GitUp/Application/AppDelegate.m
 +++ GitUp/Application/AppDelegate.m
-@@ -265,6 +265,9 @@ - (void)applicationDidFinishLaunching:(NSNotification*)notification {
-   // First launch has completed
-   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kUserDefaultsKey_FirstLaunch];
+@@ -42,7 +42,7 @@
+ #define kToolName @"gitup"
+ #define kToolInstallPath @"/usr/local/bin/" kToolName
  
-+  // Disable sparkle
-+  [[NSUserDefaults standardUserDefaults] setBool:true forKey:kUserDefaultsKey_DisableSparkle];
-+
-   // Create tool message port
-   CFMessagePortContext context = {0, (__bridge void*)self, NULL, NULL, NULL};
-   _messagePort = CFMessagePortCreateLocal(kCFAllocatorDefault, CFSTR(kToolPortName), _MessagePortCallBack, &context, NULL);
+-@interface AppDelegate () <NSUserNotificationCenterDelegate, SUUpdaterDelegate>
++@interface AppDelegate () <NSUserNotificationCenterDelegate>
+ @property(nonatomic, strong) AboutWindowController* aboutWindowController;
+ @property(nonatomic, strong) CloneWindowController* cloneWindowController;
+ @property(nonatomic, strong) PreferencesWindowController* preferencesWindowController;
+@@ -50,8 +50,6 @@ @interface AppDelegate () <NSUserNotificationCenterDelegate, SUUpdaterDelegate>
+ @end
+ 
+ @implementation AppDelegate {
+-  SUUpdater* _updater;
+-  BOOL _updatePending;
+   BOOL _manualCheck;
+ 
+   CFMessagePortRef _messagePort;
+@@ -73,20 +71,9 @@ - (CloneWindowController*)cloneWindowController {
+   return _cloneWindowController;
+ }
+ 
+-- (void)didChangeReleaseChannel:(BOOL)didChange {
+-  if (didChange) {
+-    _manualCheck = NO;
+-    [_updater checkForUpdatesInBackground];
+-  }
+-}
+-
+ - (PreferencesWindowController*)preferencesWindowController {
+   if (!_preferencesWindowController) {
+     _preferencesWindowController = [[PreferencesWindowController alloc] init];
+-    __weak typeof(self) weakSelf = self;
+-    _preferencesWindowController.didChangeReleaseChannel = ^(BOOL didChange) {
+-      [weakSelf didChangeReleaseChannel:didChange];
+-    };
+   }
+   return _preferencesWindowController;
+ }
+@@ -112,7 +99,6 @@ + (void)initialize {
+     GICommitMessageViewUserDefaultKey_ShowMargins : @(YES),
+     GICommitMessageViewUserDefaultKey_EnableSpellChecking : @(YES),
+     GIUserDefaultKey_FontSize : @(GIDefaultFontSize),
+-    kUserDefaultsKey_ReleaseChannel : PreferencesWindowController_ReleaseChannel_Stable,
+     kUserDefaultsKey_CheckInterval : @(15 * 60),
+     kUserDefaultsKey_FirstLaunch : @(YES),
+     kUserDefaultsKey_DiffWhitespaceMode : @(kGCLiveRepositoryDiffWhitespaceMode_Normal),
+@@ -193,19 +179,6 @@ - (void)applicationWillFinishLaunching:(NSNotification*)notification {
+ }
+ 
+ - (void)applicationDidFinishLaunching:(NSNotification*)notification {
+-#if !DEBUG
+-  // Initialize Sparkle and check for update immediately
+-  if (![[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsKey_DisableSparkle]) {
+-    _updater = [SUUpdater sharedUpdater];
+-    _updater.delegate = self;
+-    _updater.automaticallyChecksForUpdates = NO;
+-    _updater.sendsSystemProfile = NO;
+-    _updater.automaticallyDownloadsUpdates = YES;
+-
+-    _manualCheck = NO;
+-    [_updater checkForUpdatesInBackground];
+-  }
+-#endif
+ 
+   // Locate installed apps.
+   [GILaunchServicesLocator setup];
+@@ -367,9 +340,6 @@ - (NSDictionary*)_processToolCommand:(NSDictionary*)input {
+ #pragma mark - Actions
+ 
+ - (BOOL)validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)anItem {
+-  if (anItem.action == @selector(checkForUpdates:)) {
+-    return _updater && !_updatePending && ![_updater updateInProgress];
+-  }
+   return YES;
+ }
+ 
+@@ -390,7 +360,6 @@ - (IBAction)viewIssues:(id)sender {
+ }
+ 
+ - (IBAction)showAboutPanel:(id)sender {
+-  self.aboutWindowController.updatePending = _updatePending;
+   [self.aboutWindowController showWindow:nil];
+ }
+ 
+@@ -472,11 +441,6 @@ - (IBAction)dimissModal:(id)sender {
+   [[(NSButton*)sender window] orderOut:nil];
+ }
+ 
+-- (IBAction)checkForUpdates:(id)sender {
+-  _manualCheck = YES;
+-  [_updater checkForUpdatesInBackground];
+-}
+-
+ - (IBAction)installTool:(id)sender {
+   AuthorizationRef authorization;
+   OSStatus status = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &authorization);
+@@ -536,55 +500,4 @@ - (void)userNotificationCenter:(NSUserNotificationCenter*)center didActivateNoti
+   }
+ }
+ 
+-#pragma mark - SUUpdaterDelegate
+-
+-- (NSString*)feedURLStringForUpdater:(SUUpdater*)updater {
+-  NSString* channel = [[NSUserDefaults standardUserDefaults] stringForKey:kUserDefaultsKey_ReleaseChannel];
+-  return [NSString stringWithFormat:kURL_AppCast, channel];
+-}
+-
+-- (void)updater:(SUUpdater*)updater didFindValidUpdate:(SUAppcastItem*)item {
+-  NSString* channel = [[NSUserDefaults standardUserDefaults] stringForKey:kUserDefaultsKey_ReleaseChannel];
+-  XLOG_INFO(@"Did find app update on channel '%@' for version %@", channel, item.versionString);
+-  if (_manualCheck) {
+-    NSAlert* alert = [[NSAlert alloc] init];
+-    alert.messageText = NSLocalizedString(@"A GitUp update is available!", nil);
+-    alert.informativeText = NSLocalizedString(@"The update will download automatically in the background and be installed when you quit GitUp.", nil);
+-    [alert addButtonWithTitle:NSLocalizedString(@"OK", nil)];
+-    alert.type = kGIAlertType_Note;
+-    [alert runModal];
+-  }
+-}
+-
+-- (void)updaterDidNotFindUpdate:(SUUpdater*)updater {
+-  NSString* channel = [[NSUserDefaults standardUserDefaults] stringForKey:kUserDefaultsKey_ReleaseChannel];
+-  XLOG_VERBOSE(@"App is up-to-date at version %@ on channel '%@'", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"], channel);
+-  if (_manualCheck) {
+-    NSAlert* alert = [[NSAlert alloc] init];
+-    alert.messageText = NSLocalizedString(@"GitUp is already up-to-date!", nil);
+-    [alert addButtonWithTitle:NSLocalizedString(@"OK", nil)];
+-    alert.type = kGIAlertType_Note;
+-    [alert runModal];
+-  }
+-}
+-
+-- (void)updater:(SUUpdater*)updater didAbortWithError:(NSError*)error {
+-  NSString* channel = [[NSUserDefaults standardUserDefaults] stringForKey:kUserDefaultsKey_ReleaseChannel];
+-  if (![error.domain isEqualToString:SUSparkleErrorDomain] || (error.code != SUNoUpdateError)) {
+-    XLOG_ERROR(@"App update on channel '%@' aborted: %@", channel, error);
+-  }
+-}
+-
+-- (void)updater:(SUUpdater*)updater willInstallUpdate:(SUAppcastItem*)item {
+-  XLOG_INFO(@"Installing app update for version %@", item.versionString);
+-}
+-
+-- (void)updater:(SUUpdater*)updater willInstallUpdateOnQuit:(SUAppcastItem*)item immediateInstallationInvocation:(NSInvocation*)invocation {
+-  XLOG_INFO(@"Will install app update for version %@ on quit", item.versionString);
+-  _updatePending = YES;
+-  [self _showNotificationWithTitle:NSLocalizedString(@"Update Available", nil)
+-                            action:NULL
+-                           message:NSLocalizedString(@"Relaunch GitUp to update to version %@ (%@).", nil), item.displayVersionString, item.versionString];
+-}
+-
+ @end
 diff --git GitUp/Application/Base.lproj/MainMenu.xib GitUp/Application/Base.lproj/MainMenu.xib
 index 528efb4..711833c 100644
 --- GitUp/Application/Base.lproj/MainMenu.xib


### PR DESCRIPTION
#### Description

Patch to disable sparkle has been redone.
Closes: https://trac.macports.org/ticket/63684
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
