### PR TITLE
mysql8: fix configure on macOS 12.0

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -153,6 +153,7 @@ if {$subport eq $name} {
                     patch-cmake-install_layout.cmake.diff \
                     patch-cmake-sasl-disable-platform-check.diff \
                     patch-mysql8-workaround-no-SC_PHYS_PAGES.diff \
+                    patch-package_name.cmake.diff \
                     patch-scripts-cmakelists.diff \
                     patch-sql-local-boost.diff \
                     patch-mysql8-ffsll-apple.diff

--- a/databases/mysql8/files/patch-package_name.cmake.diff
+++ b/databases/mysql8/files/patch-package_name.cmake.diff
@@ -1,0 +1,27 @@
+From 1af75f2c4e8058f5f64a045a81008c40a3faba65 Mon Sep 17 00:00:00 2001
+From: Christopher Chavez <chrischavez@gmx.us>
+Date: Thu, 4 Nov 2021 16:07:20 -0500
+Subject: [PATCH] Fix configure on macOS x.y.z when y is 0
+
+The "Could not run sw_vers" error is output when building on macOS x.y.z
+when y is 0 (example: macOS 12.0.1) because CMAKE_MATCH_2 is set to "0",
+which when used as a condition evaluates to false.
+Check `CMAKE_MATCH_COUNT EQUAL 2` instead to know whether CMAKE_MATCH_1
+and CMAKE_MATCH_2 are properly set.
+---
+ cmake/package_name.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/package_name.cmake b/cmake/package_name.cmake
+index 058b0bcbd8cb..be1af896d515 100644
+--- a/cmake/package_name.cmake
++++ b/cmake/package_name.cmake
+@@ -88,7 +88,7 @@ MACRO(GET_PACKAGE_FILE_NAME Var)
+ 
+       STRING(REGEX MATCH
+         "ProductVersion:[\n\t ]*([0-9]+)\\.([0-9]+)" UNUSED ${SW_VERS_PRODUCTVERSION})
+-      IF(NOT CMAKE_MATCH_1 OR NOT CMAKE_MATCH_2)
++      IF(NOT CMAKE_MATCH_COUNT EQUAL 2)
+         MESSAGE(FATAL_ERROR "Could not run sw_vers")
+       ENDIF()
+ 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/63726

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
(Tested by the issue reporter)
macOS 12.0.1
Xcode 13.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
