### PR TITLE
mysql56: select() implicitly declared in configure

### DIFF
--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -12,7 +12,7 @@ set name_mysql      ${name}
 version             5.6.51
 # Set revision_client and revision_server to 0 on
 # version bump.
-set revision_client 4
+set revision_client 5
 set revision_server 1
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 categories          databases
@@ -59,6 +59,9 @@ if {$subport eq $name} {
     # we have to slightly alter this script as we change the name of the
     # VERSION file to VERSION.txt below (c++17 conflict)
     patchfiles-append   patch-mysql56-version-change.diff
+
+    # Avoid implicitly declaring select()
+    patchfiles-append   patch-include-sys-select-h.diff
 
     checksums           rmd160  c6c43b04fc34fb9ceb55eb6f5be9ce4ea3bff56d \
                         sha256  262ccaf2930fca1f33787505dd125a7a04844f40d3421289a51974b5935d9abc \

--- a/databases/mysql56/files/patch-include-sys-select-h.diff
+++ b/databases/mysql56/files/patch-include-sys-select-h.diff
@@ -1,0 +1,18 @@
+Avoid implicitly declaring select()
+Upstream-Status: Inappropriate [this patch is Darwin-specific; MySQL 5.6 is EOL; MySQL 5.7.4 removed this check for select()]
+
+diff --git a/configure.cmake b/configure.cmake
+index dddeb25b6bab..c0fb70db735b 100644
+--- a/configure.cmake
++++ b/configure.cmake
+@@ -833,9 +833,7 @@ CHECK_C_SOURCE_COMPILES("
+ #include <winsock2.h>
+ #include <ws2tcpip.h>
+ #else
+-#include <sys/types.h>
+-#include <sys/socket.h>
+-#include <netdb.h>
++#include <sys/select.h>
+ #endif
+ int main()
+ {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
  (although I do not know for certain that anything was broken)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Only configure phase is tested.
macOS 10.15.7
Xcode 12.4 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
