### PR TITLE
gocryptfs: Fix build for arm64

### DIFF
--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -123,9 +123,6 @@ go.vendors          gopkg.in/yaml.v3 \
 set builddate       "build_date_not_set"
 set ldflags         "-X \"main.GitVersion=${version}\" -X \"main.GitVersionFuse=${gitversionfuse}\" -X \"main.BuildDate=${builddate}\""
 
-depends_build-append \
-                    port:pandoc
-
 build.args          -ldflags="${ldflags}"
 
 # According to [1] there is no benefit to build gocryptfs with openssl on M1 Macs.
@@ -137,13 +134,29 @@ variant openssl description {Build with openssl support} {
     depends_lib-append  path:lib/libcrypto.dylib:openssl
 }
 
+variant doc description {Build man pages} {
+    if {${configure.build_arch} eq "arm64"} {
+        depends_build-append port:go-md2man
+
+        post-build {
+            system -W ${worksrcpath}/Documentation "${prefix}/bin/go-md2man -in=MANPAGE.md -out=${name}.1"
+            system -W ${worksrcpath}/Documentation "${prefix}/bin/go-md2man -in=MANPAGE-XRAY.md -out=${name}-xray.1"
+            system -W ${worksrcpath}/Documentation "${prefix}/bin/go-md2man -in=MANPAGE-STATFS.md -out=statfs.1"
+        }
+    } else {
+        depends_build-append port:pandoc
+
+        post-build {
+            system -W ${worksrcpath}/Documentation "sh MANPAGE-render.bash"
+        }
+    }
+}
+
+default_variants +doc
+
 if {![variant_isset openssl]} {
     build.env           CGO_ENABLED=0
     build.args-append   -tags without_openssl
-}
-
-post-build {
-    system -W ${worksrcpath}/Documentation "sh MANPAGE-render.bash"
 }
 
 destroot {


### PR DESCRIPTION
#### Description

* Introduce doc variant, which is enabled by default.
* Use go-md2man instead of pandoc on arm64 as this arch is not yet
supported by upstream yet [1].

[1]: https://github.com/jgm/pandoc/issues/6960

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
