### PR TITLE
openrct2: use correct version of objects

### DIFF
--- a/games/openrct2/Portfile
+++ b/games/openrct2/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        OpenRCT2 OpenRCT2 0.3.5 v
 github.tarball_from archive
 name                openrct2
-revision            0
+revision            1
 
 categories          games
 platforms           darwin
@@ -24,7 +24,7 @@ use_zip             yes
 
 set main_distfile       ${distfiles}
 
-set objects_version     1.2.2
+set objects_version     1.0.21
 set objects_distfile    objects-${objects_version}${extract.suffix}
 set objects_mastersite  https://github.com/${github.author}/objects/releases/download/v${objects_version}/objects${extract.suffix}?dummy=
 
@@ -45,9 +45,9 @@ checksums           ${main_distfile} \
                     sha256  8490c0bf93c2aea00435885b995f63d978aeea1acbb10753b6f2864b9adbc1a6 \
                     size    16377028 \
                     ${objects_distfile} \
-                    rmd160  698ffcf5795e924ff441fe97a7af9b65ac8e92fd \
-                    sha256  2c77023068831c68423eb51f96251d1a06f58253414e4563ca17407d654ed96b \
-                    size    3383537 \
+                    rmd160  1f826ad19c5c42a3706b1796702882298b3a3e64 \
+                    sha256  b081f885311f9afebc41d9dd4a68b7db4cf736eb815c04e307e1a426f08cfa35 \
+                    size    3159059 \
                     ${ts_distfile} \
                     rmd160  a0d44e1790a67e7400927fe567aa4814403ea5ee \
                     sha256  5284333fa501270835b5f0cf420cb52155742335f5658d7889ea35d136b52517 \

--- a/games/openrct2/Portfile
+++ b/games/openrct2/Portfile
@@ -55,12 +55,12 @@ checksums           ${main_distfile} \
 
 patchfiles          patch-jsonfwd-hpp.diff
 
-# requires 10.11 or newer at present
-# see https://trac.macports.org/ticket/55591
-if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+# requires 10.15 or newer at present due to use of C++17 filesystem header
+# (nlohmann-json uses it)
+if { ${os.platform} eq "darwin" && ${os.major} < 19 } {
     known_fail      yes
     pre-fetch {
-        ui_error "${name} requires OS X 10.11 or later"
+        ui_error "${name} requires macOS 10.15 or later"
         return -code error "incompatible OS version"
     }
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
