### PR TITLE
notcurses: Build man-pages for arm64

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -22,9 +22,27 @@ long_description    Notcurses facilitates the creation of modern TUI programs, m
 
 homepage            https://notcurses.com
 
-checksums           rmd160  f704becbc747786a2cb0c20b27278174c4ae2f54 \
+master_sites-append https://github.com/dankamongmen/${name}/releases/download/v${version}/:bootstrap
+distfiles-append    ${name}-doc-${version}${extract.suffix}:bootstrap
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  f704becbc747786a2cb0c20b27278174c4ae2f54 \
                     sha256  d06971005e4cf637cc90a694323c580791d1450a77b1700ae8deb453678d3243 \
-                    size    10091053
+                    size    10091053 \
+                    ${name}-doc-${version}${extract.suffix} \
+                    rmd160  c93f94c33da7ee008c2184ab1f69c8b6e0ea2ebb \
+                    sha256  4740550f5a981c433c256b48072969b7111cae34d2add36d417e63b8d94c8641 \
+                    size    134433
+
+extract.only        ${distname}${extract.suffix}
+
+# create directory for ${name}-doc archive
+post-extract {
+    system -W ${workpath} "mkdir ${name}-doc-${version}"
+    system -W ${workpath}/${name}-doc-${version} "/usr/bin/gzip -dc\
+        ${distpath}/${name}-doc-${version}${extract.suffix} |\
+        /usr/bin/tar -xf -"
+}
 
 compiler.c_standard 2011
 compiler.cxx_standard \
@@ -32,7 +50,6 @@ compiler.cxx_standard \
 
 depends_build-append \
                     port:doctest \
-                    port:pandoc \
                     port:pkgconfig
 
 depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
@@ -40,6 +57,17 @@ depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
                     port:ncurses \
                     port:zlib
 
+configure.args-append \
+                    -DUSE_PANDOC=OFF
+
 patchfiles          patch-excise-filesystem-include.diff
+
+post-destroot {
+    set notcurses-doc ${workpath}/${name}-doc-${version}
+    xinstall -m 0644 {*}[glob ${notcurses-doc}/*.1] \
+        ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 {*}[glob ${notcurses-doc}/*.3] \
+        ${destroot}${prefix}/share/man/man3
+}
 
 test.run            yes


### PR DESCRIPTION
See: https://trac.macports.org/ticket/64063

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
