### PR TITLE
pcre2: update to 10.39, revise upstream sources

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -8,7 +8,10 @@ if {${subport} eq ${name}} {
     revision        0
 }
 subport pcre2 {
-    version         10.37
+    PortGroup       github 1.0
+
+    github.setup    PhilipHazel pcre2 10.39 pcre2-
+    github.tarball_from releases
     revision        0
 }
 categories          devel
@@ -29,8 +32,7 @@ depends_lib         port:bzip2 \
                     port:libedit \
                     port:zlib
 
-master_sites        sourceforge:project/pcre/${subport}/${version} \
-                    https://ftp.pcre.org/pub/pcre \
+master_sites-append sourceforge:project/pcre/${subport}/${version} \
                     ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre \
                     ftp://ftp.fu-berlin.de/unix/misc/pcre \
                     ftp://ftp.tin.org/pub/libs/pcre
@@ -40,9 +42,9 @@ use_bzip2           yes
 set rmd160(pcre)    9792fbed380a39be36674e74839b9a2a6a4ce65a
 set sha256(pcre)    4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8
 set size(pcre)      1578809
-set rmd160(pcre2)   260daa9d31e76ecc428e84ab3f2ed3ba41b7ee37
-set sha256(pcre2)   4d95a96e8b80529893b4562be12648d798b957b1ba1aae39606bbc2ab956d270
-set size(pcre2)     1729384
+set rmd160(pcre2)   ad093c4cffd04323022a1753cd650cb100f9ddb8
+set sha256(pcre2)   0f03caf57f81d9ff362ac28cd389c055ec2bf0678d277349a1a4bee00ad6d440
+set size(pcre2)     1730729
 checksums           rmd160  $rmd160(${subport}) \
                     sha256  $sha256(${subport}) \
                     size    $size(${subport})


### PR DESCRIPTION
#### Description

From the [PCRE website](https://pcre.org/):

> Note that the former ftp.pcre.org FTP site is no longer available.

> You can download the current release of the PCRE2 library from its official home on GitHub:
>
>     https://github.com/PhilipHazel/pcre2/releases

This PR aims to therefore implement these changes, in line with [other package managers](https://repology.org/project/pcre2/information).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
