### PR TITLE
py-pyaudio: add Python 3.10 subport

### DIFF
--- a/python/py-pyaudio/Portfile
+++ b/python/py-pyaudio/Portfile
@@ -4,58 +4,48 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-pyaudio
-set my_name             PyAudio
+python.rootname         PyAudio
 version                 0.2.11
+revision                1
+
 categories-append       audio
-platforms               darwin
 maintainers             {@Jakker NLnetLabs.nl:jaap} openmaintainer
 license                 MIT
 
 description             PyAudio provides Python bindings for PortAudio
-long_description        PyAudio provides Python bindings for PortAudio, \
-                        the cross-platform audio I/O library. With PyAudio, \
-                        you can easily use Python to play and record audio \
-                        on a variety of platforms.
+long_description        ${description}, the cross-platform audio I/O library. \
+                        With PyAudio, you can easily use Python to play and \
+                        record audio on a variety of platforms.
 
-homepage                http://people.csail.mit.edu/hubert/pyaudio/
-
-master_sites            pypi:P/PyAudio/
-
-distname                ${my_name}-${version}
+homepage                https://people.csail.mit.edu/hubert/pyaudio/
 
 checksums               rmd160  7a6bb88f56622555e77eb799e4ee74ff970b6e92 \
                         sha256  93bfde30e0b64e63a46f2fd77e85c41fd51182a4a3413d9edfaf9ffaa26efb74 \
                         size    37428
-revision                1
 
-worksrcdir              PyAudio-${version}
-
-python.versions         27 35 36 37 38 39
+python.versions         27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools \
-                        port:py${python.version}-sphinx
+                        port:py${python.version}-setuptools
 
     depends_lib-append  port:portaudio
 
     patchfiles          patch-setup.py.diff
+
     post-patch {
         reinplace "s|__PREFIX__|${prefix}|g" ${worksrcpath}/setup.py
     }
 
-    python.link_binaries no
-
     post-destroot {
-        xinstall -d ${destroot}${prefix}/share/doc/py${python.version}-pyaudio/examples
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+
         xinstall -m 0644 -W ${worksrcpath} README CHANGELOG \
-            ${destroot}${prefix}/share/doc/py${python.version}-pyaudio
+            ${destroot}${docdir}
         xinstall -m 0644 {*}[glob ${worksrcpath}/examples/*] \
-            ${destroot}${prefix}/share/doc/py${python.version}-pyaudio/examples
+            ${destroot}${docdir}/examples
     }
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
-    livecheck.name      ${my_name}
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

- 'Error: Failed to test py-pyaudio: py-pyaudio has no tests turned on.'
- No existing Trac tickets exist
- Fairly certain there aren't any binary files.