### PR TITLE
py-aubio: fix build on macOS before Mavericks

### DIFF
--- a/python/py-aubio/Portfile
+++ b/python/py-aubio/Portfile
@@ -26,11 +26,18 @@ python.versions     37 38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-pip \
                     port:py${python.version}-setuptools
 
     depends_lib-append \
                     port:py${python.version}-numpy
+
+    # macOS 10.8 (Mountain Lion, darwin 12) or below requires fftw-3
+    if {${os.platform} eq "darwin" && ${os.major} < 13} {
+        depends_lib-append \
+                    port:fftw-3-single
+
+        patchfiles  fftw3-setup.py.patch
+    }
 
     livecheck.type  none
 }

--- a/python/py-aubio/files/fftw3-setup.py.patch
+++ b/python/py-aubio/files/fftw3-setup.py.patch
@@ -1,0 +1,25 @@
+diff --git python/lib/moresetuptools.py python/lib/moresetuptools.py
+index f639ae88..274b11b7 100644
+--- python/lib/moresetuptools.py
++++ python/lib/moresetuptools.py
+@@ -111,7 +111,6 @@ def add_external_deps(ext, usedouble = False):
+     # add accelerate on darwin
+     if sys.platform.startswith('darwin'):
+         ext.extra_link_args += ['-framework', 'Accelerate']
+-        ext.define_macros += [('HAVE_ACCELERATE', 1)]
+         ext.define_macros += [('HAVE_SOURCE_APPLE_AUDIO', 1)]
+         ext.define_macros += [('HAVE_SINK_APPLE_AUDIO', 1)]
+ 
+diff --git setup.py setup.py
+index 88f8f070..1eb82da7 100755
+--- setup.py
++++ setup.py
+@@ -17,7 +17,7 @@ __aubio_version__ = get_aubio_version()
+ 
+ include_dirs = []
+ library_dirs = []
+-define_macros = [('AUBIO_VERSION', '%s' % __aubio_version__)]
++define_macros = [('HAVE_FFTW3F', '1'), ('AUBIO_VERSION', '%s' % __aubio_version__)]
+ extra_link_args = []
+ 
+ include_dirs += ['python/ext']


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->