### PR TITLE
redis: update to 6.2.6

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -10,7 +10,7 @@ PortGroup           makefile 1.0
 legacysupport.newest_darwin_requires_legacy 15
 
 name                redis
-version             6.2.5
+version             6.2.6
 categories          databases
 platforms           darwin
 license             BSD
@@ -24,9 +24,9 @@ set redis_domain    redis.io
 homepage            https://${redis_domain}
 master_sites        https://download.${redis_domain}/releases/
 
-checksums           rmd160  1c0d20f2c57d2cb0918e58b36a584ecaa3d8d9b0 \
-                    sha256  4b9a75709a1b74b3785e20a6c158cab94cf52298aa381eea947a678a60d551ae \
-                    size    2465302
+checksums           rmd160  98607041365692d7feb19bf861b4bb32e799047e \
+                    sha256  5b2b8b7a50111ef395bf1c1d5be11e6e167ac018125055daa8b5c2317ae131ab \
+                    size    2476542
 
 patchfiles          patch-redis.conf.diff
 


### PR DESCRIPTION
#### Description

Tested locally with some simple redis-cli usage.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
