### PR TITLE
KeePassXC: add KeePassXC-devel subport & some fixes

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -8,6 +8,7 @@ PortGroup               compiler_blacklist_versions 1.0
 PortGroup               gpg_verify 1.0
 
 name                    KeePassXC
+subport                 KeePassXC-devel  {}
 categories              security aqua
 maintainers             nomaintainer
 description             KeePassXC is a cross-platform community-driven port \
@@ -20,15 +21,19 @@ platforms               darwin
 license                 GPL-2+
 license_noconflict      openssl
 
-github.setup            keepassxreboot keepassxc 2.6.6
-revision                3
-github.tarball_from     releases
-distname                keepassxc-${version}-src
-use_xz                  yes
-distfiles-append        ${distname}${extract.suffix}.sig
+if {${subport} eq ${name}} {
+    # stable
+    github.setup        keepassxreboot keepassxc 2.6.6
+    revision            4
+    github.tarball_from releases
+    distname            keepassxc-${version}-src
+    use_xz              yes
+    distfiles-append    ${distname}${extract.suffix}.sig
 
-# See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
-checksums               ${distname}${extract.suffix} \
+    conflicts           KeePassXC-devel
+
+    # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
+    checksums           ${distname}${extract.suffix} \
                         rmd160  c3933aadf16a103f3ae4a5c2150a4c298e15dbe0 \
                         sha256  3603b11ac39b289c47fac77fa150e05fd64b393d8cfdf5732dc3ef106650a4e2 \
                         size    7640532 \
@@ -37,8 +42,38 @@ checksums               ${distname}${extract.suffix} \
                         sha256  162e577f790bd254aa73db388dd91c0f34e57dac5b83ae831bc72c3c12ad00e3 \
                         size    488
 
-gpg_verify.use_gpg_verification \
+    gpg_verify.use_gpg_verification \
                         yes
+
+    patchfiles          patch-no-deployqt.diff \
+                        patch-no-findpackage-path.diff \
+                        patch-old-mac.diff
+} else {
+    # devel subport
+    github.setup        keepassxreboot keepassxc a3dc977e58470644f2acca77905285d44b22f2b8
+    set githash         [string range ${github.version} 0 6]
+    version             20211122+git${githash}
+
+    conflicts           KeePassXC
+
+    checksums           rmd160  fe1f549411cebe5f2a1366eb92d9b56c107d1e17 \
+                        sha256  e48208f3aab88b7a0a366c97f7b049bca6fce9f5f0664d636652347dbdcaf519 \
+                        size    10072744
+
+    gpg_verify.use_gpg_verification \
+                        no
+
+    depends_lib-append  port:botan
+
+    patchfiles          devel/patch-no-deployqt.diff \
+                        devel/patch-no-findpackage-path.diff \
+                        devel/patch-old-mac.diff
+
+    post-destroot {
+        ln -s ${applications_dir}/KeePassXC.app/Contents/MacOS/keepassxc-proxy \
+        ${destroot}${prefix}/bin/keepassxc-proxy
+    }
+}
 
 if {[option gpg_verify.use_gpg_verification]} {
     post-checksum {
@@ -70,10 +105,6 @@ depends_lib-append      port:argon2 \
 
 compiler.cxx_standard   2011
 
-patchfiles              patch-no-deployqt.diff \
-                        patch-no-findpackage-path.diff \
-                        patch-old-mac.diff
-
 # KeePassXC uses -fstack-protector-strong on Clang [1]. That flag is not
 # available until clang 602 [2] or upstream clang 3.5 [3]
 # [1] https://github.com/keepassxreboot/keepassxc/blob/develop/CMakeLists.txt
@@ -82,11 +113,6 @@ patchfiles              patch-no-deployqt.diff \
 # [3] https://github.com/llvm-project/clang/blob/release_34/lib/CodeGen/CodeGenModule.cpp
 #     https://github.com/llvm-project/clang/blob/release_35/lib/CodeGen/CodeGenModule.cpp
 compiler.blacklist-append {clang < 602}
-
-pre-configure {
-    reinplace "s#/usr/local/bin#${prefix}/bin#" \
-        ${worksrcpath}/CMakeLists.txt
-}
 
 configure.pre_args-append \
     -DCMAKE_INSTALL_PREFIX=${applications_dir} \

--- a/security/KeePassXC/files/devel/patch-no-deployqt.diff
+++ b/security/KeePassXC/files/devel/patch-no-deployqt.diff
@@ -1,0 +1,64 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -453,11 +453,6 @@
+ 
+ if(APPLE)
+     set(CMAKE_MACOSX_RPATH TRUE)
+-    find_program(MACDEPLOYQT_EXE macdeployqt HINTS ${Qt5_PREFIX}/bin ${Qt5_PREFIX}/tools/qt5/bin ENV PATH)
+-    if(NOT MACDEPLOYQT_EXE)
+-        message(FATAL_ERROR "macdeployqt is required to build on macOS")
+-    endif()
+-    message(STATUS "Using macdeployqt: ${MACDEPLOYQT_EXE}")
+ elseif(WIN32)
+     find_program(WINDEPLOYQT_EXE windeployqt HINTS ${Qt5_PREFIX}/bin ${Qt5_PREFIX}/tools/qt5/debug/bin ENV PATH)
+     if(NOT WINDEPLOYQT_EXE)
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -404,11 +404,6 @@
+     set(CPACK_PACKAGE_FILE_NAME "${PROGNAME}-${KEEPASSXC_VERSION}")
+     include(CPack)
+ 
+-    add_custom_command(TARGET ${PROGNAME}
+-            POST_BUILD
+-            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app 2> /dev/null
+-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+-            COMMENT "Deploying app bundle")
+ endif()
+ 
+ install(TARGETS ${PROGNAME}
+--- src/autotype/mac/CMakeLists.txt
++++ src/autotype/mac/CMakeLists.txt
+@@ -7,8 +7,8 @@
+ if(WITH_APP_BUNDLE)
+     add_custom_command(TARGET keepassxc-autotype-cocoa
+             POST_BUILD
++            COMMAND ${CMAKE_COMMAND} -E make_directory ${PLUGIN_INSTALL_DIR}
+             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libkeepassxc-autotype-cocoa.so ${PLUGIN_INSTALL_DIR}/libkeepassxc-autotype-cocoa.so
+-            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PLUGIN_INSTALL_DIR}/libkeepassxc-autotype-cocoa.so -no-plugins 2> /dev/null
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+             COMMENT "Deploying autotype plugin")
+ else()
+--- src/cli/CMakeLists.txt
++++ src/cli/CMakeLists.txt
+@@ -73,8 +73,8 @@
+     set(CLI_APP_DIR "${CMAKE_BINARY_DIR}/src/${CLI_INSTALL_DIR}")
+     add_custom_command(TARGET keepassxc-cli
+             POST_BUILD
++            COMMAND ${CMAKE_COMMAND} -E make_directory ${CLI_APP_DIR}
+             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/keepassxc-cli ${CLI_APP_DIR}/keepassxc-cli
+-            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${CLI_APP_DIR}/keepassxc-cli -no-plugins 2> /dev/null
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+             COMMENT "Deploying keepassxc-cli")
+ endif()
+--- src/proxy/CMakeLists.txt
++++ src/proxy/CMakeLists.txt
+@@ -33,8 +33,8 @@
+         set(PROXY_APP_DIR "${CMAKE_BINARY_DIR}/src/${PROXY_INSTALL_DIR}")
+         add_custom_command(TARGET keepassxc-proxy
+                 POST_BUILD
++                COMMAND ${CMAKE_COMMAND} -E make_directory ${PROXY_APP_DIR}
+                 COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/keepassxc-proxy ${PROXY_APP_DIR}/keepassxc-proxy
+-                COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PROXY_APP_DIR}/keepassxc-proxy -no-plugins 2> /dev/null
+                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+                 COMMENT "Deploying keepassxc-proxy")
+     endif()

--- a/security/KeePassXC/files/devel/patch-no-findpackage-path.diff
+++ b/security/KeePassXC/files/devel/patch-no-findpackage-path.diff
@@ -1,0 +1,22 @@
+Fixes: https://trac.macports.org/ticket/61740
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -424,16 +424,8 @@
+ if(UNIX AND NOT APPLE)
+     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} DBus X11Extras REQUIRED)
+ elseif(APPLE)
+-    find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED HINTS
+-            /usr/local/opt/qt/lib/cmake
+-            /usr/local/Cellar/qt/*/lib/cmake
+-            /opt/homebrew/opt/qt/lib/cmake
+-            ENV PATH)
+-    find_package(Qt5 COMPONENTS MacExtras HINTS
+-            /usr/local/opt/qt/lib/cmake
+-            /usr/local/Cellar/qt/*/lib/cmake
+-            /opt/homebrew/opt/qt/lib/cmake
+-            ENV PATH)
++    find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED)
++    find_package(Qt5 COMPONENTS MacExtras)
+ else()
+     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED)
+ endif()

--- a/security/KeePassXC/files/devel/patch-old-mac.diff
+++ b/security/KeePassXC/files/devel/patch-old-mac.diff
@@ -1,0 +1,355 @@
+From 0bc9890ba149037cd8385619ba121939edb63f9b Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Thu, 11 Nov 2021 08:50:21 +0100
+Subject: [PATCH 1/6] fix compilation on macOS with clang < 9
+
+The code uses @available syntax which is new in clang 9
+This prevents compilation on older version of macOS that don't
+use this version. For example on El Capitan.
+This fix will allow to compile on such older systems.
+---
+ src/gui/osutils/macutils/AppKitImpl.mm | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/gui/osutils/macutils/AppKitImpl.mm b/src/gui/osutils/macutils/AppKitImpl.mm
+index 76fe7fe06d..ddbe2ad5b9 100644
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
+@@ -139,6 +139,7 @@ - (bool) isDarkMode
+ //
+ - (bool) isStatusBarDark
+ {
++#if __clang_major__ >= 9
+     if (@available(macOS 10.17, *)) {
+         // This is an ugly hack, but I couldn't find a way to access QTrayIcon's NSStatusItem.
+         NSStatusItem* dummy = [[NSStatusBar systemStatusBar] statusItemWithLength:0];
+@@ -146,6 +147,7 @@ - (bool) isStatusBarDark
+         [[NSStatusBar systemStatusBar] removeStatusItem:dummy];
+         return [appearance containsString:@"dark"];
+     }
++#endif
+ 
+     return [self isDarkMode];
+ }
+@@ -176,6 +178,7 @@ - (bool) enableAccessibility
+ //
+ - (bool) enableScreenRecording
+ {
++#if __clang_major__ >= 9
+     if (@available(macOS 10.15, *)) {
+         // Request screen recording permission on macOS 10.15+
+         // This is necessary to get the current window title
+@@ -193,6 +196,7 @@ - (bool) enableScreenRecording
+             return NO;
+         }
+     }
++#endif
+     return YES;
+ }
+ 
+
+From 202b05d81076e34a0d1938851e6187555f59cb96 Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Thu, 11 Nov 2021 08:58:49 +0100
+Subject: [PATCH 2/6] fix compilation on Qt not having
+ QOperatingSystemVersion::MacOSBigSur
+
+The code uses 'QOperatingSystemVersion::MacOSBigSur' which doesn't exist
+in all Qt versions (it has been backported to Qt 5.12.10+ & 5.15.1+ only).
+On older macos systems like El Capitan the last supported
+version of Qt is 5.11
+
+This will fix compilation issue on such older systems and on systems
+running with Qt not supporting QOperatingSystemVersion::MacOSBigSur
+
+Compilation error was:
+error: no member named 'MacOSBigSur' in 'QOperatingSystemVersion'
+---
+ src/gui/styles/base/BaseStyle.cpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/gui/styles/base/BaseStyle.cpp b/src/gui/styles/base/BaseStyle.cpp
+index 0068943b43..ec3fd9b8ac 100644
+--- src/gui/styles/base/BaseStyle.cpp
++++ src/gui/styles/base/BaseStyle.cpp
+@@ -41,8 +41,10 @@
+ 
+ #ifdef Q_OS_MACOS
+ #include <QMainWindow>
++#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
+ #include <QOperatingSystemVersion>
+ #endif
++#endif
+ 
+ #include "gui/Icons.h"
+ 
+@@ -279,16 +281,22 @@ namespace Phantom
+ #ifdef Q_OS_MACOS
+             QColor tabBarBase(const QPalette& pal)
+             {
++#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 10) && QT_VERSION < QT_VERSION_CHECK(5, 13, 0)                               \
++    || QT_VERSION >= QT_VERSION_CHECK(5, 15, 1)
+                 if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur) {
+                     return hack_isLightPalette(pal) ? QRgb(0xD4D4D4) : QRgb(0x2A2A2A);
+                 }
++#endif
+                 return hack_isLightPalette(pal) ? QRgb(0xDD1D1D1) : QRgb(0x252525);
+             }
+             QColor tabBarBaseInactive(const QPalette& pal)
+             {
++#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 10) && QT_VERSION < QT_VERSION_CHECK(5, 13, 0)                               \
++    || QT_VERSION >= QT_VERSION_CHECK(5, 15, 1)
+                 if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur) {
+                     return hack_isLightPalette(pal) ? QRgb(0xF5F5F5) : QRgb(0x2D2D2D);
+                 }
++#endif
+                 return hack_isLightPalette(pal) ? QRgb(0xF4F4F4) : QRgb(0x282828);
+             }
+ #endif
+
+From 15bd8e3b22be3040b5f44d83dfeb553c7640b8c4 Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Sun, 14 Nov 2021 10:13:39 +0100
+Subject: [PATCH 3/6] Fix compilation when osx <= 10.9
+
+* AppKitImpl.mm: button property is new in 10.10. It is used for a feature of KeePassXC
+  that is only available from 10.17 onwards. So we don't need it when compiling on <= 10.9
+error: property 'button' not found on object of type 'NSStatusItem *'
+        NSString* appearance = [dummy.button.effectiveAppearance.name lowercaseString];
+                                      ^
+---
+ src/gui/osutils/macutils/AppKitImpl.mm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/gui/osutils/macutils/AppKitImpl.mm b/src/gui/osutils/macutils/AppKitImpl.mm
+index ddbe2ad5b9..52d328e241 100644
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
+@@ -139,7 +139,7 @@ - (bool) isDarkMode
+ //
+ - (bool) isStatusBarDark
+ {
+-#if __clang_major__ >= 9
++#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101000
+     if (@available(macOS 10.17, *)) {
+         // This is an ugly hack, but I couldn't find a way to access QTrayIcon's NSStatusItem.
+         NSStatusItem* dummy = [[NSStatusBar systemStatusBar] statusItemWithLength:0];
+
+From 8b0027dd1ed1243754ea77f3e6b0b2c3b65a0db1 Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Sun, 14 Nov 2021 14:47:50 +0100
+Subject: [PATCH 4/6] Fix compilation when osx <= 10.8
+
+* AppKitImpl.mm: AXIsProcessTrustedWithOptions exists from 10.9 onwards
+error: use of undeclared identifier 'kAXTrustedCheckOptionPrompt'
+error: use of undeclared identifier 'AXIsProcessTrustedWithOptions'
+---
+ src/gui/osutils/macutils/AppKitImpl.mm | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/gui/osutils/macutils/AppKitImpl.mm b/src/gui/osutils/macutils/AppKitImpl.mm
+index 52d328e241..77450b1636 100644
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
+@@ -168,9 +168,15 @@ - (void) userSwitchHandler:(NSNotification*) notification
+ //
+ - (bool) enableAccessibility
+ {
+-    // Request accessibility permissions for Auto-Type type on behalf of the user
+-    NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
+-    return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));
++#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 1090
++    if (@available(macOS 10.9, *)) {
++        // Request accessibility permissions for Auto-Type type on behalf of the user
++        NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
++        return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));
++    }
++#else
++    return YES;
++#endif
+ }
+ 
+ //
+
+From 57dfd7e603a693603dd1439afcd0308187f2aaf2 Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Sun, 14 Nov 2021 15:40:41 +0100
+Subject: [PATCH 5/6] Fix compilation when osx <= 10.7
+
+* MacUtils.cpp: CoreGraphics exists from 10.8 onwards only, capslock detection feature
+  would have to be implemented on OSX <= 10.7
+
+* AppKitImpl.mm: CGDisplayStreamRef exists from 10.8 onwards only. It is used for a
+  feature of KeePassXC that is only available from 10.15 onwards. So we don't need it
+  when compiling on <= 10.7
+error: unknown type name 'CGDisplayStreamRef'
+
+* AppKitImpl.mm: Syntax is not understood by 10.7, update it to be understandable by <= 10.7
+error: expected method to read dictionary element not found on object of type 'NSDictionary *'
+    NSRunningApplication* app = userInfo[NSWorkspaceApplicationKey];
+                                ^
+---
+ src/gui/osutils/macutils/AppKitImpl.mm | 4 ++--
+ src/gui/osutils/macutils/MacUtils.cpp  | 7 +++++++
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/src/gui/osutils/macutils/AppKitImpl.mm b/src/gui/osutils/macutils/AppKitImpl.mm
+index 77450b1636..b3ee9fc5d9 100644
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
+@@ -60,7 +60,7 @@ - (id) initWithObject:(AppKit*)appkit
+ - (void) didDeactivateApplicationObserver:(NSNotification*) notification
+ {
+     NSDictionary* userInfo = notification.userInfo;
+-    NSRunningApplication* app = userInfo[NSWorkspaceApplicationKey];
++    NSRunningApplication* app = [userInfo objectForKey:NSWorkspaceApplicationKey];
+ 
+     if (app.processIdentifier != [self ownProcessId]) {
+         self.lastActiveApplication = app;
+@@ -184,7 +184,7 @@ - (bool) enableAccessibility
+ //
+ - (bool) enableScreenRecording
+ {
+-#if __clang_major__ >= 9
++#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
+     if (@available(macOS 10.15, *)) {
+         // Request screen recording permission on macOS 10.15+
+         // This is necessary to get the current window title
+diff --git a/src/gui/osutils/macutils/MacUtils.cpp b/src/gui/osutils/macutils/MacUtils.cpp
+index 6e4b478bfc..5b47516034 100644
+--- src/gui/osutils/macutils/MacUtils.cpp
++++ src/gui/osutils/macutils/MacUtils.cpp
+@@ -26,7 +26,10 @@
+ #include <QWindow>
+ 
+ #include <ApplicationServices/ApplicationServices.h>
++
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
+ #include <CoreGraphics/CGEventSource.h>
++#endif
+ 
+ #define INVALID_KEYCODE 0xFFFF
+ 
+@@ -138,7 +141,11 @@ void MacUtils::setLaunchAtStartup(bool enable)
+ 
+ bool MacUtils::isCapslockEnabled()
+ {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
+     return (CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState) & kCGEventFlagMaskAlphaShift) != 0;
++#else
++    return false;
++#endif
+ }
+ 
+ /**
+
+From 6b51d7296a75e67865e726d1b29eb1b97ef4df53 Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Mon, 15 Nov 2021 01:00:31 +0100
+Subject: [PATCH 6/6] Fix compilation error on OS X 10.11
+
+src/core/Alloc.cpp:44:10: error: no type named 'free' in namespace 'std'
+    std::free(ptr);
+    ~~~~~^
+
+This is a regression, since it was fixed in [1]
+
+Per [2], std::free() needs #include <cstdlib>. That file is included
+indirectly on newer systems.
+
+[1] https://github.com/keepassxreboot/keepassxc/commit/7c6c027d33b06eb706f93e3d178a2305d7bcfd56
+[2] https://en.cppreference.com/w/cpp/memory/c/free
+---
+ src/core/Alloc.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/core/Alloc.cpp b/src/core/Alloc.cpp
+index 266f2a3861..b9ae09221a 100644
+--- src/core/Alloc.cpp
++++ src/core/Alloc.cpp
+@@ -16,6 +16,7 @@
+  */
+ 
+ #include <botan/mem_ops.h>
++#include <cstdlib>
+ #if defined(Q_OS_MACOS)
+ #include <malloc/malloc.h>
+ #elif defined(Q_OS_FREEBSD)
+
+From f024f18c71dd6f285d5106ded3dbeca7b648d133 Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Mon, 22 Nov 2021 09:25:12 +0100
+Subject: [PATCH] fix compilation on older macs
+
+These methods are only available from macOS 10.15
+  - kSecAccessControlWatch
+  - LAPolicy.deviceOwnerAuthenticationWithBiometricsOrWatch
+---
+ src/touchid/TouchID.mm | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/src/touchid/TouchID.mm b/src/touchid/TouchID.mm
+index a2cefecf..283c33ed 100644
+--- src/touchid/TouchID.mm
++++ src/touchid/TouchID.mm
+@@ -95,18 +95,24 @@ bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKe
+     // prepare adding secure entry to the macOS KeyChain
+     CFErrorRef error = NULL;
+     SecAccessControlRef sacObject;
++#if __clang_major__ >= 9
+     if (@available(macOS 10.15, *)) {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+         // kSecAccessControlWatch is only available for macOS 10.15 and later
+         sacObject = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                                     kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                                                     kSecAccessControlOr | kSecAccessControlBiometryCurrentSet | kSecAccessControlWatch,
+                                                     &error);
++#endif
+     } else {
++#endif
+         sacObject = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                                     kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                                                     kSecAccessControlTouchIDCurrentSet, // depr: kSecAccessControlBiometryCurrentSet,
+                                                     &error);
++#if __clang_major__ >= 9
+     }
++#endif
+
+
+     if (sacObject == NULL || error != NULL) {
+@@ -234,11 +240,17 @@ bool TouchID::isAvailable()
+         LAContext* context = [[LAContext alloc] init];
+
+         LAPolicy policyCode;
++#if __clang_major__ >= 9
+         if (@available(macOS 10.15, *)) {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometricsOrWatch;
++#endif
+         } else {
++#endif
+             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
++#if __clang_major__ >= 9
+         }
++#endif
+
+         bool canAuthenticate = [context canEvaluatePolicy:policyCode error:nil];
+         [context release];
+@@ -274,11 +286,17 @@ bool TouchID::authenticate(const QString& message) const
+         NSString* authMessage = msg.toNSString(); // autoreleased
+
+         LAPolicy policyCode;
++#if __clang_major__ >= 9
+         if (@available(macOS 10.15, *)) {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometricsOrWatch;
++#endif
+         } else {
++#endif
+             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
++#if __clang_major__ >= 9
+         }
++#endif
+
+         [context evaluatePolicy:policyCode
+                 localizedReason:authMessage reply:^(BOOL success, NSError* error) {

--- a/security/KeePassXC/files/patch-no-findpackage-path.diff
+++ b/security/KeePassXC/files/patch-no-findpackage-path.diff
@@ -1,3 +1,4 @@
+Fixes: https://trac.macports.org/ticket/61740
 --- CMakeLists.txt
 +++ CMakeLists.txt
 @@ -402,8 +402,8 @@

--- a/security/KeePassXC/files/patch-old-mac.diff
+++ b/security/KeePassXC/files/patch-old-mac.diff
@@ -63,7 +63,7 @@ error: use of undeclared identifier 'AXIsProcessTrustedWithOptions'
 -    NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
 -    return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));
 +#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 1090
-+    if (@available(macOS 10.15, *)) {
++    if (@available(macOS 10.9, *)) {
 +        // Request accessibility permissions for Auto-Type type on behalf of the user
 +        NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
 +        return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));


### PR DESCRIPTION
* remove obsolete reinsplace statement
* app KeePassXC-devel subport
* fix typo in patch-old-mac.diff

KeePassXC-devel requires botan >= 2.11. For now macports has v2.10 but PR https://github.com/macports/macports-ports/pull/12965 updates botan to 2.18.2

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
