### PR TITLE
ld64: avoid +llvm90 for ld64_xcode

### DIFF
--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -6,7 +6,7 @@ PortGroup               compiler_blacklist_versions 1.0
 name                    ld64
 epoch                   2
 version                 3
-revision                3
+revision                4
 set dyld_version        655.1.1
 categories              devel
 platforms               darwin
@@ -367,11 +367,11 @@ if {${subport} eq ${name}} {
             default_variants +llvm33
         }
 
-        if {![some_llvm_variant_set] && ${os.major} >= 9} {
+        if {![some_llvm_variant_set] && ![variant_isset ld64_xcode] && ${os.major} >= 9} {
             default_variants +llvm90
         }
 
-        if {![some_llvm_variant_set] && ${os.major} >= 9} {
+        if {![some_llvm_variant_set] && ![variant_isset ld64_xcode] && ${os.major} >= 9} {
             pre-fetch {
                 ui_error "Your platform cannot be configured without LTO support in ld64.  Please enable one of the llvmXX variants, and try again."
                 return -code error "Your platform cannot be configured without LTO support in ld64.  Please enable one of the llvmXX variants, and try again."

--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -23,21 +23,27 @@ long_description        ld64 combines several object files and libraries, \
 checksums           dyld-655.1.1.tar.gz \
                     rmd160  eef3ce30381e5fa23152c637e3bde2d8cf4cde0b \
                     sha256  8ca6e3cf0263d3f69dfa65e0846e2bed051b0cff92e796352ad178e7e4c92f1d \
+                    size    907171 \
                     ld64-97-standalone-libunwind-headers.patch \
                     rmd160  f6da71e097aa61b1055b3fdc12cd39aafed5f492 \
                     sha256  370d02757ea628b5dd145c099e42fc4eb88cc09cf459a59e32d14bbc9b4a105e \
+                    size    141802 \
                     ld64-97.17.tar.gz \
                     rmd160  d52df7d7f741c8bedd29cbac73dbb9db992b4795 \
                     sha256  02bd46af0809eaa415d096d7d41c3e8e7d80f7d8d181840866fb87f036b4e089 \
+                    size    421947 \
                     ld64-127.2.tar.gz \
                     rmd160  8ee709341549a1944732daef6ebab7ef1acfcc6e \
                     sha256  97b75547b2bd761306ab3e15ae297f01e7ab9760b922bc657f4ef72e4e052142 \
+                    size    496975 \
                     ld64-236.3.tar.gz \
                     rmd160  6a3f44aa9ae57a60d2cff5b3d47be7972ad83029 \
                     sha256  8ef36729b643201081ab45ebd8586ede8f9968bc17614b679a940faa82875ca6 \
+                    size    624400 \
                     ld64-274.2.tar.gz \
                     rmd160  16e57faf2b1d3f3808fb8e4b167cf23a14f106b0 \
                     sha256  175d89c419e99d49a7a5f7e4196d3cef4c9e19cc17a425c332e86df6b516f7d7 \
+                    size    671652 \
                     ld64-450.3.tar.gz \
                     rmd160  4d263cff143228e021c438d3c2d1800ff367c895 \
                     sha256  140619e676e099581771dbad98277850ff731cd23938bed95b4d7171616acca1 \
@@ -261,7 +267,7 @@ if {${subport} eq ${name}} {
     # advanced users running darwin 10 to darwin 15 at present will have to manually upgrade to ld64_latest to get the newest ld64
     # it might be possible to work around this using a bootstrap install of ld64, or a wrapper script that calls the newest ld64 installed
 
-    # darwin 16 and 17 can build libtapi but their xcode comes with an older ld64 than ld64_latest, 
+    # darwin 16 and 17 can build libtapi but their xcode comes with an older ld64 than ld64_latest,
     # so they default to ld64_latest to get the newest ld64
 
     # Xcode 11 has a newer ld64 than the current ld64_latest


### PR DESCRIPTION
#### Description

Avoid forcing `llvm-9.0` when `ld64` defaults to `+ld64_xcode`

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
