### PR TITLE
py-{xdis,spark_parser,uncompyle6}: update to latest version, add py310 subport

### DIFF
--- a/python/py-spark_parser/Portfile
+++ b/python/py-spark_parser/Portfile
@@ -5,7 +5,9 @@ PortGroup           python 1.0
 
 name                py-spark_parser
 version             1.8.9
+
 platforms           darwin
+supported_archs     noarch
 license             MIT
 maintainers         {khindenburg @kurthindenburg} openmaintainer
 
@@ -17,22 +19,25 @@ long_description \
     scanner which does its job by combining Python regular expressions.
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  8c9297dc69d81dbd4651b601c01d40e8027ebada \
                     sha256  a7bb97b97953fb8bf0cd8158d820b6467ef1e7f747738e82248ae4c824f1e25a \
                     size    118345
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-click
 
-    depends_test-append     port:py${python.version}-nose
-    test.run            yes
-    test.env            PYTHONPATH=${worksrcpath}/build/lib
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.dir        ${worksrcpath}/test
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-uncompyle6/Portfile
+++ b/python/py-uncompyle6/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-uncompyle6
-version             3.7.4
+version             3.8.0
 revision            0
 
 categories-append   devel
@@ -18,11 +18,11 @@ long_description    ${description}
 
 homepage            https://github.com/rocky/python-uncompyle6/
 
-checksums           rmd160  5b3eb3edff065c151ab240f7691d49a10ee78a2e \
-                    sha256  af8330861bf940e7a3ae0f06d129b8e645191a36bf73ca15ff51997a837d41f8 \
-                    size    2381166
+checksums           rmd160  1586db389d1b92bd33df1f67aad70c96de03393a \
+                    sha256  620633618f6dfc1f3e78187e220934d78ffc639c0e39daeca1fc535aab817014 \
+                    size    2453838
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     post-patch {

--- a/python/py-xdis/Portfile
+++ b/python/py-xdis/Portfile
@@ -2,11 +2,14 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0
 
-name                py-xdis
-version             5.0.11
 # Note if you update this, make sure it supports the newest versions
 # of pythonXY in magics.py
+github.setup        rocky python-xdis 6.0.2
+name                py-xdis
+revision            0
+
 platforms           darwin
 supported_archs     noarch
 license             GPL-2
@@ -23,15 +26,31 @@ long_description \
     (NYU) called ACOR that estimates the autocorrelation time \
     of time series data very quickly.
 
-homepage            https://github.com/rocky/python-xdis
+checksums           rmd160  fb5e2904c99ae71c1f3bdf5755cabc00cc14ad2b \
+                    sha256  6e86397ce07bbb7f39fb290b415a8cd3f9e599b57073947d749a76057ad0edb2 \
+                    size    242275
 
-checksums           rmd160  babd854eb5ad58793699f0c3fd690b4ddf68d10e \
-                    sha256  089740d8c4878ed6373f88972fa421c49f14006cbcdfb3fc90398ad85b3c6664 \
-                    size    235969
-
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
+    if {${python.version} == 27} {
+        git.branch  python-2.4-to-2.7
+        github.setup rocky python-xdis de128bbcf33bd2aa68637b0067fc9834b1147a18
+        version     6.0.2
+        revision    0
+        checksums   rmd160  db0901529fdd132c328ac03ca5fb10d1a68c67bf \
+                    sha256  e49577a7aed77741991a6fddbe469e1475f38358fa73e462532b0c6356b07757 \
+                    size    237791
+    } elseif {${python.version} == 35} {
+        git.branch  python-3.3-to-3.5
+        github.setup rocky python-xdis 51a9e59d9abfa5242dcae86db22cd206c85de07c
+        version     6.0.2
+        revision    0
+        checksums   rmd160  3f7085d6e0af0163306c1be1ca111e8923b05f10 \
+                    sha256  44dc53821cb2dcf4e18441826846cde6137633068b9348350a27cca22320402b \
+                    size    242499
+    }
+
     depends_lib-append  port:py${python.version}-click \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-six


### PR DESCRIPTION
#### Description
-  py-uncompyle6: update to 3.8.0, add py310 subport 
- py-spark_parser: add py310 subport, set `noarch`, switch to `pytest` as `nose` is deprecated and does not work under PY310
-  py-xdis: update to 6.0.2, add py310 

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
