### PR TITLE
py-zope-hookable: Add Python 310, use pypi defaults

### DIFF
--- a/python/py-zope-hookable/Portfile
+++ b/python/py-zope-hookable/Portfile
@@ -3,23 +3,23 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set real_name       zope.hookable
 name                py-zope-hookable
+python.rootname     zope.hookable
 version             5.1.0
 revision            0
-worksrcdir          ${real_name}-${version}
-distfiles           ${real_name}-${version}${extract.suffix}
 categories-append   zope
 license             ZPL-2.1
 maintainers         {mps @Schamschula} openmaintainer
-description         This package supports the efficient creation of “hookable” objects, \
-                    which are callable objects that are meant to be optionally replaced.
-long_description    {*}${description}
-platforms           darwin
-homepage            https://pypi.python.org/pypi/${real_name}
-master_sites        pypi:z/${real_name}
+supported_archs     x86_64
 
-python.versions     36 37 38 39
+description         Zope hookable.
+long_description    This package supports the efficient creation of \
+                    “hookable” objects, which are callable objects \
+                    that are meant to be optionally replaced.
+
+homepage            https://github.com/zopefoundation/zope.hookable
+
+python.versions     37 38 39 310
 
 checksums           rmd160  83fd5b6b2d0c1f2b1ea35a26de9c5faddb3799af \
                     sha256  8fc3e6cd0486c6af48e3317c299def719b57538332a194e0b3bc6a772f4faa0e \
@@ -31,8 +31,5 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools \
                     port:py${python.version}-pyobjc
 
-    livecheck.type      none
-} else {
-    livecheck.type  regex
-    livecheck.regex ${real_name}-(\[0-9.\]+)${extract.suffix}
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
