### PR TITLE
KeePassXC: remove fix that is no more used

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -24,7 +24,7 @@ license_noconflict      openssl
 if {${subport} eq ${name}} {
     # stable
     github.setup        keepassxreboot keepassxc 2.6.6
-    revision            4
+    revision            5
     github.tarball_from releases
     distname            keepassxc-${version}-src
     use_xz              yes
@@ -53,7 +53,7 @@ if {${subport} eq ${name}} {
     github.setup        keepassxreboot keepassxc d3b28f86515df73194d1102253b739b51b1909f5
     set githash         [string range ${github.version} 0 6]
     version             20211123+git${githash}
-    revision            0
+    revision            1
 
     conflicts           KeePassXC
 
@@ -133,13 +133,6 @@ configure.pre_args-append \
 # https://github.com/keepassxreboot/keepassxc/issues/2484
 if {${os.major} >= 16} {
     configure.pre_args-append   -DWITH_XC_TOUCHID=ON
-}
-
-if {${os.major} < 16} {
-    pre-configure {
-        # error: call to unavailable function 'operator delete': introduced in macOS 10.12
-        reinplace "s|-fsized-deallocation||" ${worksrcpath}/CMakeLists.txt
-    }
 }
 
 post-destroot {


### PR DESCRIPTION
According to changes in CMakeLists.txt, since 2.6.0 KeePassXC checks if
'-fsized-deallocation' can be used during configuration.

So this piece of code is probably not needed anymore in the Portfile

(This couldn't be tested on <= 10.12)

I'm still doubting on whether this is still needed or not...

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
