### PR TITLE
jdupes: update to 1.20.2

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jbruchon jdupes 1.20.1 v
+github.setup        jbruchon jdupes 1.20.2 v
 revision            0
-checksums           rmd160  244247bd07037629b36401c9aaca082923e4ed28 \
-                    sha256  e93568d1967518cace5bd26ab52328c05cb13bd3e95f225cba3c15d9c0c5fd35 \
-                    size    94108
+checksums           rmd160  ffad1b8a7e1c15247aa8dc4cbe7f9b07c57ce4c5 \
+                    sha256  54a03a338bac1081c57d2ca64c72f6f616d85b728ada47690a86010ac63cee23 \
+                    size    94371
 
 platforms           darwin
 categories          sysutils


### PR DESCRIPTION
#### Description
jdupes: update to 1.20.2

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
