### PR TITLE
github CI: run on forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ on:
     paths-ignore:
       - '.github/**'
   push:
-    branches:
-      - update/*
+    branches-ignore:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Right now CI is runs only when someone is created PR.

It is quite simple to run CI inside fork's by simple allowing it.

Main repo contains only one `master` branch and I've excluded it from workflow.

Thus, you may see that this commit is started to build on my repository: https://github.com/catap/macports-ports/actions

Why? It allows to run CI without open a PR.