### PR TITLE
neomutt: update to 20211029

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        neomutt neomutt 20200925
-revision            1
+github.setup        neomutt neomutt 20211029
+revision            0
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -21,9 +21,9 @@ long_description    Mutt is a small but very powerful text-based MIME \
                     groups of messages.
 homepage            https://neomutt.org
 
-checksums           rmd160  37978a334d56cd97ce3d44ab810dc984008b6e0b \
-                    sha256  d3810dd665a839d5dfb4130a837ae6d0735a634bd2d936db21051ba160b4bf6e \
-                    size    3441887
+checksums           rmd160  73543a5f899b455c90b32beb30411dc0b7ffff0a \
+                    sha256  0814be975ef74793a8a9a0a6b856cfe63ed41443f1523b0f7c82716c3d5c990a \
+                    size    3703334
 
 depends_lib         path:bin/perl:perl5 \
                     path:lib/libssl.dylib:openssl \
@@ -36,22 +36,20 @@ depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 post-patch {
     # Use MacPorts Perl
     reinplace -W ${worksrcpath} "s|/usr/bin/perl|${prefix}/bin/perl|g" \
-              docs/gen-map-doc \
-              doxygen/doxygen.conf
+              docs/gen-map-doc
 
     reinplace -W ${worksrcpath} "s|/usr/bin/|${prefix}/bin/|g" \
-              contrib/sample.neomuttrc-tlr \
+              contrib/samples/sample.neomuttrc-tlr \
+              contrib/samples/smime_keys_test.pl \
               contrib/smime_keys \
-              contrib/smime_keys_test.pl \
               docs/manual.xml.head
     reinplace -W ${worksrcpath} "s|/usr/libexec/|${prefix}/libexec/|g" \
-              contrib/gpg.rc \
-              contrib/smime.rc \
+              contrib/samples/gpg.rc \
+              contrib/samples/smime.rc \
               docs/manual.xml.head
     reinplace -W ${worksrcpath} "s|/usr/local/|${prefix}/|g" \
-              init.h \
               contrib/hcache-bench/README.md \
-              contrib/sample.neomuttrc \
+              contrib/samples/sample.neomuttrc \
               docs/manual.xml.head
     reinplace -W ${worksrcpath} "s|/usr/share|${prefix}/share|g" \
               docs/manual.xml.head
@@ -146,10 +144,6 @@ variant rocksdb description {Enable header cache using RocksDB database} {
 variant sasl description {Simple Authentication and Security Layer support} {
     configure.args-append       --with-sasl=${prefix}
     depends_lib-append          port:cyrus-sasl2
-}
-variant slang description {Use S-lang instead of ncurses} {
-    configure.args-append       --with-ui=slang --with-slang=${prefix}
-    depends_lib-replace         port:ncurses port:slang2
 }
 variant tdb description {Enable header cache using Trivial database} {
     configure.args-append       --with-tdb=${prefix}


### PR DESCRIPTION
#### Description

Update to 20211029.

Among other changes, the slang GUI was retired, so remove the slang variant.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
