### PR TITLE
gitweb: use openssl 1.1

### DIFF
--- a/devel/gitweb/Portfile
+++ b/devel/gitweb/Portfile
@@ -2,10 +2,15 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           openssl 1.0
 PortGroup           cargo 1.0
 
+# use openssl 1.1 release
+openssl.branch      1.1
+openssl.configure   pkgconfig build_flags
+
 github.setup        yoannfleurydev gitweb 0.3.3 v
-revision            2
+revision            3
 
 description         Open the current remote git repository in your browser
 
@@ -23,10 +28,9 @@ checksums           ${distname}${extract.suffix} \
                     sha256  484b1c56973e06c2ad7b33ccdaafa8ef6fba236681c7f8cd04027738b5335cd3 \
                     size    5907311
 
-depends_build-append port:pkgconfig
+build.env-append    OPENSSL_DIR=[openssl::install_area]
 
-depends_lib-append  path:lib/libssl.dylib:openssl \
-                    port:libgit2
+depends_lib-append  port:libgit2
 
 github.tarball_from archive
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
gitweb does not work with OpenSSL 3, updating to use the OpenSSL 1.0 PortGroup. Fixes https://trac.macports.org/ticket/63959

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.5.1 20G80 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
