### PR TITLE
mysql8: peg OpenSSL to version 1.1, switch to MacPorts’ libevent

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -18,7 +18,7 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     0
+set revision_client     1
 set revision_server     0
 
 set name_mysql          ${name}
@@ -46,6 +46,8 @@ if {$subport eq $name} {
     PortGroup           legacysupport 1.1
     PortGroup           openssl 1.0
 
+    openssl.branch      1.1
+
     description         Multithreaded SQL database server
     long_description    MySQL is an open-source, multi-threaded SQL database.
     license             GPL-2
@@ -70,6 +72,7 @@ if {$subport eq $name} {
                         size    128699082
 
     depends_lib-append  port:cyrus-sasl2 \
+                        port:libevent \
                         port:icu \
                         port:zlib \
                         port:zstd
@@ -137,9 +140,11 @@ if {$subport eq $name} {
         -DWITH_BOOST:PATH="${worksrcpath}/../${boost_distname}" \
         -DWITH_ICU:PATH="${prefix}" \
         -DWITH_INNODB_MEMCACHED=1 \
+        -DWITH_LIBEVENT=system \
+        -DLIBEVENT_INCLUDE_PATH:PATH="${prefix}/include" \
+        -DLIBEVENT_LIB_PATHS:PATH="${prefix}/lib" \
         -DWITH_PROTOBUF=bundled \
         -DWITH_SASL:PATH="${prefix}" \
-        -DWITH_SSL:PATH="${prefix}" \
         -DWITH_ZLIB:PATH=system \
         -DWITH_ZSTD=system
 
@@ -148,6 +153,9 @@ if {$subport eq $name} {
         -DWITH_ROUTER:BOOL=OFF
 #       -DROUTER_INSTALL_LIBDIR="lib/${name_mysql}" \
 #       -DROUTER_INSTALL_PLUGINDIR="lib/${name_mysql}/mysqlrouter"
+
+    # setns() is a Linux system call
+    configure.checks.implicit_function_declaration.whitelist-append setns
 
     patch.pre_args  -p1
     patchfiles      patch-cmake-install_macros-protobuf-path.cmake.diff \


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/63909

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Only configure phase is tested. This port previously built fine with OpenSSL 1.1.
macOS 10.15.7
Xcode 12.4 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
