### PR TITLE
fzy: Use makefile port group

### DIFF
--- a/devel/fzy/Portfile
+++ b/devel/fzy/Portfile
@@ -1,8 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem          1.0
+PortGroup           makefile 1.0
 PortGroup           github 1.0
 
 github.setup        jhawthorn fzy 1.0
+revision            1
 categories          devel
 platforms           darwin
 license             MIT
@@ -18,7 +20,4 @@ checksums           rmd160  2ede1ebddd76596fbc49d4b57c9843ad8e192a89 \
                     sha256  e27f6f65ced83615b95885f85f18af64a86810c98c457acc456a2cffdf0a7809 \
                     size    47458
 
-use_configure       no
-build.args-append   CC="${configure.cc} [get_canonical_archflags cc]"
-destroot.destdir    DESTDIR=${destroot} PREFIX=${prefix}
 test.run            yes


### PR DESCRIPTION
#### Description

The side effect of this change is that the universal variant now works.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
