### PR TITLE
syncthing: update to 1.18.4

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.18.3 v
+go.setup            github.com/syncthing/syncthing 1.18.4 v
 revision            0
 categories          net
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  fa463500bd18a2319e7ada276447cd24620d7083 \
-                        sha256  1e2cc4613a8c58d563fb28ee947e886d482ffdc21ce4e790cb6c66b1711b6824 \
-                        size    6153389
+                        rmd160  4135ce51b5373d38a5bbad956476425cb72c4564 \
+                        sha256  9b6dbfcfdc2d46cfebbec42395da4029ea1b809a60d3ececc62996e1c3123117 \
+                        size    6168695
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    496545a6307b \


### PR DESCRIPTION
#### Description

Updates syncthing to 1.18.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
