### PR TITLE
farbfeld: new port

### DIFF
--- a/graphics/farbfeld/Portfile
+++ b/graphics/farbfeld/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           legacysupport 1.1
+PortGroup           makefile 1.0
+
+name                farbfeld
+version             4
+revision            0
+license             ISC
+
+categories          graphics
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+description         Suckless image format with conversion tools
+long_description    ${description}
+
+homepage            https://tools.suckless.org/${name}/
+platforms           darwin
+
+master_sites        http://dl.suckless.org/farbfeld/
+
+checksums           rmd160  a67fe136a84a76a0cb99add741c9f14f5f986624 \
+                    sha256  c7df5921edd121ca5d5b1cf6fb01e430aff9b31242262e4f690d3af72ccbe72a \
+                    size    10340
+
+depends_lib-append  port:libpng \
+                    port:libjpeg-turbo
+
+legacysupport.newest_darwin_requires_legacy 10
+
+makefile.override   CC PREFIX
+
+compiler.c_standard 1999
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
#### Description
**[farbfeld](http://tools.suckless.org/farbfeld/)** is a lossless image format which is easy to parse, pipe and compress.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
