### PR TITLE
blender: Fix `OSL_SHADER_DIR-NOTFOUND` compile error

### DIFF
--- a/graphics/blender/Portfile
+++ b/graphics/blender/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 
 name                blender
 version             2.91.2
-revision            4
+revision            5
 categories          graphics multimedia
 platforms           darwin
 license             GPL-2+
@@ -247,6 +247,27 @@ list(APPEND USD_LIBRARIES\\
         reinplace {/set._embree_libraries_force_load/,/set.EMBREE_LIBRARIES .*_embree_libraries_force_load/s/^/#/} \
             ${platform_apple.cmake}
     }
+
+    # Fix hard-coded paths in the Find*.cmake scripts
+    foreach f [glob -directory \
+        ${worksrcpath}/build_files/cmake/Modules *.cmake \
+    ] {
+        foreach re [list \
+            "s|/usr/local|${prefix}|" \
+            "s|/usr/lib|${prefix}/lib|" \
+            "s|/usr/include|${prefix}/include|" \
+            "s|/usr/share|${prefix}/share|" \
+            "s|/opt/lib/\[0-9A-Za-z\]+|${prefix}/lib|" \
+            "s|/opt/include|${prefix}/include|" \
+            "s|/opt/share|${prefix}/share|" \
+        ] {
+            reinplace -q -E $re $f
+        }
+    }
+    reinplace -E "s|(${prefix}/lib)|\\1/opencollada|" \
+        ${worksrcpath}/build_files/cmake/Modules/FindOpenCOLLADA.cmake
+    reinplace -E "s|(${prefix}/lib)|\\1/usd|" \
+        ${worksrcpath}/build_files/cmake/Modules/FindUSD.cmake
 
     foreach re [list \
         "s/@@py_ver@@/$py_ver/g" \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This PR fixes the case where the compile fails with a `OSL_SHADER_DIR-NOTFOUND` error. The error occurs because Blender's CMake scripts are unable to find the directory that contains the OSL shaders, due to the search paths being hard-coded to search in `/usr/local`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
