### PR TITLE
lagrange: update to 1.8.0

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.7.2 v
+github.setup        skyjake lagrange 1.8.0 v
 revision            0
 github.tarball_from releases
 categories          net gemini
@@ -20,12 +20,13 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  8f251bf3ff82e08fcc0f9c83e91368e947ae4fc6 \
-                    sha256  cac15e05397285f40283bb0dd2f14f3985906fb82e28909fa62c452a2fb827bb \
-                    size    22814543
+checksums           rmd160  cec5e31bc87526e59dd1470446f258528113ee49 \
+                    sha256  eff814565193b68726b04cf88e2c9c85d01c245175b40e73475565e10f6f571b \
+                    size    8477551
 
 depends_build-append \
-                    port:pkgconfig
+                    port:pkgconfig \
+                    port:zip
 depends_lib-append  port:fribidi \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:libsdl2 \
@@ -38,9 +39,6 @@ depends_lib-append  port:fribidi \
 
 compiler.c_standard 2011
 compiler.blacklist-append {clang < 800}
-
-configure.args-append "-DENABLE_HARFBUZZ_MINIMAL:BOOL=OFF"
-configure.args-append "-DENABLE_FRIBIDI_BUILD:BOOL=OFF"
 
 destroot {
     copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
