### PR TITLE
vtk-m: fix +openmp build

### DIFF
--- a/graphics/vtk-m/Portfile
+++ b/graphics/vtk-m/Portfile
@@ -55,6 +55,8 @@ variant openmp description {Enable OpenMP support} {
         -DVTKm_ENABLE_OPENMP=OFF -DVTKm_ENABLE_OPENMP=ON
 
     compiler.openmp_version 4.0
+    configure.cppflags-append -fopenmp-version=40
+    configure.ldflags-append -L${prefix}/lib/libomp -lomp
 }
 
 variant tbb description {Enable Intel Threading Building Blocks support} {


### PR DESCRIPTION
Clang < 10 require `-fopenmp-version` for OpenMP > 3.1

Add missing linker flags

Fixes: https://trac.macports.org/ticket/64031

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools
MacPorts clang 9

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
