### PR TITLE
libjpeg-turbo: update to 2.1.1

### DIFF
--- a/graphics/libjpeg-turbo/Portfile
+++ b/graphics/libjpeg-turbo/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 
 name                libjpeg-turbo
 set my_name         libjpeg-turbo
-version             2.1.0
+version             2.1.1
 revision            0
 categories          graphics
 platforms           darwin
@@ -33,10 +33,10 @@ master_sites        sourceforge:project/${my_name}/${version}
 distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 
-checksums           sha1    6bf63c869105d341011cd4915816de888338231a \
-                    rmd160  cdb947d63425a8d17b1d83e478f4581ab090a74e \
-                    sha256  bef89803e506f27715c5627b1e3219c95b80fc31465d4452de2a909d382e4444 \
-                    size    2255497
+checksums           sha1    f9c3c17479f4fa2c76dba15125552fc9f6bfda80 \
+                    rmd160  61540f131dbfd5564fba7aee0cecfdd3bab164b9 \
+                    sha256  b76aaedefb71ba882cbad4e9275b30c2ae493e3195be0a099425b5c6b99bd510 \
+                    size    2256321
 
 if {![info exists universal_possible]} {
     set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]


### PR DESCRIPTION
#### Description

Update port to 2.1.1. Note that the corresponding Devel port was updated 24 days ago, and that update has been vetted by several of us.

CC: @evanmiller

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2136
Xcode 9.2 9C40b

macOS 10.13.6 17G14019
Xcode 10.1 10B61

macOS 10.14.6 18G103
Xcode 11.3.1 11C505

macOS 10.15.6 19G2021
Xcode 12.0 12A7209

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?