### PR TITLE
librsvg-devel: tweak librsvg_fallback

### DIFF
--- a/graphics/librsvg-devel/Portfile
+++ b/graphics/librsvg-devel/Portfile
@@ -45,15 +45,7 @@ license_noconflict  gobject-introspection \
 # rust @1.30.1 fails to build on 10.10 and earlier
 # https://trac.macports.org/ticket/57768
 # Update - As of rust 1.51.0 it now builds on 10.9 and newer.
-
-# rust does not yet support Apple Silicon
-# https://github.com/rust-lang/rust/issues/73908
-
 set max_darwin_for_rust 13
-
-if {![info exists universal_possible]} {
-    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
-}
 
 #----------------------------------------------------------------------------------------
 # Developer-only override, allowing easy testing of desired behavior:
@@ -71,9 +63,8 @@ if {[info exists librsvg.override.fallback]} {
 } else {
     if {${os.platform} eq "darwin" && (
             ${os.major} < ${max_darwin_for_rust}
-            || ${build_arch} eq "arm64"
             || ${build_arch} eq "i386"
-            || ${universal_possible} && [variant_isset universal]
+            || "i386" in ${configure.universal_archs}
         )} {
         set librsvg_fallback yes
     } else {


### PR DESCRIPTION
#### Description

The current cargo/rust ports support arm64 so there shouldn't be a need to force the fallback for arm64 target, not had chance to confirm on my M1 system but brew does have a prebuilt arm64 bottle already see [librsvg.rb](https://github.com/Homebrew/homebrew-core/blob/master/Formula/librsvg.rb)

Removed the unneeded compact code for universal handling, tweaked fallback to only be used when universal contains i386 arch. (tested on my Intel Macbook)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
