### PR TITLE
ruby22: fix build for Tiger/i386

### DIFF
--- a/lang/ruby22/Portfile
+++ b/lang/ruby22/Portfile
@@ -87,6 +87,9 @@ platform darwin {
     if {${os.major} < 10} {
         configure.args-append --disable-dtrace
     }
+    if {${os.major} == 8} {
+        patchfiles-append    patch-ruby22-tigeri386.diff
+    }
 }
 
 # Ignore minor version for archdir, like i686-darwin9.

--- a/lang/ruby22/files/patch-ruby22-tigeri386.diff
+++ b/lang/ruby22/files/patch-ruby22-tigeri386.diff
@@ -1,0 +1,39 @@
+Context registers on Tiger don't have double underscores.
+
+diff --git signal.c signal.c
+index 1bbf23d..5602a2e 100644
+--- signal.c
++++ signal.c
+@@ -773,9 +773,9 @@ check_stack_overflow(const uintptr_t addr, const ucontext_t *ctx)
+ #   endif
+ # elif defined __APPLE__
+ #   if defined(__LP64__)
+-    const uintptr_t sp = mctx->__ss.__rsp;
++    const uintptr_t sp = mctx->ss.rsp;
+ #   else
+-    const uintptr_t sp = mctx->__ss.__esp;
++    const uintptr_t sp = mctx->ss.esp;
+ #   endif
+ # elif defined __FreeBSD__
+ #   if defined(__amd64__)
+diff --git vm_dump.c vm_dump.c
+index 1a81f96..67e1866 100644
+--- vm_dump.c
++++ vm_dump.c
+@@ -13,6 +13,7 @@
+ #include "addr2line.h"
+ #include "vm_core.h"
+ #include "iseq.h"
++#include <ucontext.h>
+ 
+ /* see vm_insnhelper.h for the values */
+ #ifndef VMDEBUG
+@@ -836,7 +837,7 @@ print_machine_register(size_t reg, const char *reg_name, int col_count, int max_
+ # ifdef __linux__
+ #   define dump_machine_register(reg) (col_count = print_machine_register(mctx->gregs[REG_##reg], #reg, col_count, 80))
+ # elif defined __APPLE__
+-#   define dump_machine_register(reg) (col_count = print_machine_register(mctx->__ss.__##reg, #reg, col_count, 80))
++#   define dump_machine_register(reg) (col_count = print_machine_register(mctx->ss.reg, #reg, col_count, 80))
+ # endif
+ 
+ static void


### PR DESCRIPTION
#### Description

Patch adapted from @kencu's TigerPorts

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
