### PR TITLE
nim: update to 1.6.0

### DIFF
--- a/lang/nim/Portfile
+++ b/lang/nim/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 
 name                nim
-version             1.4.4
+version             1.6.0
 revision            0
 license             MIT
 categories          lang
 platforms           darwin
-supported_archs     i386 x86_64 ppc64
+supported_archs     i386 x86_64 ppc64 arm64
 maintainers         {@gpanders gpanders.com:greg} \
                     openmaintainer
 
@@ -22,10 +22,9 @@ long_description    Nim is a statically typed compiled systems programming \
 homepage            https://nim-lang.org
 
 master_sites        ${homepage}/download/
-
-checksums           rmd160  df2568109792112495aaed4273f222bf8623f95b \
-                    sha256  9f43f5da8f7130b137d59e49f3911f0c35cc1e94e68c333c50c59ef8b65dd6f6 \
-                    size    159095112
+checksums           rmd160  282eef46808c00347588e16fc84a704dd639fece \
+                    sha256  a427d21e48112ea0860704d8cd071e1874cd566dc3f17760b4a54b86e4d16a2f \
+                    size    185077178
 
 use_configure       no
 
@@ -33,7 +32,13 @@ variant doc description {Build HTML docs} {}
 
 build {
     # See https://nim-lang.github.io/Nim/packaging.html
-    system -W ${worksrcpath} "./build.sh --os ${os.platform} --cpu ${os.arch}"
+    set nim_build_arch ${os.arch}
+    if {${build_arch} eq "arm64" } {
+        # nim looks for aarch64 and not arm/arm64
+        set nim_build_arch "aarch64"
+    }
+    system -W ${worksrcpath} "./build.sh --os ${os.platform} --cpu ${nim_build_arch}"
+
     system -W ${worksrcpath} "./bin/nim c koch"
     system -W ${worksrcpath} "./koch boot -d:release"
     system -W ${worksrcpath} "./koch tools -d:release"


### PR DESCRIPTION
#### Description

- updates nim to the latest release
- adds support for arm64/M1

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6 20G165 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
