### PR TITLE
Fixed `PYTHONPATH`'s `glob`

### DIFF
--- a/python/py-distorm/Portfile
+++ b/python/py-distorm/Portfile
@@ -31,8 +31,11 @@ if {${name} ne ${subport}} {
 
     depends_test-append port:yasm
 
+    pre-test {
+        test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
     test.run            yes
-    test.env            PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
     test.cmd            ${python.bin} python/test_distorm3.py
     test.target
 

--- a/python/py-gobject/Portfile
+++ b/python/py-gobject/Portfile
@@ -67,8 +67,11 @@ if {${subport} ne ${name}} {
     destroot.target         install
     destroot.destdir        DESTDIR=${destroot}
 
+    pre-test {
+        test.env            PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
     test.run        yes
-    test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
     test.target     check
 
     post-destroot {

--- a/python/py-jellyfish/Portfile
+++ b/python/py-jellyfish/Portfile
@@ -30,10 +30,13 @@ if {${name} ne ${subport}} {
     depends_test-append \
                     port:py${python.version}-pytest
 
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
     test.run        yes
     test.cmd        py.test-${python.branch}
     test.target     ${worksrcpath}/build/lib*/jellyfish/test.py
-    test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-ngl/Portfile
+++ b/python/py-ngl/Portfile
@@ -64,10 +64,13 @@ if {${name} ne ${subport}} {
                             F2CLIBS_PREFIX=${prefix}/lib/
     }
 
-    livecheck.type   none
+    livecheck.type          none
 
-    test.run         yes
-    test.env-append         PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    pre-test {
+        test.env-append     PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    test.run                yes
     test.cmd                ${python.bin} ./build/scripts-${python.branch}/pynglex
     test.target
     test.args               -w x11 ngl01p

--- a/python/py-numeric/Portfile
+++ b/python/py-numeric/Portfile
@@ -47,8 +47,11 @@ if {$subport ne $name} {
         }
     }
     
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
     test.run        yes
-    test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
     test.cmd        ${python.bin} Test/test.py
     test.target
     

--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -42,9 +42,12 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-numpy \
                             port:py${python.version}-pandas
 
+    pre-test {
+        # needed since the module is placed in something like ${worksrcpath}/build/lib.macosx-10.11-x86_64-3.7
+        test.env            PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
     test.cmd                nosetests-${python.branch}
-# needed since the module is placed in something like ${worksrcpath}/build/lib.macosx-10.11-x86_64-3.7
-    test.env                PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
     test.target
     test.run                yes
 }

--- a/python/py-pyrfc3339/Portfile
+++ b/python/py-pyrfc3339/Portfile
@@ -28,7 +28,10 @@ if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-tz
 
     depends_test-append port:py${python.version}-nose
-    test.run            yes
-    test.env            PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
 
+    pre-test {
+        test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
+    test.run            yes
 }

--- a/python/py-pyrsistent/Portfile
+++ b/python/py-pyrsistent/Portfile
@@ -42,10 +42,13 @@ if {${name} ne ${subport}} {
         port:py${python.version}-pytest \
         port:py${python.version}-pytest-runner
 
+    pre-test {
+        test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
     test.run            yes
     test.cmd            py.test-${python.branch}
     test.target
-    test.env            PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
 
     livecheck.type      none
 }

--- a/python/py-pyzstd/Portfile
+++ b/python/py-pyzstd/Portfile
@@ -26,8 +26,11 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
     test.run        yes
-    test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
 
     livecheck.type  none
 }

--- a/python/py-xlsx2csv/Portfile
+++ b/python/py-xlsx2csv/Portfile
@@ -32,9 +32,12 @@ if {${subport} ne ${name}} {
         reinplace "s|__PYTHON_VERSION__|${python.branch}|g" ${worksrcpath}/test/run
     }
 
+    pre-test {
+        test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+
     test.run            yes
     test.cmd            ${python.bin} ${worksrcpath}/test/run
-    test.env            PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
     test.target
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

This PR fixed a global issue with empty `PYTHONPATH` when it uses `glob`. So, this closes https://trac.macports.org/ticket/64045

Anyway, some affected ports cann't be tested localy:
 - `py27-ngl`: https://trac.macports.org/ticket/64046
 - `py27-numeric`: https://trac.macports.org/ticket/64047
 - `py39-gobject`: https://trac.macports.org/ticket/64048

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->