### PR TITLE
plumed: update to v2.7.3

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.7.2 v
+github.setup        plumed plumed2 2.7.3 v
 name                plumed
 
 categories          science
@@ -25,9 +25,9 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  87d54981199bd70e6ceeb894222ff2a5caf27180 \
-                    sha256  7ab21b793d2a73fed3e8a16a3545a4a46d60241bd3f13465192e051e7ce3570f \
-                    size    106488002
+checksums           rmd160  25b9e84980d08583c782780281b241f5eca47e55 \
+                    sha256  5d7f052697b05d0a2c3b934606d8890b2655b68070fa3a22009d83f8aea5a73f \
+                    size    106492582
 
 # Enable optional features.
 # --enable-asmjit:        Compile internal asmjit. Notice that internal asmjit is protected in
@@ -119,14 +119,17 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 9b35296e4c89b0ccc8f55f13ae7ce195a0aa149c
-    version             2.8-20210727
+    github.setup        plumed plumed2 ef90a2cd5e5c2ccd51dc48c3462c37967ef73910
+    version             2.8-20211201
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  2646f9849fb6ff1c38d600eede8d67dcb350beff \
-                        sha256  95b54829a2d4cf355578183e58ab37f1c5ff6fcb5f3f8d4350cb9a3009842947 \
-                        size    107286908
+    checksums           rmd160  c5b0dbcb7ab6cf26092a57fd91d2eb739dc91bea \
+                        sha256  f689ddb2b4931de6ded67061d7e7d4501e3dd5d6d40785b107a675d17cf545ec \
+                        size    107893701
+    configure.ldflags-delete -lxdrfile
+    depends_lib-delete       port:xdrfile
+    configure.args-delete    --enable-asmjit
 }
 
 # Allow running tests from MacPorts


### PR DESCRIPTION
#### Description

Updated plumed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
