### PR TITLE
pgplot: add support for Monterey

### DIFF
--- a/graphics/pgplot/Portfile
+++ b/graphics/pgplot/Portfile
@@ -6,7 +6,7 @@ PortGroup           compilers 1.0
 name                pgplot
 conflicts           miriad
 version             5.2.2
-revision            12
+revision            13
 categories          graphics devel
 license             Noncommercial
 platforms           darwin
@@ -47,7 +47,8 @@ patchfiles          patch-makemake.diff \
                     patch-drivers.list.patch \
                     patch-drivers-pndriv.c.diff \
                     patch-proccom.c.diff \
-                    implicit.patch
+                    implicit.patch \
+                    avoid_multichars.diff
 
 # See #37551
 if { [string match *64 ${build_arch}] } {

--- a/graphics/pgplot/files/avoid_multichars.diff
+++ b/graphics/pgplot/files/avoid_multichars.diff
@@ -1,0 +1,23 @@
+--- src/pgaxis.f.orig	1997-03-26 00:00:34.000000000 +0100
++++ src/pgaxis.f	2021-11-15 00:06:05.000000000 +0100
+@@ -61,7 +61,7 @@
+ C  DISP   (input)  : displacement of baseline of tick labels to
+ C                    right of axis, in units of the character height.
+ C  ORIENT (input)  : orientation of label text, in degrees; angle between
+-C                    baseline of text and direction of axis (0-360°).
++C                    baseline of text and direction of axis (0-360).
+ C--
+ C 25-Mar-1997 - new routine [TJP].
+ C-----------------------------------------------------------------------
+diff -Nurd pgplot.old/src/pgtick.f pgplot/src/pgtick.f
+--- src/pgtick.f.orig	1997-06-09 23:56:44.000000000 +0200
++++ src/pgtick.f	2021-11-15 00:05:51.000000000 +0100
+@@ -27,7 +27,7 @@
+ C  DISP   (input)  : displacement of label text to
+ C                    right of axis, in units of the character height.
+ C  ORIENT (input)  : orientation of label text, in degrees; angle between
+-C                    baseline of text and direction of axis (0-360°).
++C                    baseline of text and direction of axis (0-360).
+ C  STR    (input)  : text of label (may be blank).
+ C--
+ C 25-Mar-1997 - new routine [TJP].


### PR DESCRIPTION
#### Description

New patch to support MacOS 12 (Monterey)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode Command Line Tools 13.1.0.0.1.1633545042


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
