### PR TITLE
kubectx: Fixed/Updated dependency to kubectl-1.22

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  63b2b1f45a352baa6e05bd65baf425d1b13cd0bc \
                     sha256  85ff8ff3882c4b5eda4d7c90e98d7fca8bdab54cb54a71fb11e7ad0b291439ed \
                     size    520687
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.21
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.22
 
 use_configure       no
 build {}


### PR DESCRIPTION
The kubectl-1.21 is broken for many folks:

  - https://trac.macports.org/ticket/63503

Bumping to kubectl-1.22 fixes it:

  - https://trac.macports.org/ticket/63503#comment:10

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
