### PR TITLE
tkimg: attempt to fix ARM build

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -34,6 +34,9 @@ patchfiles-append       patch-quartz.diff
 #    https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-tcltk/tkimg
 #    https://packages.debian.org/sid/libtk-img
 
+# https://trac.macports.org/ticket/64067
+patchfiles-append       patch-arm-neon.diff
+
 # for dtplite
 depends_build-append    port:tcllib
 

--- a/graphics/tkimg/files/patch-arm-neon.diff
+++ b/graphics/tkimg/files/patch-arm-neon.diff
@@ -1,0 +1,37 @@
+Index: libpng/configure.ac
+===================================================================
+--- libpng/configure.ac	(revision 548)
++++ libpng/configure.ac	(working copy)
+@@ -65,6 +65,7 @@
+ TEA_ADD_SOURCES([pngtcl.c pngtclStubInit.c])
+ 
+ TEA_ADD_SOURCES([
++	../compat/libpng/arm/arm_init.c	../compat/libpng/arm/filter_neon_intrinsics.c	../compat/libpng/arm/palette_neon_intrinsics.c
+ 	../compat/libpng/png.c	../compat/libpng/pngerror.c	../compat/libpng/pngmem.c
+ 	../compat/libpng/pngpread.c	../compat/libpng/pngread.c	../compat/libpng/pngrio.c
+ 	../compat/libpng/pngrtran.c	../compat/libpng/pngrutil.c	../compat/libpng/pngset.c
+Index: libpng/configure
+===================================================================
+--- libpng/configure	(revision 548)
++++ libpng/configure	(working copy)
+@@ -5451,6 +5451,7 @@
+ 
+ 
+     vars="
++	../compat/libpng/arm/arm_init.c	../compat/libpng/arm/filter_neon_intrinsics.c	../compat/libpng/arm/palette_neon_intrinsics.c
+ 	../compat/libpng/png.c	../compat/libpng/pngerror.c	../compat/libpng/pngmem.c
+ 	../compat/libpng/pngpread.c	../compat/libpng/pngread.c	../compat/libpng/pngrio.c
+ 	../compat/libpng/pngrtran.c	../compat/libpng/pngrutil.c	../compat/libpng/pngset.c
+Index: libpng/Makefile.in
+===================================================================
+--- libpng/Makefile.in	(revision 548)
++++ libpng/Makefile.in	(working copy)
+@@ -269,7 +269,7 @@
+ # As necessary, add $(srcdir):$(srcdir)/compat:....
+ #========================================================================
+ 
+-VPATH = $(srcdir):$(srcdir)/../compat/libpng
++VPATH = $(srcdir):$(srcdir)/../compat/libpng:$(srcdir)/../compat/libpng/arm
+ 
+ .c.@OBJEXT@:
+ 	$(COMPILE) -c `@CYGPATH@ $<` -o $@


### PR DESCRIPTION
See: https://trac.macports.org/ticket/64067

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools

Although x86_64 is not affected by this issue, the files providing the missing functions needed on ARM now build.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
