### PR TITLE
py-pyside2: remove qtwebengine on arm architecture

### DIFF
--- a/python/py-pyside2/Portfile
+++ b/python/py-pyside2/Portfile
@@ -90,7 +90,6 @@ if {${name} ne ${subport}} {
         qtsvg \
         qttools \
         qtwebchannel \
-        qtwebengine \
         qtwebsockets
 
     if {[vercmp ${qt5.version} 5.6] >=0 } {
@@ -101,6 +100,13 @@ if {${name} ne ${subport}} {
     if {[vercmp ${qt5.version} 5.9] >=0 } {
         qt5.depends_component \
             qtremoteobjects
+    }
+
+    # qt5-qtwebengine is currently broken on arm64 and Monterey,
+    # see https://trac.macports.org/ticket/62059
+    if { ${os.arch} ne "arm" && ${os.arch} ne "arm64" && ${os.major} < 21 } {
+        qt5.depends_component \
+            qtwebengine
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

The port py-qtwebengine is currently broken on arm architecture (see [ticket 63725](https://trac.macports.org/ticket/63725)). This is being addressed by #12595 but the fix is still plagued with at least one arm-specific issue.

Would it make sense to remove qtwebengine from py-pyside2 _on arm targets_ while py-qtwebengine is being fixed? If so, this is what this PR attempts to do. If this is not appropriate for some reason, I'll happily close this PR.

Note: this is my first contribution attempt and it is likely that I oversaw something.


###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
