### PR TITLE
libfido2: update to version 1.9.0

### DIFF
--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           openssl 1.0
 
 github.setup        Yubico libfido2 1.9.0
-revision            1
+revision            0
 
 categories          security crypto
 platforms           darwin
@@ -23,5 +24,4 @@ depends_build-append \
                     port:mandoc \
                     port:pkgconfig
 
-depends_lib-append  port:libcbor \
-                    path:lib/libssl.dylib:openssl
+depends_lib-append  port:libcbor


### PR DESCRIPTION
* update to version 1.9.0
* use PortGroup openssl 1.0
* confirmed it builds openssl 3.0

#### Description

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
