### PR TITLE
lagrange: update to 1.8.2

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,8 +9,8 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.8.0 v
-revision            1
+github.setup        skyjake lagrange 1.8.2 v
+revision            0
 github.tarball_from releases
 categories          net gemini
 platforms           darwin
@@ -20,9 +20,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  cec5e31bc87526e59dd1470446f258528113ee49 \
-                    sha256  eff814565193b68726b04cf88e2c9c85d01c245175b40e73475565e10f6f571b \
-                    size    8477551
+checksums           rmd160  aaa2b39d34eb0e81aae788b815979da1754b4d00 \
+                    sha256  375a3640284d29a182ffec138298c9590d7228a390113023164a6a312c7e64f1 \
+                    size    8532909
 
 depends_build-append \
                     port:pkgconfig \
@@ -39,6 +39,9 @@ depends_lib-append  port:fribidi \
 
 compiler.c_standard 2011
 compiler.blacklist-append {clang < 800}
+
+# OpenSSL 3.0 deprecations, see https://codeberg.org/skyjake/the_Foundation/issues/9
+configure.cppflags-append -Wno-deprecated-declarations
 
 destroot {
     copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}


### PR DESCRIPTION
#### Description
* [Changelog](https://github.com/skyjake/lagrange/releases)
* fix build with OpenSSL 3.0 (#12807)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
