### PR TITLE
py-buildbot-macports-custom-views: remove port

### DIFF
--- a/devel/buildbot-macports-custom-views/Portfile
+++ b/devel/buildbot-macports-custom-views/Portfile
@@ -28,20 +28,3 @@ depends_build-append \
                     port:buildbot-pkg
 
 depends_run-append  port:buildbot-www
-
-# These obsolete subports can be removed after August 2021.
-set old_subports [list py-${name} py38-${name}]
-foreach old_subport ${old_subports} {
-    subport ${old_subport} {
-        PortGroup   obsolete 1.0
-        replaced_by ${name}
-        revision    1
-    }
-}
-pre-activate {
-    foreach old_subport ${old_subports} {
-        if {![catch {set installed [lindex [registry_active ${old_subport}] 0]}]} {
-            registry_deactivate_composite ${old_subport} {} [list ports_nodepcheck 1]
-        }
-    }
-}


### PR DESCRIPTION
Obsolete, replaced by `buildbot-macports-custom-views`
in 4e05d4b698 over a year ago.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
