### PR TITLE
notcurses 2.4.9: update with patch for macos compilation

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        dankamongmen notcurses 2.4.8 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          devel
 platforms           darwin
@@ -39,5 +39,7 @@ depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
                     port:libunistring \
                     port:ncurses \
                     port:zlib
+
+patchfiles          patch-excise-filesystem-include.diff
 
 test.run            yes

--- a/devel/notcurses/files/patch-excise-filesystem-include.diff
+++ b/devel/notcurses/files/patch-excise-filesystem-include.diff
@@ -1,0 +1,10 @@
+--- src/tests/main.cpp
++++ src/tests/main.cpp
+@@ -7,7 +7,6 @@
+ #include <iostream>
+ #include <climits>
+ #include <sys/stat.h>
+-#include <filesystem>
+ 
+ const char* datadir = NOTCURSES_SHARE;
+ // NCLOGLEVEL_INFO for initial testing framework creation. we then switch to


### PR DESCRIPTION
#### Description

#13103 updated `devel/notcurses` to 2.4.9, but the 10.4 build was broken due to an errant `#include`. Add a patch to excise it. It was not actually being used.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
