### PR TITLE
telescope: new port

### DIFF
--- a/net/telescope/Portfile
+++ b/net/telescope/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        omar-polo telescope 0.6.1
+revision            0
+categories          net
+license             ISC
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+platforms           darwin
+description         A Gemini Browser
+long_description    Telescope is a Emacs/w3m-inspired browser for the "small internet" \
+                    that supports Gemini, Gopher and Finger
+
+checksums           rmd160  a102dd750da7c8d0db5aa6633b0f8e67651758df \
+                    sha256  01f69127a2d457878c43459d2eeefa2a455e99a0f56878ae7dbb9bce487ff0cd \
+                    size    1276576
+
+depends_build       port:autoconf \
+                    port:bison \
+                    port:pkgconfig
+
+depends_lib         path:lib/libtls.dylib:libressl \
+                    port:libevent \
+                    port:ncurses
+
+use_autoreconf      yes


### PR DESCRIPTION
#### Description
[**Telescope**](https://github.com/omar-polo/telescope) is a Emacs/w3m-inspired browser for the "small internet" that supports Gemini, Gopher and Finger.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
