### PR TITLE
py-mkl{-include}: update to 2021.4.0, add py310 subport

### DIFF
--- a/python/py-mkl/Portfile
+++ b/python/py-mkl/Portfile
@@ -25,7 +25,6 @@ extract.suffix      .whl
 extract.only
 
 python.versions     27 35 36 37 38 39 310
-python.default_version 38
 
 # Intel only supports 10.12 and newer
 if {${os.platform} eq "darwin" && ${os.major} <= 15} {
@@ -38,7 +37,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 15} {
 
 # add sub-ports for headers
 foreach _py ${python.versions} {
-    subport py${_py}-mkl-include { }
+    subport py${_py}-mkl-include {
+        python.rootname     mkl_include
+    }
 }
 
 if {${name} ne ${subport}} {
@@ -50,57 +51,55 @@ if {${name} ne ${subport}} {
 
     build { }
 
-    # strip pyXY from subport name
-    set local_name [string replace ${subport} 0 4 ]
-
-    homepage https://pypi.org/project/${local_name}
+    homepage    https://pypi.org/project/${python.rootname}
 
     if {[string match "*-include" $subport]} {
 
         if {${os.platform} eq "darwin" && ${os.major} < 19} {
 
-            master_sites   https://files.pythonhosted.org/packages/4f/49/c24113b33981a2c3e6915eb94f50c56ea61639963339e03eaed37787cc81/
-            distname       mkl_include-${version}-py2.py3-none-macosx_10_12_intel.macosx_10_12_x86_64
+            master_sites    https://files.pythonhosted.org/packages/4f/49/c24113b33981a2c3e6915eb94f50c56ea61639963339e03eaed37787cc81/
+            distname        mkl_include-${version}-py2.py3-none-macosx_10_12_intel.macosx_10_12_x86_64
 
-            checksums      rmd160  097dd5bcbcc0a704e065cbdc629c7a10bf9e0b71 \
-                           sha256  dd9e2224dcdbede569c996f971e663f64f184a432ccb01f2dceca768a77cb2b4 \
-                           size    871122
+            checksums       rmd160  097dd5bcbcc0a704e065cbdc629c7a10bf9e0b71 \
+                            sha256  dd9e2224dcdbede569c996f971e663f64f184a432ccb01f2dceca768a77cb2b4 \
+                            size    871122
 
         } else {
 
-            master_sites   https://files.pythonhosted.org/packages/96/15/cb0b6d590a7fa8a5df38da43f5909be065eb78b9d7c8187e8ddd4b6ca8eb/
-            distname       mkl_include-${version}-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64
+            master_sites    https://files.pythonhosted.org/packages/96/15/cb0b6d590a7fa8a5df38da43f5909be065eb78b9d7c8187e8ddd4b6ca8eb/
+            distname        mkl_include-${version}-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64
 
-            checksums      rmd160  e9a2c5199d3997cfcbbe704fc5e4bf2b9a258e3d \
-                           sha256  d8b3ad7254047c952aa1e3059ed2a8c671cf70dc3a8aa7f7195757ee7936b75f \
-                           size    902519
+            checksums       rmd160  e9a2c5199d3997cfcbbe704fc5e4bf2b9a258e3d \
+                            sha256  d8b3ad7254047c952aa1e3059ed2a8c671cf70dc3a8aa7f7195757ee7936b75f \
+                            size    902519
 
         }
 
-        depends_lib-append port:py${python.version}-mkl
+        depends_lib-append  port:py${python.version}-mkl
 
     } else {
 
         if {${os.platform} eq "darwin" && ${os.major} < 19} {
 
-            master_sites   https://files.pythonhosted.org/packages/ac/1e/c713b011b90cd238023df1c0025130c40bc40870a46273d942e89114233c/
-            distname       mkl-${version}-py2.py3-none-macosx_10_12_intel.macosx_10_12_x86_64
+            master_sites    https://files.pythonhosted.org/packages/ac/1e/c713b011b90cd238023df1c0025130c40bc40870a46273d942e89114233c/
+            distname        mkl-${version}-py2.py3-none-macosx_10_12_intel.macosx_10_12_x86_64
 
-            checksums      rmd160  62011c74574b354c8996edfdd1d6b3d5e1aa2623 \
-                           sha256  23c8e8ba2cac703d8bc357d2bf10519e91dc4371e7dd1decf461f70db20b9783 \
-                           size    193800193
+            checksums       rmd160  62011c74574b354c8996edfdd1d6b3d5e1aa2623 \
+                            sha256  23c8e8ba2cac703d8bc357d2bf10519e91dc4371e7dd1decf461f70db20b9783 \
+                            size    193800193
         } else {
 
-            master_sites   https://files.pythonhosted.org/packages/b6/b2/b8c755092e3881d6b5ea74be49c7bf3758b6174296626aed39c3416a1b02/
-            distname       mkl-${version}-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64
+            master_sites    https://files.pythonhosted.org/packages/b6/b2/b8c755092e3881d6b5ea74be49c7bf3758b6174296626aed39c3416a1b02/
+            distname        mkl-${version}-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64
 
-            checksums      rmd160  a0148fc03cb0a6c95a75cdf30dd67e5032345cf2 \
-                           sha256  67460f5cd7e30e405b54d70d1ed3ca78118370b65f7327d495e9c8847705e2fb \
-                           size    186391276
+            checksums       rmd160  a0148fc03cb0a6c95a75cdf30dd67e5032345cf2 \
+                            sha256  67460f5cd7e30e405b54d70d1ed3ca78118370b65f7327d495e9c8847705e2fb \
+                            size    186391276
 
         }
 
-        depends_lib-append port:tbb port:libomp
+        depends_lib-append  port:libomp \
+                            port:tbb
 
         post-destroot {
             set PythonVersionWithDot [string index ${python.version} 0].[string range ${python.version} 1 end]
@@ -113,7 +112,7 @@ if {${name} ne ${subport}} {
 
     }
 
-    destroot.cmd  pip-${python.branch}
+    destroot.cmd    pip-${python.branch}
     destroot.args          \
         --ignore-installed \
         --no-cache-dir     \
@@ -122,12 +121,5 @@ if {${name} ne ${subport}} {
         ${distpath}/${distfiles}
     destroot.post_args
 
-    if {[string match "py-*" $subport]} {
-        livecheck.url   ${homepage}
-        livecheck.type  regex
-        livecheck.regex "${local_name}\ (\\d+(\\.\\d+)+)"
-    } else {
-        livecheck.type  none
-    }
-
+    livecheck.type  none
 }

--- a/python/py-mkl/Portfile
+++ b/python/py-mkl/Portfile
@@ -7,7 +7,7 @@ name                py-mkl
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
     version         2019.0
 } else {
-    version         2021.2.0
+    version         2021.4.0
 }
 revision            0
 platforms           darwin
@@ -24,7 +24,7 @@ long_description    ${description}
 extract.suffix      .whl
 extract.only
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 python.default_version 38
 
 # Intel only supports 10.12 and newer
@@ -68,17 +68,17 @@ if {${name} ne ${subport}} {
 
         } else {
 
-            master_sites   https://files.pythonhosted.org/packages/16/5e/4dfe5bca8f0aa7b9369bc6b336ba8c76c3d50a61252c053a5250380143ae/
-            distname       mkl_include-${version}-py2.py3-none-macosx_10_15_x86_64
+            master_sites   https://files.pythonhosted.org/packages/96/15/cb0b6d590a7fa8a5df38da43f5909be065eb78b9d7c8187e8ddd4b6ca8eb/
+            distname       mkl_include-${version}-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64
 
-            checksums      rmd160  052b1627aa7d23e8c96beebaa479f66a8d14f60f \
-                           sha256  1d230c8197d3d959a762f93fb9f01e646609c2dce6baf2644378c430f0b45a7f \
-                           size    895005
+            checksums      rmd160  e9a2c5199d3997cfcbbe704fc5e4bf2b9a258e3d \
+                           sha256  d8b3ad7254047c952aa1e3059ed2a8c671cf70dc3a8aa7f7195757ee7936b75f \
+                           size    902519
 
         }
 
         depends_lib-append port:py${python.version}-mkl
-        
+
     } else {
 
         if {${os.platform} eq "darwin" && ${os.major} < 19} {
@@ -91,19 +91,19 @@ if {${name} ne ${subport}} {
                            size    193800193
         } else {
 
-            master_sites   https://files.pythonhosted.org/packages/71/57/9c355e1c215f39ab2fa44aac9d617659e09f8e1aff0e5bddc742bcf8c6f7/
-            distname       mkl-${version}-py2.py3-none-macosx_10_15_x86_64
+            master_sites   https://files.pythonhosted.org/packages/b6/b2/b8c755092e3881d6b5ea74be49c7bf3758b6174296626aed39c3416a1b02/
+            distname       mkl-${version}-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64
 
-            checksums      rmd160  7aca67881758c0d637b9fba860bdbd13f2f676d1 \
-                           sha256  340d9c33a26f62cbcbe5b755fa4c454fce7f7a0a5d7e8aa45ec589b23ed107ea \
-                           size    184653459
+            checksums      rmd160  a0148fc03cb0a6c95a75cdf30dd67e5032345cf2 \
+                           sha256  67460f5cd7e30e405b54d70d1ed3ca78118370b65f7327d495e9c8847705e2fb \
+                           size    186391276
 
         }
 
         depends_lib-append port:tbb port:libomp
-        
+
         post-destroot {
-            set PythonVersionWithDot [join [split ${python.version} ""] "."]
+            set PythonVersionWithDot [string index ${python.version} 0].[string range ${python.version} 1 end]
             set py_lib_root ${prefix}/Library/Frameworks/Python.framework/Versions/${PythonVersionWithDot}/lib
             foreach dlib [glob -directory ${destroot}${py_lib_root} *.dylib] {
                 system "install_name_tool -add_rpath ${prefix}/lib        ${dlib}"


### PR DESCRIPTION
#### Description
- update to latest version
- add subport for Python 3.10, fix `PythonVersionWithDot`
- add/conform to modeline
- use `python.rootname` and default livecheck

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
