### PR TITLE
pkcs11-helper: reverted back to openssl 1.1 due to fix openssl 3 related problems

### DIFF
--- a/security/pkcs11-helper/Portfile
+++ b/security/pkcs11-helper/Portfile
@@ -2,9 +2,12 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           openssl 1.0
 
 github.setup        OpenSC pkcs11-helper 1.27 pkcs11-helper-
-revision            1
+revision            2
+
+openssl.branch      1.1
 
 categories          security
 platforms           darwin freebsd
@@ -20,8 +23,7 @@ checksums           rmd160  59c17287ec3ae4c4256364d45ec80d0621b911c5 \
                     size    115333
 
 depends_lib         port:gnutls \
-                    port:pkgconfig \
-                    path:lib/libssl.dylib:openssl
+                    port:pkgconfig
 
 use_autoreconf      yes
 


### PR DESCRIPTION
#### Description

- reverted back to openssl 1.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1
Xcode 13.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
