### PR TITLE
roll: update to 2.6.0

### DIFF
--- a/games/roll/Portfile
+++ b/games/roll/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        matteocorti roll 2.1.1 v
+github.setup        matteocorti roll 2.6.0 v
 categories          games
 platforms           darwin
 maintainers         nomaintainer
@@ -16,8 +16,9 @@ long_description    rolls a user-defined dice sequence
 homepage            https://matteocorti.github.io/roll/
 
 github.tarball_from releases
-checksums           rmd160  4f905141a9f54f14c80b3b83df0a3dc6e75842b9 \
-                    sha256  5d499c690d30cbe93dc571eb8e3f11d1505ce4595c8151646777548ef89a7997
+checksums           rmd160  b40f481fb37cb6326743f79ff6a394d991efae92 \
+                    sha256  f550e91a4a483a567cfe5ff59fecebce81b01b48e330f80cb7ffe817a4e21460 \
+                    size    155558
 
 use_parallel_build  yes
 


### PR DESCRIPTION
2.1.1 would not build because it was incompatible with modern versions of bison. 2.6.0 (latest as of this writing) includes a fix for that.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> _No ticket was filed._
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?  _Port provides no tests/does not have tests turned on._
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
