### PR TITLE
ruby ports: enable parallel builds: part 2 (ruby19 through ruby25)

### DIFF
--- a/lang/ruby19/Portfile
+++ b/lang/ruby19/Portfile
@@ -36,7 +36,6 @@ checksums			md5 0d8b272b05c3449dc848bb7570f65bfe \
 					rmd160 59cfcaf4e02957f53bf83557962b0d428156bc01 \
 					sha1 35600f4e2ac98653fa8a634104cb6ab3d47a1535 \
 					sha256 b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e
-use_parallel_build	no
 
 depends_lib			port:libiconv \
 					port:readline \
@@ -206,6 +205,10 @@ variant mactk conflicts tk description "Build using Mac OS X Tk Framework" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
 		# use ruby built-in universal mechanism.
 		configure.args-append   --with-arch=[join ${universal_archs} ,]
 		# clear macports' universal flags

--- a/lang/ruby20/Portfile
+++ b/lang/ruby20/Portfile
@@ -34,7 +34,6 @@ checksums           md5 3544031334f4665aa2eb1414babc9345 \
                     rmd160 3b6fd5d89e6e53fb71f512f44b710148698a6e29 \
                     sha1 504be2eae6cdfe93aa7ed02ec55e35043d067ad5 \
                     sha256 087ad4dec748cfe665c856dbfbabdee5520268e94bb81a1d8565d76c3cc62166
-use_parallel_build  no
 
 depends_lib         port:readline \
                     port:zlib \
@@ -149,6 +148,10 @@ variant mactk conflicts tk description "Build using Mac OS X Tk Framework" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
         # use ruby built-in universal mechanism.
         configure.args-append   --with-arch=[join ${universal_archs} ,]
         # clear macports' universal flags

--- a/lang/ruby21/Portfile
+++ b/lang/ruby21/Portfile
@@ -34,7 +34,6 @@ checksums           md5 62bd1cbfcbc22e4d137462bce992f6d1 \
                     rmd160 ba54bd691e5ac9c5f1379b8687894735b1afe18b \
                     sha1 39524185b580a3390a3b5019819c8b28d3249766 \
                     sha256 4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e
-use_parallel_build  no
 
 depends_lib         port:readline \
                     port:zlib \
@@ -153,6 +152,10 @@ variant gmp description "use gmp" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
         # use ruby built-in universal mechanism.
         configure.args-append   --with-arch=[join ${universal_archs} ,]
         # clear macports' universal flags

--- a/lang/ruby22/Portfile
+++ b/lang/ruby22/Portfile
@@ -35,7 +35,6 @@ checksums           md5 bef1909a4c885157870ef69548cdad3a \
                     rmd160 b766f369db78f002c6bdf4d54592af6dbc7d0295 \
                     sha1 72ee1dcfd96199d2c3092b77db7a7f439c0abd08 \
                     sha256 a54204d2728283c9eff0cf81d654f245fa5b3447d0824f1a6bc3b2c5c827381e
-use_parallel_build  no
 
 depends_lib         port:readline \
                     port:zlib \
@@ -170,6 +169,10 @@ variant jemalloc description "use jemalloc" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
         # use ruby built-in universal mechanism.
         configure.args-append   --with-arch=[join ${universal_archs} ,]
         # clear macports' universal flags

--- a/lang/ruby23/Portfile
+++ b/lang/ruby23/Portfile
@@ -35,8 +35,6 @@ checksums           md5 78045332e298dfd859ceef9fe946950f \
                     sha1 91b31abdba00a346c155fd32bd32d3cec3b73bc4 \
                     sha256 4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c
 
-use_parallel_build  no
-
 depends_lib         port:readline \
                     port:zlib \
                     port:libyaml \
@@ -162,6 +160,10 @@ variant jemalloc description "use jemalloc" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
         # use ruby built-in universal mechanism.
         configure.args-append   --with-arch=[join ${universal_archs} ,]
         # clear macports' universal flags

--- a/lang/ruby24/Portfile
+++ b/lang/ruby24/Portfile
@@ -53,8 +53,6 @@ checksums           md5 b10a7d2fcaf218c98edbaf57efc36e58 \
                     sha1 96737b609f4a82f8696669a17017a46f3bd07549 \
                     sha256 6ea3ce7fd0064524ae06dbdcd99741c990901dfc9c66d8139a02f907d30b95a8
 
-use_parallel_build  no
-
 # ruby/openssl does not support openssl-3
 openssl.branch      1.1
 
@@ -173,6 +171,10 @@ variant jemalloc description "use jemalloc" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
         # use ruby built-in universal mechanism.
         configure.args-append   --with-arch=[join ${universal_archs} ,]
         # clear macports' universal flags

--- a/lang/ruby25/Portfile
+++ b/lang/ruby25/Portfile
@@ -36,8 +36,6 @@ checksums           md5 9e905a545a729af1f1620ddfc2976fe5 \
                     sha1 6ac21486996aa38a71f858d28d01ada5593d0b45 \
                     sha256 bebbe3fe7899acd3ca2f213de38158709555e88a13f85ba5dc95239654bcfeeb
 
-use_parallel_build  no
-
 # ruby/openssl does not support openssl-3
 openssl.branch      1.1
 
@@ -164,6 +162,10 @@ variant jemalloc description "use jemalloc" {
 }
 
 variant universal {
+        # Disable parallel builds for Universal case
+        # See: https://trac.macports.org/ticket/24240
+        use_parallel_build      no
+
         # use ruby built-in universal mechanism.
         configure.args-append   --with-arch=[join ${universal_archs} ,]
         # clear macports' universal flags


### PR DESCRIPTION
#### Description

Continuation of [PR 12891 - ruby ports: enable parallel builds: part 1 (ruby26, ruby27, ruby30)](https://github.com/macports/macports-ports/pull/12891)

Enable parallel builds for Ruby releases from 1.9 through 2.5, inclusive. As with the previous PR, parallel builds are only enabled for non-Universal builds, due to a known issue with the latter.

See: https://trac.macports.org/ticket/63895

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
N/A

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?