### PR TITLE
openssl3: Only apply atomic patch when needed

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -7,7 +7,7 @@ PortGroup           muniversal 1.0
 set major_v         3
 name                openssl$major_v
 version             ${major_v}.0.0
-revision            4
+revision            5
 
 # Please revbump these ports when updating OpenSSL.
 #  - freeradius (#43461)
@@ -61,7 +61,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 # https://github.com/openssl/openssl/pull/16584
 # https://github.com/openssl/openssl/issues/16551
 # Fixes "Undefined symbols for architecture i386: ___atomic_is_lock_free"
-if { ${configure.build_arch} eq "i386" || "i386" in ${configure.universal_archs} } {
+if {(${configure.build_arch} eq "i386") || (${universal_possible} && [variant_isset universal] && "i386" in ${configure.universal_archs})} {
     patchfiles-append   patch-fix-i386-atomics.diff
 }
 


### PR DESCRIPTION
Prior the patch applied even if building for x86_64 if the host supported i386 as per @ryandesign

This was done on mobile so I can’t preform the additional checks currently.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
