### PR TITLE
py-cryptography: update to openssl3 now that dependencies are also up…

### DIFF
--- a/python/py-cryptography/Portfile
+++ b/python/py-cryptography/Portfile
@@ -44,10 +44,7 @@ if {${name} ne ${subport}
     if {${python.version} eq 27
         || ${os.platform} eq "darwin" && ${os.major} < ${cryptography_darwin_min_ver}} {
         github.setup    pyca cryptography 2.9.2
-        revision        2
-
-        # Build fails with OpenSSL 3; use 1.1 for now
-        openssl.branch  1.1
+        revision        3
 
         description     Legacy support of Python cryptography.
 


### PR DESCRIPTION
#### Description

Updates py-cryptography to openssl 3 now that Cairo is updated.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
