### PR TITLE
offlineimap: update to 8.0.0

### DIFF
--- a/mail/offlineimap/Portfile
+++ b/mail/offlineimap/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        OfflineIMAP offlineimap 7.3.4 v
+github.setup        OfflineIMAP offlineimap3 8.0.0 v
+name                offlineimap
 categories          mail python
 platforms           darwin
 license             {GPL-2+ OpenSSLException}
@@ -36,20 +37,21 @@ long_description    OfflineIMAP is a tool to simplify your e-mail reading. \
 
 homepage            http://offlineimap.org/
 
-checksums           rmd160  e14eeb6f74ed16d54f35fd24669a67069038aaf3 \
-                    sha256  c0820f1f4495507e2e8c0d2e1743adb747b4d1010a4827541a5ca8cf33176994 \
-                    size    724547
+checksums           rmd160  891aff60037250e3bcb36c298b20e3b86e1f08b4 \
+                    sha256  8b34481dda8c5e79e88dea9e79975e9572661c5d46c218fbb3dc4146d3421cb8 \
+                    size    702669
 
-python.default_version 27
+python.default_version 310
 
 depends_build       port:py${python.version}-docutils \
                     port:py${python.version}-sphinx \
                     port:asciidoc \
                     port:docbook-xsl-nons
 
-depends_lib         port:py${python.version}-rfc6555 \
-                    port:py${python.version}-selectors2 \
-                    port:py${python.version}-six
+depends_lib         port:py${python.version}-distro \
+                    port:py${python.version}-gssapi \
+                    port:py${python.version}-imaplib2 \
+                    port:py${python.version}-rfc6555
 
 post-build {
     system -W ${worksrcpath} "PATH='${python.prefix}/bin:$env(PATH)' make docs"

--- a/python/py-distro/Portfile
+++ b/python/py-distro/Portfile
@@ -14,7 +14,7 @@ long_description    {*}${description}
 platforms           darwin
 homepage            https://github.com/nir0s/distro
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 checksums           rmd160  735d8872fcda1f3f28d8d4bda4d71fbe02d49ca5 \
                     sha256  83f5e5a09f9c5f68f60173de572930effbcc0287bb84fdc4426cb4168c088424 \

--- a/python/py-imaplib2/Portfile
+++ b/python/py-imaplib2/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-imaplib2
+version             3.6
+revision            0
+
+categories-append   mail devel
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+description         A threaded Python IMAP4 client.
+long_description    ${description}
+
+homepage            https://github.com/jazzband/imaplib2/
+
+checksums           rmd160  2e8e893f8145f9a613c1d36c07007edec470132b \
+                    sha256  96cb485b31868a242cb98d5c5dc67b39b22a6359f30316de536060488e581e5b \
+                    size    26252
+
+python.versions     37 38 39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}

--- a/python/py-rfc6555/Portfile
+++ b/python/py-rfc6555/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-rfc6555
-version             0.0.0
+version             0.1.0
 revision            0
 categories-append   devel
 platforms           darwin
@@ -20,14 +20,21 @@ long_description    Python implementation of the Happy Eyeballs Algorithm descri
 
 homepage            https://github.com/sethmlarson/rfc6555
 
-checksums           rmd160  7bd0464b9353f10892fca2cca5943962ec5f9cfa \
-                    sha256  191cbba0315b53654155321e56a93466f42cd0a474b4f341df4d03264dcb5217 \
-                    size    11218
+checksums           rmd160  5a2e58cbbdbe6134dcd4f0d86867e236081774ab \
+                    sha256  123905b8f68e2bec0c15f321998a262b27e2eaadea29a28bd270021ada411b67 \
+                    size    10094
 
-python.versions     27 38 39
+python.versions     27 38 39 310
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    livecheck.type      none
+
+    if {${python.version} == 27} {
+        depends_lib-append \
+                    port:py${python.version}-selectors2
+    }
+
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description

The best part of this update is moving away from python 2.7! It allows to close https://trac.macports.org/ticket/63915

Anyway, this PR includes:
 - py-imaplib2: new port
 - py-rfc6555: update to 0.1.0
 - py310-distro: new subport

Thus, offlineimap work on python-3.10 but it depends on https://github.com/macports/macports-ports/pull/12916

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->