### PR TITLE
android-platform-tools: Set install_libs to no

### DIFF
--- a/java/android-platform-tools/Portfile
+++ b/java/android-platform-tools/Portfile
@@ -8,6 +8,7 @@ set ver_hash        e8b2b4cbe47c728c1e54c5f524440b52d4e1a33c
 # Starting from 30.0.1 there's this long string in the file name. Probably commit hash.
 # Can be found in https://dl-ssl.google.com/android/repository/repository2-1.xml
 categories          java devel
+installs_libs       no
 maintainers         nomaintainer
 
 homepage            https://developer.android.com/studio/


### PR DESCRIPTION
#### Description

As android-platform-tools does not install any shared libs disable
`install_libs` specifically so it can be used as dependency in ports
that do not specify `supported_archs x86_64` specifically.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
