### PR TITLE
gtk3-devel: add patch to improve Quartz drawing performance

### DIFF
--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -11,7 +11,7 @@ name                gtk3-devel
 conflicts           gtk3
 set my_name         gtk3
 version             3.24.30
-revision            0
+revision            1
 epoch               0
 
 set proj_name       gtk+
@@ -251,6 +251,8 @@ if {${universal_possible} && [variant_isset universal]} {
 variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo quartz
     require_active_variants path:lib/pkgconfig/pango.pc:pango quartz
+
+    patchfiles-append       patch-gdkwindow-quartz-performance.diff
 
     configure.args-append   --enable-quartz-backend
 }

--- a/gnome/gtk3-devel/files/patch-gdkwindow-quartz-performance.diff
+++ b/gnome/gtk3-devel/files/patch-gdkwindow-quartz-performance.diff
@@ -1,0 +1,90 @@
+From 243672d3e226af8f901353004cb8d063c8c3f21a Mon Sep 17 00:00:00 2001
+From: John Ralls <jralls@ceridwen.us>
+Date: Sun, 17 Oct 2021 14:53:11 -0700
+Subject: [PATCH] Use cairo_image_surfaces for most drawing.
+
+Paint to the window's CGContextRef surface only in
+gdk_window_end_paint_internal.
+
+Fixes https://gitlab.gnome.org/GNOME/gtk/-/issues/3714
+---
+ gdk/quartz/gdkwindow-quartz.c | 20 ++++++++++++++++----
+ gdk/quartz/gdkwindow-quartz.h |  2 ++
+ 2 files changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/gdk/quartz/gdkwindow-quartz.c b/gdk/quartz/gdkwindow-quartz.c
+index a5c5c31945..a1ab1e2f6d 100644
+--- gdk/quartz/gdkwindow-quartz.c
++++ gdk/quartz/gdkwindow-quartz.c
+@@ -296,11 +296,12 @@ gdk_quartz_create_cairo_surface (GdkWindowImplQuartz *impl,
+ 				 int                  width,
+ 				 int                  height)
+ {
+-  CGContextRef cg_context;
++  CGContextRef cg_context = NULL;
+   GdkQuartzCairoSurfaceData *surface_data;
+   cairo_surface_t *surface;
+
+-  cg_context = gdk_quartz_window_get_context (impl, TRUE);
++  if (impl->use_cg_context)
++    cg_context = gdk_quartz_window_get_context (impl, TRUE);
+
+   surface_data = g_new (GdkQuartzCairoSurfaceData, 1);
+   surface_data->window_impl = impl;
+@@ -310,7 +311,7 @@ gdk_quartz_create_cairo_surface (GdkWindowImplQuartz *impl,
+     surface = cairo_quartz_surface_create_for_cg_context (cg_context,
+                                                           width, height);
+   else
+-    surface = cairo_quartz_surface_create(CAIRO_FORMAT_ARGB32, width, height);
++    surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+
+   cairo_surface_set_user_data (surface, &gdk_quartz_cairo_key,
+                                surface_data,
+@@ -348,12 +349,22 @@ static void
+ gdk_window_impl_quartz_init (GdkWindowImplQuartz *impl)
+ {
+   impl->type_hint = GDK_WINDOW_TYPE_HINT_NORMAL;
++  impl->use_cg_context = FALSE;
+ }
+
+ static gboolean
+ gdk_window_impl_quartz_begin_paint (GdkWindow *window)
+ {
+-  return FALSE;
++  GdkWindowImplQuartz *impl = GDK_WINDOW_IMPL_QUARTZ (window->impl);
++  impl->use_cg_context = FALSE;
++  return TRUE;
++}
++
++static void
++gdk_window_impl_quartz_end_paint (GdkWindow *window)
++{
++  GdkWindowImplQuartz *impl = GDK_WINDOW_IMPL_QUARTZ (window->impl);
++  impl->use_cg_context = TRUE;
+ }
+
+ static void
+@@ -3084,6 +3095,7 @@ gdk_window_impl_quartz_class_init (GdkWindowImplQuartzClass *klass)
+   impl_class->get_shape = gdk_quartz_window_get_shape;
+   impl_class->get_input_shape = gdk_quartz_window_get_input_shape;
+   impl_class->begin_paint = gdk_window_impl_quartz_begin_paint;
++  impl_class->end_paint = gdk_window_impl_quartz_end_paint;
+   impl_class->get_scale_factor = gdk_quartz_window_get_scale_factor;
+
+   impl_class->focus = gdk_quartz_window_focus;
+diff --git a/gdk/quartz/gdkwindow-quartz.h b/gdk/quartz/gdkwindow-quartz.h
+index 1175f072e4..c085d5cc59 100644
+--- gdk/quartz/gdkwindow-quartz.h
++++ gdk/quartz/gdkwindow-quartz.h
+@@ -64,6 +64,8 @@ struct _GdkWindowImplQuartz
+   gint shadow_top;
+
+   gint shadow_max;
++
++  gboolean use_cg_context;
+ };
+
+ struct _GdkWindowImplQuartzClass
+--
+GitLab
+


### PR DESCRIPTION
#### Description

[This patch](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4071) is from GNOME's merge requests and is a result of the [discussion here](https://gitlab.gnome.org/GNOME/gtk/-/issues/3714).

It is not merged, but another maintainer says it looks good to merge in.

I tested this with qalculate-gtk and it makes a very significant performance difference. Without this patch, the app will just beachball probably about half the time as it waits for itself to render. With this patch applied, no beachball. Almost seamless.

This will improve GTK 3 performance within Quartz for most things, but not everything. I do not think it will break anything.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
