### PR TITLE
qgis3: update to 3_22_0

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 PortGroup           qt5     1.0
 PortGroup           active_variants 1.1
 
-github.setup        qgis QGIS 3_20_3 final-
+github.setup        qgis QGIS 3_22_0 final-
 name                qgis3
 version             [string map {_ .} ${github.version}]
 revision            5
@@ -23,9 +23,9 @@ license             GPL-2+
 
 homepage            https://www.qgis.org/
 
-checksums           rmd160  87bc5f349413a31f548c241ec9d9ba4bb1cc95a4 \
-                    sha256  42f03339831242ddea34c93fc7754906fe6285dd199c07258e77aa4f51c4eb18 \
-                    size    156715435
+checksums           rmd160  4798ad9bacf954c7db1e0f8df1f429b2f4092f11 \
+                    sha256  c26f3283e0d754fabf1413c2c746c2ac8054947e6141eb34d96a852583377bd9 \
+                    size    158206164
 
 compiler.cxx_standard  2014
 
@@ -61,7 +61,8 @@ depends_build-append \
 
 patchfiles          patch-app_info_plist_in.diff \
                     patch-CMakelists_txt.diff \
-                    patch-MacBundleMacros.cmake.diff
+                    patch-MacBundleMacros.cmake.diff \
+                    patch-SIPMacros.cmake.diff
 
 post-patch {
     reinplace -E "s|@PREFIX@|${prefix}|g" \
@@ -189,7 +190,8 @@ foreach pyver ${python_suffixes} {
                                     port:py${pyver}-six \
                                     port:py${pyver}-protobuf3
 
-            depends_build-append    port:py${pyver}-sip4
+            depends_build-append    port:py${pyver}-pyqt-builder \
+                                    port:py${pyver}-sip
 
             depends_run-append      port:py${pyver}-psycopg2 \
                                     port:py${pyver}-requests \

--- a/gis/qgis3/files/patch-SIPMacros.cmake.diff
+++ b/gis/qgis3/files/patch-SIPMacros.cmake.diff
@@ -1,0 +1,15 @@
+--- cmake/SIPMacros.cmake.old	2021-11-16 01:33:28.000000000 -0500
++++ cmake/SIPMacros.cmake	2021-11-16 01:33:53.000000000 -0500
+@@ -174,10 +174,10 @@
+   SET_PROPERTY(TARGET ${_logical_name} PROPERTY AUTOMOC OFF)
+   TARGET_INCLUDE_DIRECTORIES(${_logical_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/${_module_path}/build)
+ 
+-  IF (${SIP_VERSION_STR} VERSION_LESS 5.0.0)
++  #IF (${SIP_VERSION_STR} VERSION_LESS 5.0.0)
+     # require c++14 only -- sip breaks with newer versions due to reliance on throw(...) annotations removed in c++17
+     TARGET_COMPILE_FEATURES(${_logical_name} PRIVATE cxx_std_14)
+-  ENDIF (${SIP_VERSION_STR} VERSION_LESS 5.0.0)
++  #ENDIF (${SIP_VERSION_STR} VERSION_LESS 5.0.0)
+ 
+   SET_TARGET_PROPERTIES(${_logical_name} PROPERTIES CXX_VISIBILITY_PRESET default)
+   IF (NOT APPLE)


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

`qgis3@3_20_3` did not build for me with Python support because `sip4` does not support the latest PyQt5. This PR updates to QGIS 3_22_0, which supports SIP 6.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G103 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`? (no new lint errors)
- [x] tried existing tests with `sudo port test`? (no tests)
- [x] tried a full install with `sudo port -vst install`? (tries to run `ps`, which is not permitted)
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
