### PR TITLE
ace: version update to 7.0.5

### DIFF
--- a/devel/ace/Portfile
+++ b/devel/ace/Portfile
@@ -1,11 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        DOCGroup ACE_TAO ACE+TAO-7_0_5
+github.tarball_from releases
 
 name                ace
 set name_package    ACE
-version             6.5.2
-revision            1
+version             7.0.5
+revision            0
 distname            ${name_package}-${version}
 categories          devel
 maintainers         {gmail.com:tlockhart1976 @lockhart} {remedy.nl:jwillemsen @jwillemsen} openmaintainer
@@ -27,7 +31,6 @@ long_description    The ADAPTIVE Communication Environment (ACE) is a freely ava
 conflicts           tao
 
 homepage            https://www.dre.vanderbilt.edu/~schmidt/ACE.html
-master_sites        https://download.dre.vanderbilt.edu/previous_versions
 
 universal_variant   yes
 
@@ -39,11 +42,11 @@ patchfiles          patch-ace-config.h.diff \
                     patch-include-makeinclude-platform_macros.GNU.diff \
                     patch-archflags.diff
 
-checksums           rmd160  20c75a6e764d4896f946e35350c1b579c6537c07 \
-                    sha256  f0393d6df25ee92e0cbc6539c68ccf122caae0ffd5ae9a786163403bb2306cc5 \
-                    size    8074873
+checksums           rmd160  7154f78548c105c99e23c3b9445326dfc78cf360 \
+                    sha256  438bf41e184a5262e2b79f95edb6fd8384fb7ea69e249c54e75daf059a8d9757 \
+                    size    8286805
 
-set os.name "highsierra"
+set os.name "mojave"
 array set os.names {
      7  panther
      8  tiger


### PR DESCRIPTION
#### Description

Version update to 6.5.15, it's now compiles fine under 12.0.1 and 11.6.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 x86-64
Xcode 13.1

macOS 12.0.1 x86-64
Xcode 13.1

macOS 10.13.6 x86-64
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
