### PR TITLE
KeePassXC: fix patch to compile on 10.7-10.9

### DIFF
--- a/security/KeePassXC/files/patch-old-mac.diff
+++ b/security/KeePassXC/files/patch-old-mac.diff
@@ -33,7 +33,7 @@ error: property 'button' not found on object of type 'NSStatusItem *'
  //
  - (bool) isStatusBarDark
  {
-+#if __clang_major__ >= 9 && defined MAC_OS_X_VERSION_10_10
++#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101000
      if (@available(macOS 10.17, *)) {
          // This is an ugly hack, but I couldn't find a way to access QTrayIcon's NSStatusItem.
          NSStatusItem* dummy = [[NSStatusBar systemStatusBar] statusItemWithLength:0];
@@ -62,7 +62,7 @@ error: use of undeclared identifier 'AXIsProcessTrustedWithOptions'
 -    // Request accessibility permissions for Auto-Type type on behalf of the user
 -    NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
 -    return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));
-+#if __clang_major__ >= 9 && defined MAC_OS_X_VERSION_10_9
++#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 1090
 +    if (@available(macOS 10.15, *)) {
 +        // Request accessibility permissions for Auto-Type type on behalf of the user
 +        NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
@@ -91,7 +91,7 @@ error: unknown type name 'CGDisplayStreamRef'
  //
  - (bool) enableScreenRecording
  {
-+#if __clang_major__ >= 9 && defined MAC_OS_X_VERSION_10_8
++#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
      if (@available(macOS 10.15, *)) {
          // Request screen recording permission on macOS 10.15+
          // This is necessary to get the current window title
@@ -164,7 +164,7 @@ Subject: [PATCH] Fix compilation when osx <= 10.7
  #include <QStandardPaths>
  #include <QTimer>
  
-+#if defined MAC_OS_X_VERSION_10_8
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
  #include <CoreGraphics/CGEventSource.h>
 -
 +#endif
@@ -175,7 +175,7 @@ Subject: [PATCH] Fix compilation when osx <= 10.7
  
  bool MacUtils::isCapslockEnabled()
  {
-+#if defined MAC_OS_X_VERSION_10_8
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
      return (CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState) & kCGEventFlagMaskAlphaShift) != 0;
 +#else
 +	return false;


### PR DESCRIPTION
For now, on the official builders of 10.7 to 10.9 it still doesn't build.

I noticed the official builder of 10.9 has SDK=10.9 but it seems to
actually use 10.10 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk.

replace `defined MAC_OS_X_VERSION_*` by `MAC_OS_X_VERSION_MIN_REQUIRED >=`

thanks to jmr

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
