### PR TITLE
gdb add +python310 variant

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -90,7 +90,7 @@ post-destroot {
     }
 }
 
-set pythons_suffixes {27 35 36 37 38 39}
+set pythons_suffixes {27 35 36 37 38 39 310}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {
@@ -99,7 +99,7 @@ foreach s ${pythons_suffixes} {
 
 foreach s ${pythons_suffixes} {
     set p python${s}
-    set v [string index ${s} 0].[string index ${s} 1]
+    set v [string index ${s} 0].[string range ${s} 1 end]
     set i [lsearch -exact ${pythons_ports} ${p}]
     set c [lreplace ${pythons_ports} ${i} ${i}]
     variant ${p} description "Build GDB with Python ${v} Scripting" conflicts {*}${c} "


### PR DESCRIPTION
#### Description

Add support for python3.10 in gdb

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
