### PR TITLE
dvdrtools: fix compile problems under 11.x and 12.x

### DIFF
--- a/sysutils/dvdrtools/Portfile
+++ b/sysutils/dvdrtools/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                dvdrtools
 version             0.2.1
+revision            1
 categories          sysutils
 license             GPL-2
 platforms           darwin
@@ -25,7 +26,8 @@ platform darwin {
                     "LIBS=-framework CoreFoundation -framework IOKit"
         patchfiles  patch-scsi-mac-iokit.c.diff \
                     patch-cdda2wav-cdda2wav.c.diff \
-                    patch-cdrecord-cdrecord.c.diff
+                    patch-cdrecord-cdrecord.c.diff \
+                    patch-fix-missing-include.diff
 }
 
 configure.args      --mandir=${prefix}/share/man

--- a/sysutils/dvdrtools/files/patch-fix-missing-include.diff
+++ b/sysutils/dvdrtools/files/patch-fix-missing-include.diff
@@ -1,0 +1,10 @@
+--- cdrecord/fifo.c.orig	2003-12-12 00:22:32.000000000 +0100
++++ cdrecord/fifo.c	2021-11-05 21:02:07.000000000 +0100
+@@ -684,6 +684,7 @@
+ #include <standard.h>
+ #include <utypes.h>	/* includes sys/types.h */
+ 
++#include <schily.h>
+ #include "cdrecord.h"
+ 
+ EXPORT	void	init_fifo	__PR((long));


### PR DESCRIPTION
#### Description

Under 11.x and 12.x dvdrtools (like lot's of other ports too) requires '-Wno-implicit-function-declaration', so i've added it.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1
Xcode 13.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
