### PR TITLE
nco: add variant esmf to replace accelerate and atlas

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 github.setup        nco nco 5.0.3
-revision            1
+revision            2
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             GPL-3
@@ -65,14 +65,7 @@ configure.args      --disable-dependency-tracking \
                     --disable-openmp
 
 if {[gcc_variant_isset] || [clang_variant_isset]} {
-    default_variants    +openmp
-}
-
-if {[variant_isset atlas]} {
-    configure.ldflags-append    -lsatlas
-} else {
-    default_variants-append     +accelerate
-    configure.ldflags-append    -lvecLibFort
+    default_variants-append +openmp
 }
 
 post-destroot {
@@ -100,12 +93,10 @@ variant mpich description {enable MPI with mpich (currently MPI is not supported
 variant openmpi description {enable MPI with openmpi (currently MPI is not supported)} {
 }
 
-variant accelerate conflicts atlas description {use Accelerate framework for LAPACK} {
-    depends_lib-append  port:vecLibFort
-}
-
-variant atlas conflicts accelerate description {use Atlas for LAPACK} {
-    depends_lib-append  port:atlas
+variant esmf description {use ESMF (Earth System Modeling Framework)} {
+    configure.args-delete   --disable-esmf
+    configure.args-append   --enable-esmf
+    depends_lib-append      port:esmf
 }
 
 livecheck.type              regex


### PR DESCRIPTION
#### Description

Variants accelerate or atlas are obsolete as either LAPACK interface would only be used in association with --enable-esmf, while --disable-esmf was set since nco v4.5.2. So they did not have any impact on the executables.

Now introducing variant esmf which sets --enable-esmf. Since package esmf already has variants accelerate and atlas, to link either libveclibFort or libsatlas, they are not needed here.

This also makes nco compile again on Monterey (without +esmf) as veclibFort does not compile yet on Monterey (https://trac.macports.org/ticket/63717)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode Command Line Tools 13.1.0.0.1.1633545042

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
