### PR TITLE
kristall-devel: new port

### DIFF
--- a/net/kristall-devel/Portfile
+++ b/net/kristall-devel/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+PortGroup           openssl 1.0
+PortGroup           qmake5  1.0
+
+set commit_sha      6b39f24484bb0796f3f383401f95904f85b74d7b
+github.setup        MasterQ32 kristall ${commit_sha}
+github.tarball_from archive
+name                kristall-devel
+version             20211120
+revision            0
+
+homepage            https://kristall.random-projects.net
+
+description         Small-Internet Browser for Gemini, Gopher, Finger & HTTP
+
+long_description    Kristall is a browser without support for css/js/wasm or \
+                    graphical websites. It can display user-styled documents \
+                    in several formats, including gemini, html, markdown, ... \
+                    provided by a server via gemini, gopher, http, finger, ...
+
+categories          net
+license             GPL-3.0
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+platforms           darwin
+
+checksums           rmd160  d9f34448935e33245a2331f26a87b2020837c36d \
+                    sha256  7423cb65af90736188622ac8400afde3731d049be61d2fccbe21e7ec22f437e0 \
+                    size    22018299
+
+patchfiles          patch-project-file.diff
+
+post-patch {
+    set project_file ${worksrcpath}/src/kristall.pro
+
+    reinplace "s|@@KRISTALL_VERSION@@|${version}-devel|"        ${project_file}
+    reinplace "s|@@OPENSSL_INCLUDE@@|[openssl::include_dir]|"   ${project_file}
+    reinplace "s|@@OPENSSL_LIB@@|[openssl::include_dir]|"       ${project_file}
+}
+
+destroot {
+    copy ${worksrcpath}/kristall.app ${destroot}${applications_dir}
+}
+
+qt5.depends_build_component qttools
+
+qt5.depends_component       qtmultimedia \
+                            qtsvg
+
+configure.args-append       ${worksrcpath}/src/kristall.pro
+
+notes "Please find Kristal in the MacPorts Applications directory."

--- a/net/kristall-devel/files/patch-project-file.diff
+++ b/net/kristall-devel/files/patch-project-file.diff
@@ -1,0 +1,34 @@
+--- ./src/kristall.pro	2021-11-21 01:22:26.000000000 -0500
++++ ./src/kristall.pro	2021-11-21 01:24:50.000000000 -0500
+@@ -9,7 +9,7 @@
+ # deprecated API in order to know how to port your code away from it.
+ DEFINES += QT_DEPRECATED_WARNINGS
+ 
+-DEFINES += KRISTALL_VERSION="\"$(shell cd $$PWD; git describe --tags)\""
++DEFINES += KRISTALL_VERSION=@@KRISTALL_VERSION@@
+ 
+ # You can also make your code fail to compile if it uses deprecated APIs.
+ # In order to do so, uncomment the following line.
+@@ -57,20 +57,8 @@
+ }
+ 
+ macx {
+-    # Homebrew include paths
+-    contains(QMAKE_HOST.arch, arm.*):{
+-        INCLUDEPATH += /opt/homebrew/opt/qt5/include
+-        LIBS += -L/opt/homebrew/opt/qt5/lib
+-    
+-        INCLUDEPATH += /opt/homebrew/opt/openssl/include
+-        LIBS += -L/opt/homebrew/opt/openssl/lib
+-    } else {
+-        INCLUDEPATH += /usr/local/opt/qt/include
+-        LIBS += -L/usr/local/opt/qt/lib
+-
+-        INCLUDEPATH += /usr/local/opt/openssl/include
+-        LIBS += -L/usr/local/opt/openssl/lib
+-    }
++    INCLUDEPATH += @@OPENSSL_INCLUDE@@
++    LIBS += -L@@OPENSSL_LIB@@
+ 
+     ICON = icons/AppIcon.icns
+ }


### PR DESCRIPTION
Devel port for **[Kristall](https://github.com/MasterQ32/kristall)**, a "small-internet" browser supporting gemini, http, https, gopher, finger built on Qt.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
