### PR TITLE
openrct2: update to 0.3.5.1

### DIFF
--- a/games/openrct2/Portfile
+++ b/games/openrct2/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        OpenRCT2 OpenRCT2 0.3.5 v
+github.setup        OpenRCT2 OpenRCT2 0.3.5.1 v
 github.tarball_from archive
 name                openrct2
-revision            1
+revision            0
 
 categories          games
 platforms           darwin
@@ -19,7 +19,6 @@ long_description    ${description} A construction and management simulation \
                     video game that simulates amusement park management. Requires \
                     files from the original RollerCoaster Tycoon 2 in order to work.
 
-extract.suffix      .zip
 use_zip             yes
 
 set main_distfile       ${distfiles}
@@ -41,9 +40,9 @@ master_sites        ${github.master_sites}:main \
                     ${ts_mastersite}:ts
 
 checksums           ${main_distfile} \
-                    rmd160  7f3c8454f6167832bfdb34bfd9bb949fe6ec8e2b \
-                    sha256  8490c0bf93c2aea00435885b995f63d978aeea1acbb10753b6f2864b9adbc1a6 \
-                    size    16377028 \
+                    rmd160  27c57ef322fb8d1b22c62523fd8842ad45ea1896 \
+                    sha256  c20e580c9c424ecbca84e185d6d77526f0eaf6e7584b6633e79e43807afea757 \
+                    size    16389894 \
                     ${objects_distfile} \
                     rmd160  1f826ad19c5c42a3706b1796702882298b3a3e64 \
                     sha256  b081f885311f9afebc41d9dd4a68b7db4cf736eb815c04e307e1a426f08cfa35 \


### PR DESCRIPTION
#### Description

This forces `github.master_sites` because of differing archive formats. The title sequences and objects are zip but the github portgroup makes it difficult to get zips instead of tar.gz.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
