### PR TITLE
libreoffice: build on arm64

### DIFF
--- a/devel/box2d/Portfile
+++ b/devel/box2d/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        erincatto Box2D 2.4.1 v
+revision            1
 
 name                box2d
 categories          devel
@@ -26,6 +27,6 @@ compiler.cxx_standard 2011
 compiler.thread_local_storage yes
 
 configure.args-append \
-                    -DBOX2D_BUILD_UNIT_TESTS=ON \
+                    -DBOX2D_BUILD_UNIT_TESTS=OFF \
                     -DBOX2D_BUILD_TESTBED=OFF \
                     -DBOX2D_BUILD_DOCS=OFF

--- a/devel/clucene/Portfile
+++ b/devel/clucene/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
-PortGroup               cmake 1.0
+PortGroup               cmake 1.1
 PortGroup               conflicts_build 1.0
 PortGroup               muniversal 1.0
 
 name                    clucene
 version                 2.3.3.4
-revision                2
+revision                3
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              devel
 platforms               darwin
@@ -22,7 +22,8 @@ homepage                http://clucene.sourceforge.net/
 master_sites            sourceforge:project/clucene/clucene-core-unstable/${branch}
 
 checksums               rmd160  5acfc9c8acd167b3684cfc731a60fd9c5465cc9b \
-                        sha256  ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab
+                        sha256  ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab \
+                        size 2241498
 
 depends_lib             port:zlib
 
@@ -34,12 +35,18 @@ patchfiles              0001-Fix-.pc-file-by-adding-clucene-shared-library.patch
 
 patchfiles-append       patch-src-shared-CLucene-LuceneThreads.h.diff \
                         patch-src-shared-CLucene-config-repl_tchar.h.diff \
-                        patch-${name}-contribs-lib.diff 
+                        patch-${name}-contribs-lib.diff
 
 post-patch {
     # patch out installing bundled Boost headers
     reinplace "/ADD_SUBDIRECTORY (src\\/ext)/d" CMakeLists.txt
     system "rm -rf src/ext"
+
+    # it detects fstat64 and stat64 on arm64 which doesn't exist
+    if {${build_arch} eq {arm64} && ${os.platform} eq "darwin"} {
+        reinplace "s|fstati64;_fstati64;fstat64;fstat;_fstat|fstat;_fstat|" ${worksrcpath}/src/shared/CMakeLists.txt
+        reinplace "s|stati64;_stati64;stat64;stat;_stat|stat;_stat|" ${worksrcpath}/src/shared/CMakeLists.txt
+    }
 }
 
 configure.args-append   -DBUILD_CONTRIBS_LIB=ON \


### PR DESCRIPTION
#### Description

Here a fix of two ports which is required to build an Libreoffice on M1.

~Anyway, libreoffice supports macOS 12 only in 7.3.0.0 https://github.com/LibreOffice/core/commit/71b227dfa46fbc9fbf9b9f2046705939ab0a02bf which hasn't been releaed yet.~

~This is a sort fixing in advance I guess.~

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->