### PR TITLE
py-importlib-metadata: enable pep517 build

### DIFF
--- a/python/py-importlib-metadata/Portfile
+++ b/python/py-importlib-metadata/Portfile
@@ -59,5 +59,16 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-typing_extensions
     }
 
+    if {${python.version} >= 36} {
+        python.pep517   yes
+        # break circular dependency with python-install
+        python.add_dependencies no
+        depends_build-append   port:py-bootstrap-modules
+        depends_lib-append     port:python${python.version}
+        build.env-append    PYTHONPATH=${prefix}/share/py-bootstrap-modules
+        build.args      --skip-dependency-check
+        destroot.env-append PYTHONPATH=${prefix}/share/py-bootstrap-modules
+    }
+
     livecheck.type      none
 }


### PR DESCRIPTION
This is a dependency of py-python-install with some python versions, so it needs to use py-bootstrap-modules to avoid circular deps.