### PR TITLE
notcurses: update to version 2.4.9

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        dankamongmen notcurses 2.4.8 v
+github.setup        dankamongmen notcurses 2.4.9 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ long_description    Notcurses facilitates the creation of modern TUI programs, m
 
 homepage            https://notcurses.com
 
-checksums           rmd160  f704becbc747786a2cb0c20b27278174c4ae2f54 \
-                    sha256  d06971005e4cf637cc90a694323c580791d1450a77b1700ae8deb453678d3243 \
-                    size    10091053
+checksums           rmd160  a2ef05c75b388c435026fbae7d7acc94126bbf26 \
+                    sha256  a2771ad1633e0158f8273fa8b30b5bce0f12e1205e863045f4ae186b6b52f537 \
+                    size    10097240
 
 compiler.c_standard 2011
 compiler.cxx_standard \


### PR DESCRIPTION
#### Description

This is the last release from the 2.x series. The next release, 3.0.0, will be an API+ABI break.
https://github.com/dankamongmen/notcurses/releases/tag/v2.4.9

3.0.0 will make (optional, but recommended) use of libdeflate, which appears to be missing from MacPorts. I'll try to get it packaged up before then.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

```
[cobra-la](1) $ sudo port test devel/notcurses/
Password:
Warning: port definitions are more than two weeks old, consider updating them by running 'port selfupdate'.
--->  Computing dependencies for notcurses
--->  Fetching distfiles for notcurses
--->  Attempting to fetch notcurses-2.4.9.tar.gz from https://ywg.ca.distfiles.macports.org/mirror/macports/distfiles/notcurses
--->  Attempting to fetch notcurses-2.4.9.tar.gz from https://distfiles.macports.org/notcurses
--->  Attempting to fetch notcurses-2.4.9.tar.gz from https://github.com/dankamongmen/notcurses/archive/v2.4.9
--->  Verifying checksums for notcurses
--->  Extracting notcurses
--->  Configuring notcurses
--->  Building notcurses
--->  Testing notcurses
[cobra-la](0) $ 
```
