### PR TITLE
jreleaser: update to 0.9.0

### DIFF
--- a/devel/jreleaser/Portfile
+++ b/devel/jreleaser/Portfile
@@ -4,11 +4,11 @@ PortSystem       1.0
 PortGroup        java 1.0
 
 name             jreleaser
-version          0.8.0
+version          0.9.0
 revision         0
-                 
+
 categories       devel java
-license          Apache-2
+license          Apache-2.0
 maintainers      @aalmiray
 platforms        darwin
 supported_archs  noarch
@@ -16,21 +16,23 @@ supported_archs  noarch
 description      Release projects quickly and easily with JReleaser
 long_description JReleaser is a release automation tool. Its goal is to simplify creating releases \
                  and publishing artifacts to multiple package managers while providing customizable options. \
+                  \
                  JReleaser takes inputs from popular builds tools (Ant, Maven, Gradle) such as JAR files, binary \
                  distributions (.zip, .tar), JLink images, or any other file that you’d like to publish as a Git \
                  release on popular Git services such as Github or Gitlab. Distribution files can additionally be \
                  published to be consumed by popular package managers as Homebrew, Snapcraft, or get ready to be \
                  launched via JBang. Releases may be announced in a variety of channels such as Twitter, Zulip, or SDKMAN!
+
 homepage         https://jreleaser.org
 
 master_sites     https://github.com/jreleaser/jreleaser/releases/download/v${version}
 use_zip          yes
 
-checksums        rmd160 5c45d1a69f3649d9702ba07b3c61dd860d2dfcbb \
-                 sha256 be7d14d22d38e7a3fbd1a105f9d55d46afd773c9d8b0f983e6539692a042fca6 \
-                 size   22022685
+checksums        rmd160 814b44dcbfe9559c7eb554583b33eca818a13949 \
+                 sha256 2a0e82f59400bfa0e87ed42ca10a824ce830d856df28a944e1ae1467cdad18fa \
+                 size   22229605
 
-java.version     1.8.+
+java.version     1.8+
 
 use_configure    no
 
@@ -38,20 +40,20 @@ build {}
 
 destroot {
     set target ${destroot}${prefix}/share/java/${name}
-    
+
     # Create the target java directory
     xinstall -m 755 -d ${target}
-    
+
     # Copy over the needed elements of our directory tree
     foreach d { bin lib } {
         copy ${worksrcpath}/${d} ${target}
     }
 
-    # Remove extraneous bat files
+    # Remove extraneous files
     foreach f [glob -directory ${target}/bin *.bat] {
         delete ${f}
     }
-    
+
     ln -s ../share/java/${name}/bin/jreleaser ${destroot}${prefix}/bin/jreleaser
 }
 


### PR DESCRIPTION
#### Description

Updates JReleaser to v0.9.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
