### PR TITLE
py-crypto dependents: migrate to py-pycryptodome

### DIFF
--- a/devel/bzr/Portfile
+++ b/devel/bzr/Portfile
@@ -4,7 +4,7 @@ PortGroup     python 1.0
 name          bzr
 # prior to updating bzr, please check https://trac.macports.org/ticket/52561
 version       2.6.0
-revision      2
+revision      3
 epoch         1
 set branch    [join [lrange [split ${version} .] 0 1] .]
 categories    devel python
@@ -35,7 +35,7 @@ patchfiles    patch-setup.py.diff \
               patch-CVE-2017-14176.diff
 
 depends_lib-append  port:py${python.version}-paramiko \
-                    port:py${python.version}-crypto \
+                    port:py${python.version}-pycryptodome \
                     port:py${python.version}-curl \
                     port:py${python.version}-docutils \
                     port:py${python.version}-pyrex

--- a/net/scapy/Portfile
+++ b/net/scapy/Portfile
@@ -37,7 +37,7 @@ if {${subport} eq ${name}} {
     checksums       rmd160 0c614cedc5aadd15fc8c2d1a350fe0a6ebe84fae \
                     sha256  8c9b38bbc20d4fdd0bfc2c971fed9a170c0ef6572dab564e17c44a8c11e164af \
                     size    3323770
-    revision        0
+    revision        1
 
     conflicts ${name}-devel
 
@@ -53,7 +53,7 @@ if {${subport} eq ${name}} {
     checksums       rmd160  54d93cfdbdef548dd3a3a31f1bb79b3a5fb213a4 \
                     sha256  2f5c8716aa63bb604bb05461fdf83ac1f414bef8be977a09363c065c9fe556e2 \
                     size    3923390
-    revision        0
+    revision        1
 
     long_description    ${long_description} \
         This port is kept up with the ${name} GIT 'master' branch, is typically updated weekly to monthly.
@@ -66,7 +66,7 @@ homepage              http://www.secdev.org/projects/${name}
 depends_lib-append    port:py${python.version}-gnureadline \
                       port:py${python.version}-pylibpcap \
                       port:py${python.version}-libdnet \
-                      port:py${python.version}-crypto
+                      port:py${python.version}-pycryptodome
 
 default_variants +gnuplot +graphviz
 

--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -8,7 +8,7 @@ name                youtube-dl
 
 if {${subport} eq ${name}} {
     github.setup    ytdl-org ${subport} 2021.06.06
-    revision        0
+    revision        1
     checksums       rmd160  24478101dbb1a9f5b634ed872e407c4e8d088041 \
                     sha256  3ccb0e4db9fd172338ed1c32bae0be2f716458dca4143e55732ff55260b20ac3 \
                     size    3336227
@@ -36,7 +36,7 @@ if {${subport} eq ${name}} {
 
 subport yt-dlp {
     github.setup    yt-dlp ${subport} 2021.10.22
-    revision        0
+    revision        1
     checksums       rmd160  6a540747c032afc5b1c243bd354c86b9cfbaa219 \
                     sha256  075d7e04fb8882bd4722859e93d0eb465a8f7c13921fd091ed3791be2b670476 \
                     size    4041073
@@ -120,4 +120,4 @@ if {[variant_isset python27]} {
 }
 
 # WARNING: hlsnative has detected features it does not support, extraction will be delegated to ffmpeg
-depends_lib-append          port:py${python.version}-crypto
+depends_lib-append          port:py${python.version}-pycryptodome

--- a/python/py-crypto/Portfile
+++ b/python/py-crypto/Portfile
@@ -7,6 +7,13 @@ name                py-crypto
 version             2.6.1
 revision            2
 
+#------------------------------------------------------------------------------
+# Obsolete Date: 2021-11-06
+#
+# NOTE: Also remove auto-deactivate logic related to this port, from
+#   'py-pycryptodome', when this port is ultimately deleted.
+#------------------------------------------------------------------------------
+
 replaced_by         py-pycryptodome
 
 set python_rootname [regsub ^py- [option name] ""]

--- a/python/py-crypto/Portfile
+++ b/python/py-crypto/Portfile
@@ -1,52 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
+PortGroup           obsolete 1.0
 
 name                py-crypto
 version             2.6.1
-revision            1
+revision            2
 
-categories-append   security
-platforms           darwin freebsd
-license             public-domain PSF
-maintainers         nomaintainer
+replaced_by         py-pycryptodome
 
-description         Collection of cryptographic algorithms and protocols
-long_description    Collection of cryptographic algorithms and protocols, \
-                    implemented for use from python. Among are MD2, MD4, \
-                    RIPEMD, AES, ARC2, Blowfish, CAST, DES, Triple-DES, \
-                    IDEA, RC5, ARC4, simple XOR, RSA, DSA, ElGamal, qNEW.
-
-homepage            https://www.dlitz.net/software/pycrypto/
-master_sites        https://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/
-distname            pycrypto-${version}
-
-checksums           rmd160  ac0db079e5e4be9daf739e094c10e96291dbc009 \
-                    sha256  f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c \
-                    size    446240
-
-python.versions     27 35 36 37 38 39
-
-if {${name} ne ${subport}} {
-    # See: See: https://trac.macports.org/ticket/63481
-    conflicts           py${python.version}-pycryptodome
-
-    depends_lib-append  port:gmp
-
-    post-destroot {
-        xinstall -d ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 0644 -W ${worksrcpath} \
-                ACKS ChangeLog COPYRIGHT README TODO \
-                ${destroot}${prefix}/share/doc/${subport}
+set python_rootname [regsub ^py- [option name] ""]
+set python_versions {27 35 36 37 38 39}
+foreach pv ${python_versions} {
+    subport "py${pv}-${python_rootname}" {
+        replaced_by py${pv}-pycryptodome
     }
-
-    test.run            yes
-    test.target         test
-
-    livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       ${homepage}
-    livecheck.regex     pycrypto-(\[0-9\.\]+).tar.gz
 }

--- a/python/py-ezpycrypto/Portfile
+++ b/python/py-ezpycrypto/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-ezpycrypto
 version             0.1.1
-revision            1
+revision            2
 categories-append   security
 platforms           darwin
 supported_archs     noarch
@@ -31,7 +31,7 @@ checksums           md5     6e30f9e6a16aca849431568e1a5b0ee1 \
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-crypto
+    depends_lib-append  port:py${python.version}-pycryptodome
 
     test.run        yes
     test.cmd        ${python.bin}

--- a/python/py-keyczar/Portfile
+++ b/python/py-keyczar/Portfile
@@ -25,6 +25,9 @@ python.versions     27
 platforms           darwin
 supported_archs     noarch
 
+patchfiles-append   patch-requires-pycryptodome.diff \
+                    patch-setup-pycryptodome.diff
+
 checksums           sha256  42e6f7d5de24bce33fd86b6cfa2b7a80bbb0e55443bb608d815a545df7f43665 \
                     rmd160  2a59d61666f367e864a9d19889ffb05e82f9e632 \
                     size    3535280

--- a/python/py-keyczar/Portfile
+++ b/python/py-keyczar/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 name                py-keyczar
 github.setup        google keyczar Python_release_0.716
 regexp {([^_]+)$} ${version} version
-revision            0
+revision            1
 
 categories-append   devel crypto
 license             Apache-2
@@ -31,7 +31,7 @@ checksums           sha256  42e6f7d5de24bce33fd86b6cfa2b7a80bbb0e55443bb608d815a
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-asn1 \
-                        port:py${python.version}-crypto \
+                        port:py${python.version}-pycryptodome \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-simplejson
 

--- a/python/py-keyczar/files/patch-requires-pycryptodome.diff
+++ b/python/py-keyczar/files/patch-requires-pycryptodome.diff
@@ -1,0 +1,8 @@
+--- python/python_keyczar.egg-info/requires.txt.orig	2021-11-05 19:35:25.000000000 -0400
++++ python/python_keyczar.egg-info/requires.txt	2021-11-05 19:35:44.000000000 -0400
+@@ -1,2 +1,2 @@
+-pycrypto>2.0
+-pyasn1
+\ No newline at end of file
++pycryptodome>3.0
++pyasn1

--- a/python/py-keyczar/files/patch-setup-pycryptodome.diff
+++ b/python/py-keyczar/files/patch-setup-pycryptodome.diff
@@ -1,0 +1,11 @@
+--- python/setup.py.orig	2016-05-04 23:54:29.000000000 -0400
++++ python/setup.py	2021-11-05 19:45:11.000000000 -0400
+@@ -36,7 +36,7 @@
+       version='0.71h',
+       packages=['keyczar'],
+       package_dir={'keyczar': 'src/keyczar'},
+-      install_requires=['pycrypto>2.0', 'pyasn1'],
++      install_requires=['pycryptodome>3.0', 'pyasn1'],
+       maintainer='Google, Inc.',
+       maintainer_email='keyczar-discuss@googlegroups.com',
+       license='http://www.apache.org/licenses/LICENSE-2.0',

--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pycryptodome
 version             3.10.1
-revision            0
+revision            1
 
 homepage            https://www.pycryptodome.org
 
@@ -25,11 +25,19 @@ checksums           rmd160  c10290cefe964891fac78e8fd32e4d3e667bcdd0 \
                     size    3762120
 
 if {${name} ne ${subport}} {
-    # See: See: https://trac.macports.org/ticket/63481
-    conflicts           py${python.version}-crypto
-
     depends_build-append \
                         port:py${python.version}-setuptools
 
     livecheck.type      none
+
+    set pycrypto_name   py${python.version}-crypto
+} else {
+    set pycrypto_name   py-crypto
+}
+
+pre-activate {
+    # Deactivate obsolete port 'py-crypto', if installed
+    if {![catch {set installed [lindex [registry_active ${pycrypto_name}] 0]}]} {
+        registry_deactivate_composite ${pycrypto_name} "" [list ports_nodepcheck 1]
+    }
 }

--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -35,6 +35,10 @@ if {${name} ne ${subport}} {
     set pycrypto_name   py-crypto
 }
 
+#------------------------------------------------------------------------------
+# NOTE: Remove this logic - along with declaration of 'pycrypto_name', above,
+#   when obsolete port 'py-crypto' is ultimately deleted.
+#------------------------------------------------------------------------------
 pre-activate {
     # Deactivate obsolete port 'py-crypto', if installed
     if {![catch {set installed [lindex [registry_active ${pycrypto_name}] 0]}]} {

--- a/python/py-recaptcha/Portfile
+++ b/python/py-recaptcha/Portfile
@@ -32,10 +32,12 @@ checksums           rmd160  7dffe66b7fd37f5be2a7d7b2bf24c3978f46c8e9 \
                     sha256  28c6853c1d13d365b7dc71a6b05e5ffb56471f70a850de318af50d3d7c0dea2f \
                     size    7389
 
-
 python.versions     27
 
 if {${name} ne ${subport}} {
+    patchfiles-append   patch-requires-pycryptodome.diff \
+                        patch-setup-pycryptodome.diff
+ 
     depends_build       port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-pycryptodome
     post-destroot {

--- a/python/py-recaptcha/Portfile
+++ b/python/py-recaptcha/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-recaptcha
 version             1.0.6
+revision            1
 categories-append   graphics
 platforms           darwin freebsd
 supported_archs     noarch
@@ -36,7 +37,7 @@ python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools
-    depends_lib-append  port:py${python.version}-crypto
+    depends_lib-append  port:py${python.version}-pycryptodome
     post-destroot {
         xinstall -m 644 ${worksrcpath}/build/lib/recaptcha/__init__.py \
                 ${destroot}${python.pkgd}/recaptcha/

--- a/python/py-recaptcha/files/patch-requires-pycryptodome.diff
+++ b/python/py-recaptcha/files/patch-requires-pycryptodome.diff
@@ -1,0 +1,9 @@
+--- recaptcha_client.egg-info/requires.txt.orig	2021-11-06 08:28:39.000000000 -0400
++++ recaptcha_client.egg-info/requires.txt	2021-11-06 08:28:49.000000000 -0400
+@@ -1,4 +1,4 @@
+ 
+ 
+ [mailhide]
+-pycrypto
+\ No newline at end of file
++pycryptodome

--- a/python/py-recaptcha/files/patch-setup-pycryptodome.diff
+++ b/python/py-recaptcha/files/patch-setup-pycryptodome.diff
@@ -1,0 +1,11 @@
+--- setup.py.orig	2021-11-06 08:29:01.000000000 -0400
++++ setup.py	2021-11-06 08:29:16.000000000 -0400
+@@ -46,7 +46,7 @@
+       packages = find_packages(),
+ 
+       extras_require = {
+-        'mailhide' : ['pycrypto'],
++        'mailhide' : ['pycryptodome'],
+         },
+       namespace_packages = ['recaptcha'],
+       )

--- a/science/EGSimulation/Portfile
+++ b/science/EGSimulation/Portfile
@@ -28,7 +28,8 @@ homepage            ${github.homepage}/tree/master/Simulations/Python/EG%20Stati
 distname            ${name}-${version}
 
 checksums           rmd160  d6b5d09981836ab80a8d1512df227b6685150b60 \
-                    sha256  226181ccb0c42aa040541d051360c44778ccce226d5ccd7198222e008440bac7
+                    sha256  226181ccb0c42aa040541d051360c44778ccce226d5ccd7198222e008440bac7 \
+                    size    5932
 
 python.default_version     27
 

--- a/science/EGSimulation/Portfile
+++ b/science/EGSimulation/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben EconScripts 1.2
 name                EGSimulation
+revision            1
 categories          science
 platforms           darwin
 maintainers         ad.wsu.edu:tazz_ben
@@ -31,6 +32,6 @@ checksums           rmd160  d6b5d09981836ab80a8d1512df227b6685150b60 \
 
 python.default_version     27
 
-depends_lib-append  port:py${python.version}-crypto \
+depends_lib-append  port:py${python.version}-pycryptodome \
                     port:py${python.version}-numpy \
                     port:py${python.version}-scipy

--- a/security/volatility/Portfile
+++ b/security/volatility/Portfile
@@ -26,7 +26,8 @@ long_description    The Volatility Framework is a completely open collection \
 homepage            http://www.volatilityfoundation.org/
 
 checksums           rmd160  54262bb1957fef98e0c6776aee753c4231b21d5d \
-                    sha256  b341518a3828806679cf1d68a5f0f32eb3dd7934be7a721e9a883d5be728fd23
+                    sha256  b341518a3828806679cf1d68a5f0f32eb3dd7934be7a721e9a883d5be728fd23 \
+                    size    2953599
 
 supported_archs     noarch
 

--- a/security/volatility/Portfile
+++ b/security/volatility/Portfile
@@ -3,6 +3,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        volatilityfoundation volatility 2.5
+revision            1
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -32,7 +33,7 @@ supported_archs     noarch
 python.default_version  27
 
 depends_build-append    port:py${python.version}-setuptools
-depends_lib-append      port:py${python.version}-crypto \
+depends_lib-append      port:py${python.version}-pycryptodome \
                         port:py${python.version}-distorm
 depends_run-append      port:yara
 


### PR DESCRIPTION
#### Description

Python lib `py-crypto` is now at end-of-life, and has been replaced by `py-pycryptodome`. Continued use of the former has security implications, as open vulnerabilities currently exist. (And are unlikely to be fixed.) While the latter is being actively maintained, and is intended to be used as a drop-in replacement.

In addition, `py-crypto` conflicts with `py-pycryptodome`, further complicating our users' experience.

Fixes: https://trac.macports.org/ticket/63481

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?