### PR TITLE
jake / npm5: Remove references to deleted nodejs6 port

### DIFF
--- a/devel/jake/Portfile
+++ b/devel/jake/Portfile
@@ -22,12 +22,6 @@ checksums           rmd160  6c854bac3652902cb4c4bacb2dca8023bb43da2b \
 depends_lib         path:bin/node:nodejs10
 depends_build       path:bin/npm:npm6
 
-platform darwin {
-    if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs10 path:bin/node:nodejs6
-    }
-}
-
 use_configure       no
 
 destroot.args       PREFIX=${prefix}

--- a/devel/npm5/Portfile
+++ b/devel/npm5/Portfile
@@ -37,12 +37,6 @@ worksrcdir          "package"
 
 depends_lib         path:bin/node:nodejs8
 
-platform darwin {
-    if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs8 path:bin/node:nodejs6
-    }
-}
-
 use_configure       no
 
 patchfiles          patch-lib-update.js.diff


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/63757

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
