### PR TITLE
py-requests-cache - update to 0.8.1

### DIFF
--- a/python/py-cattrs/Portfile
+++ b/python/py-cattrs/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cattrs
+version             1.8.0
+revision            0
+license             MIT
+maintainers         nomaintainer
+supported_archs     noarch
+
+description         cattrs is an open source Python library for structuring and unstructuring data.
+long_description    {*}${description}. cattrs works best with attrs classes, dataclasses and the usual Python collections, \
+                    but other kinds of classes are supported by manually registering converters.
+
+homepage            https://github.com/python-attrs/cattrs
+
+python.versions     37 38 39 310
+
+checksums           rmd160  7cc352191d51c4cfbedc1eacf8ad5b61045736ca \
+                    sha256  5c121ab06a7cac494813c228721a7feb5a6423b17316eeaebf13f5a03e5b0d53 \
+                    size    22501
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-attrs
+
+    livecheck.type  none
+}

--- a/python/py-requests-cache/Portfile
+++ b/python/py-requests-cache/Portfile
@@ -1,16 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        reclosedev requests-cache 6717a336430eb7e6fe17e75c5517f3076ca85b42
-version             0.5.2
-revision            0
 name                py-requests-cache
+version             0.8.1
+revision            0
 
 categories-append   devel
-platforms           darwin
 license             BSD
 supported_archs     noarch
 maintainers         nomaintainer
@@ -18,34 +15,49 @@ maintainers         nomaintainer
 description         Transparent persistent cache for py-requests
 long_description    ${description}
 
-checksums           rmd160  511d993d81abeffca4d13414a036be94c5c9ce23 \
-                    sha256  1ea8b866db2b16a9b058626c7e1bde0cf669e96abc436cdef352f60237e23ab9 \
-                    size    29527
+homepage            https://requests-cache.readthedocs.io/en/stable/
 
-python.versions     27 35 36 37 38
+checksums           rmd160  41cd04c6a75cd6d10ce08c5e3562ab4517fbe267 \
+                    sha256  27d3eb276ab3affa9864dfc0475241d6d960dd566d57ec46ffa7759c2c74ed1c \
+                    size    1510446
+
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
     depends_lib-append \
-                    port:py${python.version}-requests
+                    port:py${python.version}-appdirs       \
+                    port:py${python.version}-attrs         \
+                    port:py${python.version}-cattrs        \
+                    port:py${python.version}-requests      \
+                    port:py${python.version}-url-normalize \
+                    port:py${python.version}-urllib3
+
+    if {${python.version} < 37} {
+        version     0.5.2
+        revision    0
+        checksums   rmd160  ccd76aca28b1ba826a88beb5fc65f16aec26e583 \
+                    sha256  813023269686045f8e01e2289cc1e7e9ae5ab22ddd1e2849a9093ab3ab7270eb \
+                    size    31159
+        depends_lib port:py${python.version}-requests
+
+    }
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
+
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} README.rst CONTRIBUTORS.rst \
-            LICENSE HISTORY.rst ${destroot}${docdir}
+
+        if {${python.version} < 37} {
+            xinstall -m 0644 -W ${worksrcpath} README.rst CONTRIBUTORS.rst \
+                LICENSE HISTORY.rst ${destroot}${docdir}
+        } else {
+            xinstall -m 0644 -W ${worksrcpath} README.md CONTRIBUTORS.md \
+                LICENSE HISTORY.md ${destroot}${docdir}
+        }
     }
-
-    depends_test-append \
-                    port:py${python.version}-mock \
-                    port:py${python.version}-pytest
-
-    test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-url-normalize/Portfile
+++ b/python/py-url-normalize/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-url-normalize
+version             1.4.3
+revision            0
+categories-append   devel net
+supported_archs     noarch
+license             LGPL-2+
+
+python.versions     37 38 39 310
+
+maintainers         nomaintainer
+
+description         URI Normalization function
+
+long_description    ${description}
+
+homepage            https://github.com/niksite/url-normalize
+
+checksums           rmd160  2b189448fd045c9a9a47cb3d2af04e6f3dfea1c0 \
+                    sha256  d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2 \
+                    size    6024
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

Update py-requests-cache to 0.81.  This required 2 new ports (py-url-normalize and py-cattrs) as well as some new dependents.

Per ups ream release notes, this update also deprecates compatibility with python < python-27, so I've created a new port to cover those using py27-requests cache which is the legacy Portfile minus the calls to py-3x

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
