### PR TITLE
hugo: update to 0.89.4

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.89.3 v
+go.setup            github.com/gohugoio/hugo 0.89.4 v
 revision            0
-checksums           rmd160  2ac5a6e3a092b3fd15a071d86fc50215700d71ca \
-                    sha256  1c83b51fcb5eaf6fa5743f3bb79330a6fcab765c5a994f69553f8a327019f759 \
-                    size    37377063
+checksums           rmd160  ddc5481eb7abb0ad52efd699e40ca773755805a5 \
+                    sha256  a4b0246abc310f032b324f80983c6cb8ab4bbf3bb8b6da740b35735ae8514565 \
+                    size    37375481
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.89.4

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
