### PR TITLE
ifeffit: patches to compile on Catalina

### DIFF
--- a/science/ifeffit/Portfile
+++ b/science/ifeffit/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           compilers 1.0
 
 github.setup        newville ifeffit 1.2.13
-revision            7
+revision            8
 categories          science
 platforms           darwin
 license             Permissive
@@ -14,18 +14,23 @@ maintainers         {nist.gov:joe.fowler @joefowler} openmaintainer
 description         IFEFFIT is a program and programming library for analyzing x-ray absorption fine-structure (XAFS) data.
 
 long_description    ${description} \
-                    As its name may suggest, IFEFFIT1 gives an interactive method for fitting XAFS data using calculations \
-                    from FEFF, and is based on the fitting program FEFFIT of the UWXAFS3.0 Analysis Package.
+    IFEFFIT1 gives an interactive method for fitting XAFS data using calculations from \
+    FEFF. It is based on the fitting program FEFFIT of the UWXAFS3.0 Analysis Package. \
+    It is NOT actively maintained since 2014. Consider port py-xraylarch as a replacement.
 
 homepage            http://cars.uchicago.edu/ifeffit
 
 checksums           rmd160  7b09aa5722a4aa638364c35e15d64b857cdb822b \
-                    sha256  79fa938643a1417c5b01be4b6196bd0ea6bf40685448ba98546c7989b0f48a48
+                    sha256  79fa938643a1417c5b01be4b6196bd0ea6bf40685448ba98546c7989b0f48a48 \
+                    size    4238666
 
 depends_lib         port:pgplot \
                     port:libpng \
                     port:ncurses \
                     port:xorg-libX11
+
+# Patches needed to compile under recent Xcode. See https://trac.macports.org/ticket/61570
+patchfiles          implicit.patch
 
 # the ifeffit script to determine pgplot's linking options is broken
 # so we have to supply them explicitly

--- a/science/ifeffit/files/implicit.patch
+++ b/science/ifeffit/files/implicit.patch
@@ -1,0 +1,63 @@
+--- src/cmdline/Makefile.in.orig	2021-11-04 09:14:27.000000000 -0600
++++ src/cmdline/Makefile.in	2021-11-04 09:15:36.000000000 -0600
+@@ -81,13 +81,13 @@
+ PGPLOT_LIBS = @PGPLOT_LIBS@
+ RANLIB = @RANLIB@
+ VERSION = @VERSION@
+-TERMCAP_LIB = @TERMCAP_LIB@
++TERMCAP_LIB = 
+ canonical_host_type = @canonical_host_type@
+ 
+ bin_PROGRAMS = ifeffit
+ ifeffit_SOURCES = iff_shell.c ifeffit.h commands.h
+ # readline_LIB = -L$(top_srcdir)/readline -lreadline $(TERMCAP_LIB)
+-readline_LIB =  $(top_srcdir)/readline/libreadline.a $(TERMCAP_LIB)
++readline_LIB =  $(top_srcdir)/readline/libreadline.a $(TERMCAP_LIB) -lncurses
+ ### -ltermcap
+ 
+ ifeffit_LDADD = ../lib/libifeffit.a  $(PGPLOT_LIBS) $(readline_LIB) $(MN_FLIBS)
+--- readline/rltty.c.orig	2021-11-04 08:24:08.000000000 -0600
++++ readline/rltty.c	2021-11-04 08:24:18.000000000 -0600
+@@ -37,9 +37,7 @@
+ 
+ #include "rldefs.h"
+ 
+-#if defined (GWINSZ_IN_SYS_IOCTL)
+-#  include <sys/ioctl.h>
+-#endif /* GWINSZ_IN_SYS_IOCTL */
++#include <sys/ioctl.h>
+ 
+ #include "rltty.h"
+ #include "readline.h"
+--- readline/terminal.c.orig	2021-11-04 08:34:16.000000000 -0600
++++ readline/terminal.c	2021-11-04 08:34:28.000000000 -0600
+@@ -51,9 +51,7 @@
+ /* System-specific feature definitions and include files. */
+ #include "rldefs.h"
+ 
+-#if defined (GWINSZ_IN_SYS_IOCTL) && !defined (TIOCGWINSZ)
+-#  include <sys/ioctl.h>
+-#endif /* GWINSZ_IN_SYS_IOCTL && !TIOCGWINSZ */
++#include <sys/ioctl.h>
+ 
+ #include "rltty.h"
+ #include "tcap.h"
+--- src/cmdline/iff_shell.c.orig	2021-11-04 08:40:28.000000000 -0600
++++ src/cmdline/iff_shell.c	2021-11-04 08:46:23.000000000 -0600
+@@ -57,11 +57,16 @@
+ typedef int Function ();
+ #endif 
+ 
++#ifdef HAVE_UNISTD_H
++#  include <unistd.h> /* for chdir and getcwd */
++#endif
++
+ 
+ int   sys_exec(), sys_help();
+ int   com_list(), com_more();
+ int    com_pwd(), com_cd();
+ int   iff_load_file(), write_history_file();
++int   execute_line(char *);
+ char  *stripwhite(), *progname, *home;
+ static char comstr[1024], line_ex[1024], hist_file[512];
+ void   initialize_readline();


### PR DESCRIPTION
#### Description

`ifeffit` won't compile under latest OS X, including Big Sur and Catalina. These patches add the right `#include` statements to work with the latest organization of include files, libraries, and compilers. 

Fixes https://trac.macports.org/ticket/61570

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
