### PR TITLE
mysql56, mysql8: use MacPorts’ libedit

### DIFF
--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -12,7 +12,7 @@ set name_mysql      ${name}
 version             5.6.51
 # Set revision_client and revision_server to 0 on
 # version bump.
-set revision_client 3
+set revision_client 4
 set revision_server 1
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 categories          databases
@@ -65,6 +65,7 @@ if {$subport eq $name} {
                         size    32411131
 
     depends_lib-append  port:ncurses \
+                        port:libedit \
                         port:libevent \
                         port:tcp_wrappers \
                         port:zlib
@@ -123,6 +124,7 @@ if {$subport eq $name} {
                         -DDEFAULT_CHARSET:STRING=utf8 \
                         -DDEFAULT_COLLATION:STRING=utf8_general_ci \
                         -DWITH_EMBEDDED_SERVER:BOOL=ON \
+                        -DWITH_EDITLINE=system \
                         -DWITH_ZLIB:STRING=system \
                         -DWITH_UNIT_TESTS:BOOL=ON \
                         -DENABLE_DOWNLOADS:BOOL=OFF \

--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -16,7 +16,7 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     3
+set revision_client     4
 set revision_server     0
 
 set name_mysql          ${name}
@@ -73,6 +73,7 @@ if {$subport eq $name} {
 
     depends_lib-append  port:cyrus-sasl2 \
                         port:icu \
+                        port:libedit \
                         port:libevent \
                         port:zlib \
                         port:zstd
@@ -138,6 +139,7 @@ if {$subport eq $name} {
         -DMYSQL_UNIX_ADDR:PATH="${prefix}/var/run/${name_mysql}/mysqld.sock" \
         -DSYSCONFDIR:PATH="${prefix}/etc/${name_mysql}" \
         -DWITH_BOOST:PATH="${worksrcpath}/../${boost_distname}" \
+        -DWITH_EDITLINE=system \
         -DWITH_ICU:PATH="${prefix}" \
         -DWITH_INNODB_MEMCACHED=1 \
         -DWITH_LIBEVENT=system \


### PR DESCRIPTION
…instead of bundled libedit (as already done for `mysql57` in 38aa1a0ec8)
Fixes: https://trac.macports.org/ticket/64006

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Only configure phase is tested. I would like @laggardkernel or other knowledgable user to confirm the editline issue is resolved.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
