### PR TITLE
tor: Fix activate issue when torrc already exists

### DIFF
--- a/security/tor/Portfile
+++ b/security/tor/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                tor
 conflicts           tor-devel
 version             0.4.6.8
-revision            0
+revision            1
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -33,7 +33,7 @@ depends_lib         port:libevent \
 
 set torUser         _tor
 set torGroup        _tor
-add_users           ${torUser} group=${torGroup} home=${prefix}/var/lib/tor
+add_users           ${torUser} group=${torGroup} home=${prefix}/var/lib/${name}
 
 configure.args      --disable-silent-rules
 
@@ -45,31 +45,50 @@ configure.args-append \
 
 post-destroot {
     # Create a working torrc file with basic, locked-down permissions
-    xinstall -o ${torUser} -g ${torGroup} -m 0640 ${destroot}${prefix}/etc/tor/torrc.sample ${destroot}${prefix}/etc/tor/torrc
-    system -W ${destroot}${prefix}/etc/tor "cat >> torrc <<LOCAL_TOR_CONFIGURATION
+    xinstall -o ${torUser} -g ${torGroup} -m 0640 ${destroot}${prefix}/etc/${name}/torrc.sample ${destroot}${prefix}/etc/${name}/torrc
+    system -W ${destroot}${prefix}/etc/${name} "cat >> torrc <<LOCAL_TOR_CONFIGURATION
 
 # Local Tor configuration
 SocksPolicy accept 127.0.0.1  # accept only localhost connections
 SocksPolicy reject *
 ExitPolicy reject *:*  # no exits allowed
-DataDirectory ${prefix}/var/lib/tor
-PidFile ${prefix}/var/run/tor/tor.pid
+DataDirectory ${prefix}/var/lib/${name}
+PidFile ${prefix}/var/run/${name}/${name}.pid
 # tor process uid
 User ${torUser}
 LOCAL_TOR_CONFIGURATION"
-    # save the existing config if it exists
-    if {[file exists ${prefix}/etc/tor/torrc]} {
-        file rename ${prefix}/etc/tor/torrc \
-                    ${prefix}/etc/tor/torrc.previous
+    # backup torrc files
+    if {[file exists ${prefix}/etc/${name}/torrc]} {
+        move ${destroot}${prefix}/etc/${name}/torrc \
+                    ${destroot}${prefix}/etc/${name}/torrc.new
+        copy ${prefix}/etc/${name}/torrc \
+                    ${destroot}${prefix}/etc/${name}/torrc.mp_backup
+        file attributes ${prefix}/etc/${name}/torrc.mp_backup \
+                    -owner ${torUser} -group ${torGroup} \
+                    -permissions 0660
     }
 }
 
 post-activate {
     # DataDirectory and PID file Ddirectory permissions
-    system "chown ${torUser}:${torGroup} ${prefix}/var/lib/tor"
-    system "chmod 0750 ${prefix}/var/lib/tor"
-    system "chown ${torUser}:${torGroup} ${prefix}/var/run/tor"
-    system "chmod 0750 ${prefix}/var/run/tor"
+    system "chown ${torUser}:${torGroup} ${prefix}/var/lib/${name}"
+    system "chmod 0750 ${prefix}/var/lib/${name}"
+    system "chown ${torUser}:${torGroup} ${prefix}/var/run/${name}"
+    system "chmod 0750 ${prefix}/var/run/${name}"
+
+    if {![file exists ${prefix}/etc/${name}/torrc]} {
+        # restore config files
+        if {[file exists ${prefix}/etc/${name}/torrc.mp_backup]} {
+            copy ${prefix}/etc/${name}/torrc.mp_backup \
+                    ${prefix}/etc/${name}/torrc
+        } else {
+            copy ${prefix}/etc/${name}/torrc.new \
+                    ${prefix}/etc/${name}/torrc
+        }
+        file attributes ${prefix}/etc/${name}/torrc \
+                    -owner ${torUser} -group ${torGroup} \
+                    -permissions 0660
+    }
 }
 
 test.run            yes
@@ -78,22 +97,22 @@ test.target         check
 platform darwin {
     startupitem.create          yes
     startupitem.name            Tor
-    startupitem.start           "\[ -f \"${prefix}/etc/tor/torrc\" \] \\"
-    startupitem.start-append    "\t&& ${prefix}/bin/tor \\"
-    startupitem.start-append    "\t\t-f ${prefix}/etc/tor/torrc 2>/dev/null"
-    startupitem.stop            "if \[ -f \"${prefix}/var/run/tor/tor.pid\" \]; then"
-    startupitem.stop-append     "\tkill `cat ${prefix}/var/run/tor/tor.pid` \\"
-    startupitem.stop-append     "\t\t&& rm -f ${prefix}/var/run/tor/tor.pid"
+    startupitem.start           "\[ -f \"${prefix}/etc/${name}/torrc\" \] \\"
+    startupitem.start-append    "\t&& ${prefix}/bin/${name} \\"
+    startupitem.start-append    "\t\t-f ${prefix}/etc/${name}/torrc 2>/dev/null"
+    startupitem.stop            "if \[ -f \"${prefix}/var/run/${name}/${name}.pid\" \]; then"
+    startupitem.stop-append     "\tkill `cat ${prefix}/var/run/${name}/${name}.pid` \\"
+    startupitem.stop-append     "\t\t&& rm -f ${prefix}/var/run/${name}/${name}.pid"
     startupitem.stop-append     "else"
-    startupitem.stop-append     "\t/usr/bin/killall -SIGUSR1 tor 2>/dev/null"
+    startupitem.stop-append     "\t/usr/bin/killall -SIGUSR1 ${name} 2>/dev/null"
     startupitem.stop-append     "fi"
-    startupitem.pidfile         none ${prefix}/var/run/tor/tor.pid
+    startupitem.pidfile         none ${prefix}/var/run/${name}/${name}.pid
 }
 
-destroot.keepdirs   ${destroot}${prefix}/var/lib/tor \
-                    ${destroot}${prefix}/var/run/tor \
-                    ${destroot}${prefix}/var/log/tor
+destroot.keepdirs   ${destroot}${prefix}/var/lib/${name} \
+                    ${destroot}${prefix}/var/run/${name} \
+                    ${destroot}${prefix}/var/log/${name}
 
 livecheck.type      regex
 livecheck.url       ${master_sites}?C=M\;O=D
-livecheck.regex     tor-(\\d+\\.\\d+\\.\\d+\\.\\d+)${extract.suffix}
+livecheck.regex     ${name}-(\\d+\\.\\d+\\.\\d+\\.\\d+)${extract.suffix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
