### PR TITLE
kustomize: update to 4.4.1

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.4.0 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.4.1 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  5e4a1d20da2c27fc120446c3df507430740ea0e8 \
-                    sha256  1a2117196352b4d981506ec47733c0ccd74499e975b2ea09bd836d9b53aa46d1 \
-                    size    25258295
+checksums           rmd160  4088e7e4c37dca5bfae6284fb0057e8d54ecff9c \
+                    sha256  3b7e3a8b9b171af182316050f114594a7a799b86735627840bc8f234b32c0cd0 \
+                    size    25264722
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 4.4.1.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?