### PR TITLE
libreoffice: update to 7.2.3.1

### DIFF
--- a/devel/glm/Portfile
+++ b/devel/glm/Portfile
@@ -25,6 +25,8 @@ github.tarball_from releases
 use_7z              yes
 worksrcdir          ${name}
 
+patchfiles          patch-remove-werror.diff
+
 post-extract {
     # The directories in the archive are restricted so that only the extracting
     # user can look inside them.

--- a/devel/glm/files/patch-remove-werror.diff
+++ b/devel/glm/files/patch-remove-werror.diff
@@ -1,0 +1,11 @@
+--- test/CMakeLists.txt.old	2021-11-10 03:46:06.000000000 -0500
++++ test/CMakeLists.txt	2021-11-10 03:46:29.000000000 -0500
+@@ -197,7 +197,7 @@
+ 		message("GLM: Clang - ${CMAKE_CXX_COMPILER_ID} compiler")
+ 	endif()
+ 
+-	add_compile_options(-Werror -Weverything)
++	add_compile_options(-Weverything)
+ 	add_compile_options(-Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-c++11-long-long -Wno-padded -Wno-gnu-anonymous-struct -Wno-nested-anon-types)
+ 	add_compile_options(-Wno-undefined-reinterpret-cast -Wno-sign-conversion -Wno-unused-variable -Wno-missing-prototypes -Wno-unreachable-code -Wno-missing-variable-declarations -Wno-sign-compare -Wno-global-constructors -Wno-unused-macros -Wno-format-nonliteral)
+ 

--- a/office/libreoffice/Portfile
+++ b/office/libreoffice/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           boost 1.0
 
 name                libreoffice
-version             7.2.2.2
+version             7.2.3.1
 revision            0
 categories          office aqua
 license             {LGPL-3 MPL-1.1}
@@ -45,17 +45,17 @@ distfiles           ${main_distfile}:main \
                     libcmis-0.5.2.tar.xz:libcmis
 
 checksums           libreoffice-${version}.tar.xz \
-                    rmd160  66a057b0a8af593eb3255e92af87ab97f5913023 \
-                    sha256  813bc3caa48c3c4af35b6a48bcf9cd19305ff0b81ce9b5304052c10ce5b02b71 \
-                    size    252478892 \
+                    rmd160  a93754d1444f7ea3e89888259a3598a7e82d4add \
+                    sha256  152bf8dcb3d23e109c0a1c5558596f86abe04f604ef549f145e93ecfb08a06a3 \
+                    size    252772748 \
                     libreoffice-dictionaries-${version}.tar.xz \
-                    rmd160  df23199fd49084548664dd66b5a6259baf767883 \
-                    sha256  f2969ef38ab9c91f3efdc3fde9b4572aff938edc4b942bd66119377d5aabc1f7 \
-                    size    49521532 \
+                    rmd160  226165b5f8f5f7270e998d448d12c3e786f6843b \
+                    sha256  db902dd20ecef02fd2a9909fcdd0bed0974526f68f4f7260df99a7ccf211b9a9 \
+                    size    49513408 \
                     libreoffice-translations-${version}.tar.xz \
-                    rmd160  090f02dab191e621b96abff5167803e7d8980929 \
-                    sha256  988a63ae2d50454c6f6c547b5f9331c7c45295f6d792b37fdced7557baca1ce6 \
-                    size    192517028 \
+                    rmd160  1c53bb58df740abb81b09c41a0fa2f993c9070f7 \
+                    sha256  5eba5d6d75a07987ae8f29fe592143ed3acbaa95c737bd0a6dcbc4f0c26d71e8 \
+                    size    192586924 \
                     dtoa-20180411.tgz \
                     rmd160  8d1bba737d8b58c3fb09533f35af2a03e05d9849 \
                     sha256  0082d0684f7db6f62361b76c4b7faba19e0c7ce5cb8e36c4b65fea8281e711b4 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Bump LibreOffice to 7.2.3.1

Also attempting to use system libcmis in the second commit. I will remove it if it does not work in CI.

I cannot test this locally as glm does not build on Monterey.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
