### PR TITLE
darktable: update to 3.6.1

### DIFF
--- a/graphics/darktable/Portfile
+++ b/graphics/darktable/Portfile
@@ -1,17 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               legacysupport 1.1
 PortGroup               github 1.0
 PortGroup               active_variants 1.1
 PortGroup               app 1.0
 PortGroup               cmake 1.1
+PortGroup               perl5 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            darktable-org darktable 3.2.1 release-
+github.setup            darktable-org darktable 3.6.1 release-
 name                    darktable
 conflicts               darktable-devel
 set my_name             darktable
-revision                3
+revision                0
 categories              graphics
 platforms               darwin
 supported_archs         x86_64
@@ -32,9 +34,14 @@ github.tarball_from     releases
 dist_subdir             ${my_name}
 use_xz                  yes
 
-checksums               rmd160  865b0810a3f9e86aa223121cb7074aeeeaab784f \
-                        sha256  6e3683ea88dc0a0271be7eca4fd594b9e46b1b7194847825a8d0a0c12bdeb90c \
-                        size    3920728
+checksums               rmd160  6636046ef165cf8f673974aa29121e89c05aafad \
+                        sha256  a2bfc7c103b824945457a9bfed9e52f007fa1d030f9dbcb3ff0327851be42d14 \
+                        size    4685928
+
+# Enable use of 'macports-libcxx' for macOS 10.12 and earlier, as port uses
+# libcxx features normally only available on 10.13 and later.
+legacysupport.use_mp_libcxx \
+                        yes
 
 # avoid
 #     Unknown build type: MACPORTS.  Please specify one of:
@@ -45,17 +52,27 @@ if {[variant_isset debug]} {
     cmake.build_type    Release
 }
 
+perl5.branches          5.30
+
+# OpenMP-related patch: By default, CMake script excludes the use of MacPorts
+# Clang 9, among others. Ease the compiler restrictions for OpenMP.
+patchfiles-append       patch-openmp-compiler-versions.diff
+
 # darktable sets its own optimization flags
 configure.optflags
 
-depends_build-append    port:intltool \
+depends_build-append    \
+                        port:cctools \
+                        port:intltool \
                         port:pkgconfig \
                         port:po4a \
-                        port:perl5.28
+                        port:perl${perl5.major}
 
-depends_lib-append      port:atk \
+depends_lib-append      \
+                        port:atk \
                         path:lib/pkgconfig/cairo.pc:cairo \
                         port:curl \
+                        port:desktop-file-utils \
                         port:exiv2 \
                         port:flickcurl \
                         port:GraphicsMagick \
@@ -64,6 +81,7 @@ depends_lib-append      port:atk \
                         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         port:gmic \
                         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                        path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                         port:ilmbase \
                         port:iso-codes \
                         path:include/turbojpeg.h:libjpeg-turbo \
@@ -88,8 +106,7 @@ depends_lib-append      port:atk \
                         port:tiff \
                         port:zlib
 
-depends_run             port:adwaita-icon-theme \
-                        port:desktop-file-utils
+depends_run             port:adwaita-icon-theme
 
 # sets march optimization to generic
 configure.args-append   -DBINARY_PACKAGE_BUILD=ON
@@ -100,7 +117,7 @@ configure.args-append   -DBUILD_CMSTEST=OFF \
                         -DUSE_KWALLET=OFF \
                         -DUSE_OPENMP=OFF \
                         -DUSE_UNITY=OFF \
-                        -Dperl_BIN=${prefix}/bin/perl5.28
+                        -Dperl_BIN=${perl5.bin}
 
 post-build {
     set wrap [open "${workpath}/darktable-app" w 0755]
@@ -123,18 +140,20 @@ post-activate    {
     system "env XDG_DATA_DIRS=${prefix}/share ${prefix}/bin/update-mime-database -V ${prefix}/share/mime"
 }
 
+app.name                ${my_name}
 app.executable          ${workpath}/darktable-app
 app.icon                packaging/macosx/Icons.icns
 
 universal_variant       no
 
-compiler.cxx_standard   2014
+compiler.cxx_standard   2017
 
 # compiling src/osx/osx.mm with GCC results in a cascade of errors
 compiler.blacklist-append      *gcc*
 
-#Point.h:80:23: error: no member named 'abs' in namespace 'std'
-compiler.blacklist-append {clang < 900}
+# Point.h:80:23: error: no member named 'abs' in namespace 'std'
+# NOTE: Now requires a minimum of Xcode Clang 10.0.1, as of v3.6.x
+compiler.blacklist-append {clang < 1001}
 
 variant x11 conflicts quartz {
     patchfiles-append       patch-darktable-no-quartz.diff
@@ -155,7 +174,7 @@ variant openmp description {enable support for OpenMP} {
     configure.args-replace  -DUSE_OPENMP=OFF -DUSE_OPENMP=ON
 }
 if {[variant_isset openmp]} {
-    compiler.openmp_version 4.0
+    compiler.openmp_version 4.5
     if {[info exists compiler.log_verbose_output]} {
         compiler.log_verbose_output no
     } else {

--- a/graphics/darktable/files/patch-openmp-compiler-versions.diff
+++ b/graphics/darktable/files/patch-openmp-compiler-versions.diff
@@ -1,0 +1,62 @@
+--- cmake/compiler-versions.cmake.orig	2021-11-06 17:31:50.000000000 -0400
++++ cmake/compiler-versions.cmake	2021-11-06 17:33:28.000000000 -0400
+@@ -45,24 +45,24 @@
+   if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND
+       ((CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 8) OR
+        (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 10)))
+-    message(FATAL_ERROR "LLVM Clang C compiler version ${CMAKE_C_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
++    message(WARNING "LLVM Clang C compiler version ${CMAKE_C_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
+   endif()
+   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+       ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8) OR
+        (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)))
+-    message(FATAL_ERROR "LLVM Clang C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
++    message(WARNING "LLVM Clang C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
+   endif()
+ 
+   # OpenMP is not supported with XCode 10.2-10.3 (based on LLVM7) / XCode 11.4-11.7 (based on LLVM9).
+   if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND
+       ((CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0.1 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 11.0.0) OR
+        (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.3 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12.0.0)))
+-    message(FATAL_ERROR "XCode (Apple clang) C compiler version ${CMAKE_C_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
++    message(WARNING "XCode (Apple clang) C compiler version ${CMAKE_C_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
+   endif()
+   if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+       ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0.1 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0.0) OR
+        (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.3 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0.0)))
+-    message(FATAL_ERROR "XCode (Apple clang) C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
++    message(WARNING "XCode (Apple clang) C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
+   endif()
+ endif()
+ 
+--- src/external/rawspeed/cmake/compiler-versions.cmake.orig	2021-11-06 17:31:50.000000000 -0400
++++ src/external/rawspeed/cmake/compiler-versions.cmake	2021-11-06 17:33:28.000000000 -0400
+@@ -45,24 +45,24 @@
+   if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND
+       ((CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 8) OR
+        (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 10)))
+-    message(FATAL_ERROR "LLVM Clang C compiler version ${CMAKE_C_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
++    message(WARNING "LLVM Clang C compiler version ${CMAKE_C_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
+   endif()
+   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+       ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8) OR
+        (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)))
+-    message(FATAL_ERROR "LLVM Clang C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
++    message(WARNING "LLVM Clang C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
+   endif()
+ 
+   # OpenMP is not supported with XCode 10.2-10.3 (based on LLVM7) / XCode 11.4-11.7 (based on LLVM9).
+   if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND
+       ((CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0.1 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 11.0.0) OR
+        (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.3 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12.0.0)))
+-    message(FATAL_ERROR "XCode (Apple clang) C compiler version ${CMAKE_C_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
++    message(WARNING "XCode (Apple clang) C compiler version ${CMAKE_C_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
+   endif()
+   if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+       ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0.1 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0.0) OR
+        (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.3 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0.0)))
+-    message(FATAL_ERROR "XCode (Apple clang) C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
++    message(WARNING "XCode (Apple clang) C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is not supported in with-OpenMP build mode.")
+   endif()
+ endif()
+ 


### PR DESCRIPTION
#### Description

Update DarkTable to 3.6.1

Closes: https://trac.macports.org/ticket/63634

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?