### PR TITLE
mysql8: clean up

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -101,7 +101,6 @@ if {$subport eq $name} {
 
         configure.args-append \
             -DWITH_DEBUG:BOOL=ON \
-            -DWITH_DTRACE:BOOL= ON \
             -DINSTALL_MYSQLTESTDIR:PATH="share/${name_mysql}/mysql-test" \
             -DWITH_UNIT_TESTS=ON
     } else {
@@ -109,7 +108,6 @@ if {$subport eq $name} {
 
         configure.args-append \
             -DWITH_DEBUG=OFF \
-            -DWITH_DTRACE:BOOL=OFF \
             -DWITH_UNIT_TESTS=OFF
     }
 
@@ -133,7 +131,6 @@ if {$subport eq $name} {
     configure.args-append \
         -DFORCE_UNSUPPORTED_COMPILER=ON \
         -DDOWNLOAD_BOOST=0 \
-        -DENABLE_DOWNLOADS:BOOL=OFF \
         -DINSTALL_LAYOUT:STRING=MACPORTS \
         -DMYSQL_DATADIR:PATH="${prefix}/var/db/${name_mysql}" \
         -DMYSQL_UNIX_ADDR:PATH="${prefix}/var/run/${name_mysql}/mysqld.sock" \
@@ -155,6 +152,9 @@ if {$subport eq $name} {
         -DWITH_ROUTER:BOOL=OFF
 #       -DROUTER_INSTALL_LIBDIR="lib/${name_mysql}" \
 #       -DROUTER_INSTALL_PLUGINDIR="lib/${name_mysql}/mysqlrouter"
+
+    # setns() is a Linux system call
+    configure.checks.implicit_function_declaration.whitelist-append setns
 
     patch.pre_args  -p1
     patchfiles      patch-cmake-install_macros-protobuf-path.cmake.diff \


### PR DESCRIPTION
DTrace support was removed in 8.0.1
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html#mysqld-8-0-1-deprecation-removal

`ENABLE_DOWNLOADS` ignored as of 8.0.26; was for an optional dependency that is now bundled
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-26.html#mysqld-8-0-26-bug

Ignore `setns()` (Linux system call) implicitly declared during configure

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
In progress…
~~Only configure phase is tested (without `debug` variant)
macOS 10.15.7
Xcode 12.4 command line tools~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
