### PR TITLE
aerc: add +notmuch variant

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -5,6 +5,7 @@ PortGroup           makefile 1.0
 
 name                aerc
 version             0.5.2
+revision            1
 categories          mail
 license             MIT
 maintainers         nomaintainer
@@ -25,9 +26,13 @@ checksums           rmd160  f935c02ae5bcd37a2100e035bda451045204fa52 \
 depends_build       port:go \
                     port:scdoc
 
-depends_lib         port:notmuch
+default_variants    +notmuch
 
-build.args          GOFLAGS="-tags=notmuch"
+variant notmuch description {Enable support for notmuch integration} {
+    depends_lib         port:notmuch
+    build.args          GOFLAGS="-tags=notmuch"
+}
+
 build.target
 
 livecheck.url       https://git.sr.ht/~sircmpwn/aerc/refs


### PR DESCRIPTION
#### Description

adds the `+notmuch` variant (and enables by default to maintain current state) to support the _optional_ notmuch integration with aerc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
 Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
