### PR TITLE
py-cycler: Restore compatibility with Python <3.6

### DIFF
--- a/python/py-cycler/Portfile
+++ b/python/py-cycler/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-cycler
 version             0.11.0
-revision            0
+revision            1
 
 categories-append   math
 supported_archs     noarch
@@ -23,6 +23,9 @@ checksums           rmd160  8a4654f4791d88bcb3ad066c0d365acd7ee23db8 \
                     size    18784
 
 python.versions     27 35 36 37 38 39 310
+
+# Revert the two upstream commits that broke Python <3.6
+patchfiles          patch-PrePython36.diff
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-cycler/files/patch-PrePython36.diff
+++ b/python/py-cycler/files/patch-PrePython36.diff
@@ -1,0 +1,77 @@
+--- ./cycler.py.orig	2021-10-25 14:20:29.000000000 -0700
++++ ./cycler.py	2021-11-15 14:14:07.000000000 -0800
+@@ -40,6 +40,8 @@ Results in::
+     {'color': 'b', 'linestyle': '-.'}
+ """
+ 
++from __future__ import (absolute_import, division, print_function,
++                        unicode_literals)
+ 
+ import copy
+ from functools import reduce
+@@ -101,7 +103,7 @@ def concat(left, right):
+     return reduce(add, (_cycler(k, _l[k] + _r[k]) for k in left.keys))
+ 
+ 
+-class Cycler:
++class Cycler(object):
+     """
+     Composable cycles.
+ 
+@@ -225,7 +227,7 @@ class Cycler:
+         """
+         ret = cls(None)
+         ret._left = list({label: v} for v in itr)
+-        ret._keys = {label}
++        ret._keys = set([label])
+         return ret
+ 
+     def __getitem__(self, key):
+@@ -257,7 +259,7 @@ class Cycler:
+         """
+         if len(self) != len(other):
+             raise ValueError("Can only add equal length cycles, "
+-                             f"not {len(self)} and {len(other)}")
++                             "not {0} and {1}".format(len(self), len(other)))
+         return Cycler(self, other, zip)
+ 
+     def __mul__(self, other):
+@@ -341,7 +343,7 @@ class Cycler:
+         if self._right is None:
+             lab = self.keys.pop()
+             itr = list(v[lab] for v in self)
+-            return f"cycler({lab!r}, {itr!r})"
++            return "cycler({lab!r}, {itr!r})".format(lab=lab, itr=itr)
+         else:
+             op = op_map.get(self._op, '?')
+             msg = "({left!r} {op} {right!r})"
+@@ -352,11 +354,11 @@ class Cycler:
+         output = "<table>"
+         sorted_keys = sorted(self.keys, key=repr)
+         for key in sorted_keys:
+-            output += f"<th>{key!r}</th>"
++            output += "<th>{key!r}</th>".format(key=key)
+         for d in iter(self):
+             output += "<tr>"
+             for k in sorted_keys:
+-                output += f"<td>{d[k]!r}</td>"
++                output += "<td>{val!r}</td>".format(val=d[k])
+             output += "</tr>"
+         output += "</table>"
+         return output
+--- ./doc/source/conf.py.orig	2021-10-28 20:39:12.000000000 -0700
++++ ./doc/source/conf.py	2021-11-15 14:14:07.000000000 -0800
+@@ -1,4 +1,5 @@
+ #!/usr/bin/env python3
++# -*- coding: utf-8 -*-
+ #
+ # cycler documentation build configuration file, created by
+ # sphinx-quickstart on Wed Jul  1 13:32:53 2015.
+--- ./test_cycler.py.orig	2021-10-25 14:20:29.000000000 -0700
++++ ./test_cycler.py	2021-11-15 14:14:07.000000000 -0800
+@@ -1,3 +1,5 @@
++from __future__ import (absolute_import, division, print_function)
++
+ from collections import defaultdict
+ from operator import add, iadd, mul, imul
+ from itertools import product, cycle, chain


### PR DESCRIPTION
The upstream code dropped support for Python <3.6.  So far, undoing
this only involves a few small changes, so it's patched here.  If this
becomes unmanageable at a later time, it may become necessary to pin
the version for older Python versions.

TESTED:
Tested with Python 2.7 and 3.5-3.10, on 10.4-10.5 ppc, 10.4-10.6 i386,
and 10.5-10.15 x86_64.  Passed in all cases that didn't involve broken
dependencies, including all 10.6-10.15 cases.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
