### PR TITLE
privoxy: Fix -passout passphrase duplication code with newline bug

### DIFF
--- a/www/privoxy/Portfile
+++ b/www/privoxy/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 
 name                privoxy
 version             3.0.32
-revision            4
+revision            5
 categories          www security net
 platforms           darwin
 license             GPL-2
@@ -284,15 +284,14 @@ variant https_inspection \
 
     post-activate {
         # CA passphrase
+        # generate a strong password, use for openssl -passin and -passout
         set tls_ca_passphrase \
             [correct_horse_battery_staple]
         set tls_ca_passphrase_fd \
             [open ${tls_ca_dir}/private/passphrase.txt w 0600]
-        # see `man openssl` for -passin and -passout used together
         # -passin or -passout
         puts ${tls_ca_passphrase_fd} \
             ${tls_ca_passphrase}
-        puts ${tls_ca_passphrase_fd} "\n"
         # -passout
         puts ${tls_ca_passphrase_fd} \
             ${tls_ca_passphrase}
@@ -333,6 +332,8 @@ variant https_inspection \
                 -inkey private/ca.key.pem -in certs/ca.cert.pem \\
                 -passin file:private/passphrase.txt \\
                 -passout file:private/passphrase.txt
+            # verify .p12 passphrase
+            openssl pkcs12 -noout -in certs/ca.p12 -passin file:private/passphrase.txt
 TLS_PRIVOXY_ROOT_CA
 "
 
@@ -383,13 +384,17 @@ TLS_PRIVOXY_ROOT_CA
     notes "Configure HTTPS inspection by creating a local Privoxy \
 certificate authority (CA). As sudo:
 
-        cp -r ${prefix}/etc/privoxy/ca.macports ca.hostname && cd ca.hostname
+        cp -R ${prefix}/etc/privoxy/ca.macports ca.hostname && cd ca.hostname
         # edit openssl.cnf for your local organizationName, commonName, etc.
 
+        # generate a strong password, use for both -passin and -passout
+        # avoid passphrases with '#' as the passphrase is set in config
         sf-pwgen --algorithm memorable --count 2 --length 24 2>/dev/null \\
             | paste -s -d -- '-' 1> private/passphrase.txt
+        cat private/passphrase.txt private/passphrase.txt > private/passphrase-dbl.txt \\
+            && mv private/passphrase-dbl.txt private/passphrase.txt \\
+            || rm -f private/passphrase-dbl.txt
         chmod go-rwx private/passphrase.txt
-        # avoid passphrases with '#' as the passphrase is set in config
 
         # private key (EC)
         openssl genpkey -out private/ca.key.pem -algorithm EC \\
@@ -408,7 +413,9 @@ certificate authority (CA). As sudo:
         openssl x509 -outform der -in certs/ca.cert.pem -out certs/ca.cer
         openssl pkcs12 -export -out certs/ca.p12 -inkey private/ca.key.pem \\
             -in certs/ca.cert.pem -passin file:private/passphrase.txt \\
-            -passout pass:\$(head private/passphrase.txt)
+            -passout file:private/passphrase.txt
+        # verify .p12 passphrase
+        openssl pkcs12 -noout -in certs/ca.p12 -passin file:private/passphrase.txt
 
         # Install the Privoxy PKI
         cp -p private/ca.key.pem certs/ca.cert.pem certs/ca.cer certs/ca.p12 \\

--- a/www/privoxy/files/openssl.cnf
+++ b/www/privoxy/files/openssl.cnf
@@ -24,9 +24,12 @@
 # touch index.txt
 # echo 1000 > serial
 
-# CA certificate encrypted key passphrase
+# CA certificate encrypted key passphrase, both -passin and -passout
 # sf-pwgen --algorithm memorable --count 2 --length 24 2>/dev/null | paste -s -d -- '-' \
 #     1>private/passphrase.txt || true
+# cat private/passphrase.txt private/passphrase.txt > private/passphrase-dbl.txt \
+#     && mv private/passphrase-dbl.txt private/passphrase.txt \
+#     || rm -f private/passphrase-dbl.txt
 # chmod go-rwx private/passphrase.txt
 
 # CA encrypted key
@@ -35,8 +38,8 @@
 #     -pkeyopt ec_paramgen_curve:P-384 -aes256 \
 #     -pass file:private/passphrase.txt
 # RSA
-# openssl genrsa -aes256 -out private/ca.key.pem \
-#     -passout file:private/passphrase.txt
+# # openssl genrsa -aes256 -out private/ca.key.pem \
+# #     -passout file:private/passphrase.txt
 
 # CA certificate
 # openssl req -config openssl.cnf \
@@ -57,7 +60,9 @@
 # openssl pkcs12 -export -out certs/ca.p12 \
 #     -inkey private/ca.key.pem -in certs/ca.cert.pem \
 #     -passin file:private/passphrase.txt \
-#     -passout pass:$(head -1 private/passphrase.txt)
+#     -passout file:private/passphrase.txt
+# verify .p12 passphrase
+# openssl pkcs12 -noout -in certs/ca.p12 -passin file:private/passphrase.txt
 
 [ca]
 default_ca        = CA_default


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
