### PR TITLE
josm: update to 18303

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18193
+version             18303
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -17,11 +17,11 @@ long_description    ${name} is a feature-rich editor for the \
 homepage            https://josm.openstreetmap.de
 
 master_sites        ${homepage}/download/macosx/
-distname            josm-macos-${version}-java16
+distname            josm-macos-${version}-java17
 
-checksums           rmd160  c1050eebef935c6ecfee22048a53588ad6186a27 \
-                    sha256  3a80d7e6d3d32eb52019f05ad757455727ae5d26a2f1024d7902d6c28b7692c9 \
-                    size    75340212
+checksums           rmd160  5aa6488f7115a93e5661be101252f3815779a954 \
+                    sha256  b3c32e5dc0e5f83c235ceb5fea5b69c5849e084f51dbfc7d889b360686478173 \
+                    size    77640118
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2021-11-01: Stable release 18303](https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.10)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
