### PR TITLE
salt: clean up

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -134,16 +134,6 @@ homepage          https://saltstack.com/
         destroot.cmd-append --with-salt-version=${version}
     }
 
-pre-fetch {
-    # Setting startupitems' executable with args didn't
-    # work in MacPorts 2.6.2 and earlier. See
-    # https://github.com/macports/macports-base/pull/191
-    if {[vercmp [macports_version] 2.6.3] < 0} {
-        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
-        return -code error "incompatible MacPorts version"
-    }
-}
-
     patchfiles patch-macports_syspaths.diff
 
     post-patch {
@@ -187,22 +177,4 @@ foreach daemon ${daemons} {
         name            ${name}-${daemon} \
         logfile         ${prefix}/var/log/${name}/${daemon} \
         executable      "${prefix}/bin/${name}-${daemon} --config-dir=${prefix}/etc/${name} --pid-file=${prefix}/var/run/${name}-${daemon}.pid"
-
-    # These subports and deactivate hacks can be removed after July 2021.
-    subport ${name}-${daemon} {
-        revision        1
-        replaced_by     ${name}
-    }
-}
-pre-activate {
-    foreach daemon ${daemons} {
-        # ${name}-${daemon} <= 3000.3_0 installed plists now installed by ${name}.
-        if {![catch {set installed [lindex [registry_active ${name}-${daemon}] 0]}]} {
-            set installed_version [lindex ${installed} 1]
-            set installed_revision [lindex ${installed} 2]
-            if {([vercmp ${installed_version} 3000.3] < 0) || ([vercmp ${installed_version} 3000.3] == 0 && ${installed_revision} == 0)} {
-                registry_deactivate_composite ${name}-${daemon} {} [list ports_nodepcheck 1]
-            }
-        }
-    }
 }


### PR DESCRIPTION
Changes were made in 7b61e0d6fe over a year ago: MacPorts < 2.6.3 error, pre-activate, obsoleted subports (replaced by `salt`)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
