### PR TITLE
xxhash: attempt to fix C11 build failure

### DIFF
--- a/devel/xxhash/Portfile
+++ b/devel/xxhash/Portfile
@@ -17,7 +17,15 @@ checksums           rmd160  ec02a0ef27f9c52cd6dcefeceb0650e521bd0773 \
                     sha256  a6cc02f455d89a552ed7a06f42b5221fd8652b93495e8ff4fda421ae09c8e173 \
                     size    171563
 
-compiler.cxx_standard   2011
+if {[string match "*gcc-4.*" ${configure.compiler}]} {
+    # See https://trac.macports.org/ticket/60710 for why this is needed.
+    patchfiles      patch-Makefile.diff
+}
+
+# On compilers that default to C11 mode, build fails with
+# Undefined symbols for architecture x86_64: "_static_assert"
+compiler.c_standard 1999
+configure.cflags-append -std=c99
 
 subport ${name} {
     license         GPL-2+


### PR DESCRIPTION
See: https://trac.macports.org/ticket/64113

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.7.5
Xcode 4.6.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
