### PR TITLE
wrk: fix build for arm64

### DIFF
--- a/net/wrk/Portfile
+++ b/net/wrk/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compilers 1.0
 PortGroup           xcode_workaround 1.0
+PortGroup           openssl 1.0
 
 github.setup        wg wrk 4.1.0
-revision            1
+revision            2
 
 categories          net
 platforms           darwin
@@ -20,21 +21,33 @@ checksums           rmd160  66508bc4bea66d7731510164037beaac5fe44de5 \
                     sha256  49c309c834c484243d1f381505e7723326c5a9b6e328d88adef9ead804c8d83e \
                     size    6478150
 
-depends_build-append    port:perl5
+depends_build-append \
+                    port:perl5
+
+depends_lib-append  port:luajit
+
+pre-configure {
+    reinplace "s|WITH_LUAJIT)/include|WITH_LUAJIT)/include/luajit-2.1|g" \
+            ${worksrcpath}/Makefile
+}
 
 # https://trac.macports.org/ticket/59346
-xcode_workaround.type append_to_compiler_name
+xcode_workaround.type \
+                    append_to_compiler_name
 
-build.args-append       CC="${configure.cc}" \
-                        CXX="${configure.cxx}" \
-                        CPP=${configure.cpp} \
-                        VER=${version}
+build.args-append   CC="${configure.cc}" \
+                    CXX="${configure.cxx}" \
+                    CPP=${configure.cpp} \
+                    VER=${version}
+
+build.target-append WITH_LUAJIT=${prefix} \
+                    WITH_OPENSSL=[openssl::install_area]
 
 # Avoid configure phase
-use_configure no
+use_configure       no
 
 # wrk make fails with parallel build
-use_parallel_build no
+use_parallel_build  no
 
 # No make install so copy static binary to bin dir
 destroot {


### PR DESCRIPTION
#### Description

This is a tricky fix. `wrk` ships with `openssl` and `luajit`, and used version of `openssl` hasn't got support of arm64.

Here I've switched `wrk` to use MacPorts version of `openssl` and `luajit` that allows to build it on arm64 without any issue.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->