### PR TITLE
Py oct add py310

### DIFF
--- a/python/py-oct2py/Portfile
+++ b/python/py-oct2py/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 name                py-oct2py
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 python.default_version 27
 
 github.setup        blink1073 oct2py 5.3.0 v

--- a/python/py-oct2py/Portfile
+++ b/python/py-oct2py/Portfile
@@ -7,7 +7,6 @@ PortGroup           python 1.0
 name                py-oct2py
 
 python.versions     27 36 37 38 39 310
-python.default_version 27
 
 github.setup        blink1073 oct2py 5.3.0 v
 checksums           rmd160  a3c3708255e695b1cfa44750fb45c3eae7bfdd67 \

--- a/python/py-octave_kernel/Portfile
+++ b/python/py-octave_kernel/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  6c6f6e8590389d504220586f1ab40dff1405a274 \
                     sha256  2eeab98a51ce8eddb182d90e5324f1c0bf49b9b42bce6bb996e4afe198ebcb35 \
                     size    27353
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_lib-append  \


### PR DESCRIPTION
Created this PR for the owner of Octave_Kernel ... this addition is trivial & works in my testing

#### Description

Add Python 3.10 support for Python Octave ports: Oct2Py and Octave_Kernel.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G306
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
