### PR TITLE
poetry, py-cachecontrol: update packages

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    poetry
-version                 1.1.11
+version                 1.1.12
 revision                0
 categories-append       devel
 platforms               darwin
@@ -23,9 +23,9 @@ long_description        Poetry: Dependency Management for Python. \
 
 homepage                https://python-poetry.org/
 
-checksums               rmd160  341856b46f96107aa4ea0b157e3c2d05e448c426 \
-                        sha256  7d7d22f55fbebb830cc85b1c69cd7a91fd85f49e5396e7a14b953645a470f69e \
-                        size    135723
+checksums               rmd160  2c3b8a3137d0433188de89f91a8b156f4d2baced \
+                        sha256  5c66e2357fe37b552462a88b7d31bfa2ed8e84172208becd666933c776252567 \
+                        size    135789
 
 variant python37 conflicts python38 python39 description {Use Python 3.7} {}
 variant python38 conflicts python37 python39 description {Use Python 3.8} {}

--- a/python/py-cachecontrol/Portfile
+++ b/python/py-cachecontrol/Portfile
@@ -5,14 +5,14 @@ PortGroup           python 1.0
 
 name                py-cachecontrol
 python.rootname     CacheControl
-version             0.12.6
+version             0.12.10
 revision            0
 categories-append   devel
 platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 
@@ -23,9 +23,9 @@ long_description    \
 
 homepage            https://github.com/ionrock/cachecontrol
 
-checksums           rmd160  67bcb07c66fed67504390434cce0e02050336f72 \
-                    sha256  be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8 \
-                    size    14616
+checksums           rmd160  ccd3316c2041e9bfccf6e2d8399158305b241281 \
+                    sha256  d8aca75b82eec92d84b5d6eb8c8f66ea16f09d2adb09dbca27fe2d5fc8d3732d \
+                    size    15646
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Update poetry and its dependency py-cachecontrol.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
