### PR TITLE
KeePassXC-devel: fix compilation on older systems

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -53,6 +53,7 @@ if {${subport} eq ${name}} {
     github.setup        keepassxreboot keepassxc a3dc977e58470644f2acca77905285d44b22f2b8
     set githash         [string range ${github.version} 0 6]
     version             20211122+git${githash}
+    revision            1
 
     conflicts           KeePassXC
 
@@ -67,6 +68,8 @@ if {${subport} eq ${name}} {
 
     patchfiles          devel/patch-no-deployqt.diff \
                         devel/patch-no-findpackage-path.diff \
+                        devel/patch-FindOpenMP.diff \
+                        devel/patch-old-mac-other.diff \
                         devel/patch-old-mac.diff
 
     post-destroot {

--- a/security/KeePassXC/files/devel/patch-FindOpenMP.diff
+++ b/security/KeePassXC/files/devel/patch-FindOpenMP.diff
@@ -1,0 +1,15 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -253,7 +253,11 @@ if(WITH_APP_BUNDLE)
+ endif()
+ 
+ add_gcc_compiler_flags("-fno-common")
+-check_add_gcc_compiler_flag("-fopenmp")
++find_package(OpenMP) # Add OpenMP compiler flags (trial to fix compilation on osx 10.10 with appleClang 7.0)
++if(OpenMP_FOUND)
++    add_gcc_compiler_cflags(${OpenMP_C_FLAGS})
++    add_gcc_compiler_cxxflags(${OpenMP_CXX_FLAGS})
++endif()
+ add_gcc_compiler_flags("-Wall -Wextra -Wundef -Wpointer-arith -Wno-long-long")
+ add_gcc_compiler_flags("-Wformat=2 -Wmissing-format-attribute")
+ add_gcc_compiler_flags("-fvisibility=hidden")

--- a/security/KeePassXC/files/devel/patch-old-mac-other.diff
+++ b/security/KeePassXC/files/devel/patch-old-mac-other.diff
@@ -1,0 +1,32 @@
+--- src/core/CustomData.cpp
++++ src/core/CustomData.cpp
+@@ -27,7 +27,7 @@ const QString CustomData::BrowserLegacyKeyPrefix = QStringLiteral("Public Key: "
+ const QString CustomData::ExcludeFromReportsLegacy = QStringLiteral("KnownBad");
+
+ // Fallback item for return by reference
+-static const CustomData::CustomDataItem NULL_ITEM;
++static const CustomData::CustomDataItem NULL_ITEM {}; // Fix compilation on osx 10.11
+
+ CustomData::CustomData(QObject* parent)
+     : ModifiableObject(parent)
+diff --git a/tests/TestTools.cpp b/tests/TestTools.cpp
+index edfeb503..74f06667 100644
+--- tests/TestTools.cpp
++++ tests/TestTools.cpp
+@@ -93,12 +93,14 @@ void TestTools::testEnvSubstitute()
+
+ void TestTools::testValidUuid()
+ {
+-    auto validUuid = Tools::uuidToHex(QUuid::createUuid());
++    static const QUuid q1 = QUuid::createUuid(); // Fix for osx 10.7-10.9
++    auto validUuid = Tools::uuidToHex(q1);
+     auto nonRfc4122Uuid = "1234567890abcdef1234567890abcdef";
+     auto emptyUuid = QString();
+     auto shortUuid = validUuid.left(10);
+     auto longUuid = validUuid + "baddata";
+-    auto nonHexUuid = Tools::uuidToHex(QUuid::createUuid()).replace(0, 1, 'p');
++    static const QUuid q2 = QUuid::createUuid(); // Fix for osx 10.7-10.9
++    auto nonHexUuid = Tools::uuidToHex(q2).replace(0, 1, 'p');
+
+     QVERIFY(Tools::isValidUuid(validUuid));
+     /* Before https://github.com/keepassxreboot/keepassxc/pull/1770/, entry


### PR DESCRIPTION
Try to fix compilation issues on osx 10.7-10.11

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
