### PR TITLE
godot: work around compile error on macOS <= 10.10

### DIFF
--- a/games/godot/Portfile
+++ b/games/godot/Portfile
@@ -24,6 +24,7 @@ long_description    Godot Engine is a cross-platform game engine for \
 
 if {$subport eq ${name}} {
     github.setup    godotengine ${name} 3.3.2 "" -stable
+    revision        1
 
     checksums       rmd160  6a0d77597ed84308d030c243118e01b79a87f88c \
                     sha256  dde0c91b2aaa7db21bd1e1ca82f6c20491e8548c20511bdcf506160f4b852bd8 \
@@ -60,6 +61,26 @@ depends_build       port:scons \
 
 if {${os.platform} eq "darwin" && ${os.major} <= 15} {
     patchfiles      legacy-osx-defines.diff
+}
+
+if {$subport eq ${name} && \
+    ${os.platform} eq "darwin" && ${os.major} <  15} {
+    # On old versions of macOS, the build seems to think that the value
+    # of the preprocessor macro MAC_OS_X_VERSION_MAX_ALLOWED is
+    # >= 101200, which is supposed to correspond to macOS 10.12 Sierra.
+    # As discussed in GitHub PR #12269
+    # (https://github.com/macports/macports-ports/pull/12269),
+    # something is causing the preprocessor to think that values such as
+    # 101000, 1090, etc. are >= 101200, which in turn is causing the
+    # compiler to try to #include <os/log.h>. This causes a compile
+    # error on older macOSes, because this header only exists starting
+    # in the macOS 10.12 SDK.
+    #
+    # This patch file works around the issue by deleting the problematic
+    # code. If, in the future, we can discover the real reason why the
+    # numerical comparison is behaving incorrectly, and find a fix, then
+    # it might be possible to eliminate the need for this patch file.
+    patchfiles-append macosx-version-log_h-workaround.diff
 }
 
 post-patch {

--- a/games/godot/files/macosx-version-log_h-workaround.diff
+++ b/games/godot/files/macosx-version-log_h-workaround.diff
@@ -1,0 +1,121 @@
+--- platform/osx/os_osx.mm.orig	2021-05-24 07:39:13.000000000 -0400
++++ platform/osx/os_osx.mm	2021-11-08 16:09:55.000000000 -0500
+@@ -48,9 +48,6 @@
+ #include <IOKit/IOKitLib.h>
+ #include <IOKit/hid/IOHIDKeys.h>
+ #include <IOKit/hid/IOHIDLib.h>
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
+-#include <os/log.h>
+-#endif
+ 
+ #include <dlfcn.h>
+ #include <fcntl.h>
+@@ -493,11 +490,7 @@
+ 	trackingArea = nil;
+ 	imeInputEventInProgress = false;
+ 	[self updateTrackingAreas];
+-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+-	[self registerForDraggedTypes:[NSArray arrayWithObject:NSPasteboardTypeFileURL]];
+-#else
+ 	[self registerForDraggedTypes:[NSArray arrayWithObject:NSFilenamesPboardType]];
+-#endif
+ 	markedText = [[NSMutableAttributedString alloc] init];
+ 	return self;
+ }
+@@ -643,18 +636,6 @@
+ 	Vector<String> files;
+ 	NSPasteboard *pboard = [sender draggingPasteboard];
+ 
+-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+-	NSArray *items = pboard.pasteboardItems;
+-	for (NSPasteboardItem *item in items) {
+-		NSString *path = [item stringForType:NSPasteboardTypeFileURL];
+-		NSString *ns = [NSURL URLWithString:path].path;
+-		char *utfs = strdup([ns UTF8String]);
+-		String ret;
+-		ret.parse_utf8(utfs);
+-		free(utfs);
+-		files.push_back(ret);
+-	}
+-#else
+ 	NSArray *filenames = [pboard propertyListForType:NSFilenamesPboardType];
+ 	for (NSString *ns in filenames) {
+ 		char *utfs = strdup([ns UTF8String]);
+@@ -663,7 +644,6 @@
+ 		free(utfs);
+ 		files.push_back(ret);
+ 	}
+-#endif
+ 
+ 	if (files.size()) {
+ 		OS_OSX::singleton->main_loop->drop_files(files, 0);
+@@ -1837,69 +1817,7 @@
+ 	return "OSX";
+ }
+ 
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
+-class OSXTerminalLogger : public StdLogger {
+-public:
+-	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR) {
+-		if (!should_log(true)) {
+-			return;
+-		}
+-
+-		const char *err_details;
+-		if (p_rationale && p_rationale[0])
+-			err_details = p_rationale;
+-		else
+-			err_details = p_code;
+-
+-		switch (p_type) {
+-			case ERR_WARNING:
+-				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
+-					os_log_info(OS_LOG_DEFAULT,
+-							"WARNING: %{public}s: %{public}s\nAt: %{public}s:%i.",
+-							p_function, err_details, p_file, p_line);
+-				}
+-				logf_error("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n", p_function,
+-						err_details);
+-				logf_error("\E[0;33m   At: %s:%i.\E[0m\n", p_file, p_line);
+-				break;
+-			case ERR_SCRIPT:
+-				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
+-					os_log_error(OS_LOG_DEFAULT,
+-							"SCRIPT ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
+-							p_function, err_details, p_file, p_line);
+-				}
+-				logf_error("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m%s\n", p_function,
+-						err_details);
+-				logf_error("\E[0;35m   At: %s:%i.\E[0m\n", p_file, p_line);
+-				break;
+-			case ERR_SHADER:
+-				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
+-					os_log_error(OS_LOG_DEFAULT,
+-							"SHADER ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
+-							p_function, err_details, p_file, p_line);
+-				}
+-				logf_error("\E[1;36mSHADER ERROR: %s: \E[0m\E[1m%s\n", p_function,
+-						err_details);
+-				logf_error("\E[0;36m   At: %s:%i.\E[0m\n", p_file, p_line);
+-				break;
+-			case ERR_ERROR:
+-			default:
+-				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
+-					os_log_error(OS_LOG_DEFAULT,
+-							"ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
+-							p_function, err_details, p_file, p_line);
+-				}
+-				logf_error("\E[1;31mERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
+-				logf_error("\E[0;31m   At: %s:%i.\E[0m\n", p_file, p_line);
+-				break;
+-		}
+-	}
+-};
+-
+-#else
+-
+ typedef UnixTerminalLogger OSXTerminalLogger;
+-#endif
+ 
+ void OS_OSX::alert(const String &p_alert, const String &p_title) {
+ 	if (is_no_window_mode_enabled()) {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This PR attempts to work around the issues that have been documented in #12269 .

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
