### PR TITLE
mysql56, mysql57, mysql8: license fixes

### DIFF
--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -17,8 +17,6 @@ set revision_server 1
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 categories          databases
 platforms           darwin
-# https://downloads.mysql.com/docs/licenses/mysqld-5.6-gpl-en.pdf
-license             {GPL-2 OpenSSLException}
 maintainers         nomaintainer
 homepage            https://www.mysql.com/
 
@@ -32,7 +30,8 @@ if {$subport eq $name} {
     openssl.branch      1.1
 
     revision            ${revision_client}
-    license             GPL-2
+    # https://downloads.mysql.com/docs/licenses/mysqld-5.6-gpl-en.pdf
+    license             {GPL-2 OpenSSLException}
     description         Multithreaded SQL database server
     long_description    MySQL is an open-source, multi-threaded SQL database.
 

--- a/databases/mysql57/Portfile
+++ b/databases/mysql57/Portfile
@@ -13,8 +13,6 @@ set revision_server 0
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 categories          databases
 platforms           darwin
-# https://downloads.mysql.com/docs/licenses/mysqld-5.7-gpl-en.pdf
-license             {GPL-2 OpenSSLException}
 maintainers         nomaintainer
 homepage            https://www.mysql.com/
 
@@ -31,7 +29,8 @@ if {$subport eq $name} {
     configure.cxxflags-append -std=c++11
 
     revision            ${revision_client}
-    license             GPL-2
+    # https://downloads.mysql.com/docs/licenses/mysqld-5.7-gpl-en.pdf
+    license             {GPL-2 OpenSSLException}
     description         Multithreaded SQL database server
     long_description    MySQL is an open-source, multi-threaded SQL database.
 

--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -9,8 +9,6 @@ set boost_version       1.73.0
 
 categories              databases
 platforms               darwin
-# https://downloads.mysql.com/docs/licenses/mysqld-8.0-gpl-en.pdf
-license                 {GPL-2 OpenSSLException}
 
 homepage                https://dev.mysql.com
 
@@ -52,7 +50,8 @@ if {$subport eq $name} {
 
     description         Multithreaded SQL database server
     long_description    MySQL is an open-source, multi-threaded SQL database.
-    license             GPL-2
+    # https://downloads.mysql.com/docs/licenses/mysqld-8.0-gpl-en.pdf
+    license             {GPL-2 OpenSSLException}
 
     revision            ${revision_client}
 

--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -273,7 +273,7 @@ as follows:
 
 subport ${name_mysql}-server {
     revision            ${revision_server}
-    license             GPL-2
+    license             BSD
     description         Run ${name_mysql} as server
     long_description    {*}${description}
 


### PR DESCRIPTION
#### Description

 * Remove duplicate `license` command in mysql56, mysql57, mysql8 which was not allowing `OpenSSLException` to take effect

 * Change `mysql8-server` subport to BSD license: mysql*-server subports were traditionally licensed as BSD. Presumably, this was because they are merely convenience ports which allow running MySQL as a launch daemon service: they only consists of a sample .plist configuration file and necessary portfile commands, and so were only subject to the MacPorts ports tree license (i.e. 3-clause BSD) rather than the MySQL license.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
