### PR TITLE
mercurial: fix zsh completion

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -10,7 +10,7 @@ name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
 version             5.9.3
-revision            0
+revision            1
 categories          devel python
 platforms           darwin
 license             GPL-2+
@@ -111,7 +111,7 @@ post-destroot {
 
     set site-functions ${destroot}${prefix}/share/zsh/site-functions
     xinstall -d ${site-functions}
-    xinstall ${worksrcpath}/contrib/zsh_completion ${site-functions}/_mercurial
+    xinstall ${worksrcpath}/contrib/zsh_completion ${site-functions}/_hg
 }
 
 post-activate {


### PR DESCRIPTION
#### Description
> Rename this file to _hg and copy it into your zsh function path.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
