### PR TITLE
hugo: update to 0.89.1

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.88.1 v
+go.setup            github.com/gohugoio/hugo 0.89.1 v
 revision            0
-checksums           rmd160  4f9d17de222f7a77cf55a094f84846898134b7dc \
-                    sha256  c12fc18a0ed092c56981e261a352b106a90abae029a5d060cd0f4aa6427594da \
-                    size    37010247
+checksums           rmd160  ba3d99f4df83f669edbed99c7ca7724bbfc0b892 \
+                    sha256  7440cf81ced2864067cae85e8f58a9a52277052ebd7d6abdce93b57663f9cbb7 \
+                    size    37378361
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.89.1

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
