### PR TITLE
libusb-devel: fix pre-Catalina build issues

### DIFF
--- a/devel/libusb/Portfile
+++ b/devel/libusb/Portfile
@@ -50,15 +50,22 @@ if {${subport} eq ${name}} {
     github.livecheck.regex  {([0-9.]+)}
 
 } else {
+    PortGroup       legacysupport 1.1
+
+    # IOKit/USB.h - fixes GCC 4.5+ issue pre-Catalina
+    # https://trac.macports.org/ticket/61868
+    # (As of 2021-11-07 the fix requires legacy-support-devel - bump
+    # this logic to the top once it is included in mainline legacy-support)
+    legacysupport.newest_darwin_requires_legacy 18
 
     long_description {*}${long_description} \
         This port provides devel version of ${name}, updated weekly to monthly.
 
-    github.setup    libusb libusb e88b77ff6e848df299e4d9ed4926581991b7ffdf
-    version         20210922-[string range ${github.version} 0 7]
-    checksums       rmd160  51a69532612ae81f2e425180f22a00b25e487650 \
-                    sha256  9105bf049e1c32ab4e664fc8213888ecea261e91001bb0100abe4d66bd0a29fa \
-                    size    368931
+    github.setup    libusb libusb 7b342030d293019696ff536a95105c654167461a
+    version         20211107-[string range ${github.version} 0 7]
+    checksums       rmd160  a0601f83da4719699e0c731de3bd0c5fdcbcbae0 \
+                    sha256  e69e770aaa85941def30c11cfb09aa1a6d3b637236f528b578b5343a4381a5f3 \
+                    size    372522
     revision        0
 
     conflicts       libusb


### PR DESCRIPTION
#### Description

Pull an upstream SDK fix and also flip on legacysupport for the new USB.h changes (requires `legacy-support-devel`). Tested locally through build phase. Only `-devel` port is affected.

Closes: https://trac.macports.org/ticket/63668
See: https://github.com/libusb/libusb/pull/1023
See: https://trac.macports.org/ticket/61868
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
