### PR TITLE
qca-qt5: fix build on macOS 10.7-10.11

### DIFF
--- a/devel/qca/Portfile
+++ b/devel/qca/Portfile
@@ -61,7 +61,7 @@ switch ${Qt_Major} {
         }
         patchfiles-append \
                         patch-qca-ossl.diff \
-                        patch-unique_ptr.diff \
+                        patch-missing-headers.diff \
                         qt5/patch-qca210-qt550.diff \
                         qt5/patch-support-older-qt5.diff
         configure.args-append \

--- a/devel/qca/files/patch-missing-headers.diff
+++ b/devel/qca/files/patch-missing-headers.diff
@@ -50,3 +50,16 @@ index 9c81746844f9d8543f7e9eff8603662f495d7a1e..aa8c1dd78eac220278834f0ff340f26e
  
  #include <openssl/err.h>
  #include <openssl/opensslv.h>
+diff --git a/src/qca_default.cpp b/src/qca_default.cpp
+index 294b90565e50c493da36eb6a5ba998fe2cb48645..7c017d7d0a3d49ee85dd58bd2eaefc387ba5d784 100644
+--- a/src/qca_default.cpp
++++ b/src/qca_default.cpp
+@@ -30,6 +30,8 @@
+ #include "qca_systemstore.h"
+ #endif
+ 
++#include <cstdlib>
++
+ #define FRIENDLY_NAMES
+ 
+ namespace QCA {

--- a/devel/qca/files/qt5/patch-support-older-qt5.diff
+++ b/devel/qca/files/qt5/patch-support-older-qt5.diff
@@ -13,10 +13,24 @@ index 6e290245cb9d4c7b6a208dbe245aab3105f4fd0a..ffaeaf43d6d8da08084dabe9a6498274
  
  set(CMAKE_AUTOMOC ON)
 diff --git a/plugins/qca-gnupg/gpgaction.cpp b/plugins/qca-gnupg/gpgaction.cpp
-index c739dd1a7f63c18fe68f256ac91622299460215e..22efab0d2a0171da55173269d4a785d36cc2d501 100644
+index c739dd1a7f63c18fe68f256ac91622299460215e..314659dec708a5367a28ac69bec520ec000136e2 100644
 --- a/plugins/qca-gnupg/gpgaction.cpp
 +++ b/plugins/qca-gnupg/gpgaction.cpp
-@@ -586,6 +586,12 @@ void GpgAction::processStatusLine(const QString &line)
+@@ -35,7 +35,13 @@ static QDateTime getTimestamp(const QString &s)
+     if (s.contains(QLatin1Char('T'))) {
+         return QDateTime::fromString(s, Qt::ISODate);
+     } else {
++#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+         return QDateTime::fromSecsSinceEpoch(s.toInt());
++#else
++        QDateTime dt;
++        dt.setTime_t(s.toInt());
++        return dt;
++#endif
+     }
+ }
+ 
+@@ -586,6 +592,12 @@ void GpgAction::processStatusLine(const QString &line)
      QString s, rest;
      s = nextArg(line, &rest);
  
@@ -29,7 +43,7 @@ index c739dd1a7f63c18fe68f256ac91622299460215e..22efab0d2a0171da55173269d4a785d3
      if (s == QLatin1String("NODATA")) {
          // only set this if it'll make it better
          if (curError == GpgOp::ErrorUnknown)
-@@ -665,12 +671,12 @@ void GpgAction::processStatusLine(const QString &line)
+@@ -665,12 +677,12 @@ void GpgAction::processStatusLine(const QString &line)
          output.verifyResult = GpgOp::VerifyBad;
      } else if (s == QLatin1String("ERRSIG")) {
          output.wasSigned       = true;
@@ -256,3 +270,223 @@ index a94d15cc4db598d42b6d6d884be9a6186d27e76c..c4b6812034f50e6206d83e3d292df60c
      QCOMPARE(testString, QStringLiteral("4000000000000-40000000000002000000000000\n"));
  
      // Botan's addition tests
+diff --git a/src/qca_default.cpp b/src/qca_default.cpp
+index 294b90565e50c493da36eb6a5ba998fe2cb48645..5c8b7c3e113f7f2f7cb9151f5b4b8464e388b8f0 100644
+--- a/src/qca_default.cpp
++++ b/src/qca_default.cpp
+@@ -1250,7 +1250,12 @@ public:
+     {
+         const QDateTime now = QDateTime::currentDateTime();
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+         uint t = now.toSecsSinceEpoch();
++#else
++        // implementation from v2.2.1:
++        uint t = now.toTime_t();
++#endif
+         if (now.time().msec() > 0)
+             t /= now.time().msec();
+         std::srand(t);
+diff --git a/src/support/logger.cpp b/src/support/logger.cpp
+index cda4ee46b8a83c2a341135320c7ea7437c6eba82..bdd22d008664102a2ea0946563572d141e44aa26 100644
+--- a/src/support/logger.cpp
++++ b/src/support/logger.cpp
+@@ -20,6 +20,19 @@
+ 
+ #include "qca_support.h"
+ 
++#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
++namespace QtPrivate {
++template <typename T> struct QAddConst { typedef const T Type; };
++}
++
++// this adds const to non-const objects (like std::as_const)
++template <typename T>
++Q_DECL_CONSTEXPR typename QtPrivate::QAddConst<T>::Type &qAsConst(T &t) Q_DECL_NOTHROW { return t; }
++// prevent rvalue arguments:
++template <typename T>
++void qAsConst(const T &&) Q_DECL_EQ_DELETE;
++#endif
++
+ namespace QCA {
+ 
+ AbstractLogDevice::AbstractLogDevice(const QString &name, QObject *parent)
+diff --git a/plugins/qca-botan/qca-botan.cpp b/plugins/qca-botan/qca-botan.cpp
+index e335edbff3c4b620885cb0e8a745c98f84c4de73..51187b9b44fb868098c6d7ca9111cf89277b2e1a 100644
+--- a/plugins/qca-botan/qca-botan.cpp
++++ b/plugins/qca-botan/qca-botan.cpp
+@@ -36,6 +36,19 @@
+ #include <cstdlib>
+ #include <iostream>
+ 
++#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
++namespace QtPrivate {
++template <typename T> struct QAddConst { typedef const T Type; };
++}
++
++// this adds const to non-const objects (like std::as_const)
++template <typename T>
++Q_DECL_CONSTEXPR typename QtPrivate::QAddConst<T>::Type &qAsConst(T &t) Q_DECL_NOTHROW { return t; }
++// prevent rvalue arguments:
++template <typename T>
++void qAsConst(const T &&) Q_DECL_EQ_DELETE;
++#endif
++
+ //-----------------------------------------------------------
+ class botanRandomContext : public QCA::RandomContext
+ {
+diff --git a/plugins/qca-gnupg/gpgproc/gpgproc_p.h b/plugins/qca-gnupg/gpgproc/gpgproc_p.h
+index 7c21f251b49b7bdcd141f62608501dcc502d93ff..73ab82aa76e78f037ea928fb38f3a9c9e674a42b 100644
+--- a/plugins/qca-gnupg/gpgproc/gpgproc_p.h
++++ b/plugins/qca-gnupg/gpgproc/gpgproc_p.h
+@@ -46,11 +46,15 @@ public:
+                 &QProcessSignalRelay::proc_readyReadStandardError,
+                 Qt::QueuedConnection);
+         connect(proc, &QProcess::bytesWritten, this, &QProcessSignalRelay::proc_bytesWritten, Qt::QueuedConnection);
++#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+         connect(proc,
+                 QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+                 this,
+                 &QProcessSignalRelay::proc_finished,
+                 Qt::QueuedConnection);
++#else
++        connect(proc, SIGNAL(finished(int)), SLOT(proc_finished(int)), Qt::QueuedConnection);
++#endif
+         connect(proc, &QProcess::errorOccurred, this, &QProcessSignalRelay::proc_error, Qt::QueuedConnection);
+     }
+ 
+diff --git a/plugins/qca-ossl/qca-ossl.cpp b/plugins/qca-ossl/qca-ossl.cpp
+index 9c81746844f9d8543f7e9eff8603662f495d7a1e..74c5f49c6754b0350a3367ac90d404e4e756b2b2 100644
+--- a/plugins/qca-ossl/qca-ossl.cpp
++++ b/plugins/qca-ossl/qca-ossl.cpp
+@@ -3474,8 +3475,13 @@ public:
+         BN_free(bn);
+ 
+         // validity period
++#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+         ASN1_TIME_set(X509_get_notBefore(x), opts.notValidBefore().toSecsSinceEpoch());
+         ASN1_TIME_set(X509_get_notAfter(x), opts.notValidAfter().toSecsSinceEpoch());
++##else
++        ASN1_TIME_set(X509_get_notBefore(x), opts.notValidBefore().toTime_t());
++        ASN1_TIME_set(X509_get_notAfter(x), opts.notValidAfter().toTime_t());
++#endif
+ 
+         // public key
+         X509_set_pubkey(x, pk);
+@@ -3878,8 +3884,13 @@ public:
+         BN_free(bn);
+ 
+         // validity period
++#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+         ASN1_TIME_set(X509_get_notBefore(x), QDateTime::currentDateTimeUtc().toSecsSinceEpoch());
+         ASN1_TIME_set(X509_get_notAfter(x), notValidAfter.toSecsSinceEpoch());
++#else
++        ASN1_TIME_set(X509_get_notBefore(x), QDateTime::currentDateTimeUtc().toTime_t());
++        ASN1_TIME_set(X509_get_notAfter(x), notValidAfter.toTime_t());
++#endif
+ 
+         X509_set_pubkey(x, static_cast<const MyPKeyContext *>(req.subjectPublicKey())->get_pkey());
+         X509_set_subject_name(x, subjectName);
+diff --git a/plugins/qca-pkcs11/qca-pkcs11.cpp b/plugins/qca-pkcs11/qca-pkcs11.cpp
+index ae13bf0a3c34f87614f446ecebd32fa43976e611..3d707d5b1f1d2f1ff0e81dd9b53d48a818263960 100644
+--- a/plugins/qca-pkcs11/qca-pkcs11.cpp
++++ b/plugins/qca-pkcs11/qca-pkcs11.cpp
+@@ -1048,8 +1048,11 @@ private:
+ 
+         Certificate cert = Certificate::fromDER(QByteArray((char *)blob, blob_size));
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+         *expiration = cert.notValidAfter().toSecsSinceEpoch();
+-
++#else
++        *expiration = cert.notValidAfter().toTime_t();
++#endif
+         return TRUE; // krazy:exclude=captruefalse
+     }
+ 
+diff --git a/examples/saslclient/saslclient.cpp b/examples/saslclient/saslclient.cpp
+index 99db413c63bdbecc185e468e6357458a614c4eed..7e0613d7be8e175a0800c5b1fddb0bb23f1dc62e 100644
+--- a/examples/saslclient/saslclient.cpp
++++ b/examples/saslclient/saslclient.cpp
+@@ -152,8 +152,10 @@ public:
+         connect(sock, &QTcpSocket::readyRead, this, &ClientTest::sock_readyRead);
+ #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+         connect(sock, &QTcpSocket::errorOccurred, this, &ClientTest::sock_error);
+-#else
++#elif QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+         connect(sock, QOverload<QAbstractSocket::SocketError>::of(&QTcpSocket::error), this, &ClientTest::sock_error);
++#else
++        connect(sock, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(sock_error(QAbstractSocket::SocketError)));
+ #endif
+ 
+         sasl = new QCA::SASL(this);
+diff --git a/examples/saslserver/saslserver.cpp b/examples/saslserver/saslserver.cpp
+index 0983dc7e82e8b48769a68a9ff9db3c3721dbd26a..4cb5a8806561e6e4300db8857cee559c89519c92 100644
+--- a/examples/saslserver/saslserver.cpp
++++ b/examples/saslserver/saslserver.cpp
+@@ -183,11 +183,13 @@ public:
+         connect(sock, &QTcpSocket::readyRead, this, &ServerTestHandler::sock_readyRead);
+ #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+         connect(sock, &QTcpSocket::errorOccurred, this, &ServerTestHandler::sock_error);
+-#else
++#elif QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+         connect(sock,
+                 QOverload<QAbstractSocket::SocketError>::of(&QTcpSocket::error),
+                 this,
+                 &ServerTestHandler::sock_error);
++#else
++        connect(sock, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(sock_error(QAbstractSocket::SocketError)));
+ #endif
+         connect(sock, &QTcpSocket::bytesWritten, this, &ServerTestHandler::sock_bytesWritten);
+ 
+diff --git a/examples/sslservtest/sslservtest.cpp b/examples/sslservtest/sslservtest.cpp
+index 4e4cfd4d3b4bd7c877c442cb5a3f0f759c194823..85f203d5dcdfcd25e461b5ce20a1d55f84b71446 100644
+--- a/examples/sslservtest/sslservtest.cpp
++++ b/examples/sslservtest/sslservtest.cpp
+@@ -162,8 +162,10 @@ private Q_SLOTS:
+         connect(sock, &QTcpSocket::disconnected, this, &SecureServer::sock_disconnected);
+ #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+         connect(sock, &QTcpSocket::errorOccurred, this, &SecureServer::sock_error);
+-#else
++#elif QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+         connect(sock, QOverload<QAbstractSocket::SocketError>::of(&QTcpSocket::error), this, &SecureServer::sock_error);
++#else
++        connect(sock, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(sock_error(QAbstractSocket::SocketError)));
+ #endif
+         connect(sock, &QTcpSocket::bytesWritten, this, &SecureServer::sock_bytesWritten);
+ 
+diff --git a/examples/ssltest/ssltest.cpp b/examples/ssltest/ssltest.cpp
+index 471bd119e1fcd14aff8a1dc20a0d49ee54df770f..166faf6bbe52a515187f9f3cbc676763e9b28588 100644
+--- a/examples/ssltest/ssltest.cpp
++++ b/examples/ssltest/ssltest.cpp
+@@ -114,8 +114,10 @@ public:
+         connect(sock, &QTcpSocket::readyRead, this, &SecureTest::sock_readyRead);
+ #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+         connect(sock, &QTcpSocket::errorOccurred, this, &SecureTest::sock_error);
+-#else
++#elif QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+         connect(sock, QOverload<QAbstractSocket::SocketError>::of(&QTcpSocket::error), this, &SecureTest::sock_error);
++#else
++        connect(sock, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(sock_error(QAbstractSocket::SocketError)));
+ #endif
+ 
+         ssl = new QCA::TLS;
+diff --git a/examples/tlssocket/tlssocket.cpp b/examples/tlssocket/tlssocket.cpp
+index 9264d8939b00ab82765dae4015108c3ee2f3ee94..e711ba4c34097cce5aab57f4134b759657ebff73 100644
+--- a/examples/tlssocket/tlssocket.cpp
++++ b/examples/tlssocket/tlssocket.cpp
+@@ -50,11 +50,13 @@ public:
+         connect(sock, &QTcpSocket::bytesWritten, this, &TLSSocket::Private::sock_bytesWritten);
+ #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+         connect(sock, &QTcpSocket::errorOccurred, this, &TLSSocket::Private::sock_error);
+-#else
++#elif QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+         connect(sock,
+                 QOverload<QAbstractSocket::SocketError>::of(&QTcpSocket::error),
+                 this,
+                 &TLSSocket::Private::sock_error);
++#else
++        connect(sock, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(sock_error(QAbstractSocket::SocketError)));
+ #endif
+ 
+         tls = new QCA::TLS(this);


### PR DESCRIPTION
#### Description

Fix builds for 10.7 through 10.11.

Fixes: https://trac.macports.org/ticket/63980
Fixes: https://trac.macports.org/ticket/63983

###### Tested on
Testing on older macOS releases - at a minimum, 10.7 and 10.9 - currently in-progress. The PR description will be updated, once everything has been validated.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
