### PR TITLE
py-zope-component: Bugfixes and improvements

### DIFF
--- a/python/py-zope-component/Portfile
+++ b/python/py-zope-component/Portfile
@@ -3,23 +3,23 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set real_name       zope.component
 name                py-zope-component
+python.rootname     zope.component
 version             5.0.1
 revision            0
 categories-append   zope
 license             ZPL-2.1
 maintainers         {mps @Schamschula} openmaintainer
-description         This package represents the core of the Zope Component Architecture.
+supported_archs     noarch
+
+description         This package represents the core of the Zope \
+                    Component Architecture.
+
 long_description    {*}${description}
-platforms           darwin
-homepage            https://pypi.python.org/pypi/${real_name}
-master_sites        pypi:z/${real_name}
-distfiles           ${real_name}-${version}${extract.suffix}
 
-worksrcdir          ${real_name}-${version}
+homepage            https://github.com/zopefoundation/zope.component
 
-python.versions     27 35 36 37 38 39
+python.versions     27 37 38 39 310
 
 checksums           rmd160  ed565d05f197bcb4d41937e754134ba82b7e2b76 \
                     sha256  32cbe426ba8fa7b62ce5b211f80f0718a0c749cc7ff09e3f4b43a57f7ccdf5e5 \
@@ -32,7 +32,11 @@ if {${name} ne ${subport}} {
     depends_lib-append  \
                     port:py${python.version}-zope-event \
                     port:py${python.version}-zopeinterface
-} else {
-    livecheck.type  regex
-    livecheck.regex ${real_name}-(\[0-9.\]+)${extract.suffix}
+
+    if {[string index ${python.version} 0] >= 3} {
+        depends_lib-append  \
+                    port:py${python.version}-zope-hookable
+    }
+
+    livecheck.type  none
 }


### PR DESCRIPTION
* Add zope.hookable dependency
* rm Python 35 36
* add Python 310
* Use pypi defaults
* Add supported_archs noarch

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
