### PR TITLE
ruby ports: enable parallel builds: part 1 (ruby26, ruby27, ruby30)

### DIFF
--- a/lang/ruby26/Portfile
+++ b/lang/ruby26/Portfile
@@ -33,8 +33,6 @@ checksums           md5 c53761123d17e929cfe248f50429bcab \
                     sha256 dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6 \
                     size 14131671
 
-use_parallel_build  no
-
 # ruby/openssl does not support openssl-3
 openssl.branch      1.1
 
@@ -148,6 +146,10 @@ variant jemalloc description "use jemalloc" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
         # use ruby built-in universal mechanism.
         configure.args-append   --with-arch=[join ${universal_archs} ,]
         # clear macports' universal flags

--- a/lang/ruby27/Portfile
+++ b/lang/ruby27/Portfile
@@ -32,8 +32,6 @@ checksums           md5 52705d799ed851dd3bfd5634265cde46 \
                     sha1 f5bdecded2d68e4f2f0ab1d20137e8b4b0614e52 \
                     sha256 bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48
 
-use_parallel_build  no
-
 # ruby/openssl does not support openssl-3
 openssl.branch      1.1
 
@@ -135,6 +133,10 @@ variant jemalloc description "use jemalloc" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
         # use ruby built-in universal mechanism.
         configure.args-append   --with-arch=[join ${universal_archs} ,]
         # clear macports' universal flags

--- a/lang/ruby30/Portfile
+++ b/lang/ruby30/Portfile
@@ -33,7 +33,6 @@ checksums           md5 b973af486291a1e17ad50d88472bfa86 \
                     sha256 5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1 \
 					size 19941179
 
-use_parallel_build  no
 universal_variant   no
 
 # ruby/openssl does not support openssl-3


### PR DESCRIPTION
#### Description

Virtually all Ruby ports disable parallel builds at present. This has a negative impact both on our buildbots, as well as our users.

Note that there is one Ruby port where parallel builds are enabled - `ruby186` - without any known issues.

As a starting point, enable for the three latest Ruby releases: 2.6, 2.7, and 3.0. Note that parallel builds are only enabled for non-Universal builds, due to a known issue with the latter.

Fixes: [63895 - ruby ports: enable parallel builds](https://trac.macports.org/ticket/63895)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?