### PR TITLE
libunistring: update Portfile to fix broken Tiger (10.4) build: trac …

### DIFF
--- a/textproc/libunistring/Portfile
+++ b/textproc/libunistring/Portfile
@@ -31,6 +31,14 @@ checksums           rmd160  d64da9245ed843c62d69c76498146bc87787c37d \
 depends_build       bin:perl:perl5 \
                     port:texinfo
 
+# use gmake on 10.4, see:
+# https://trac.macports.org/ticket/63790
+platform darwin 8 {
+    depends_build-append \
+                    port:gmake
+    build.cmd       gmake
+}
+
 depends_lib         port:libiconv
 
 patchfiles          0010-AC_INIT.patch \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/63790

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Proposed fix to libunistring's Portfile to allow it to build properly on MacOSX 10.4 (Tiger) (see trac ticket #63790).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11 8S165 Power Macintosh
Xcode: DevToolsCore-798.0 DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
