### PR TITLE
scrcpy: update to 1.21

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           meson 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        Genymobile scrcpy 1.20 v
+github.setup        Genymobile scrcpy 1.21 v
 revision            0
 
 categories          multimedia
@@ -24,13 +24,13 @@ extract.only        ${distfiles}
 distfiles-append    ${name}-server-v${version}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  dc807e9ec422ac6e7dc4e806353e51e64b0e646c \
-                    sha256  c9350493d223a427bf0c32f7c075322d607af6fb348f9a57188f6c2cb644eea9 \
-                    size    343606 \
+                    rmd160  01d0ca05fa78236a23a2c8a7c48138ff283be5ba \
+                    sha256  edef3d0c976e75f0e2e1a9dfa36a4b6e22247feaa19dda307df8038f527c2c25 \
+                    size    360696 \
                     ${name}-server-v${version} \
-                    rmd160  bcad5ef4b09f01b0aeb3fe318eab6205e1533e2f \
-                    sha256  b20aee4951f99b060c4a44000ba94de973f9604758ef62beb253b371aad3df34 \
-                    size    37139
+                    rmd160  9ac3a6b4a52658466d021958a35c0129aa583f65 \
+                    sha256  dbcccab523ee26796e55ea33652649e4b7af498edae9aa75e4d4d7869c0ab848 \
+                    size    40067
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

See: https://github.com/Genymobile/scrcpy/releases/tag/v1.21

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
