### PR TITLE
scrcpy: Set supported_archs to noarch

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -38,7 +38,22 @@ depends_build-append \
 depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
                     port:libsdl2
 
-depends_run-append  port:android-platform-tools
+variant adb description {Install android-platform-tools for adb} {
+    depends_run-append  port:android-platform-tools
+}
+
+if {${configure.build_arch} eq "x86_64"} {
+    default_variants +adb
+}
+
+if {![variant_isset adb]} {
+    notes "
+        adb has to be available in your PATH at runtime. You can either:
+        * Install it via MacPorts: `sudo port install android-platform-tools`
+        * Install it via Android Studio and add it to your PATH
+        * Install scrcpy using the +adb variant: `sudo port install scrcpy +adb`
+    "
+}
 
 configure.args-append \
                     --buildtype release \


### PR DESCRIPTION
#### Description

This enables scrcpy to be installed on arm64 devices, even if its
dependency android-platform-tools is only available for x86_64 devices.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d
and 
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
