### PR TITLE
mysql56, mysql57, mysql8: use MacPorts’ libevent

### DIFF
--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -12,7 +12,7 @@ set name_mysql      ${name}
 version             5.6.51
 # Set revision_client and revision_server to 0 on
 # version bump.
-set revision_client 2
+set revision_client 3
 set revision_server 1
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 categories          databases
@@ -65,6 +65,7 @@ if {$subport eq $name} {
                         size    32411131
 
     depends_lib-append  port:ncurses \
+                        port:libevent \
                         port:tcp_wrappers \
                         port:zlib
 
@@ -128,6 +129,9 @@ if {$subport eq $name} {
                         -DENABLE_GCOV:BOOL=OFF \
                         -DENABLE_DTRACE:BOOL=OFF \
                         -DWITH_LIBWRAP:BOOL=ON \
+                        -DWITH_LIBEVENT=system \
+                        -DLIBEVENT_INCLUDE_PATH:PATH="${prefix}/include" \
+                        -DLIBEVENT_LIB_PATHS:PATH="${prefix}/lib" \
                         -DWITH_INNODB_MEMCACHED=1 \
                         -DWITH_PARTITION_STORAGE_ENGINE=1
     configure.cppflags-delete \

--- a/databases/mysql57/Portfile
+++ b/databases/mysql57/Portfile
@@ -8,7 +8,7 @@ set name_mysql      ${name}
 version             5.7.36
 set boost_version   1.59.0
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client 0
+set revision_client 1
 set revision_server 0
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 categories          databases
@@ -58,6 +58,7 @@ if {$subport eq $name} {
 
     depends_lib-append  port:ncurses \
                         port:libedit \
+                        port:libevent \
                         port:cyrus-sasl2 \
                         port:zlib
     depends_run-append  port:mysql_select
@@ -117,6 +118,9 @@ if {$subport eq $name} {
         -DENABLE_DTRACE:BOOL=OFF \
         -DWITH_LIBWRAP:BOOL=OFF \
         -DWITH_INNODB_MEMCACHED=1 \
+        -DWITH_LIBEVENT=system \
+        -DLIBEVENT_INCLUDE_PATH:PATH="${prefix}/include" \
+        -DLIBEVENT_LIB_PATHS:PATH="${prefix}/lib" \
         -DWITH_PARTITION_STORAGE_ENGINE=1 \
         -DDOWNLOAD_BOOST=1 \
         -DWITH_BOOST=${worksrcpath}/../${boost_distname} \

--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -16,7 +16,7 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     1
+set revision_client     2
 set revision_server     0
 
 set name_mysql          ${name}
@@ -140,6 +140,9 @@ if {$subport eq $name} {
         -DWITH_BOOST:PATH="${worksrcpath}/../${boost_distname}" \
         -DWITH_ICU:PATH="${prefix}" \
         -DWITH_INNODB_MEMCACHED=1 \
+        -DWITH_LIBEVENT=system \
+        -DLIBEVENT_INCLUDE_PATH:PATH="${prefix}/include" \
+        -DLIBEVENT_LIB_PATHS:PATH="${prefix}/lib" \
         -DWITH_PROTOBUF=bundled \
         -DWITH_SASL:PATH="${prefix}" \
         -DWITH_ZLIB:PATH=system \


### PR DESCRIPTION
…instead of building bundled libevent

#### Description
See https://github.com/macports/macports-ports/pull/12915#issuecomment-966753694: the bundled libevent may be disabling a feature during configure due to Xcode ≥ 12 implicit function declaration errors, which MacPorts’ libevent seems unaffected by.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
