### PR TITLE
retroarch: update to 1.9.13

### DIFF
--- a/emulators/retroarch/Portfile
+++ b/emulators/retroarch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        libretro RetroArch 1.9.12 v
+github.setup        libretro RetroArch 1.9.13 v
 revision            0
 
 name                retroarch
@@ -15,9 +15,9 @@ categories          emulators games
 description         Frontend for the libretro API.
 long_description    {*}${description}
 
-checksums           rmd160  7293cf94efa694c70d20f190ab1070f5f7ee5036 \
-                    sha256  7866e3eb7c8dcfdffc13bd9cd967c16b0d72ecc06e461904fed97bb61dec236d \
-                    size    41526474
+checksums           rmd160  e516b3c20a6f548e8360390920bed341d7211707 \
+                    sha256  1c4e71295c9a4dc2e7268e4436cb50f746905f8ea67aa26d06ff3f9cd7b85ff8 \
+                    size    41530715
 
 # See https://github.com/libretro/RetroArch/issues/8641
 patchfiles          patch-${name}-library-dirs.diff


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
