### PR TITLE
privoxy: Default configuration for HTTP/2 keep alive behavior

### DIFF
--- a/www/privoxy/files/patch-config.diff
+++ b/www/privoxy/files/patch-config.diff
@@ -1,113 +1,15 @@
---- ./config	2021-10-06 21:08:43.000000000 -0400
-+++ ./config	2021-10-06 21:22:55.000000000 -0400
-@@ -259,7 +259,7 @@
- #
- #      No trailing "/", please.
- #
--confdir .
-+confdir @@PREFIX@@/etc/privoxy
- #
- #  2.2. templdir
- #  ==============
-@@ -344,7 +344,7 @@
- #
- #      No trailing "/", please.
- #
--logdir .
-+logdir @@PREFIX@@/var/log/privoxy
- #
- #  2.5. actionsfile
- #  =================
-@@ -385,6 +385,8 @@
- actionsfile match-all.action # Actions that are applied to all sites and maybe overruled later on.
- actionsfile default.action   # Main actions file
- actionsfile user.action      # User customizations
-+#actionsfile @@PREFIX@@/etc/adblock2privoxy/privoxy/ab2p.system.action
-+#actionsfile @@PREFIX@@/etc/adblock2privoxy/privoxy/ab2p.action
- #actionsfile regression-tests.action     # Tests for privoxy-regression-test
- #
- #  2.6. filterfile
-@@ -431,6 +433,8 @@
- #
- filterfile default.filter
- filterfile user.filter      # User customizations
-+#filterfile @@PREFIX@@/etc/adblock2privoxy/privoxy/ab2p.system.filter
-+#filterfile @@PREFIX@@/etc/adblock2privoxy/privoxy/ab2p.filter
- #
- #  2.7. logfile
- #  =============
-@@ -1363,6 +1367,7 @@
- #        forward  <[2-3][0-9a-f][0-9a-f][0-9a-f]:*>   .
- #
- #
-+
- #  5.2. forward-socks4, forward-socks4a, forward-socks5 and forward-socks5t
- #  =========================================================================
- #
-@@ -1704,7 +1709,7 @@
+--- ./config	2021-10-03 11:03:31.000000000 -0400
++++ ./config	2021-11-03 18:57:06.000000000 -0400
+@@ -1704,7 +1704,7 @@
  #
  #      keep-alive-timeout 300
  #
 -keep-alive-timeout 5
-+keep-alive-timeout 300
++#keep-alive-timeout 5
  #
  #  6.5. tolerate-pipelining
  #  =========================
-@@ -1747,7 +1752,7 @@
- #
- #      tolerate-pipelining 1
- #
--tolerate-pipelining 1
-+#tolerate-pipelining 1
- #
- #  6.6. default-server-timeout
- #  ============================
-@@ -1798,7 +1803,7 @@
- #
- #      default-server-timeout 60
- #
--#default-server-timeout 5
-+default-server-timeout 60
- #
- #  6.7. connection-sharing
- #  ========================
-@@ -1868,7 +1873,7 @@
- #
- #      connection-sharing 1
- #
--#connection-sharing 1
-+connection-sharing 1
- #
- #  6.8. socket-timeout
- #  ====================
-@@ -1900,7 +1905,7 @@
- #
- #      socket-timeout 300
- #
--socket-timeout 300
-+socket-timeout 60
- #
- #  6.9. max-client-connections
- #  ============================
-@@ -1962,7 +1967,7 @@
- #
- #      max-client-connections 256
- #
--#max-client-connections 256
-+max-client-connections 256
- #
- #  6.10. listen-backlog
- #  =====================
-@@ -2137,7 +2142,7 @@
- #      Privoxy will not compress buffered content below a certain
- #      length.
- #
--#enable-compression 1
-+enable-compression 1
- #
- #  6.14. compression-level
- #  ========================
-@@ -2466,9 +2471,9 @@
+@@ -2466,9 +2466,9 @@
  #
  #  Example:
  #
@@ -119,7 +21,7 @@
  #
  #  7.2. ca-cert-file
  #  ==================
-@@ -2625,9 +2630,9 @@
+@@ -2625,9 +2625,9 @@
  #      +-----------------------------------------------------+
  #  Example:
  #


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
