### PR TITLE
qt5-qtwebengine: do not attempt building on arm64, macOS 12

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1650,6 +1650,19 @@ foreach {module module_info} [array get modules] {
                     }
                 }
 
+                # https://trac.macports.org/ticket/63725
+                if { ${os.major} >= 21} {
+                    known_fail  yes
+                    pre-fetch {
+                        ui_error "${subport} currently does not build on macOS 12 or later"
+                        return -code error "incompatible OS version"
+                    }
+                }
+
+                # arm64 not yet supported
+                # https://trac.macports.org/ticket/62059
+                supported_archs       x86_64
+
                 # UsingTheRightCompiler (https://trac.macports.org/wiki/UsingTheRightCompiler)
                 build.env-append      CXX=${configure.cxx}
                 build.env-append      CC=${configure.cc}


### PR DESCRIPTION
[skip ci]

See: https://trac.macports.org/ticket/62059
See: https://trac.macports.org/ticket/63725

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
