### PR TITLE
gmt6: update to 6.3.0

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -10,7 +10,7 @@ github.tarball_from releases
 distname            ${github.project}-${github.version}-src
 revision            9
 subport gmt6 {
-    github.setup    GenericMappingTools gmt 6.2.0
+    github.setup    GenericMappingTools gmt 6.3.0
     revision        0
     epoch           1
 }
@@ -43,9 +43,9 @@ if {${subport} eq "gmt5"} {
                         sha256  078d4997507cb15344c74a874568985e45bdbd6d3a72d330c74c47f4c0359bb1 \
                         size    59175704
 } else {
-    checksums           rmd160  2818673fdde5e1187a3c7e70028833ebc817dcc8 \
-                        sha256  a01f0a14d48bbc0b14855670f366df3cb8238f0ccdfa26fe744968b4f1c14d54 \
-                        size    56104264
+    checksums           rmd160  5888661c856804e296a6f388f5218914f4f1e4c3 \
+                        sha256  69e29b62ee802a3a64260d6a1e023f1350e3bf4070221aa1307bf8a9e56c1ee5 \
+                        size    55396792
 }
 
 depends_lib         port:curl \


### PR DESCRIPTION
#### Description
Simple update to upstream version 6.3.0
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode Command Line Tools 13.1.0.0.1.1633545042

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
