### PR TITLE
xdiskusage: remove old pre-activate

### DIFF
--- a/x11/xdiskusage/Portfile
+++ b/x11/xdiskusage/Portfile
@@ -33,11 +33,3 @@ destroot.destdir    prefix=${destroot}${prefix} mandir=${destroot}${prefix}/shar
 
 app.name            ${name}
 app.retina          yes
-
-pre-activate {
-    # xdiskusage 1.48 inadvertently installed unregistered items into ${portdbpath} due to
-    # https://github.com/macports/macports-ports/commit/aa5eb8202702b64197b438bbb9eff630bde258c5
-    # (`fltk-config --post` creates files *in the current directory*)
-    # This cleanup hack can be removed after June 2021.
-    delete ${portdbpath}/${name} ${portdbpath}/${name}.app
-}


### PR DESCRIPTION
Added in 2af3213942 over a year ago.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
