### PR TITLE
tesseract: Update to version 4.1.3

### DIFF
--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -3,20 +3,30 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-if {${subport} in [list tesseract tesseract-training]} {
-    github.setup    tesseract-ocr tesseract 4.1.1
-    checksums       rmd160  2dd932d66b7271443ecce27359459f319a1af1a8 \
-                    sha256  5e477a1219c8a7e0dde16d2452edcd978525bea7b9cb9e1a9b3cc78e603c454b \
-                    size    1975412
-} else {
-    github.setup    tesseract-ocr tessdata  4.0.0
-    revision        0
-    checksums       rmd160  037e33f19787c2f08544bcde213eb202f73d9546 \
-                    sha256  1c36d1e521e6420ea9c8bf13d8a45f67d54fdcf6a132fa72370ae85464118b96 \
-                    size    669255785
+name                tesseract
 
-    name            tesseract
+if {${subport} in [list tesseract tesseract-training]} {
+    github.setup    tesseract-ocr tesseract 4.1.3
+    checksums       rmd160  e2037d64e5549ed0de715ef2d2b082149f3f9232 \
+                    sha256  26ea123135c3e0b4f204cd097a9d43ab4293f23425e96128df48e6da1960b40f \
+                    size    1975794
+} elseif {[variant_isset best]} {
+    github.setup    tesseract-ocr tessdata_best  4.1.0
+    checksums       rmd160  753e227df9393d064a78d3243a5bc6fdce20f73c \
+                    sha256  61e07fc0d2e52f0d1a41dc92a1542725f68ed3110f1df3bae715973cd8042851 \
+                    size    1387835400
+} elseif {[variant_isset fast]} {
+    github.setup    tesseract-ocr tessdata_fast 4.1.0
+    checksums       rmd160  8163a934780db1b80edb94e5e1df45427aa4ff23 \
+                    sha256  54d80714745d79955e7997fa0df6d3c43b1b1989179d5e64a67290a2eea8be64 \
+                    size    352218148
+} else {
+    github.setup    tesseract-ocr tessdata 4.1.0
+    checksums       rmd160  f314b4fa97b64c5bc1c8318bbfce0484d63823d2 \
+                    sha256  251c890578e37f6d829c706b7e3728c751e2b061ac57b549b14f8769137dcf0e \
+                    size    668512655
 }
+
 categories          textproc graphics pdf
 platforms           darwin
 license             Apache-2
@@ -25,26 +35,32 @@ maintainers         {mark @markemer} openmaintainer
 
 description         Open source OCR engine
 
-long_description    The Tesseract OCR engine was one of the top  3  engines in \
-                    the 1995 UNLV Accuracy test.  Between 1995 and 2006 it had \
-                    little work done on it,  but it is  probably  one  of  the \
-                    most accurate  open  source  OCR  engines  available.  The \
-                    source code will read a binary, grey or  color  image  and \
-                    output text.  A tiff reader is built  in  that  will  read \
-                    uncompressed TIFF images,  or libtiff can be added to read \
-                    compressed images.
+long_description    This package contains an OCR engine - libtesseract and a \
+                    command line program - tesseract. Tesseract 4 adds a new \
+                    neural net (LSTM) based OCR engine which is focused on line \
+                    recognition, but also still supports the legacy Tesseract \
+                    OCR engine of Tesseract 3 which works by recognizing \
+                    character patterns.
 
 if {${subport} eq ${name}} {
-    revision                2
-
     github.livecheck.regex  {(\d\.\d+(\.\d+)?(?!-rc))}
 } else {
     livecheck.type          none
 }
 
-subport ${name}-training {
-    revision                2
+if {${subport} in [list tesseract tesseract-training]} {
+    notes "To use tesseract you must also install one of its language data subports. (ex tesseract-eng)"
+}
 
+variant best conflicts fast description {Use best training data} {
+    notes-append "Legacy OCR Engine mode (--oem 0) is not supported by this variant"
+}
+
+variant fast conflicts best description {Use fast training data} {
+    notes-append "Legacy OCR Engine mode (--oem 0) is not supported by this variant"
+}
+
+subport ${name}-training {
     depends_lib-append      path:lib/pkgconfig/cairo.pc:cairo \
                             port:icu \
                             path:lib/pkgconfig/pango.pc:pango


### PR DESCRIPTION
#### Description

* Update to version 4.1.3
* Fix compilation bug on macOS 11 and 12 due to version.txt
* Add notes for tesseract build
* Add variants for the 3 types of training data available

Closes: https://trac.macports.org/ticket/41821
Closes: https://trac.macports.org/ticket/63923

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C5031d x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
