### PR TITLE
fzf: Update to version 0.28.0

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/junegunn/fzf 0.27.3
+go.setup            github.com/junegunn/fzf 0.28.0
 revision            0
 
 categories          sysutils
@@ -14,9 +14,9 @@ description         A command-line fuzzy finder written in Go
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  958a1925d32233f51fe9b271dd94863062b39de8 \
-                        sha256  7845d581e94497a529eb0626ef74f360833ae0bc1769e9a4bb44bbd762c066c1 \
-                        size    202800 \
+                        rmd160  6925fd6c4456518cd9e6ecf2978a03849d543d3f \
+                        sha256  1deb7fad0a48d986ed2b573cb47fd4e2c37d93eb66abd44a8fec03b6674c86be \
+                        size    205793
 
 go.vendors          golang.org/x/text \
                         lock    v0.3.6 \


### PR DESCRIPTION
#### Description

See: https://github.com/junegunn/fzf/releases/tag/0.28.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
