### PR TITLE
nushell: update to 0.39.0

### DIFF
--- a/shells/nushell/Portfile
+++ b/shells/nushell/Portfile
@@ -4,12 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        nushell nushell 0.38.0
+github.setup        nushell nushell 0.39.0
 revision            0
 categories          shells
 platforms           darwin
 license             MIT
-maintainers         {@b4nst gmail.com:bastyen.a} openmaintainer
+maintainers         {@b4nst gmail.com:bastyen.a} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         A new type of shell
 long_description    ${description}
@@ -19,9 +21,9 @@ homepage            https://www.nushell.sh
 build.args          --features extra
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  3e5e5baea6f744ba1e90c9d2bf5b272e86450ac3 \
-                    sha256  308d5b2074a93c620009d7cd1c0d9d2588916943b9ac1af4fa115baffb34f945 \
-                    size    6297324
+                    rmd160  1d96c0f58dd2264cea70edcd24e4ed97d38ffd91 \
+                    sha256  0f5d174c8200f35d93f97b3ae61e8f4487307f038e524822843ee48220e7ed0b \
+                    size    6297106
 
 destroot {
     delete {*}[glob ${worksrcpath}/target/[cargo.rust_platform]/release/*.d]
@@ -300,7 +302,6 @@ cargo.crates \
     neso                             0.5.0  6b3c31defbcb081163db18437fd88c2a267cb3e26f7bd5e4b186e4b1b38fe8c8 \
     new_debug_unreachable            1.0.4  e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54 \
     nibble_vec                       0.1.0  77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
-    nipper                           0.1.9  761382864693f4bb171abf9e8de181a320b00464a83a9a5071059057b1fe0116 \
     nix                             0.20.1  df8e5e343312e7fbeb2a52139114e9e702991ef9c2aea6817ff2440b35647d56 \
     nix                             0.22.1  e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \


### PR DESCRIPTION
- add @herbygillot as co-maintainer

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
