### PR TITLE
postgresql14: update to 14.1, update LLVM version

### DIFF
--- a/databases/postgresql14-doc/Portfile
+++ b/databases/postgresql14-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql14-doc
 conflicts           postgresql10-doc postgresql11-doc postgresql12-doc \
     postgresql13-doc
-version             14.0
+version             14.1
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -22,9 +22,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql14
 
-checksums           rmd160  4765f3847c874c62b7d3ecc1fc046f9fb14a5c68 \
-                    sha256  ee2ad79126a7375e9102c4db77c4acae6ae6ffe3e082403b88826d96d927a122 \
-                    size    21836842
+checksums           rmd160  ee2ed97f46ec8e00ad6252ae81006f44f659b701 \
+                    sha256  4d3c101ea7ae38982f06bdc73758b53727fb6402ecd9382006fa5ecc7c2ca41f \
+                    size    21887101
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql14-server/Portfile
+++ b/databases/postgresql14-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql14-server
-version             14.0
+version             14.1
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql14
-version             14.0
-revision            1
+version             14.1
+revision            0
 
 categories          databases
 platforms           darwin
@@ -27,9 +27,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  4765f3847c874c62b7d3ecc1fc046f9fb14a5c68 \
-                    sha256  ee2ad79126a7375e9102c4db77c4acae6ae6ffe3e082403b88826d96d927a122 \
-                    size    21836842
+checksums           rmd160  ee2ed97f46ec8e00ad6252ae81006f44f659b701 \
+                    sha256  4d3c101ea7ae38982f06bdc73758b53727fb6402ecd9382006fa5ecc7c2ca41f \
+                    size    21887101
 
 use_bzip2           yes
 
@@ -152,7 +152,7 @@ variant tcl description {add Tcl support} {
 }
 
 variant llvm description {add support for JIT compilation} {
-    set llvm_ver 11
+    set llvm_ver 13
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {


### PR DESCRIPTION
#### Description

Tested with a pg_restore

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
