### PR TITLE
py-importlib-resources: enable pep517 build

### DIFF
--- a/python/py-importlib-resources/Portfile
+++ b/python/py-importlib-resources/Portfile
@@ -74,6 +74,19 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-zipp
     }
 
+    if {${python.version} >= 36} {
+        depends_build-append \
+                    port:py${python.version}-setuptools_scm
+        python.pep517   yes
+        # break circular dependency with python-install
+        python.add_dependencies no
+        depends_build-append   port:py-bootstrap-modules
+        depends_lib-append     port:python${python.version}
+        build.env-append    PYTHONPATH=${prefix}/share/py-bootstrap-modules
+        build.args      --skip-dependency-check
+        destroot.env-append PYTHONPATH=${prefix}/share/py-bootstrap-modules
+    }
+
     test.run        yes
     test.cmd        ${python.bin} -m unittest discover
     test.target


### PR DESCRIPTION
Also add missing setuptools_scm dep.

This is a dependency of py-python-install with some python versions, so it needs to use py-bootstrap-modules to avoid circular deps.