### PR TITLE
jreleaser: new port

### DIFF
--- a/devel/jreleaser/Portfile
+++ b/devel/jreleaser/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+PortGroup        java 1.0
+
+name             jreleaser
+version          0.8.0
+revision         0
+                 
+categories       devel java
+license          Apache-2
+maintainers      @aalmiray
+platforms        darwin
+supported_archs  noarch
+
+description      Release projects quickly and easily with JReleaser
+long_description JReleaser is a release automation tool. Its goal is to simplify creating releases \
+                 and publishing artifacts to multiple package managers while providing customizable options. \
+                 JReleaser takes inputs from popular builds tools (Ant, Maven, Gradle) such as JAR files, binary \
+                 distributions (.zip, .tar), JLink images, or any other file that you’d like to publish as a Git \
+                 release on popular Git services such as Github or Gitlab. Distribution files can additionally be \
+                 published to be consumed by popular package managers as Homebrew, Snapcraft, or get ready to be \
+                 launched via JBang. Releases may be announced in a variety of channels such as Twitter, Zulip, or SDKMAN!
+homepage         https://jreleaser.org
+
+master_sites     https://github.com/jreleaser/jreleaser/releases/download/v${version}
+use_zip          yes
+
+checksums        rmd160 5c45d1a69f3649d9702ba07b3c61dd860d2dfcbb \
+                 sha256 be7d14d22d38e7a3fbd1a105f9d55d46afd773c9d8b0f983e6539692a042fca6 \
+                 size   22022685
+
+java.version     1.8.+
+
+use_configure    no
+
+build {}
+
+destroot {
+    set target ${destroot}${prefix}/share/java/${name}
+    
+    # Create the target java directory
+    xinstall -m 755 -d ${target}
+    
+    # Copy over the needed elements of our directory tree
+    foreach d { bin lib } {
+        copy ${worksrcpath}/${d} ${target}
+    }
+
+    # Remove extraneous bat files
+    foreach f [glob -directory ${target}/bin *.bat] {
+        delete ${f}
+    }
+    
+    ln -s ../share/java/${name}/bin/jreleaser ${destroot}${prefix}/bin/jreleaser
+}
+
+livecheck.type   regex
+livecheck.url    https://jreleaser.org/releases/latest/download/VERSION
+livecheck.regex  (\[0-9.\]+\\.\[0-9.\]+\\.\[0-9.\]+)


### PR DESCRIPTION
#### Description

JReleaser is a release automation tool. Its goal is to simplify creating releases and publishing artifacts to multiple package managers while providing customizable options.

More information can be found at ​https://jreleaser.org

###### Tested on

macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
