### PR TITLE
retdec-devel: update to 20211107

### DIFF
--- a/devel/retdec/Portfile
+++ b/devel/retdec/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           openssl 1.0
 
 github.setup        avast retdec 4.0 v
-revision            1
+revision            2
 conflicts           ${name}-devel
 
 categories          devel
@@ -29,6 +30,19 @@ post-patch {
     reinplace "s|\${CMAKE_INSTALL_PREFIX}|${destroot}\${CMAKE_INSTALL_PREFIX}|" ${worksrcpath}/CMakeLists.txt
     reinplace "s|\${CMAKE_INSTALL_PREFIX}|${destroot}\${CMAKE_INSTALL_PREFIX}|" ${worksrcpath}/support/CMakeLists.txt
     reinplace "s|DESTINATION \${SUPPORT_TARGET_DIR}/|DESTINATION \${RETDEC_INSTALL_SUPPORT_DIR}|" ${worksrcpath}/support/CMakeLists.txt
+
+    if {${name} eq ${subport}} {
+        # v4.0 requires stricly to use AppleClang
+        # anyway, it can be build by macports clang at old system
+        reinplace "s|\"AppleClang\"|\"AppleClang\" AND NOT \"\${CMAKE_CXX_COMPILER_ID}\" STREQUAL \"Clang\"|" ${worksrcpath}/deps/openssl/CMakeLists.txt
+    }
+}
+
+if {${name} eq ${subport}} {
+    # v4.0 includes OpenSSL 1.1.1c => use the same version.
+    # See https://github.com/avast/retdec/pull/807
+    openssl.branch  1.1
+
 }
 
 compiler.cxx_standard   2017
@@ -47,7 +61,6 @@ depends_build-append \
                     port:automake \
                     port:git \
                     port:libtool \
-                    port:openssl \
                     port:pkgconfig
 
 depends_lib-append  port:python39 \
@@ -59,15 +72,19 @@ depends_run-append  path:bin/dot:graphviz \
 subport retdec-devel {
     conflicts       $name
 
-    version         20211026
-    github.setup    avast retdec 59deef2049b8e5118402c7c86b44f9d6bbc5a437
-    revision        1
+    version         20211107
+    github.setup    avast retdec f49ecb6ff6b8b220f3f2fa4b6b6354eeb59921e8
+    revision        0
 
-    checksums       rmd160  fcb1da52fd605e36c573e3dde7f9043eedcc2b83 \
-                    sha256  550bcfb33e655fce1238f7c204191429433b9ad3423cf251c18e40177142b363 \
-                    size    12132198
+    checksums       rmd160  e441f2b9c724d11d6d6f67392c6b28baccb51f0e \
+                    sha256  c476bc92651c061fce3f1dd7913bfb9ff2e78fcf9e76d00ceb7dc75db7bb0041 \
+                    size    12138375
+
+    patchfiles-append \
+                    patch-openssl-3.0.diff
 
     patchfiles-delete \
+                    patch-openssl-3.0-v40.diff \
                     patch-python3.diff \
                     patch-yara-syntax-error.diff
 

--- a/devel/retdec/files/patch-openssl-3.0.diff
+++ b/devel/retdec/files/patch-openssl-3.0.diff
@@ -1,0 +1,80 @@
+commit 3dbe9deaf35ad423769104db70dd062dba2973cc
+Author: Kirill A. Korinsky <kirill@korins.ky>
+Date:   Mon Nov 8 11:48:09 2021 +0100
+
+    Update API for OpenSSL 3.0
+    
+    Fixes: https://github.com/avast/retdec/issues/1040
+
+diff --git a/deps/authenticode-parser/src/authenticode.c b/deps/authenticode-parser/src/authenticode.c
+index bd860fe3..724b64f9 100644
+--- a/deps/authenticode-parser/src/authenticode.c
++++ b/deps/authenticode-parser/src/authenticode.c
+@@ -581,7 +581,11 @@ AuthenticodeArray* parse_authenticode(const uint8_t* pe_data, long pe_len)
+             continue;
+         }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x3000000fL
++        int mdlen = EVP_MD_get_size(md);
++#else
+         int mdlen = EVP_MD_size(md);
++#endif
+         sig->file_digest.len = mdlen;
+         sig->file_digest.data = (uint8_t*)malloc(mdlen);
+         if (!sig->file_digest.data)
+diff --git a/deps/authenticode-parser/src/certificate.c b/deps/authenticode-parser/src/certificate.c
+index 7686c516..2f1a4f0c 100644
+--- a/deps/authenticode-parser/src/certificate.c
++++ b/deps/authenticode-parser/src/certificate.c
+@@ -287,7 +287,11 @@ Certificate* certificate_new(X509* x509)
+     EVP_PKEY* pkey = X509_get0_pubkey(x509);
+     if (pkey) {
+         result->key = pubkey_to_pem(pkey);
++#if OPENSSL_VERSION_NUMBER >= 0x3000000fL
++        result->key_alg = strdup(OBJ_nid2sn(EVP_PKEY_get_base_id(pkey)));
++#else
+         result->key_alg = strdup(OBJ_nid2sn(EVP_PKEY_base_id(pkey)));
++#endif
+     }
+ 
+     return result;
+diff --git a/deps/authenticode-parser/src/countersignature.c b/deps/authenticode-parser/src/countersignature.c
+index 5bc2c108..59ca8038 100644
+--- a/deps/authenticode-parser/src/countersignature.c
++++ b/deps/authenticode-parser/src/countersignature.c
+@@ -137,7 +137,11 @@ Countersignature* pkcs9_countersig_new(
+      * but other times it is just purely and I didn't find another way to  distinguish it but only
+      * based on the length of data we get. Found mention of this in openssl mailing list:
+      * https://mta.openssl.org/pipermail/openssl-users/2015-September/002054.html */
++#if OPENSSL_VERSION_NUMBER >= 0x3000000fL
++    size_t mdLen = EVP_MD_get_size(md);
++#else
+     size_t mdLen = EVP_MD_size(md);
++#endif
+     if (mdLen == decLen) {
+         isValid = !memcmp(calc_digest, decData, mdLen);
+     } else {
+@@ -238,7 +242,11 @@ Countersignature* ms_countersig_new(const uint8_t* data, long size, ASN1_STRING*
+ 
+     uint8_t calc_digest[EVP_MAX_MD_SIZE];
+     calculate_digest(md, enc_digest->data, enc_digest->length, calc_digest);
++#if OPENSSL_VERSION_NUMBER >= 0x3000000fL
++    int mdLen = EVP_MD_get_size(md);
++#else
+     int mdLen = EVP_MD_size(md);
++#endif
+ 
+     if (digestLen != mdLen || memcmp(calc_digest, digestData, mdLen) != 0) {
+         result->verify_flags = COUNTERSIGNATURE_VFY_DOESNT_MATCH_SIGNATURE;
+@@ -251,7 +259,11 @@ Countersignature* ms_countersig_new(const uint8_t* data, long size, ASN1_STRING*
+ 
+     TS_VERIFY_CTX_set_flags(ctx, TS_VFY_VERSION | TS_VFY_IMPRINT);
+     TS_VERIFY_CTX_set_store(ctx, store);
++#if OPENSSL_VERSION_NUMBER >= 0x3000000fL
++    TS_VERIFY_CTX_set_store(ctx, p7->d.sign->cert);
++#else
+     TS_VERIFY_CTS_set_certs(ctx, p7->d.sign->cert);
++#endif
+     TS_VERIFY_CTX_set_imprint(ctx, calc_digest, mdLen);
+ 
+     bool isValid = TS_RESP_verify_token(ctx, p7) == 1;


### PR DESCRIPTION
#### Description

This changes also enabled support of OpenSSL 3 via `openssl` PortGroup for `retdec-devel`.

Anyway, `v4.0` is shipped with OpenSSL 1.1.1 and should be build against OpenSSL 1.1 branch.

Fixes: https://trac.macports.org/ticket/63882

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->