### PR TITLE
nsd: update to version 4.3.8

### DIFF
--- a/net/nsd/Portfile
+++ b/net/nsd/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                nsd
-version             4.2.1
-revision            3
+version             4.3.8
+revision            0
 categories          net
 platforms           darwin
 license             BSD
@@ -20,9 +20,9 @@ set nsdgroup        nsd
 homepage            https://www.nlnetlabs.nl/projects/nsd/about/
 master_sites        https://www.nlnetlabs.nl/downloads/nsd/
 
-checksums           rmd160  79ba64d55ca1d473be16f00dbedf80e5122a13ce \
-                    sha256  d17c0ea3968cb0eb2be79f2f83eb299b7bfcc554b784007616eed6ece828871f \
-                    size    1145713
+checksums           rmd160  f7f0af8d12b819b435134d516bef769e596af1ee \
+                    sha256  11897e25f72f5a98f9202bd5378c936886d54376051a614d3688e451e9cb99e1 \
+                    size    1225840
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl


### PR DESCRIPTION
* update to version 4.3.8
* solves issue that the previous version would not compile with OpenSSL3

#### Description

Updates NSD to 4.3.8. The previous version would no longer compile after the update of MacPorts to OpenSSL3. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
