### PR TITLE
hugo: update to 0.89.3

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.89.2 v
+go.setup            github.com/gohugoio/hugo 0.89.3 v
 revision            0
-checksums           rmd160  0a887df773484f408ac11295dbc3254eaf8231af \
-                    sha256  cc89d4a993bdaff6795f0e3a32880a99b918c88b3ea0fd0b0f6a35762c732338 \
-                    size    37375627
+checksums           rmd160  2ac5a6e3a092b3fd15a071d86fc50215700d71ca \
+                    sha256  1c83b51fcb5eaf6fa5743f3bb79330a6fcab765c5a994f69553f8a327019f759 \
+                    size    37377063
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.89.3

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
