### PR TITLE
tkimg: update to 1.4.13

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -4,7 +4,8 @@ PortSystem              1.0
 PortGroup               active_variants 1.1
 
 name                    tkimg
-version                 1.4.11
+version                 1.4.13
+revision                0
 categories              graphics
 license                 Tcl/Tk
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -18,9 +19,9 @@ master_sites            sourceforge:tkimg/tkimg/[join [lrange [split ${version} 
 distname                Img-${version}-Source
 worksrcdir              Img-${version}
 
-checksums               rmd160  7d7f40c59753f7fa2b5d84e86bfd0d285a61ef2e \
-                        sha256  a6b297950f701ec62b4931649ca5feb205d14d08020fe366d6cf69f0e7e05f88 \
-                        size    7610956
+checksums               rmd160  3fc3942847eef222046652719eee4c21b11e4151 \
+                        sha256  f0868c1cad9752dcf1234f81f00c417d34a11c0f0dd499ba469df29f1c40d163 \
+                        size    8366556
 
 # ensure tkimg works when tk is installed +quartz
 patchfiles-append       patch-quartz.diff


### PR DESCRIPTION
#### Description
From ANNOUNCE:
```
Changes compared to version 1.4.12:
  - Disable support of zstd in libtiff.

Changes compared to version 1.4.11:
  - Corrected bug in BMP and XBM parser.
  - Updated external libraries: JPEG 9d, PNG 1.6.37, TIFF 4.1.0.
  - Updated to latest TEA files.
  - Corrected nmake builds.
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools
(both +x11 and +quartz)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
