### PR TITLE
xsel: disable check for autoconf vfork AC_FUNC_FORK

### DIFF
--- a/x11/xsel/Portfile
+++ b/x11/xsel/Portfile
@@ -28,6 +28,15 @@ depends_build           port:xorg-libXt
 
 depends_lib             port:xorg-libX11
 
+# cache autoconf vfork check to yes on darwin 21+ (macOS Monterey) disabling
+# the autoconf vfork macro "#define vfork fork" that will result in a build
+# failure due to vfork deprecation warning in macOS Monterey and -Werror
+# https://trac.macports.org/ticket/63748
+# https://github.com/kfish/xsel/issues/42
+if {${os.platform} eq "darwin" && ${os.major} >= 21} {
+    configure.args-append ac_cv_func_vfork=yes
+}
+
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${subport}
     xinstall -d ${docdir}


### PR DESCRIPTION
* disable check for autoconf AC_FUNC_FORK vfork checking caching to yes.
* AC_FUNC_FORK will create a `#define vfork fork` macro in config.h
* vfork has been mark depercated in macOS 12.
* This macro will mark fork() usage as depercated due to
  config.h being included before system header <unistd.h>.

Re: https://github.com/kfish/xsel/issues/42
Closes: https://trac.macports.org/ticket/63748

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1, 10.15.6
Xcode 13.1, 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
