### PR TITLE
libcaca: fix Tiger build

### DIFF
--- a/graphics/libcaca/Portfile
+++ b/graphics/libcaca/Portfile
@@ -56,6 +56,11 @@ depends_lib         port:ncurses port:zlib
 # temporary patch to fix use of implcitily declared function
 patchfiles-append   patch-libcaca-common-image.diff
 
+platform darwin 8 {
+    # https://trac.macports.org/ticket/63758
+    patchfiles-append patch-libcaca-tiger.diff
+}
+
 use_autoconf         yes
 # these dependencies are removed by use_autoconf, so add them after
 depends_build-append port:libtool port:autoconf port:automake

--- a/graphics/libcaca/files/patch-libcaca-tiger.diff
+++ b/graphics/libcaca/files/patch-libcaca-tiger.diff
@@ -1,0 +1,15 @@
+The =~ operator was introduced in Bash 3.
+
+This code path is not executed with --disable-cocoa.
+
+--- a/configure.ac.orig
++++ b/configure.ac
+@@ -269,7 +269,7 @@
+    [ac_cv_my_have_cocoa="yes"])
+   CFLAGS="$save_CFLAGS"
+   if test "${ac_cv_my_have_cocoa}" = "yes"; then
+-    [[[ "$target_os" =~ [0-9]+ ]]] && darwin_ver="${BASH_REMATCH[[0]]}"
++#   [[[ "$target_os" =~ [0-9]+ ]]] && darwin_ver="${BASH_REMATCH[[0]]}"
+     case x${target} in
+     xpowerpc*darwin*)
+       # 10.3 needed to link with X11


### PR DESCRIPTION
#### Description

Builds locally; the code path in question is never executed by MacPorts but generates a syntax error on Tiger.

Closes: https://trac.macports.org/ticket/63758
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
