### PR TITLE
py-pep517: fix file timestamp error on Tiger

### DIFF
--- a/python/py-pep517/Portfile
+++ b/python/py-pep517/Portfile
@@ -22,6 +22,12 @@ checksums           md5 7ed0adb5f737c316e071d48d66329a5d \
 
 python.versions     36 37 38 39 310
 
+# ValueError: ZIP does not support timestamps before 1980
+platform darwin 8 {
+    extract.post_args "| ${prefix}/bin/gnutar --no-same-owner -xf -"
+    depends_extract port:gnutar
+}
+
 if {$subport ne $name} {
     python.pep517   yes
     python.add_dependencies no


### PR DESCRIPTION
#### Description

Same underlying issue as #12975; for whatever reason stock `gnutar` does not properly decode timestamps in the source archive, leading to a build error. Tested through build.

See: https://trac.macports.org/ticket/63926
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
