### PR TITLE
py-mysqlclient: add support for python39 and python310.  Also add support mariadb-10.6

### DIFF
--- a/python/py-mysqlclient/Portfile
+++ b/python/py-mysqlclient/Portfile
@@ -19,7 +19,7 @@ maintainers         {ctreleaven @ctreleaven} openmaintainer
 description         Python3 interface to MySQL/MariaDB, fork of MySQL-python
 long_description    ${description}
 
-python.versions     38
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     set mysql_config {}
@@ -42,47 +42,53 @@ if {${name} ne ${subport}} {
             ![variant_isset mariadb10_3] &&
             ![variant_isset mariadb10_4] &&
             ![variant_isset mariadb10_5] &&
+            ![variant_isset mariadb10_6] &&
             ![variant_isset percona55]} {
-            return -code error "you must select either mysql57, mysql8, mariadb55, mariadb10_2 through mariadb10_5 or percona55"
+            return -code error "you must select either mysql57, mysql8, mariadb55, mariadb10_2 through mariadb10_6 or percona55"
         }
     }
 
-    variant mysql57 conflicts mysql8 mariadb55 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 percona55 description {Access mysql57} {
+    variant mysql57 conflicts mysql8 mariadb55 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 mariadb10_6 percona55 description {Access mysql57} {
         depends_lib-append  port:mysql57
         set mysql_config lib/mysql57/bin/mysql_config
     }
 
-    variant mysql8 conflicts mysql57 mariadb55 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 percona55 description {Access mysql8} {
+    variant mysql8 conflicts mysql57 mariadb55 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 mariadb10_6 percona55 description {Access mysql8} {
         depends_lib-append  port:mysql8
         set mysql_config lib/mysql8/bin/mysql_config
     }
 
-    variant mariadb55 conflicts mysql57 mysql8 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 percona55 description {Access mariadb55} {
+    variant mariadb55 conflicts mysql57 mysql8 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 mariadb10_6 percona55 description {Access mariadb55} {
         depends_lib-append  port:mariadb
         set mysql_config lib/mariadb/bin/mysql_config
     }
 
-    variant mariadb10_2 conflicts mysql57 mysql8 mariadb10_3 mariadb10_4 mariadb10_5 mariadb55 percona55 description {Access mariadb-10.2} {
+    variant mariadb10_2 conflicts mysql57 mysql8 mariadb10_3 mariadb10_4 mariadb10_5 mariadb10_6 mariadb55 percona55 description {Access mariadb-10.2} {
         depends_lib-append  port:mariadb-10.2
         set mysql_config lib/mariadb-10.2/bin/mysql_config
     }
 
-    variant mariadb10_3 conflicts mysql57 mysql8 mariadb10_2 mariadb10_4 mariadb10_5 mariadb55 percona55 description {Access mariadb-10.3} {
+    variant mariadb10_3 conflicts mysql57 mysql8 mariadb10_2 mariadb10_4 mariadb10_5 mariadb10_6 mariadb55 percona55 description {Access mariadb-10.3} {
         depends_lib-append  port:mariadb-10.3
         set mysql_config lib/mariadb-10.3/bin/mysql_config
     }
 
-    variant mariadb10_4 conflicts mysql57 mysql8 mariadb10_2 mariadb10_3 mariadb10_5 mariadb55 percona55 description {Access mariadb-10.4} {
+    variant mariadb10_4 conflicts mysql57 mysql8 mariadb10_2 mariadb10_3 mariadb10_5 mariadb10_6 mariadb55 percona55 description {Access mariadb-10.4} {
         depends_lib-append  port:mariadb-10.4
         set mysql_config lib/mariadb-10.4/bin/mysql_config
     }
 
-    variant mariadb10_5 conflicts mysql57 mysql8 mariadb10_2 mariadb10_3 mariadb10_4 mariadb55 percona55 description {Access mariadb-10.5} {
+    variant mariadb10_5 conflicts mysql57 mysql8 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_6 mariadb55 percona55 description {Access mariadb-10.5} {
         depends_lib-append  port:mariadb-10.5
         set mysql_config lib/mariadb-10.5/bin/mysql_config
     }
 
-    variant percona55 conflicts mysql57 mysql8 mariadb55 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 description {Access percona} {
+    variant mariadb10_6 conflicts mysql57 mysql8 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 mariadb55 percona55 description {Access mariadb-10.6} {
+        depends_lib-append  port:mariadb-10.6
+        set mysql_config lib/mariadb-10.6/bin/mysql_config
+    }
+
+    variant percona55 conflicts mysql57 mysql8 mariadb55 mariadb10_2 mariadb10_3 mariadb10_4 mariadb10_5 mariadb10_6 description {Access percona} {
         depends_lib-append  port:percona
         set mysql_config lib/percona/bin/mysql_config
     }
@@ -94,6 +100,7 @@ if {${name} ne ${subport}} {
             ![variant_isset mariadb10_3] &&
             ![variant_isset mariadb10_4] &&
             ![variant_isset mariadb10_5] &&
+            ![variant_isset mariadb10_6] &&
             ![variant_isset percona55]} {
         default_variants +mariadb10_2
     }


### PR DESCRIPTION
#### Description

Adds subports that support python39, python310.  Add support for mariadb-10.6

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
