### PR TITLE
macos-fortress: Default configuration for HTTP/2 keep alive behavior

### DIFF
--- a/net/macos-fortress/files/privoxy-config.macports
+++ b/net/macos-fortress/files/privoxy-config.macports
@@ -1716,7 +1716,7 @@ split-large-forms 0
 #
 #      keep-alive-timeout 300
 #
-keep-alive-timeout 300
+#keep-alive-timeout 5
 #
 #  6.5. tolerate-pipelining
 #  =========================
@@ -1759,7 +1759,7 @@ keep-alive-timeout 300
 #
 #      tolerate-pipelining 1
 #
-#tolerate-pipelining 1
+tolerate-pipelining 1
 #
 #  6.6. default-server-timeout
 #  ============================
@@ -1810,7 +1810,7 @@ keep-alive-timeout 300
 #
 #      default-server-timeout 60
 #
-default-server-timeout 60
+#default-server-timeout 5
 #
 #  6.7. connection-sharing
 #  ========================
@@ -1880,7 +1880,7 @@ default-server-timeout 60
 #
 #      connection-sharing 1
 #
-connection-sharing 1
+#connection-sharing 1
 #
 #  6.8. socket-timeout
 #  ====================

--- a/net/macos-fortress/files/privoxy-config.patch
+++ b/net/macos-fortress/files/privoxy-config.patch
@@ -1,5 +1,5 @@
---- ./config	2021-10-23 04:48:06.000000000 -0400
-+++ ./config	2021-10-23 05:03:06.000000000 -0400
+--- ./config	2021-10-06 21:08:43.000000000 -0400
++++ ./config	2021-11-03 19:32:55.000000000 -0400
 @@ -192,6 +192,7 @@
  #      shown.
  #
@@ -8,30 +8,26 @@
  #
  #  1.4. proxy-info-url
  #  ====================
-@@ -385,8 +386,9 @@
+@@ -385,6 +386,9 @@
  actionsfile match-all.action # Actions that are applied to all sites and maybe overruled later on.
  actionsfile default.action   # Main actions file
  actionsfile user.action      # User customizations
--#actionsfile @PREFIX@/etc/adblock2privoxy/privoxy/ab2p.system.action
--#actionsfile @PREFIX@/etc/adblock2privoxy/privoxy/ab2p.action
 +actionsfile @PREFIX@/etc/macos-fortress/macos-fortress-hosts.action
 +actionsfile @PREFIX@/etc/adblock3privoxy/privoxy/ab2p.system.action
 +actionsfile @PREFIX@/etc/adblock2privoxy/privoxy/ab2p.action
  #actionsfile regression-tests.action     # Tests for privoxy-regression-test
  #
  #  2.6. filterfile
-@@ -433,8 +435,8 @@
+@@ -431,6 +435,8 @@
  #
  filterfile default.filter
  filterfile user.filter      # User customizations
--#filterfile @PREFIX@/etc/adblock2privoxy/privoxy/ab2p.system.filter
--#filterfile @PREFIX@/etc/adblock2privoxy/privoxy/ab2p.filter
 +filterfile @PREFIX@/etc/adblock2privoxy/privoxy/ab2p.system.filter
 +filterfile @PREFIX@/etc/adblock2privoxy/privoxy/ab2p.filter
  #
  #  2.7. logfile
  #  =============
-@@ -679,7 +681,7 @@
+@@ -675,7 +681,7 @@
  #      Note that Privoxy does not validate the specified hostname
  #      value.
  #
@@ -40,7 +36,7 @@
  #
  #  4. ACCESS CONTROL AND SECURITY
  #  ===============================
-@@ -788,7 +790,7 @@
+@@ -784,7 +790,7 @@
  #
  #        listen-address [::1]:8118
  #
@@ -49,15 +45,16 @@
  #
  #  4.2. toggle
  #  ============
-@@ -1367,6 +1369,11 @@
+@@ -1363,6 +1369,12 @@
  #        forward  <[2-3][0-9a-f][0-9a-f][0-9a-f]:*>   .
  #
  #
-+forward /      .                                                               
-+forward :443   .                                                               
-+                                                                               
-+# I2P                                                                          
-+#forward .i2p @PROXY_HOSTNAME@:4443                                            
- 
++forward /      .
++forward :443   .
++
++# I2P
++#forward .i2p @PROXY_HOSTNAME@:4443
++
  #  5.2. forward-socks4, forward-socks4a, forward-socks5 and forward-socks5t
  #  =========================================================================
+ #


### PR DESCRIPTION
* Make default privoxy config consistent with #12792

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
