### PR TITLE
boost176/177: Fix misleading comment

### DIFF
--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -106,9 +106,10 @@ patchfiles-append patch-export_serialization_explicit_template_instantiations.di
 patchfiles-append patch-revert-lib-name-tagged.diff
 
 # Availability.h -> AvailabilityMacros.h on Tiger
-# A better fix was accepted upstream:
+# The attempted fix:
 # https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
-# So this patch can be removed for Boost 1.77 or later.
+# is insufficient because GCC 6/7 still defines __cpp_lib_uncaught_exceptions
+# in the absence of __STRICT_ANSI__
 platform darwin 8 {
     patchfiles-append patch-tiger-availability.diff
 }

--- a/devel/boost177/Portfile
+++ b/devel/boost177/Portfile
@@ -107,9 +107,10 @@ patchfiles-append patch-export_serialization_explicit_template_instantiations.di
 patchfiles-append patch-revert-lib-name-tagged.diff
 
 # Availability.h -> AvailabilityMacros.h on Tiger
-# A better fix was accepted upstream:
+# The attempted fix:
 # https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
-# So this patch can be removed for Boost 1.77 or later.
+# is insufficient because GCC 6/7 still defines __cpp_lib_uncaught_exceptions
+# in the absence of __STRICT_ANSI__
 platform darwin 8 {
     patchfiles-append patch-tiger-availability.diff
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
