### PR TITLE
libzzip 0.13.72: fix the build with +sdl variant enabled

### DIFF
--- a/archivers/libzzip/Portfile
+++ b/archivers/libzzip/Portfile
@@ -73,16 +73,16 @@ post-destroot {
 
         close ${channel}
     }
+
+    if {[variant_isset sdl]} {
+        xinstall -m 0644 ${worksrcpath}/docs/README.SDL ${destroot}${docdir}
+    }
 }
 
 variant sdl description {Enable SDL support} {
     depends_lib-append      port:libsdl
 
     configure.args-replace  -DZZIPSDL=OFF -DZZIPSDL=ON
-
-    post-destroot {
-        xinstall -m 0644 ${worksrcpath}/docs/README.SDL ${destroot}${docdir}
-    }
 }
 
 test.run        yes


### PR DESCRIPTION
when build with +sdl the post-destroot section fails with
Error: Failed to destroot libzzip: can't read "docdir": no such variable

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
