### PR TITLE
elixir: update to 1.12.3

### DIFF
--- a/lang/elixir/Portfile
+++ b/lang/elixir/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        elixir-lang elixir 1.11.2 v
+github.setup        elixir-lang elixir 1.12.3 v
 github.tarball_from archive
 epoch               1
 categories          lang
@@ -24,9 +24,9 @@ homepage            http://elixir-lang.org/
 
 depends_lib         port:erlang
 
-checksums           rmd160 4e12b0db7e08d97ea2b346596de9c5317a91f03a \
-                    sha256 318f0a6cb372186b0cf45d2e9c9889b4c9e941643fd67ca0ab1ec32710ab6bf5 \
-                    size   2391833
+checksums           rmd160 8ac7467e844136f38c2d4124f0c083a6eab5d15f \
+                    sha256 c5affa97defafa1fd89c81656464d61da8f76ccfec2ea80c8a528decd5cb04ad \
+                    size   2461828
 
 # bin/mix
 conflicts           arb


### PR DESCRIPTION
#### Description

Closes https://trac.macports.org/ticket/63477 by updating Portfile to build Elixir 1.12.3 from Github source.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1519 x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
