### PR TITLE
cadaver: fix macOS 10.15 build

### DIFF
--- a/www/cadaver/Portfile
+++ b/www/cadaver/Portfile
@@ -6,7 +6,7 @@ name                cadaver
 version             0.23.3
 revision            3
 categories          www
-maintainers         {puffin.lb.shuttle.de:michael.klein @mklein-de} openmaintainer
+maintainers         {fossekall.de:michael.klein @mklein-de} openmaintainer
 description         Commandline client for DAV
 long_description    cadaver is a command-line WebDAV client for Unix.  It \
                     supports file upload, download, on-screen display, \
@@ -29,5 +29,11 @@ depends_lib         port:expat \
                     port:readline
 
 configure.args      --with-expat \
-                    --with-ssl \
-                    --with-force-ssl
+                    --with-neon=${prefix} \
+                    --with-ssl
+
+post-patch {
+    # Ugly hack to support neon 0.30.x, because neither the included
+    # autogen.sh nor the usual GNU automadness tools worked for me.
+    reinplace "s|27 28 29|27 28 29 30|g" ${worksrcpath}/configure
+}

--- a/www/cadaver/Portfile
+++ b/www/cadaver/Portfile
@@ -33,7 +33,7 @@ configure.args      --with-expat \
                     --with-ssl
 
 post-patch {
-    # Ugly hack to support neon 0.30.x, because neither the included
+    # Ugly hack to support neon 0.3x.y, because neither the included
     # autogen.sh nor the usual GNU automadness tools worked for me.
-    reinplace "s|27 28 29|27 28 29 30|g" ${worksrcpath}/configure
+    reinplace "s|27 28 29|27 28 29 30 31|g" ${worksrcpath}/configure
 }


### PR DESCRIPTION
- patch configure script to add support neon 0.30.x
- always use macports neon
- update maintainer address

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G6032 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
