### PR TITLE
libewf: version bump from 20201210 to 20201230 and reverting back to openssl 1.1

### DIFF
--- a/security/libewf/Portfile
+++ b/security/libewf/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           openssl 1.0
 
-github.setup        libyal libewf 20201210
-revision            1
+github.setup        libyal libewf 20201230
+revision            0
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -22,16 +23,17 @@ github.tarball_from releases
 distname            ${name}-experimental-${version}
 worksrcdir          ${name}-${version}
 
-checksums           rmd160  39285fa3bf684a0f7d729781bc0e5830b14fb653 \
-                    sha256  748d567b66ec0510dccaa77a1cb0bb78113df5da734a4847b4d82dd191386837 \
-                    size    2585847
+checksums           rmd160  14a14f59e4353339dba5f0a39ac2e38d25575047 \
+                    sha256  d74af88cfcec037d271d0ce3760fd59304c6d4fc0eb24c2ff01adadf864f3207 \
+                    size    2582683
 
 depends_build       port:pkgconfig
+
+openssl.branch      1.1
 
 depends_lib         port:bzip2 \
                     port:gettext \
                     port:libiconv \
-                    path:lib/libssl.dylib:openssl \
                     path:lib/pkgconfig/fuse.pc:osxfuse \
                     port:zlib
 
@@ -45,7 +47,7 @@ platform linux {
 
 configure.args      --with-bzip2=${prefix} \
                     --with-libfuse=${prefix} \
-                    --with-openssl=${prefix} \
+                    --with-openssl=[openssl::install_area] \
                     --with-zlib=${prefix} \
                     --without-libbfio \
                     --without-libcaes \


### PR DESCRIPTION
#### Description

- version bump from 20201210 to 20201230
- fixing openssl3 related compile problems with a switchback to openssl 1.1

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1
Xcode 13.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
