### PR TITLE
minivmac*: clean up

### DIFF
--- a/emulators/minivmac-devel/Portfile
+++ b/emulators/minivmac-devel/Portfile
@@ -127,11 +127,7 @@ if {${my_subport} eq ${my_name}} {
     build.dir                   ${workpath}/build
 
     post-extract {
-if {[vercmp [macports_version] 2.6.99] >= 0} {
         system -W ${workpath} "unzip -q [shellescape ${distpath}/${my_icons_distfile}]"
-} else {
-        system -W ${workpath} "unzip -q '${distpath}/${my_icons_distfile}'"
-}
     }
 
     post-patch {
@@ -169,11 +165,7 @@ if {[vercmp [macports_version] 2.6.99] >= 0} {
                 set all_configure_args [concat ${configure.pre_args} ${configure.args} ${configure.post_args}]
 
                 # Run the configure script.
-if {[vercmp [macports_version] 2.6.99] >= 0} {
                 system -W ${build.dir}/${my_variation_dir} "CC=[shellescape ${configure.cc}] CFLAGS=[shellescape ${configure.optflags}] [shellescape ${worksrcpath}/configure] ${all_configure_args}"
-} else {
-                system -W ${build.dir}/${my_variation_dir} "CC='${configure.cc}' CFLAGS='${configure.optflags}' '${worksrcpath}/configure' ${all_configure_args}"
-}
 
                 lappend my_variation_dirs [strsed ${my_variation_dir} {g/ /\\\\ /}]
 
@@ -222,23 +214,6 @@ if {[vercmp [macports_version] 2.6.99] >= 0} {
         foreach {my_machine unused} ${my_variations} {
             set my_dest_mnvm_dat "${destroot}${my_app_dir}/Mini vMac ${my_machine}.app/Contents/mnvm_dat"
             destroot.keepdirs-append ${my_dest_mnvm_dat}
-        }
-    }
-
-    pre-activate {
-        if {![catch {set installed [lindex [registry_active ${name}] 0]}]} {
-            set installed_version [lindex ${installed} 1]
-            set installed_revision [lindex ${installed} 2]
-            set installed_epoch [lindex ${installed} 5]
-            if {[vercmp ${installed_epoch} 4] < 0 || (
-                [vercmp ${installed_epoch} 4] == 0 && (
-                    [vercmp ${installed_version} 36.00alpha-20180506] < 0 || (
-                    [vercmp ${installed_version} 36.00alpha-20180506] == 0 && [vercmp ${installed_revision} 1] < 0
-                    )
-                )
-                )} {
-                registry_deactivate_composite ${name} "" [list ports_nodepcheck 1]
-            }
         }
     }
 }

--- a/emulators/minivmac/Portfile
+++ b/emulators/minivmac/Portfile
@@ -112,11 +112,7 @@ if {${my_subport} eq ${my_name}} {
     build.dir                   ${workpath}/build
 
     post-extract {
-if {[vercmp [macports_version] 2.6.99] >= 0} {
         system -W ${workpath} "unzip -q [shellescape ${distpath}/${my_icons_distfile}]"
-} else {
-        system -W ${workpath} "unzip -q '${distpath}/${my_icons_distfile}'"
-}
     }
 
     post-patch {
@@ -164,11 +160,7 @@ if {[vercmp [macports_version] 2.6.99] >= 0} {
                 set all_configure_args [concat ${configure.pre_args} ${configure.args} ${configure.post_args}]
 
                 # Run the configure script.
-if {[vercmp [macports_version] 2.6.99] >= 0} {
                 system -W ${build.dir}/${my_variation_dir} "CC=[shellescape ${configure.cc}] CFLAGS=[shellescape ${configure.optflags}] [shellescape ${worksrcpath}/configure] ${all_configure_args}"
-} else {
-                system -W ${build.dir}/${my_variation_dir} "CC='${configure.cc}' CFLAGS='${configure.optflags}' '${worksrcpath}/configure' ${all_configure_args}"
-}
 
                 lappend my_variation_dirs [strsed ${my_variation_dir} {g/ /\\\\ /}]
 
@@ -217,21 +209,6 @@ if {[vercmp [macports_version] 2.6.99] >= 0} {
         foreach {my_machine unused} ${my_variations} {
             set my_dest_mnvm_dat "${destroot}${my_app_dir}/Mini vMac ${my_machine}.app/Contents/mnvm_dat"
             destroot.keepdirs-append ${my_dest_mnvm_dat}
-        }
-    }
-
-    pre-activate {
-        if {![catch {set installed [lindex [registry_active ${name}] 0]}]} {
-            set installed_version [lindex ${installed} 1]
-            set installed_revision [lindex ${installed} 2]
-            set installed_epoch [lindex ${installed} 5]
-            if {[vercmp ${installed_epoch} 0] == 0 && (
-                    [vercmp ${installed_version} 3.5.8] < 0 || (
-                    [vercmp ${installed_version} 3.5.8] == 0 && [vercmp ${installed_revision} 1] < 0
-                    )
-                )} {
-                registry_deactivate_composite ${name} "" [list ports_nodepcheck 1]
-            }
         }
     }
 }


### PR DESCRIPTION
Remove old pre-activate added over 3 years ago in f6eb5a8f82

Remove handling for MacPorts < 2.7.0

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
