### PR TITLE
openssl*: Restore versioned libs at top level

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            1
+revision            2
 
 categories          devel security
 platforms           darwin
@@ -58,7 +58,15 @@ destroot {
     foreach b [glob [openssl::bin_dir]/*] {
         ln -s ${b} ${destroot}/${prefix}/bin/
     }
+    set versioned_suffix ${openssl.branch}.dylib
+    set suffix_len [string length ${versioned_suffix}]
     fs-traverse f [openssl::lib_dir] {
+        # Versioned symlinks will be supplied by versioned port
+        set f_len [string length ${f}]
+        set f_end [string range ${f} [expr ${f_len} - ${suffix_len}] ${f_len}]
+        if { ${f_end} == ${versioned_suffix} } {
+            continue
+        }
         set lf [string map "[openssl::install_area] ${prefix}" $f]
         if { [file isdirectory ${f}] } {
             xinstall -d ${destroot}${lf}

--- a/devel/openssl10/Portfile
+++ b/devel/openssl10/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 set short_v         1.0
 name                openssl[string map {. {}} $short_v]
 version             ${short_v}.2u
-revision            4
+revision            5
 
 categories          devel security
 platforms           darwin
@@ -121,6 +121,11 @@ post-destroot {
     move ${destroot}${prefix}/share/man ${destroot}/${my_prefix}/share/
     # Create link to certs from curl-ca-bundle in install prefix
     ln -s ${prefix}/share/curl/curl-ca-bundle.crt ${destroot}${my_prefix}/etc/openssl/cert.pem
+    # Provide versioned symlinks in top-level lib dir
+    foreach n {crypto ssl} {
+        set name lib${n}.${short_v}.0.dylib
+        ln -s ${my_prefix}/lib/${name} ${destroot}${prefix}/lib/${name}
+    }
 }
 
 destroot.destdir    INSTALL_PREFIX=${destroot}

--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -9,7 +9,7 @@ name                openssl[string map {. {}} $short_v]
 # The revision of the openssl shim port should be bumped whenever
 # the version or revision is changed here.
 version             ${short_v}.1l
-revision            5
+revision            6
 
 # Please revbump these ports when updating OpenSSL.
 #  - freeradius (#43461)
@@ -135,6 +135,11 @@ post-destroot {
     move ${destroot}${prefix}/share/man ${destroot}/${my_prefix}/share/
     # Create link to certs from curl-ca-bundle in install prefix
     ln -s ${prefix}/share/curl/curl-ca-bundle.crt ${destroot}${my_prefix}/etc/openssl/cert.pem
+    # Provide versioned symlinks in top-level lib dir
+    foreach n {crypto ssl} {
+        set name lib${n}.${short_v}.dylib
+        ln -s ${my_prefix}/lib/${name} ${destroot}${prefix}/lib/${name}
+    }
 }
 
 destroot.args       MANDIR=${prefix}/share/man MANSUFFIX=ssl

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 8
 set major_v         3
 name                openssl$major_v
 version             ${major_v}.0.0
-revision            6
+revision            7
 
 # Please revbump these ports when updating OpenSSL.
 #  - freeradius (#43461)
@@ -182,6 +182,11 @@ post-destroot {
     move ${destroot}${prefix}/share/man ${destroot}/${my_prefix}/share/
     # Create link to certs from curl-ca-bundle in install prefix
     ln -s ${prefix}/share/curl/curl-ca-bundle.crt ${destroot}${my_prefix}/etc/openssl/cert.pem
+    # Provide versioned symlinks in top-level lib dir
+    foreach n {crypto ssl} {
+        set name lib${n}.${major_v}.dylib
+        ln -s ${my_prefix}/lib/${name} ${destroot}${prefix}/lib/${name}
+    }
 }
 
 destroot.args       MANDIR=${prefix}/share/man MANSUFFIX=ssl


### PR DESCRIPTION
The libraries with versioned names can be installed in the top-level
${prefix}/lib directory without conflict.  Doing this (at least for
openssl11) allows the existing dependent installs to continue working.
The unversioned libraries still need to be provided by the shim port,
pointing to only the one version chosen as the default by the shim
port.

Due to the transfer of ownership of a top-level library, a transient
activation failure may occur.  There doesn't seem to be a good fix for
this, though a forced activation or out-of order activation fixes it.

TESTED:
Built, installed, and tested on 10.4-10.5 ppc, 10.4-10.6 i386, and
10.5-10.15 x86_64.  The openssl11 tests fail on 10.6-10.8 as before.
The openssl3 tests also fail on 10.6-10.8, as well as on 10.10-10.11,
which is almost certainly unrelated to this change.
The preexisting ntpsec @1.2.1_0 install now works again.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
