### PR TITLE
gpsd-devel: remove obsolete port

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -221,19 +221,3 @@ if {![variant_isset plot]} {
         delete "${destroot}${prefix}/share/man/man1/gpsplot.1"
     }
 }
-
-# The gpsd-devel subport is obsolete as of 04-Jan-2020.
-# Handle it last so that it can override the dependencies.
-
-subport gpsd-devel {
-
-    PortGroup           obsolete 1.0
-
-    # Copy last pre-obsolete version, with revbump
-    git.branch          a4ecde71556018f6d7a70831165169fffd0cc3a1
-    version             20190817-[string range ${git.branch} 0 7]
-    revision            1
-
-    replaced_by         gpsd
-
-}


### PR DESCRIPTION
Replaced by `gpsd` in 8eae529e86 over a year ago.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
