### PR TITLE
KeePassXC: fix compilation issue of 2.6.6 on El Capitan

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -21,7 +21,7 @@ license                 GPL-2+
 license_noconflict      openssl
 
 github.setup            keepassxreboot keepassxc 2.6.6
-revision                0
+revision                1
 github.tarball_from     releases
 distname                keepassxc-${version}-src
 use_xz                  yes

--- a/security/KeePassXC/files/patch-old-mac.diff
+++ b/security/KeePassXC/files/patch-old-mac.diff
@@ -16,3 +16,45 @@
      return YES;
  }
  
+--- src/gui/styles/base/BaseStyle.orig.cpp	2021-11-10 11:10:45.000000000 +0100
++++ src/gui/styles/base/BaseStyle.cpp	2021-11-10 11:07:30.000000000 +0100
+@@ -292,16 +292,20 @@
+ #ifdef Q_OS_MACOS
+             QColor tabBarBase(const QPalette& pal)
+             {
++#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+                 if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur) {
+                     return hack_isLightPalette(pal) ? QRgb(0xD4D4D4) : QRgb(0x2A2A2A);
+                 }
++#endif
+                 return hack_isLightPalette(pal) ? QRgb(0xDD1D1D1) : QRgb(0x252525);
+             }
+             QColor tabBarBaseInactive(const QPalette& pal)
+             {
++#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+                 if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur) {
+                     return hack_isLightPalette(pal) ? QRgb(0xF5F5F5) : QRgb(0x2D2D2D);
+                 }
++#endif
+                 return hack_isLightPalette(pal) ? QRgb(0xF4F4F4) : QRgb(0x282828);
+             }
+ #endif
+--- src/gui/osutils/macutils/AppKitImpl.orig.mm	2021-11-10 11:29:13.000000000 +0100
++++ src/gui/osutils/macutils/AppKitImpl.mm	2021-11-10 11:28:28.000000000 +0100
+@@ -139,6 +139,7 @@
+ //
+ - (bool) isStatusBarDark
+ {
++#if __clang_major__ >= 9
+     if (@available(macOS 10.17, *)) {
+         // This is an ugly hack, but I couldn't find a way to access QTrayIcon's NSStatusItem.
+         NSStatusItem* dummy = [[NSStatusBar systemStatusBar] statusItemWithLength:0];
+@@ -146,7 +147,7 @@
+         [[NSStatusBar systemStatusBar] removeStatusItem:dummy];
+         return [appearance containsString:@"dark"];
+     }
+-
++#endif
+     return [self isDarkMode];
+ }
+ 


### PR DESCRIPTION
#### Description

KeePassXC: fix compilation issue of 2.6.6 on El Capitan (closes [#62220](https://trac.macports.org/ticket/62220))

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
