### PR TITLE
nodejs16/17: link against system zlib

### DIFF
--- a/devel/nodejs16/Portfile
+++ b/devel/nodejs16/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs16
 version                 16.13.0
-revision                1
+revision                2
 
 categories              devel net
 platforms               darwin
@@ -44,7 +44,8 @@ set py_ver              3.9
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 depends_lib-append      port:python${py_ver_nodot} \
-                        path:lib/libssl.dylib:openssl
+                        path:lib/libssl.dylib:openssl \
+                        port:zlib
 
 # TODO: when icu is upgraded to v68.x, use MacPorts'.
 #depends_lib-append             port:icu
@@ -96,12 +97,24 @@ post-patch {
     }
 }
 
+pre-configure {
+    # Copy zlib headers here because we do not want to prepend the entire
+    # ${prefix}/include to the include path (the build will then attempt to use
+    # ICU 67 headers)
+    file mkdir ${workpath}/zlib-inc
+    file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
+        ${workpath}/zlib-inc/
+}
+
 configure.args-append   --without-npm
 # TODO: when icu is upgraded to v68.x, use MacPorts'.
 # configure.args-append   --with-intl=system-icu
 configure.args-append   --shared-openssl
 configure.args-append   --shared-openssl-includes=${prefix}/include/openssl
 configure.args-append   --shared-openssl-libpath=${prefix}/lib
+configure.args-append   --shared-zlib
+configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
+configure.args-append   --shared-zlib-libpath=${prefix}/lib
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64 arm64

--- a/devel/nodejs17/Portfile
+++ b/devel/nodejs17/Portfile
@@ -12,6 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs17
 version                 17.1.0
+revision                1
 
 categories              devel net
 platforms               darwin
@@ -42,7 +43,8 @@ depends_build-append    port:pkgconfig
 set py_ver              3.9
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
-depends_lib-append      port:python${py_ver_nodot}
+depends_lib-append      port:python${py_ver_nodot} \
+                        port:zlib
 
 # TODO: when icu is upgraded to v68.x, use MacPorts'.
 #depends_lib-append             port:icu
@@ -91,9 +93,21 @@ post-patch {
     }
 }
 
+pre-configure {
+    # Copy zlib headers here because we do not want to prepend the entire
+    # ${prefix}/include to the include path (the build will then attempt to use
+    # ICU 67 headers)
+    file mkdir ${workpath}/zlib-inc
+    file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
+        ${workpath}/zlib-inc/
+}
+
 configure.args-append   --without-npm
 # TODO: when icu is upgraded to v68.x, use MacPorts'.
 # configure.args-append   --with-intl=system-icu
+configure.args-append   --shared-zlib
+configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
+configure.args-append   --shared-zlib-libpath=${prefix}/lib
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64 arm64


### PR DESCRIPTION
#### Description

Fixes https://trac.macports.org/ticket/63774

My guess is that some code from Node's variant of zlib is getting optimised incorrectly with the new Apple Clang version, but I did not look into it much. Normally we link against system libs anyway, and this fixes the issue we are having.

Also there are more opportunties for system lib linking:

* brotli
* c-ares
* http-parser
* libuv
* nghttp2
* nghttp3 (no port yet)
* ngtcp2 (no port yet)

Only bumping these two versions as these are the versions supported around the time of Monterey's release and only Monterey is affected by the zlib static code issue.

- nodejs16: link against system zlib
- nodejs17: link against system zlib

Revbump is to force a rebuild for those affected (and unfortunately those who aren't, but I have never seen `revision` used conditionally).

I do not know how far back the patch should go if we decide to patch nodejs15 and before that. However, linking against system libs is still seen as an improvement.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
