### PR TITLE
emacs{,-app}-devel: update to 20211113

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -96,14 +96,14 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     legacysupport.newest_darwin_requires_legacy 13
 
-    set date        2021-10-20
+    set date        2021-11-13
     epoch           4
     version         [string map {- {}} ${date}]
     revision        0
 
     fetch.type      git
     git.url         --shallow-since=${date}T00:00:00 https://github.com/emacs-mirror/emacs.git
-    git.branch      5f5189e9be6c70c4db99e8057287d16955b9c620
+    git.branch      eb4567e5be17e30583baebced562cb83595643e3
 
     # --shallow-since needs a newer version of git than on some older systems
     # So use MacPorts version


### PR DESCRIPTION
#### Description

Update to the latest commit in order to bring in https://github.com/emacs-mirror/emacs/commit/a60053f8368e058229721f1bf1567c2b1676b239 which solves severe slowdown in spawning external processes in Monterey (see https://lists.gnu.org/archive/html/emacs-devel/2021-11/msg00174.html).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->