### PR TITLE
beets: switch to python 3.10, part 1

### DIFF
--- a/python/py-about-time/Portfile
+++ b/python/py-about-time/Portfile
@@ -22,15 +22,23 @@ checksums           rmd160  b41aa6f357b20e0ea6923f48cd23a474a9d33063 \
                     sha256  586b329450c9387d1ae8c42d2db4f5b4c57a54508d0f1b7bb00322ffd5ce9f9b \
                     size    11029
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
+    depends_test-append \
+                    port:py${python.version}-pytest
+
     post-destroot {
         file delete -force ${destroot}/${python.prefix}/LICENSE
     }
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target     tests
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-acoustid/Portfile
+++ b/python/py-acoustid/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  eab4ff70a8681b538625e4de65f845b26664e270 \
                     sha256  c279d9c30a7f481f1420fc37db65833b5f9816cd364dc2acaa93a11c482d4141 \
                     size    15869
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-alive-progress/Portfile
+++ b/python/py-alive-progress/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  35d110802b8624be11d364a2936da0eb03ccc109 \
                     sha256  c418ccbf9b900b25b156db3978e9e2bc740c6c7f1db470da323b7f6c33808d68 \
                     size    97374
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -32,9 +32,17 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-about-time \
                     port:py${python.version}-grapheme
 
+    depends_test-append \
+                    port:py${python.version}-pytest
+
     post-destroot {
         file delete -force ${destroot}/${python.prefix}/LICENSE
     }
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target     tests
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-aubio/Portfile
+++ b/python/py-aubio/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  27d2b00ff798c284e7b071edd560e520bbf525bc \
                     sha256  df1244f6c4cf5bea382c8c2d35aa43bc31f4cf631fe325ae3992c219546a4202 \
                     size    479008
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-audioread/Portfile
+++ b/python/py-audioread/Portfile
@@ -12,7 +12,7 @@ categories-append   audio
 platforms           darwin
 supported_archs     noarch
 license             MIT
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         cross-library (GStreamer + Core Audio + MAD + FFmpeg)\
                     audio decoding for Python.
@@ -29,7 +29,7 @@ checksums           rmd160  a04cd24d3250b85d752dd559d7ef044b718e8d64 \
                     sha256  31106314b4953eb931ccf1dce747e72afd30f39fb638ecf388f4674e353785c3 \
                     size    111815
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-beautifulsoup4/Portfile
+++ b/python/py-beautifulsoup4/Portfile
@@ -10,7 +10,7 @@ revision            0
 categories-append   textproc
 license             MIT
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 supported_archs     noarch
 description         Python HTML/XML parser
 long_description    Beautiful Soup is a Python HTML/XML parser designed for \
@@ -22,7 +22,7 @@ checksums           rmd160  7eeacbc454924c5ef06ab965fea80a185c7a555b \
 
 homepage            https://www.crummy.com/software/BeautifulSoup/
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     if {${python.version} < 36} {
@@ -63,6 +63,8 @@ if {${name} ne ${subport}} {
     }
 
     default_variants    +html5lib +lxml
+
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-blinker/Portfile
+++ b/python/py-blinker/Portfile
@@ -26,7 +26,7 @@ checksums           sha256  471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466
                     rmd160  54a649ae37e54924ebfe75149c3d19b0d25aa1a4 \
                     size    111476
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     livecheck.type  none

--- a/python/py-bottlenose/Portfile
+++ b/python/py-bottlenose/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  a63666b30af5051546576052616836e4a0b9e9ee \
                     sha256  a4e356eac8c7998091f82f70c30239a99de83729b199e4e053ce3c9acb592df3 \
                     size    116538
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-cached-property/Portfile
+++ b/python/py-cached-property/Portfile
@@ -9,7 +9,7 @@ revision            0
 
 categories-append   devel
 license             BSD
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 platforms           darwin
 supported_archs     noarch
 
@@ -22,7 +22,7 @@ checksums           rmd160  6e71b64b85916848204c38187573c500b87b9b2c \
                     sha256  9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130 \
                     size    12244
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${subport} ne ${name}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-confuse/Portfile
+++ b/python/py-confuse/Portfile
@@ -24,7 +24,7 @@ maintainers         {@catap korins.ky:kirill} openmaintainer
 checksums           rmd160  3146cb35edda54698699705a2c378a8aa6d527f3 \
                     sha256  d60104c0b2a708041ac27487fa6ee69bd37d910549659c7ba92f52cbe2ced4dc \
                     size    45780
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -32,6 +32,12 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-yaml
+
+    test.run        yes
+    test.cmd        ${python.bin}
+    test.args       -m unittest discover
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-country/Portfile
+++ b/python/py-country/Portfile
@@ -11,7 +11,7 @@ revision            0
 platforms           darwin
 supported_archs     noarch
 license             LGPL-2.1
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         ISO country, subdivision, language, currency and script definitions and their translations
 long_description    {*}${description}.
@@ -22,7 +22,7 @@ checksums           rmd160  945eb071b7769061343ed9f43b5388452ed457a5 \
                     sha256  81084a53d3454344c0292deebc20fcd0a1488c136d4900312cbd465cf552cb42 \
                     size    10137217
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {

--- a/python/py-discogs-client/Portfile
+++ b/python/py-discogs-client/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  a06935ba7b98d1f49b86fa426a336738640a6819 \
                     sha256  89e35ee23c43401d065d118d4be8d8b76214c8cc6c3e78bd4b9b45992258b1fe \
                     size    32604
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -35,6 +35,8 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-dateutil \
                     port:py${python.version}-oauthlib \
                     port:py${python.version}-requests
+
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-flask-cors/Portfile
+++ b/python/py-flask-cors/Portfile
@@ -33,7 +33,7 @@ checksums           rmd160  b2bdad9a93050c23bf63742cf3df512866a7d350 \
                     sha256  adf86ec2566ddae75819c5a69d0ca8f8b4e6b589899e7df6cab9726ed1b7897d \
                     size    31016
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-flask/Portfile
+++ b/python/py-flask/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-flask
-version             1.1.2
+version             1.1.4
 revision            0
-checksums           rmd160  b28143a7f4f5c9b99e34f45dce277320765073d9 \
-                    sha256  4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060 \
-                    size    637516
+checksums           rmd160  03b23def022b1cf6afdcae01cb840f4623288c43 \
+                    sha256  0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196 \
+                    size    635920
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             BSD

--- a/python/py-fonttools/Portfile
+++ b/python/py-fonttools/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  a5332a7fcbd7b6596ca79c0ecba08e03582f7355 \
                     sha256  8c8f84131bf04f3b1dcf99b9763cec35c347164ab6ad006e18d2f99fcab05529 \
                     size    4532250
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     use_zip         yes

--- a/python/py-fonttools/files/fonttools-310
+++ b/python/py-fonttools/files/fonttools-310
@@ -1,0 +1,5 @@
+bin/fonttools-3.10
+bin/pyftmerge-3.10
+bin/pyftsubset-3.10
+bin/ttx-3.10
+${frameworks_dir}/Python.framework/Versions/3.10/share/man/man1/ttx.1

--- a/python/py-grapheme/Portfile
+++ b/python/py-grapheme/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  1997cabe5c3b15bd1b3699c521e158528d1fad7b \
                     sha256  44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca \
                     size    207306
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-html5lib/Portfile
+++ b/python/py-html5lib/Portfile
@@ -12,7 +12,7 @@ categories-append   textproc devel
 license             Permissive
 platforms           darwin
 supported_archs     noarch
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         Library for working with HTML documents
 long_description    A Python implementation of a HTML parser based on the \
@@ -23,7 +23,7 @@ checksums           rmd160  11c51e956d700383e5e57e401d76f8ceb98b07e8 \
                     sha256  2a57d32c2061305c1fa8de9a228d3659ff75126ccd91f31e21bebd7124a5de4c \
                     size    257986
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ibroadcast/Portfile
+++ b/python/py-ibroadcast/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  3ca6c526c19105dd38b093219f5c21c6b2a382ba \
                     sha256  12693b9bd8c65c9ec04fb639491da2bd53a8b254156d880410d5458903b72da2 \
                     size    12762
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ifaddr/Portfile
+++ b/python/py-ifaddr/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  b524efab1ae747efdba26a5a98bd8b84fa4e055d \
                     sha256  1f9e8a6ca6f16db5a37d3356f07b6e52344f6f9f7e806d618537731669eb1a94 \
                     size    9281
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-itsdangerous/Portfile
+++ b/python/py-itsdangerous/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-itsdangerous
 version             1.1.0
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -23,8 +23,6 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools
 
     test.run        yes
-    test.cmd        ${python.bin} tests.py
-    test.target
 
     livecheck.type  none
 }

--- a/python/py-jellyfish/Portfile
+++ b/python/py-jellyfish/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jellyfish
-version             0.8.2
+version             0.8.9
 revision            0
 
 platforms           darwin
 license             BSD
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         A library for doing approximate and phonetic matching\
                     of strings.
@@ -17,11 +17,11 @@ long_description    {*}${description}
 
 homepage            http://github.com/jamesturk/jellyfish
 
-checksums           rmd160  7d368c6ca64f9542599b977e8f44495228b3a985 \
-                    sha256  a499741401512d05bbd3556e448e960bc908eba3879fb73d450e8e91566a030b \
-                    size    134200
+checksums           rmd160  5d8b2b587d3e6163c6c5d08a756f233982490344 \
+                    sha256  90d25e8f5971ebbcf56f216ff5bb65d6466572b78908c88c47ab588d4ea436c2 \
+                    size    137296
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -30,14 +30,10 @@ if {${name} ne ${subport}} {
     depends_test-append \
                     port:py${python.version}-pytest
 
-    pre-test {
-        test.env-append \
-                    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
     test.run        yes
     test.cmd        py.test-${python.branch}
-    test.target     jellyfish/test.py
+    test.target     ${worksrcpath}/build/lib*/jellyfish/test.py
+    test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-jsonpath-rw/Portfile
+++ b/python/py-jsonpath-rw/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  a7071db0a51a94e97868c03d50098ae022022a41 \
                     sha256  05c471281c45ae113f6103d1268ec7a4831a2e96aa80de45edc89b11fac4fbec \
                     size    13814
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-jwt/Portfile
+++ b/python/py-jwt/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-jwt
 python.rootname     PyJWT
-version             2.1.0
+version             2.3.0
 revision            0
 
 categories-append   security
@@ -19,15 +19,18 @@ long_description    {*}${description}
 
 homepage            https://github.com/jpadilla/pyjwt
 
-checksums           rmd160  3aaf0f2fe2ed6f6faed1ec9bd3900baff27bb1ae \
-                    sha256  fba44e7898bbca160a2b2b501f492824fc8382485d3a6f11ba5d0c1937ce6130 \
-                    size    60092
+checksums           rmd160  c862a165978caaa8a28ec56658fec189bae2d043 \
+                    sha256  b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41 \
+                    size    62279
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    depends_test-append \
+                    port:py${python.version}-pytest
 
     # legacy support
     if {${python.version} eq 27} {
@@ -44,6 +47,11 @@ if {${name} ne ${subport}} {
         notes-append \
             "This is a legacy version of ${python.rootname} for Python ${python.version}."
     }
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target     tests
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-langdetect/Portfile
+++ b/python/py-langdetect/Portfile
@@ -23,14 +23,17 @@ checksums           rmd160 58d714ce38b2de2db4a11837bd7db62a24d9fe55 \
                     sha256 cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0 \
                     size   981474
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
 
     depends_build-append \
-                        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
 
-    depends_run-append  port:py${python.version}-six
+    depends_run-append \
+                    port:py${python.version}-six
 
-    livecheck.type      none
+    test.run        yes
+
+    livecheck.type  none
 }

--- a/python/py-last/Portfile
+++ b/python/py-last/Portfile
@@ -24,13 +24,18 @@ checksums           rmd160  6fc3f5261372945fb2d10b4d0bf266da02620446 \
                     sha256  71fd876e3753009bd10ea55b3f8f7c5d68591ee18a4127d257fc4a418010aa5c \
                     size    43760
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
-    depends_build-append  \
+    depends_build-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm \
                     port:py${python.version}-setuptools_scm_git_archive
+
+    depends_test-append \
+                    port:py${python.version}-flaky
+
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-mediafile/Portfile
+++ b/python/py-mediafile/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  e9ca78e61b3604b5460a3ea3e361371fac4bfe4b \
                     sha256  878ccc378b77f2d6c175abea135ea25631f28c722e01e1a051924d962ebea165 \
                     size    551910
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -34,6 +34,12 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-six \
                     port:py${python.version}-mutagen
+
+    test.run        yes
+    test.cmd        ${python.bin}
+    test.args       -m unittest discover
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-mpd2/Portfile
+++ b/python/py-mpd2/Portfile
@@ -24,11 +24,17 @@ checksums           rmd160  4186a1d487d9cf3b46878bab7d98f1002a15ca07 \
                     sha256  7a67834e22d97e7cd77f8951c8baf87c149285c67d67d73550ce034302561ae5 \
                     size    57445
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    test.run        yes
+    test.cmd        ${python.bin}
+    test.args       -m unittest discover
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-munkres/Portfile
+++ b/python/py-munkres/Portfile
@@ -28,11 +28,13 @@ checksums           rmd160  d91c3ef91bb5e023b0cdd4716cbf9fe75821b2f2 \
                     sha256  fc44bf3c3979dada4b6b633ddeeb8ffbe8388ee9409e4d4e8310c2da1792db03 \
                     size    14047
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-musicbrainzngs/Portfile
+++ b/python/py-musicbrainzngs/Portfile
@@ -24,11 +24,13 @@ checksums           rmd160  81735f581536f9b6ffaa5606b53732d29c7cc24e \
                     sha256  ab1c0100fd0b305852e65f2ed4113c6de12e68afd55186987b8ed97e0f98e627 \
                     size    117469
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-oauthlib/Portfile
+++ b/python/py-oauthlib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-oauthlib
-version             3.1.0
+version             3.1.1
 revision            0
 
 categories-append   net security
@@ -21,11 +21,11 @@ homepage            https://github.com/oauthlib/oauthlib
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  9f860862bed7fda84d53f2882cef33dc15133dc8 \
-                    sha256  bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889 \
-                    size    155362
+checksums           rmd160  1ee81d217311e971298be031730cc72a5dc4bafd \
+                    sha256  8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3 \
+                    size    161395
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-rarfile/Portfile
+++ b/python/py-rarfile/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  2be283cfabc9c6dc57735f773c858dbe2fd01e32 \
                     sha256  67548769229c5bda0827c1663dce3f54644f9dbfba4ae86d4da2b2afd3e602a1 \
                     size    148026
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -31,6 +31,13 @@ if {${name} ne ${subport}} {
 
     depends_run-append \
                     port:unrar
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-reflink/Portfile
+++ b/python/py-reflink/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  59ff15dd3f67016c3b509f9c24517dda60595c5b \
                     sha256  c9253582db24413bfd703abfc1b2a49de78f31b4907239f286e9a1929a1e6e3a \
                     size    14638
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     # Backport https://gitlab.com/rubdos/pyreflink/-/merge_requests/10

--- a/python/py-requests-oauthlib/Portfile
+++ b/python/py-requests-oauthlib/Portfile
@@ -10,7 +10,7 @@ categories-append   devel net
 platforms           darwin
 supported_archs     noarch
 license             ISC
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         OAuth for Humans
 long_description    ${description}: an easy-to-use Python interface for building \
@@ -20,7 +20,7 @@ checksums           rmd160  8f6a80350eb0dd2a336fa3c7565a3a7865c6e858 \
                     sha256  1bbea903af00869f60e975e8a645108b70923aaf3c29d9477226d5181cd90e04 \
                     size    45436
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -29,6 +29,8 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-requests \
                     port:py${python.version}-oauthlib
+
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-soco/Portfile
+++ b/python/py-soco/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  34b0187994f6a0a1dc6da66b62840e326a50d97e \
                     sha256  d8e5fd7dbae72decc1a0a414d00971bbb89d35eaacb08e0844f110f456427bcc \
                     size    712408
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -32,6 +32,11 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-ifaddr \
                     port:py${python.version}-requests \
                     port:py${python.version}-xmltodict
+
+    depends_test-append \
+                    port:py${python.version}-wheel
+
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-termplotlib/Portfile
+++ b/python/py-termplotlib/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  003e6303c82d8e68dfa7363c1bc99b4717c1d0e3 \
                     sha256  c04cbd67ac61753eac9162a99cbe87c379d4c5daf720af1df55f4423c094203e \
                     size    24517
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 python.pep517       yes
 

--- a/python/py-termtables/Portfile
+++ b/python/py-termtables/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  231b9706fe44b08d097e4bdb69cf3c534dc266c1 \
                     sha256  797c6afeb78abdab97cd5bfbbd2fc1bfbd9630052699dc881b27b334bcc6a73f \
                     size    17745
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 python.pep517       yes
 

--- a/python/py-ttfquery/Portfile
+++ b/python/py-ttfquery/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  fe4f7f20d218c59e41e9085851680978787e4686 \
                     sha256  18e18eb03c18ea7dd08ed1b369adfd55c3815e34b69c9e321659b0c9f5576e44 \
                     size    18434
 
-python.versions     27 37 38 39
+python.versions     27 37 38 39 310
 
 if {$subport ne $name} {
     depends_build-append \

--- a/python/py-unicodedata2/Portfile
+++ b/python/py-unicodedata2/Portfile
@@ -18,11 +18,18 @@ checksums           rmd160  db6df91022fe12560732e22a06472c49e98f2840 \
                     sha256  a83e504fb0e8ed4757194e61c3f7b69fb3c914856057bea968d0950f80f947fa \
                     size    1137398
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
+
+    if {${python.version} >= 310} {
+        # Backported https://github.com/fonttools/unicodedata2/pull/49
+        patchfiles      patch-unicodedata2-py3-unicodedata.c
+    }
+
+    test.run            yes
 
     livecheck.type      none
 }

--- a/python/py-unicodedata2/files/patch-unicodedata2-py3-unicodedata.c
+++ b/python/py-unicodedata2/files/patch-unicodedata2-py3-unicodedata.c
@@ -1,0 +1,15 @@
+--- unicodedata2/py3/unicodedata.c.orig	2020-03-20 18:40:50 UTC
++++ unicodedata2/py3/unicodedata.c
+@@ -16,7 +16,12 @@
+ #define PY_SSIZE_T_CLEAN
+ 
+ #include "Python.h"
++#if PY_MINOR_VERSION < 10
+ #include "ucnhash.h"
++#else
++#define Py_BUILD_CORE
++#include "internal/pycore_ucnhash.h"
++#endif
+ #include "structmember.h"
+ #include "unicodectype.h"
+ 

--- a/python/py-xdg/Portfile
+++ b/python/py-xdg/Portfile
@@ -32,7 +32,7 @@ checksums       sha256  80bd93aae5ed82435f20462ea0208fb198d8eec262e831ee06ce9ddb
                 rmd160  d17da0fb4fb7a0af8d66b07821dea4d25fae64a6 \
                 size    59753
 
-python.versions 27 35 36 37 38 39
+python.versions 27 35 36 37 38 39 310
 
 
 if {${name} ne ${subport}} {

--- a/python/py-xmltodict/Portfile
+++ b/python/py-xmltodict/Portfile
@@ -25,18 +25,18 @@ checksums           rmd160  937e519c77a0289eea28c646179be0e1e785d853 \
                     sha256  50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21 \
                     size    18481
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
     depends_test-append \
-                    port:py${python.version}-nose
+                    port:py${python.version}-pytest
 
     test.run        yes
-    test.cmd        nosetests-${python.branch}
-    test.target
+    test.cmd        py.test-${python.branch}
+    test.target     tests
     test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {

--- a/python/py-zbar/Portfile
+++ b/python/py-zbar/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  e863508491e4237c91d5c3ea8c1d79f601a9a630 \
                     sha256  ce49f08ad1ede72cf8d9df43de83be7cfda54df9da9bd77cc027cc3a58c05036 \
                     size    41545
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -31,6 +31,8 @@ if {${name} ne ${subport}} {
     depends_run-append \
                     port:py${python.version}-Pillow \
                     port:zbar
+
+    test.run        yes
 
     livecheck.type  none
 }

--- a/python/py-zopfli/Portfile
+++ b/python/py-zopfli/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-zopfli
-version             0.1.7
+version             0.1.9
 revision            0
 
 platforms           darwin
 license             Apache-2
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         Zopfli module for python
 long_description    ${description}
@@ -17,15 +17,19 @@ long_description    ${description}
 homepage            https://github.com/obp/py-zopfli
 use_zip             yes
 
-checksums           rmd160  ef2fe2fe2129550270f144cdbff79886225f3268 \
-                    sha256  512892714f0e3dcc9a77222cb509ed519f41ce2b92467e47a4b406a23b48561a \
-                    size    75709
+checksums           rmd160  515dcab9846387ccf4725a8c0fdaf6938816c7b2 \
+                    sha256  78de3cc08a8efaa8013d61528907d91ac4d6cc014ffd8a41cc10ee75e9e60d7b \
+                    size    79873
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
+
+python.pep517       yes
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-wheel \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-setuptools_scm
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]


### PR DESCRIPTION
#### Description

Here the first part of switching beets to python 3.10; it adds to all required python modules py310 subports.

<!--
Beets 1.5.0 was released before Python 3.10, but it haven't got any issue, and current master can run on Python 3.10 without any errors.

Because I haven't use all its plugin, some of them can be broken and switching to Python 3.10 seems as good opportune to test it and fix it :)
-->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->