### PR TITLE
python3{9,10}: Use openssl PG instead of shim port

### DIFF
--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -2,12 +2,13 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup openssl 1.0
 
 name                python310
 
 # Remember to keep py310-tkinter and py310-gdbm's versions sync'd with this
 version             3.10.0
-revision            3
+revision            4
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang
@@ -48,7 +49,6 @@ depends_lib         port:bzip2 \
                     port:libedit \
                     port:libffi \
                     port:ncurses \
-                    path:lib/libssl.dylib:openssl \
                     port:sqlite3 \
                     port:xz \
                     port:zlib

--- a/lang/python39/Portfile
+++ b/lang/python39/Portfile
@@ -2,11 +2,13 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup openssl 1.0
 
 name                python39
 
 # Remember to keep py39-tkinter and py39-gdbm's versions sync'd with this
 version             3.9.9
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang
@@ -48,7 +50,6 @@ depends_lib         port:bzip2 \
                     port:libedit \
                     port:libffi \
                     port:ncurses \
-                    path:lib/libssl.dylib:openssl \
                     port:sqlite3 \
                     port:xz \
                     port:zlib


### PR DESCRIPTION
Avoids dependency on openssl shim port by using openssl PG to directly configure builds.

Avoiding having openssl include/libs in primary prefix is useful in preventing accidental usage, e.g. when a port should be using openssl 1.1 from the isolated libexec area, but build is poorly configured and finds the shim port in the primary prefix instead.