### PR TITLE
bash: update to 5.1.12

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                bash
 set bash_version    5.1
-set bash_patchlevel 8
+set bash_patchlevel 12
 subport bash50 {
     # used by bashdb port
     set bash_version    5.0
@@ -78,7 +78,23 @@ if {${subport} eq ${name}} {
                         bash51-008 \
                         rmd160  1188a76917ca3602e4f10ece8b74cc500f5dd1aa \
                         sha256  f22cf3c51a28f084a25aef28950e8777489072628f972b12643b4534a17ed2d1 \
-                        size    1821
+                        size    1821 \
+                        bash51-009 \
+                        rmd160  1ce1c1a91ad1bbdbec5ec2e74b56ec4a93314249 \
+                        sha256  e45cda953ab4b4b4bde6dc34d0d8ca40d1cc502046eb28070c9ebcd47e33c3ee \
+                        size    1627 \
+                        bash51-010 \
+                        rmd160  f25ea7bc947e7b10a5c5e450386f7892ef55ebeb \
+                        sha256  a2c8d7b2704eeceff7b1503b7ad9500ea1cb6e9393faebdb3acd2afdd7aeae2a \
+                        size    1700 \
+                        bash51-011 \
+                        rmd160  76f459fa9b2193d9457d6b437e547cfe4363ceac \
+                        sha256  58191f164934200746f48459a05bca34d1aec1180b08ca2deeee3bb29622027b \
+                        size    2229 \
+                        bash51-012 \
+                        rmd160  ddd681c0b2fa328157528532388615a3f4abc16a \
+                        sha256  10f189c8367c4a15c7392e7bf70d0ff6953f78c9b312ed7622303a779273ab98 \
+                        size    6372
 } elseif {${subport} eq "bash50"} {
    checksums           ${distname}${extract.suffix} \
                        rmd160  a081428a896d617855499376b670eca3433a27c1 \


### PR DESCRIPTION
#### Description

Update bash to the latest patchlevel. Still no release of bashdb.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1419 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
