### PR TITLE
gopass: update to 1.13.0

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.12.8 v
+go.setup            github.com/gopasspw/gopass 1.13.0 v
 categories          security
 maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 license             MIT
@@ -15,9 +15,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  c7580b4638330fd81f1e3200a4f387282d22f2b1 \
-                        sha256  f6bee0adee2715d711c6f062015604f0f06a0b68597548e3869170f1e8011f1b \
-                        size    2180566
+                        rmd160  cddf1ab2afc9747c5fd72dd2cd214a03c650a7a7 \
+                        sha256  9d8daa667c5d568e5a887c2292c12bad6093cfd9bbfeba58e3711a78962a4516 \
+                        size    2182239
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -59,30 +59,30 @@ go.vendors          rsc.io/qr \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
                     golang.org/x/term \
-                        lock    6886f2dfbf5b \
-                        rmd160  8688e7b350892399f2918c70c87435016c64c572 \
-                        sha256  e52745c19f7ebe30ab78db8af43216b6795928089a433925ef3ebef0eaad98f3 \
-                        size    14938 \
+                        lock    03fcf44c2211 \
+                        rmd160  a1b9592e95373ba617ef579a2f7015cfdc871343 \
+                        sha256  3673415a6d3d106d49b487715e151fc64245502ef547c16e8e13edb6b8f2f492 \
+                        size    14975 \
                     golang.org/x/sys \
-                        lock    63515b42dcdf \
-                        rmd160  c00cd97dd5a737ca9049130f84fffe1b40f379b1 \
-                        sha256  24526e1ff5494c59acf642bac86dff4ec0ca6074732c557cb22eab2bfbf84f76 \
-                        size    1210631 \
+                        lock    0c823b97ae02 \
+                        rmd160  6e5330d53b301f41301f0552aa201d6fcec9d3f6 \
+                        sha256  1f3d4258b21bf5daec3ca25193d6d5190ca7dd95e9d2f58f4587147aff7bb123 \
+                        size    1224733 \
                     golang.org/x/oauth2 \
-                        lock    2bc19b11175f \
-                        rmd160  c9df20100b53e8a7ecee251aa9c62292996e9e0e \
-                        sha256  8fe1df422742e2d1b07b36bd22c7eaeb8f8a9ae1c34aa464d364491e49660a89 \
-                        size    85656 \
+                        lock    d3ed0bb246c8 \
+                        rmd160  d66bbada6578d17da9208ee8c215d4e1ead6aef7 \
+                        sha256  7a0c986063c9580fed9223411152d3ea8126d54597be8184fe613097b95d7489 \
+                        size    87604 \
                     golang.org/x/net \
-                        lock    e898025ed96a \
-                        rmd160  6a4d90944957dfff46fd424e76f8bbd468fa83a5 \
-                        sha256  4d9f66d6821d5d2785f87c7656d7c4e18aec286e3dfc8d04c0950ef40ae9d398 \
-                        size    1253234 \
+                        lock    69e39bad7dc2 \
+                        rmd160  722be2fbb86549a951d74beb4d35f882de120354 \
+                        sha256  f66db35109dbd76aac9039afbcbe891513580ff8edf986d1ed8773bcc0511d49 \
+                        size    1263978 \
                     golang.org/x/crypto \
-                        lock    32db794688a5 \
-                        rmd160  02ab581de5510ce94205e0fe5a58aacd2cd375b8 \
-                        sha256  2276178323ee1992d2e845e78ffb8fdce625ef24602b97719428fddaf9f2192f \
-                        size    1732601 \
+                        lock    ceb1ce70b4fa \
+                        rmd160  6c45c79b117cc3d8ea5c69497553774c26427b76 \
+                        sha256  f67aa2bec7215eb0a6c3f0863612a1a59ea0a103245748f4d9c81b9784350a3f \
+                        size    1732118 \
                     github.com/xrash/smetrics \
                         lock    039620a65673 \
                         rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
@@ -149,15 +149,15 @@ go.vendors          rsc.io/qr \
                         sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
                         size    3366 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.13 \
-                        rmd160  91c4e10ae78db94432a94bc7f9816df4093ec8d7 \
-                        sha256  6a6b35588efb0abec5a951246775a4cb47fab11ff161715875de4c02c9cdf309 \
-                        size    4445 \
+                        lock    v0.0.14 \
+                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
+                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
+                        size    4705 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.8 \
-                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
-                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
-                        size    9576 \
+                        lock    v0.1.11 \
+                        rmd160  8c86c57e575979c1544343e23053b73be022cfe5 \
+                        sha256  4b8c7305e79232b627217d894382b7c3cd35371347e3fc7231fbce13500d0a38 \
+                        size    9808 \
                     github.com/martinhoefling/goxkcdpwgen \
                         lock    7dc3d102eca3 \
                         rmd160  f8b32dbe86765d33f5f6e57cc3047f6951bd6957 \
@@ -234,10 +234,10 @@ go.vendors          rsc.io/qr \
                         sha256  54c06c5988808eca9affe01cabe122e02ba4af5763f29fff1c341dce1424aa21 \
                         size    62423 \
                     github.com/fatih/color \
-                        lock    v1.12.0 \
-                        rmd160  71a007da8ad943b7e3b070ab9a272e576adad676 \
-                        sha256  69e7bf877a72e225b3d9f424ca644a17f67209f5e311e910f1650cdb7f1b62a8 \
-                        size    10712 \
+                        lock    v1.13.0 \
+                        rmd160  0c56533948a292eb8c5181e9a88a45fbd1267bf5 \
+                        sha256  a65b114bfe507384e1660730803ffb4437c63a24dd11a5d7f61c77f048caa55f \
+                        size    10828 \
                     github.com/dustin/go-humanize \
                         lock    v1.0.0 \
                         rmd160  e8641035159ea3e8839ee086f01f966443956303 \
@@ -296,10 +296,10 @@ go.vendors          rsc.io/qr \
                         size    39144 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
-                        lock    v1.0.0-rc.3 \
-                        rmd160  3ec904a8771f1f6553ddfbab782ef1123b367f65 \
-                        sha256  73b676e994d1190e3957d57e631af8aaabd8a775e2cf9c2601addbfd1fdaf09d \
-                        size    59027
+                        lock    v1.0.0 \
+                        rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
+                        sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
+                        size    59693
 
 set go_ldflags      "-s -w -X main.version=${version}"
 build.args          -ldflags \"${go_ldflags}\"


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.13.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
