### PR TITLE
xca: use openssl PG, pinned to version 1.1

### DIFF
--- a/security/xca/Portfile
+++ b/security/xca/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem                  1.0
 PortGroup                   github 1.0
+PortGroup                   openssl 1.0
 PortGroup                   qt5 1.0
 
 github.setup                chris2511 xca 2.4.0 RELEASE.
-revision            1
+revision                    1
 github.tarball_from         releases
 
 categories                  security crypto
@@ -44,10 +45,11 @@ variant RemoteSQL description { Add support MySQL/MariaDB and PostgreSQL databas
                             psql-plugin
 }
 
-depends_lib-append          port:libtool \
-                            path:lib/libssl.dylib:openssl
+depends_lib-append          port:libtool
 
-configure.cppflags-append   -L${prefix}/lib
+openssl.branch              1.1
+
+configure.cppflags-append   -L[openssl::lib_dir]
 
 post-patch {
     move ${worksrcpath}/VERSION ${worksrcpath}/VERSION.txt


### PR DESCRIPTION
#### Description

Fix build issue caused by openssl 3.0

###### Type(s)

- [x] bugfix

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
