### PR TITLE
librsync: update to version 2.3.2

### DIFF
--- a/net/librsync/Portfile
+++ b/net/librsync/Portfile
@@ -1,10 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
 
-name                librsync
-version             0.9.7
-revision            3
+github.setup        librsync librsync 2.3.2 v
+github.tarball_from releases
+
+revision            0
 categories          net devel
 platforms           darwin
 maintainers         nomaintainer
@@ -22,34 +25,15 @@ long_description    librsync is a free software library that implements \
                     wire-compatible with rsync 2.x, and is not likely to be \
                     in the future.
 
-homepage            http://librsync.sourceforge.net/
-master_sites        sourceforge:project/librsync/librsync/${version}
+homepage            https://librsync.github.io/
 
-checksums           sha256  6633e4605662763a03bb6388529cbdfd3b11a9ec55b8845351c1bd9a92bc41d6 \
-                    rmd160  39ca29334d0efabc0ee9e4d44abbe73a7d2fe831
+checksums           sha256  ef8ce23df38d5076d25510baa2cabedffbe0af460d887d86c2413a1c2b0c676f \
+                    rmd160  cb2c372c3dc550e6b3d090f761cce8bda7db87a9 \
+                    size    194461
 
 depends_lib         port:bzip2 \
                     port:popt \
                     port:zlib
-
-# These patches have been downloaded into the MacPorts repository since it saves
-# having to fetch them from CVS.  Respectively, they can be viewed at:
-# 
-# http://librsync.cvs.sourceforge.net/librsync/librsync/doc/rdiff.1?r1=1.1&r2=1.2&view=patch
-# http://librsync.cvs.sourceforge.net/librsync/librsync/mdfour.h?r1=1.7&r2=1.8&view=patch
-# http://librsync.cvs.sourceforge.net/librsync/librsync/patch.c?r1=1.30&r2=1.31&view=patch
-patchfiles          patch-librsync__doc__rdiff.1 \
-                    patch-librsync__mdfour.h \
-                    patch-librsync__patch.c \
-                    configure.ac.patch
-
-# Needed for universal and arm64 support
-use_autoreconf      yes
-autoreconf.args     -fvi
-
-configure.cflags-append -std=gnu89
-
-configure.args      --enable-shared
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
Migrate to github repo instead of sourceforge

#### Description

Update librsync to 2.3.2; this should resolve https://trac.macports.org/ticket/63624
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->