### PR TITLE
ntpsec: Fix openssl shim conflict.

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -4,11 +4,10 @@ PortSystem          1.0
 PortGroup           waf 1.0
 PortGroup           python 1.0
 PortGroup           openssl 1.0
-PortGroup           conflicts_build 1.0
 
 name                ntpsec
 version             1.2.1
-revision            2
+revision            3
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -48,18 +47,23 @@ python.versions     27
 # Also note that the new ffi-based Python client library doesn't work properly
 # on the Mac, so we use the old extension-based version.
 
-# Not yet ready for openssl 3
+# The installed ntpsec code builds correctly with openssl3, though one of
+# the "attic" programs included (erroneously) in the default build does not.
+# Although this is easily fixed, openssl3 itself currently fails to build
+# in certain cases, so we keep this on openssl11 for now.
+#
+# Since OpenSSL 1.1 is still fully supported, adequate for ntpsec, and has no
+# licensing issues for ntpsec, there's no rush to move to OpenSSL 3, which might
+# as well wait for the next ntpsec release (or later, if openssl3 isn't fully
+# fixed by then).
 openssl.branch      1.1
-# Build does not correctly configure itself to ignore openssl shim port
-# sym-links in primary prefix, so have to declare a build conflicit to avoid it
-# opportunitistically using them instead of the correct openssl11 installation.
-conflicts_build     openssl
+# NOTE: doesn't work with libressl
 
 depends_build-append port:bison port:pkgconfig
-# NOTE: doesn't work with libressl
 depends_lib-append  port:python${python.version}
 
-patchfiles          patch-PreHighSierra.diff
+# Consolidated patchfile, based on GitHub/fhgwwight/macports-releases
+patchfiles          patch-allfixes.diff
 
 use_configure       yes
 configure.post_args-delete --nocache
@@ -73,6 +77,11 @@ configure.args      --alltests \
 # Make sure we use waf, not setup.py for build
 build.cmd           ${waf.python} ./waf
 destroot.cmd        ${build.cmd}
+
+# Although the normal build procedure includes the tests, we also allow
+# them separately so that "port test" works.
+test.run            yes
+test.target         check
 
 default_variants    +doc
 

--- a/sysutils/ntpsec/files/patch-allfixes.diff
+++ b/sysutils/ntpsec/files/patch-allfixes.diff
@@ -1,5 +1,5 @@
 --- ./attic/backwards.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/backwards.c	2021-07-28 18:53:02.000000000 -0700
++++ ./attic/backwards.c	2021-11-20 13:51:42.000000000 -0800
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -10,7 +10,7 @@
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
 --- ./attic/clocks.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/clocks.c	2021-07-28 18:53:02.000000000 -0700
++++ ./attic/clocks.c	2021-11-20 13:51:42.000000000 -0800
 @@ -9,6 +9,8 @@
  #include <unistd.h>
  
@@ -21,7 +21,7 @@
    const int type;
    const char* name;
 --- ./attic/cmac-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/cmac-timing.c	2021-07-28 18:53:02.000000000 -0700
++++ ./attic/cmac-timing.c	2021-11-20 13:51:42.000000000 -0800
 @@ -35,6 +35,8 @@
  #include <openssl/params.h> 
  #endif
@@ -32,7 +32,7 @@
  
  
 --- ./attic/digest-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/digest-timing.c	2021-07-28 18:53:02.000000000 -0700
++++ ./attic/digest-timing.c	2021-11-20 13:51:42.000000000 -0800
 @@ -33,6 +33,8 @@
  #include <openssl/ssl.h>
  #endif
@@ -43,7 +43,7 @@
  
  #ifndef EVP_MD_CTX_reset
 --- ./attic/random.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/random.c	2021-07-28 18:53:02.000000000 -0700
++++ ./attic/random.c	2021-11-20 13:51:42.000000000 -0800
 @@ -10,6 +10,8 @@
  #include <openssl/opensslv.h>    /* for OPENSSL_VERSION_NUMBER */
  #include <openssl/rand.h>
@@ -54,7 +54,7 @@
  #define BILLION 1000000000
  #define HISTSIZE 2500
 --- ./include/ntp_machine.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./include/ntp_machine.h	2021-07-28 18:53:02.000000000 -0700
++++ ./include/ntp_machine.h	2021-11-20 13:51:42.000000000 -0800
 @@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
@@ -208,7 +208,7 @@
  int ntp_set_tod (struct timespec *tvs);
  
 --- ./include/ntp_stdlib.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./include/ntp_stdlib.h	2021-07-28 18:53:02.000000000 -0700
++++ ./include/ntp_stdlib.h	2021-11-20 13:51:42.000000000 -0800
 @@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -220,7 +220,7 @@
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
 --- ./include/ntp_syscall.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./include/ntp_syscall.h	2021-07-28 18:53:02.000000000 -0700
++++ ./include/ntp_syscall.h	2021-11-20 13:51:42.000000000 -0800
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -234,7 +234,7 @@
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
 --- ./libntp/clockwork.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./libntp/clockwork.c	2021-07-28 18:53:02.000000000 -0700
++++ ./libntp/clockwork.c	2021-11-20 13:51:42.000000000 -0800
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -249,7 +249,7 @@
  #include "ntp.h"
  #include "ntp_machine.h"
 --- ./libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./libntp/statestr.c	2021-07-28 18:53:02.000000000 -0700
++++ ./libntp/statestr.c	2021-11-20 13:51:42.000000000 -0800
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -351,7 +351,7 @@
  /*
   * statustoa - return a descriptive string for a peer status
 --- ./ntpd/ntp_control.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpd/ntp_control.c	2021-07-28 18:53:02.000000000 -0700
++++ ./ntpd/ntp_control.c	2021-11-20 13:51:42.000000000 -0800
 @@ -1361,6 +1361,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
@@ -476,7 +476,7 @@
  	case CS_K_PPS_FREQ:
  		CTL_IF_KERNPPS(
 --- ./ntpd/ntp_loopfilter.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2021-07-28 18:53:02.000000000 -0700
++++ ./ntpd/ntp_loopfilter.c	2021-11-20 13:51:42.000000000 -0800
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -699,7 +699,7 @@
  }
 -
 --- ./ntpd/ntp_timer.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2021-07-28 18:53:02.000000000 -0700
++++ ./ntpd/ntp_timer.c	2021-11-20 13:51:42.000000000 -0800
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -723,7 +723,7 @@
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
 --- ./ntpd/refclock_local.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpd/refclock_local.c	2021-07-28 18:53:02.000000000 -0700
++++ ./ntpd/refclock_local.c	2021-11-20 13:51:42.000000000 -0800
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -747,7 +747,7 @@
  	refclock_receive(peer);
  }
 --- ./ntpfrob/precision.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpfrob/precision.c	2021-07-28 18:53:02.000000000 -0700
++++ ./ntpfrob/precision.c	2021-11-20 13:51:42.000000000 -0800
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -757,7 +757,7 @@
  #define	DEFAULT_SYS_PRECISION	-99
  
 --- ./tests/libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./tests/libntp/statestr.c	2021-07-28 18:53:02.000000000 -0700
++++ ./tests/libntp/statestr.c	2021-11-20 13:51:42.000000000 -0800
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -779,7 +779,7 @@
  
  // statustoa
 --- ./wafhelpers/bin_test.py.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./wafhelpers/bin_test.py	2021-07-28 18:53:02.000000000 -0700
++++ ./wafhelpers/bin_test.py	2021-11-20 13:51:42.000000000 -0800
 @@ -103,6 +103,12 @@ def cmd_bin_test(ctx):
      if ctx.env['PYTHON_CURSES']:
          cmd_map_python.update(cmd_map_python_curses)
@@ -794,7 +794,7 @@
          if not run(cmd, cmd_map[cmd] % version):
              fails += 1
 --- ./wafhelpers/options.py.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./wafhelpers/options.py	2021-07-28 18:53:02.000000000 -0700
++++ ./wafhelpers/options.py	2021-11-20 13:51:42.000000000 -0800
 @@ -21,6 +21,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -805,7 +805,7 @@
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
 --- ./wscript.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./wscript	2021-07-28 18:53:02.000000000 -0700
++++ ./wscript	2021-11-20 13:51:42.000000000 -0800
 @@ -562,7 +562,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
@@ -815,7 +815,19 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -776,6 +776,21 @@ int main(int argc, char **argv) {
+@@ -619,6 +619,11 @@ int main(int argc, char **argv) {
+         ctx.check_cc(msg="Checking for OpenSSL's crypto library",
+                      lib="crypto", mandatory=True)
+ 
++    # KLUDGE: Make sure selected SSL version is seen before system's.
++    # Assumes that CRYPTO and SSL paths are the same.
++    ctx.env.INCLUDES = ctx.env.INCLUDES_CRYPTO + ctx.env.INCLUDES
++    ctx.env.LIBPATH = ctx.env.LIBPATH_CRYPTO + ctx.env.LIBPATH
++
+     # Optional functions.  Do all function checks here, otherwise
+     # we're likely to duplicate them.
+     optional_functions = (
+@@ -776,6 +781,21 @@ int main(int argc, char **argv) {
          ctx.define("ENABLE_FUZZ", 1,
                     comment="Enable fuzzing low bits of time")
  


### PR DESCRIPTION
This adds an ugly wscript patch to ensure that the OpenSSL version
selection is honored in the build, thereby avoiding a sensitivity to
the shim port's selection.

Also enables "port test", though the normal build procedure runs the
tests, anyway.

Renames the patchfile to something more general.

The revbump may not be strictly necessary, but is included to track
the updated patch.

TESTED:
Ran build/test/install with the usual variant combinations, on
10.4-10.5 ppc, 10.4-10.6 i386, and 10.6-10.15 x86_64.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
