### PR TITLE
openssl3: enable FIPS provider

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -7,7 +7,7 @@ PortGroup           muniversal 1.0
 set major_v         3
 name                openssl$major_v
 version             ${major_v}.0.0
-revision            2
+revision            3
 
 # Please revbump these ports when updating OpenSSL.
 #  - freeradius (#43461)
@@ -88,6 +88,7 @@ configure.cmd       ./Configure
 configure.pre_args  --prefix=${my_prefix}
 configure.args      -L${prefix}/lib \
                     --openssldir=${my_prefix}/etc/openssl \
+                    enable-fips \
                     shared \
                     zlib
 


### PR DESCRIPTION
#### Description
Enable the FIPS provider which isn't build by default. See the suggestion by @kencu on the [mailinglist](https://lists.macports.org/pipermail/macports-dev/2021-November/043866.html) and earlier in a PR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
