### PR TITLE
ruby-build: update to 20211124

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20210804 v
+github.setup        rbenv ruby-build 20211124 v
 categories          ruby
 license             MIT
 platforms           darwin
@@ -14,9 +14,9 @@ maintainers         {mojca @mojca} openmaintainer
 description         Compile and install Ruby
 long_description    ${description}
 
-checksums           rmd160  82aa1950ae1265d8bf9c8addbc544ca35a254bd9 \
-                    sha256  9046c4a59db32deac0e2eb597e07f3458a1028faebdcb812876d97bbebf91793 \
-                    size    72099
+checksums           rmd160  a38d2497e3e06f7dc1d83f4be07b7052967df984 \
+                    sha256  cef2db42fe526dd614dc308e9092081c624f93c49ab2853ad9e71d3a0cb907cc \
+                    size    73025
 
 use_configure       no
 build {}


### PR DESCRIPTION
-------

#### Description

Update to 20211124

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->