### PR TITLE
py-wheel: enable pep517 build

### DIFF
--- a/python/py-wheel/Portfile
+++ b/python/py-wheel/Portfile
@@ -26,8 +26,7 @@ python.versions     27 34 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools \
-                    port:py${python.version}-setuptools_scm
+                    port:py${python.version}-setuptools
 
     if {${python.version} == 34} {
         version     0.33.6
@@ -38,6 +37,17 @@ if {${name} ne ${subport}} {
 
         depends_run-append \
                     port:py${python.version}-setuptools
+    }
+    if {${python.version} >= 36} {
+        python.pep517   yes
+        # break circular dependency with py-build
+        python.add_dependencies no
+        depends_build-append   port:py-bootstrap-modules \
+                               port:py${python.version}-python-install
+        depends_lib-append     port:python${python.version}
+        build.env-append    PYTHONPATH=${prefix}/share/py-bootstrap-modules
+        build.args      --skip-dependency-check
+        destroot.env-append PYTHONPATH=${prefix}/share/py-bootstrap-modules
     }
 
     livecheck.type  none


### PR DESCRIPTION
Also remove setuptools_scm dependency. The change that required it was
reverted upstream in version 0.34.1.
