### PR TITLE
mysql8: add missing libevent dependency

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -16,7 +16,7 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     2
+set revision_client     3
 set revision_server     0
 
 set name_mysql          ${name}
@@ -74,6 +74,7 @@ if {$subport eq $name} {
 
     depends_lib-append  port:cyrus-sasl2 \
                         port:icu \
+                        port:libevent \
                         port:zlib \
                         port:zstd
 


### PR DESCRIPTION
…which I meant to add in #12918.

Fixes: https://trac.macports.org/ticket/63947

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
~~macOS x.y
Xcode x.y~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
