### PR TITLE
qt5-qtwebkit: Fix compilation issues on SDK 12 / Monterey

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1920,6 +1920,17 @@ foreach {module module_info} [array get modules] {
                 # see https://bugreports.qt.io/browse/QTBUG-84037
                 patchfiles-append patch-qtquick3d-assimp.diff
             }
+            # Add known_fail special case logic
+            if { ${module} eq "qtmultimedia" } {
+                known_fail  yes
+                if { ${os.major} >= 20} {
+                    known_fail  yes
+                    pre-fetch {
+                        ui_error "${subport} currently does not build on macOS 11 or later"
+                        return -code error "incompatible OS version"
+                    }
+                }
+            }
         }
     }
 }

--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -702,7 +702,7 @@ array set modules {
         {"Qt WebKit" "Qt WebKit Widgets"}
         "community support only (use Qt WebEngine)"
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtwebkit-examples {
@@ -1574,6 +1574,19 @@ foreach {module module_info} [array get modules] {
 
             # special case
             if { ${module} eq "qtwebkit" } {
+                # Fix issue in Monterey where the include search path finds and tries
+                # to link against similarly named header files in "${prefix}/include"
+                # that conflict with webkit's own header files
+                # See https://trac.macports.org/ticket/63877
+                configure.cppflags-delete "-I${prefix}/include"
+                configure.cxxflags-delete "-I${prefix}/include"
+                configure.cflags-delete "-I${prefix}/include"
+
+                # SDK 12 now requires an explicit call to use NS_FORMAT_ARGUMENT for NSString
+                # See https://trac.macports.org/ticket/63877
+                configure.cppflags-append \
+                    '-DNS_FORMAT_ARGUMENT\(A\)=' \
+                    -D_Nullable_result=_Nullable
 
                 # use MacPorts icu
                 #


### PR DESCRIPTION
#### Description

Fixes qt5-qtwebkit compilation issues on SDK 12 / Monterey.  The first fix fixes a conflict where the linker grabs the wrong header files, the second fixes the "NSString" error on build. 

I've also added a "known_fail" to qt5-qtmultimedia-docs to get it [further] through the CI process.

Fixes: [https://trac.macports.org/ticket/63877](https://trac.macports.org/ticket/63877) 

These changes have been tested to compile and function on macOS Monterey arm and intel and also on High SIerra.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

AND

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

AND

macOS 10.13.6 17G2208 x86_64
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
