### PR TITLE
py-authheaders: Submission

### DIFF
--- a/python/py-authheaders/Portfile
+++ b/python/py-authheaders/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-authheaders
+version             0.14.1
+categories-append   devel mail
+platforms           darwin
+license             MIT
+
+python.versions     38 39
+
+maintainers         nomaintainer
+
+description         Library for the generation of email authentication headers
+long_description    A library wrapping email authentication header \
+                    verification and generation. The library can \
+                    perform DKIM, SPF, and DMARC validation, and the \
+                    results are packaged into the Authentication-Results \
+                    header.
+
+homepage            https://github.com/ValiMail/authentication-headers
+
+checksums           rmd160  492d5743a95c5c41c40fe141307ea1b769bc6aaf \
+                    sha256  4e601b5b54080019a2f548fadf80ddf9c5538615607c7fb602936404aafe67e2 \
+                    size    101412
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-authres \
+                    port:py${python.version}-dkimpy \
+                    port:py${python.version}-dnspython \
+                    port:py${python.version}-ipaddress \
+                    port:py${python.version}-publicsuffix2
+
+    livecheck.type  none
+}


### PR DESCRIPTION
Depends upon #13128.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
