### PR TITLE
git: update to 2.34.1

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,13 +4,15 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.34.0
+version             2.34.1
 revision            0
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
                     control system focusing on speed and efficiency.
-maintainers         {ciserlohn @ci42} openmaintainer
+maintainers         {ciserlohn @ci42} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 categories          devel
 license             GPL-2 LGPL-2.1+
 installs_libs       no
@@ -24,13 +26,13 @@ distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}${extract.suffix} \
-                    rmd160  dab824afafa6fbca972ef1f87c7328006d4ab991 \
-                    sha256  fd6cb9b26665794c61f9ca917dcf00e7c19b0c02be575ad6ba9354fa6962411f \
-                    size    6623924 \
+                    rmd160  2bec7cddacda8f685e96ce6d534d6fc5ec7b5a84 \
+                    sha256  3a0755dd1cfab71a24dd96df3498c29cd0acd13b04f3d08bf933e81286db802c \
+                    size    6623760 \
                     git-manpages-${version}${extract.suffix} \
-                    rmd160  e7d210d988ac02f089f18da96b1dbb6ef779a4fa \
-                    sha256  47eafa3517ef5fc7a6e914ad2ee6a6e4d830a4bb6830dba13175850860492c72 \
-                    size    497252
+                    rmd160  295300e85a66565b204a903e5abd8dd2209956d8 \
+                    sha256  9c635dd772ff21bcc4b7bab9f0de0dd01afb34b0eda3c83907e026bd3b3c7eb8 \
+                    size    497280
 
 perl5.require_variant   false
 perl5.conflict_variants yes
@@ -156,9 +158,9 @@ variant pcre description {Use pcre} {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}${extract.suffix} \
-                            rmd160  882eb53f75d4056f98ba8725759b069a2d02225b \
-                            sha256  c95d838dbd4b8c28d9f00beca776c06d94031be05fa39cf33fb08ae5f0aee250 \
-                            size    1406204
+                            rmd160  b9c7972dc870313b4e57d8af281dbd56f1e151d0 \
+                            sha256  7896a36c6497293c8d63d3bc120b063b6521eb1be7658540d1a6e67f0af5c4f3 \
+                            size    1406464
 
     patchfiles-append       patch-git-subtree.html.diff
 
@@ -251,7 +253,7 @@ For more information, run
 
 NOTE: ${prefix}/etc/gitconfig will be over-written on port upgrades, and
       thus it is NOT recommended to place any personal customisations in
-      this file. Instead use your personal configuration file 
+      this file. Instead use your personal configuration file
          \(\$HOME/.gitconfig\)
       for any additional modifications you wish to make.
 "


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
