### PR TITLE
KeePassXC: fix compiliation with quazip1 & check deallocation functio…

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -24,7 +24,7 @@ license_noconflict      openssl
 if {${subport} eq ${name}} {
     # stable
     github.setup        keepassxreboot keepassxc 2.6.6
-    revision            4
+    revision            5
     github.tarball_from releases
     distname            keepassxc-${version}-src
     use_xz              yes
@@ -46,14 +46,16 @@ if {${subport} eq ${name}} {
                         yes
 
     patchfiles          patch-no-deployqt.diff \
+                        patch-sized_deallocation.diff \
                         patch-no-findpackage-path.diff \
+                        patch-quazip.diff \
                         patch-old-mac.diff
 } else {
     # devel subport
     github.setup        keepassxreboot keepassxc d3b28f86515df73194d1102253b739b51b1909f5
     set githash         [string range ${github.version} 0 6]
     version             20211123+git${githash}
-    revision            0
+    revision            1
 
     conflicts           KeePassXC
 
@@ -67,8 +69,10 @@ if {${subport} eq ${name}} {
     depends_lib-append  port:botan
 
     patchfiles          devel/patch-no-deployqt.diff \
+                        patch-sized_deallocation.diff \
                         devel/patch-no-findpackage-path.diff \
                         devel/patch-old-mac-other.diff \
+                        devel/patch-quazip.diff \
                         devel/patch-old-mac.diff
 
     post-destroot {
@@ -101,7 +105,7 @@ depends_lib-append      port:argon2 \
                         port:libsodium \
                         port:readline \
                         port:qrencode \
-                        port:quazip \
+                        port:quazip1 \
                         port:ykpers \
                         port:zlib
 
@@ -133,13 +137,6 @@ configure.pre_args-append \
 # https://github.com/keepassxreboot/keepassxc/issues/2484
 if {${os.major} >= 16} {
     configure.pre_args-append   -DWITH_XC_TOUCHID=ON
-}
-
-if {${os.major} < 16} {
-    pre-configure {
-        # error: call to unavailable function 'operator delete': introduced in macOS 10.12
-        reinplace "s|-fsized-deallocation||" ${worksrcpath}/CMakeLists.txt
-    }
 }
 
 post-destroot {

--- a/security/KeePassXC/files/devel/patch-quazip.diff
+++ b/security/KeePassXC/files/devel/patch-quazip.diff
@@ -1,0 +1,29 @@
+From 6cfadfaabafed8d0db213044a0bd22537609381c Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Sat, 13 Nov 2021 15:11:35 +0100
+Subject: [PATCH] add support for QuaZip >= 1.0
+
+---
+ src/keeshare/CMakeLists.txt | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/keeshare/CMakeLists.txt b/src/keeshare/CMakeLists.txt
+index af4bc61a8d..8749c2e4ec 100644
+--- src/keeshare/CMakeLists.txt
++++ src/keeshare/CMakeLists.txt
+@@ -23,7 +23,14 @@ if(WITH_XC_KEESHARE)
+ 
+     # Try to find libquazip5, if found, enable secure sharing
+     find_package(QuaZip)
+-    if(QUAZIP_FOUND)
++    find_package(QuaZip-Qt5)
++    if(QuaZip-Qt5_FOUND)
++        message(STATUS "Using QuaZip-Qt5 (quazip ${QuaZip-Qt5_VERSION})")
++        set(WITH_XC_KEESHARE_SECURE ON PARENT_SCOPE)
++        target_include_directories(keeshare SYSTEM PRIVATE QuaZip::QuaZip)
++        target_link_libraries(keeshare PRIVATE QuaZip::QuaZip)
++    elseif(NOT QuaZip-Qt5_FOUND AND QUAZIP_FOUND)
++        message(STATUS "Using QuaZip (quazip <1.0)")
+         set(WITH_XC_KEESHARE_SECURE ON PARENT_SCOPE)
+         target_include_directories(keeshare SYSTEM PRIVATE ${QUAZIP_INCLUDE_DIR})
+         target_link_libraries(keeshare PRIVATE ${QUAZIP_LIBRARIES})

--- a/security/KeePassXC/files/patch-quazip.diff
+++ b/security/KeePassXC/files/patch-quazip.diff
@@ -1,0 +1,45 @@
+From 6cfadfaabafed8d0db213044a0bd22537609381c Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Sat, 13 Nov 2021 15:11:35 +0100
+Subject: [PATCH] add support for QuaZip >= 1.0
+
+---
+ src/keeshare/CMakeLists.txt | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/keeshare/CMakeLists.txt b/src/keeshare/CMakeLists.txt
+index af4bc61a8d..8749c2e4ec 100644
+--- src/keeshare/CMakeLists.txt
++++ src/keeshare/CMakeLists.txt
+@@ -23,7 +23,14 @@ if(WITH_XC_KEESHARE)
+ 
+     # Try to find libquazip5, if found, enable secure sharing
+     find_package(QuaZip)
+-    if(QUAZIP_FOUND)
++    find_package(QuaZip-Qt5)
++    if(QuaZip-Qt5_FOUND)
++        message(STATUS "Using QuaZip-Qt5 (quazip ${QuaZip-Qt5_VERSION})")
++        set(WITH_XC_KEESHARE_SECURE ON PARENT_SCOPE)
++        target_include_directories(keeshare SYSTEM PRIVATE QuaZip::QuaZip)
++        target_link_libraries(keeshare PRIVATE QuaZip::QuaZip)
++    elseif(NOT QuaZip-Qt5_FOUND AND QUAZIP_FOUND)
++        message(STATUS "Using QuaZip (quazip <1.0)")
+         set(WITH_XC_KEESHARE_SECURE ON PARENT_SCOPE)
+         target_include_directories(keeshare SYSTEM PRIVATE ${QUAZIP_INCLUDE_DIR})
+         target_link_libraries(keeshare PRIVATE ${QUAZIP_LIBRARIES})
+Subject: [PATCH] Find quazip.h as installed by version 0.9
+
+quazip 0.9 has quazip.h in /opt/local/include/quazip5/quazip.h
+quazip 1.1 has quazip.h in /opt/local/include/QuaZip-Qt5-1.1/quazip/quazip.h
+
+--- cmake/FindQuaZip.cmake
++++ cmake/FindQuaZip.cmake
+@@ -7,7 +7,7 @@
+     find_path(QUAZIP_INCLUDE_DIRS quazip.h PATH_SUFFIXES quazip5)
+ elseif(APPLE)
+     find_library(QUAZIP_LIBRARIES quazip1-qt5)
+-    find_path(QUAZIP_INCLUDE_DIRS quazip.h PATH_SUFFIXES quazip)
++    find_path(QUAZIP_INCLUDE_DIRS quazip.h PATH_SUFFIXES quazip quazip5)
+ else()
+     # Try pkgconfig first
+     find_package(PkgConfig QUIET)

--- a/security/KeePassXC/files/patch-sized_deallocation.diff
+++ b/security/KeePassXC/files/patch-sized_deallocation.diff
@@ -1,0 +1,47 @@
+From fef0356d0d2b1be8ba9f6d7429314478934a6d13 Mon Sep 17 00:00:00 2001
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Wed, 24 Nov 2021 19:01:00 +0100
+Subject: [PATCH] Enable "-fsized-deallocation" iif deallocation functions are
+ present
+
+On some systems, although "-fsized-deallocation" compiler flag is there,
+compilation will fail because some deallocation functions are missing.
+Typically 'operator delete ( void* ptr, std::size_t sz )' is missing on some
+macOS systems.
+
+This will check their presence.
+
+On macOS we can have this case when using a compiler that supports the flag,
+while the OS doesn't have all the deallocation functions. Typically,
+::operator delete(ptr, size) appeared in macOS 10.12
+
+Reported error was:
+error: call to unavailable function 'operator delete': introduced in macOS 10.12
+---
+ CMakeLists.txt | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d8d0393f0..5452dc3c5 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -314,7 +314,18 @@ endif()
+ add_gcc_compiler_cflags("-std=c99")
+ add_gcc_compiler_cxxflags("-std=c++11")
+ 
+-check_add_gcc_compiler_flag("-fsized-deallocation" CXX)
++check_cxx_compiler_flag("-fsized-deallocation" CXX_HAS_fsized_deallocation)
++if(CXX_HAS_fsized_deallocation)
++    # Do additional check: the deallocation functions must be there too.
++    set(CMAKE_REQUIRED_FLAGS "-fsized-deallocation")
++    check_cxx_source_compiles("#include <new>
++        int main() { void * ptr = nullptr; std::size_t size = 1; ::operator delete(ptr, size); }"
++        HAVE_DEALLOCATION_FUNCTIONS)
++    if(HAVE_DEALLOCATION_FUNCTIONS)
++        check_add_gcc_compiler_flag("-fsized-deallocation" CXX)
++    endif()
++    unset(CMAKE_REQUIRED_FLAGS)
++endif()
+ 
+ if(APPLE AND CMAKE_COMPILER_IS_CLANGXX)
+     add_gcc_compiler_cxxflags("-stdlib=libc++")


### PR DESCRIPTION
* quazip was not well detected. This fixes it.

* Replace "-fsized-deallocation" pre-configure reinplace of Portfile by a patch
that detects whether the system provides requested deallocation function. Iif
present, -fsized-deallocation will be enabled.
This is useful for macOS < 10.12 systems which don't have all these functions

Patch was tested on 10.11 -> detection fails, as expected
Patch was tested on 10.13 -> detection succeeds, as expected

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

&

macOS 10.13.6 17G65
Xcode 9.4.1


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
