### PR TITLE
opensmtpd: Use OpenSSL portgroup

### DIFF
--- a/mail/opensmtpd/Portfile
+++ b/mail/opensmtpd/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem          1.0
 PortGroup           legacysupport 1.0
+PortGroup           openssl 1.0
 
 name                opensmtpd
 version             6.8.0p2
-revision            2
+revision            3
 categories          mail
 platforms           darwin
 license             ISC
@@ -29,8 +30,7 @@ checksums           rmd160  740a0904594f47caa1261b4be3bc7de8165678e7 \
 
 depends_build       port:bison
 
-depends_lib         port:libevent \
-                    path:lib/libssl.dylib:openssl
+depends_lib         port:libevent
 
 startupitem.create      yes
 startupitem.executable  ${prefix}/sbin/smtpd -F


### PR DESCRIPTION
#### Description

Use OpenSSL portgroup instead of explicit dependency.

This requires a revision bump because of the transition from openssl 1.1
to openssl 3 behivd the scenes. This accomplishes what #12807 tried to
do.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
