### PR TITLE
gcc11: Update (arm) to 11.2.0

### DIFF
--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -44,19 +44,27 @@ master_sites        https://ftpmirror.gnu.org/gcc/gcc-${version}/ \
 # https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/gcc.rb
 # Branch from the Darwin maintainer of GCC with Apple Silicon support
 if { ${os.arch} eq "arm" } {
-    version         11.1.0
-    revision        2
+    version         11.2.0
+    revision        0
     master_sites    https://github.com/fxcoudert/gcc/archive
-    distname        gcc-${version}-arm-20210504
-    checksums       rmd160  ccb26e52571aff9230f4bdf067fe8c9d1fb79235 \
-                    sha256  ce862b4a4bdc8f36c9240736d23cd625a48af82c2332d2915df0e16e1609a74c \
-                    size    125460899
+    distname        gcc-${version}-arm-20211126
+    checksums       rmd160  ce5d0621028c8ff2bf3ab677b29f6c14e4c86dfe \
+                    sha256  39416a5a2a0e00c5096937c456ca7632958271b438398184b9a55f6d437f681d \
+                    size    125611219
 } else {
     distname        gcc-${version}
     use_xz          yes
     checksums       rmd160  0fdd0b2c0954ccbd32e24f027d7b55fd26dcc627 \
                     sha256  d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b \
                     size    80888824
+
+    if { ${os.platform} eq "darwin" } {
+        # Add preliminary Darwin 21 support to GCC 11.
+        # This should be removed, when GCC 11 supports Darwin 21 officially and the
+        # respective version is used by macports.
+        # See also: https://github.com/iains/gcc-darwin-arm64/commit/20f61faaed3b335d792e38892d826054d2ac9f15
+        patchfiles-append patch-darwin21-support.diff
+    }
 }
 
 subport             libgcc11 { revision [ expr ${revision} + 0 ] }
@@ -64,11 +72,6 @@ subport             libgcc11 { revision [ expr ${revision} + 0 ] }
 patchfiles          patch-Make-lang.in.diff
 
 if { ${os.platform} eq "darwin" } {
-    # Add preliminary Darwin 21 support to GCC 11.
-    # This should be removed, when GCC 11 supports Darwin 21 officially and the
-    # respective version is used by macports.
-    # See also: https://github.com/iains/gcc-darwin-arm64/commit/20f61faaed3b335d792e38892d826054d2ac9f15
-    patchfiles-append patch-darwin21-support.diff
     # This following patch works around a problem on MacOS 12.0 with fortran
     # See also: https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=fabe8cc41e9b01913e2016861237d1d99d7567bf
     patchfiles-append patch-darwin21-fortran.diff


### PR DESCRIPTION
#### Description

Updating to the latest tag from the arm port fixes the build.

Closes: https://trac.macports.org/ticket/63677

See also: Homebrew/homebrew-core@fec95e92

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
