### PR TITLE
Update to OpenSSL 3 by default

### DIFF
--- a/_resources/port1.0/group/openssl-1.0.tcl
+++ b/_resources/port1.0/group/openssl-1.0.tcl
@@ -27,7 +27,7 @@ default openssl_cache_configure    ""
 proc openssl::default_branch {} {
     # NOTE - Whenever the default branch is bumped, the revision
     # in the openssl shim port should be reset back to 0.
-    return 1.1
+    return 3
 }
 
 proc openssl::branch {} {

--- a/aqua/Chmox/Portfile
+++ b/aqua/Chmox/Portfile
@@ -3,7 +3,7 @@ PortGroup xcode 1.0
 
 name		Chmox
 version		0.4
-revision	4
+revision	5
 categories	aqua textproc
 maintainers	nomaintainer
 description	Read CHM documents on your Mac

--- a/aqua/DateLine/Portfile
+++ b/aqua/DateLine/Portfile
@@ -3,7 +3,7 @@ PortGroup               xcode 1.0
 
 name                    DateLine
 version                 0.61
-revision                2
+revision                3
 categories-append       amusements
 maintainers             nomaintainer
 description             displays linear calendar on desktop

--- a/aqua/MacBiff/Portfile
+++ b/aqua/MacBiff/Portfile
@@ -3,7 +3,7 @@ PortGroup               xcode 1.0
 
 name                    MacBiff
 version                 1.1.16
-revision                1
+revision                2
 categories              aqua net
 supported_archs         i386 x86_64
 maintainers             nomaintainer

--- a/aqua/barrier/Portfile
+++ b/aqua/barrier/Portfile
@@ -7,6 +7,7 @@ PortGroup           qt5 1.0
 PortGroup           app 1.0
 
 github.setup        debauchee barrier 2.3.3 v
+revision            1
 categories          aqua net sysutils
 platforms           darwin
 license             GPL-2

--- a/aqua/osx2x/Portfile
+++ b/aqua/osx2x/Portfile
@@ -6,7 +6,7 @@ PortGroup       xcode 1.0
 name            osx2x
 version         2.4.0
 set my_version  2.4
-revision        8
+revision        9
 set git_hash    3cc708236898ab789bb99a5fba7420ff76ede9f7
 license         BSD
 platforms       darwin

--- a/aqua/pgAdmin3/Portfile
+++ b/aqua/pgAdmin3/Portfile
@@ -5,7 +5,7 @@ PortGroup           wxWidgets 1.0
 
 name                pgAdmin3
 version             1.22.2
-revision            1
+revision            2
 
 categories          aqua
 maintainers         nomaintainer

--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -11,7 +11,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                qt4-mac
 version             4.8.7
-revision            12
+revision            13
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 categories          aqua

--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -169,7 +169,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtcharts {
@@ -919,7 +919,7 @@ foreach {module module_info} [array get modules] {
 
     subport ${name}-${module} {
 
-        distname        ${module}-${middle_name}-src-${version}
+        distname ${module}-${middle_name}-src-${version}
 
         revision ${revision_string}
 
@@ -1836,7 +1836,7 @@ foreach {sql_names sql_info} [array get sql_plugins] {
 
         PortGroup qmake5 1.0
 
-        distname        qtbase-${middle_name}-src-${version}
+        distname qtbase-${middle_name}-src-${version}
 
         revision ${revision_string}
 
@@ -1916,10 +1916,10 @@ foreach {sql_names sql_info} [array get sql_plugins] {
 subport ${name}-docs {
     # meta-port to install documentation for various modules
 
-    revision            0
+    revision          0
 
-    description         Documentation for Qt Tool Kit ${qt_major}
-    long_description    Documentation for Qt Tool Kit ${qt_major}
+    description       Documentation for Qt Tool Kit ${qt_major}
+    long_description  {*}${description}
 
     master_sites
     distfiles

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -164,7 +164,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 6"
+        "revision 7"
         "License: "
     }
     qtcanvas3d {
@@ -1715,10 +1715,10 @@ foreach {sql_names sql_info} [array get sql_plugins] {
 subport ${name}-docs {
     # meta-port to install documentation for various modules
 
-    revision            0
+    revision          0
 
-    description         Documentation for Qt Tool Kit ${qt_major}
-    long_description    Documentation for Qt Tool Kit ${qt_major}
+    description       Documentation for Qt Tool Kit ${qt_major}
+    long_description  {*}${description}
 
     master_sites
     distfiles

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -164,7 +164,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtcharts {
@@ -1734,10 +1734,10 @@ foreach {sql_names sql_info} [array get sql_plugins] {
 subport ${name}-docs {
     # meta-port to install documentation for various modules
 
-    revision            0
+    revision          0
 
-    description         Documentation for Qt Tool Kit ${qt_major}
-    long_description    Documentation for Qt Tool Kit ${qt_major}
+    description       Documentation for Qt Tool Kit ${qt_major}
+    long_description  {*}${description}
 
     master_sites
     distfiles

--- a/aqua/x2goclient/Portfile
+++ b/aqua/x2goclient/Portfile
@@ -7,7 +7,7 @@ qt4.debug_variant       no
 
 name                    x2goclient
 version                 4.1.2.2
-revision                0
+revision                1
 checksums               sha256  c9953267c40fa67119ad96a73bacb1f266196da2059f0cdcd1b8d5199421d12a \
                         rmd160  bc8d71587e5c278632150db0a84836963b791b3e \
                         size    2576404

--- a/archivers/dar/Portfile
+++ b/archivers/dar/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dar
 version             2.7.2
-revision            0
+revision            1
 checksums           rmd160  0a39355abc53699f54c6d49ea81d24302b4364f7 \
                     sha256  973fa977c19b32b1f9ecb62153c810ba8696f644eca048f214c77ad0e8eca255 \
                     size    2294187

--- a/archivers/minizip-ng/Portfile
+++ b/archivers/minizip-ng/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        zlib-ng minizip-ng 3.0.3
-revision            0
+revision            1
 checksums           rmd160  66ffb92ec13c31d9b1870d557ff20ab00ca0fc07 \
                     sha256  5f1dd0d38adbe9785cb9c4e6e47738c109d73a0afa86e58c4025ce3e2cc504ed \
                     size    638966

--- a/archivers/wimlib/Portfile
+++ b/archivers/wimlib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                wimlib
 version             1.13.4
-revision            0
+revision            1
 checksums           rmd160  3309c5b9a3107c448ea1cb8759829282f563d2ab \
                     sha256  4b87dd0ad9cc1a58cee5721afebb98011dab549e72f2b55533f315f08b2ede12 \
                     size    1040411

--- a/archivers/xar/Portfile
+++ b/archivers/xar/Portfile
@@ -6,7 +6,7 @@ PortGroup           clang_dependency 1.0
 name                xar
 set apple_version   452
 version             1.8.0.${apple_version}
-revision            0
+revision            1
 
 categories          archivers sysutils
 platforms           darwin freebsd linux

--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -7,7 +7,7 @@ github.setup            grame-cncm faust 96f22a55e86dac30cbf2e38ba115f5723ed6b09
 # When updating faust-devel to a new version, please rebuild faustlive-devel
 # simultaneously by increasing its revision or updating it to a new version.
 version                 2.11-20181109
-revision                1
+revision                2
 
 name                    faust-devel
 conflicts               faust

--- a/audio/faust/Portfile
+++ b/audio/faust/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            grame-cncm faust 2.5.23
-revision                1
+revision                2
 github.tarball_from     releases
 
 conflicts               faust-devel

--- a/audio/faustlive-devel/Portfile
+++ b/audio/faustlive-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            grame-cncm faustlive f7edb2ff41d4987fb302fbce51723616eb728f19
 version                 2.46-20181019
-revision                2
+revision                3
 
 name                    faustlive-devel
 categories              audio

--- a/audio/gmpc/Portfile
+++ b/audio/gmpc/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            gmpc
 version         11.8.16
-revision        4
+revision        5
 categories      audio
 platforms       darwin
 license         GPL-2+

--- a/audio/icecast2/Portfile
+++ b/audio/icecast2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                icecast2
 version             2.4.4
-revision            1
+revision            2
 categories          audio net
 license             GPL-2
 maintainers         nomaintainer

--- a/audio/libshout2/Portfile
+++ b/audio/libshout2/Portfile
@@ -5,7 +5,7 @@ PortSystem      1.0
 name            libshout2
 set my_name     [strsed ${name} {g/[0-9]//}]
 version         2.4.5
-revision        0
+revision        1
 checksums       rmd160  4605469f44989a65b163a1df8559ba3414fd7632 \
                 sha256  d9e568668a673994ebe3f1eb5f2bee06e3236a5db92b8d0c487e1c0f886a6890 \
                 size    543991

--- a/audio/opusfile/Portfile
+++ b/audio/opusfile/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                opusfile
 version             0.12
-revision            0
+revision            1
 categories          audio
 license             BSD
 platforms           darwin

--- a/audio/xmms2/Portfile
+++ b/audio/xmms2/Portfile
@@ -5,7 +5,7 @@ PortGroup               waf 1.0
 
 name                    xmms2
 version                 0.8DrO_o
-revision                22
+revision                23
 categories              audio
 # Mostly LGPL, some plugins and clients are GPL
 license                 LGPL-2.1+ GPL-2+ GPL-2

--- a/benchmarks/polygraph/Portfile
+++ b/benchmarks/polygraph/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    polygraph
 version                 4.3.2
-revision                3
+revision                4
 categories              benchmarks www
 platforms               darwin
 maintainers             nomaintainer

--- a/comms/c3270/Portfile
+++ b/comms/c3270/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                c3270
 version             3.3.15ga9
-revision            2
+revision            3
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          comms
 platforms           darwin

--- a/comms/sofia-sip/Portfile
+++ b/comms/sofia-sip/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            sofia-sip
 version         1.12.11
-revision        2
+revision        3
 license         LGPL-2.1
 categories      comms
 maintainers     nomaintainer

--- a/comms/telepathy-idle/Portfile
+++ b/comms/telepathy-idle/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            telepathy-idle
 version         0.2.0
-revision        3
+revision        4
 license         LGPL-2.1
 description     The ${name} IRC connection manager component of Telepathy - a Flexible Communications Framework
 

--- a/databases/duckdb/Portfile
+++ b/databases/duckdb/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.0
 
 github.setup        cwida duckdb 0.3.0 v
-revision            0
+revision            1
 
 homepage            https://www.duckdb.org
 

--- a/databases/libdrizzle/Portfile
+++ b/databases/libdrizzle/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                libdrizzle
 version             5.1.4
-revision            2
+revision            3
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          databases devel
 maintainers         nomaintainer

--- a/databases/libgda5/Portfile
+++ b/databases/libgda5/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 name                libgda5
 set gname           libgda
 version             5.2.9
-revision            4
+revision            5
 license             {GPL-2 LGPL}
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         GDA provides uniform access to different kinds of data sources.

--- a/databases/mariadb-10.2/Portfile
+++ b/databases/mariadb-10.2/Portfile
@@ -11,8 +11,8 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
-set revision_server 0
+set revision_client 1
+set revision_server 1
 categories          databases
 platforms           darwin
 license             GPL-2

--- a/databases/mariadb-10.3/Portfile
+++ b/databases/mariadb-10.3/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                mariadb-10.3
@@ -11,8 +11,8 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
-set revision_server 0
+set revision_client 1
+set revision_server 1
 categories          databases
 platforms           darwin
 license             GPL-2

--- a/databases/mariadb-10.4/Portfile
+++ b/databases/mariadb-10.4/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                mariadb-10.4
@@ -11,8 +11,8 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
-set revision_server 0
+set revision_client 1
+set revision_server 1
 categories          databases
 platforms           darwin
 license             GPL-2

--- a/databases/mariadb-10.5/Portfile
+++ b/databases/mariadb-10.5/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                mariadb-10.5
@@ -11,8 +11,8 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
-set revision_server 0
+set revision_client 1
+set revision_server 1
 categories          databases
 platforms           darwin
 license             GPL-2

--- a/databases/mariadb-10.6/Portfile
+++ b/databases/mariadb-10.6/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                mariadb-10.6
@@ -11,8 +11,8 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
-set revision_server 0
+set revision_client 1
+set revision_server 1
 categories          databases
 platforms           darwin
 license             GPL-2

--- a/databases/msodbcsql17/Portfile
+++ b/databases/msodbcsql17/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                msodbcsql17
 version             17.7.1.1
+revision            1
 categories          databases
 platforms           darwin
 supported_archs     x86_64

--- a/databases/mysql5/Portfile
+++ b/databases/mysql5/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 name                    mysql5
 version                 5.1.72
 # Please set revision_client and revision_server to 0 if you bump version.
-set revision_client     4
+set revision_client     5
 set revision_server     1
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
 homepage                https://www.mysql.com/

--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -12,8 +12,8 @@ set name_mysql      ${name}
 version             5.6.51
 # Set revision_client and revision_server to 0 on
 # version bump.
-set revision_client 0
-set revision_server 0
+set revision_client 1
+set revision_server 1
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 categories          databases
 platforms           darwin

--- a/databases/openldap-devel/Portfile
+++ b/databases/openldap-devel/Portfile
@@ -7,7 +7,7 @@ name                openldap-devel
 conflicts           openldap
 set my_name         openldap
 version             2.6.0
-revision            0
+revision            1
 categories          databases
 maintainers         {mascguy @mascguy} openmaintainer
 license             openldap

--- a/databases/openldap/Portfile
+++ b/databases/openldap/Portfile
@@ -7,7 +7,7 @@ name                openldap
 conflicts           openldap-devel
 set my_name         openldap
 version             2.4.58
-revision            0
+revision            1
 categories          databases
 maintainers         {mascguy @mascguy} openmaintainer
 license             openldap

--- a/databases/percona/Portfile
+++ b/databases/percona/Portfile
@@ -8,8 +8,8 @@ set name_package    ${name}-server
 set version_mysql   8.0.16
 set release         7
 # Please set revision_client and revision_server to 0 if you bump version_mysql or release.
-set revision_client 3
-set revision_server 1
+set revision_client 4
+set revision_server 2
 set boost_version   1.69.0
 version             ${version_mysql}-${release}
 categories          databases
@@ -22,7 +22,7 @@ if {$subport eq $name} {
 
     PortGroup           cmake 1.1
     PortGroup           select 1.0
-    PortGroup           legacysupport 1.0
+    PortGroup           legacysupport 1.1
 
     set version_branch  [join [lrange [split ${version} .] 0 1] .]
     set boost_distver   [join [split ${boost_version} .] _]

--- a/databases/pgbouncer/Portfile
+++ b/databases/pgbouncer/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 
 name                pgbouncer
 version             1.16.0
+revision            1
 categories          databases
 platforms           darwin
 license             ISC

--- a/databases/postgresql10/Portfile
+++ b/databases/postgresql10/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql10
 version             10.18
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin

--- a/databases/postgresql11/Portfile
+++ b/databases/postgresql11/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql11
 version             11.13
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin

--- a/databases/postgresql12/Portfile
+++ b/databases/postgresql12/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql12
 version             12.8
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin

--- a/databases/postgresql13/Portfile
+++ b/databases/postgresql13/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql13
 version             13.4
-revision            1
+revision            2
 
 categories          databases
 platforms           darwin

--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql14
 version             14.0
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin

--- a/databases/postgresql80/Portfile
+++ b/databases/postgresql80/Portfile
@@ -6,7 +6,7 @@ deprecated.upstream_support no
 
 name			postgresql80
 version			8.0.26
-revision  4
+revision  5
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql81/Portfile
+++ b/databases/postgresql81/Portfile
@@ -6,7 +6,7 @@ deprecated.upstream_support no
 
 name			postgresql81
 version			8.1.23
-revision  4
+revision  5
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql82/Portfile
+++ b/databases/postgresql82/Portfile
@@ -8,7 +8,7 @@ deprecated.upstream_support no
 
 name			postgresql82
 version			8.2.23
-revision  4
+revision  5
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql83/Portfile
+++ b/databases/postgresql83/Portfile
@@ -8,7 +8,7 @@ deprecated.upstream_support no
 
 name			postgresql83
 version			8.3.23
-revision  4
+revision  5
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql90/Portfile
+++ b/databases/postgresql90/Portfile
@@ -12,7 +12,7 @@ deprecated.upstream_support no
 #remember to update the -doc and -server as well
 name			postgresql90
 version			9.0.23
-revision		7
+revision		8
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql91/Portfile
+++ b/databases/postgresql91/Portfile
@@ -12,7 +12,7 @@ deprecated.upstream_support no
 #remember to update the -doc and -server as well
 name			postgresql91
 version			9.1.24
-revision		6
+revision		7
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql92/Portfile
+++ b/databases/postgresql92/Portfile
@@ -12,7 +12,7 @@ deprecated.upstream_support no
 #remember to update the -doc and -server as well
 name			postgresql92
 version			9.2.24
-revision        4
+revision        5
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql93/Portfile
+++ b/databases/postgresql93/Portfile
@@ -12,7 +12,7 @@ deprecated.upstream_support no
 #remember to update the -doc and -server as well
 name			postgresql93
 version			9.3.25
-revision			3
+revision			4
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql94/Portfile
+++ b/databases/postgresql94/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name			postgresql94
 version			9.4.26
-revision        0
+revision        1
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql95/Portfile
+++ b/databases/postgresql95/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name			postgresql95
 version			9.5.25
-revision        0
+revision        1
 
 categories		databases
 platforms		darwin

--- a/databases/postgresql96/Portfile
+++ b/databases/postgresql96/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql96
 version             9.6.23
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin

--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -11,6 +11,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                redis
 version             6.2.6
+revision            1
 categories          databases
 platforms           darwin
 license             BSD

--- a/databases/xeus-sqlite/Portfile
+++ b/databases/xeus-sqlite/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            jupyter-xeus xeus-sqlite 0.5.1
-revision                0
+revision                1
 categories              databases
 license                 BSD
 maintainers             {mps @Schamschula} openmaintainer

--- a/devel/apache-arrow/Portfile
+++ b/devel/apache-arrow/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           boost 1.0
 
 github.setup        apache arrow 3.0.0 apache-arrow-
-revision            13
+revision            14
 name                ${github.author}-${github.project}
 
 categories          devel

--- a/devel/capnproto/Portfile
+++ b/devel/capnproto/Portfile
@@ -6,7 +6,7 @@ PortGroup               legacysupport 1.1
 
 name                    capnproto
 version                 0.9.1
-revision                0
+revision                1
 checksums               rmd160  575ba0e6b24f27f3435179fb685dde4077e1b650 \
                         sha256  83680aaef8c192b884e38eab418b8482d321af6ae7ab7befa3a9370b8e716aad \
                         size    1664913

--- a/devel/cargo-c/Portfile
+++ b/devel/cargo-c/Portfile
@@ -5,7 +5,7 @@ PortGroup                   github 1.0
 PortGroup                   cargo  1.0
 
 github.setup                lu-zero cargo-c 0.7.3 v
-revision                    0
+revision                    1
 
 license                     MIT
 categories                  devel

--- a/devel/darwinbuild-legacy/Portfile
+++ b/devel/darwinbuild-legacy/Portfile
@@ -43,7 +43,7 @@ if {${os.platform} eq "darwin" && ${os.major} > 9} {
 
 # pick up the old revision number to continue the proper flow
 version             0.8.0
-revision            656
+revision            657
 
 
 build.post_args-append \

--- a/devel/eet/Portfile
+++ b/devel/eet/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 name                    eet
 epoch                   2
 version                 1.7.10
-revision                3
+revision                4
 maintainers             ryandesign openmaintainer
 categories              devel x11
 platforms               darwin

--- a/devel/fbopenssl/Portfile
+++ b/devel/fbopenssl/Portfile
@@ -3,7 +3,7 @@ PortSystem 1.0
 name             fbopenssl
 conflicts        kerberos5
 version          0.0.4
-revision         5
+revision         6
 categories       devel
 # COPYING missing from tarball, exists in upstream cvs
 license          Apache-2

--- a/devel/fbthrift/Portfile
+++ b/devel/fbthrift/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           boost 1.0
 
 github.setup        facebook fbthrift 2021.06.07.00 v
-revision            0
+revision            1
 categories          devel
 platforms           darwin
 license             Apache-2

--- a/devel/fizz/Portfile
+++ b/devel/fizz/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           boost 1.0
 
 github.setup        facebookincubator fizz 2021.06.07.00 v
-revision            0
+revision            1
 categories          devel
 platforms           darwin
 license             BSD

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -13,7 +13,7 @@ legacysupport.newest_darwin_requires_legacy 18
 legacysupport.use_mp_libcxx                 yes
 
 github.setup        facebook folly 2021.09.20.00 v
-revision            0
+revision            1
 
 categories          devel
 platforms           darwin

--- a/devel/fossil/Portfile
+++ b/devel/fossil/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fossil
 version             2.15.2
-revision            0
+revision            1
 epoch               20110901182519
 categories          devel
 platforms           darwin

--- a/devel/getdns/Portfile
+++ b/devel/getdns/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake   1.1
 
 name                getdns
 version             1.6.0
-revision            0
+revision            1
 
 categories          devel
 platforms           darwin

--- a/devel/ghsum/Portfile
+++ b/devel/ghsum/Portfile
@@ -11,7 +11,7 @@ perl5.default_branch    5.28
 perl5.create_variants   ${perl5.branches}
 
 github.setup        rodnaph ghsum 0.1.1
-revision            0
+revision            1
 categories          devel shells macports
 platforms           darwin
 maintainers         nomaintainer

--- a/devel/git-crypt/Portfile
+++ b/devel/git-crypt/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            AGWA git-crypt 0.6.0
-revision                2
+revision                3
 homepage                https://www.agwa.name/projects/git-crypt/
 categories              devel
 platforms               darwin

--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                git
 version             2.33.1
-revision            1
+revision            2
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \

--- a/devel/gitui/Portfile
+++ b/devel/gitui/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 
 github.setup        extrawurst gitui 0.18.0 v
 github.tarball_from archive
-revision            1
+revision            2
 
 description         Blazing fast terminal-ui for git written in Rust.
 

--- a/devel/gitweb/Portfile
+++ b/devel/gitweb/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        yoannfleurydev gitweb 0.3.3 v
-revision            1
+revision            2
 
 description         Open the current remote git repository in your browser
 

--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        grpc grpc 1.41.1 v
-revision            0
+revision            1
 categories          devel
 maintainers         nomaintainer
 license             Apache-2

--- a/devel/gsoap/Portfile
+++ b/devel/gsoap/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                gsoap
 version             2.8.66
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 categories          devel

--- a/devel/gwenhywfar4/Portfile
+++ b/devel/gwenhywfar4/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 
 name                gwenhywfar4
 version             4.20.2
+revision            1
 # this is specific to this port and *version* for downloading it
 set release         108
 

--- a/devel/gwenhywfar5/Portfile
+++ b/devel/gwenhywfar5/Portfile
@@ -8,6 +8,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        aqbanking gwenhywfar 5.7.3
+revision            1
 name                gwenhywfar5
 
 checksums           rmd160  80199ee1e6507dfa34b47416a1fd971957da6d43 \

--- a/devel/idevicerestore/Portfile
+++ b/devel/idevicerestore/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libimobiledevice idevicerestore 1.0.0
-revision            0
+revision            1
 
 categories          devel
 platforms           darwin
@@ -62,7 +62,7 @@ configure.cmd       ./autogen.sh
 subport idevicerestore-devel {
     github.setup    libimobiledevice idevicerestore 8ebee55718190c5bec5fb24128f2e3b986174397
     version         20200709
-    revision        0
+    revision        1
 
     checksums       rmd160  6a9819ea4cbf4385bcbf3b776728983c57f21838 \
                     sha256  ff7a74581c55f2348c1f5d4ef7190962173017f21bf92c030db4e6717ee90a19 \

--- a/devel/ldid/Portfile
+++ b/devel/ldid/Portfile
@@ -5,7 +5,9 @@ PortGroup           github 1.0
 
 name                ldid
 github.setup        sbingner ldid 458093e
+revision            1
 version             2.1.4
+revision            1
 # The actual 2.1.4 release has no Makefile
 categories          devel
 platforms           darwin

--- a/devel/libevent/Portfile
+++ b/devel/libevent/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libevent libevent 2.1.12 release- -stable
-revision            0
+revision            1
 checksums           rmd160  1fdb4e00ee9fc1be5e91f61ccaa63dd847e9b341 \
                     sha256  92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb \
                     size    1100847

--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -9,7 +9,7 @@ PortGroup           muniversal 1.0
 # don't forget to update py-pygit2 and libgit2-glib as well
 github.setup        libgit2 libgit2 1.3.0 v
 github.tarball_from archive
-revision            0
+revision            1
 epoch               1
 categories          devel
 platforms           darwin

--- a/devel/libhsplasma/Portfile
+++ b/devel/libhsplasma/Portfile
@@ -5,7 +5,7 @@ PortGroup                   cmake 1.0
 
 name                        libhsplasma
 version                     0.0-20111023
-revision        4
+revision        5
 categories                  devel
 platforms                   darwin
 maintainers                 ryandesign

--- a/devel/libimobiledevice/Portfile
+++ b/devel/libimobiledevice/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libimobiledevice libimobiledevice 1.3.0
-revision            0
+revision            1
 
 categories          devel
 platforms           darwin
@@ -50,7 +50,7 @@ configure.args      --disable-silent-rules \
 subport libimobiledevice-devel {
     github.setup    libimobiledevice libimobiledevice 333eb1aec92f02b0b61f9ec23880861b93d42c60
     version         20200618
-    revision        0
+    revision        1
 
     checksums       rmd160  27591925392cbc0ee4076ab02491b1d8e832f7bc \
                     sha256  127cb57199e4538eee7e8e01f711cb1cb53d73b70181b0ba6c37c8371ab4faca \

--- a/devel/libjwt/Portfile
+++ b/devel/libjwt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        benmcollins libjwt 1.9.0 v
-revision            1
+revision            2
 
 platforms           darwin
 categories          devel

--- a/devel/libmongo-client/Portfile
+++ b/devel/libmongo-client/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        algernon libmongo-client 0.1.8 libmongo-client-
-revision            2
+revision            3
 categories          devel
 platforms           darwin
 maintainers         ryandesign openmaintainer

--- a/devel/libmowgli-2/Portfile
+++ b/devel/libmowgli-2/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            atheme libmowgli-2 2.1.3 v
-revision                1
+revision                2
 categories              devel
 license                 ISC
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/devel/libpdel/Portfile
+++ b/devel/libpdel/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		libpdel
 version		0.6.1
-revision	1
+revision	2
 categories	devel www
 license		Permissive BSD
 maintainers	nomaintainer

--- a/devel/libretls/Portfile
+++ b/devel/libretls/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libretls
 version             3.4.1
-revision            0
+revision            1
 categories          devel
 platforms           darwin
 license             ISC

--- a/devel/libsockets/Portfile
+++ b/devel/libsockets/Portfile
@@ -3,7 +3,7 @@ PortGroup           muniversal 1.0
 
 name                libsockets
 version             2.3.9.9
-revision            2
+revision            3
 categories          devel net
 platforms           darwin
 license             GPL-2

--- a/devel/libssh/Portfile
+++ b/devel/libssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 name                libssh
 epoch               1
 version             0.9.6
-revision            0
+revision            1
 set major           [join [lrange [split ${version} .] 0 1] .]
 master_sites        https://www.libssh.org/files/${major}
 use_xz              yes

--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                libssh2
 version             1.9.0
-revision            0
+revision            1
 categories          devel net
 platforms           darwin
 maintainers         {wohner.eu:normen @Gminfly} openmaintainer

--- a/devel/libtins/Portfile
+++ b/devel/libtins/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        mfontanini libtins 4.2 v
+revision            1
 categories          devel net
 platforms           darwin
 license             BSD

--- a/devel/libwebsockets/Portfile
+++ b/devel/libwebsockets/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 
 github.setup        warmcat libwebsockets 4.3.0 v
 github.tarball_from archive
-revision            0
+revision            1
 categories          devel net
 platforms           darwin
 license             LGPL-2.1

--- a/devel/lua-luasec/Portfile
+++ b/devel/lua-luasec/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        brunoos luasec 0.6alpha luasec-
-revision            2
+revision            3
 name                lua-luasec
 categories          devel
 license             MIT

--- a/devel/mico/Portfile
+++ b/devel/mico/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                mico
 version             2.3.13
-revision            5
+revision            6
 homepage            http://www.mico.org/
 description         Fully compliant CORBA implementation
 long_description    MICO is a mature, secure, robust, fully \

--- a/devel/nodejs10/Portfile
+++ b/devel/nodejs10/Portfile
@@ -12,6 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs10
 version                 10.24.1
+revision            1
 
 categories              devel net
 platforms               darwin

--- a/devel/nodejs12/Portfile
+++ b/devel/nodejs12/Portfile
@@ -12,6 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs12
 version                 12.22.7
+revision            1
 
 categories              devel net
 platforms               darwin

--- a/devel/nodejs13/Portfile
+++ b/devel/nodejs13/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs13
 version                 13.14.0
-revision                1
+revision                2
 
 categories              devel net
 platforms               darwin

--- a/devel/nodejs14/Portfile
+++ b/devel/nodejs14/Portfile
@@ -12,6 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs14
 version                 14.18.1
+revision            1
 
 categories              devel net
 platforms               darwin

--- a/devel/nodejs15/Portfile
+++ b/devel/nodejs15/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs15
 version                 15.14.0
-revision                1
+revision                2
 
 categories              devel net
 platforms               darwin

--- a/devel/nodejs16/Portfile
+++ b/devel/nodejs16/Portfile
@@ -12,6 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs16
 version                 16.13.0
+revision            1
 
 categories              devel net
 platforms               darwin

--- a/devel/nodejs8/Portfile
+++ b/devel/nodejs8/Portfile
@@ -6,6 +6,7 @@ PortGroup               legacysupport 1.1
 
 name                    nodejs8
 version                 8.17.0
+revision            1
 
 categories              devel net
 platforms               darwin

--- a/devel/openslp/Portfile
+++ b/devel/openslp/Portfile
@@ -2,7 +2,7 @@ PortSystem      1.0
 
 name            openslp
 version         1.2.1
-revision        4
+revision        5
 categories      devel net
 license         BSD
 platforms       darwin

--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            4
+revision            0
 
 categories          devel security
 platforms           darwin

--- a/devel/osslsigncode/Portfile
+++ b/devel/osslsigncode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        mtrojnar osslsigncode 2.0
-revision            0
+revision            1
 categories          devel security
 maintainers         nomaintainer
 license             GPL-3

--- a/devel/pev/Portfile
+++ b/devel/pev/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                pev
 version             0.80
-revision            2
+revision            3
 maintainers         {g5pw @g5pw} openmaintainer
 
 categories          devel

--- a/devel/pijul/Portfile
+++ b/devel/pijul/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo 1.0
 
 name                pijul
 version             0.10.0
-revision            1
+revision            2
 categories          devel
 platforms           darwin
 license             GPL-2+

--- a/devel/poco/Portfile
+++ b/devel/poco/Portfile
@@ -27,7 +27,7 @@ set docdir          ${prefix}/share/doc/${name}
 if {${subport} eq ${name}} {
     PortGroup           cmake 1.1
 
-    revision            3
+    revision            4
     checksums           rmd160  b3ba1f1cb925b24626ab09a6cb055edf99380464 \
                         sha256  2cde4b50778013ab3b7a522aa59bccaa7e85a8ccfc654a354c4d9611b6ce1758 \
                         size    5313561

--- a/devel/qca/Portfile
+++ b/devel/qca/Portfile
@@ -120,7 +120,7 @@ foreach qv ${qt.versions} {
 
     # plugins depend on the corresponding main port and the libraries of which they expose the Functionality
     subport ${name}${qv}-ossl {
-        revision                1
+        revision                2
         license                 LGPL-2.1+
         depends_lib             port:${name}${qv} path:lib/libssl.dylib:openssl
         configure.args-append   -DBUILD_PLUGINS:STRING="ossl"
@@ -139,7 +139,7 @@ foreach qv ${qt.versions} {
         build.dir               ${workpath}/build/plugins/qca-gnupg
     }
     subport ${name}${qv}-pkcs11 {
-        revision                1
+        revision                2
         license                 LGPL-2.1+
         depends_lib             port:${name}${qv} path:lib/libssl.dylib:openssl port:nss port:pkcs11-helper
         configure.args-append   -DBUILD_PLUGINS:STRING="pkcs11"

--- a/devel/radare2/Portfile
+++ b/devel/radare2/Portfile
@@ -5,7 +5,7 @@ PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
 
 github.setup        radareorg radare2 5.4.2
-revision            0
+revision            1
 categories          devel
 platforms           darwin
 license             LGPL-3+

--- a/devel/retdec/Portfile
+++ b/devel/retdec/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        avast retdec 4.0 v
-revision            0
+revision            1
 conflicts           ${name}-devel
 
 categories          devel
@@ -61,7 +61,7 @@ subport retdec-devel {
 
     version         20211026
     github.setup    avast retdec 59deef2049b8e5118402c7c86b44f9d6bbc5a437
-    revision        0
+    revision        1
 
     checksums       rmd160  fcb1da52fd605e36c573e3dde7f9043eedcc2b83 \
                     sha256  550bcfb33e655fce1238f7c204191429433b9ad3423cf251c18e40177142b363 \

--- a/devel/rizin/Portfile
+++ b/devel/rizin/Portfile
@@ -5,7 +5,7 @@ PortGroup           github  1.0
 PortGroup           meson   1.0
 
 github.setup        rizinorg rizin 0.3.0 v
-revision            0
+revision            1
 epoch               1
 categories          devel
 platforms           darwin

--- a/devel/tcl-tls/Portfile
+++ b/devel/tcl-tls/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                tcl-tls
 version             1.7.21
-revision            0
+revision            1
 categories          devel
 license             Tcl/Tk
 platforms           darwin

--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -12,7 +12,7 @@ version         0.13.0
 checksums       rmd160 04cd735494a9d8558c2d22d1b99315ca859749c8 \
                 sha256 7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179 \
                 size   4154357
-revision        1
+revision        2
 
 categories      devel
 license         Apache-2

--- a/devel/uboot-tools/Portfile
+++ b/devel/uboot-tools/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                uboot-tools
 github.setup        u-boot u-boot 2020.10 v
-revision            0
+revision            1
 github.tarball_from archive
 license             GPL-2
 categories          devel

--- a/devel/virtuoso-6/Portfile
+++ b/devel/virtuoso-6/Portfile
@@ -6,7 +6,7 @@ PortGroup           conflicts_build 1.0
 name                virtuoso-6
 set myname          virtuoso
 version             6.1.8
-revision            5
+revision            6
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             GPL

--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           boost 1.0
 
 github.setup        facebook wangle 2021.06.07.00 v
-revision            0
+revision            1
 categories          devel
 platforms           darwin
 license             BSD

--- a/devel/wrangler/Portfile
+++ b/devel/wrangler/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        cloudflare wrangler 1.19.4 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://workers.cloudflare.com
 

--- a/devel/wsdlpull/Portfile
+++ b/devel/wsdlpull/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                wsdlpull
 version             1.24
-revision            2
+revision            3
 categories          devel
 license             LGPL
 platforms           darwin

--- a/devel/xeus/Portfile
+++ b/devel/xeus/Portfile
@@ -6,7 +6,7 @@ PortGroup               compiler_blacklist_versions 1.0
 PortGroup               github 1.0
 
 github.setup            jupyter-xeus xeus 2.2.0
-revision                0
+revision                1
 categories              devel science
 license                 BSD
 maintainers             {mps @Schamschula} openmaintainer

--- a/devel/xmlrpc-c/Portfile
+++ b/devel/xmlrpc-c/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xmlrpc-c
 version             1.51.07
-revision            0
+revision            1
 categories          devel www
 # tools/turbocharger is Apache-1
 license             BSD MIT Apache-1

--- a/devel/zeroc-ice33/Portfile
+++ b/devel/zeroc-ice33/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name            zeroc-ice33
 version         3.3.1
-revision        6
+revision        7
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      devel
 maintainers     nomaintainer

--- a/devel/zeroc-ice34/Portfile
+++ b/devel/zeroc-ice34/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            zeroc-ice34
 version         3.4.2
-revision        6
+revision        7
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      devel
 maintainers     nomaintainer

--- a/devel/zeroc-ice35/Portfile
+++ b/devel/zeroc-ice35/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            zeroc-ice35
 version         3.5.1
-revision        4
+revision        5
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      devel
 maintainers     nomaintainer

--- a/editors/amp/Portfile
+++ b/editors/amp/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        jmacdonald amp 0.6.2
-revision            1
+revision            2
 
 homepage            https://amp.rs
 

--- a/editors/textmate2/Portfile
+++ b/editors/textmate2/Portfile
@@ -6,7 +6,7 @@ PortGroup               github 1.0
 
 epoch                   5
 github.setup            textmate textmate 2.0.6 v
-revision                1
+revision                2
 
 maintainers             {cal @neverpanic} openmaintainer
 name                    textmate2

--- a/finance/litecoin/Portfile
+++ b/finance/litecoin/Portfile
@@ -6,7 +6,7 @@ PortGroup           qt5 1.0
 PortGroup           boost 1.0
 
 github.setup        litecoin-project litecoin 0.16.3 v
-revision            6
+revision            7
 checksums           rmd160  aa2470a9e4f32c62953c5aae460471e0e3f1f801 \
                     sha256  0dccc577d704bd48226d11b749cca3bd7cadd23694ccbb15a87a0806704a69c3 \
                     size    6045235

--- a/fuse/encfs/Portfile
+++ b/fuse/encfs/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        vgough encfs 1.9.5 v
-revision            1
+revision            2
 categories          fuse
 platforms           darwin
 maintainers         nomaintainer

--- a/games/PlasmaClient/Portfile
+++ b/games/PlasmaClient/Portfile
@@ -6,7 +6,7 @@ PortGroup                   cmake 1.0
 name                        PlasmaClient
 epoch                       2
 version                     0.0.4a-434
-revision                    6
+revision                    7
 categories                  games
 platforms                   darwin
 maintainers                 ryandesign

--- a/games/gtkevemon/Portfile
+++ b/games/gtkevemon/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                gtkevemon
 epoch               1
 version             1.9
-revision            2
+revision            3
 set build_version   155
 set hg_tag          4787afa0ad96
 categories          games

--- a/games/ldmud/Portfile
+++ b/games/ldmud/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 PortGroup github 1.0
 
 github.setup    ldmud ldmud 3.6.4
+revision            1
 categories      games
 maintainers     {toby @tobypeterson}
 description     modern LPMud gamedriver

--- a/games/libggz/Portfile
+++ b/games/libggz/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            libggz
 version         0.0.14.1
-revision        4
+revision        5
 categories      games
 platforms       darwin
 maintainers     nomaintainer

--- a/games/openrct2/Portfile
+++ b/games/openrct2/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        OpenRCT2 OpenRCT2 0.3.4.1 v
 github.tarball_from archive
 name                openrct2
-revision            0
+revision            1
 
 categories          games
 platforms           darwin

--- a/games/pennmush/Portfile
+++ b/games/pennmush/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                pennmush
 version             1.8.3p9
-revision            4
+revision            5
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          games
 license             Artistic-1 BSD

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -12,7 +12,7 @@ PortGroup           debug 1.0
 mpi.setup
 
 github.setup        OSGeo gdal 3.3.1 v
-revision            1
+revision            2
 checksums           rmd160  7d2e737733248346201cad75987f258e065dc14d \
                     sha256  48ab00b77d49f08cf66c60ccce55abb6455c3079f545e60c90ee7ce857bccb70 \
                     size    12933888

--- a/gis/qgis/Portfile
+++ b/gis/qgis/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 PortGroup           qt4     1.0
 
 github.setup        qgis QGIS 2_18_17 final-
-revision            6
+revision            7
 name                qgis
 version             [string map {_ .} ${github.version}]
 categories          gis

--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -9,7 +9,7 @@ PortGroup           active_variants 1.1
 github.setup        qgis QGIS 3_20_3 final-
 name                qgis3
 version             [string map {_ .} ${github.version}]
-revision            3
+revision            4
 categories          gis
 maintainers         {vince @Veence} openmaintainer
 description         QGIS 3 is a user-friendly GIS based on Qt 5

--- a/gnome/balsa/Portfile
+++ b/gnome/balsa/Portfile
@@ -5,6 +5,7 @@ PortGroup           yelp 1.0
 
 name                balsa
 version             2.5.9
+revision            1
 license             GPL-3
 description         GNOME e-mail client
 long_description    Balsa is an e-mail client for GNOME, highly \

--- a/gnome/gnome-vfs-monikers/Portfile
+++ b/gnome/gnome-vfs-monikers/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name		gnome-vfs-monikers
 version		2.15.3
-revision    3
+revision    4
 set branch      [join [lrange [split ${version} .] 0 1] .]
 description	Bonobo components for gnome-vfs.
 long_description \

--- a/gnome/gnome-vfs/Portfile
+++ b/gnome/gnome-vfs/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 
 name            gnome-vfs
 version         2.24.4
-revision        4
+revision        5
 set branch      [join [lrange [split ${version} .] 0 1] .]
 maintainers     nomaintainer
 categories      gnome

--- a/gnome/grisbi/Portfile
+++ b/gnome/grisbi/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                grisbi
 version             1.0.0
-revision            4
+revision            5
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome
 platforms           darwin

--- a/gnustep/gnustep-base/Portfile
+++ b/gnustep/gnustep-base/Portfile
@@ -3,7 +3,7 @@ PortGroup   gnustep 1.0
 
 name                gnustep-base
 version             1.19.1
-revision            4
+revision            5
 platforms           darwin
 # libs are LGPL, tools are GPL
 license             {LGPL-3+ GPL-3+}

--- a/graphics/dvisvgm/Portfile
+++ b/graphics/dvisvgm/Portfile
@@ -23,7 +23,7 @@ github.setup        mgieseki dvisvgm 2.12
 checksums           rmd160  037d06784902d1792c901459783ab9817b744ca1 \
                     sha256  55ecd1014c2e66fae285e41da33e832ab20aa7f2fdc42388b695c1233e7d78e8 \
                     size    2694386
-revision            0
+revision            1
 
 use_autoconf        yes
 autoconf.cmd        ${worksrcpath}/autogen.sh

--- a/graphics/podofo/Portfile
+++ b/graphics/podofo/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 
 name                podofo
 version             0.9.6
-revision            3
+revision            4
 license             GPL-2 LGPL-2
 categories          graphics
 maintainers         {devans @dbevans} openmaintainer

--- a/graphics/sane-backends/Portfile
+++ b/graphics/sane-backends/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 
 name                        sane-backends
 version                     1.0.31
-revision                    1
+revision                    2
 set upload_tag              8bf1cae2e1803aefab9e5331550e5d5d
 categories                  graphics
 platforms                   darwin

--- a/irc/bahamut/Portfile
+++ b/irc/bahamut/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                bahamut
 conflicts           expect whois
 version             2.0.7
-revision            2
+revision            3
 maintainers         ryandesign openmaintainer
 categories          irc
 platforms           darwin

--- a/irc/bitchx/Portfile
+++ b/irc/bitchx/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		bitchx
 version		1.2.1
-revision	1
+revision	2
 categories	irc
 license             BSD
 maintainers	nomaintainer

--- a/irc/eggdrop/Portfile
+++ b/irc/eggdrop/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            eggheads eggdrop 1.8.3 v
-revision                1
+revision                2
 checksums               rmd160  3ebf6c6260dfb21f8684b7dfe26be03f167cab21 \
                         sha256  a4b8957e39fd342e862dae3c305523e4c8aab628d3dfafa148be40ab41259ef4 \
                         size    1756536

--- a/irc/epic4/Portfile
+++ b/irc/epic4/Portfile
@@ -1,6 +1,7 @@
 PortSystem 1.0
 name             epic4
 version          2.10.10
+revision            1
 categories       irc
 maintainers      {toby @tobypeterson} openmaintainer
 description      The (E)nhanced (P)rogrammable (I)RC-II (C)lient

--- a/irc/epic5/Portfile
+++ b/irc/epic5/Portfile
@@ -1,6 +1,7 @@
 PortSystem 1.0
 name             epic5
 version          2.1.6
+revision            1
 categories       irc
 maintainers      {toby @tobypeterson} openmaintainer
 description      (E)nhanced (P)rogrammable (I)RC-II (C)lient 5

--- a/irc/hexchat/Portfile
+++ b/irc/hexchat/Portfile
@@ -5,7 +5,7 @@ PortGroup           meson 1.0
 
 name                hexchat
 version             2.14.2
-revision            2
+revision            3
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          irc
 maintainers         {raimue @raimue} \

--- a/irc/ircii/Portfile
+++ b/irc/ircii/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                ircii
 conflicts           ircii-classic
 version             20170704
-revision            1
+revision            2
 categories          irc
 platforms           darwin
 maintainers         nomaintainer

--- a/irc/irssi/Portfile
+++ b/irc/irssi/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        irssi irssi 1.2.3
-revision            0
+revision            1
 categories          irc
 platforms           darwin
 license             {GPL-2+ OpenSSLException}

--- a/irc/ngircd/Portfile
+++ b/irc/ngircd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                ngircd
 version             26.1
-revision            0
+revision            1
 
 categories          irc
 platforms           darwin

--- a/irc/quassel/Portfile
+++ b/irc/quassel/Portfile
@@ -6,7 +6,7 @@ PortGroup       qt5 1.0
 PortGroup       github 1.0
 
 github.setup    quassel quassel 0.13.1
-revision        1
+revision        2
 
 categories      irc
 license         GPL-2 GPL-3

--- a/irc/znc/Portfile
+++ b/irc/znc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                znc
 version             1.7.4
-revision            3
+revision            4
 categories          irc
 platforms           darwin
 maintainers         nomaintainer

--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -5,6 +5,7 @@ PortGroup           java 1.0
 
 name                tomcat-native
 version             1.2.28
+revision            1
 categories          java www
 maintainers         {thebishops.org:matt @mattbishop} openmaintainer
 license             Apache-2

--- a/kde/kdelibs4/Portfile
+++ b/kde/kdelibs4/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdelibs4
 version             4.14.3
-revision            16
+revision            17
 categories          kde kde4
 maintainers         {nicos @NicosPavlov}
 license             LGPL-2+ GPL-2+ BSD

--- a/kde/smokekde/Portfile
+++ b/kde/smokekde/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                smokekde
 version             4.14.3
-revision            5
+revision            6
 categories          kde kde4 devel
 platforms           darwin
 license             GPL-2+ LGPL-2

--- a/lang/Io/Portfile
+++ b/lang/Io/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.0
 
 github.setup            IoLanguage io 2017.09.06
-revision                5
+revision                6
 name                    Io
 categories              lang
 # mostly BSD, but some LGPL and GPL files

--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        crystal-lang crystal 1.2.0
-revision            0
+revision            1
 categories          lang
 platforms           darwin
 supported_archs     x86_64 arm64

--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                erlang
 version             23.1
-revision            1
+revision            2
 
 categories          lang erlang
 maintainers         {ciserlohn @ci42}

--- a/lang/mit-scheme/Portfile
+++ b/lang/mit-scheme/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                    mit-scheme
 epoch                   1
 version                 9.2
-revision                3
+revision                4
 categories              lang
 license                 {GPL-2+ OpenSSLException}
 platforms               darwin

--- a/lang/pypy/Portfile
+++ b/lang/pypy/Portfile
@@ -7,7 +7,7 @@ PortGroup           deprecated 1.0
 
 gitlab.instance     https://foss.heptapod.net
 gitlab.setup        pypy pypy 7.3.7
-revision            0
+revision            1
 
 categories          lang python devel
 license             MIT PSF
@@ -125,7 +125,7 @@ if {${python.branch} == 2.7} {
     set use_prefix no
 } elseif {${python.branch} == 3.6} {
     version             7.3.3
-    revision            2
+    revision            3
     deprecated.eol_version yes
     livecheck.type      none
 

--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -8,7 +8,7 @@ name                python27
 epoch               2
 # Remember to keep py27-tkinter and py27-gdbm's versions sync'd with this
 version             2.7.18
-revision            3
+revision            4
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]

--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -7,6 +7,7 @@ name                python310
 
 # Remember to keep py310-tkinter and py310-gdbm's versions sync'd with this
 version             3.10.0
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang

--- a/lang/python311-devel/Portfile
+++ b/lang/python311-devel/Portfile
@@ -7,6 +7,7 @@ name                python311-devel
 
 # Remember to keep py311-tkinter and py311-gdbm's versions sync'd with this
 version             3.11.0a1
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang

--- a/lang/python34/Portfile
+++ b/lang/python34/Portfile
@@ -9,7 +9,7 @@ name                python34
 epoch               20170810
 # Remember to keep py34-tkinter and py34-gdbm's versions sync'd with this
 version             3.4.10
-revision            6
+revision            7
 
 deprecated.eol_version  yes
 

--- a/lang/python35/Portfile
+++ b/lang/python35/Portfile
@@ -9,7 +9,7 @@ name                python35
 epoch               20170810
 # Remember to keep py35-tkinter and py35-gdbm's versions sync'd with this
 version             3.5.10
-revision            2
+revision            3
 
 deprecated.eol_version  yes
 

--- a/lang/python36/Portfile
+++ b/lang/python36/Portfile
@@ -8,6 +8,7 @@ name                python36
 epoch               20170717
 # Remember to keep py36-tkinter and py36-gdbm's versions sync'd with this
 version             3.6.15
+revision            1
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]

--- a/lang/python37/Portfile
+++ b/lang/python37/Portfile
@@ -7,6 +7,7 @@ name                python37
 
 # Remember to keep py37-tkinter and py37-gdbm's versions sync'd with this
 version             3.7.12
+revision            1
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]

--- a/lang/python38/Portfile
+++ b/lang/python38/Portfile
@@ -9,7 +9,7 @@ name                python38
 epoch               1
 # Remember to keep py38-tkinter, py38-htmldocs, and py38-gdbm's versions sync'd with this
 version             3.8.12
-revision            1
+revision            2
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]

--- a/lang/python39/Portfile
+++ b/lang/python39/Portfile
@@ -7,6 +7,7 @@ name                python39
 
 # Remember to keep py39-tkinter and py39-gdbm's versions sync'd with this
 version             3.9.7
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang

--- a/lang/qore-asn1-module/Portfile
+++ b/lang/qore-asn1-module/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                qore-asn1-module
 version             0.0.3
-revision        3
+revision        4
 categories          lang
 license             LGPL-2.1
 maintainers         {davidnichols @davidnich}

--- a/lang/qore-json-module/Portfile
+++ b/lang/qore-json-module/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                qore-json-module
 version             1.7
-revision            1
+revision            2
 categories          lang
 license             {LGPL-2.1 MIT}
 maintainers         {davidnichols @davidnich}

--- a/lang/qore-xml-module/Portfile
+++ b/lang/qore-xml-module/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                qore-xml-module
 version             1.4.1
-revision            1
+revision            2
 categories          lang
 license             {LGPL-2.1 MIT}
 maintainers         {davidnichols @davidnich}

--- a/lang/qore/Portfile
+++ b/lang/qore/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                qore
 version             1.0.9
+revision            1
 categories          lang
 license             {LGPL-2.1 MIT}
 maintainers         {davidnichols @davidnich} openmaintainer

--- a/mail/alpine/Portfile
+++ b/mail/alpine/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                alpine
 version             2.25
+revision            1
 categories          mail
 license             Apache-2
 maintainers         netpurgatory.com:john gmail.com:jerryyhom openmaintainer

--- a/mail/cclient/Portfile
+++ b/mail/cclient/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            cclient
 version         2007f
-revision        3
+revision        4
 checksums       rmd160  298b09c2da9650cb7bc70094da49bab57878ae20 \
                 sha256  53e15a2b5c1bc80161d42e9f69792a3fa18332b7b771910131004eb520004a28 \
                 size    1990304

--- a/mail/courier-imap/Portfile
+++ b/mail/courier-imap/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                courier-imap
 version             4.18.2
-revision            1
+revision            2
 checksums           rmd160  29039eab60b395b6112c1f4320c33932ca17389c \
                     sha256  f66ceda3e5aa853e13f417302dfb83b312709e95f1bbcdafcd6214d76a94e79a
 

--- a/mail/cyrus-imapd/Portfile
+++ b/mail/cyrus-imapd/Portfile
@@ -6,7 +6,7 @@ PortGroup           legacysupport    1.0
 
 name                cyrus-imapd
 version             2.4.20
-revision            4
+revision            5
 perl5.branches      5.28
 categories          mail
 platforms           darwin

--- a/mail/cyrus5-imapd/Portfile
+++ b/mail/cyrus5-imapd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                cyrus5-imapd
 version             2.5.4
-revision            2
+revision            3
 categories          mail
 platforms           darwin
 license             BSD-old

--- a/mail/deletemail/Portfile
+++ b/mail/deletemail/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name			deletemail
 version			0.5
-revision        3
+revision        4
 categories		mail
 platforms		darwin
 license			BSD

--- a/mail/dovecot/Portfile
+++ b/mail/dovecot/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        dovecot core 2.3.16
 name                dovecot
-revision            0
+revision            1
 epoch               20060722
 set core_version    ${version}
 

--- a/mail/exim/Portfile
+++ b/mail/exim/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                    exim
 version                 4.94.2
-revision                0
+revision                1
 checksums               rmd160  4de1b7cca08ccbcaf3987332d15cd1fbc6135c9b \
                         sha256  051861fc89f06205162f12129fb7ebfe473383bb6194bf8642952bfd50329274 \
                         size    1838076

--- a/mail/fetchmail/Portfile
+++ b/mail/fetchmail/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fetchmail
 version             6.4.21
-revision            0
+revision            1
 categories          mail
 platforms           darwin
 license             {GPL-2 OpenSSLException}
@@ -39,7 +39,7 @@ if {${name} eq ${subport}} {
 
 subport fetchmail-devel {
     version         6.5.0.beta5
-    revision        0
+    revision        1
 
     checksums       rmd160  fd6ec69e643c538c626243f1592121859c78f6da \
                     sha256  25d8dcf6cbbccaf9f407cbcd85df7805b917a3ce9c5215011a719337a5bb86bc

--- a/mail/imap-uw/Portfile
+++ b/mail/imap-uw/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                imap-uw
 version             2007f
-revision            3
+revision            4
 categories          mail
 platforms           darwin
 license             Apache-2

--- a/mail/imapfilter/Portfile
+++ b/mail/imapfilter/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        lefcha imapfilter 2.7.5 v
-revision            0
+revision            1
 categories          mail
 platforms           darwin
 maintainers         nomaintainer

--- a/mail/isync/Portfile
+++ b/mail/isync/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    isync
 version                 1.4.3
-revision                0
+revision                1
 categories              mail
 platforms               darwin
 license                 GPL-2

--- a/mail/libesmtp/Portfile
+++ b/mail/libesmtp/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 8
 github.setup        libesmtp libESMTP 1.1.0 v
 
 name                libesmtp
-revision            0
+revision            1
 categories          mail
 platforms           darwin
 maintainers         nomaintainer

--- a/mail/libetpan/Portfile
+++ b/mail/libetpan/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            dinhviethoa libetpan 1.9.4
-revision                1
+revision                2
 categories              mail devel
 platforms               darwin
 license                 BSD

--- a/mail/mail-server/Portfile
+++ b/mail/mail-server/Portfile
@@ -5,7 +5,7 @@ PortGroup               active_variants 1.1
 
 name                    mail-server
 version                 1.3
-revision                0
+revision                1
 categories              mail net
 platforms               darwin
 supported_archs         noarch

--- a/mail/mailsync/Portfile
+++ b/mail/mailsync/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                mailsync
 version             5.2.1
-revision            6
+revision            7
 categories          mail
 platforms           darwin
 license             GPL-2

--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        neomutt neomutt 20200925
-revision            0
+revision            1
 categories          mail
 platforms           darwin
 license             GPL-2+

--- a/mail/opendkim/Portfile
+++ b/mail/opendkim/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                opendkim
 version             2.10.3
-revision            3
+revision            4
 categories          mail
 license             {BSD restrictive/distributable}
 maintainers         nomaintainer

--- a/mail/opensmtpd/Portfile
+++ b/mail/opensmtpd/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.0
 
 name                opensmtpd
 version             6.8.0p2
-revision            1
+revision            2
 categories          mail
 platforms           darwin
 license             ISC

--- a/mail/rspamd/Portfile
+++ b/mail/rspamd/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 github.setup        rspamd rspamd 3.1
-revision            0
+revision            1
 
 categories          mail
 license             BSD

--- a/mail/s-nail/Portfile
+++ b/mail/s-nail/Portfile
@@ -6,7 +6,7 @@ PortSystem          1.0
 # https://lists.sdaoden.eu/pipermail/s-mailx/2019-September/001286.html
 name                s-nail
 version             14.9.15
-revision            1
+revision            2
 categories          mail
 license             {BSD-old BSD}
 maintainers         nomaintainer

--- a/mail/sympa/Portfile
+++ b/mail/sympa/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 PortGroup           github 1.0
 
 github.setup        sympa-community sympa 6.2.58
+revision            1
 github.tarball_from releases
 
 set branch          [join [lrange [split ${version} .] 0 1] .]

--- a/mail/tpop3d/Portfile
+++ b/mail/tpop3d/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		tpop3d
 version		1.5.3
-revision	5
+revision	6
 categories	mail
 license		GPL-2
 platforms	darwin

--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -68,7 +68,7 @@ supported_archs         x86_64
 ##
 if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     version             2.2.8
-    revision            11
+    revision            12
     license             GPL-2+
 
     platforms           darwin

--- a/multimedia/despotify/Portfile
+++ b/multimedia/despotify/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                despotify
 version             20110115
-revision            3
+revision            4
 categories          multimedia
 license             BSD MIT
 maintainers         nomaintainer

--- a/multimedia/gpac/Portfile
+++ b/multimedia/gpac/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        gpac gpac 1.0.1 v
-revision            1
+revision            2
 categories          multimedia
 platforms           darwin
 maintainers         nomaintainer

--- a/multimedia/mythtv.27/Portfile
+++ b/multimedia/mythtv.27/Portfile
@@ -13,6 +13,7 @@ set lastcommit      20180201
 set corerev         4
 set pluginsrev      3
 github.setup        MythTV mythtv ${shorthash}
+revision            0
 
 name                mythtv${majorversion}
 checksums           rmd160  6f76a7fbaf52745f99074173c004467b6fd1383f \
@@ -64,6 +65,7 @@ if { ${subport} eq ${name} } {
 subport mythtv-core${majorversion} {
 	name                mythtv-core${majorversion}
 	version             0${majorversion}${minorversion}-Fixes-${lastcommit}
+    revision            1
 	revision			${corerev}
 
 	description         personal video recorder (PVR) and media centre system

--- a/multimedia/reddsaver/Portfile
+++ b/multimedia/reddsaver/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        manojkarthick reddsaver 0.4.0 v
-revision            0
+revision            1
 
 description         CLI tool to download saved and upvoted media from Reddit
 

--- a/multimedia/shairport-sync/Portfile
+++ b/multimedia/shairport-sync/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        mikebrady shairport-sync 2.8.6
-revision            2
+revision            3
 
 categories          multimedia
 platforms           darwin

--- a/net/FreeRDP/Portfile
+++ b/net/FreeRDP/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake   1.1
 
 epoch               3
 github.setup        FreeRDP FreeRDP 2.4.1
-revision            0
+revision            1
 categories          net
 platforms           darwin
 license             Apache

--- a/net/apple-pki-bundle/Portfile
+++ b/net/apple-pki-bundle/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                apple-pki-bundle
 version             2018-09-27
-revision            1
+revision            2
 categories          net www security
 license             OpenSSL
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer

--- a/net/argus-monitor/Portfile
+++ b/net/argus-monitor/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                argus-monitor
 version             3.7
-revision            6
+revision            7
 categories          net
 license             Artistic
 maintainers         nomaintainer

--- a/net/axel/Portfile
+++ b/net/axel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        axel-download-accelerator axel 2.17.10 v
-revision            0
+revision            1
 categories          net www
 platforms           darwin
 maintainers         {@i0ntempest me.com:szf1234} openmaintainer

--- a/net/baresip/Portfile
+++ b/net/baresip/Portfile
@@ -17,7 +17,7 @@ github.setup        baresip baresip 1.1.0 v
 checksums           rmd160  f1f03ab052df92198f982d71932792dc4e31a110 \
                     sha256  75ecc9037f55cb141658a5559c2ef84e12c721b7d69bb55f4640ffc82815eca2 \
                     size    1105494
-revision            0
+revision            1
 
 depends_lib \
     port:libre \

--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -5,6 +5,7 @@ PortGroup       legacysupport 1.0
 
 name            bind9
 version         9.16.22
+revision            1
 categories      net
 maintainers     {geeklair.net:dluke @danielluke}
 platforms       darwin freebsd sunos

--- a/net/blackbag/Portfile
+++ b/net/blackbag/Portfile
@@ -2,7 +2,7 @@ PortSystem       1.0
 
 name             blackbag
 version          0.9.1
-revision         5
+revision         6
 categories       net security
 platforms        darwin
 # Copyright 2005 Matasano Security, LLC <tqbf@matasano.com> - All Rights Reserved

--- a/net/btpd/Portfile
+++ b/net/btpd/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 PortGroup           github 1.0
 
 github.setup        btpd btpd 0.16 v
-revision 2
+revision 3
 categories	net
 license		BSD
 platforms	darwin

--- a/net/calendar-contacts-server/Portfile
+++ b/net/calendar-contacts-server/Portfile
@@ -10,7 +10,7 @@ name                calendar-contacts-server
 # version from https://github.com/apple/ccs-calendarserver/blob/master/setup.py
 # with date of git commit appended
 version             9.3.20200212
-revision            1
+revision            2
 categories          net mail
 platforms           darwin
 supported_archs     noarch

--- a/net/centerim/Portfile
+++ b/net/centerim/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                centerim
 version             4.22.10
-revision            5
+revision            6
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/net/cryfs/Portfile
+++ b/net/cryfs/Portfile
@@ -6,7 +6,7 @@ PortGroup                 cmake 1.1
 PortGroup                 boost 1.0
 
 github.setup              cryfs cryfs 0.10.3
-revision                  1
+revision                  2
 github.tarball_from       releases
 
 license                   LGPL-3

--- a/net/csup/Portfile
+++ b/net/csup/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name			csup
 version			20060318
-revision        3
+revision        4
 categories		net devel
 license			BSD
 platforms		darwin

--- a/net/ctorrent/Portfile
+++ b/net/ctorrent/Portfile
@@ -10,7 +10,7 @@ PortSystem          1.0
 
 name                ctorrent
 version             3.3.2
-revision            3
+revision            4
 homepage            https://sourceforge.net/projects/dtorrent/
 categories          net
 license             GPL-2

--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -33,7 +33,7 @@ checksums                       ${curl_distfile} \
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
 
-    revision                    0
+    revision                    1
 
     depends_build               port:pkgconfig
 

--- a/net/cvsync/Portfile
+++ b/net/cvsync/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name             cvsync
 version          0.24.18
-revision         3
+revision         4
 categories       net
 license          BSD
 maintainers      nomaintainer

--- a/net/davix/Portfile
+++ b/net/davix/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport               1.0
 
 github.setup        cern-fts davix 0_8_0 R_
 version             [string map {_ .} ${github.version}]
-revision            0
+revision            1
 github.tarball_from releases
 distname            ${github.project}-${version}
 

--- a/net/dhcp/Portfile
+++ b/net/dhcp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dhcp
 version             4.1-ESV-R15-P1
-revision            1
+revision            2
 categories          net
 license             ISC BSD SSLeay
 description         ISC dhcpd server

--- a/net/dnsperf/Portfile
+++ b/net/dnsperf/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        DNS-OARC dnsperf 2.8.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          net sysutils
 platforms           darwin

--- a/net/docsis/Portfile
+++ b/net/docsis/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        rlaager docsis 0.9.8 upstream/
-revision            4
+revision            5
 categories          net
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer

--- a/net/drill/Portfile
+++ b/net/drill/Portfile
@@ -6,7 +6,7 @@ PortGroup           github      1.0
 
 github.setup        fcsonline drill 0.7.2
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Drill is an HTTP load testing application written in Rust \
                     inspired by Ansible syntax

--- a/net/echoping/Portfile
+++ b/net/echoping/Portfile
@@ -2,7 +2,7 @@ PortSystem		1.0
 
 name			echoping
 version			6.0.2
-revision		5
+revision		6
 categories		net
 license			{GPL-2 OpenSSLException}
 maintainers		nomaintainer

--- a/net/ejabberd/Portfile
+++ b/net/ejabberd/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                ejabberd
 version             18.12.1
-revision            1
+revision            2
 categories          net
 platforms           darwin
 license             GPL-2

--- a/net/esniper/Portfile
+++ b/net/esniper/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                esniper
 version             2.35.0
-revision            2
+revision            3
 categories          net
 license             BSD
 platforms           darwin

--- a/net/et/Portfile
+++ b/net/et/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        MisterTea EternalTerminal 6.1.7 et-v
-revision            3
+revision            4
 name                et
 categories          net
 license             Apache-2

--- a/net/ettercap/Portfile
+++ b/net/ettercap/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 
 github.setup        Ettercap ettercap 0.8.3.1 v
-revision            0
+revision            1
 categories          net security
 platforms           darwin freebsd
 maintainers         nomaintainer

--- a/net/fetch/Portfile
+++ b/net/fetch/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		fetch
 version		9.0.0-RELEASE
-revision 2
+revision 3
 categories	net
 maintainers	nomaintainer
 description	FreeBSD file fetching utility

--- a/net/gftp/Portfile
+++ b/net/gftp/Portfile
@@ -2,7 +2,7 @@ PortSystem      1.0
 
 name            gftp
 version         2.0.18
-revision        8
+revision        9
 categories      net
 license         GPL-2+
 platforms       darwin

--- a/net/gq/Portfile
+++ b/net/gq/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            gq
 version         1.2.3
-revision        2
+revision        3
 categories      net
 platforms       darwin
 maintainers     nomaintainer

--- a/net/gvpe/Portfile
+++ b/net/gvpe/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name             gvpe
 version          3.1
+revision            1
 categories       net
 license          {GPL-3+ OpenSSLException}
 maintainers      nomaintainer

--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -6,7 +6,7 @@ PortGroup           makefile 1.0
 
 name                haproxy
 version             2.4.8
-revision            0
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 

--- a/net/httping/Portfile
+++ b/net/httping/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                httping
 version             2.5
-revision            1
+revision            2
 categories          net www
 license             {GPL-2 OpenSSLException}
 maintainers         nomaintainer

--- a/net/httrack/Portfile
+++ b/net/httrack/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                httrack
 version             3.49.2
-revision            2
+revision            3
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -29,7 +29,7 @@ post-destroot {
 
 if {${subport} eq ${name}} {
     github.setup        esnet iperf 3.10.1
-    revision            0
+    revision            1
 
     checksums           rmd160  3767478cec638542e5bbc5e5ebfeb9aec5f72422 \
                         sha256  f4c1765b165605542852b25a28a8d07eb2d30ee5d85c3106480edddca6088563 \
@@ -41,7 +41,7 @@ if {${subport} eq ${name}} {
 subport ${name}-devel {
     github.setup        esnet iperf 8bd43a27745a299560f39efcf8a44c73bc0ab08c
     version             20210928
-    revision            0
+    revision            1
 
     checksums           rmd160  3858b07d1cee013edc133856a575a7097ae3321b \
                         sha256  6ae5c338ae6c25b91832f5c2fd55d622581c7c9902a1d4daf90dfdc4d57eb568 \

--- a/net/jabberd/Portfile
+++ b/net/jabberd/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 
 github.setup    jabberd2 jabberd2 2.3.4 jabberd-
-revision        3
+revision        4
 name            jabberd
 categories      net
 platforms       darwin

--- a/net/kerberos5/Portfile
+++ b/net/kerberos5/Portfile
@@ -5,7 +5,7 @@ PortGroup                   compiler_blacklist_versions 1.0
 
 name                        kerberos5
 version                     1.19.2
-revision                    0
+revision                    1
 
 checksums                   rmd160  4bfca5c90706363ff3aa0d0eee419a47589321de \
                             sha256  10453fee4e3a8f8ce6129059e5c050b8a65dab1c257df68b99b3112eaa0cdf6a \

--- a/net/kumofs/Portfile
+++ b/net/kumofs/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                kumofs
 version             0.4.12
-revision            3
+revision            4
 homepage            http://kumofs.sourceforge.net/
 categories          net
 platforms           darwin

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        skyjake lagrange 1.8.0 v
-revision            0
+revision            1
 github.tarball_from releases
 categories          net gemini
 platforms           darwin

--- a/net/ldns/Portfile
+++ b/net/ldns/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                ldns
 
 version             1.7.1
-revision            0
+revision            1
 categories          net devel
 platforms           darwin
 license             BSD

--- a/net/lftp/Portfile
+++ b/net/lftp/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                lftp
 version             4.9.2
-revision            3
+revision            4
 categories          net
 platforms           darwin
 maintainers         {mps @Schamschula} openmaintainer

--- a/net/libfetch/Portfile
+++ b/net/libfetch/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		libfetch
 version		9.0.0-RELEASE
-revision 2
+revision 3
 categories	net
 maintainers	nomaintainer
 description	FreeBSD file fetching library

--- a/net/libmsn/Portfile
+++ b/net/libmsn/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                libmsn
 version             4.1
-revision            2
+revision            3
 categories          net
 license             {GPL-2+ OpenSSLException}
 platforms           darwin

--- a/net/libpftp/Portfile
+++ b/net/libpftp/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name			libpftp
 version			0.7
-revision		1
+revision		2
 categories		net
 license			GPL-2
 platforms		darwin

--- a/net/libpftputil/Portfile
+++ b/net/libpftputil/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name			libpftputil
 version			0.4
-revision		2
+revision		3
 categories		net
 platforms		darwin
 maintainers		nomaintainer

--- a/net/librdkafka/Portfile
+++ b/net/librdkafka/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        edenhill librdkafka 1.7.0 v
-revision            0
+revision            1
 
 categories          net
 platforms           darwin

--- a/net/libre/Portfile
+++ b/net/libre/Portfile
@@ -17,7 +17,7 @@ github.setup        baresip re 2.0.1 v
 checksums           rmd160  4f23053dd00938f9df6ffc91b08b54e3230f2872 \
                     sha256  2fadb30911d09cd7f8a3faee0672f3d03c16de9d7dcafeabd8dce41133563da0 \
                     size    342954
-revision            0
+revision            1
 
 depends_lib \
     port:zlib \

--- a/net/librem/Portfile
+++ b/net/librem/Portfile
@@ -16,7 +16,7 @@ github.setup        baresip rem 1.0.0 v
 checksums           rmd160  6d122eb2c386cfc29aa8427ceb73e63e151ae2a7 \
                     sha256  7adec440616377c268130f00ac9e0d4f338dd880c9747d96d7031046e6489a68 \
                     size    47226
-revision            0
+revision            1
 
 
 depends_lib-append  \

--- a/net/libsrtp/Portfile
+++ b/net/libsrtp/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                libsrtp
 version             2.1.0
-revision            1
+revision            2
 categories          net devel
 maintainers         {db.org:aeh @alfredh} openmaintainer
 description         Secure Real-time Transport Protocol (SRTP)
@@ -33,7 +33,7 @@ livecheck.regex     {/v(\d+(?:\.\d+)*)}
 
 subport libsrtp1 {
     version             1.5.4
-    revision            1
+    revision            2
 
     checksums           rmd160  9a02b2644839147dd794d368cede6cf7f23d75e4 \
                         sha256  56a7b521c25134f48faff26b0b1e3d4378a14986a2d3d7bc6fefb48987304ff0

--- a/net/libstrophe/Portfile
+++ b/net/libstrophe/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        strophe libstrophe 0.10.1
-revision            0
+revision            1
 checksums           rmd160  a28ca3c97ee7883e979e14313c13a096732a5694 \
                     sha256  28a1634a61ccfa9d1073041428c5a6b00280d5017c1cef9d7528f1f8504b3774 \
                     size    173603

--- a/net/libtorrent-devel/Portfile
+++ b/net/libtorrent-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        rakshasa libtorrent 3a6a61a4138048134f9048aef81a52f9bf821b29
 version             20181027
-revision            1
+revision            2
 
 name                libtorrent-devel
 conflicts           libtorrent

--- a/net/libtorrent-rasterbar/Portfile
+++ b/net/libtorrent-rasterbar/Portfile
@@ -9,7 +9,7 @@ PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
 github.setup        arvidn libtorrent 2.0.4 v
-revision            0
+revision            1
 name                libtorrent-rasterbar
 license             BSD
 categories          net

--- a/net/libtorrent/Portfile
+++ b/net/libtorrent/Portfile
@@ -8,7 +8,7 @@ PortGroup           github 1.0
 # https://github.com/rakshasa/rtorrent/releases/download/v0.9.8/libtorrent-0.13.8.tar.gz
 
 github.setup        rakshasa libtorrent 0.13.8 v
-revision            0
+revision            1
 
 conflicts           libtorrent-devel
 categories          net

--- a/net/makuosan/Portfile
+++ b/net/makuosan/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    makuosan
 version                 1.2.1
-revision        3
+revision        4
 homepage                http://lab.klab.org/wiki/Makuosan
 categories              net
 platforms               darwin

--- a/net/megatools/Portfile
+++ b/net/megatools/Portfile
@@ -5,7 +5,7 @@ PortGroup           meson 1.0
 
 name                megatools
 version             1.11.0-git-20200830
-revision            0
+revision            1
 checksums           rmd160  7ca2ffda247681d0eb97846dc1624b4984ea47f9 \
                     sha256  a6ac5b8c9e51f180dff4af82ac431eee04d73ee35366191d1fe47def6ebc3b65 \
                     size    103448

--- a/net/mosquitto/Portfile
+++ b/net/mosquitto/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 
 name                mosquitto
 version             2.0.9
-revision            0
+revision            1
 
 categories          net devel
 platforms           darwin

--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -7,6 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           boost 1.0
 
 github.setup        Nheko-Reborn mtxclient 0.3.1 v
+revision            1
 epoch               2
 categories          net chat devel
 platforms           darwin

--- a/net/munge/Portfile
+++ b/net/munge/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dun munge 0.5.14 munge-
-revision            1
+revision            2
 categories          net security
 license             {GPL-3+ LGPL-3+}
 maintainers         kornel.us:karl openmaintainer

--- a/net/nagios-plugins/Portfile
+++ b/net/nagios-plugins/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                nagios-plugins
 version             2.3.3
-revision            0
+revision            1
 categories          net
 license             GPL-3+
 maintainers         nomaintainer

--- a/net/nagios/Portfile
+++ b/net/nagios/Portfile
@@ -4,7 +4,7 @@ PortSystem  1.0
 
 name            nagios
 version         4.4.6
-revision        0
+revision        1
 categories      net
 license         GPL-2
 maintainers     nomaintainer

--- a/net/nefu/Portfile
+++ b/net/nefu/Portfile
@@ -2,7 +2,7 @@ PortSystem		1.0
 
 name			nefu
 version			1.4.0
-revision        3
+revision        4
 categories		net
 license			BSD
 maintainers		nomaintainer

--- a/net/net-snmp/Portfile
+++ b/net/net-snmp/Portfile
@@ -5,7 +5,7 @@ PortGroup               perl5 1.0
 
 name                    net-snmp
 version                 5.9.1
-revision                0
+revision                1
 checksums               rmd160  3e9cdfbb383abfb981854aede71476fe7df35ae6 \
                         sha256  eb7fd4a44de6cddbffd9a92a85ad1309e5c1054fb9d5a7dd93079c8953f48c3f \
                         size    6711774

--- a/net/netatalk/Portfile
+++ b/net/netatalk/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                netatalk
 version             2.0.5
-revision            5
+revision            6
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/net/nmap/Portfile
+++ b/net/nmap/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		nmap
 version		7.92
-revision	1
+revision	2
 categories	net
 maintainers	darkart.com:opendarwin.org {geeklair.net:dluke @danielluke}
 description	Port scanning utility for large networks

--- a/net/nsd/Portfile
+++ b/net/nsd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                nsd
 version             4.2.1
-revision            2
+revision            3
 categories          net
 platforms           darwin
 license             BSD

--- a/net/oha/Portfile
+++ b/net/oha/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo  1.0
 
 github.setup        hatoo oha 0.4.7 v
-revision            0
+revision            1
 
 categories          net devel
 platforms           darwin

--- a/net/openfortivpn/Portfile
+++ b/net/openfortivpn/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        adrienverge openfortivpn 1.17.1 v
-revision            0
+revision            1
 
 categories          net
 platforms           darwin

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             8.8p1
-revision            0
+revision            1
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/net/openvpn2/Portfile
+++ b/net/openvpn2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                openvpn2
 version             2.5.4
-revision            0
+revision            1
 distname            openvpn-${version}
 categories          net security
 platforms           darwin

--- a/net/openvpn3/Portfile
+++ b/net/openvpn3/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        OpenVPN openvpn3 3.6.4 release/
-revision            0
+revision            1
 categories          net security
 platforms           darwin
 maintainers         {i0ntempest @i0ntempest} openmaintainer

--- a/net/pdns-recursor/Portfile
+++ b/net/pdns-recursor/Portfile
@@ -5,7 +5,7 @@ PortGroup           boost 1.0
 
 name                pdns-recursor
 version             4.2.0
-revision            2
+revision            3
 categories          net
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer

--- a/net/pftp/Portfile
+++ b/net/pftp/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name			pftp
 version			0.4
-revision			2
+revision			3
 categories		net
 license			GPL-2
 platforms		darwin

--- a/net/proftpd/Portfile
+++ b/net/proftpd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                proftpd
 version             1.3.7b
-revision            0
+revision            1
 checksums           rmd160  6e923753558f28ed39f7efe0cf5f98e27c766b69 \
                     sha256  d1560d191f81ee9c0b295aea76f44e2d6c0b2d0f912c835c80bc1bbca473471e \
                     size    20422741

--- a/net/proxytunnel/Portfile
+++ b/net/proxytunnel/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name            proxytunnel
 version         1.9.0
-revision        2
+revision        3
 categories      net
 license         GPL-2+
 platforms       darwin

--- a/net/pwlib/Portfile
+++ b/net/pwlib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                pwlib
 version             1.5.2
-revision            3
+revision            4
 categories          net
 license             MPL-1 MIT BSD Permissive
 platforms           darwin

--- a/net/qBittorrent/Portfile
+++ b/net/qBittorrent/Portfile
@@ -23,7 +23,7 @@ homepage        https://www.qbittorrent.org
 
 if {${os.platform} ne "darwin" || ${os.major} >= 17} {
     github.setup    qbittorrent qBittorrent 4.3.9 release-
-    revision        0
+    revision        1
     checksums       rmd160  bbd2b403a8f450631eab5c6cac550718fc4341f0 \
                     sha256  f39842a7b8143521c827123ab0cdc12556c0a46a7c7691d210218dbc4e63d39c \
                     size    8510502
@@ -46,7 +46,7 @@ if {${os.platform} ne "darwin" || ${os.major} >= 17} {
     # libc++ on Sierra and older
     # Also 4.3.4 to 4.3.4.1 required Qt 5.12 then lowered to 5.11 after
     github.setup    qbittorrent qBittorrent 4.3.2 release-
-    revision        2
+    revision        3
     checksums       rmd160  543c1a5b59c15912cde31d98bed55810709aef75 \
                     sha256  187b8625e8787384a68a30eff3702b0e5c246512cb20013a38a25553cb18c5e7 \
                     size    7867939

--- a/net/qpid-proton/Portfile
+++ b/net/qpid-proton/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        apache qpid-proton 0.31.0
-revision            0
+revision            1
 
 description         Qpid Proton is a high-performance, lightweight AMQP \
                     1.0 messaging library.

--- a/net/rabbitmq-c/Portfile
+++ b/net/rabbitmq-c/Portfile
@@ -6,7 +6,7 @@ PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
 
 github.setup        alanxz rabbitmq-c 0.11.0 v
-revision            0
+revision            1
 checksums           rmd160  bb398685b963eae1ef3399b05bd75932051b5d17 \
                     sha256  871b5dc59f3346ab805d7b2dd0a9cbdbe930fbef0fc38e52ea7b5af03d4f736c \
                     size    145678

--- a/net/radmind/Portfile
+++ b/net/radmind/Portfile
@@ -2,6 +2,7 @@ PortSystem		1.0
 
 name			radmind
 version			1.14.1
+revision            1
 categories		net sysutils
 license			BSD
 maintainers		nomaintainer

--- a/net/rancid/Portfile
+++ b/net/rancid/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 name                rancid
 version             3.12
+revision            1
 categories          net
 license             BSD-old
 maintainers         nomaintainer

--- a/net/rpki-client/Portfile
+++ b/net/rpki-client/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                rpki-client
 version             7.4
-revision            0
+revision            1
 
 categories          net
 platforms           darwin

--- a/net/rsync/Portfile
+++ b/net/rsync/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                rsync
 conflicts           rsync-hfscomp
 version             3.2.3
-revision            0
+revision            1
 checksums           rmd160  6eea543c7034f1ef4997f72011d4fcdda2a960da \
                     sha256  becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e \
                     size    1069784

--- a/net/rtorrent-devel/Portfile
+++ b/net/rtorrent-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        rakshasa rtorrent c62fa6a75649efe8cedb91c66d1b05b2b1be8872
 version             20181027
-revision            1
+revision            2
 
 name                rtorrent-devel
 conflicts           rtorrent

--- a/net/rtorrent/Portfile
+++ b/net/rtorrent/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 PortGroup           github 1.0
 
 github.setup        rakshasa rtorrent 0.9.8 v
-revision            0
+revision            1
 github.tarball_from releases
 
 conflicts           rtorrent-devel

--- a/net/shellinabox/Portfile
+++ b/net/shellinabox/Portfile
@@ -9,7 +9,7 @@ PortGroup               legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup            shellinabox shellinabox 2.20 v
-revision                1
+revision                2
 categories              net shells www
 platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer

--- a/net/snort/Portfile
+++ b/net/snort/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name            snort
 version         2.9.18.1
-revision        0
+revision        1
 categories      net
 maintainers     nomaintainer
 license         GPL-2

--- a/net/squid2/Portfile
+++ b/net/squid2/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            squid2
 version         2.7.STABLE9
-revision        1
+revision        2
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      net
 platforms       darwin

--- a/net/squid3/Portfile
+++ b/net/squid3/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            squid3
 version         3.5.28
-revision        1
+revision        2
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      net
 platforms       darwin

--- a/net/squid4/Portfile
+++ b/net/squid4/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 
 name            squid4
 version         4.17
+revision            1
 categories      net
 platforms       darwin
 license         GPL-2+

--- a/net/ssldump/Portfile
+++ b/net/ssldump/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                ssldump
 version             0.9b3
-revision            5
+revision            6
 categories          net
 license             BSD-old
 maintainers         nomaintainer

--- a/net/sslscan/Portfile
+++ b/net/sslscan/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup github 1.0
 
 github.setup    rbsec sslscan 2.0.10
-revision        0
+revision        1
 categories      net
 maintainers     {raimue @raimue} \
                 openmaintainer

--- a/net/sstp-client/Portfile
+++ b/net/sstp-client/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                sstp-client
 version             1.0.13
-revision            0
+revision            1
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/net/suck/Portfile
+++ b/net/suck/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 name       suck
 version    4.3.2
-revision   6
+revision   7
 categories net
 maintainers gmail.com:springer.jonathan
 description grab news from a remote NNTP news server.

--- a/net/sysmon/Portfile
+++ b/net/sysmon/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name            sysmon
 version         0.93
-revision        2
+revision        3
 categories      net
 maintainers     {geeklair.net:dluke @danielluke}
 description     sysmon network monitoring software

--- a/net/tcpdump/Portfile
+++ b/net/tcpdump/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tcpdump
 version             4.99.1
-revision            0
+revision            1
 categories          net
 maintainers         {mps @Schamschula} openmaintainer
 license             BSD

--- a/net/tcpflow/Portfile
+++ b/net/tcpflow/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        simsong tcpflow 1.5.2 tcpflow-
-revision            1
+revision            2
 
 categories          net security
 platforms           darwin freebsd

--- a/net/tinc/Portfile
+++ b/net/tinc/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                tinc
 version             1.0.36
-revision            1
+revision            2
 categories          net
 maintainers         nomaintainer
 license             {GPL-2+ OpenSSLException}
@@ -45,7 +45,7 @@ subport tinc-devel {
     conflicts       tinc
 
     version         1.1pre17
-    revision        1
+    revision        2
     checksums       rmd160  32f943918218d393be275d4881a01dd7a49de05a \
                     sha256  61b9c9f9f396768551f39216edcc41918c65909ffd9af071feb3b5f9f9ac1c27 \
                     size    927313

--- a/net/tlswrap/Portfile
+++ b/net/tlswrap/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tlswrap
 version             1.04
-revision            3
+revision            4
 categories          net security
 platforms           darwin
 maintainers         nomaintainer

--- a/net/tnftp/Portfile
+++ b/net/tnftp/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                tnftp
 version             20210827
+revision            1
 categories          net
 license             BSD
 maintainers         {samodelkin.net:fjoe @mkhon} openmaintainer

--- a/net/transmission-x11/Portfile
+++ b/net/transmission-x11/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        transmission transmission 3.00
-revision            0
+revision            1
 name                transmission-x11
 categories          net x11
 license             {GPL-2 OpenSSLException}

--- a/net/trojan/Portfile
+++ b/net/trojan/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           boost 1.0
 
 github.setup        trojan-gfw trojan 1.16.0 v
-revision            1
+revision            2
 categories          net security
 maintainers         {@i0ntempest me.com:szf1234} openmaintainer
 platforms           darwin

--- a/net/ttyd/Portfile
+++ b/net/ttyd/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.0
 
 github.setup        tsl0922 ttyd 1.6.3
-revision            0
+revision            1
 checksums           rmd160  924fb4e6f3b7628bf5baa15c1c7ffb6ce230d86f \
                     sha256  1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9 \
                     size    500424

--- a/net/uftp3/Portfile
+++ b/net/uftp3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                uftp3
 version             3.7.2
-revision            2
+revision            3
 categories          net
 platforms           darwin
 license             GPL-3+

--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
 version             1.13.2
-revision            1
+revision            2
 
 categories          net
 license             BSD

--- a/net/vtun/Portfile
+++ b/net/vtun/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                vtun
 version             3.0.4
-revision            1
+revision            2
 categories          net security
 platforms           darwin
 maintainers         nomaintainer

--- a/net/wap11gui/Portfile
+++ b/net/wap11gui/Portfile
@@ -3,7 +3,7 @@ PortGroup app 1.0
 
 name			wap11gui
 version			0.12
-revision		19
+revision		20
 categories		net
 license			GPL-2+
 maintainers		nomaintainer

--- a/net/websocketpp/Portfile
+++ b/net/websocketpp/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        zaphoyd websocketpp 0.8.2
-revision            0
+revision            1
 categories          net devel
 platforms           darwin
 supported_archs     i386 x86_64

--- a/net/wireshark2/Portfile
+++ b/net/wireshark2/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                wireshark2
 version             2.6.19
-revision            1
+revision            2
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         {darkart.com:opendarwin.org @ghosthound}

--- a/net/wireshark22/Portfile
+++ b/net/wireshark22/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                wireshark22
 version             2.2.10
-revision            5
+revision            6
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         darkart.com:opendarwin.org

--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -31,7 +31,7 @@ long_description    A network analyzer that lets you capture and \
 
 if {${os.major} >= 16} {
     version         3.4.9
-    revision        0
+    revision        1
 
     checksums       sha256  c6525e829bd24525ee699aa207ecd27c50646d64263a669671badfb71cd99620 \
                     rmd160  7fd30ef3b906fa2301b6a77bd4623633d0b46f23 \
@@ -43,7 +43,7 @@ if {${os.major} >= 16} {
     livecheck.regex "Stable Release \\((\\d+(?:\\.\\d+)*)"
 } else {
     version         3.4.1
-    revision        3
+    revision        4
 
     checksums       sha256  f8165211f5b4a4f6708df73ef9be51df917927f2da78348b32d3a6eb5fc458a3 \
                     rmd160  1b5e1fee340c149b70dbe8e8cf935518b06656e8 \

--- a/net/wireshark30/Portfile
+++ b/net/wireshark30/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                wireshark30
 version             3.0.9
-revision            1
+revision            2
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         {darkart.com:opendarwin.org @ghosthound}

--- a/net/wpa_passphrase/Portfile
+++ b/net/wpa_passphrase/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            wpa_passphrase
 version         2.9
+revision            1
 
 platforms       darwin
 categories      net

--- a/net/xymon-client/Portfile
+++ b/net/xymon-client/Portfile
@@ -6,7 +6,7 @@ name                    xymon-client
 set shortname           xymon
 conflicts               xymon-server
 version                 4.3.26
-revision                3
+revision                4
 categories              net
 platforms               darwin
 license                 {GPL-2 OpenSSLException}

--- a/net/xymon-server/Portfile
+++ b/net/xymon-server/Portfile
@@ -7,7 +7,7 @@ set shortname           xymon
 conflicts               xymon-client
 epoch                   1
 version                 4.3.26
-revision                3
+revision                4
 categories              net
 platforms               darwin
 license                 {GPL-2 OpenSSLException}

--- a/net/yafc/Portfile
+++ b/net/yafc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                yafc
 version             1.3.7
-revision            3
+revision            4
 categories          net
 platforms           darwin
 license             {GPL-2+ OpenSSLException}

--- a/net/zabbix4/Portfile
+++ b/net/zabbix4/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                zabbix4
-revision            0
+revision            1
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
 platforms           darwin
@@ -52,7 +52,7 @@ if {$zver == 4} {
 
 if {$zver == 42 || $zver == 44} {
     # REMOVE JANUARY 2022
-    revision        1
+    revision        2
     PortGroup       obsolete 1.0
 
     replaced_by     zabbix5

--- a/net/zeek/Portfile
+++ b/net/zeek/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 
 name                zeek
 version             4.1.1
-revision            0
+revision            1
 categories          net security
 platforms           darwin
 maintainers         {mps @Schamschula} openmaintainer

--- a/office/eureka/Portfile
+++ b/office/eureka/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        simeg eureka 1.8.1 v
+revision            1
 
 categories          office
 platforms           darwin

--- a/perl/p5-crypt-openssl-bignum/Portfile
+++ b/perl/p5-crypt-openssl-bignum/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Crypt-OpenSSL-Bignum 0.09
-revision            1
+revision            2
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         OpenSSL's multiprecision integer arithmetic

--- a/perl/p5-crypt-openssl-dsa/Portfile
+++ b/perl/p5-crypt-openssl-dsa/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Crypt-OpenSSL-DSA 0.19
-revision            1
+revision            2
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Crypt::OpenSSL::DSA - Digital Signature Algorithm using OpenSSL

--- a/perl/p5-crypt-openssl-ec/Portfile
+++ b/perl/p5-crypt-openssl-ec/Portfile
@@ -4,11 +4,12 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
+revision            1
 perl5.setup         Crypt-OpenSSL-EC 1.32
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Crypt::OpenSSL::EC - Perl extension for OpenSSL EC (Elliptic Curves) library
-long_description    ${description}
+long_description    {*}${description}
 
 platforms           darwin
 

--- a/perl/p5-crypt-openssl-ecdsa/Portfile
+++ b/perl/p5-crypt-openssl-ecdsa/Portfile
@@ -7,7 +7,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Crypt-OpenSSL-ECDSA 0.08
-revision            1
+revision            2
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Crypt::OpenSSL::ECDSA - Perl extension for OpenSSL ECDSA \

--- a/perl/p5-crypt-openssl-random/Portfile
+++ b/perl/p5-crypt-openssl-random/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Crypt-OpenSSL-Random 0.15
-revision            1
+revision            2
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Crypt::OpenSSL::Random - OpenSSL/LibreSSL pseudo-random number generator access

--- a/perl/p5-crypt-openssl-rsa/Portfile
+++ b/perl/p5-crypt-openssl-rsa/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Crypt-OpenSSL-RSA 0.31
-revision            2
+revision            3
 categories-append   security
 license             {Artistic-1 GPL}
 maintainers         nomaintainer

--- a/perl/p5-crypt-openssl-x509/Portfile
+++ b/perl/p5-crypt-openssl-x509/Portfile
@@ -4,11 +4,12 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
+revision            1
 perl5.setup         Crypt-OpenSSL-X509 1.902
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Perl extension to OpenSSL's X509 API.
-long_description    ${description}
+long_description    {*}${description}
 platforms           darwin
 
 checksums           rmd160  d1c2790d8e7ecfcc401e962ac946c26dedc5724a \

--- a/perl/p5-crypt-smime/Portfile
+++ b/perl/p5-crypt-smime/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Crypt-SMIME 0.27
-revision            0
+revision            1
 license             {Artistic-1 GPL}
 maintainers         {devans @dbevans} openmaintainer
 description         Crypt::SMIME - S/MIME message signing, verification, encryption and decryption

--- a/perl/p5-crypt-ssleay/Portfile
+++ b/perl/p5-crypt-ssleay/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Crypt-SSLeay 0.72
-revision            1
+revision            2
 maintainers         nomaintainer
 license             Artistic-2
 description         module to add SSL support to LWP

--- a/perl/p5-git-raw/Portfile
+++ b/perl/p5-git-raw/Portfile
@@ -4,11 +4,12 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
+revision            1
 perl5.setup         Git-Raw 0.87
 license             {Artistic-1 GPL}
 maintainers         {devans @dbevans} openmaintainer
 description         Git::Raw - Perl bindings to the Git linkable library (libgit2)
-long_description    ${description}
+long_description    {*}${description}
 
 platforms           darwin
 

--- a/perl/p5-net-dns-sec/Portfile
+++ b/perl/p5-net-dns-sec/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
-
+revision            1
 perl5.setup         Net-DNS-SEC 1.18 ../../authors/id/N/NL/NLNETLABS
 license             MIT
 maintainers         {devans @dbevans} openmaintainer

--- a/perl/p5-net-ssh2/Portfile
+++ b/perl/p5-net-ssh2/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
+revision            1
 perl5.setup         Net-SSH2 0.72
 license             {Artistic-1 GPL}
 maintainers         oaf.dk:mni openmaintainer

--- a/perl/p5-net-ssleay/Portfile
+++ b/perl/p5-net-ssleay/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         Net-SSLeay 1.90
-revision            3
+revision            4
 license             Artistic-2
 maintainers         nomaintainer
 description         Perl extension for using OpenSSL

--- a/php/php-event/Portfile
+++ b/php/php-event/Portfile
@@ -14,7 +14,7 @@ php.pecl                yes
 
 if {[vercmp ${php.branch} 5.4] >= 0} {
     version             3.0.6
-    revision            0
+    revision            1
     checksums           rmd160  2e0ceae210a9ebd6ad6dd7fd00160af3fe38fdfc \
                         sha256  04de37c3274f40109595adbd6283ea29256285264290b00880365bf8235079cc \
                         size    198565

--- a/php/php-mongo/Portfile
+++ b/php/php-mongo/Portfile
@@ -6,7 +6,7 @@ PortGroup       php 1.1
 
 name            php-mongo
 version         1.6.16
-revision        2
+revision        3
 categories      php databases devel
 license         Apache-2
 platforms       darwin

--- a/php/php-swoole/Portfile
+++ b/php/php-swoole/Portfile
@@ -15,32 +15,32 @@ php.pecl                yes
 
 if {[vercmp ${php.branch} 7.2] >= 0} {
     version             4.7.1
-    revision            0
+    revision            1
     checksums           rmd160  275d5c12da9a6bdae4c616005032f751d3c2e845 \
                         sha256  508fefdcb0d0899458ec7efaaa8972c66cd27d5ac83da0ef214792acce8a6fb5 \
                         size    1670458
 } elseif {[vercmp ${php.branch} 7.1] >= 0} {
     version             4.5.11
-    revision            0
+    revision            1
     checksums           rmd160  787880685a821869f19c1b6f4645857b75a048fe \
                         sha256  2d85752ee2b0944399c2901bb22832f196ba3f7ba4262c239d12ed494e2460dd \
                         size    1554142
 } elseif {[vercmp ${php.branch} 7.0] >= 0} {
     version             4.3.6
-    revision            0
+    revision            1
     checksums           rmd160  e77d9a43dbbc6c133e42bf564af9d975e8874838 \
                         sha256  9253d1cb3ae109e18473efc51d14a99067417c28f4c66b1b0a0cdae5141253f9 \
                         size    1349407
 } elseif {[vercmp ${php.branch} 5.5] >= 0} {
     # https://github.com/swoole/swoole-src/issues/1783
     version             2.0.11
-    revision            3
+    revision            4
     checksums           rmd160  7238015b141faf59d9662d4ab21c73bb66b58e35 \
                         sha256  07df75ede4bf0833d2c2443b666a5c3054bc498a78f5251babc1b0e7cc8cd573 \
                         size    769029
 } else {
     version             1.10.5
-    revision            3
+    revision            4
     checksums           rmd160  48b8c3bf5999e5365b3e804440464114500120ed \
                         sha256  5c1dc0b82772ca1c352de4ddf20deeb35f06e4c5a01beba5a446d78a1f747bd2 \
                         size    730797

--- a/print/lib3mf/Portfile
+++ b/print/lib3mf/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 
 github.setup        3MFConsortium lib3mf 2.2.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          print graphics devel
 license             BSD

--- a/python/py-cryptography/Portfile
+++ b/python/py-cryptography/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        pyca cryptography 35.0.0
 name                py-${github.project}
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -43,7 +43,7 @@ if {${name} ne ${subport}
     if {${python.version} eq 27
         || ${os.platform} eq "darwin" && ${os.major} < ${cryptography_darwin_min_ver}} {
         github.setup    pyca cryptography 2.9.2
-        revision        0
+        revision        1
 
         description     Legacy support of Python cryptography.
 

--- a/python/py-curl/Portfile
+++ b/python/py-curl/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-curl
 python.rootname     pycurl
 version             7.44.1
-revision            0
+revision            1
 
 categories-append   net devel
 platforms           darwin
@@ -29,7 +29,7 @@ python.versions     27 37 38 39
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {
         version     7.43.0.3
-        revision    1
+        revision    2
         checksums   rmd160  32673e8d1e9ed4872d9b9d5d8272963f7749cc74 \
                     sha256  6f08330c5cf79fa8ef68b9912b9901db7ffd34b63e225dce74db56bb21deda8e \
                     size    215003

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -5,7 +5,7 @@ PortGroup          python 1.0
 
 name               py-m2crypto
 version            0.38.0
-revision           0
+revision           1
 categories-append  crypto devel
 platforms          darwin
 # demos include some Apache-2 and ZPL-2 files but are not installed

--- a/python/py-openssl/Portfile
+++ b/python/py-openssl/Portfile
@@ -5,7 +5,7 @@ PortGroup python    1.0
 PortGroup github    1.0
 
 github.setup        pyca pyopenssl 19.1.0
-revision            1
+revision            2
 name                py-openssl
 categories-append   devel security
 license             Apache-2

--- a/python/py-psycopg2/Portfile
+++ b/python/py-psycopg2/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-psycopg2
 version             2.9.1
+revision            1
 
 categories-append   databases
 maintainers         {snc @nerdling} openmaintainer

--- a/science/gdcm/Portfile
+++ b/science/gdcm/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 
 name                    gdcm
 version                 3.0.5
-revision                1
+revision                2
 categories              science graphics
 license                 BSD
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/gdcm2/Portfile
+++ b/science/gdcm2/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 
 name                    gdcm2
 version                 2.8.9
-revision                3
+revision                4
 categories              science graphics
 license                 BSD
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/htcondor/Portfile
+++ b/science/htcondor/Portfile
@@ -8,7 +8,7 @@ PortGroup               active_variants 1.1
 
 github.setup            htcondor htcondor 8_8_1 V
 version                 [strsed ${github.version} g/_/\./]
-revision                2
+revision                3
 maintainers             {aronnax @lpsinger}
 
 categories              science parallel net

--- a/science/iAIDA/Portfile
+++ b/science/iAIDA/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           boost 1.0
 
 github.setup        apfeiffer1 iAIDA 1.1.4 iAIDA-
-revision            7
+revision            8
 name                iAIDA
 categories          science
 maintainers         {mojca @mojca} {gmail.com:apfeiffer1 apfeiffer1} openmaintainer

--- a/science/ldas-tools-al/Portfile
+++ b/science/ldas-tools-al/Portfile
@@ -5,7 +5,7 @@ PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-al
 version       2.5.7
-revision      1
+revision      2
 categories    science
 platforms     darwin
 maintainers   {ligo.org:ed.maros @emaros}

--- a/science/ldas-tools-framecpp/Portfile
+++ b/science/ldas-tools-framecpp/Portfile
@@ -5,7 +5,7 @@ PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-framecpp
 version       2.5.8
-revision      1
+revision      2
 categories    science
 platforms     darwin
 maintainers   {ligo.org:ed.maros @emaros}

--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 github.setup        nco nco 5.0.3
-revision            0
+revision            1
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             GPL-3

--- a/science/root5/Portfile
+++ b/science/root5/Portfile
@@ -10,7 +10,7 @@ PortGroup           github 1.0
 #github.setup       root-mirror root 5-34-36 v
 github.setup        root-mirror root c06fdea
 version             5.34.37
-revision            6
+revision            7
 
 livecheck.type      none
 

--- a/science/root6/Portfile
+++ b/science/root6/Portfile
@@ -14,7 +14,7 @@ PortGroup           legacysupport                 1.1
 # Please also check if Gate needs a revbump after root6 update
 github.setup        root-project root 6-24-06 v
 version             [string map {- .} ${github.version}]
-revision            0
+revision            1
 livecheck.version   ${github.version}
 
 # Use git commit

--- a/science/stellarium-qt4/Portfile
+++ b/science/stellarium-qt4/Portfile
@@ -10,7 +10,7 @@ github.setup        Stellarium stellarium 75d3f92af766dbeb92a1d89ff682233bec6658
 
 name                stellarium-qt4
 version             0.12.11-20190501
-revision            0
+revision            1
 categories          science
 platforms           darwin
 license             GPL-2+

--- a/science/wview/Portfile
+++ b/science/wview/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                wview
 version             5.21.7
-revision            2
+revision            3
 categories          science
 maintainers         macports.org:mbclark
 homepage            http://wviewweather.com/

--- a/security/afflib/Portfile
+++ b/security/afflib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        sshock AFFLIBv3 3.7.19 v
-revision            0
+revision            1
 name                afflib
 categories          security
 platforms           darwin

--- a/security/aircrack-ng/Portfile
+++ b/security/aircrack-ng/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 epoch               1
 github.setup        aircrack-ng aircrack-ng 1.6
-revision            0
+revision            1
 checksums           rmd160  895537d6c14f9ce5efa9913d2933a1bfe19604da \
                     sha256  4f0bfd486efc6ea7229f7fbc54340ff8b2094a0d73e9f617e0a39f878999a247 \
                     size    7933308

--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                botan
 version             2.10.0
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          security devel
 platforms           darwin

--- a/security/cpabe/Portfile
+++ b/security/cpabe/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                cpabe
 version             0.11
-revision            2
+revision            3
 categories          security
 platforms           darwin
 maintainers         nomaintainer

--- a/security/crackpkcs12/Portfile
+++ b/security/crackpkcs12/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                crackpkcs12
 version             0.2.9
-revision            2
+revision            3
 categories          security
 platforms           darwin
 license             {GPL-3+ OpenSSLException}

--- a/security/ctool/Portfile
+++ b/security/ctool/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name			ctool
 version			1.2.3
-revision		4
+revision		5
 categories		security
 license			Noncommercial
 maintainers		nomaintainer

--- a/security/cyrus-sasl2/Portfile
+++ b/security/cyrus-sasl2/Portfile
@@ -3,22 +3,10 @@
 PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               muniversal 1.0
-PortGroup               legacysupport 1.0
+PortGroup               legacysupport 1.1
 
 github.setup            cyrusimap cyrus-sasl 2.1.27 cyrus-sasl-
-revision                3
-
-platform darwin 20 {
-    if {${version} eq "2.1.27"} {
-        incr revision
-    }
-    pre-configure {
-        if {[vercmp [macports_version] 2.7.0] < 0} {
-            ui_error "${subport} @${version} requires MacPorts 2.7.0 or greater"
-            return -code error "incompatible MacPorts version"
-        }
-    }
-}
+revision                5
 
 name                    cyrus-sasl2
 categories              security net

--- a/security/hydra/Portfile
+++ b/security/hydra/Portfile
@@ -4,7 +4,7 @@ PortGroup               github 1.0
 
 github.setup            vanhauser-thc thc-hydra 9.2 v
 name                    hydra
-revision                0
+revision                1
 categories              security net
 platforms               darwin
 maintainers             {i0ntempest @i0ntempest} openmaintainer

--- a/security/ike-scan/Portfile
+++ b/security/ike-scan/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        royhills ike-scan 1.9.4
-revision            0
+revision            1
 checksums           rmd160  fd743f703f16f2b06679eb29eb85e26fdd01683c \
                     sha256  2865014185c129ac443beb7bf80f3c5eb93adb504cd307c5b6709199abf7c121 \
                     size    1360202

--- a/security/lastpass-cli/Portfile
+++ b/security/lastpass-cli/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        lastpass lastpass-cli 1.3.3 v
-revision            1
+revision            2
 
 categories          security
 platforms           darwin

--- a/security/libaes_siv/Portfile
+++ b/security/libaes_siv/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        dfoxfranke libaes_siv 1.0.0 v
-revision            1
+revision            2
 categories          security devel
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 

--- a/security/libbswabe/Portfile
+++ b/security/libbswabe/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libbswabe
 version             0.9
-revision            2
+revision            3
 categories          security
 platforms           darwin
 maintainers         nomaintainer

--- a/security/libewf/Portfile
+++ b/security/libewf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libyal libewf 20201210
-revision            0
+revision            1
 categories          security
 platforms           darwin
 maintainers         nomaintainer

--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        Yubico libfido2 1.9.0
-revision            0
+revision            1
 
 categories          security crypto
 platforms           darwin

--- a/security/libp11/Portfile
+++ b/security/libp11/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            OpenSC libp11 0.4.11 libp11-
 github.tarball_from     releases
-revision                0
+revision                1
 categories              security
 platforms               darwin
 license                 LGPL-2.1

--- a/security/libu2f-server/Portfile
+++ b/security/libu2f-server/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                libu2f-server
 version             1.1.0
-revision            3
+revision            4
 categories          security
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer

--- a/security/medusa/Portfile
+++ b/security/medusa/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name               medusa
 version            2.1.1
-revision           2
+revision           3
 categories         security net
 license            {GPL-2 OpenSSLException}
 platforms          darwin

--- a/security/openpace/Portfile
+++ b/security/openpace/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            frankmorgner openpace 1.1.0
-revision                1
+revision                2
 categories              security libs
 platforms               darwin
 license                 GPL-3

--- a/security/openpgpsdk/Portfile
+++ b/security/openpgpsdk/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                openpgpsdk
 version             0.9
-revision            4
+revision            5
 categories          security devel
 license             BSD
 maintainers         nomaintainer

--- a/security/opensc/Portfile
+++ b/security/opensc/Portfile
@@ -5,6 +5,7 @@ PortGroup               github 1.0
 
 name                    opensc
 github.setup            OpenSC OpenSC 0.21.0
+revision            1
 categories              security
 platforms               darwin
 license                 LGPL-2.1

--- a/security/openvas-client/Portfile
+++ b/security/openvas-client/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    openvas-client
 version                 2.0.5
-revision        4
+revision        5
 set download_id         617
 platforms               darwin
 categories              security

--- a/security/ophcrack/Portfile
+++ b/security/ophcrack/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                ophcrack
 version             3.8.0
+revision            1
 categories          security
 license             {GPL-2+ OpenSSLException}
 maintainers         nomaintainer

--- a/security/pkcs11-helper/Portfile
+++ b/security/pkcs11-helper/Portfile
@@ -4,14 +4,16 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        OpenSC pkcs11-helper 1.27 pkcs11-helper-
-revision            0
+revision            1
+
 categories          security
 platforms           darwin freebsd
 license             GPL-2+ BSD
 maintainers         nomaintainer
 
-description         Library that simplifies the interaction with PKCS#11 providers for end-user applications using a simple API and optional OpenSSL engine
-long_description    ${description}
+description         Library that simplifies the interaction with PKCS#11 providers for end-user \
+                    applications using a simple API and optional OpenSSL engine
+long_description    {*}${description}
 
 checksums           rmd160  59c17287ec3ae4c4256364d45ec80d0621b911c5 \
                     sha256  792d7b1ad6e681145b2b3d22cb88afcc43d597761a53d7475ef36ccbdb64d709 \

--- a/security/pwsafe/Portfile
+++ b/security/pwsafe/Portfile
@@ -2,7 +2,7 @@ PortSystem              1.0
 
 name                    pwsafe
 version                 0.2.0
-revision                8
+revision                9
 categories              security
 license                 GPL-2+
 maintainers             nomaintainer

--- a/security/rsyncrypto/Portfile
+++ b/security/rsyncrypto/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                rsyncrypto
 version             1.14
-revision            0
+revision            1
 checksums           rmd160  84e8f680e419a2c4b935ba6f51dc7216fc51df04 \
                     sha256  4f1e2605449c7d35b69d77bce95cb652a8ba1a0996b3babd776fcc98a5a7deff \
                     size    405166

--- a/security/scrypt/Portfile
+++ b/security/scrypt/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                    scrypt
 version                 1.2.1
-revision                1
+revision                2
 description             key derivation function
 long_description        The scrypt key derivation function was originally developed \
     for use in the Tarsnap online backup system and is designed to be far more secure \

--- a/security/sequoia-pgp/Portfile
+++ b/security/sequoia-pgp/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                sequoia-pgp
 version             0.25.0
+revision            1
 categories          security
 maintainers         {jann @roederja} openmaintainer
 license             GPL-3+

--- a/security/sguil-client/Portfile
+++ b/security/sguil-client/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                sguil-client
 version             0.6.1
-revision            2
+revision            3
 categories          security net
 license             QPL-1 Permissive
 maintainers         nomaintainer

--- a/security/skipfish/Portfile
+++ b/security/skipfish/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                skipfish
 version             2.10b
-revision            5
+revision            6
 license             Apache-2
 categories          security
 maintainers         nomaintainer

--- a/security/softhsm/Portfile
+++ b/security/softhsm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                softhsm
 version             2.6.1
-revision            0
+revision            1
 categories          security
 platforms           darwin
 license             BSD

--- a/security/ssss/Portfile
+++ b/security/ssss/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        okoeroo ssss 1.0.1
-revision            2
+revision            3
 categories          security
 platforms           darwin
 maintainers         nikhef.nl:okoeroo

--- a/security/stunnel/Portfile
+++ b/security/stunnel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                stunnel
 version             5.60
-revision            0
+revision            1
 set major           [lindex [split ${version} .] 0]
 categories          security net
 platforms           darwin

--- a/security/tcpcrypt-devel/Portfile
+++ b/security/tcpcrypt-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
 
 github.setup        scslab tcpcrypt 0.5 v
-revision            1
+revision            2
 checksums           rmd160  3a4f7825302de5d0fe4ab482d2a38454504c9588 \
                     sha256  e8508cfd5d175786cb91e0cfed0a2442a480387f8099440fc369509f8c3c7402 \
                     size    824377

--- a/security/tinyca2/Portfile
+++ b/security/tinyca2/Portfile
@@ -10,7 +10,7 @@ perl5.create_variants   ${perl5.branches}
 
 name                tinyca2
 version             0.7.5
-revision            9
+revision            10
 license             GPL
 categories          security net
 maintainers         nomaintainer

--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                tor-devel
 conflicts           tor
 version             0.4.5.2-alpha
-revision            0
+revision            1
 categories          security
 platforms           darwin
 maintainers         nomaintainer

--- a/security/tor/Portfile
+++ b/security/tor/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                tor
 conflicts           tor-devel
 version             0.4.4.6
-revision            0
+revision            1
 categories          security
 platforms           darwin
 maintainers         nomaintainer

--- a/security/tripwire/Portfile
+++ b/security/tripwire/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        Tripwire tripwire-open-source 2.4.3.7
-revision            0
+revision            1
 checksums           rmd160  33942a8559f34bfa804f41444470fe3f4fc54071 \
                     sha256  18d40b85f04b8822717d9a3e987887600840a3753f0e9a9f6ab77692d5658450 \
                     size    1002257

--- a/security/unhash/Portfile
+++ b/security/unhash/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name                unhash
 version             1.1
-revision            3
+revision            4
 categories          security
 platforms           darwin
 maintainers         nomaintainer

--- a/security/voms/Portfile
+++ b/security/voms/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        italiangrid voms 2_0_9
-revision            2
+revision            3
 version             [strsed ${github.version} {g/_/./}]
 categories          security
 platforms           darwin

--- a/security/xca/Portfile
+++ b/security/xca/Portfile
@@ -5,6 +5,7 @@ PortGroup                   github 1.0
 PortGroup                   qt5 1.0
 
 github.setup                chris2511 xca 2.4.0 RELEASE.
+revision            1
 github.tarball_from         releases
 
 categories                  security crypto

--- a/security/xml-security-c/Portfile
+++ b/security/xml-security-c/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                xml-security-c
 version             2.0.3
+revision            1
 categories          security xml textproc shibboleth
 license             Apache-2
 maintainers         {snc @nerdling} {scantor @scantor}

--- a/security/xmlsec/Portfile
+++ b/security/xmlsec/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 
 name                        xmlsec
 version                     1.2.33
-revision                    0
+revision                    1
 checksums                   rmd160  2ab28ddb1e3f5936ee44e837e569f91ec0db2fc3 \
                             sha256  26041d35a20a245ed5a2fb9ee075f10825664d274220cb5190340fa87a4d0931 \
                             size    1991955

--- a/security/xmltooling/Portfile
+++ b/security/xmltooling/Portfile
@@ -5,7 +5,7 @@ PortGroup           boost 1.0
 
 name                xmltooling
 version             3.2.0
-revision            1
+revision            2
 categories          security textproc xml shibboleth
 license             Apache-2
 maintainers         {snc @nerdling} {scantor @scantor}

--- a/security/yara/Portfile
+++ b/security/yara/Portfile
@@ -8,7 +8,7 @@ PortGroup               legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup            VirusTotal yara 4.1.3 v
-revision                0
+revision                1
 
 categories              security
 license                 GPL-2+

--- a/security/yubico-piv-tool/Portfile
+++ b/security/yubico-piv-tool/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.0
 
 github.setup        Yubico yubico-piv-tool 2.2.0 yubico-piv-tool-
+revision            1
 categories          security
 platforms           darwin
 license             BSD

--- a/sysutils/OpenIPMI/Portfile
+++ b/sysutils/OpenIPMI/Portfile
@@ -1,14 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem          1.0
 PortGroup           conflicts_build 1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 
 # requires clock_gettime()
 legacysupport.newest_darwin_requires_legacy 15
 
 name                OpenIPMI
 version             2.0.32
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 license             {GPL-2 LGPL-2}
 categories          sysutils

--- a/sysutils/bacula/Portfile
+++ b/sysutils/bacula/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                bacula
 version             9.4.4
-revision            0
+revision            1
 categories          sysutils
 platforms           darwin
 license             {AGPL-3 OpenSSLException}

--- a/sysutils/bacula5/Portfile
+++ b/sysutils/bacula5/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                bacula5
 set realname        bacula
 version             5.2.13
-revision            3
+revision            4
 categories          sysutils
 platforms           darwin
 license             {AGPL-3 OpenSSLException}

--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                borgbackup
 version             1.1.17
-revision            1
+revision            2
 
 checksums           rmd160  0d19544016343d8f02d753fabae6387da709f036 \
                     sha256  7ab924fc017b24929bedceba0dcce16d56f9868bf9b5050d2aae2eb080671674 \

--- a/sysutils/boxbackup/Portfile
+++ b/sysutils/boxbackup/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            boxbackup
 version         0.11.1
-revision        3
+revision        4
 categories      sysutils net
 license         BSD-old
 maintainers     {ecronin @ecronin} openmaintainer

--- a/sysutils/burp/Portfile
+++ b/sysutils/burp/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            burp
 version         2.1.32
-revision        1
+revision        2
 
 categories      sysutils
 license         {AGPL-3+ OpenSSLException}

--- a/sysutils/cardpeek/Portfile
+++ b/sysutils/cardpeek/Portfile
@@ -5,7 +5,7 @@ PortGroup           conflicts_build 1.0
 
 name                cardpeek
 version             0.8.4
-revision            4
+revision            5
 categories          sysutils
 platforms           darwin
 license             {GPL-3+ OpenSSLException}

--- a/sysutils/cfengine3/Portfile
+++ b/sysutils/cfengine3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                cfengine3
 version             3.18.0
-revision            0
+revision            1
 categories          sysutils
 platforms           darwin
 license             GPL-3

--- a/sysutils/clamav/Portfile
+++ b/sysutils/clamav/Portfile
@@ -4,6 +4,7 @@ PortGroup cmake 1.1
 
 name			clamav
 version		 	0.104.1
+revision            1
 categories		sysutils
 maintainers	 	{geeklair.net:dluke @danielluke}
 description	 	clamav antivirus software

--- a/sysutils/dupd/Portfile
+++ b/sysutils/dupd/Portfile
@@ -5,6 +5,7 @@ PortGroup             makefile 1.0
 
 name                  dupd
 version               1.7.1
+revision            1
 description           Convenient and fast CLI to find duplicate files.
 homepage              http://www.virkki.com/dupd
 license               GPL-3

--- a/sysutils/flameshot/Portfile
+++ b/sysutils/flameshot/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake   1.1
 PortGroup               qt5     1.0
 
 github.setup            flameshot-org flameshot 0.10.1 v
-revision                0
+revision                1
 
 homepage                https://flameshot.org
 

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                3
+revision                4
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588

--- a/sysutils/gearmand/Portfile
+++ b/sysutils/gearmand/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 PortGroup           boost 1.0
 
 github.setup        gearman gearmand 1.1.18
-revision            6
+revision            7
 categories          sysutils net devel
 maintainers         nomaintainer
 platforms           darwin

--- a/sysutils/ipmitool/Portfile
+++ b/sysutils/ipmitool/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 10
 # Using head of ipmitool until next release for openssl build fixes
 github.setup    ipmitool ipmitool 11c7605c0d5423f90f399f5e830d1095089f38a1
 version         1.8.18.20210622
-revision        0
+revision        1
 checksums       rmd160  273ded688a39ca722d5de4a7a11497b37e9833b9 \
                 sha256  f5e7c03254e3714fd14f5780833c028a03f97fa9a9832ff95644a80969e1411a \
                 size    638260

--- a/sysutils/john/Portfile
+++ b/sysutils/john/Portfile
@@ -76,7 +76,7 @@ destroot {
 subport john-jumbo {
     conflicts           john
     version             1.9.0
-    revision            1
+    revision            2
     set jumbo_patchlvl  1
     license             GPL-2 GPL-3+ Apache-2 Restrictive
     master_sites        https://www.openwall.com/john/k/

--- a/sysutils/md5sha1sum/Portfile
+++ b/sysutils/md5sha1sum/Portfile
@@ -2,7 +2,7 @@ PortSystem		1.0
 
 name			md5sha1sum
 version			0.9.5
-revision		3
+revision		4
 categories		sysutils
 license			{GPL-2+ OpenSSLException}
 maintainers		flyn.org:mike

--- a/sysutils/monit/Portfile
+++ b/sysutils/monit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                monit
 version             5.27.0
-revision            0
+revision            1
 
 categories          sysutils
 platforms           darwin freebsd linux netbsd openbsd solaris

--- a/sysutils/netdata/Portfile
+++ b/sysutils/netdata/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 
 github.setup            netdata netdata 1.29.3 v
-revision                1
+revision                2
 
 github.tarball_from     releases
 distname                ${name}-v${version}
@@ -109,7 +109,7 @@ subport ${name}-dashboard {
     long_description    {*}${description}
 
     github.setup        netdata dashboard 2.16.0 v
-    revision            1
+    revision            2
 
     github.tarball_from releases
     distname            dashboard

--- a/sysutils/ntp/Portfile
+++ b/sysutils/ntp/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		ntp
 version		4.2.8p15
-revision	0
+revision	1
 categories	sysutils net
 maintainers	{geeklair.net:dluke @danielluke}
 description	NTP is a protocol designed to synchronize the clocks of computers over a network.

--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 name                ntpsec
 version             1.2.1
-revision            0
+revision            1
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP

--- a/sysutils/rpm/Portfile
+++ b/sysutils/rpm/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                rpm
 version             4.4.9
-revision            22
+revision            23
 perl5.branches      5.28
 platforms           darwin freebsd linux
 license             GPL-2 LGPL-2

--- a/sysutils/rpm54/Portfile
+++ b/sysutils/rpm54/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 
 name                rpm54
 version             5.4.15
-revision            8
+revision            9
 set date            20140824
 set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin freebsd linux

--- a/sysutils/sleuthkit/Portfile
+++ b/sysutils/sleuthkit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        sleuthkit sleuthkit 4.11.1 sleuthkit-
-revision            0
+revision            1
 
 checksums           rmd160  d848551282020e2e43729dc2d5d3a45624cb2f10 \
                     sha256  c3999f4a727bf5bc8a46bba933dcfb95c4170e52c76916d1137b534a3576405f \

--- a/sysutils/socat/Portfile
+++ b/sysutils/socat/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name            socat
 version         1.7.4.1
-revision        0
+revision        1
 
 homepage        http://www.dest-unreach.org/socat
 

--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        starship starship 0.58.0 v
-revision            1
+revision            2
 
 homepage            https://starship.rs
 

--- a/sysutils/stressdrive/Portfile
+++ b/sysutils/stressdrive/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 PortGroup           xcode 1.0
 
 github.setup        rentzsch stressdrive 1.3.2
+revision            1
 categories          sysutils
 platforms           darwin
 maintainers         {@toy yandex.com:bstj} openmaintainer

--- a/sysutils/synergy/Portfile
+++ b/sysutils/synergy/Portfile
@@ -38,7 +38,7 @@ patchfiles patch-openssl.diff
 compiler.cxx_standard   2011
 
 if {${subport} eq ${name}} {
-    revision                0
+    revision                1
 
     configure.args-append   -DSYNERGY_BUILD_LEGACY_INSTALLER=OFF
 
@@ -61,7 +61,7 @@ if {${subport} eq ${name}} {
 }
 
 subport ${name}-app {
-    revision                0
+    revision                1
 
     patchfiles-append       patch-Info.plist.in.diff
 

--- a/sysutils/tarsnap/Portfile
+++ b/sysutils/tarsnap/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tarsnap
 version             1.0.39
-revision            1
+revision            2
 categories          sysutils
 platforms           darwin
 maintainers         {bgilbert @bgilbert} openmaintainer

--- a/sysutils/yafic/Portfile
+++ b/sysutils/yafic/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            yafic
 version         1.2.2
-revision        3
+revision        4
 categories      sysutils
 maintainers     nomaintainer
 platforms       darwin

--- a/textproc/angle-grinder/Portfile
+++ b/textproc/angle-grinder/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 
 github.setup        rcoh angle-grinder 0.18.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Slice and dice log files on the command line.
 

--- a/textproc/html-xml-utils/Portfile
+++ b/textproc/html-xml-utils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                html-xml-utils
 version             7.0
-revision            4
+revision            5
 categories          textproc
 platforms           darwin
 maintainers         nomaintainer

--- a/textproc/libmrss/Portfile
+++ b/textproc/libmrss/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name			libmrss
 version			0.19.2
-revision  2
+revision  3
 license         LGPL-2.1+
 categories		textproc devel
 platforms		darwin

--- a/textproc/sword/Portfile
+++ b/textproc/sword/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                sword
 version             1.9.0
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          textproc
 platforms           darwin

--- a/www/NetSurf/Portfile
+++ b/www/NetSurf/Portfile
@@ -5,7 +5,7 @@ PortGroup           makefile 1.0
 
 name                NetSurf
 version             3.10
-revision            0
+revision            1
 checksums           rmd160  2ba50fcb148d1b229e48b80f2a2c24daf2948783 \
                     sha256  495adf6b6614ce36fca6c605f7c321f9cb4a3df838043158122678ce2b3325b7 \
                     size    8537919

--- a/www/QupZilla/Portfile
+++ b/www/QupZilla/Portfile
@@ -6,7 +6,7 @@ universal_variant   no
 PortGroup           qmake5 1.0
 
 github.setup        QupZilla qupzilla 2.2.6 v
-revision            1
+revision            2
 name                QupZilla
 categories          www
 platforms           darwin

--- a/www/apache2/Portfile
+++ b/www/apache2/Portfile
@@ -5,7 +5,7 @@ PortGroup           apache2 1.0
 
 name                apache2
 version             2.4.51
-revision            0
+revision            1
 checksums           rmd160  339cf2df89613855dc44affe6296ba1b1652db14 \
                     sha256  20e01d81fecf077690a4439e3969a9b22a09a8d43c525356e863407741b838f4 \
                     size    7653609

--- a/www/arora/Portfile
+++ b/www/arora/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           qmake 1.0
 
 github.setup        arora arora 0.11.0
-revision            2
+revision            3
 categories          www aqua
 platforms           darwin
 maintainers         nomaintainer

--- a/www/cadaver/Portfile
+++ b/www/cadaver/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                cadaver
 version             0.23.3
-revision            2
+revision            3
 categories          www
 maintainers         {puffin.lb.shuttle.de:michael.klein @mklein-de} openmaintainer
 description         Commandline client for DAV

--- a/www/cgit/Portfile
+++ b/www/cgit/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                cgit
 version             1.2.3
-revision            1
+revision            2
 
 # See Makefile GIT_VER
 set git_version     2.25.1

--- a/www/cpprestsdk/Portfile
+++ b/www/cpprestsdk/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
 github.setup        Microsoft cpprestsdk 2.10.16 v
-revision            1
+revision            2
 categories          www devel
 platforms           darwin
 supported_archs     i386 x86_64

--- a/www/edbrowse/Portfile
+++ b/www/edbrowse/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                edbrowse
 version             3.4.10
-revision            4
+revision            5
 categories          www
 license             GPL
 maintainers         nomaintainer

--- a/www/elinks-devel/Portfile
+++ b/www/elinks-devel/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                elinks-devel
 conflicts           elinks
 version             0.12pre6
-revision            5
+revision            6
 categories          www
 maintainers         nomaintainer
 platforms           darwin

--- a/www/elinks/Portfile
+++ b/www/elinks/Portfile
@@ -5,7 +5,7 @@ name                elinks
 conflicts           elinks-devel
 epoch               1
 version             0.11.7
-revision            6
+revision            7
 categories          www
 platforms           darwin
 license             GPL-2

--- a/www/goaccess/Portfile
+++ b/www/goaccess/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                goaccess
 version             1.5.2
-revision            0
+revision            1
 categories          www
 license             MIT
 maintainers         {mps @Schamschula} openmaintainer

--- a/www/h2o/Portfile
+++ b/www/h2o/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        h2o h2o 2.2.6 v
-revision            0
+revision            1
 categories          www
 platforms           darwin
 license             MIT

--- a/www/hurl/Portfile
+++ b/www/hurl/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 
 github.setup        Orange-OpenSource hurl 1.4.0
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://hurl.dev
 

--- a/www/libwww/Portfile
+++ b/www/libwww/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            libwww
 version         5.4.2
-revision        1
+revision        2
 categories      www
 license         W3C
 platforms       darwin

--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -5,7 +5,7 @@ PortGroup                   legacysupport 1.0
 
 name                        lighttpd
 version                     1.4.61
-revision                    0
+revision                    1
 checksums                   rmd160  bc29f71ac97be06a23dc86a83ed4fc9bfbb1d668 \
                             sha256  43f0d63d04a1b7c5b8aab07e0612e44ccad0afc0614bab784c5b019872363432 \
                             size    1010624

--- a/www/links/Portfile
+++ b/www/links/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            links
 version         2.25
-revision        0
+revision        1
 description     Lynx-like WWW browser that supports tables, menus, etc
 
 long_description \

--- a/www/links1/Portfile
+++ b/www/links1/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name             links1
 version          1.03
-revision         1
+revision         2
 distname         links-${version}
 categories       www
 license          GPL-2+

--- a/www/litmus/Portfile
+++ b/www/litmus/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                litmus
 version             0.13
-revision            3
+revision            4
 categories          www
 platforms           darwin
 license             GPL-2

--- a/www/lws/Portfile
+++ b/www/lws/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name             lws
 version          0.6.1
-revision         1
+revision         2
 categories       www
 license          Permissive
 maintainers      nomaintainer

--- a/www/lynx/Portfile
+++ b/www/lynx/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                lynx
 set milestone       2.8.9
 version             ${milestone}rel.1
-revision            1
+revision            2
 categories          www
 platforms           darwin
 license             {GPL-2 OpenSSLException}

--- a/www/mod_authn_otp/Portfile
+++ b/www/mod_authn_otp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        archiecobbs mod-authn-otp 1.1.5
-revision            1
+revision            2
 name                mod_authn_otp
 
 categories          www

--- a/www/mod_ca/Portfile
+++ b/www/mod_ca/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mod_ca
 version             0.2.2
+revision            1
 categories          www security
 platforms           darwin
 maintainers         {redwax.org:dirkx @dirkx} openmaintainer

--- a/www/mod_crl/Portfile
+++ b/www/mod_crl/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mod_crl
 version             0.2.2
+revision            1
 categories          www security
 platforms           darwin
 maintainers         {redwax.org:dirkx @dirkx} openmaintainer

--- a/www/mod_csr/Portfile
+++ b/www/mod_csr/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mod_csr
 version             0.2.3
+revision            1
 categories          www security
 platforms           darwin
 maintainers         {redwax.org:dirkx @dirkx} openmaintainer

--- a/www/mod_ocsp/Portfile
+++ b/www/mod_ocsp/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mod_ocsp
 version             0.2.2
+revision            1
 categories          www security
 platforms           darwin
 maintainers         {redwax.org:dirkx @dirkx} openmaintainer

--- a/www/mod_pkcs12/Portfile
+++ b/www/mod_pkcs12/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mod_pkcs12
 version             0.2.1
+revision            1
 categories          www security
 platforms           darwin
 maintainers         {redwax.org:dirkx @dirkx} openmaintainer

--- a/www/mod_qos/Portfile
+++ b/www/mod_qos/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mod_qos
 version             11.69
-revision            0
+revision            1
 categories          www
 license             Apache-2
 maintainers         nomaintainer

--- a/www/mod_scep/Portfile
+++ b/www/mod_scep/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mod_scep
 version             0.2.3
+revision            1
 categories          www security
 platforms           darwin
 license             Apache-2

--- a/www/mod_spkac/Portfile
+++ b/www/mod_spkac/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mod_spkac
 version             0.2.2
+revision            1
 categories          www security
 platforms           darwin
 maintainers         {redwax.org:dirkx @dirkx} openmaintainer

--- a/www/mod_timestamp/Portfile
+++ b/www/mod_timestamp/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mod_timestamp
 version             0.2.1
+revision            1
 categories          www security
 platforms           darwin
 maintainers         {redwax.org:dirkx @dirkx} openmaintainer

--- a/www/neon/Portfile
+++ b/www/neon/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 
 name            neon
 version         0.31.2
-revision        0
+revision        1
 categories      www
 maintainers     nomaintainer
 description     An HTTP and WebDAV client library with a C interface

--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -47,6 +47,7 @@ if {${subport} eq ${name}} {
 }
 
 subport nghttp2-tools {
+    incr revision
     description         Tools for nghttp2, an implementation of HTTP/2 in C.
     long_description    HTTP/2 client, server and proxy tools, as well as a \
                         load test and benchmarking tool for HTTP/2.

--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                nginx
 version             1.21.4
-revision            0
+revision            1
 categories          www mail
 platforms           darwin
 license             BSD

--- a/www/nostromo/Portfile
+++ b/www/nostromo/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    nostromo
 version                 1.9.3
-revision                3
+revision                4
 categories              www
 license                 ISC
 platforms               darwin

--- a/www/pound/Portfile
+++ b/www/pound/Portfile
@@ -2,7 +2,7 @@ PortSystem        1.0
 
 name              pound
 version           2.6
-revision          2
+revision          3
 categories        www
 license           GPL-3
 platforms         darwin

--- a/www/raptor2/Portfile
+++ b/www/raptor2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                raptor2
 version             2.0.15
-revision            5
+revision            6
 set major           [lindex [split ${version} .] 0]
 description         Raptor RDF Parser Toolkit
 long_description    Raptor is an open source C library that provides a set of \

--- a/www/rasqal/Portfile
+++ b/www/rasqal/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                rasqal
 version             0.9.33
-revision            1
+revision            2
 description         Raptor RDF Query Library
 long_description    Rasqal is an open source C library that handles Resource \
                     Description Framework (RDF) query syntaxes, query \

--- a/www/redland/Portfile
+++ b/www/redland/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                redland
 version             1.0.17
-revision            1
+revision            2
 description         Redland RDF Library
 long_description    Redland is a set of free software libraries that provide \
                     support for the Resource Description Framework (RDF).

--- a/www/restinio/Portfile
+++ b/www/restinio/Portfile
@@ -8,7 +8,7 @@ PortGroup                   compiler_blacklist_versions 1.0
 PortGroup                   boost 1.0
 
 github.setup                Stiffstream restinio 0.4.8 v.
-revision                    2
+revision                    3
 categories                  www devel
 platforms                   darwin
 license                     BSD

--- a/www/siege/Portfile
+++ b/www/siege/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                siege
 version             4.1.1
-revision            0
+revision            1
 categories          www benchmarks
 platforms           darwin
 maintainers         nomaintainer

--- a/www/slowhttptest/Portfile
+++ b/www/slowhttptest/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        shekyan slowhttptest 1.8.2 v
-revision            0
+revision            1
 checksums           rmd160  06140a878b356376083d585569b3281e8bcc16cc \
                     sha256  faa83dc45e55c28a88d3cca53d2904d4059fe46d86eca9fde7ee9061f37c0d80 \
                     size    131160

--- a/www/w3m/Portfile
+++ b/www/w3m/Portfile
@@ -6,7 +6,7 @@ name                w3m
 set sf_version      0.5.3
 set debian_revision 38
 version             ${sf_version}-${debian_revision}
-revision            0
+revision            1
 categories          www
 license             MIT
 maintainers         nomaintainer
@@ -27,7 +27,7 @@ if {${name} eq ${subport}} {
     master_sites    sourceforge:project/w3m/w3m/w3m-${sf_version}
 
     distname        ${name}-${sf_version}
-    revision        1
+    revision        2
 
     checksums       rmd160  6a0153bc53f7c107c700404262ce1b4d02e6dd91 \
                     sha256  e994d263f2fd2c22febfbe45103526e00145a7674a0fda79c822b97c2770a9e3 \

--- a/www/zola/Portfile
+++ b/www/zola/Portfile
@@ -5,7 +5,7 @@ PortGroup           github  1.0
 PortGroup           cargo   1.0
 
 github.setup        getzola zola 0.14.1 v
-revision            0
+revision            1
 
 homepage            https://www.getzola.org
 

--- a/x11/winetricks/Portfile
+++ b/x11/winetricks/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            Winetricks winetricks 20210825
-revision                0
+revision                1
 checksums               rmd160  f324815fad1b8641270368e64f90a9e8d307cba5 \
                         sha256  da3f6d39d1a4280d66d77704bbe1119be8fc4ae3a28396f386d96f4cdb079fbf \
                         size    689734

--- a/x11/x3270/Portfile
+++ b/x11/x3270/Portfile
@@ -2,7 +2,7 @@ PortSystem			1.0
 
 name				x3270
 version				3.3.11ga6
-revision   3
+revision   4
 set branch			[join [lrange [split ${version} .] 0 1] .]
 categories			x11
 maintainers			nomaintainer


### PR DESCRIPTION
- update openssl shim port and PG to use openssl 3 by default.
- rev bump all ports depending on openssl (using attached script).

Closes: [63801 - python ports: update to use openssl 3, allowing dependent binaries to be redistributed](https://trac.macports.org/ticket/63801)

[macports-bump-rev.sh.txt](https://github.com/macports/macports-ports/files/7478378/macports-bump-rev.sh.txt)


