### PR TITLE
yubico-piv-tool: Fix incompatibility with openssl3, fix build with cmake 1.1 PG

### DIFF
--- a/security/yubico-piv-tool/Portfile
+++ b/security/yubico-piv-tool/Portfile
@@ -3,14 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
-PortGroup           openssl 1.0
-
-# Note yet ready for openssl 3.
-# Check on future updates by removing this line
-openssl.branch      1.1
 
 github.setup        Yubico yubico-piv-tool 2.2.1 yubico-piv-tool-
-revision            0
+revision            1
 categories          security
 platforms           darwin
 license             BSD
@@ -28,6 +23,8 @@ homepage            https://developers.yubico.com/yubico-piv-tool
 checksums           rmd160  ddc9c1607c90d4514880d8a74682b53ca5ad1ff1 \
                     sha256  27d98723473cb4af8d5f692e0453102201690b4337d2a7b276a102e0eb57ed08 \
                     size    1310292
+
+patchfiles          81b063f53db8a3d74077522a6ff4f1640cc3fe70.patch
 
 depends_build-append \
                     port:check \

--- a/security/yubico-piv-tool/Portfile
+++ b/security/yubico-piv-tool/Portfile
@@ -32,8 +32,8 @@ depends_build-append \
                     port:help2man \
                     port:pkgconfig
 
-configure.args-replace \
-                    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH=OFF
+configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 post-destroot {
     # symlink PKCS#11 module in the standard pkcs11 module directory

--- a/security/yubico-piv-tool/files/81b063f53db8a3d74077522a6ff4f1640cc3fe70.patch
+++ b/security/yubico-piv-tool/files/81b063f53db8a3d74077522a6ff4f1640cc3fe70.patch
@@ -1,0 +1,33 @@
+From 81b063f53db8a3d74077522a6ff4f1640cc3fe70 Mon Sep 17 00:00:00 2001
+From: Clemens Lang <cal@macports.org>
+Date: Sun, 14 Nov 2021 18:21:28 +0100
+Subject: [PATCH] Avoid header include guard conflict with OpenSSL 3
+
+OpenSSL 3.x ships an openssl/types.h header that's protected with an
+OPENSSL_TYPES_H include guard macro. OpenSSL's headers fail to parse
+when ykcs11/openssl_types.h defines this symbol.
+
+Switch the include guard for the file to YKCS11_OPENSSL_TYPES_H to
+prevent this from happening.
+
+Signed-off-by: Clemens Lang <cal@macports.org>
+Upstream-Status: Submitted [https://github.com/Yubico/yubico-piv-tool/pull/334]
+---
+ ykcs11/openssl_types.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ykcs11/openssl_types.h b/ykcs11/openssl_types.h
+index c526d815..f3e1a7c0 100644
+--- ./ykcs11/openssl_types.h
++++ ./ykcs11/openssl_types.h
+@@ -28,8 +28,8 @@
+  *
+  */
+ 
+-#ifndef OPENSSL_TYPES_H
+-#define OPENSSL_TYPES_H
++#ifndef YKCS11_OPENSSL_TYPES_H
++#define YKCS11_OPENSSL_TYPES_H
+ 
+ #include <openssl/bn.h>
+ #include <openssl/x509.h>


### PR DESCRIPTION
#### Description

This port needs to be built without `CMAKE_BUILD_WITH_INSTALL_RPATH` enabled, and correctly said so before the last update – however, switching it to the cmake 1.1 PortGroup broke the line that did so in the Portfile.

Additionally, fix the incompatibility with OpenSSL 3 correctly, rather than falling back to OpenSSL 1.1.

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64
No Xcode

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?