### PR TITLE
GraphicsMagick: use OpenMP with Apple-provided clang. (!)

### DIFF
--- a/graphics/GraphicsMagick/Portfile
+++ b/graphics/GraphicsMagick/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    GraphicsMagick
 version                 1.3.36
-revision                1
+revision                2
 checksums               rmd160  379eb922f8b66dd2de05641eb24cd55f44503ef7 \
                         sha256  5d5b3fde759cdfc307aaf21df9ebd8c752e3f088bb051dd5df8aac7ba7338f46 \
                         size    5600712
@@ -46,6 +46,10 @@ use_xz                  yes
 # llvm-gcc-4.2 gives "Undefined symbols for architecture x86_64: ___builtin_object_size"
 compiler.blacklist      *llvm-gcc-4.2
 
+# OpenMP is very beneficial for GM: http://www.graphicsmagick.org/OpenMP.html
+configure.cppflags-append   -Xpreprocessor -fopenmp -I${prefix}/include/libomp
+configure.ldflags-append    -L${prefix}/lib/libomp -lomp
+
 configure.args          --with-jbig=no \
                         --with-jpeg=yes \
                         --with-wmf=no \
@@ -66,7 +70,8 @@ configure.args          --with-jbig=no \
                         --with-ttf=yes \
                         --with-webp=yes \
                         --without-umem \
-                        --enable-shared=yes
+                        --enable-shared=yes \
+                        --enable-openmp
 
 use_parallel_build      yes
 

--- a/graphics/GraphicsMagick/Portfile
+++ b/graphics/GraphicsMagick/Portfile
@@ -39,7 +39,8 @@ depends_lib             port:libxml2 \
                         port:lcms2 \
                         port:jasper \
                         path:include/turbojpeg.h:libjpeg-turbo \
-                        port:webp
+                        port:webp \
+                        port:libomp
 
 use_xz                  yes
 


### PR DESCRIPTION
First off, the benefit:

```
$ gm benchmark -stepthreads 1 -duration 10 convert \
                                              -size 2048x1080 pattern:granite -operator all Noise-Gaussian 30% null:
Results: 1 threads 53 iter 10.09s user 10.100828s total 5.247 iter/s 5.253 iter/cpu 1.00 speedup 1.000 karp-flatt
Results: 2 threads 100 iter 19.99s user 10.009332s total 9.991 iter/s 5.003 iter/cpu 1.90 speedup 0.050 karp-flatt
Results: 3 threads 151 iter 29.99s user 10.006118s total 15.091 iter/s 5.035 iter/cpu 2.88 speedup 0.022 karp-flatt
Results: 4 threads 192 iter 39.97s user 10.004212s total 19.192 iter/s 4.804 iter/cpu 3.66 speedup 0.031 karp-flatt
Results: 5 threads 222 iter 50.18s user 10.044851s total 22.101 iter/s 4.424 iter/cpu 4.21 speedup 0.047 karp-flatt
Results: 6 threads 239 iter 59.98s user 10.020555s total 23.851 iter/s 3.985 iter/cpu 4.55 speedup 0.064 karp-flatt
```

(4.5x speedup on this particular benchmark vs. single-threaded.)

[See Also GraphicsMagick's page on OpenMP](http://www.graphicsmagick.org/OpenMP.html)

I was clued into getting Apple's clang to output OpenMP code via `-Xpreprocessor -fopenmp`. It still relies on MacPorts' `libomp` port for `omp.h` and the actual OpenMP runtime, but doesn't require installing clang-9.0, for example. (Thanks MP!) 

I'm not sure how long this trick has worked -- and it is a trick; at most the preprocessor would add an include path thanks to `-fopenmp`, but Xcode doesn't ship with `omp.h`... but this construction avoids the logic that is rejecting the `-fopenmp` flag otherwise, and is generating OpenMP code, as seen below:

```bash
$ clang --version
Apple clang version 12.0.0 (clang-1200.0.32.27)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

$ clang -o omp_test.o omp_test.c && nm omp_test.o
0000000100000000 T __mh_execute_header
0000000100003f50 T _main
                 U dyld_stub_binder

$ clang -Xpreprocessor -fopenmp -c -o omp_test.o omp_test.c && nm omp_test.o
0000000000000050 t _.omp_outlined.
                 U ___kmpc_for_static_fini
                 U ___kmpc_for_static_init_4
                 U ___kmpc_fork_call
0000000000000000 T _main
0000000000000188 d l___unnamed_1
0000000000000170 d l___unnamed_2

$ clang -fopenmp -c -o omp_test.o omp_test.c && nm omp_test.o
clang: error: unsupported option '-fopenmp'
```
(Tested here with a minimal example containing a `#pragma omp parallel for` loop in main()):

So what do people think about this? Is supporting OpenMP without requiring llvm/clang install something we're interested in pursuing? At the very least, if someone can test on older platforms to see where/when this breaks so we can put in the appropriate switches to "bring out the big guns" when only necessary.

**There's a part of me that just says to use `compiler.openmp_version 2.5` and let it drag in MacPorts clang to compile, but I thought I would put this up here to see what other people thought.** Certainly this "trick" could stop working with any new XCode release.
