### PR TITLE
py-reportlab: update to 3.6.2, add py310 subport

### DIFF
--- a/python/py-reportlab/Portfile
+++ b/python/py-reportlab/Portfile
@@ -26,6 +26,14 @@ checksums           rmd160  12c13059744117c384ce593dae676a2197dcff18 \
                     size    4501397
 
 if {${name} ne ${subport}} {
+    if {${python.version} <= 27} {
+        version     3.5.68
+        revision    0
+        checksums   rmd160  96db163e57d1fb065dc2f3def9e2736764e0b5c9 \
+                    sha256  efef6a97e3ab49f3f40037dbf9a4166668a17cc6aaba13d5ecbabdf854a9b332 \
+                    size    4512985
+    }
+
     depends_build-append    port:py${python.version}-setuptools
 
     depends_lib-append      port:freetype \

--- a/python/py-reportlab/Portfile
+++ b/python/py-reportlab/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-reportlab
-version             3.6.1
+version             3.6.2
 revision            0
 categories-append   textproc
 platforms           darwin
 license             BSD
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -21,9 +21,9 @@ long_description    The ReportLab Toolkit is a library for programatically \
 
 homepage            https://www.reportlab.com/software/opensource/rl-toolkit/
 
-checksums           rmd160  58327ab1dd63af72a225a9ae6a262a5ba12a8c10 \
-                    sha256  68f9324000cfc5570b5a59a92306691b5d655078a399f20bc72c2581fe903261 \
-                    size    4511585
+checksums           rmd160  12c13059744117c384ce593dae676a2197dcff18 \
+                    sha256  f0c4b47b012d893b0b9f5703cf6f01b5593714a3fc1e7dc73efbbfe26bb7e16a \
+                    size    4501397
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Closes https://trac.macports.org/ticket/64053

I don't really know how to use reportlab but I confirmed that it installs and is able to be imported on Python 3.10.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->