### PR TITLE
nmap: correct licence to Restrictive/Distributable

### DIFF
--- a/net/nmap/Portfile
+++ b/net/nmap/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:sw=4:ts=4:sts=4
 
 PortSystem 1.0
 
@@ -8,7 +8,8 @@ revision	3
 categories	net
 maintainers	darkart.com:opendarwin.org {geeklair.net:dluke @danielluke}
 description	Port scanning utility for large networks
-license		{GPL-2 OpenSSLException}
+# see https://github.com/nmap/nmap/issues/2199
+license		Restrictive/Distributable
 homepage	https://nmap.org/
 platforms	darwin freebsd
 


### PR DESCRIPTION
Nmap is licensed under unique terms, derived from the GPL but explicitly inconsistent with it. The licence doesn't seem to restrict MacPorts redistributing neither source nor archives, but it is definitely incompatible with other GPL-licensed software. So, `Restrictive/Distributable` seems the apt choice.

As the `OpenSSLException` clarification is irrelevant to this licence, I removed it.

While at it, I adjusted the modeline to prevent `port lint nmap` from complaining about tabs.

See: https://github.com/nmap/nmap/issues/2199
Closes: https://trac.macports.org/ticket/63941

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
