### PR TITLE
pdfgrep: Update to 2.1.2 and fix build on <= 10.7

### DIFF
--- a/textproc/pdfgrep/Portfile
+++ b/textproc/pdfgrep/Portfile
@@ -1,8 +1,12 @@
 PortSystem          1.0
 
 name                pdfgrep
-version             2.1.1
-revision            1
+version             2.1.2
+revision            0
+checksums           rmd160  59fe7845f96c988a3f96cf324a0bb72fcc6d8b97 \
+                    sha256  0ef3dca1d749323f08112ffe68e6f4eb7bc25f56f90a2e933db477261b082aba \
+                    size    197289
+
 conflicts           pdfgrep-legacy
 categories          textproc
 platforms           darwin
@@ -12,12 +16,8 @@ description         A tool to search text in PDF files.
 long_description \
    Pdfgrep is a tool to search text in PDF files. It works similar to grep.
 
-homepage            https://pdfgrep.org/
-master_sites        https://pdfgrep.org/download/
-
-checksums           rmd160  ef5df881b370e0342f33f9775cb156adb796027d \
-                    sha256  2c8155f30fe5d9d8ec4340e48133ed0b241496bbebe29498931f975c67a10c0b \
-                    size    196526
+homepage            https://pdfgrep.org
+master_sites        ${homepage}/download/
 
 compiler.cxx_standard 2011
 
@@ -25,6 +25,8 @@ depends_build       port:pkgconfig
 depends_lib         port:poppler \
                     port:pcre \
                     port:libgcrypt
+
+patchfiles          scandir.patch
 
 configure.args      --without-unac
 

--- a/textproc/pdfgrep/files/scandir.patch
+++ b/textproc/pdfgrep/files/scandir.patch
@@ -1,0 +1,50 @@
+The prototype of scandir changed in the 10.8 SDK. Use the old prototype on old SDKs.
+https://gitlab.com/pdfgrep/pdfgrep/-/merge_requests/14
+--- src/cache.cc.orig	2018-11-19 05:44:28.000000000 -0600
++++ src/cache.cc	2021-12-02 18:31:06.000000000 -0600
+@@ -35,6 +35,15 @@
+ #include <errno.h>
+ #include <string.h>
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
++#define HAVE_NEW_SCANDIR
++#if (defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED < 1080)
++#undef HAVE_NEW_SCANDIR
++#endif
++
+ using namespace std;
+ 
+ Cache::Cache(string cache_file)
+@@ -86,9 +95,13 @@
+ 
+ // I feel so bad...
+ static const char *cache_directory;
+-static int agesort(const struct dirent ** a, const struct dirent **b) {
+-	std::string A = string(cache_directory) + "/" + (*a)->d_name;
+-	std::string B = string(cache_directory) + "/" + (*b)->d_name;
++#ifdef HAVE_NEW_SCANDIR
++static int agesort(const struct dirent **a, const struct dirent **b) {
++#else
++static int agesort(const void *a, const void *b) {
++#endif
++	std::string A = string(cache_directory) + "/" + (*(const struct dirent **)a)->d_name;
++	std::string B = string(cache_directory) + "/" + (*(const struct dirent **)b)->d_name;
+ 
+ 	struct stat bufa, bufb;
+ 	if (stat(A.c_str(), &bufa) != 0) return 0;
+@@ -97,7 +110,11 @@
+ 	return bufb.st_mtime - bufa.st_mtime;
+ }
+ 
+-static int agefilter(const struct dirent * a) {
++#ifdef HAVE_NEW_SCANDIR
++static int agefilter(const struct dirent *a) {
++#else
++static int agefilter(struct dirent *a) {
++#endif
+ 	if (a->d_name[0] == '.') return false;
+ 	std::string A = string(cache_directory) + "/" + a->d_name;
+ 	struct stat bufa;


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/62108

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.7.5
Xcode 4.6.3

macOS 10.15.6
Xcode 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
