### PR TITLE
openrct2: make distfiles contain versions in filenames

### DIFF
--- a/games/openrct2/Portfile
+++ b/games/openrct2/Portfile
@@ -24,11 +24,13 @@ use_zip             yes
 
 set main_distfile       ${distfiles}
 
-set objects_distfile    objects${extract.suffix}
-set objects_mastersite  https://github.com/${github.author}/objects/releases/download/v1.2.2
+set objects_version     1.2.2
+set objects_distfile    objects-${objects_version}${extract.suffix}
+set objects_mastersite  https://github.com/${github.author}/objects/releases/download/v${objects_version}/objects${extract.suffix}?dummy=
 
-set ts_distfile         title-sequences${extract.suffix}
-set ts_mastersite       https://github.com/${github.author}/title-sequences/releases/download/v0.1.2c
+set ts_version          0.1.2c
+set ts_distfile         title-sequences-${ts_version}${extract.suffix}
+set ts_mastersite       https://github.com/${github.author}/title-sequences/releases/download/v${ts_version}/title-sequences${extract.suffix}?dummy=
 
 distfiles           ${main_distfile}:main \
                     ${objects_distfile}:objects \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

https://github.com/macports/macports-ports/pull/12853#issuecomment-964424250

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
