### PR TITLE
quazip: revert to 0.9.1 & add quazip1 package for v1.1

### DIFF
--- a/archivers/quazip/Portfile
+++ b/archivers/quazip/Portfile
@@ -1,28 +1,29 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+PortGroup               qt5 1.0
 
-PortGroup               cmake   1.1
-PortGroup               github  1.0
-PortGroup               qt5     1.0
-
-github.setup            stachenov quazip 1.1 v
-github.tarball_from     archive
+github.setup            stachenov quazip 0.9.1 v
+epoch                   1
 revision                0
+# See https://github.com/stachenov/quazip/releases for SHA256 archive checksums
+checksums               rmd160  12d0089dfd38b19d96030c3a1fc703ce66474eeb \
+                        sha256  5d36b745cb94da440432690050e6db45b99b477cfe9bc3b82fd1a9d36fff95f5 \
+                        size    155775
+
+categories              archivers devel
+platforms               darwin
+license                 LGPL-2.1
+maintainers             nomaintainer
 
 description             Qt/C++ wrapper over minizip
 
 long_description        The C++ wrapper for Gilles Vollant's ZIP/UNZIP \
                         package (AKA Minizip) using Trolltech's Qt library.
 
-checksums               rmd160  322d5a769deb59cef367d58cb857efaf15935ea4 \
-                        sha256  54edce9c11371762bd4f0003c2937b5d8806a2752dd9c0fd9085e90792612ad0 \
-                        size    153870
-
-categories              archivers devel
-license                 LGPL-2.1
-maintainers             nomaintainer
-platforms               darwin
+github.tarball_from     archive
 
 depends_lib-append      port:zlib
 

--- a/archivers/quazip1/Portfile
+++ b/archivers/quazip1/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+
+PortGroup               cmake   1.1
+PortGroup               github  1.0
+PortGroup               qt5     1.0
+
+github.setup            stachenov quazip 1.1 v
+github.tarball_from     archive
+revision                0
+name                    quazip1
+
+description             Qt/C++ wrapper over minizip
+
+long_description        The C++ wrapper for Gilles Vollant's ZIP/UNZIP \
+                        package (AKA Minizip) using Trolltech's Qt library.
+
+checksums               rmd160  322d5a769deb59cef367d58cb857efaf15935ea4 \
+                        sha256  54edce9c11371762bd4f0003c2937b5d8806a2752dd9c0fd9085e90792612ad0 \
+                        size    153870
+
+categories              archivers devel
+license                 LGPL-2.1
+maintainers             nomaintainer
+platforms               darwin
+
+depends_lib-append      port:zlib
+
+compiler.cxx_standard   2011


### PR DESCRIPTION
The way this is done may still need to be discussed in the ticket

* This reverts commit b783795d8de942ec76149db5a62c550c50f409cd.
* increment epoch to quazip package
* add quazip1 package for version 1.1

Closes: https://trac.macports.org/ticket/63939

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
