### PR TITLE
emacs-{,app-}devel: fix build on arm64

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -125,6 +125,34 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
         compiler.library_path-prepend \
                                  ${prefix}/lib/gcc11
 
+        # gcc11 can't be build on Monterey / arm64, use gcc-devel instead
+        if {${build_arch} eq {arm64} && ${os.platform} eq "darwin" && ${os.major} eq 21} {
+            depends_lib-delete   port:gcc11
+            depends_lib-append   port:gcc-devel
+
+            compiler.cpath-delete \
+                                 ${prefix}/include/gcc11
+            compiler.cpath-prepend \
+                                 ${prefix}/include/gcc-devel
+
+            compiler.library_path-delete \
+                                 ${prefix}/lib/gcc11
+            compiler.library_path-prepend \
+                                 ${prefix}/lib/gcc-devel
+
+            # by some reason compiler.library_path isn't included into `@rpath`
+            configure.env-append "DYLD_LIBRARY_PATH=${prefix}/lib/gcc-devel"
+            build.env-append     "DYLD_LIBRARY_PATH=${prefix}/lib/gcc-devel"
+            pre-destroot {
+                system "install_name_tool -add_rpath ${prefix}/lib/gcc-devel ${worksrcpath}/src/emacs"
+                system "install_name_tool -add_rpath ${prefix}/lib/gcc-devel ${worksrcpath}/src/temacs"
+
+                if {$subport eq "emacs-app-devel"} {
+                    system "install_name_tool -add_rpath ${prefix}/lib/gcc-devel ${worksrcpath}/nextstep/Emacs.app/Contents/MacOS/Emacs"
+                }
+            }
+        }
+
         build.args-append        NATIVE_FULL_AOT=1 \
             {BYTE_COMPILE_EXTRA_FLAGS='--eval "(setq comp-speed 2)"'}
     }


### PR DESCRIPTION
#### Description

gcc11 can't be build on arm64, use gcc-devel instead

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->