### PR TITLE
google-cloud-sdk: update to 365.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             364.0.0
+version             365.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  ebb81a74737b1f7880ecc0831b2391ee9691a34c \
-                    sha256  21810b6b9d8bdb47aea6ed491f02cbc9d71366309abab77037f93d67c45efa6b \
-                    size    96853090
+    checksums       rmd160  1b9011809b0053ed803fa52ebf7c097ee466bd4a \
+                    sha256  ce776030bd83d6e6a27ec89fffddad61ede8a55f51c30fec3869c335be9dc5ea \
+                    size    96973278
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  246bfafae8f3a4b94aee36142a80698f352dc110 \
-                    sha256  14265ce00c477150daebe2c76a38ef8e17177682ddd4a23707c756d0e6bf525c \
-                    size    93119170
+    checksums       rmd160  a17ef559e9b256098dc3cb3196fe38ebaedb4446 \
+                    sha256  9e05d06a5067361d3c47866d293ee23c2e9d87f2fb505b6cf39a535910bb4810 \
+                    size    93239956
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  8997272a5ad986d3ffe86492a4a9443fdd9e8ca7 \
-                    sha256  b55748f87d9240d49fc857f71439e43f2d67e1f97329316af5c388dad2a1e552 \
-                    size    93046563
+    checksums       rmd160  17f5459127e8471d48ebd1244d29040ef3865851 \
+                    sha256  477886b3a4fe7444bd3aa89afdd1b7d39977dea09699bd8b8b8a884cbc49e9e5 \
+                    size    93164660
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 365.0.0.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?