### PR TITLE
p5-perl-tidy: update to 20211029

### DIFF
--- a/perl/p5-perl-tidy/Portfile
+++ b/perl/p5-perl-tidy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
-perl5.setup         Perl-Tidy 20201207 ../../authors/id/S/SH/SHANCOCK
+perl5.setup         Perl-Tidy 20211029 ../../authors/id/S/SH/SHANCOCK
 license             GPL-2+
 maintainers         nomaintainer
 description         Parses and beautifies perl source
@@ -16,8 +16,8 @@ long_description    Perltidy reads a perl script and writes an indented, \
 
 platforms           darwin
 
-checksums           rmd160  779bde62172c75fe5a565ead43ff4e2dbd01032a \
-                    sha256  2e4504e493a623674fff9d5e5c0865467f198cf20444d5503dd9ddcd95003d11 \
-                    size    728781
+checksums           rmd160  2ae23862867bdd3b817430357b0537ef84e55aee \
+                    sha256  ec03b1e36a57d094569a30082688f722253401c7cc934ac64d2e3eb4de880eda \
+                    size    850004
 
 supported_archs     noarch


### PR DESCRIPTION
#### Description

Update p5-perl-tidy to the latest version (20211029).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
