### PR TITLE
haproxy: Currently requires OpenSSL 1.1

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -1,12 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+# `haproxy` currently does not support OpenSSL 3. Therefore, now this port is
+# using OpenSSL 1.1.
+#
+# See https://trac.macports.org/ticket/6395
 PortSystem          1.0
+PortGroup           openssl 1.0
 PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                haproxy
 version             2.4.8
-revision            1
+revision            2
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
@@ -36,9 +41,8 @@ checksums           rmd160  0f508976791d5e85d00e51ba554e03b93be51c28 \
                     sha256  e3e4c1ad293bc25e8d8790cc5e45133213dda008bfd0228bf3077259b32ebaa5 \
                     size    3599555
 
-depends_lib         path:lib/libssl.dylib:openssl \
-                    port:pcre \
-                    port:zlib
+openssl.branch      1.1
+depends_lib         port:pcre port:zlib
 
 use_configure       no
 
@@ -52,6 +56,8 @@ build.target        TARGET=osx
 pre-build {
     build.args      LD="${configure.cc}"\
                     LDFLAGS="${configure.ldflags}" \
+                    SSL_INC=[openssl::include_dir] \
+                    SSL_LIB=[openssl::lib_dir] \
                     V=1 \
                     USE_LIBCRYPT=1 \
                     USE_OPENSSL=1 \


### PR DESCRIPTION
#### Description

`haproxy` currently does not support OpenSSL 3. Therefore, now this port is using OpenSSL 1.1.

See https://trac.macports.org/ticket/6395


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
@aphor
