### PR TITLE
ffmpeg/ffmpeg-devel: enable public binary publish

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -62,6 +62,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
+# Enable public binary publish
+license_noconflict  python39
+
 checksums           rmd160  ebb1f042b2ba4f13be86339d30522cd73eb6da3e \
                     sha256  eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02 \
                     size    9557516

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -62,6 +62,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
+# Enable public binary publish
+license_noconflict  python39
+
 checksums           rmd160  ebb1f042b2ba4f13be86339d30522cd73eb6da3e \
                     sha256  eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02 \
                     size    9557516


### PR DESCRIPTION
#### Description

Per the following commit discussion, public binaries for these two ports have been blocked since `glib2` was updated to 2.62.6. That's because the latter is now dependent on Python 3.9. However, it's not 100% clear whether that should prevent binary distribution:

https://github.com/macports/macports-ports/commit/c2dfd7f59fd6e10d26e6fdef9245cc44eab56ad0#commitcomment-55609268

This PR serves as a formal opportunity for review and discussion. And if folks agree that MacPorts can distribute binaries for these ports, then the changes will also enable that.

Present state of these ports:
```
macports-infra$ jobs/port_binary_distributable.tcl -v ffmpeg
"ffmpeg" is not distributable because its license "GPL" conflicts with license "OpenSSL": librsvg -> glib2 -> python39 -> openssl -> openssl11
"ffmpeg" is not distributable because its license "GPL" conflicts with license "SSLeay": librsvg -> glib2 -> python39 -> openssl -> openssl11
```

After making the change:
```
macports-infra$ jobs/port_binary_distributable.tcl -v ffmpeg
"ffmpeg" is distributable
```

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?