### PR TITLE
py-zipp: enable pep517 build

### DIFF
--- a/python/py-zipp/Portfile
+++ b/python/py-zipp/Portfile
@@ -41,6 +41,15 @@ if {${name} ne ${subport}} {
         if {${python.version} < 34} {
             depends_lib-append  port:py${python.version}-contextlib2
         }
+    } else {
+        python.pep517   yes
+        # break circular dependency with python-install
+        python.add_dependencies no
+        depends_build-append   port:py-bootstrap-modules
+        depends_lib-append     port:python${python.version}
+        build.env-append    PYTHONPATH=${prefix}/share/py-bootstrap-modules
+        build.args      --skip-dependency-check
+        destroot.env-append PYTHONPATH=${prefix}/share/py-bootstrap-modules
     }
 
     livecheck.type      none


### PR DESCRIPTION
This is an indirect dependency of py36-python-install, so it needs to use py-bootstrap-modules to avoid circular dependencies.