### PR TITLE
k9s: update to 0.25.4

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.25.3 v
+go.setup            github.com/derailed/k9s 0.25.4 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 platforms           darwin
 
-checksums           rmd160  92016af8f74314ee3492f2b0e80af3cceff54722 \
-                    sha256  1068d18d20ae66babd88f77ec00280a13f318277cadd49cda5ab506924ddade0 \
-                    size    6252490
+checksums           rmd160  1e83823618397503c664021faac06d71e2763a8d \
+                    sha256  50901c293e01ed763dc87732586af8e69dbdf3f8707106591a0b8d43e2c4cd5c \
+                    size    6254023
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

Update to k9s 0.25.4.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?