### PR TITLE
py-typing_extensions: enable pep517 build

### DIFF
--- a/python/py-typing_extensions/Portfile
+++ b/python/py-typing_extensions/Portfile
@@ -6,7 +6,7 @@ PortGroup python 1.0
 name                py-typing_extensions
 version             3.10.0.2
 license             PSF
-platforms           darwin
+supported_archs     noarch
 maintainers         {toby @tobypeterson} openmaintainer
 description         Backported and Experimental Type Hints for Python
 long_description    The typing module was added to the standard library in Python 3.5 \
@@ -19,8 +19,6 @@ long_description    The typing module was added to the standard library in Pytho
                     added to the typing module, such as Protocol or TypedDict.
 
 homepage            https://github.com/python/typing/blob/master/typing_extensions/README.rst
-master_sites        pypi:t/typing_extensions
-distname            typing_extensions-${version}
 
 checksums           rmd160  b9ba0200913df912b7cb026177a7dc428880b180 \
                     sha256  49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e \
@@ -28,10 +26,17 @@ checksums           rmd160  b9ba0200913df912b7cb026177a7dc428880b180 \
 
 python.versions     36 37 38 39 310
 
+python.pep517       yes
+
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
+    # break circular dependency with py-python-install
+    python.add_dependencies no
+    depends_build-append   port:py-bootstrap-modules
+    depends_lib-append     port:python${python.version}
+    build.env-append    PYTHONPATH=${prefix}/share/py-bootstrap-modules
+    build.args      --skip-dependency-check
+    destroot.env-append PYTHONPATH=${prefix}/share/py-bootstrap-modules
 
     livecheck.type          none
-} else {
-    livecheck.type          pypi
 }


### PR DESCRIPTION
Also mark noarch and remove some redundant options.
