### PR TITLE
sylpheed: become maintainer, update to 3.7.0, fix building on macOS 11 and newer

### DIFF
--- a/mail/sylpheed/Portfile
+++ b/mail/sylpheed/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                sylpheed
-version             3.5.1
-revision            1
+version             3.7.0
+revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          mail
 platforms           darwin
@@ -22,12 +22,15 @@ homepage            http://sylpheed.sraoss.jp/en/
 master_sites        http://sylpheed.sraoss.jp/sylpheed/v${branch}
 use_bzip2           yes
 
-checksums           rmd160  9ecf4bee6718f6499533abb464638af6c39e595c \
-                    sha256  3a5a04a13a0e2f32cdbc6e09d92b5143ca96df5fef23425cd81d96b8bd5b1087
+checksums           rmd160  09ee37dfc063e76fc3780de613cfd80be917d6d8 \
+                    sha256  eb23e6bda2c02095dfb0130668cf7c75d1f256904e3a7337815b4da5cb72eb04 \
+                    size    3612328
 
 depends_build       port:pkgconfig
 
 depends_lib         path:lib/pkgconfig/gtk+-2.0.pc:gtk2
+
+patchfiles          dynamic_lookup-11.patch
 
 configure.args      --disable-compface \
                     --disable-gpgme \

--- a/mail/sylpheed/Portfile
+++ b/mail/sylpheed/Portfile
@@ -8,7 +8,7 @@ revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          mail
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {hotplate.co.nz:michael @fincham} openmaintainer
 license             {GPL-2 LGPL-2.1}
 
 description         Fast, lightweight GTK+ mail client

--- a/mail/sylpheed/files/dynamic_lookup-11.patch
+++ b/mail/sylpheed/files/dynamic_lookup-11.patch
@@ -1,0 +1,27 @@
+Fix the usual macOS 11 libtool bug.
+--- configure.orig	2021-11-08 21:33:52.000000000 +1300
++++ configure	2021-11-08 21:36:31.000000000 +1300
+@@ -8818,17 +8818,12 @@
+       _lt_dar_allow_undefined='${wl}-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+-	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+-	10.[012]*)
+-	  _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
+-	10.*)
+-	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
++    darwin*)
++      case $MACOSX_DEPLOYMENT_TARGET,$host in
++	   10.[012],*|,*powerpc*-darwin[5-8]*)      
++	     _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
++	   *)
++	     _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;
+   esac


### PR DESCRIPTION
#### Description

I'd like to become the maintainer for this port. I've attached two commits: firstly, just making myself the maintainer (and adding openmaintainer), and secondly to update to the upstream version 3.7.0 and add the usual libtool patch to fix building on recent macOS versions. 

I've got a few other tidy-ups I'd like to do to this package (like adding variant descriptions, making the SSL build default, cleaning up unused patches) which I'll action later. I've tested this build with both +x11 and +quartz versions of GTK2.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?