### PR TITLE
botan: disable all intrinsics by default, add 'native' variant

### DIFF
--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                botan
 version             2.18.2
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          security devel
 platforms           darwin
@@ -68,6 +68,28 @@ configure.args-append --docdir=share/doc \
                       --with-sqlite3 \
                       --with-zlib
 
+# List of all intrisics that can be disabled
+set intrinsics {}
+lappend intrinsics sse2
+lappend intrinsics ssse3
+lappend intrinsics sse4.1
+lappend intrinsics sse4.2
+lappend intrinsics avx2
+lappend intrinsics bmi2
+lappend intrinsics rdrand
+lappend intrinsics rdseed
+lappend intrinsics aes-ni
+lappend intrinsics sha-ni
+lappend intrinsics altivec
+lappend intrinsics neon
+lappend intrinsics armv8crypto
+lappend intrinsics powercrypto
+
+# Disable all the intrinsics
+foreach elem $intrinsics {
+    configure.args-append --disable-$elem
+}
+
 if {[string match *clang* ${configure.compiler}]} {
     configure.args-append --cc=clang
 } elseif {[string match *gcc* ${configure.compiler}]} {
@@ -83,6 +105,13 @@ if {${os.major} <= 14} {
 configure.optflags  -O3
 
 platform darwin { configure.args-append --os=darwin }
+
+# Variant to re-enable use of intrinsics
+variant native description {Enable all intrinsics} {
+    foreach elem $intrinsics {
+        configure.args-delete --disable-$elem
+    }
+}
 
 # botan way of setting cpu type in build phase
 array set merger_configure_args {


### PR DESCRIPTION
#### Description
~~add variants to configure with some intrinsics disabled~~
disable all intrinsics by default, add 'native' variant

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
