### PR TITLE
py-poppler-qt5: update to 21.1.0, build with latest SIP

### DIFF
--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -1,13 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           qt5 1.0
 PortGroup           python 1.0
 
 name                py-poppler-qt5
 python.rootname     python-poppler-qt5
-version             0.75.0
-revision            1
+version             21.1.0
+revision            0
 
 platforms           darwin
 license             LGPL-2.1+
@@ -23,39 +22,73 @@ long_description    ${python.rootname} is a Python binding for Poppler-Qt5 \
 
 homepage            https://github.com/wbsoft/${python.rootname}
 
-checksums           md5     e411d6c8bb25faa9208387b1075895ad \
-                    rmd160  ac42b3a4fbcd63e79fbfa42537f75087f06b170b \
-                    sha256  ea0ec9ebe995705ab19a301290365652e62bab5c9b05db5697c7bf2173335107 \
-                    size    23608
+checksums           md5     83a1c785aa3d0a0b0e82a7805492eabb \
+                    rmd160  26aea457226155b8a6120fa0e19f631a38c8afcc \
+                    sha256  add766db2c04026a6087f38f2044e66c8b053c81002f3753d8059713497d022d \
+                    size    28235
 
 python.versions     27 35 36 37 38 39
 
 compiler.cxx_standard   2011
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    if {${python.version} eq 27} {
+        PortGroup       qt5 1.0
 
-    depends_lib-append      port:poppler-qt5 \
-                            port:py${python.version}-sip4 \
-                            port:py${python.version}-pyqt5
+        depends_lib-append \
+                        port:py${python.version}-sip4
 
-    patchfiles              patch-fix-qt-dirs.diff
+        patchfiles      patch-fix-qt-dirs.diff
 
-    post-patch {
-        reinplace "s|%%QMAKE%%|${qt_qmake_cmd}|g" ${worksrcpath}/setup.py
+        post-patch {
+            reinplace "s|%%QMAKE%%|${qt_qmake_cmd}|g" ${worksrcpath}/setup.py
+        }
+    } else {
+        PortGroup       qmake5 1.0
+
+        patchfiles      patch-types.sip.diff \
+                        patch-fix-py36.diff
+
+        depends_build-append \
+                        port:py${python.version}-pyqt-builder
+
+        depends_lib-append \
+                        port:py${python.version}-sip
+
+        build.cmd       sip-build-${python.branch}
+        build.args-append \
+                        --qmake ${qt_qmake_cmd} \
+                        --verbose
+        build.target
+
+        pre-destroot {
+            reinplace "s|sip-distinfo|sip-distinfo-${python.branch}|g" \
+                ${build.dir}/build/Makefile
+        }
+
+        destroot.cmd    make
+        destroot.dir    ${build.dir}/build
     }
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:poppler-qt5 \
+                    port:py${python.version}-pyqt5
 
     post-destroot {
         set doc_dir ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${doc_dir}
-        xinstall -m 644 -W ${worksrcpath} \
-            ChangeLog \
-            LICENSE \
-            README.rst \
+        xinstall -m 0644 -W ${worksrcpath} \
+            ChangeLog LICENSE README.rst \
             ${doc_dir}
+
         set examples_dir ${destroot}${prefix}/share/examples/${subport}
         xinstall -d ${examples_dir}
-        xinstall -m 644 -W ${worksrcpath} demo.py ${examples_dir}
+        xinstall -m 0644 -W ${worksrcpath}/demo \
+            demo.py merge-annotations.py \
+            ${examples_dir}
     }
 
     livecheck.type  none

--- a/python/py-poppler-qt5/files/patch-fix-py36.diff
+++ b/python/py-poppler-qt5/files/patch-fix-py36.diff
@@ -1,0 +1,15 @@
+see: https://github.com/frescobaldi/python-poppler-qt5/pull/44
+
+diff --git project.py project.py
+index 17df8da..74e397c 100644
+--- project.py
++++ project.py
+@@ -42,7 +42,7 @@ class PopplerQt5Bindings(PyQtBindings):
+     def run_pkg_config(option):
+         output = subprocess.check_output(
+             ['pkg-config', option, 'poppler-qt5'],
+-            text=True)
++            universal_newlines=True)
+         return output.rstrip()
+ 
+     def apply_user_defaults(self, tool):

--- a/python/py-poppler-qt5/files/patch-types.sip.diff
+++ b/python/py-poppler-qt5/files/patch-types.sip.diff
@@ -1,0 +1,105 @@
+see: https://github.com/frescobaldi/python-poppler-qt5/pull/45
+
+diff --git types.sip types.sip
+index 239b8c9..81cb283 100644
+--- types.sip
++++ types.sip
+@@ -331,5 +331,98 @@ template <TYPE>
+ };
+
+
++/**
++ * Convert QVector< QPair<TYPE, TYPE> >
++ * from and to a Python list of a 2-item tuple
++ */
++
++template<TYPE>
++%MappedType QVector< QPair<TYPE, TYPE> >
++{
++%TypeHeaderCode
++#include <qvector.h>
++#include <qpair.h>
++%End
++
++%ConvertFromTypeCode
++  // Create the list.
++  PyObject *l;
++
++  if ((l = PyList_New(sipCpp->size())) == NULL)
++      return NULL;
++
++  // Set the list elements.
++  for (int i = 0; i < sipCpp->size(); ++i)
++  {
++    QPair<TYPE, TYPE>* p = new QPair<TYPE, TYPE>(sipCpp->at(i));
++    PyObject *ptuple = PyTuple_New(2);
++    PyObject *pfirst;
++    PyObject *psecond;
++
++    TYPE *sfirst = new TYPE(p->first);
++    if ((pfirst = sipConvertFromType(sfirst, sipType_TYPE, sipTransferObj)) == NULL)
++    {
++      Py_DECREF(l);
++      Py_DECREF(ptuple);
++      return NULL;
++    }
++    PyTuple_SET_ITEM(ptuple, 0, pfirst);
++
++    TYPE *ssecond = new TYPE(p->second);
++    if ((psecond = sipConvertFromType(ssecond, sipType_TYPE, sipTransferObj)) == NULL)
++    {
++      Py_DECREF(l);
++      Py_DECREF(ptuple);
++      Py_DECREF(pfirst);
++      return NULL;
++    }
++    PyTuple_SET_ITEM(ptuple, 1, psecond);
++
++    PyList_SET_ITEM(l, i, ptuple);
++  }
++
++  return l;
++%End
++
++%ConvertToTypeCode
++  const sipTypeDef* qpair_type = sipFindType("QPair<TYPE, TYPE>");
++
++  // Check the type if that is all that is required.
++  if (sipIsErr == NULL)
++  {
++    if (!PySequence_Check(sipPy))
++      return 0;
++
++    for (int i = 0; i < PySequence_Size(sipPy); ++i)
++      if (!sipCanConvertToType(PySequence_ITEM(sipPy, i), qpair_type, SIP_NOT_NONE))
++        return 0;
++
++    return 1;
++  }
++
++
++  QVector< QPair<TYPE, TYPE> > *qv = new QVector< QPair<TYPE, TYPE> >;
++
++  for (int i = 0; i < PySequence_Size(sipPy); ++i)
++  {
++    int state;
++    QPair<TYPE, TYPE> * p = reinterpret_cast< QPair<TYPE, TYPE> * >(sipConvertToType(PySequence_ITEM(sipPy, i), qpair_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
++
++    if (*sipIsErr)
++    {
++      sipReleaseType(p, qpair_type, state);
++      delete qv;
++      return 0;
++    }
++    qv->append(*p);
++    sipReleaseType(p, qpair_type, state);
++  }
++
++  *sipCppPtr = qv;
++  return sipGetState(sipTransferObj);
++%End
++
++};
++
+
+ /* kate: indent-width 4; space-indent on; hl c++; indent-mode cstyle; */


### PR DESCRIPTION
#### Description

First version of this PR by @reneeotten, see #12450.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
