### PR TITLE
beets-devel: update to 20211103

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,13 +39,13 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets 8fb1c03ca5a10abbf4eccd88b0499b533023c120
-    version         20211102
+    github.setup    beetbox beets 3b531811b982119c6e598433e413e8ca9f2ad068
+    version         20211103
     revision        0
 
-    checksums       rmd160  cc913ce6fb592d374f5c196c36a0db32d15c7bc1 \
-                    sha256  7bbe4a770e96015b92f5a5a0b97fad5bab31b2bd7d2a418b4c314cc7aa42d429 \
-                    size    1663855
+    checksums       rmd160  be782a980a9f3a53054cd22aeec05e929b2bf69f \
+                    sha256  1b4289eed1b63bb05450540dc3f8d31de981497196b49965e53623646e947abf \
+                    size    1665854
 
     depends_build-append \
                     port:py${python.version}-sphinx
@@ -64,7 +64,6 @@ if {${name} eq ${subport} || "${name}-devel" eq ${subport}} {
                     port:py${python.version}-discogs-client \
                     port:py${python.version}-flask \
                     port:py${python.version}-flask-cors \
-                    port:py${python.version}-gmusicapi \
                     port:py${python.version}-jellyfish \
                     port:py${python.version}-langdetect \
                     port:py${python.version}-last \
@@ -84,6 +83,7 @@ if {${name} eq ${subport} || "${name}-devel" eq ${subport}} {
 
     if {${name} eq ${subport}} {
         depends_lib-append \
+                    port:py${python.version}-gmusicapi \
                     port:py${python.version}-six
     }
 


### PR DESCRIPTION
-------

#### Description

@mascguy I guess that this port will build for all supported macOS ;)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->