### PR TITLE
py-parsing: enable pep517 build

### DIFF
--- a/python/py-parsing/Portfile
+++ b/python/py-parsing/Portfile
@@ -40,6 +40,16 @@ if {${name} ne ${subport}} {
         checksums   rmd160  2dbbca645985bb7f4b4d7a36b6ba3958302adfb9 \
                     sha256  c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
                     size    649718
+    } else {
+        python.pep517   yes
+        depends_build-append    port:py${python.version}-wheel
+        # break circular dependency with py-build
+        python.add_dependencies no
+        depends_build-append   port:py-bootstrap-modules
+        depends_lib-append     port:python${python.version}
+        build.env-append    PYTHONPATH=${prefix}/share/py-bootstrap-modules
+        build.args      --skip-dependency-check
+        destroot.env-append PYTHONPATH=${prefix}/share/py-bootstrap-modules
     }
 
     test.run        yes


### PR DESCRIPTION
This is one of the dependencies of py-build, so it needs to use py-bootstrap-modules to avoid circular dependencies.