### PR TITLE
gitlab-runner: update to 14.5.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 14.4.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 14.5.0 v
 
 categories          devel
 platforms           darwin
@@ -22,9 +22,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  9d275870dc3ebf0b876eda2961469c2d2f82b751 \
-                    sha256  ca598a7624e48a32ada0fe780df2042489a0f2199694ef1f17b0ef1091a36723 \
-                    size    9130465
+checksums           rmd160  e0b3f366c199349c6d2d04030d301318c64d66de \
+                    sha256  2c3061528f6eb714b5893bc3f5575b52bcface3272074717e0c18b3da783df97 \
+                    size    9143600
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 14.5.0.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?