### PR TITLE
kcov: add rpath for LLDB

### DIFF
--- a/devel/kcov/Portfile
+++ b/devel/kcov/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 14
 
 github.setup        SimonKagstrom kcov 38 v
-revision            0
+revision            1
 checksums           rmd160  7bc2dfb463ec46c5ae541894fc522c18a615e9f2 \
                     sha256  b37af60d81a9b1e3b140f9473bdcb7975af12040feb24cc666f9bb2bb0be68b4 \
                     size    306098
@@ -36,7 +36,8 @@ depends_build-append \
 depends_lib-append  port:curl \
                     port:zlib
 
-patchfiles          bin-to-c-source.py.use-python38.patch
+patchfiles          bin-to-c-source.py.use-python38.patch \
+                    kcov-lldb-rpath.patch
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/src/bin-to-c-source.py

--- a/devel/kcov/files/kcov-lldb-rpath.patch
+++ b/devel/kcov/files/kcov-lldb-rpath.patch
@@ -1,0 +1,11 @@
+--- src/CMakeLists.txt.orig	2021-12-07 21:15:06.000000000 -0800
++++ src/CMakeLists.txt	2021-12-07 21:32:38.000000000 -0800
+@@ -443,7 +443,7 @@
+       set(LLDB_LIBRARY_INSTALL_NAME "${LLDB_LIBRARY}/Versions/Current/LLDB")
+ 	  add_custom_command(TARGET ${KCOV}
+         POST_BUILD COMMAND
+-        "${CMAKE_INSTALL_NAME_TOOL}" -change @rpath/LLDB.framework/LLDB "${LLDB_LIBRARY_INSTALL_NAME}" $<TARGET_FILE:${KCOV}>
++        "${CMAKE_INSTALL_NAME_TOOL}" -change @rpath/LLDB.framework/LLDB "${LLDB_LIBRARY_INSTALL_NAME}" -change @rpath/LLDB.framework/Versions/A/LLDB "${LLDB_LIBRARY_INSTALL_NAME}" $<TARGET_FILE:${KCOV}>
+         COMMENT "Changing LLDB install name from @rpath/LLDB.framework/LLDB to ${LLDB_LIBRARY_INSTALL_NAME}")
+ 	endif()
+ endif()


### PR DESCRIPTION
#### Description

On at least OS X 11 and 12 (all I have available for testing now),
kcov currently fails to start:

```
dyld[3855]: Library not loaded: @rpath/LLDB.framework/Versions/A/LLDB
  Referenced from: /opt/local/bin/kcov
  Reason: tried: '/opt/local/lib/LLDB.framework/Versions/A/LLDB' (no such file), '/opt/local/lib/LLDB.framework/Versions/A/LLDB' (no such file), '/Library/Frameworks/LLDB.framework/Versions/A/LLDB' (no such file), '/System/Library/Frameworks/LLDB.framework/Versions/A/LLDB' (no such file)
```

LLDB.framework isn't in the system path on these versions of OS X. The
only copy on my systems is in
`/Library/Developer/CommandLineTools/Library/PrivateFrameworks`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
