### PR TITLE
gopass-hibp: new port

### DIFF
--- a/security/gopass-hibp/Portfile
+++ b/security/gopass-hibp/Portfile
@@ -1,0 +1,218 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/gopasspw/gopass-hibp 1.12.0 v
+revision            0
+categories          security
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+license             MIT
+
+description         Gopass haveibeenpwnd.com integration
+long_description    ${description}
+homepage            https://www.gopass.pw
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  dd68141ca4632fbf68653d77ddec9f2cdf5792b8 \
+                        sha256  5c5b5bd61170c50707eef9d2f1923bdc5eb0b3ee4a3e2b24234b9b66e7ba2ca4 \
+                        size    16587
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    496545a6307b \
+                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
+                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
+                        size    90145 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.3.0 \
+                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
+                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
+                        size    72838 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.60.1 \
+                        rmd160  aea42f00ec6f7c0bdc0cda906257b0b7aba80a37 \
+                        sha256  3db6855d923d5719ddfaa7a3f1a8910723f8bd943692205c045509e797bda82f \
+                        size    49265 \
+                    golang.org/x/text \
+                        lock    v0.3.3 \
+                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
+                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
+                        size    7745597 \
+                    golang.org/x/term \
+                        lock    2321bbc49cbf \
+                        rmd160  94c32506cb76cee410574c49d6b4cfe294a8159d \
+                        sha256  3bf7b61de210c621fb70e697c0020789bfbe426754d0f743978e77f84a7472f1 \
+                        size    15286 \
+                    golang.org/x/sys \
+                        lock    9b0068b26619 \
+                        rmd160  6d61a58b0982fbb00c93307192beb37383faf72c \
+                        sha256  947d8814655ee3607d4b9f8a3e244b352fbf04ed8a6a223b3fd5c20c7f21fd6b \
+                        size    1104270 \
+                    golang.org/x/net \
+                        lock    f5854403a974 \
+                        rmd160  cfaf8471269327bcdce1142b44ded72a4584ddf9 \
+                        sha256  a1fcb7946757072ba7453de05fa82e9b977318307a88082c5e4b24057885babb \
+                        size    1178342 \
+                    golang.org/x/crypto \
+                        lock    eec23a3978ad \
+                        rmd160  098b29e5fb0c1a0fa7a118e433eb5d952053391b \
+                        sha256  da658dad4a60a368edea1cbb28651cf44b46b06fdd726462c5696aa5283f12c2 \
+                        size    1725759 \
+                    github.com/urfave/cli \
+                        lock    v2.3.0 \
+                        rmd160  fec9e73bc45d02b2afe43e8d9c76398722494e4b \
+                        sha256  3138857026c9564559b3e734b9b8abfeda57354fc4aa87717879882bff68ef09 \
+                        size    3408338 \
+                    github.com/shurcooL/sanitized_anchor_name \
+                        lock    v1.0.0 \
+                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
+                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
+                        size    2144 \
+                    github.com/russross/blackfriday \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
+                    github.com/rs/xid \
+                        lock    v1.2.1 \
+                        rmd160  2cff9628752a94fc62ab0e83436c61df7195eed1 \
+                        sha256  38881e009bacdbf91f6e586207b346eb9ec93f06335331c07a5e0b2ad41ee3f6 \
+                        size    9555 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/modern-go/reflect2 \
+                        lock    v1.0.1 \
+                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
+                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
+                        size    14407 \
+                    github.com/modern-go/concurrent \
+                        lock    bacd9c7ef1dd \
+                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
+                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
+                        size    7533 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/minio/sha256-simd \
+                        lock    v0.1.1 \
+                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
+                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
+                        size    65042 \
+                    github.com/minio/minio-go \
+                        lock    v7.0.7 \
+                        rmd160  f7269c3b9de8bf8a2545cb947ff1edc9631b5f19 \
+                        sha256  d23d5ee4dcbec90b8797afee393283558fb81cb7f35bd228003219cad19ff0ec \
+                        size    236183 \
+                    github.com/minio/md5-simd \
+                        lock    v1.1.0 \
+                        rmd160  7929f1dc43d777a143a826c47948490d8ed121e0 \
+                        sha256  49d89141ce43f38098b264acf3b3d9341d553a1f82816485f1c036e18deb2b58 \
+                        size    99242 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.8 \
+                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
+                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
+                        size    9576 \
+                    github.com/klauspost/cpuid \
+                        lock    v1.3.1 \
+                        rmd160  0c161f6a90600c80e908141c2a81130ba703307e \
+                        sha256  8db60afc9f494af07150fff47e676377588d36fb5ee3cc181ec59ff35c238c79 \
+                        size    367163 \
+                    github.com/json-iterator/go \
+                        lock    v1.1.10 \
+                        rmd160  963a70cf0a7d056f6b00fb2224687895612a35e2 \
+                        sha256  e82947d6f32c1cf730c796409eabc8051c208c2eafabe793d196d448529a7f0f \
+                        size    83377 \
+                    github.com/hashicorp/golang-lru \
+                        lock    v0.5.4 \
+                        rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
+                        sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
+                        size    13435 \
+                    github.com/hashicorp/go-multierror \
+                        lock    v1.1.0 \
+                        rmd160  868d9a6f0732cba1b2dfbb73556b6a194c797c03 \
+                        sha256  9bd88c4f96aa4c4dcca5c0124e48f540c59754586653924b5e4b7de3af0f8c4a \
+                        size    12091 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.1.0 \
+                        rmd160  25e655fc958685dd949900eea8c3d97f33d85eab \
+                        sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
+                        size    8586 \
+                    github.com/gopasspw/gopass \
+                        lock    v1.12.0 \
+                        rmd160  4a9bdad822d23c9ef617cd95dd4840211c126df9 \
+                        sha256  0803ca8692be48345c82f04ba9aae414cd5a62a7deb3b55c9880d2741c139117 \
+                        size    2043231 \
+                    github.com/google/uuid \
+                        lock    v1.1.1 \
+                        rmd160  69112e9735ecc1d5360a3cc31531f8be661a007f \
+                        sha256  70be7dec37826f2cbe13acfe534ce74cbb2107c1e348eb4e8365f7d900002e40 \
+                        size    13552 \
+                    github.com/google/go-querystring \
+                        lock    v1.0.0 \
+                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
+                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
+                        size    7536 \
+                    github.com/google/go-github \
+                        lock    v17.0.0 \
+                        rmd160  2c1917adfc161a2252354d558352180079005d8d \
+                        sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
+                        size    212064 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.4 \
+                        rmd160  e53e85e2f7651ce4e0dd20f8621380a60d9d5cc0 \
+                        sha256  4b3ea98b1c2c83814a405d824c68521315dbddd9dada9a9992d1abebd2cca290 \
+                        size    101028 \
+                    github.com/fatih/color \
+                        lock    v1.10.0 \
+                        rmd160  d33ae416337f02c181700fe76c05aec814791423 \
+                        sha256  2caf3481614a1a3dcbec15506d9549867a8538e60a8f3d057a619557ec6faa9b \
+                        size    1267972 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v2.0.0 \
+                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
+                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
+                        size    52040 \
+                    github.com/cenkalti/backoff \
+                        lock    v2.2.1 \
+                        rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
+                        sha256  4f6a3d7d9fdc5e02522faed8e96539476f646ab64983633a92ea1b71e18bca4f \
+                        size    8633 \
+                    github.com/caspr-io/yamlpath \
+                        lock    502e8d113a9b \
+                        rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
+                        sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
+                        size    6334 \
+                    github.com/blang/semver \
+                        lock    v4.0.0 \
+                        rmd160  ab0e0d974dcbc784840d4bcc76584242436c51fa \
+                        sha256  bf4d622c039173a4e0903738d8b5c788c3c63bb8cfa7485611f38aece3504d0f \
+                        size    27781 \
+                    filippo.io/edwards25519 \
+                        repo    github.com/FiloSottile/edwards25519 \
+                        lock    v1.0.0-beta.2 \
+                        rmd160  354dcb123ca7b351468e010b8ddc7af28bc22aa5 \
+                        sha256  9280a341851b2e4a5ef1142a1a38a30e2b66c8bb63b7d7ce8bd2f2b53e0bab89 \
+                        size    77471 \
+                    filippo.io/age \
+                        repo    github.com/FiloSottile/age \
+                        lock    v1.0.0-beta7 \
+                        rmd160  42e2be4b481d365ed33b8cad6c10fd091b5dd70e \
+                        sha256  1abc43fe7d6959742cb2e7ef9b8219620325734bb3e926e4b999fe5447a8bf59 \
+                        size    42223
+
+build.args          -ldflags '-X main.version=${version}'
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
gopass-hibp is missed after #11249.

[gopass 1.12.0](https://github.com/gopasspw/gopass/releases/tag/v1.12.0):

> NOTE: This release drops the integrations that were moved to their own repos,
> i.e. git-credential-gopass, gopass-hibp, gopass-jsonapi and
> gopass-summon-provider.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
