### PR TITLE
py-zope-i18nmessageid: Submission

### DIFF
--- a/python/py-zope-i18nmessageid/Portfile
+++ b/python/py-zope-i18nmessageid/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-zope-i18nmessageid
+python.rootname     zope.i18nmessageid
+version             5.0.1
+revision            0
+python.versions     38 39 310
+maintainers         nomaintainer
+platforms           darwin
+license             ZPL-2.1
+
+description         Message Identifiers for internationalization
+long_description    To translate any text, we must be able to discover \
+                    the source domain of the text. A source domain is \
+                    an identifier that identifies a project that \
+                    produces program source strings. Source strings \
+                    occur as literals in python programs, text in \
+                    templates, and some text in XML data. The project \
+                    implies a source language and an application \
+                    context.
+
+categories-append   zope
+
+homepage            https://github.com/zopefoundation/zope.i18nmessageid
+
+checksums           rmd160  d73bcabe12ec89baa16fab7c4e56ca675d7ebb99 \
+                    sha256  9534142b684c986f5303f469573978e5a340f05ba2eee4f872933f1c38b1b059 \
+                    size    28217
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
