### PR TITLE
rawtherapee: new port

### DIFF
--- a/graphics/rawtherapee/Portfile
+++ b/graphics/rawtherapee/Portfile
@@ -1,0 +1,189 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           active_variants 1.1
+PortGroup           app 1.0
+
+name                rawtherapee
+app.name            RawTherapee
+version             5.8
+categories          graphics
+platforms           darwin
+supported_archs     x86_64 arm64
+license             GPL-3
+maintainers         @jasonliu-- openmaintainer
+
+homepage            https://rawtherapee.com
+description         raw photo processing program
+long_description    ${app.name} is a powerful, cross-platform \
+                    ${description}. It is designed for developing raw \
+                    files from a broad range of digital cameras, as \
+                    well as HDR DNG files and non-raw image formats \
+                    (JPEG, TIFF, and PNG).
+
+master_sites        https://rawtherapee.com/shared/source/
+use_xz              yes
+checksums           rmd160  79a01872a7edcc64e78b3d05d17d0a38fcb4f83f \
+                    sha256  360528a0aae922eb5af8742f415475fb91b6d62a739da5f2804828f04ec40853 \
+                    size    12653148
+
+compiler.cxx_standard 2011
+compiler.openmp_version 3.1
+
+depends_lib-append  port:gtkmm3 \
+                    port:gtk-osx-application-gtk3 \
+                    port:adwaita-icon-theme \
+                    port:fftw-3 \
+                    port:fftw-3-single \
+                    port:lcms2 \
+                    port:lensfun \
+                    port:libiptcdata \
+                    port:libsigcxx2
+
+require_active_variants gtk3    quartz
+require_active_variants gtkmm3  quartz
+require_active_variants fftw-3          openmp
+require_active_variants fftw-3-single   openmp
+
+set app_contents ${applications_dir}/${app.name}.app/Contents
+
+configure.args-append   -DBUNDLE_BASE_INSTALL_DIR=$app_contents/MacOS \
+                        -DDATADIR=$app_contents/Resources \
+                        -DLIBDIR=$app_contents/Frameworks
+
+if {${build_arch} eq "x86_64"} {
+    configure.args-append   -DPROC_TARGET_NUMBER=1 \
+                            -DPROC_LABEL="generic processor"
+} elseif {${build_arch} eq "arm64"} {
+    configure.args-append   -DPROC_TARGET_NUMBER=2
+}
+
+app.executable      ${build.dir}/rtgui/${name}
+app.icon            tools/osx/${name}.icns
+app.retina          yes
+
+post-destroot {
+    # The following steps somewhat mimic certain parts of the
+    # ${worksrcpath}/tools/osx/macosx_bundle.sh script. However, we only
+    # selectively perform some of the steps from the upstream-provided
+    # script because (1) we are already taking advantage of MacPorts'
+    # 'app' PortGroup, which performs some of the same actions, and
+    # (2) the 'macosx_bundle.sh' script performs many undesirable
+    # actions, such as actually copying ALL of RawTherapee's
+    # dependencies' library files directly into the .app bundle, and
+    # then using install_name_tool to retroactively modify the @rpaths
+    # in the binary executable to point to these local copies of dylibs.
+    # In addition, their script also packs the .app bundle into a DMG,
+    # so it's pretty safe to assume that their script is meant to be
+    # used to generate a fully portable installer for distribution.
+
+    # XDG = X Desktop Group, now known as freedesktop.org
+    set xdg_share_root ${destroot}${prefix}/share
+
+    set xdg_desktop_entries $xdg_share_root/applications
+    xinstall -d $xdg_desktop_entries
+    ln -s $app_contents/Resources/share/applications/${name}.desktop \
+          $xdg_desktop_entries/
+
+    set xdg_desktop_icons $xdg_share_root/icons/hicolor
+    xinstall -d $xdg_desktop_icons
+    set icon_resolutions [list 16x16 24x24 48x48 256x256]
+    foreach ico_res $icon_resolutions {
+        xinstall -d $xdg_desktop_icons/$ico_res/apps
+        ln -s $app_contents/Resources/share/icons/hicolor/$ico_res/apps/${name}.png \
+              $xdg_desktop_icons/$ico_res/apps/
+    }
+
+    set xdg_metainfo $xdg_share_root/metainfo
+    xinstall -d $xdg_metainfo
+    ln -s $app_contents/Resources/share/metainfo/com.${name}.${app.name}.appdata.xml \
+          $xdg_metainfo/
+
+    set relative_manpath share/man/man1
+    ln -s $app_contents/Resources/$relative_manpath/${name}.1 \
+          ${destroot}${prefix}/$relative_manpath/
+
+    set osx_tools ${worksrcpath}/tools/osx
+
+    # Executable loader
+    xinstall -d ${destroot}$app_contents/MacOS/bin
+    move ${destroot}$app_contents/MacOS/${app.name} \
+         ${destroot}$app_contents/MacOS/bin/${name}
+    xinstall $osx_tools/executable_loader.in \
+         ${destroot}$app_contents/MacOS/${app.name}
+    set regexes [list \
+        {s|Applications|Applications/MacPorts|} \
+        "s|(lib=\").*|\\1${prefix}/lib\"|" \
+        "s|(resources=\").*|\\1${prefix}\"|" \
+        "s|(etc=\").*|\\1${prefix}/etc\"|" \
+    ]
+    foreach re $regexes {
+        reinplace -E $re ${destroot}$app_contents/MacOS/${app.name}
+    }
+
+    xinstall -m 644 $osx_tools/Info.plist-bin.in \
+        ${destroot}$app_contents/MacOS/bin/Info.plist
+
+    # There's no need to rename the executable to 'rawtherapee-bin'.
+    # Not really sure why the upstream devs do it that way.
+    foreach f [list \
+        ${destroot}$app_contents/MacOS/${app.name} \
+        ${destroot}$app_contents/MacOS/bin/Info.plist \
+    ] {
+        reinplace -E {s/(herapee)-bin/\1/} $f
+    }
+
+    # We overwrite the Info.plist file generated by the 'app' PortGroup
+    # with the one provided in the RawTherapee source code, because the
+    # one provided by the devs is more complete than the one generated
+    # by the PortGroup.
+    xinstall -m 644 $osx_tools/Info.plist.in \
+        ${destroot}$app_contents/Info.plist
+    set regexes [list \
+        "s/@version@/${version}/" \
+        "s/@shortVersion@/${version}/" \
+        "s/@arch@/${build_arch}/" \
+        "/CFBundleExecutable/,/CFBundleGetInfoString/s/${name}/${app.name}/" \
+        "s/${name}.${name}/${name}.${app.name}/" \
+    ]
+    foreach re $regexes {
+        reinplace $re ${destroot}$app_contents/Info.plist
+    }
+    reinplace "s/${name}.${name}/${name}.${app.name}/" \
+        ${destroot}$app_contents/MacOS/bin/Info.plist
+    # Change the name of the .icns file to match the one specified in
+    # the upstream-provided Info.plist file.
+    delete ${destroot}$app_contents/Resources/${app.name}.icns
+    set icns_files [list ${name} profile]
+    foreach icns_file $icns_files {
+        copy $osx_tools/${icns_file}.icns \
+             ${destroot}$app_contents/Resources/
+    }
+
+    ln -s $app_contents/MacOS/${app.name} \
+          ${destroot}${prefix}/bin/${name}
+    ln -s $app_contents/MacOS/${name}-cli ${destroot}${prefix}/bin/
+}
+
+post-activate {
+    system [join [list \
+        ${prefix}/bin/update-desktop-database \
+        ${prefix}/share/applications \
+    ] " "]
+    system [join [list \
+        ${prefix}/bin/glib-compile-schemas \
+        ${prefix}/share/glib-2.0/schemas \
+    ] " "]
+    system [join [list \
+        "env XDG_DATA_DIRS=${prefix}/share" \
+        "${prefix}/bin/update-mime-database -V ${prefix}/share/mime" \
+    ] " "]
+}
+
+variant tcmalloc \
+    description {Use Google's TCMalloc library for memory allocation} \
+{
+    depends_lib-append      port:gperftools
+    configure.args-append   -DENABLE_TCMALLOC=ON
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

[RawTherapee](http://rawtherapee.com) is a powerful, cross-platform raw photo processing program. It is designed for developing raw files from a broad range of digital cameras, as well as HDR DNG files and non-raw image formats (JPEG, TIFF, and PNG).

Note: On my macOS 10.11 machine, whenever I quit the app, it is crashing with the following error:

```
malloc: *** error for object 0x7fda1b483500: pointer being freed was not allocated
Abort trap: 6
```

I'm not sure whether this is also happening on other versions of macOS. Other than the crash upon quit, the app seems to be functioning fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
