### PR TITLE
MPlayer: Support arm64 architecture.

### DIFF
--- a/multimedia/MPlayer/Portfile
+++ b/multimedia/MPlayer/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                MPlayer
 version             1.3.0
-revision            7
+revision            8
 categories          multimedia
 license             GPL-2+
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -30,12 +30,13 @@ depends_lib \
     port:rtmpdump
 
 master_sites    http://www.mplayerhq.hu/MPlayer/releases/ \
-		ftp://ftp.mplayerhq.hu/MPlayer/releases/ 
+                ftp://ftp.mplayerhq.hu/MPlayer/releases/
 use_xz          yes
 
 checksums           sha1    11db20434a4e1aabb9c52f7712241dae1b3730e3 \
                     rmd160  b6688b186f41267ca3cec59c67afe34396c51ade \
-                    sha256  3ad0846c92d89ab2e4e6fb83bf991ea677e7aa2ea775845814cbceb608b09843
+                    sha256  3ad0846c92d89ab2e4e6fb83bf991ea677e7aa2ea775845814cbceb608b09843 \
+                    size    13278984
 
 # Do not use the following environment variables, otherwise the build phase
 # will fail.
@@ -78,6 +79,7 @@ configure.args-append \
 
 patchfiles configure.x11.patch configure.vorbis.patch
 patchfiles-append patch-libvo-osx-objc-common-opengl-headers.diff
+patchfiles-append patch-configure-arm64.diff
 
 # https://trac.macports.org/ticket/58055
 patchfiles-append patch-mplayer-libx264-updated.diff
@@ -272,11 +274,7 @@ variant esd \
 }
 
 platform macosx {
-    if {${configure.build_arch} eq "x86_64"} {
-        configure.args-append   --disable-qtx
-    } else {
-        configure.args-append   --enable-qtx
-    }
+    configure.args-append   --disable-qtx
 }
 
 variant glx requires x11 description {Enable glx output support.  Due to a bug in mplayer, this disables corevideo support} {

--- a/multimedia/MPlayer/files/patch-configure-arm64.diff
+++ b/multimedia/MPlayer/files/patch-configure-arm64.diff
@@ -1,0 +1,36 @@
+--- configure.orig	2021-11-05 21:56:54.000000000 -0400
++++ configure	2021-11-05 22:12:54.000000000 -0400
+@@ -642,6 +642,7 @@
+ vfpv3=auto
+ setend=auto
+ neon=auto
++armv8=no
+ armthumb=auto
+ _iwmmxt=auto
+ _mtrr=auto
+@@ -1716,7 +1717,7 @@
+       alpha) host_arch=alpha ;;
+       sun4*|sparc*) host_arch=sparc ;;
+       parisc*|hppa*|9000*) host_arch=hppa ;;
+-      aarch64*) host_arch=aarch64 ;;
++      aarch64*|arm64*) host_arch=aarch64 ;;
+       arm*|zaurus|cats) host_arch=arm ;;
+       sh3|sh4|sh4a) host_arch=sh ;;
+       s390) host_arch=s390 ;;
+@@ -3236,7 +3237,7 @@
+   echores "$_iwmmxt"
+ fi
+ 
+-cpuexts_all='ALTIVEC XOP AVX AVX2 FMA3 FMA4 MMX MMX2 MMXEXT AMD3DNOW AMD3DNOWEXT SSE SSE2 SSE3 SSSE3 SSE4 SSE42 FAST_CMOV I686 FAST_CLZ ARMV5TE ARMV6 ARMV6T2 VFP VFPV3 SETEND NEON IWMMXT MMI VIS MVI'
++cpuexts_all='ALTIVEC XOP AVX AVX2 FMA3 FMA4 MMX MMX2 MMXEXT AMD3DNOW AMD3DNOWEXT SSE SSE2 SSE3 SSSE3 SSE4 SSE42 FAST_CMOV I686 FAST_CLZ ARMV5TE ARMV6 ARMV6T2 VFP VFPV3 SETEND NEON ARMV8 IWMMXT MMI VIS MVI'
+ test "$_altivec"   = yes && cpuexts="ALTIVEC $cpuexts"
+ test "$_mmx"       = yes && cpuexts="MMX $cpuexts"
+ test "$_mmxext"    = yes && cpuexts="MMX2 $cpuexts"
+@@ -3264,6 +3265,7 @@
+ test "$vfpv3"      = yes && cpuexts="VFPV3 $cpuexts"
+ test "$setend"     = yes && cpuexts="SETEND $cpuexts"
+ test "$neon"       = yes && cpuexts="NEON $cpuexts"
++test "$armv8"      = yes && cpuexts="ARMV8 $cpuexts"
+ test "$_iwmmxt"    = yes && cpuexts="IWMMXT $cpuexts"
+ test "$_vis"       = yes && cpuexts="VIS $cpuexts"
+ test "$_mvi"       = yes && cpuexts="MVI $cpuexts"


### PR DESCRIPTION
MPlayer did not compile, this is now fixed:
- Disabled quicktime format (missing headers, this is also default for x86_64).
- Properly handle arm64 as aarch64, not arm.
- Create the "ARMV8" CPU feature in configure. This should be a noop but avoids a compile error.
    
This addresses https://trac.macports.org/ticket/62254

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1, arm64
Xcode 13.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
