### PR TITLE
py-{anytree,bottlenose}: resolve conflict

### DIFF
--- a/python/py-anytree/Portfile
+++ b/python/py-anytree/Portfile
@@ -5,13 +5,13 @@ PortGroup           python 1.0
 
 name                py-anytree
 version             2.8.0
-revision            0
+revision            1
 
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         Python tree data library
 long_description    ${description}
@@ -30,6 +30,8 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-six
+
+    patchfiles      patch-setup.py.diff
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-anytree/files/patch-setup.py.diff
+++ b/python/py-anytree/files/patch-setup.py.diff
@@ -1,0 +1,12 @@
+diff --git setup.py setup.py
+index d92a271..d22a097 100644
+--- setup.py
++++ setup.py
+@@ -49,7 +49,6 @@ config['extras_require'] = {
+ }
+ config['tests_require'] = ['nose']
+ config['test_suite'] = 'nose.collector'
+-config['data_files'] = [('', ['LICENSE'])]
+ 
+ # Get the long description from the README file
+ here = path.abspath(path.dirname(__file__))

--- a/python/py-bottlenose/Portfile
+++ b/python/py-bottlenose/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        lionheart bottlenose 1.1.10
 name                py-bottlenose
-revision            0
+revision            1
 
 categories-append   devel
 platforms           darwin
@@ -29,6 +29,15 @@ python.versions     37 38 39
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    patchfiles      patch-setup.py.diff
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.md \
+            LICENSE ${destroot}${docdir}
+    }
 
     livecheck.type  none
 }

--- a/python/py-bottlenose/files/patch-setup.py.diff
+++ b/python/py-bottlenose/files/patch-setup.py.diff
@@ -1,0 +1,12 @@
+diff --git setup.py setup.py
+index 5b20c24..d7a7658 100755
+--- setup.py
++++ setup.py
+@@ -62,7 +62,6 @@ setup(
+     author_email=metadata['__email__'],
+     url='https://github.com/lionheart/bottlenose',
+     packages=["bottlenose"],
+-    data_files=[("", ["LICENSE", "README.md"])],
+     license=metadata['__license__'],
+     install_requires=install_requires,
+ )


### PR DESCRIPTION
#### Description

Both ports are installed `${python.prefix}/LICENSE`.

Closes: https://trac.macports.org/ticket/63803

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->