### PR TITLE
MenuMeters: patch to build 2.1.6.1 on 10.15 and below

### DIFF
--- a/aqua/MenuMeters/Portfile
+++ b/aqua/MenuMeters/Portfile
@@ -18,19 +18,12 @@ long_description    The MenuMeters monitors are true SystemUIServer plugins     
                     using command-drag and remember their positions in the menubar  \
                     across logins and restarts.
 
-if {${os.major} >= 20} {
-    github.setup    yujitach MenuMeters 2.1.6.1
-    revision        0
-    checksums       rmd160  d2e666567655456b19579fc618c84ba30acec872 \
-                    sha256  2dde435032cced14e60d4f98dadb25208cd7d9c338f524f1ed1eb71096ecd19e \
-                    size    1541706
-} else {
-    github.setup    yujitach MenuMeters 2.1.5
-    revision        0
-    checksums       rmd160  132cac3ddf41a778e0d62dfbbcd10a37bb037e30 \
-                    sha256  ef27af706b22e1acef014a69b13b2b672aafe07f664048c3462bf68beaef0947 \
-                    size    1541639
-}
+
+github.setup    yujitach MenuMeters 2.1.6.1
+revision        0
+checksums       rmd160  d2e666567655456b19579fc618c84ba30acec872 \
+                sha256  2dde435032cced14e60d4f98dadb25208cd7d9c338f524f1ed1eb71096ecd19e \
+                size    1541706
 
 if {${os.major} < 15} {
     known_fail      yes
@@ -39,6 +32,8 @@ if {${os.major} < 15} {
         return -code error "incompatible macOS version"
     }
 }
+
+patchfiles          patch-bc.diff
 
 xcode.configuration Release
 xcode.target        "${name} No Sparkle"

--- a/aqua/MenuMeters/files/patch-bc.diff
+++ b/aqua/MenuMeters/files/patch-bc.diff
@@ -1,0 +1,111 @@
+diff --git MenuMetersMenuExtraBase.m MenuMetersMenuExtraBase.m
+index 19b1d89..ed1b1e1 100644
+--- MenuMetersMenuExtraBase.m
++++ MenuMetersMenuExtraBase.m
+@@ -114,16 +114,20 @@
+     if([ourPrefs loadBoolPref:bundleID defaultValue:YES]){
+         if(!statusItem){
+             statusItem=[[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
++#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101600)
+             if(@available(macOS 11,*)){
+                 // 11.0.1 does not keep the position unless autosaveName is explicitly set,
+                 // see https://github.com/feedback-assistant/reports/issues/151 .
+                 // This is done here in order not to lose positions on pre-macOS 11 systems.
+                 statusItem.autosaveName=self.bundleID;
+             }
++#endif
++#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101200)
+             if(@available(macOS 10.12,*)){
+                 statusItem.behavior=NSStatusItemBehaviorRemovalAllowed;
+                 [statusItem addObserver:self forKeyPath:@"visible" options:NSKeyValueObservingOptionNew context:nil];
+             }
++#endif
+             statusItem.menu = self.menu;
+             statusItem.menu.delegate = self;
+             /*
+@@ -222,27 +226,30 @@
+ }
+ -(BOOL)isDark
+ {
++#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101400)
+     if(@available(macOS 10.14,*)){
+         // https://github.com/ruiaureliano/macOS-Appearance/blob/master/Appearance/Source/AppDelegate.swift
+         return [statusItem.button.effectiveAppearance.name containsString:@"ark"];
+-    }else{
+-        // https://stackoverflow.com/questions/25207077/how-to-detect-if-os-x-is-in-dark-mode
+-        // On 10.10 there is no documented API for theme, so we'll guess a couple of different ways.
+-        BOOL isDark = NO;
+-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+-        [defaults synchronize];
+-        NSString *interfaceStyle = [defaults stringForKey:@"AppleInterfaceStyle"];
+-        if (interfaceStyle && [interfaceStyle isEqualToString:@"Dark"]) {
+-            isDark = YES;
+-        }
+-        return isDark;
+     }
++#endif
++    // https://stackoverflow.com/questions/25207077/how-to-detect-if-os-x-is-in-dark-mode
++    // On 10.10 there is no documented API for theme, so we'll guess a couple of different ways.
++    BOOL isDark = NO;
++    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
++    [defaults synchronize];
++    NSString *interfaceStyle = [defaults stringForKey:@"AppleInterfaceStyle"];
++    if (interfaceStyle && [interfaceStyle isEqualToString:@"Dark"]) {
++        isDark = YES;
++    }
++    return isDark;
+ }
+ -(NSColor*)menuBarTextColor
+ {
++#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101400)
+     if(@available(macOS 10.14,*)){
+         return [NSColor labelColor];
+     }
++#endif
+     if (self.isDark){
+         return [NSColor whiteColor];
+     }
+@@ -258,9 +265,11 @@
+     return height;
+ }
+ - (void)setupAppearance {
++#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101400)
+     if(@available(macOS 10.14,*)){
+         [NSAppearance setCurrentAppearance:statusItem.button.effectiveAppearance];
+     }
++#endif
+ }
+ #pragma mark NSMenuDelegate
+ - (void)menuNeedsUpdate:(NSMenu*)menu {
+diff --git PrefPane/MenuMetersPref.m PrefPane/MenuMetersPref.m
+index 115e9de..ea2bdb4 100644
+--- PrefPane/MenuMetersPref.m
++++ PrefPane/MenuMetersPref.m
+@@ -166,6 +166,7 @@ static void scChangeCallback(SCDynamicStoreRef store, CFArrayRef changedKeys, vo
+     }
+     [self setupSparkleUI];
+ 
++#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101600)
+ 	if (@available(macOS 10.16, *)) {
+ 		NSToolbar *toolbar = [NSToolbar new];
+ 		toolbar.delegate = self;
+@@ -177,6 +178,7 @@ static void scChangeCallback(SCDynamicStoreRef store, CFArrayRef changedKeys, vo
+ 		[self.window.toolbar setSelectedItemIdentifier:selectedIdentifier];
+ 		prefTabs.delegate = self;
+ 	}
++#endif
+ }
+ 
+ - (NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar {
+@@ -203,9 +205,11 @@ static void scChangeCallback(SCDynamicStoreRef store, CFArrayRef changedKeys, vo
+ 	item.paletteLabel = tabItem.label;
+ 	item.label = tabItem.label;
+ 	item.action = @selector(toolbarSelection:);
++#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101600)
+ 	if (@available(macOS 10.16, *)) {
+ 		item.image = [NSImage imageWithSystemSymbolName:itemIdent accessibilityDescription:@""];
+ 	}
++#endif
+ 	return item;
+ }
+ 


### PR DESCRIPTION
#### Description

Use compile-time macros to block unknown symbols on older SDKs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
