### PR TITLE
py-clang: Update to 13.0.0 by default

### DIFF
--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -23,7 +23,7 @@ supported_archs         noarch
 
 livecheck.url           https://api.github.com/repos/llvm/llvm-project/git/refs/tags
 # Update this to the most recent clang supported
-livecheck.version       12.0.1
+livecheck.version       13.0.0
 livecheck.regex         {llvmorg-([\d.]+)\"}
 
 if {${name} ne ${subport}} {
@@ -35,18 +35,18 @@ if {${name} ne ${subport}} {
      cfe-3.7.1.src.tar.xz \
       rmd160  185b0f75970bc50682766a21794440578db87b5d \
       sha256  56e2164c7c2a1772d5ed2a3e57485ff73ff06c97dff12edbeea1acc4412b0674 \
-     clang-11.1.0.src.tar.xz \
-      rmd160  6da46dc07e6ce8bf33c6342812e3c89498bb2b27 \
-      sha256  0a8288f065d1f57cb6d96da4d2965cbea32edc572aa972e466e954d17148558b \
      clang-12.0.1.src.tar.xz \
       rmd160  662d890fe81218fbf79c25540eb09c7664bc5b8a \
-      sha256  6e912133bcf56e9cfe6a346fa7e5c52c2cde3e4e48b7a6cc6fcc7c75047da45f
+      sha256  6e912133bcf56e9cfe6a346fa7e5c52c2cde3e4e48b7a6cc6fcc7c75047da45f \
+     clang-13.0.0.src.tar.xz \
+      rmd160  41d60ff0bfa3dbd9e4f04461db1750c2d9f50ac2 \
+      sha256  5d611cbb06cfb6626be46eb2f23d003b2b80f40182898daa54b1c4e8b5b9e17e
 
     depends_build-append    port:py${python.version}-setuptools
 
     # Keeping 37 around for old systems; otherwise two latest releases.
-    set clanglist       {37    11     12}
-    set clangvlist      {3.7.1 11.1.0 12.0.1}
+    set clanglist       {37    12     13}
+    set clangvlist      {3.7.1 12.0.1 13.0.0}
 
     foreach cvnum $clanglist {
         # Explictly use (and depend on) the libclang we select during install
@@ -90,17 +90,17 @@ if {${name} ne ${subport}} {
     test.target         -m unittest discover -v
 
     if {![variant_isset clang37] &&
-        ![variant_isset clang11] &&
-        ![variant_isset clang12]} {
-        default_variants +clang12
+        ![variant_isset clang12] &&
+        ![variant_isset clang13]} {
+        default_variants +clang13
     }
 
     pre-extract {
         # Will never hit this when installing from packages, which is OK, as
         # they will have the default variant set above.
         if {![variant_isset clang37] &&
-            ![variant_isset clang11] &&
-            ![variant_isset clang12]} {
+            ![variant_isset clang12] &&
+            ![variant_isset clang13]} {
             ui_error "At least one of the clangNN variants must be active."
             return -code error "Unsupported (no) variants selected."
         }


### PR DESCRIPTION
Maintainer update.