### PR TITLE
skaffold: update to 1.35.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.35.0 v
+github.setup        GoogleContainerTools skaffold 1.35.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  cb35232007f0b00f2d58f9f2858e5a2bf984fe59 \
-                    sha256  0ce75ba329f027c9075cfddddd8a96ca08523c772733f999e236a7913b59ea14 \
-                    size    16880561
+checksums           rmd160  7fcbd62eabb8bdebc29e13a82ff00fc169d83da0 \
+                    sha256  121936ed92f85f87a0d8697787a5fab721241490618e3fd63ffda575d64be03c \
+                    size    16882290
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.35.1.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?