### PR TITLE
librsvg-devel: Add corrected +universal fallback

### DIFF
--- a/graphics/librsvg-devel/Portfile
+++ b/graphics/librsvg-devel/Portfile
@@ -68,7 +68,9 @@ if {[info exists librsvg.override.fallback]} {
     if {${os.platform} eq "darwin" && (
             ${os.major} < ${max_darwin_for_rust}
             || ${build_arch} eq "arm64"
+            || ${universal_possible} && [variant_isset universal] && "arm64" in ${configure.universal_archs}
             || ${build_arch} eq "i386"
+            || ${universal_possible} && [variant_isset universal] && "i386" in ${configure.universal_archs}
         )} {
         set librsvg_fallback yes
     } else {


### PR DESCRIPTION
#### Description
Expanded to check to ensure the fallback is only applied when required for +universal compiles that contain i386 or arm64.

The expanded check is the same as the one committed for https://github.com/macports/macports-ports/pull/12876 

```
sh-3.2# port destroot librsvg
--->  Computing dependencies for librsvg
The following dependencies will be installed: 
 cargo
 cargo-bootstrap
 libssh2
 llvm-9.0
 llvm_select
 rust
Continue? [Y/n]: 
```

```
sh-3.2# port destroot librsvg +universal
--->  Computing dependencies for librsvg
--->  Fetching distfiles for librsvg
--->  Verifying checksums for librsvg
--->  Extracting librsvg
--->  Applying patches to librsvg
--->  Configuring librsvg
--->  Building librsvg                                   
--->  Staging librsvg into destroot
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
