### PR TITLE
qt5*-qtbase: explicitly disable Vulkan support

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -169,7 +169,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 3"
+        "revision 4"
         "License: "
     }
     qtcharts {
@@ -1292,6 +1292,12 @@ foreach {module module_info} [array get modules] {
                 -no-kms                 \
                 -no-libinput            \
                 -no-system-proxies
+
+            # do not opportunistically enable Vulkan support
+            # (TODO: is Vulkan support desirable?)
+            # see https://trac.macports.org/ticket/62104
+            configure.args-append \
+                -no-feature-vulkan
 
             # MacOS/iOS options:
             configure.args-append    \

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -1149,6 +1149,12 @@ foreach {module module_info} [array get modules] {
                 -no-libinput            \
                 -no-system-proxies
 
+            # do not opportunistically enable Vulkan support
+            # (MoltenVK support unavailable in Qt < 5.12)
+            # see https://trac.macports.org/ticket/62104
+            configure.args-append \
+                -no-feature-vulkan
+
             # MacOS/iOS options:
             configure.args-append    \
                 -framework           \

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -164,7 +164,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 3"
+        "revision 4"
         "License: "
     }
     qtcharts {
@@ -1162,6 +1162,12 @@ foreach {module module_info} [array get modules] {
                 -no-mirclient           \
                 -no-libinput            \
                 -no-system-proxies
+
+            # do not opportunistically enable Vulkan support
+            # (TODO: is Vulkan support desirable?)
+            # see https://trac.macports.org/ticket/62104
+            configure.args-append \
+                -no-feature-vulkan
 
             # MacOS/iOS options:
             configure.args-append    \


### PR DESCRIPTION
Do not opportunistically enable Vulkan support (maybe it can be explicitly enabled later if desired)
Fixes: https://trac.macports.org/ticket/62104

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Only configure phase is tested.
macOS 10.15.7
Xcode 12.4 command line tools (I disabled `use_xcode yes`)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
