### PR TITLE
Update to gcc-11: bump gcc version to 11.2.0 on arm64

### DIFF
--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -44,13 +44,13 @@ master_sites        https://ftpmirror.gnu.org/gcc/gcc-${version}/ \
 # https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/gcc.rb
 # Branch from the Darwin maintainer of GCC with Apple Silicon support
 if { ${os.arch} eq "arm" } {
-    version         11.1.0
+    version         11.2.0
     revision        2
     master_sites    https://github.com/fxcoudert/gcc/archive
-    distname        gcc-${version}-arm-20210504
-    checksums       rmd160  ccb26e52571aff9230f4bdf067fe8c9d1fb79235 \
-                    sha256  ce862b4a4bdc8f36c9240736d23cd625a48af82c2332d2915df0e16e1609a74c \
-                    size    125460899
+    distname        gcc-${version}-arm-20211124
+    checksums       rmd160  b7cc6ff4ba1ec73cc959990cdd9dce413acc8129 \
+                    sha256  d7f8af7a0d9159db2ee3c59ffb335025a3d42547784bee321d58f2b4712ca5fd \
+                    size    125610784
 } else {
     distname        gcc-${version}
     use_xz          yes
@@ -62,17 +62,6 @@ if { ${os.arch} eq "arm" } {
 subport             libgcc11 { revision [ expr ${revision} + 0 ] }
 
 patchfiles          patch-Make-lang.in.diff
-
-if { ${os.platform} eq "darwin" } {
-    # Add preliminary Darwin 21 support to GCC 11.
-    # This should be removed, when GCC 11 supports Darwin 21 officially and the
-    # respective version is used by macports.
-    # See also: https://github.com/iains/gcc-darwin-arm64/commit/20f61faaed3b335d792e38892d826054d2ac9f15
-    patchfiles-append patch-darwin21-support.diff
-    # This following patch works around a problem on MacOS 12.0 with fortran
-    # See also: https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=fabe8cc41e9b01913e2016861237d1d99d7567bf
-    patchfiles-append patch-darwin21-fortran.diff
-}
 
 if { ${os.platform} eq "darwin" && ${os.major} >= 17 } {
     # On macOS 10.13 and later, compilation is extremely slow if SIP is


### PR DESCRIPTION
This will fix the build error of gcc-11 on Monterey Arm64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
