### PR TITLE
mint: fix build for macOS 10.14 and 10.15

### DIFF
--- a/devel/mint/Portfile
+++ b/devel/mint/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
+PortGroup               xcodeversion 1.0
 
 github.setup            yonaskolb Mint 0.17.1
-revision                0
+revision                1
 github.tarball_from     archive
 
 name                    mint
@@ -20,21 +21,35 @@ checksums               rmd160  9e5d01ecb931cb17d88e29c146ebf2a4ba77b463 \
                         sha256  0e3ab23e548a752f6eee3a7b98d1c137a30371e4a0ec9212840baaa56741d2e4 \
                         size    23308
 
-if {${os.platform} eq "darwin" && ${os.major} < 19} {
+minimum_xcodeversions-append {18 10.2}
+
+if {${os.platform} eq "darwin" && ${os.major} < 18} {
     known_fail yes
     pre-fetch {
-        ui_error "${name} requires macOS 10.15 or later."
+        ui_error "${name} requires macOS 10.14 or later."
         return -code error "incompatible macOS version"
     }
 }
 
-# Universal support enabled by default
+# Universal support handled manually
 universal_variant       no
 
 use_configure           no
 use_xcode               yes
 
-build.target            install
-build.args              PREFIX="${destroot}${prefix}"
+build.cmd               swift
+build.target            build
+build.args              --configuration release --disable-sandbox
 
-destroot {}
+set builtproductdir     ${worksrcpath}/.build/release
+
+# Xcode 12 (Swift 5.3) adds the --arch flag, letting us make a universal build.
+# Doing so changes the output directory of the product.
+if {[vercmp ${xcodeversion} 12.0] >= 0} {
+    build.args-append   --arch x86_64 --arch arm64
+    set builtproductdir ${worksrcpath}/.build/apple/Products/Release
+}
+
+destroot {
+    xinstall -m 755 ${builtproductdir}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Closes: https://trac.macports.org/ticket/64099

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
