### PR TITLE
google-cloud-sdk: update to 365.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             365.0.0
+version             365.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1b9011809b0053ed803fa52ebf7c097ee466bd4a \
-                    sha256  ce776030bd83d6e6a27ec89fffddad61ede8a55f51c30fec3869c335be9dc5ea \
-                    size    96973278
+    checksums       rmd160  180ed4df51e9b5844591f464142e5d0e2494a676 \
+                    sha256  b3b04f7f5577347d5c30277d4bf6aa2d1a182c1ff8f9cc04edf0dee6f0b8c4a9 \
+                    size    96973273
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a17ef559e9b256098dc3cb3196fe38ebaedb4446 \
-                    sha256  9e05d06a5067361d3c47866d293ee23c2e9d87f2fb505b6cf39a535910bb4810 \
-                    size    93239956
+    checksums       rmd160  a214491508a07022d44899ea331f48c11a7057ca \
+                    sha256  4ae8a3274eb9b6fca5761ef2eed713bc3486256d11268575febe3351e9e4d902 \
+                    size    93240163
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  17f5459127e8471d48ebd1244d29040ef3865851 \
-                    sha256  477886b3a4fe7444bd3aa89afdd1b7d39977dea09699bd8b8b8a884cbc49e9e5 \
-                    size    93164660
+    checksums       rmd160  e5398b95ac97497da5d06307dcb8b2b120d41427 \
+                    sha256  636591e597730649011f510fc8c78e2b133ef8b417992f8d923a87a528dc6d5e \
+                    size    93164676
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 365.0.1.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?