### PR TITLE
p5-www-curl: Fix build failures with recent curl

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -3,6 +3,8 @@
 PortSystem                      1.0
 PortGroup                       clang_dependency 1.0
 
+# Increase the revision of p5-www-curl whenever the version of curl gets updated.
+
 name                            curl
 version                         7.80.0
 categories                      net www

--- a/perl/p5-www-curl/Portfile
+++ b/perl/p5-www-curl/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         WWW-Curl 4.17
-revision            4
+revision            5
 license             MIT
 maintainers         {alum.wpi.edu:arno+macports @fracai} openmaintainer
 description         Perl extension interface for libcurl
@@ -26,7 +26,11 @@ if {${perl5.major} != ""} {
 # https://github.com/szbalint/WWW--Curl/issues/16
 # additional patch for compatiblity with curl 7.66.0+
 # https://rt.cpan.org/Ticket/Display.html?id=130591
+# additional patch for compatiblity with curl 7.69.0+
+# https://rt.cpan.org/Public/Bug/Display.html?id=132197
     patchfiles      curl-7.50.2-invalid-symbols.patch \
                     curl-7.66.0-rt130591.patch \
-                    patch-default-inc-excludes-dot.diff
+                    curl-7.69.0-rt132197.patch \
+                    patch-default-inc-excludes-dot.diff \
+                    cpp-rt131089.patch
 }

--- a/perl/p5-www-curl/files/cpp-rt131089.patch
+++ b/perl/p5-www-curl/files/cpp-rt131089.patch
@@ -1,0 +1,28 @@
+Use $CC -E instead of cpp which can't parse system headers.
+https://rt.cpan.org/Public/Bug/Display.html?id=131089
+
+TODO: If CC is specified on the command line (which it is in MacPorts)
+use that instead of $Config{cc}.
+--- Makefile.PL.orig	2021-11-23 11:09:49.000000000 -0600
++++ Makefile.PL	2021-11-23 11:09:24.000000000 -0600
+@@ -3,6 +3,7 @@
+ 
+ use lib '.';
+ use inc::Module::Install;
++use Config;
+ 
+ name			'WWW-Curl';
+ abstract		'Perl extension interface for libcurl';
+@@ -101,9 +102,10 @@
+      print "Found curl.h in $curl_h\n";
+      my @syms;
+      my $has_cpp = 0;
+-     open(H_IN, "-|", "cpp", $curl_h) and $has_cpp++;
++     my $cc = $Config{cc};
++     open(H_IN, "-|", $cc, "-E", $curl_h) and $has_cpp++;
+      unless ($has_cpp) {
+-         warn "No working cpp ($!).  Parsing curl.h in Perl";
++         warn "No working $cc -E ($!).  Parsing curl.h in Perl";
+          open(H_IN, "<", $curl_h) or die("Can't open curl.h at path $curl_h, because: ".$!);
+      }
+      while ( <H_IN> ) {

--- a/perl/p5-www-curl/files/curl-7.69.0-rt132197.patch
+++ b/perl/p5-www-curl/files/curl-7.69.0-rt132197.patch
@@ -1,0 +1,32 @@
+From ee910449bf764d9f582e612c9b8b61b1d18e3a7c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Thu, 9 Apr 2020 14:31:05 +0200
+Subject: [PATCH] Adapt to changes in cURL 7.69.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+WIN32 macro was removed (1adebe7886ddf20b0733bf9ccbae4ed4866dcfb6) and
+then added under a CURL_WIN32 name
+(8bd863f97b6c79f561bc063e634cecdf4badf776). This a C preprocessor
+macro for driving the C compiler, not a cURL  option. Thus this fix
+ignores it.
+
+CURLOPT(na,t,nu) macro was added
+(920deff8618a19ae80bd319851722f1b05751f69) as replacement for CINIT()
+macro. It's not a cURL option. This fix also ignores it.
+
+CPAN RT#132197
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+--- Makefile.PL.orig	2021-11-23 09:56:23.000000000 -0600
++++ Makefile.PL	2021-11-23 10:13:48.000000000 -0600
+@@ -127,7 +127,7 @@
+     close H;
+ 
+     for my $e (sort @syms) {
+-       if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURL_STRICTER\z|^CURL_DID_MEMORY_FUNC_TYPEDEFS\z|_LAST\z|_LASTENTRY\z|^CURLINC_)/) {
++       if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURL_STRICTER\z|^CURL_DID_MEMORY_FUNC_TYPEDEFS\z|^CURL_WIN32\z|^CURLOPT\z|_LAST\z|_LASTENTRY\z|^CURLINC_)/) {
+           next;
+        }
+        my ($group) = $e =~ m/^([^_]+_)/;

--- a/perl/p5-www-curl/files/patch-default-inc-excludes-dot.diff
+++ b/perl/p5-www-curl/files/patch-default-inc-excludes-dot.diff
@@ -1,3 +1,5 @@
+Fix build with perl 5.25.11 and later.
+https://rt.cpan.org/Public/Bug/Display.html?id=122110
 --- Makefile.PL.orig	2017-07-03 05:27:58.000000000 -0700
 +++ Makefile.PL	2017-07-03 05:28:33.000000000 -0700
 @@ -1,6 +1,7 @@


### PR DESCRIPTION
#### Description

Add patch to fix build failure with recent curl.

Add patch to fix spurious error messages when using recent Xcode cpp.

Closes: https://trac.macports.org/ticket/61622

Increase revision to rebuild to pick up new curl symbols. Add comment to curl port reminding us to do this in the future when curl is updated.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H15 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
