### PR TITLE
KeePassXC: Fix compilation on osx 10.7, 10.8 & 10.9

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -21,7 +21,7 @@ license                 GPL-2+
 license_noconflict      openssl
 
 github.setup            keepassxreboot keepassxc 2.6.6
-revision                2
+revision                3
 github.tarball_from     releases
 distname                keepassxc-${version}-src
 use_xz                  yes
@@ -54,6 +54,7 @@ if {[option gpg_verify.use_gpg_verification]} {
     }
 }
 
+qt5.min_version         5.5.0
 qt5.depends_component   qtmacextras qtsvg
 qt5.depends_build_component \
                         qttools

--- a/security/KeePassXC/files/patch-old-mac.diff
+++ b/security/KeePassXC/files/patch-old-mac.diff
@@ -1,13 +1,44 @@
+Subject: [PATCH] Fix compilation when osx <= 10.7
+
+* AppKitImpl.mm: Syntax is not understood by 10.7, update it to be understandable by <= 10.7
+error: expected method to read dictionary element not found on object of type 'NSDictionary *'
+    NSRunningApplication* app = userInfo[NSWorkspaceApplicationKey];
+                                ^
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
+@@ -60,7 +60,7 @@ - (id) initWithObject:(AppKit*)appkit
+ - (void) didDeactivateApplicationObserver:(NSNotification*) notification
+ {
+     NSDictionary* userInfo = notification.userInfo;
+-    NSRunningApplication* app = userInfo[NSWorkspaceApplicationKey];
++    NSRunningApplication* app = [userInfo objectForKey:NSWorkspaceApplicationKey];
+ 
+     if (app.processIdentifier != [self ownProcessId]) {
+         self.lastActiveApplication = app;
+--
+Subject: [PATCH] Fix compilation when osx <= 10.9
+
+* AppKitImpl.mm: The code uses @available syntax which is new in clang 9
+This prevents compilation on older version of macOS that don't
+use this version. For example on El Capitan.
+
+* AppKitImpl.mm: button property is new in 10.10. It is used for a feature of KeePassXC
+  that is only available from 10.17 onwards. So we don't need it when compiling on <= 10.9
+error: property 'button' not found on object of type 'NSStatusItem *'
+        NSString* appearance = [dummy.button.effectiveAppearance.name lowercaseString];
+                                      ^
 --- src/gui/osutils/macutils/AppKitImpl.mm
 +++ src/gui/osutils/macutils/AppKitImpl.mm
 @@ -139,6 +139,7 @@ - (bool) isDarkMode
  //
  - (bool) isStatusBarDark
  {
-+#if __clang_major__ >= 9
++#if __clang_major__ >= 9 && defined MAC_OS_X_VERSION_10_10
      if (@available(macOS 10.17, *)) {
          // This is an ugly hack, but I couldn't find a way to access QTrayIcon's NSStatusItem.
          NSStatusItem* dummy = [[NSStatusBar systemStatusBar] statusItemWithLength:0];
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
 @@ -146,6 +147,7 @@ - (bool) isStatusBarDark
          [[NSStatusBar systemStatusBar] removeStatusItem:dummy];
          return [appearance containsString:@"dark"];
@@ -16,11 +47,51 @@
  
      return [self isDarkMode];
  }
+--
+Subject: [PATCH] Fix compilation when osx <= 10.8
+
+* AppKitImpl.mm: AXIsProcessTrustedWithOptions exists from 10.9 onwards
+error: use of undeclared identifier 'kAXTrustedCheckOptionPrompt'
+error: use of undeclared identifier 'AXIsProcessTrustedWithOptions'
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
+@@ -168,9 +168,15 @@ - (void) userSwitchHandler:(NSNotification*) notification
+ //
+ - (bool) enableAccessibility
+ {
+-    // Request accessibility permissions for Auto-Type type on behalf of the user
+-    NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
+-    return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));
++#if __clang_major__ >= 9 && defined MAC_OS_X_VERSION_10_9
++    if (@available(macOS 10.15, *)) {
++        // Request accessibility permissions for Auto-Type type on behalf of the user
++        NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
++        return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));
++    }
++#else
++    return YES;
++#endif
+ }
+ 
+ //
+--
+Subject: [PATCH] Fix compilation when osx <= 10.7
+
+* AppKitImpl.mm: The code uses @available syntax which is new in clang 9
+This prevents compilation on older version of macOS that don't
+use this version. For example on El Capitan.
+
+* AppKitImpl.mm: CGDisplayStreamRef exists from 10.8 onwards only. It is used for a
+  feature of KeePassXC that is only available from 10.15 onwards. So we don't need it
+  when compiling on <= 10.7
+error: unknown type name 'CGDisplayStreamRef'
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
 @@ -176,6 +178,7 @@ - (bool) enableAccessibility
  //
  - (bool) enableScreenRecording
  {
-+#if __clang_major__ >= 9
++#if __clang_major__ >= 9 && defined MAC_OS_X_VERSION_10_8
      if (@available(macOS 10.15, *)) {
          // Request screen recording permission on macOS 10.15+
          // This is necessary to get the current window title
@@ -32,6 +103,19 @@
      return YES;
  }
  
+--
+Subject: [PATCH] fix compilation on Qt not having QOperatingSystemVersion::MacOSBigSur
+
+The code uses 'QOperatingSystemVersion::MacOSBigSur' which doesn't exist
+in all Qt versions (it has been backported to Qt 5.12.10+ & 5.15.1+ only).
+On older macos systems like El Capitan the last supported
+version of Qt is 5.11
+
+This will fix compilation issue on such older systems and on systems
+running with Qt not supporting QOperatingSystemVersion::MacOSBigSur
+
+Compilation error was:
+error: no member named 'MacOSBigSur' in 'QOperatingSystemVersion'
 --- src/gui/styles/base/BaseStyle.cpp
 +++ src/gui/styles/base/BaseStyle.cpp
 @@ -53,8 +53,10 @@
@@ -68,3 +152,34 @@
                  return hack_isLightPalette(pal) ? QRgb(0xF4F4F4) : QRgb(0x282828);
              }
  #endif
+--
+Subject: [PATCH] Fix compilation when osx <= 10.7
+
+* MacUtils.cpp: CoreGraphics exists from 10.8 onwards only, capslock detection feature
+  would have to be implemented on OSX < 10.7
+
+--- src/gui/osutils/macutils/MacUtils.cpp
++++ src/gui/osutils/macutils/MacUtils.cpp
+@@ -24,8 +24,9 @@
+ #include <QStandardPaths>
+ #include <QTimer>
+ 
++#if defined MAC_OS_X_VERSION_10_8
+ #include <CoreGraphics/CGEventSource.h>
+-
++#endif
+ 
+ QPointer<MacUtils> MacUtils::m_instance = nullptr;
+ 
+@@ -136,7 +137,11 @@
+ 
+ bool MacUtils::isCapslockEnabled()
+ {
++#if defined MAC_OS_X_VERSION_10_8
+     return (CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState) & kCGEventFlagMaskAlphaShift) != 0;
++#else
++	return false;
++#endif
+ }
+ 
+ /**


### PR DESCRIPTION
* Fix compilation on osx 10.7, 10.8 & 10.9
* set minimal Qt version to 5.5 (as stated by upstream since 2.5.0)
As a consequence, KeePassXC can't be built on Snow Leopard (which
uses Qt 5.3)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

Tested on El Capitan but compiled with these changes in Portfile
each of these 3:
`macosx_deployment_target 10.9`
`macosx_deployment_target 10.8`
`macosx_deployment_target 10.7`
+
```
compiler.support_environment_sdkroot yes
build.env		SDKROOT=macosx${macosx_deployment_target} \
			MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
configure.env		SDKROOT=macosx${macosx_deployment_target} \
			MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
```
and using the corresponding SDK version

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
