### PR TITLE
google-cloud-sdk: update to 363.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             362.0.0
+version             363.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4b35be0689415e66a61f2cc80df6f97b835840e4 \
-                    sha256  85cc2e84cce038f9b36a7e7334afa56d63481e3e9e8ab9bb933348173a4cd229 \
-                    size    96501233
+    checksums       rmd160  d63cd0a938b7d00c6272ab6c831bf1926db4e6d7 \
+                    sha256  b3c9cba3911f070570761e966d5565b27d9d94d2d534589f3927f77fd35b626e \
+                    size    96653259
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  32781b633339c5136e5648c69c4dec2bfaa8bb76 \
-                    sha256  ac85bbd5db9da19d5ac6cff2a3dd495edc122314a9f3788ffe67ff677db643a7 \
-                    size    92773093
+    checksums       rmd160  53623731c0c4acc0e6e9997bc50af4eab4dde152 \
+                    sha256  8fff2401f9a2ac2dee0ef335ac2273a2d6178f2ef8c3632981b80571a513553f \
+                    size    92924270
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  22fd604bdd57144810482bec315964b75b5b77b8 \
-                    sha256  7f9436df532b55b1bd9b9c51eb82665fdd363d5c72cd78ac6a0fdc9cfbbcf0c6 \
-                    size    92697158
+    checksums       rmd160  18e447192c36d3988b525da5fc048aa2976eb74d \
+                    sha256  647b2fe9930a58d0505913aabef6f9b72632df947be7fcd5301985fe90f35048 \
+                    size    92851536
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 363.0.0.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?