### PR TITLE
botan: fix compilation on osx 10.11

### DIFF
--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -39,6 +39,7 @@ depends_lib         port:bzip2 \
 
 # respect MacPorts configure values
 patchfiles-append   patch-compiler_flags.diff \
+                    patch-add-missing-header-cstdlib.diff \
                     patch-fix-missing-sys-types.h.diff \
                     patch-fix-ldflags-order.diff
 

--- a/security/botan/files/patch-add-missing-header-cstdlib.diff
+++ b/security/botan/files/patch-add-missing-header-cstdlib.diff
@@ -1,0 +1,43 @@
+From c38b9387d01af3a3e4e270219fe5e9f524a8c6de Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Mon, 22 Nov 2021 08:20:47 +0100
+Subject: [PATCH] add missing header: cstdlib
+
+for compilation on older systems (like macos 10.11)
+
+Needed for std::free() & std::calloc() on older systems [1]
+That file is included indirectly on newer systems.
+
+[1] https://en.cppreference.com/w/cpp/memory/c/free
+---
+ src/fuzzer/mem_pool.cpp                | 1 +
+ src/lib/compat/sodium/sodium_utils.cpp | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/fuzzer/mem_pool.cpp b/src/fuzzer/mem_pool.cpp
+index 722746288..c5532539b 100644
+--- src/fuzzer/mem_pool.cpp
++++ src/fuzzer/mem_pool.cpp
+@@ -12,6 +12,7 @@
+ #include <utility>
+ 
+ #include <stdlib.h>
++#include <cstdlib>
+ 
+ namespace {
+ 
+diff --git a/src/lib/compat/sodium/sodium_utils.cpp b/src/lib/compat/sodium/sodium_utils.cpp
+index 3f0a6c84e..f3908f38d 100644
+--- src/lib/compat/sodium/sodium_utils.cpp
++++ src/lib/compat/sodium/sodium_utils.cpp
+@@ -11,6 +11,7 @@
+ #include <botan/internal/os_utils.h>
+ #include <botan/internal/ct_utils.h>
+ #include <botan/loadstor.h>
++#include <cstdlib>
+ 
+ namespace Botan {
+ 
+-- 
+2.30.2
+


### PR DESCRIPTION
Tested on 10.13. But I couldn't test on 10.11 thoughtn but patch is trivial

Error was:
src/lib/compat/sodium/sodium_utils.cpp:124:44: error: no member named 'calloc' in namespace 'std'
   uint8_t* p = static_cast<uint8_t*>(std::calloc(size + sizeof(len), 1));
                                      ~~~~~^
src/lib/compat/sodium/sodium_utils.cpp:137:9: error: no type named 'free' in namespace 'std'
   std::free(p);
   ~~~~~^


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
