### PR TITLE
diskus: update to 0.7.0

### DIFF
--- a/sysutils/diskus/Portfile
+++ b/sysutils/diskus/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           cargo 1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
 
-github.setup        sharkdp diskus 0.6.0 v
+github.setup        sharkdp diskus 0.7.0 v
+github.tarball_from archive
+revision            0
 
 categories          sysutils
 platforms           darwin linux
@@ -19,57 +21,57 @@ long_description    diskus is a very simple program that computes the apparent \
     disk cache and more than 3x faster with a warm disk cache.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b4d4e67914108ea541ef9951a97fb3eba5c1798b \
-                    sha256  b33c39bc5078c262933a6beb2defe3679e386da3a6e5427c7063088e4bc6344a \
-                    size    16281
+                    rmd160  b60e54fbd4b4b4db5745364cfd705f7bffc28d50 \
+                    sha256  64b1b2e397ef4de81ea20274f98ec418b0fe19b025860e33beaba5494d3b8bd1 \
+                    size    17046
 
 cargo.crates \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-    arrayvec                        0.4.11  b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba \
-    atty                            0.2.13  1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90 \
-    bitflags                         1.1.0  3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd \
-    cfg-if                           0.1.9  b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33 \
-    clap                            2.33.0  5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
-    crossbeam-channel                0.3.9  c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa \
-    crossbeam-deque                  0.7.1  b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71 \
-    crossbeam-epoch                  0.7.2  fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9 \
-    crossbeam-queue                  0.1.2  7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b \
-    crossbeam-utils                  0.6.6  04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6 \
-    either                           1.5.3  bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
+    arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    crossbeam-channel                0.5.1  06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4 \
+    crossbeam-deque                  0.8.1  6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e \
+    crossbeam-epoch                  0.9.5  4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd \
+    crossbeam-utils                  0.8.5  d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db \
+    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
     fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-    humansize                        1.1.0  b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e \
-    itoa                             0.4.4  501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f \
-    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    humansize                        1.1.1  02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026 \
+    itoa                             0.4.8  b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                            0.2.62  34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba \
-    memoffset                        0.5.1  ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f \
-    nodrop                          0.1.13  2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
+    libc                           0.2.107  fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219 \
+    memoffset                        0.6.4  59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9 \
+    nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     num-format                       0.4.0  bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465 \
-    num_cpus                        1.10.1  bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
     rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
-    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
     rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
-    rayon                            1.2.0  83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123 \
-    rayon-core                       1.6.0  98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rayon                            1.5.1  c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90 \
+    rayon-core                       1.9.1  d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e \
     rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
-    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
-    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
-    scopeguard                       1.0.0  b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d \
-    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
-    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     tempdir                          0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
-    term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
+    term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-    unicode-width                    0.1.6  7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20 \
-    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
-    winapi                           0.3.8  8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
-    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
-    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    unicode-width                    0.1.9  3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973 \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/diskus ${destroot}${prefix}/bin/
-    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/libdiskus.rlib ${destroot}${prefix}/lib/
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 \
+        ${worksrcpath}/doc/${name}.1 ${destroot}${prefix}/share/man/man1/
 }


### PR DESCRIPTION
- Install man page
- Do not install .rlib file; diskus does not link against it, and it is
  only a product of the Rust build process, and not used by anything.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
