### PR TITLE
hugo: update to 0.89.2

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.89.1 v
+go.setup            github.com/gohugoio/hugo 0.89.2 v
 revision            0
-checksums           rmd160  ba3d99f4df83f669edbed99c7ca7724bbfc0b892 \
-                    sha256  7440cf81ced2864067cae85e8f58a9a52277052ebd7d6abdce93b57663f9cbb7 \
-                    size    37378361
+checksums           rmd160  0a887df773484f408ac11295dbc3254eaf8231af \
+                    sha256  cc89d4a993bdaff6795f0e3a32880a99b918c88b3ea0fd0b0f6a35762c732338 \
+                    size    37375627
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.89.2

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
