### PR TITLE
magic-wormhole: switch to python3.9

### DIFF
--- a/net/magic-wormhole/Portfile
+++ b/net/magic-wormhole/Portfile
@@ -31,7 +31,7 @@ checksums           rmd160  bbb9d49f4520e5168f95b35264a4fce7ce4732a7 \
                     sha256  1b0fd8a334da978f3dd96b620fa9b9348cabedf26a87f74baac7a37052928160 \
                     size    262269
 
-python.default_version  38
+python.default_version  39
 
 depends_build-append port:py${python.version}-setuptools
 

--- a/python/py-txtorcon/Portfile
+++ b/python/py-txtorcon/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  bfe72404f5a649addd8b60d0fafe92e1e99dc25f \
                     sha256  122cd081786396f57718adda1c1a5eb01b8e9a4832fcd140918b45c10359377a \
                     size    306139
 
-python.versions     38
+python.versions     38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
~#### Description~

~I'm attempting to allow magic-wormhole to depend on different python versions, but I'm running into issues doing so and I can't seem to figure out how the python ports system works:~

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?



```
$ sudo port -vst install ./
--->  Computing dependencies for magic-wormhole.
Error: Dependency 'py39-txtorcon' not found.
Error: Follow https://guide.macports.org/#project.tickets if you believe there is a bug.
Error: Processing of port magic-wormhole failed
[Exit 1]
$ cd /tmp/py-txtorcon/
$ sudo port -vst install ./
--->  Computing dependencies for py-txtorcon.
Error: Dependency 'py39-txtorcon' not found.
Error: Follow https://guide.macports.org/#project.tickets if you believe there is a bug.
Error: Processing of port py-txtorcon failed
[Exit 1]
```

~I am unsure how to proceed and how to bring this `py39-txtorcon` into existence: I briefly went looking at [documentation on dependencies](https://guide.macports.org/#reference.dependencies) but didn't see anything relevant - this dependency seems to be implicit, yet it doesn't actually exist. I went and looked at a few various portfiles for python libs, but didn't spot anything obvious.~
~Please see the changeset to see what changes I made.~

~Would anyone be able to help and/or point me in the right direction?~