### PR TITLE
qemu: build fixes for pre-10.12.4

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem 1.0
 PortGroup compiler_blacklist_versions 1.0
+PortGroup legacysupport 1.1
 
-# https://trac.macports.org/ticket/58700
-PortGroup legacysupport 1.0
+# fdopendir
+legacysupport.newest_darwin_requires_legacy 13
 
 name                    qemu
 version                 6.1.0
@@ -46,11 +47,26 @@ depends_lib             path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         path:lib/pkgconfig/pixman-1.pc:libpixman
 
 # This patch sets the python interpreter from meson's shebang line
-patchfiles              patch-qemu-configure.diff
+patchfiles-append       patch-qemu-configure.diff
+
+# "error: unknown type name 'fpunchhole_t'" pre-10.12.4
+patchfiles-append       patch-qemu-punchhole.diff
+
+# "cp: illegal option -- a"
+patchfiles-append       patch-qemu-scripts-entitlements.diff
+
+# IPPROTO workarounds
+patchfiles-append       patch-qemu-net-colo.diff
+
+# MADV_DONTNEED workaround
+patchfiles-append       patch-qemu-include-qemu-osdep.diff
+
+# MAP_JIT workaround
+patchfiles-append       patch-qemu-tcg-region.diff
 
 # "ERROR: You need at least GCC v7.5 or Clang v6.0 (or XCode Clang v10.0)"
 compiler.blacklist      {clang < 1000} {macports-clang-[3-5].*} {macports-gcc-[56]} {*gcc-[34].*}
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
+if {${os.platform} eq "darwin" && ${os.major} < 11 && [string match *clang* ${configure.compiler}]} {
     # Emulated TLS needed, which was added in LLVM 3.8
     configure.cflags-append     -femulated-tls
 }
@@ -81,6 +97,7 @@ configure.args-append   --disable-cocoa \
                         --disable-gtk \
                         --disable-opengl \
                         --enable-bzip2 \
+                        --enable-hvf \
                         --disable-curl \
                         --disable-attr \
                         --disable-vde \
@@ -107,6 +124,11 @@ configure.args-append   --disable-cocoa \
                         --disable-lzo \
                         --disable-lzfse \
                         --disable-zstd
+
+# Hypervisor.framework introduced in 10.10
+if {${os.platform} eq "darwin" && ${os.major} < 14} {
+    configure.args-replace --enable-hvf --disable-hvf
+}
 
 # libtool: unknown option character `-' in: --mode=compile
 configure.env-append   LIBTOOL=${prefix}/bin/glibtool

--- a/emulators/qemu/files/patch-qemu-include-qemu-osdep.diff
+++ b/emulators/qemu/files/patch-qemu-include-qemu-osdep.diff
@@ -1,0 +1,14 @@
+--- include/qemu/osdep.h.orig	2021-11-28 17:26:47.000000000 -0500
++++ include/qemu/osdep.h	2021-11-28 17:27:26.000000000 -0500
+@@ -430,7 +430,11 @@
+ #if defined(CONFIG_MADVISE)
+ 
+ #define QEMU_MADV_WILLNEED  MADV_WILLNEED
++#ifdef MADV_DONTNEED
+ #define QEMU_MADV_DONTNEED  MADV_DONTNEED
++#else
++#define QEMU_MADV_DONTNEED  QEMU_MADV_INVALID
++#endif
+ #ifdef MADV_DONTFORK
+ #define QEMU_MADV_DONTFORK  MADV_DONTFORK
+ #else

--- a/emulators/qemu/files/patch-qemu-net-colo.diff
+++ b/emulators/qemu/files/patch-qemu-net-colo.diff
@@ -1,0 +1,23 @@
+--- net/colo.c.orig
++++ net/colo.c
+@@ -102,16 +102,20 @@
+     case IPPROTO_TCP:
+     case IPPROTO_UDP:
+     case IPPROTO_DCCP:
++#ifdef IPPROTO_ESP
+     case IPPROTO_ESP:
++#endif
+     case IPPROTO_SCTP:
+     case IPPROTO_UDPLITE:
+         tmp_ports = *(uint32_t *)(pkt->transport_header);
+         extract_ip_and_port(tmp_ports, key, pkt);
+         break;
++#ifdef IPPROTO_AH
+     case IPPROTO_AH:
+         tmp_ports = *(uint32_t *)(pkt->transport_header + 4);
+         extract_ip_and_port(tmp_ports, key, pkt);
+         break;
++#endif
+     default:
+         break;
+     }

--- a/emulators/qemu/files/patch-qemu-punchhole.diff
+++ b/emulators/qemu/files/patch-qemu-punchhole.diff
@@ -1,0 +1,13 @@
+--- block/file-posix.c.orig
++++ block/file-posix.c
+@@ -1830,7 +1830,9 @@
+         ret = do_fallocate(s->fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                            aiocb->aio_offset, aiocb->aio_nbytes);
+         ret = translate_err(-errno);
+-#elif defined(__APPLE__) && (__MACH__)
++#elif defined(__APPLE__) && (__MACH__) && \
++      defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \
++      __MAC_OS_X_VERSION_MAX_ALLOWED >= 101204
+         fpunchhole_t fpunchhole;
+         fpunchhole.fp_flags = 0;
+         fpunchhole.reserved = 0;

--- a/emulators/qemu/files/patch-qemu-scripts-entitlements.diff
+++ b/emulators/qemu/files/patch-qemu-scripts-entitlements.diff
@@ -1,0 +1,11 @@
+--- scripts/entitlement.sh.orig
++++ scripts/entitlement.sh
+@@ -15,7 +15,7 @@
+ 
+ if $in_place; then
+   trap 'rm "$DST.tmp"' exit
+-  cp -af "$SRC" "$DST.tmp"
++  cp -pPRf "$SRC" "$DST.tmp"
+   SRC="$DST.tmp"
+ else
+   cd "$MESON_INSTALL_DESTDIR_PREFIX"

--- a/emulators/qemu/files/patch-qemu-tcg-region.diff
+++ b/emulators/qemu/files/patch-qemu-tcg-region.diff
@@ -1,0 +1,11 @@
+--- tcg/region.c.orig
++++ tcg/region.c
+@@ -775,7 +775,7 @@
+      */
+     prot = PROT_NONE;
+     flags = MAP_PRIVATE | MAP_ANONYMOUS;
+-#ifdef CONFIG_DARWIN
++#if defined(CONFIG_DARWIN) && defined(MAP_JIT)
+     /* Applicable to both iOS and macOS (Apple Silicon). */
+     if (!splitwx) {
+         flags |= MAP_JIT;


### PR DESCRIPTION
#### Description

Happy to split into multiple PRs / commits but some OS versions require multiple fixes in order to build at all.
* Conditionally enable Hypervisor.framework
* Use legacysupport 1.1 and specify its need
* Fix GCC invocation on 10.6 and earlier
* Use `cp -pPR` instead of `cp -a` for better platform compatibility ([upstream](https://lists.gnu.org/archive/html/qemu-devel/2021-11/msg05700.html))
* Wrap `IPPROTO_ESP`, `IPPROTO_AH`, `MAP_JIT`, and `MADV_DONTNEED` in appropriate `#ifdef`s
* Test SDK version before using `fpunchhole_t` ([upstream](https://lists.gnu.org/archive/html/qemu-devel/2021-11/msg05535.html))

Tested locally through destroot on 10.4.11 (more patches are needed to build on Tiger).
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
