### PR TITLE
google-cloud-sdk: update to 364.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             363.0.0
+version             364.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d63cd0a938b7d00c6272ab6c831bf1926db4e6d7 \
-                    sha256  b3c9cba3911f070570761e966d5565b27d9d94d2d534589f3927f77fd35b626e \
-                    size    96653259
+    checksums       rmd160  ebb81a74737b1f7880ecc0831b2391ee9691a34c \
+                    sha256  21810b6b9d8bdb47aea6ed491f02cbc9d71366309abab77037f93d67c45efa6b \
+                    size    96853090
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  53623731c0c4acc0e6e9997bc50af4eab4dde152 \
-                    sha256  8fff2401f9a2ac2dee0ef335ac2273a2d6178f2ef8c3632981b80571a513553f \
-                    size    92924270
+    checksums       rmd160  246bfafae8f3a4b94aee36142a80698f352dc110 \
+                    sha256  14265ce00c477150daebe2c76a38ef8e17177682ddd4a23707c756d0e6bf525c \
+                    size    93119170
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  18e447192c36d3988b525da5fc048aa2976eb74d \
-                    sha256  647b2fe9930a58d0505913aabef6f9b72632df947be7fcd5301985fe90f35048 \
-                    size    92851536
+    checksums       rmd160  8997272a5ad986d3ffe86492a4a9443fdd9e8ca7 \
+                    sha256  b55748f87d9240d49fc857f71439e43f2d67e1f97329316af5c388dad2a1e552 \
+                    size    93046563
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 364.0.0.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?