### PR TITLE
git: update to 2.34.0

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.33.1
-revision            2
+version             2.34.0
+revision            0
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -24,13 +24,13 @@ distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}${extract.suffix} \
-                    rmd160  eb4398bfd5936af6b21531239a425e7931eda488 \
-                    sha256  e054a6e6c2b088bd1bff5f61ed9ba5aa91c9a3cd509539a4b41c5ddf02201f2f \
-                    size    6558636 \
+                    rmd160  dab824afafa6fbca972ef1f87c7328006d4ab991 \
+                    sha256  fd6cb9b26665794c61f9ca917dcf00e7c19b0c02be575ad6ba9354fa6962411f \
+                    size    6623924 \
                     git-manpages-${version}${extract.suffix} \
-                    rmd160  ce2007826a7b42277e12c491d1e25e827ba2e586 \
-                    sha256  c75219f1c9f56caad4f8eb17915e4fe34ca5e1b453773df279a2cec98205ab87 \
-                    size    494288
+                    rmd160  e7d210d988ac02f089f18da96b1dbb6ef779a4fa \
+                    sha256  47eafa3517ef5fc7a6e914ad2ee6a6e4d830a4bb6830dba13175850860492c72 \
+                    size    497252
 
 perl5.require_variant   false
 perl5.conflict_variants yes
@@ -67,7 +67,6 @@ build.args          CFLAGS="${CFLAGS}" \
                     CC=${configure.cc} \
                     prefix=${prefix} \
                     CURLDIR=${prefix} \
-                    OPENSSLDIR=${prefix} \
                     ICONVDIR=${prefix} \
                     NO_FINK=1 \
                     NO_DARWIN_PORTS=1 \
@@ -157,9 +156,9 @@ variant pcre description {Use pcre} {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}${extract.suffix} \
-                            rmd160  c64c817c1c6faf6a0328efb3a8019ee6d0396107 \
-                            sha256  6a6b8a0f064c78e0033aa4fce0520325496de019b09fff99fa82eeb472038f5c \
-                            size    1396744
+                            rmd160  882eb53f75d4056f98ba8725759b069a2d02225b \
+                            sha256  c95d838dbd4b8c28d9f00beca776c06d94031be05fa39cf33fb08ae5f0aee250 \
+                            size    1406204
 
     patchfiles-append       patch-git-subtree.html.diff
 
@@ -277,7 +276,7 @@ platform darwin 8 {
     build.args-append   CC_LD_DYNPATH=-R
 }
 
-default_variants    +doc +pcre +credential_osxkeychain +diff_highlight
+default_variants        +doc +pcre +credential_osxkeychain +diff_highlight
 
 livecheck.type          regexm
 livecheck.regex         {<span class="version">.*?(\d+\.\d+\.\d+).*?</span>}


### PR DESCRIPTION
- remove vestigal OpenSSL option missed in commit 19d2c996d32f62d24bad87f72ecbe3ed51b05875

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
