### PR TITLE
upx-devel: update to 20211127

### DIFF
--- a/archivers/upx/Portfile
+++ b/archivers/upx/Portfile
@@ -28,9 +28,9 @@ if {${name} eq ${subport}} {
 }
 
 subport upx-devel {
-    github.setup    upx upx 716d203a78720002235853ff434ac20884ab1d53
+    github.setup    upx upx b4558e2049653c832cfde6c9a23d28455743853e
     github.livecheck.branch devel
-    version         20181231
+    version         20211127
 
     fetch.type      git
 
@@ -39,6 +39,9 @@ subport upx-devel {
     }
 
     conflicts       upx
+
+    compiler.cxx_standard \
+                    2014
 }
 
 use_configure       no
@@ -47,6 +50,7 @@ depends_lib         port:ucl port:zlib
 
 post-configure {
     reinplace "s|CXXFLAGS += -fno-delete-null-pointer-checks||" ${worksrcpath}/src/Makefile
+    reinplace "s|CXXFLAGS_NO_DELETE_NULL_POINTER_CHECKS ?= -fno-delete-null-pointer-checks||" ${worksrcpath}/src/Makefile
     reinplace "s| -Wvla||" ${worksrcpath}/src/Makefile
 }
 
@@ -63,5 +67,9 @@ destroot {
 
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 -W ${worksrcpath}/doc upx.doc upx.html ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 -W ${worksrcpath} BUGS COPYING LICENSE NEWS PROJECTS README README.1ST README.SRC THANKS ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} BUGS COPYING LICENSE NEWS README README.1ST README.SRC THANKS ${destroot}${prefix}/share/doc/${name}
+
+    if {${name} eq ${subport}} {
+        xinstall -m 644 -W ${worksrcpath} PROJECTS ${destroot}${prefix}/share/doc/${name}
+    }
 }

--- a/databases/usql/Portfile
+++ b/databases/usql/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/xo/usql 0.9.5 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Universal command-line interface for SQL databases
 
@@ -32,7 +32,7 @@ checksums           rmd160  5f0f71d7143f4d83fe8a50a2edd1b594d95cf9e8 \
 
 depends_build-append \
                     port:realpath \
-                    port:upx
+                    path:bin/upx:upx
 depends_lib-append  port:icu
 
 # Allow Go to download dependencies during build time

--- a/devel/retdec/Portfile
+++ b/devel/retdec/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        avast retdec 4.0 v
-revision            4
+revision            5
 conflicts           ${name}-devel
 
 categories          devel
@@ -68,7 +68,7 @@ depends_lib-append  port:python39 \
                     port:zlib
 
 depends_run-append  path:bin/dot:graphviz \
-                    port:upx
+                    path:bin/upx:upx
 
 # error: /usr/bin/ranlib: unknown option character `n' in: -no_warning_for_no_symbols
 if {${os.platform} eq "darwin" && ${os.major} < 13} {
@@ -92,7 +92,7 @@ subport retdec-devel {
 
     github.setup    avast retdec d6dee5807ea3d24c5ec1e7f1bf759e95ba3862c7
     version         20211115
-    revision        0
+    revision        1
     epoch           1
 
     checksums       rmd160  91ab301f2a02ed93d9ba47cb0f96db4b79e61200 \

--- a/devel/talisman/Portfile
+++ b/devel/talisman/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/thoughtworks/talisman 1.11.0 v
 go.package          talisman
-revision            0
+revision            1
 
 homepage            https://thoughtworks.github.io/talisman
 
@@ -30,7 +30,7 @@ installs_libs       no
 
 depends_build-append \
                     port:gox \
-                    port:upx
+                    path:bin/upx:upx
 
 build.cmd           gox
 build.args          -os="${goos}" -arch="${goarch}" \


### PR DESCRIPTION
#### Description

This PR also allow to build `usql` and `talisman` when `upx-devel` is installed on the system, and allows to use `retdec`.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->