### PR TITLE
poco: currently requires OpenSSL 1.1

### DIFF
--- a/devel/poco/Portfile
+++ b/devel/poco/Portfile
@@ -26,6 +26,7 @@ set docdir          ${prefix}/share/doc/${name}
 
 if {${subport} eq ${name}} {
     PortGroup           cmake 1.1
+    PortGroup           openssl 1.0
 
     revision            4
     checksums           rmd160  b3ba1f1cb925b24626ab09a6cb055edf99380464 \
@@ -33,14 +34,15 @@ if {${subport} eq ${name}} {
                         size    5313561
 
     use_bzip2           yes
-    
+
     depends_lib-append  port:expat \
-                        path:lib/libssl.dylib:openssl \
                         port:pcre \
                         port:zlib
-    
+
     patchfiles          DYLD_LIBRARY_PATH.patch
-    
+
+    openssl.branch      1.1
+
     compiler.c_standard 1999
     compiler.cxx_standard \
                         2014

--- a/devel/poco/Portfile
+++ b/devel/poco/Portfile
@@ -28,7 +28,7 @@ if {${subport} eq ${name}} {
     PortGroup           cmake 1.1
     PortGroup           openssl 1.0
 
-    revision            4
+    revision            5
     checksums           rmd160  b3ba1f1cb925b24626ab09a6cb055edf99380464 \
                         sha256  2cde4b50778013ab3b7a522aa59bccaa7e85a8ccfc654a354c4d9611b6ce1758 \
                         size    5313561


### PR DESCRIPTION
#### Description

poco currently requires OpenSSL 1.1, so use the openssl PortGroup accordingly ; works like a charm for me on various macOS build systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224
Xcode 13.1 13A1030d

macOS 11.6.2 20G303
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
