### PR TITLE
pkcs11-helper: update to 1.27 and patch to fix compile problems

### DIFF
--- a/security/pkcs11-helper/Portfile
+++ b/security/pkcs11-helper/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        OpenSC pkcs11-helper 1.25.1 pkcs11-helper-
-revision            1
+github.setup        OpenSC pkcs11-helper 1.27 pkcs11-helper-
+revision            0
 categories          security
 platforms           darwin freebsd
 license             GPL-2+ BSD
@@ -13,12 +13,14 @@ maintainers         nomaintainer
 description         Library that simplifies the interaction with PKCS#11 providers for end-user applications using a simple API and optional OpenSSL engine
 long_description    ${description}
 
-checksums           rmd160  1410b29ebe24434b5449c749d56cdb698fcfe639 \
-                    sha256  812ca21157aa9a3cb13954041ccfa0845d829f6ea5efbb22a05c07f59c5e2474 \
-                    size    114645
+checksums           rmd160  59c17287ec3ae4c4256364d45ec80d0621b911c5 \
+                    sha256  792d7b1ad6e681145b2b3d22cb88afcc43d597761a53d7475ef36ccbdb64d709 \
+                    size    115333
 
 depends_lib         port:gnutls \
                     port:pkgconfig \
                     path:lib/libssl.dylib:openssl
 
 use_autoreconf      yes
+
+patchfiles          patch-nssfix.diff

--- a/security/pkcs11-helper/files/patch-nssfix.diff
+++ b/security/pkcs11-helper/files/patch-nssfix.diff
@@ -1,0 +1,18 @@
+Fixing compile errors when libnss are too new.
+https://bugs.gentoo.org/794790
+https://web.archive.org/web/20211105202719/https://bugs.gentoo.org/show_bug.cgi?id=794790
+https://www.mail-archive.com/pld-cvs-commit@lists.pld-linux.org/msg473706.html
+--- include/pkcs11-helper-1.0/pkcs11.h.orig	2020-11-17 19:38:56.000000000 +0100
++++ include/pkcs11-helper-1.0/pkcs11.h	2021-06-12 20:53:07.127234688 +0200
+@@ -1262,6 +1262,11 @@
+ 
+ #define NULL_PTR NULL
+ 
++typedef CK_RV (*CK_NSS_GetFIPSStatus)(CK_SESSION_HANDLE hSession,
++                                      CK_OBJECT_HANDLE hObject,
++                                      CK_ULONG ulOperationType,
++                                      CK_ULONG *pulFIPSStatus);
++
+ /* Delete the helper macros defined at the top of the file.  */
+ #undef ck_flags_t
+ #undef ck_version


### PR DESCRIPTION
#### Description

I can not compile it under 12.0.1, so first i bumped the version to 1.27. Some of the problems are disappeared but one of it are still left. [I found a bugreport in the Gentoo's portage that are similar to mine.](https://bugs.gentoo.org/794790) The patch that i found here are worked, and i can now compile it under 12.0.1 with Xcode 13.1. 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1
Xcode 13.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
