### PR TITLE
gnuradio: use python 3.9 as default

### DIFF
--- a/_resources/port1.0/group/gnuradio-1.0.tcl
+++ b/_resources/port1.0/group/gnuradio-1.0.tcl
@@ -1,0 +1,188 @@
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+#
+# This PortGroup helps to maintain gnuradio dependencies coherent between
+# gnuradio and gnuradio modules.
+#
+# Usage:
+#
+# PortGroup           gnuradio 1.0
+#
+
+PortGroup           cmake 1.1
+PortGroup           boost 1.0
+
+categories          science comms
+platforms           darwin macosx
+
+# declare which gnuradio are you using
+options gnuradio.type
+default gnuradio.type "gnuradio"
+
+options gnuradio.python_version
+options gnuradio.default_python_variant
+
+if {[string first "37" $subport] > 1} {
+    default gnuradio.python_versions { 2.7 }
+    default gnuradio.default_python_variant +python27
+} else {
+    # the following versions use all the same python
+    default gnuradio.python_versions { 3.8 3.9 3.10 }
+    default gnuradio.default_python_variant +python39
+}
+
+# use C/C++11
+compiler.c_standard   2011
+compiler.cxx_standard 2011
+boost.version 1.71
+
+# see https://github.com/macports/macports-ports/pull/7805
+license_noconflict-append openssl
+
+# see https://github.com/macports/macports-ports/pull/7805
+license_noconflict-append graphviz
+
+# Define the available variants
+foreach py_ver ${gnuradio.python_versions} {
+    set py_ver_no_dot [join [split ${py_ver} "."] ""]
+    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
+    foreach py_over ${gnuradio.python_versions} {
+        if { ${py_ver} == ${py_over} } { continue }
+        set py_over_no_dot [join [split ${py_over} "."] ""]
+        append variant_line " conflicts python${py_over_no_dot}"
+    }
+    append variant_line { { } }
+    eval $variant_line
+    if {[variant_isset python${py_ver_no_dot}]} {
+        if {${gnuradio.default_python_variant} != "+python${py_ver_no_dot}"} {
+            set gnuradio.default_python_variant ""
+        }
+    }
+}
+
+# set default python variant if not selected
+if {${gnuradio.default_python_variant} != ""} {
+    default_variants-append "${gnuradio.default_python_variant}"
+}
+
+# If a python variant is enabled, activate it
+set active_python_version ""
+set active_python_version_no_dot ""
+foreach py_ver ${gnuradio.python_versions} {
+    set py_ver_no_dot [join [split ${py_ver} "."] ""]
+    if {[variant_isset python${py_ver_no_dot}]} {
+        set active_python_version        ${py_ver}
+        set active_python_version_no_dot ${py_ver_no_dot}
+    }
+}
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:fftw-3-single \
+    path:lib/libmpir.dylib:mpir \
+    path:lib/libvolk.dylib:volk \
+    port:gmp \
+    port:python${active_python_version_no_dot}
+
+# need matplotlib for polar encoder/decoder, runtime only
+depends_run-append \
+    port:py${active_python_version_no_dot}-matplotlib \
+    port:py${active_python_version_no_dot}-opengl \
+    port:py${active_python_version_no_dot}-scipy \
+    port:py${active_python_version_no_dot}-numpy \
+    port:py${active_python_version_no_dot}-cheetah
+
+if {[string first "37" $subport] > 1} {
+    # still require cppunit for testing; NOTE: cppunit is checked for
+    # during configure, so we need it to be in depends_lib or
+    # depends_build to be used correctly. Choose the latter since it's
+    # not required for runtime; just for build/test.
+    depends_build-append \
+        port:cppunit
+} else {
+    # add dependencies for gnuradio >= 3.8
+}
+
+if {[string first "gr37-" $subport] >= 0} {
+    depends_lib-append \
+        port:gnuradio37
+
+    depends_build-append \
+        port:swig3-python
+
+    configure.args-append \
+        -DSWIG_EXECUTABLE=${prefix}/bin/swig3
+} elseif {[string first "gr-" $subport] >= 0} {
+    depends_lib-append \
+        path:lib/libgnuradio-runtime.dylib:gnuradio
+
+    depends_build-append \
+        port:swig-python
+
+    configure.args-append \
+        -DSWIG_EXECUTABLE=${prefix}/bin/swig
+}
+
+# set build type to release or debug, not "MacPorts" since the GR
+# CMake system checks for a valid value and this is not one of them
+if {[variant_isset debug]} {
+    cmake.build_type Debug
+} else {
+    cmake.build_type Release
+}
+
+# specify the Python version to use
+set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
+configure.args-append \
+    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
+    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
+    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
+    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages \
+    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
+    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen \
+    -DCMAKE_MODULES_DIR=${prefix}/share/cmake \
+    -DGMP_INCLUDE_DIR= \
+    -DGMP_LIBRARY= \
+    -DGMPXX_LIBRARY= \
+    -DMPIR_INCLUDE_DIR=${prefix}/include \
+    -DMPIR_LIBRARY=${prefix}/lib/libmpir.dylib \
+    -DMPIRXX_LIBRARY=${prefix}/lib/libmpirxx.dylib \
+    -DENABLE_DOXYGEN=OFF \
+    -DENABLE_SPHINX=OFF
+
+# remove top-level library and include paths, such that internal ones
+# are searched before any already-installed ones.
+configure.cppflags-delete -I${prefix}/include
+configure.ldflags-delete  -L${prefix}/lib
+
+# TODO check "macports-libstdc++" or "libstdc++" should not needed anymore, right?
+# disable C/CXX standard extensions (e.g., "gnu++11" and "gnu11"
+# rather than "c++11" and "c11"). GNU Radio itself does not
+# require these extensions, and when compiling with Clang they
+# don't really do anything anyway; so, just disable them.
+configure.args-append \
+    -DCMAKE_CXX_EXTENSIONS=OFF \
+    -DCMAKE_C_EXTENSIONS=OFF
+
+variant docs description "Install documentation" {
+    # texlive-latex not needed from 3.9.0.0
+    depends_build-append \
+        port:doxygen \
+        path:bin/dot:graphviz \
+        port:py${active_python_version_no_dot}-sphinx \
+        port:texlive-latex
+
+    configure.args-delete \
+        -DENABLE_DOXYGEN=OFF \
+        -DENABLE_SPHINX=OFF \
+        -DSPHINX_EXECUTABLE=
+
+    configure.args-append \
+        -DENABLE_DOXYGEN=ON \
+        -DENABLE_SPHINX=ON \
+        -DSPHINX_EXECUTABLE=${python_framework_dir}/bin/sphinx-build
+}
+
+default_variants-append \
+    +docs

--- a/science/gnuradio/Portfile
+++ b/science/gnuradio/Portfile
@@ -15,11 +15,11 @@ license             GPL-3
 
 if {${subport} eq ${name}} {
 
-    github.setup    gnuradio gnuradio 3.8.4.0 v
-    checksums       rmd160  bd9b6388ca9073bde4bfa21af6f6918c56d68a1d \
-                    sha256  df6797c8f0258b77c577e75ad12b901586a17f37bfea0894e895d346810dbdac \
-                    size    3395273
-    revision        1
+    github.setup    gnuradio gnuradio 3.8.5.0 v
+    checksums       rmd160  098825a19d8962bac72f2f2e14fcdfee8500f307 \
+                    sha256  dd336400034b57b7bce7b1fec6c5cd99f1e9dde7b78faa2cd28105877c213b14 \
+                    size    3399901
+    revision        0
 
     long_description    ${description}: \
         This port is kept up with the GNU Radio release, \

--- a/science/gnuradio/Portfile
+++ b/science/gnuradio/Portfile
@@ -1,27 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           app 1.0
 PortGroup           active_variants 1.1
 PortGroup           conflicts_build 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gnuradio
 maintainers         {michaelld @michaelld} {ra1nb0w @ra1nb0w}
-
 description         GNU Radio is Software Defined Radio (SDR)
 homepage            https://www.gnuradio.org/
-
-categories          science comms
 license             GPL-3
-platforms           darwin macosx
-
-compiler.c_standard   2011
-compiler.cxx_standard 2011
-
-boost.version       1.71
 
 if {${subport} eq ${name}} {
 
@@ -36,9 +26,6 @@ if {${subport} eq ${name}} {
         currently ${version}, which is typically updated twice per year.
 
     conflicts           gnuradio37 gnuradio-next
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
     # temporary patch to fix and allow external setting for
     # CMAKE_C/CXX_STANDARD
@@ -75,9 +62,6 @@ subport gnuradio37 {
         will not see much maintenance\; place consider updating \
         to the \'gnuradio\' port.
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
     # force expansion of CMake-based template files
     patchfiles-append \
         patch-cmake-expand.37.diff
@@ -95,15 +79,7 @@ subport gnuradio37 {
 
     set GR_VERSION_INFO "Release 3.7"
 
-    # still require cppunit for testing; NOTE: cppunit is checked for
-    # during configure, so we need it to be in depends_lib or
-    # depends_build to be used correctly. Choose the latter since it's
-    # not required for runtime; just for build/test.
-    depends_build-append \
-        port:cppunit
-
-    # avoid issue with SWIG API changes
-    conflicts_build gnuradio37
+    conflicts_build gnuradio gnuradio-next
 
     github.livecheck.regex  {(3.7.[0-9.]+)}
 
@@ -131,10 +107,7 @@ subport gnuradio-next {
         deactivating the currently active gnuradio port, \
         cleaning any current builds, and trying again.
 
-    conflicts           gnuradio gnuradio37
-
-    set python_versions { 3.6 3.7 3.8 }
-    set default_python_variant +python37
+    conflicts       gnuradio gnuradio37
 
     # fix Quartz behaviour
     # TODO verify https://github.com/gnuradio/gnuradio/issues/2726
@@ -147,133 +120,9 @@ subport gnuradio-next {
 
 }
 
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-# see https://github.com/macports/macports-ports/pull/7805
-license_noconflict-append openssl
-
-depends_build-append \
-    port:pkgconfig
-
-depends_lib-append \
-    port:fftw-3-single \
-    path:lib/libmpir.dylib:mpir \
-    path:lib/libvolk.dylib:volk \
-    port:gmp \
-    port:python${active_python_version_no_dot} \
-    port:py${active_python_version_no_dot}-numpy \
-    port:py${active_python_version_no_dot}-cheetah
-
-# GR 3.8+ specific
-if {!(${subport} eq "gnuradio37")} {
-
-    # gr-vocoder removed in-tree libgsm, libcodec2, use system-wide libs
-    depends_lib-append \
-        port:codec2 \
-        port:libgsm
-
-    # gr_modtool requires click and click-plugins, and these are
-    # checked for at configure time, so have to use 'lib' here
-    depends_lib-append \
-        port:py${active_python_version_no_dot}-click \
-        port:py${active_python_version_no_dot}-click-plugins
-
-}
-
-# need matplotlib for polar encoder/decoder, runtime only
-depends_run-append \
-    port:py${active_python_version_no_dot}-matplotlib \
-    port:py${active_python_version_no_dot}-opengl \
-    port:py${active_python_version_no_dot}-scipy
-
-configure.args-append \
-    -DGMP_INCLUDE_DIR= \
-    -DGMP_LIBRARY= \
-    -DGMPXX_LIBRARY= \
-    -DMPIR_INCLUDE_DIR=${prefix}/include \
-    -DMPIR_LIBRARY=${prefix}/lib/libmpir.dylib \
-    -DMPIRXX_LIBRARY=${prefix}/lib/libmpirxx.dylib
-
-# remove top-level library and include paths, such that internal ones
-# are searched before any already-installed ones.
-configure.cppflags-delete -I${prefix}/include
-configure.ldflags-delete  -L${prefix}/lib
-
-# install CMake files into this directory.
-configure.args-append \
-    -DCMAKE_MODULES_DIR=${prefix}/share/cmake
-
-# set build type to release or debug, not "MacPorts" since the GR
-# CMake system checks for a valid value and this is not one of them
-if {[variant_isset debug]} {
-    cmake.build_type Debug
-} else {
-    cmake.build_type Release
-}
-
-# override default version string to be MacPorts-specific
-configure.args-append \
-    -DGR_GIT_COUNT="MacPorts" \
-    -DGR_GIT_HASH="${GR_VERSION_INFO}"
-
-# disable using internal VOLK
-configure.args-append \
-    -DENABLE_INTERNAL_VOLK=OFF
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-# TODO check "macports-libstdc++" or "libstdc++" should not needed anymore, right?
-# disable C/CXX standard extensions (e.g., "gnu++11" and "gnu11"
-# rather than "c++11" and "c11"). GNU Radio itself does not
-# require these extensions, and when compiling with Clang they
-# don't really do anything anyway; so, just disable them.
-configure.args-append \
-    -DCMAKE_CXX_EXTENSIONS=OFF \
-    -DCMAKE_C_EXTENSIONS=OFF
-
 # disable all components by default;
 # enable them only if the variant is enabled
 configure.args-append \
-    -DENABLE_DOXYGEN=OFF \
-    -DENABLE_SPHINX=OFF \
     -DENABLE_GRC=OFF \
     -DENABLE_GR_QTGUI=OFF \
     -DENABLE_GR_WXGUI=OFF \
@@ -286,7 +135,6 @@ configure.args-append \
     -DJACK_LIBRARY= \
     -DPORTAUDIO_INCLUDE_DIRS= \
     -DPORTAUDIO_LIBRARIES= \
-    -DSWIG_EXECUTABLE= \
     -DENABLE_GR_VIDEO_SDL=OFF \
     -DSDLMAIN_LIBRARY= \
     -DSDL_INCLUDE_DIR= \
@@ -299,36 +147,19 @@ configure.args-append \
     -DLOG4CPP_INCLUDE_DIRS= \
     -DLOG4CPP_LIBRARIES=
 
+# override default version string to be MacPorts-specific
+configure.args-append \
+    -DGR_GIT_COUNT="MacPorts" \
+    -DGR_GIT_HASH="${GR_VERSION_INFO}"
+
+# disable using internal VOLK
+configure.args-append \
+    -DENABLE_INTERNAL_VOLK=OFF
+
 # default: don't create the application bundle
 app.create no
 
-variant docs description "Install GNU Radio documentation" {
-
-    depends_lib-append \
-        port:xmlto
-
-    depends_build-append \
-        port:doxygen \
-        path:bin/dot:graphviz \
-        port:py${active_python_version_no_dot}-sphinx \
-        port:texlive-latex
-
-    # see https://github.com/macports/macports-ports/pull/7805
-    license_noconflict-append graphviz
-
-    configure.args-delete \
-        -DENABLE_DOXYGEN=OFF \
-        -DENABLE_SPHINX=OFF \
-        -DSPHINX_EXECUTABLE=
-
-    configure.args-append \
-        -DENABLE_DOXYGEN=ON \
-        -DENABLE_SPHINX=ON \
-        -DSPHINX_EXECUTABLE=${python_framework_dir}/bin/sphinx-build
-
-}
-
-variant grc requires swig description "Install GNU Radio Companion" {
+variant grc description "Install GNU Radio Companion" {
 
     # these are checked for at configure, then required
     # for runtime; so use depends_lib to get both.
@@ -459,6 +290,17 @@ if {${subport} eq "gnuradio37"} {
             -DwxWidgets_CONFIG_EXECUTABLE=${wxWidgets.wxconfig}
 
     }
+} else {
+    # gr-vocoder removed in-tree libgsm, libcodec2, use system-wide libs
+    depends_lib-append \
+        port:codec2 \
+        port:libgsm
+
+    # gr_modtool requires click and click-plugins, and these are
+    # checked for at configure time, so have to use 'lib' here
+    depends_lib-append \
+        port:py${active_python_version_no_dot}-click \
+        port:py${active_python_version_no_dot}-click-plugins
 }
 
 variant uhd description "Install GNU Radio with support for UHD" {
@@ -518,17 +360,6 @@ variant portaudio description "Install GNU Radio with support for portaudio audi
     configure.args-append \
         -DPORTAUDIO_INCLUDE_DIRS=${prefix}/include \
         -DPORTAUDIO_LIBRARIES=${prefix}/lib/libportaudio.dylib
-
-}
-
-variant swig description "Install GNU Radio with support for SWIG-base Python bindings" {
-
-    depends_build-append \
-        port:swig-python
-
-    configure.args-replace \
-        -DSWIG_EXECUTABLE= \
-        -DSWIG_EXECUTABLE=${prefix}/bin/swig
 
 }
 
@@ -672,8 +503,8 @@ variant x11 conflicts quartz description {Enable X11 support} {
 # per user consensus: enable all variants except +jack, +portaudio,
 # +ctrlport, +ctrlport_thrift, +performance_counters,+debug, and
 # +universal.
-default_variants +docs +grc +qtgui +uhd +wavelet \
-    +swig +sdl +zeromq
+default_variants +grc +qtgui +uhd +wavelet \
+    +sdl +zeromq
 
 post-destroot {
     # fix residual cmake module install location when

--- a/science/gr-adapt/Portfile
+++ b/science/gr-adapt/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-adapt
-categories          science comms
-platforms           darwin macosx
 license             GPL-3
 maintainers         {ra1nb0w @ra1nb0w} {michaelld @michaelld} openmaintainer
 description         Adaptive filters for GNU Radio
 long_description    ${description}
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -23,20 +17,13 @@ if {${subport} eq ${name}} {
     checksums    rmd160  05f5531bd9290190aad4719fcd605b6c9cf979f7 \
                  sha256  078d23713a44ddd6b9352a8d14821714fae652bf4b9936456fc9957c25eba663 \
                  size    463936
-    revision     5
+    revision     6
     git.branch   maint-3.8
     github.livecheck.branch maint-3.8
 
     conflicts gr37-adapt
 
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
-
 }
-
 
 subport gr37-adapt {
 
@@ -53,86 +40,6 @@ subport gr37-adapt {
 
     conflicts       gr-adapt
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-}
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:cppunit \
-    port:pkgconfig \
-    port:swig-python
-
-depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE= \
-    -DDOXYGEN_EXECUTABLE= \
-    -DCMAKE_MODULES_DIR=share/cmake
-
-variant docs description "Install ${name} documentation" {
-
-    depends_build-append \
-        port:doxygen \
-        path:bin/dot:graphviz
-
-    configure.args-delete \
-        -DDOXYGEN_DOT_EXECUTABLE= \
-        -DDOXYGEN_EXECUTABLE=
-
-    configure.args-append \
-        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
 }
 
 variant qr description "Enable QR decomposition on RLS filters" {
@@ -144,7 +51,7 @@ variant qr description "Enable QR decomposition on RLS filters" {
     configure.env-append BLA_VENDOR=OpenBLAS
 }
 
-default_variants +docs +qr
+default_variants +qr
 
 post-destroot {
     # copy GNU Radio examples

--- a/science/gr-air-modes/Portfile
+++ b/science/gr-air-modes/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-air-modes
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -23,17 +17,11 @@ if {${subport} eq ${name}} {
     checksums       rmd160  c217e9a5da47bf639f94fed4d2490d88717ca40a \
                     sha256  ec716122fd2c7e6e3f66a1d5c887b4433990c1036d2bdd4d7424808cca5a5a4e \
                     size    186306
-    revision        3
+    revision        4
 
     # NOTE: py3*-pyqwt is not available
 
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
     conflicts gr37-air-modes
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -61,12 +49,6 @@ subport gr37-air-modes {
 
     conflicts gr-air-modes
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
     depends_lib-append \
         port:qwt52 \
         port:py27-pyqwt \
@@ -76,69 +58,10 @@ subport gr37-air-modes {
 
 }
 
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
-depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    path:include/zmq.hpp:cppzmq \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
 if {${subport} eq "gr37-air-modes"} {
     configure.args-append \
         -DPYUIC4_EXECUTABLE=${python_framework_dir}/bin/pyuic4
 }
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
 
 depends_run-append \
     port:py${active_python_version_no_dot}-zmq

--- a/science/gr-ais/Portfile
+++ b/science/gr-ais/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-ais
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20151220
     revision        13
     replaced_by     gr37-ais
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-ais {
@@ -41,72 +33,4 @@ subport gr37-ais {
     conflicts \
         gr-ais
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
-depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-# install CMake files into this directory.
-configure.args-append \
-    -DCMAKE_MODULES_DIR=${prefix}/share/cmake

--- a/science/gr-baz/Portfile
+++ b/science/gr-baz/Portfile
@@ -1,13 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-baz
-categories          science comms
-platforms           darwin
 license             GPL-3
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
@@ -19,7 +16,7 @@ version             20200409-[string range ${github.version} 0 7]
 checksums           rmd160  62c7e8c1c62000b3bf8f7dee8b4ee0bbde7bc1b8 \
                     sha256  6cfb84fc38046f2429e679a9429bec8b404deb955f4cceecb33f17dc4d73110a \
                     size    516543
-revision            4
+revision            5
 
 # use C++11
 compiler.cxx_standard 2011
@@ -31,12 +28,6 @@ if {${subport} eq ${name}} {
 
     conflicts gr37-baz
 
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
-
     pre-configure {
         file copy -force ${worksrcpath}/CMakeLists-3.8.txt ${worksrcpath}/CMakeLists.txt
     }
@@ -47,73 +38,10 @@ subport gr37-baz {
 
     conflicts gr-baz
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
     pre-configure {
         file copy -force ${worksrcpath}/CMakeLists-3.7.txt ${worksrcpath}/CMakeLists.txt
     }
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:cppunit \
-    port:swig-python
-
-depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    port:doxygen \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-depends_test-append \
-    port:cppunit
 
 configure.args-append \
        -DUHD_INCLUDE_DIRS= \

--- a/science/gr-cdma/Portfile
+++ b/science/gr-cdma/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-cdma
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality for GNU Radio: a code-division multiple (user) access (CDMA) physical layer.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20161220
     revision        5
     replaced_by     gr37-cdma
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-cdma {
@@ -38,12 +30,6 @@ subport gr37-cdma {
     conflicts \
         gr-cdma
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
     patchfiles-append patch-installs.diff
     patch.pre_args -p1
     # 2nd part of patch
@@ -52,60 +38,3 @@ subport gr37-cdma {
     }
 
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen

--- a/science/gr-fcdproplus/Portfile
+++ b/science/gr-fcdproplus/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-fcdproplus
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Implements a funcube dongle pro+ source in GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -23,7 +17,7 @@ if {${subport} eq ${name}} {
     checksums       rmd160  d4cb7da467b9a9264e184d437088e253fde45ba6 \
                     sha256  ade328aeaec50882f87041a88b1baa62b1edb5fb213da1c0ec48812a0c1a5b1b \
                     size    49706    
-    revision        2
+    revision        3
 
     # force c++11 standard (strange)
     # and enable system hidapi
@@ -33,11 +27,7 @@ if {${subport} eq ${name}} {
     conflicts gr37-fcdproplus
 
     depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio \
         port:hidapi
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -55,11 +45,7 @@ subport gr37-fcdproplus {
     conflicts       gr-fcdproplus
 
     depends_lib-append \
-        port:gnuradio37 \
         path:lib/pkgconfig/libusb-1.0.pc:libusb
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 
     pre-patch {
         reinplace "/HINTS/s@/lib/@/share/@" \
@@ -68,60 +54,5 @@ subport gr37-fcdproplus {
 
 }
 
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:doxygen \
-    port:cppunit \
-    port:swig-python
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
 # disable because it fails to find Doxyfile.swig_doc.in
-configure.args-append \
-    -DENABLE_DOXYGEN=OFF \
-    -DCMAKE_CXX_STANDARD=11
+default_variants-append -docs

--- a/science/gr-foo/Portfile
+++ b/science/gr-foo/Portfile
@@ -1,21 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-foo
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     github.setup    bastibl gr-foo 13fac53de827ece4f2a5a367ed8cb3900238b3f6
@@ -24,15 +18,11 @@ if {${subport} eq ${name}} {
     checksums       rmd160  ce32f45356ede334adefc4105748cc0d8b682ada \
                     sha256  a9bc126ef7b1fad42de4e8384140bc2fc65ece1ed7f4c76c1bc98a289e98a58a \
                     size    24126    
-    revision        4
+    revision        5
 
     conflicts       gr37-foo
 
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
+    require_active_variants path:lib/libuhd.dylib:uhd path:lib/libgnuradio-runtime.dylib:gnuradio
 }
 
 
@@ -50,73 +40,9 @@ subport gr37-foo {
 
     conflicts       gr-foo
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
+    require_active_variants path:lib/libuhd.dylib:uhd gnuradio37
 
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:doxygen \
-    port:cppunit \
-    port:swig-python
-
-depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    path:lib/libuhd.dylib:uhd \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
 
 # use the git branch for livecheck
-
 github.livecheck.branch ${git.branch}

--- a/science/gr-fosphor/Portfile
+++ b/science/gr-fosphor/Portfile
@@ -1,26 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
 PortGroup           github 1.0
 PortGroup           qt5 1.0
 PortGroup           conflicts_build 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-fosphor
-categories          science comms
 homepage            http://sdr.osmocom.org/trac/wiki/fosphor
-platforms           darwin macosx
 license             GPL-3
 maintainers         {michaelld @michaelld} {ra1nb0w @ra1nb0w} openmaintainer
 description         gr-fosphor provides a GNU Radio block for RTSA-like spectrum visualization using GPU acceleration.
 long_description    ${description} \
     This port is kept up with the gr-fosphor GIT 'master' branch, which is \
     typically updated weekly to monthly.
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -29,15 +23,9 @@ if {${subport} eq ${name}} {
     checksums       rmd160  95ea3fad5f31bdf0203b21da2db9cc44e598227a \
                     sha256  0a12468c4618aff3a6ab4a3dde03fc4220db70a8c5b4198674e5e35497f8ea28 \
                     size    244575
-    revision        2
+    revision        3
 
     conflicts gr37-fosphor
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
     conflicts_build gr-fosphor
 
@@ -58,67 +46,11 @@ subport gr37-fosphor {
 
     conflicts       gr-fosphor
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:doxygen \
-    port:cppunit \
-    port:swig-python
 
 depends_lib-append \
     port:freetype \
-    port:log4cpp \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
+    port:log4cpp
 
 # DISABLED temporary patch to fix using gr_log
 #patchfiles-append patch-add_gr_log.diff
@@ -127,7 +59,6 @@ configure.args-append \
 # https://trac.macports.org/ticket/54614
 configure.args-append \
     -DENABLE_GLFW=OFF
-
 
 if {${subport} eq "gr37-fosphor"} {
 

--- a/science/gr-gfdm/Portfile
+++ b/science/gr-gfdm/Portfile
@@ -1,37 +1,25 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-gfdm
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality for GNU Radio: Generalized Frequency Division Multiplexing.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
     github.setup    jdemel gr-gfdm df94a58da883e796c18a0a5679d4992e94158c8c
     version         20200409-[string range ${github.version} 0 7]
-    revision        3
+    revision        4
 
     conflicts       gr37-gfdm
 
     patchfiles-append \
         patch-fix_build38.diff
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -49,12 +37,6 @@ subport gr37-gfdm {
     patchfiles-append \
         patch-fix_build37.diff
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
 }
 
 # Fetch from git instead of distfile because it needs submodules
@@ -63,61 +45,8 @@ post-fetch {
     system -W "${worksrcpath}" "git submodule update --init --recursive"
 }
 
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
 depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    port:fftw-3-single \
-    port:python${active_python_version_no_dot} \
     port:py${active_python_version_no_dot}-pybind11
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
 
 # unfortunately, for the moment it needs internal pybind11
 # too much effort to move out only avoid installation
@@ -126,6 +55,5 @@ configure.args-append \
     -DPYBIND11_TEST=OFF
 
 # documentation - fail -> disable
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE= \
-    -DDOXYGEN_EXECUTABLE=
+default_variants-append \
+    -docs

--- a/science/gr-gsm/Portfile
+++ b/science/gr-gsm/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-gsm
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality for GNU Radio: a set of tools for receiving information transmitted by GSM equipment/devices.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -23,7 +17,7 @@ if {${subport} eq ${name}} {
     checksums       rmd160  b0c22e3f4e1d16b364e63696bc5fa774b085b8cf \
                     sha256  8ecffa8a6f7733ac7e4e3744592534478425ce89811e4483cf687cb7ad31ad4a \
                     size    417371
-    revision        4
+    revision        5
 
     github.livecheck.branch porting_to_gr38
 
@@ -33,13 +27,6 @@ if {${subport} eq ${name}} {
         patch-fix-local-library-load_38.diff
 
     conflicts gr37-gsm
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio \
-        port:fftw-3-single
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -73,72 +60,13 @@ subport gr37-gsm {
 
     conflicts       gr-gsm
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-}
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
 }
 
 depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:cppunit \
-    port:doxygen \
     port:py${active_python_version_no_dot}-docutils
 
 depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    path:lib/libosmocore.dylib:osmocore \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
+    path:lib/libosmocore.dylib:osmocore
 
 configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen \
-    -DRST2MAN_EXECUTABLE=${python_framework_dir}/bin/rst2man.py \
-    -DCMAKE_MODULES_DIR=share/cmake
+    -DRST2MAN_EXECUTABLE=${python_framework_dir}/bin/rst2man.py

--- a/science/gr-hermeslite2/Portfile
+++ b/science/gr-hermeslite2/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           gnuradio 1.0
+
+name                gr-hermeslite2
+license             GPL-2+
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+description         GNU Radio interface module for Hermes Lite 2
+long_description    ${name} is a ${description}
+
+github.setup        daniestevez gr-hermeslite2 3cabd011e0bd1c6dbcaa5a11d9c0f3eb2b58fb8e
+version             20211214-[string range ${github.version} 0 7]
+checksums           rmd160  e362a9de119d521c01e81d396e707e7ab13e690a \
+                    sha256  592abb72e960f6b263aa2d48a807e0e5677a7fb4fa3ca08aefa2817b5c8683a8 \
+                    size    141530
+revision            0
+
+github.livecheck.branch master

--- a/science/gr-hpsdr/Portfile
+++ b/science/gr-hpsdr/Portfile
@@ -1,13 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-hpsdr
-categories          science comms
-platforms           darwin macosx
 license             GPL-2+
 maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
 description         gnuradio module for OpenHPSDR Hermes/Metis and Red Pitaya using the OpenHpsdr 1 protocol.
@@ -18,70 +15,6 @@ version             20210406-[string range ${github.version} 0 7]
 checksums           rmd160  bc694920d4a26d8389e31c14f93203e2eb512c76 \
                     sha256  fd7fb76105315e9d1964816ac2407893ba407c5b7cea5c3dbd59951343120542 \
                     size    125887
-revision            2
-
-set python_versions { 3.6 3.7 3.8 3.9 }
-set default_python_variant +python37
-
-# use C++11
-compiler.cxx_standard 2011
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:swig-python \
-    port:pkgconfig \
-    port:cppunit \
-    port:doxygen \
-    path:bin/dot:graphviz
-
-depends_lib-append \
-    path:lib/libgnuradio-runtime.dylib:gnuradio \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen \
-    -DCMAKE_MODULES_DIR=share/cmake
+revision            3
 
 github.livecheck.branch gr_3.8

--- a/science/gr-ieee802-11/Portfile
+++ b/science/gr-ieee802-11/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-ieee802-11
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -24,15 +18,9 @@ if {${subport} eq ${name}} {
     checksums       rmd160  711357dd74f36d6d15acf246fb804aa5b203823a \
                     sha256  f121d6eee6a92a2197dfea6478de1023d869b5451d4ec9d68e72ca7d3b738340 \
                     size    124342
-    revision        2
+    revision        3
 
     conflicts       gr37-ieee802-11
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -50,72 +38,10 @@ subport gr37-ieee802-11 {
 
     conflicts       gr-ieee802-11
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
 
 depends_lib-append \
-    port:log4cpp \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
+    port:log4cpp
 
 # use the git branch for livecheck
-
 github.livecheck.branch ${git.branch}

--- a/science/gr-ieee802-15-4/Portfile
+++ b/science/gr-ieee802-15-4/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-ieee802-15-4
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -24,15 +18,9 @@ if {${subport} eq ${name}} {
     checksums       rmd160  b1a1946bdd7621c2cfbc0837329fb7f4a120c1e2 \
                     sha256  0b635c7af840f3bfeaef20d8adac1682cb42a5bca2da073da888859c7a9ae867 \
                     size    94433
-    revision        4
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
+    revision        5
 
     conflicts       gr37-ieee802-15-4
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -50,73 +38,7 @@ subport gr37-ieee802-15-4 {
 
     conflicts       gr-ieee802-15-4
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
-depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    port:python${active_python_version_no_dot} \
-    port:py${active_python_version_no_dot}-matplotlib
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
 
 # use the git branch for livecheck
-
 github.livecheck.branch ${git.branch}

--- a/science/gr-iio/Portfile
+++ b/science/gr-iio/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-iio
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality for GNU Radio: IIO device source
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -23,18 +17,12 @@ if {${subport} eq ${name}} {
     checksums       rmd160  8c7309e30b378afc99fe3d3b8d03c6ee3fba2dd4 \
                     sha256  4a6c307f194655ec4fe8d1247fc9b4a6a0203f2a4686c9c948ff1877c50fa8d5 \
                     size    56107
-    revision        6
+    revision        7
 
     github.livecheck.branch \
         upgrade-3.8
 
     conflicts       gr37-iio
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -55,73 +43,12 @@ subport gr37-iio {
 
     conflicts       gr-iio
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-}
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
 }
 
 depends_build-append \
     port:bison \
-    port:flex \
-    port:pkgconfig \
-    port:doxygen \
-    port:cppunit \
-    port:swig-python
+    port:flex
 
 depends_lib-append \
     port:libad9361-iio \
-    path:lib/libiio.dylib:libiio \
-    path:lib/libvolk.dylib:volk \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen \
-    -DCMAKE_MODULES_DIR=share/cmake
+    path:lib/libiio.dylib:libiio

--- a/science/gr-iqbalance/Portfile
+++ b/science/gr-iqbalance/Portfile
@@ -1,23 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-iqbalance
-categories          science comms
 homepage            http://sdr.osmocom.org/trac/wiki/GrOsmoSDR
 license             GPL-3
-platforms           darwin macosx
 maintainers         {michaelld @michaelld} {ra1nb0w @ra1nb0w} openmaintainer
 description         gr-iqbalance provides I/Q balancing blocks for GNU Radio
 long_description    ${description}. This port is kept up with the \
     gr-iqbal GIT 'master' branch, which is typically updated monthly.
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -25,18 +19,12 @@ if {${subport} eq ${name}} {
     checksums     rmd160  e6dc5ca7e8587131a7826f77f4c55a5e4e929d17 \
                   sha256  7a133cb0329b4695d959455638fdb603e3e027cabdc51ec721e501b50cb5facc \
                   size    106418
-    revision      2
+    revision      3
 
     # move from date to version
     epoch         1
 
     conflicts     gr37-iqbalance
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -55,110 +43,7 @@ subport gr37-iqbalance {
 
     conflicts     gr-iqbalance
 
-    depends_lib-append \
-        port:gnuradio37
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:cppunit
 
 depends_lib-append \
-    port:libosmo-dsp \
-    port:fftw-3-single \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE= \
-    -DDOXYGEN_EXECUTABLE= \
-    -DCMAKE_MODULES_DIR=share/cmake \
-    -DSWIG_EXECUTABLE= \
-    -DCMAKE_CXX_STANDARD=11
-
-variant docs description "Install ${name} documentation" {
-
-    depends_build-append \
-        port:doxygen \
-        path:bin/dot:graphviz
-
-    configure.args-delete \
-        -DDOXYGEN_DOT_EXECUTABLE= \
-        -DDOXYGEN_EXECUTABLE=
-
-    configure.args-append \
-        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-}
-
-variant swig description "Install ${name} with support for SWIG-base Python bindings" {
-
-    # require gnuradio to also have this variant
-    require_active_variants \
-        path:lib/libgnuradio-runtime.dylib:gnuradio swig
-
-    configure.args-delete \
-        -DSWIG_EXECUTABLE=
-
-    if {${subport} eq "gr37-iqbalance"} {
-        depends_build-append \
-            port:swig3-python
-
-        configure.args-append \
-            -DSWIG_EXECUTABLE=${prefix}/bin/swig3
-    } else {
-        depends_build-append \
-            port:swig-python
-    }
-
-}
-
-default_variants +docs +swig
+    port:libosmo-dsp

--- a/science/gr-iridium/Portfile
+++ b/science/gr-iridium/Portfile
@@ -1,21 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-iridium
-
-categories          science comms
-platforms           darwin macosx
 license             GPL-3+
 maintainers         {ra1nb0w @ra1nb0w} {michaelld @michaelld} openmaintainer
 description         Iridium burst detector and demodulator.
 long_description    ${description}
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -24,17 +17,11 @@ if {${subport} eq ${name}} {
     checksums       rmd160  625bc88641b142eebd0f8fb4bbdcb85ab8183f82 \
                     sha256  94cd96914e2fddd3184130ca1f327b48fce6fac2b6c07db8c0b4f1e912b51d98 \
                     size    132094
-    revision        0
+    revision        1
     git.branch      maint-3.8
     github.livecheck.branch maint-3.8
 
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
     conflicts gr37-iridium
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -53,90 +40,9 @@ subport gr37-iridium {
 
     conflicts gr-iridium
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
     patchfiles-append \
         gr3.7-cmake-boost.patch
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:cppunit
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE= \
-    -DDOXYGEN_EXECUTABLE= \
-    -DCMAKE_MODULES_DIR=share/cmake
-
-variant docs description "Install ${name} documentation" {
-
-    depends_build-append \
-        port:doxygen \
-        path:bin/dot:graphviz
-
-    configure.args-delete \
-        -DDOXYGEN_DOT_EXECUTABLE= \
-        -DDOXYGEN_EXECUTABLE=
-
-    configure.args-append \
-        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-}
-
-default_variants +docs
 
 post-destroot {
     # copy GNU Radio examples

--- a/science/gr-limesdr/Portfile
+++ b/science/gr-limesdr/Portfile
@@ -1,36 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-limesdr
-categories          science comms
-platforms           darwin macosx
 license             GPL-3+
 maintainers         {ra1nb0w @ra1nb0w} {michaelld @michaelld} openmaintainer
 description         GNU Radio block for LimeSDR-USB/LimeSDR-Mini boards
 long_description    ${description}
 homepage            https://wiki.myriadrf.org/Gr-limesdr_Plugin_for_GNURadio
 
-# use C++11
-compiler.cxx_standard 2011
-
 if {${subport} eq ${name}} {
     github.setup    myriadrf gr-limesdr 3.0.1 v
     checksums       rmd160  aea48429e6d95da8309368074c61c55af7d70a88 \
                     sha256  de7ffc85b8f4d39bd4c6be6b3f2860546e2e36a18a2f04b9f89c0c130b9dbedf \
                     size    2992951
-    revision        3
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
+    revision        4
 
     conflicts gr37-limesdr
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
     github.livecheck.regex  {([0-9.]+)}
 }
@@ -47,12 +35,6 @@ subport gr37-limesdr {
 
     conflicts       gr-limesdr
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
     github.livecheck.regex  {(2.[0-9.]+)}
 }
 
@@ -60,85 +42,10 @@ subport gr-limesdr-devel {
     replaced_by     gr-limesdr
     version         3.0.1
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:swig-python \
-    port:pkgconfig \
-    port:cppunit
 
 depends_lib-append \
-    path:lib/libLimeSuite.dylib:limesuite \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE= \
-    -DDOXYGEN_EXECUTABLE= \
-    -DCMAKE_MODULES_DIR=share/cmake
-
-variant docs description "Install ${name} documentation" {
-
-    depends_build-append \
-        port:doxygen \
-        path:bin/dot:graphviz
-
-    configure.args-delete \
-        -DDOXYGEN_DOT_EXECUTABLE= \
-        -DDOXYGEN_EXECUTABLE=
-
-    configure.args-append \
-        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-}
-
-default_variants +docs
+    path:lib/libLimeSuite.dylib:limesuite
 
 post-destroot {
     # copy GNU Radio examples

--- a/science/gr-linrad/Portfile
+++ b/science/gr-linrad/Portfile
@@ -1,13 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
-PortGroup           boost 1.0
 PortGroup           github 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-linrad
-categories          science comms
-platforms           darwin macosx
 license             GPL-3
 maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
 description         GNU Radio module implementing Linrad network protocol
@@ -19,68 +16,6 @@ checksums           rmd160  0c2051f8a3a408a988633de8e433a8ce8253e96f \
                     sha256  74ecbb5263e427e0443e9d8e856e9e8fdb832dc514a36baedbbd743a66f0b697 \
                     size    125883
 revision            2
-
-set python_versions { 3.6 3.7 3.8 3.9 }
-set default_python_variant +python39
-
-# use C++11
-compiler.cxx_standard 2011
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:swig-python \
-    port:pkgconfig \
-    port:cppunit \
-    port:doxygen \
-    path:bin/dot:graphviz
-
-depends_lib-append \
-    path:lib/libgnuradio-runtime.dylib:gnuradio \
-    port:python${active_python_version_no_dot}
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen \
-    -DCMAKE_MODULES_DIR=share/cmake
 
 post-destroot {
     # copy GNU Radio examples

--- a/science/gr-lora/Portfile
+++ b/science/gr-lora/Portfile
@@ -1,29 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-lora
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides an open-source implementation of the LoRa CSS PHY.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
 
 if {${subport} eq ${name}} {
     version         20180131
     revision        2
     replaced_by     gr-lora-rpp0
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
-
-# use C++11
-compiler.cxx_standard 2011
 
 subport gr37-lora-BastilleResearch {
 
@@ -38,12 +30,6 @@ subport gr37-lora-BastilleResearch {
     conflicts \
         gr37-lora-rpp0 \
         gr-lora-rpp0
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
 
 }
 
@@ -66,13 +52,6 @@ subport gr37-lora-rpp0 {
     conflicts \
         gr37-lora-BastilleResearch \
         gr-lora-rpp0
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
 }
 
 subport gr-lora-rpp0 {
@@ -84,80 +63,13 @@ subport gr-lora-rpp0 {
     checksums       rmd160  c18dbf6cd87643e66277a06c8f8cdce42b4eadde \
                     sha256  63ca9b40c3ff69a3b18d145e5a58e65023d386c1dec1591b9dc57ffa748a1a20 \
                     size    505793
-    revision        3
+    revision        4
 
     conflicts \
         gr37-lora-BastilleResearch \
         gr37-lora-rpp0
 
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
-depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-configure.args-append \
-    -DCMAKE_CXX_STANDARD=11
 
 if {[string first "-lora-rpp0" $subport] > 0} {
 

--- a/science/gr-lte/Portfile
+++ b/science/gr-lte/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-lte
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20180220
     revision        4
     replaced_by     gr37-lte
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-lte {
@@ -38,74 +30,7 @@ subport gr37-lte {
     conflicts \
         gr-lte
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
-depends_lib-append \
-    port:fftw-3-single \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
 
 depends_test-append \
     port:zeitgeist
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-configure.args-append \
-    -DCMAKE_CXX_STANDARD=11

--- a/science/gr-mac/Portfile
+++ b/science/gr-mac/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-mac
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20140919
     revision        9
     replaced_by     gr37-mac
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-mac {
@@ -41,74 +33,7 @@ subport gr37-mac {
     conflicts \
         gr-mac
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-# install CMake files into this directory.
-configure.args-append \
-    -DCMAKE_MODULES_DIR=${prefix}/share/cmake
 
 # include examples in destroot
 post-destroot {

--- a/science/gr-mapper/Portfile
+++ b/science/gr-mapper/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-mapper
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality for GNU Radio: Symbol to Bit Mapping and Demapping Blocks
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20181023-2ea1eb68
     revision        1
     replaced_by     gr37-mapper
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-mapper {
@@ -39,71 +31,10 @@ subport gr37-mapper {
     conflicts \
         gr-mapper
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
     # patch CMake modules dir
     patchfiles-append patch-fix_cmake_dirs.diff
 
 }
 
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
 depends_build-append \
-    port:bison \
-    port:cppunit \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
+    port:bison

--- a/science/gr-ofdm/Portfile
+++ b/science/gr-ofdm/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-ofdm
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20180306
     revision        16
     replaced_by     gr37-ofdm
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 
@@ -40,12 +32,6 @@ subport gr37-ofdm {
     conflicts \
         gr-ofdm
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
     # patch to allow building using Clang and C++11
     # should also be backward compatible with GCC.
     # adds boost::thread and volk finding.
@@ -60,70 +46,9 @@ subport gr37-ofdm {
 
 }
 
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
 depends_lib-append \
-    path:lib/libvolk.dylib:volk \
     path:lib/libitpp.dylib:itpp \
     port:py${active_python_version_no_dot}-pyqt4 \
     port:py${active_python_version_no_dot}-pyqwt \
-    port:py${active_python_version_no_dot}-scipy \
-    port:py${active_python_version_no_dot}-numpy \
     path:lib/libuhd.dylib:uhd \
-    path:lib/libzmq.dylib:zmq \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-configure.args-append \
-    -DCMAKE_CXX_STANDARD=11
+    path:lib/libzmq.dylib:zmq

--- a/science/gr-osmosdr/Portfile
+++ b/science/gr-osmosdr/Portfile
@@ -1,17 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-osmosdr
 maintainers         {michaelld @michaelld} openmaintainer
-categories          science comms
 homepage            http://sdr.osmocom.org/trac/wiki/GrOsmoSDR
 license             GPL-3
-platforms           darwin macosx
 description         gr-osmosdr provides support for OsmoSDR hardware within GNU Radio
 long_description    Includes OSMO SDR support GNU Radio source and sink blocks in C++, \
     Python, and GNU Radio Companion (grc).  This port also offers a wrapper functionality \
@@ -19,24 +16,15 @@ long_description    Includes OSMO SDR support GNU Radio source and sink blocks i
     and software.  By using gr-osmosdr source you can take advantage of a common software API \
     in your applications independent of the underlying radio hardware.
 
-# use C++11
-compiler.cxx_standard 2011
-
 if {${name} eq ${subport}} {
     github.setup osmocom gr-osmosdr cffef690f29e0793cd2d6c5d028c0c929115f0ac
     version      20210117-[string range ${github.version} 0 7]
     checksums    rmd160  d80040fa6a40280dfff5e010d5f9b2575280f5e6 \
                  sha256  ce916d4fd04af6cde67e137f1ffc4ac69c12284c49f412312ace13622b1a1d07 \
                  size    252770
-    revision     2
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
+    revision     3
 
     conflicts gr37-osmosdr
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
     # add out-of-tree backend
     patchfiles-append \
@@ -60,71 +48,8 @@ subport gr37-osmosdr {
 
     conflicts gr-osmosdr
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
     github.livecheck.branch gr3.7
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:cppunit
-
-depends_lib-append \
-    path:lib/libvolk.dylib:volk \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE= \
-    -DDOXYGEN_EXECUTABLE= \
-    -DCMAKE_MODULES_DIR=share/cmake
 
 # default
 configure.args-append \
@@ -132,32 +57,6 @@ configure.args-append \
     -DENABLE_OSMOSDR=OFF \
     -DENABLE_FILE=ON \
     -DENABLE_MIRI=OFF
-
-if {[variant_isset debug]} {
-    cmake.build_type Debug
-} else {
-    cmake.build_type Release
-}
-
-variant docs description "Install ${name} documentation" {
-    depends_build-append \
-        port:doxygen \
-        path:bin/dot:graphviz
-
-    if {${subport} eq "gr-osmosdr"} {
-        depends_build-append \
-            port:py${active_python_version_no_dot}-six
-    }
-
-    configure.args-delete \
-        -DDOXYGEN_DOT_EXECUTABLE= \
-        -DDOXYGEN_EXECUTABLE=
-
-    configure.args-append \
-        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-}
-
 
 variant uhd description "Install ${name} with support for UHD" {
     # allow uhd or uhd-devel
@@ -205,28 +104,6 @@ if {![variant_isset iio]} {
         -DGNURADIO_IIO_LIBRARIES= \
         -DIIO_INCLUDE_DIRS= \
         -DIIO_LIBRARIES=
-}
-
-variant swig description "Install ${name} with support for SWIG-base Python bindings" {
-    depends_build-append \
-        port:swig-python
-
-    if {${subport} eq "gr-osmosdr"} {
-        depends_build-append \
-            port:py${active_python_version_no_dot}-mako
-    }
-
-    # require gnuradio to also have this variant
-    require_active_variants \
-        path:lib/libgnuradio-runtime.dylib:gnuradio swig
-
-    configure.args-append \
-        -DSWIG_EXECUTABLE=${prefix}/bin/swig
-}
-
-if {![variant_isset swig]} {
-    configure.args-append \
-        -DSWIG_EXECUTABLE=
 }
 
 variant hackrf description "Install ${name} with support for hackrf" {
@@ -352,7 +229,7 @@ if {${subport} eq "gr-osmosdr"} {
 }
 
 # per user concensus: enable all variants except +debug and +universal
-default_variants +docs +uhd +swig +hackrf +rtlsdr +bladeRF +airspy +redpitaya +rfspace +fcdproplus +spyserver
+default_variants +uhd +hackrf +rtlsdr +bladeRF +airspy +redpitaya +rfspace +fcdproplus +spyserver
 
 # SoapySDR and SDRPlay work on 10.9 and newer only until fixed
 platform darwin {

--- a/science/gr-pcap/Portfile
+++ b/science/gr-pcap/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-pcap
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality (blocks, GRC definitions, apps, etc) for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20170402
     revision        6
     replaced_by     gr37-pcap
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-pcap {
@@ -38,74 +30,10 @@ subport gr37-pcap {
     conflicts \
         gr-pcap
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:cppunit \
-    port:doxygen
 
 depends_lib-append \
-    path:bin/scapy:scapy \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-# install CMake files into this directory.
-configure.args-append \
-    -DCMAKE_MODULES_DIR=${prefix}/share/cmake
+    path:bin/scapy:scapy
 
 # include examples in destroot
 post-destroot {

--- a/science/gr-pyqt/Portfile
+++ b/science/gr-pyqt/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-pyqt
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality for GNU Radio: pyqt based plotters intended for plotting bursted events.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20160712
     revision        9
     replaced_by     gr37-pyqt
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-pyqt {
@@ -37,67 +29,4 @@ subport gr37-pyqt {
 
     conflicts \
          gr-pyqt
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:cppunit \
-    port:doxygen
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen

--- a/science/gr-rds/Portfile
+++ b/science/gr-rds/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-rds
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides the Radio Data System (RDS) block for GNU Radio.
 long_description    ${description}
 license             GPL-2+
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -24,16 +18,12 @@ if {${subport} eq ${name}} {
     checksums       rmd160  4aeb0969bc2e620308e3f1378b0aaaa5744d2152 \
                     sha256  c3524f4eddd311c6ae98b97ba3ea33a5ba2c93a27bea6bc2d339840d7094ccad \
                     size    210653
-    revision        2
+    revision        3
 
     conflicts       gr37-rds
 
     depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio \
         port:gr-osmosdr
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
     post-destroot {
         # copy the provided app into examples
@@ -59,11 +49,7 @@ subport gr37-rds {
     conflicts       gr-rds
 
     depends_lib-append \
-        port:gnuradio37 \
         port:gr37-osmosdr
-
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 
     post-destroot {
         # copy the provided app into examples
@@ -74,64 +60,8 @@ subport gr37-rds {
 
 }
 
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
 depends_lib-append \
-    port:libxml2 \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
+    port:libxml2
 
 # use the git branch for livecheck
-
 github.livecheck.branch ${git.branch}

--- a/science/gr-satellites/Portfile
+++ b/science/gr-satellites/Portfile
@@ -1,20 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-satellites
-categories          science comms
-platforms           darwin macosx
 license             GPL-3
 maintainers         {ra1nb0w @ra1nb0w} {michaelld @michaelld} openmaintainer
 description         GNU Radio decoders for several Amateur satellites.
 long_description    ${description}
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
 
@@ -22,15 +16,9 @@ if {${subport} eq ${name}} {
     checksums       rmd160  c2c9def1f9b73cebfdfc2d8134430659b17aa194 \
                     sha256  f549029b75a0303a9dfe69980d4048c2cf57feca59503168cf40c4bfde2102be \
                     size    3843946
-    revision        0
-
-    depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio
+    revision        1
 
     conflicts gr37-satellites
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
     github.livecheck.regex  {(3\.[0-9.]+)}
 
@@ -48,95 +36,16 @@ subport gr37-satellites {
 
     conflicts gr-satellites
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
     depends_lib-append \
-        port:gnuradio37 \
         port:libfec
 
     livecheck.type none
 
 }
 
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:cppunit \
-    port:pkgconfig \
-    port:swig-python
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
 depends_run-append \
     port:py${active_python_version_no_dot}-construct \
     port:py${active_python_version_no_dot}-requests
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE= \
-    -DDOXYGEN_EXECUTABLE= \
-    -DCMAKE_MODULES_DIR=share/cmake
-
-variant docs description "Install ${name} documentation" {
-
-    depends_build-append \
-        port:doxygen \
-        path:bin/dot:graphviz
-
-    configure.args-delete \
-        -DDOXYGEN_DOT_EXECUTABLE= \
-        -DDOXYGEN_EXECUTABLE=
-
-    configure.args-append \
-        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
-
-}
-
-default_variants +docs
 
 post-destroot {
     # copy GNU Radio examples

--- a/science/gr-sdrplay/Portfile
+++ b/science/gr-sdrplay/Portfile
@@ -1,27 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem            1.0
-PortGroup             cmake 1.1
-PortGroup           boost 1.0
+PortGroup             gnuradio 1.0
 
 name                  gr-sdrplay
-categories            science comms
-platforms             darwin macosx
 license               GPL-3+
 maintainers           {ra1nb0w @ra1nb0w} {michaelld @michaelld} openmaintainer
 description           GNU Radio block for SDRPlay boards
 long_description      ${description}
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20180717-d28ae3d3
     revision        1
     replaced_by     gr37-sdrplay
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-sdrplay {
@@ -42,11 +34,7 @@ subport gr37-sdrplay {
 
     conflicts gr37-sdrplay
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
     depends_lib-append \
-        port:gnuradio37 \
         port:SDRplay
 
     livecheck.type    regexm
@@ -55,64 +43,6 @@ subport gr37-sdrplay {
     livecheck.regex   {/HB9FXQ/gr-sdrplay/-/commit/([0-9a-z]*)}
 
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:cppunit \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE= \
-    -DDOXYGEN_EXECUTABLE= \
-    -DCMAKE_MODULES_DIR=share/cmake
 
 post-destroot {
     # copy GNU Radio examples

--- a/science/gr-specest/Portfile
+++ b/science/gr-specest/Portfile
@@ -1,19 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           compilers 1.0
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-specest
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides spectral estimation blocks for GNU Radio.
 long_description    ${description}
 license             GPL-3
-platforms           darwin
 
 # Claims to use c++11 but actually needs constexpr constants 
 compiler.cxx_standard 2017
@@ -27,16 +24,12 @@ if {${subport} eq ${name}} {
     checksums       rmd160  9b44d1d1b49a1d7624115ae76bbc539b91a96783 \
                     sha256  63b75c426f14b9d0b817cdfbc58724e8c44c4d590217943792a6d30a12cf8e34 \
                     size    568696
-    revision        2
+    revision        3
 
     conflicts gr37-specest
 
     depends_lib-append \
-        path:lib/libgnuradio-runtime.dylib:gnuradio \
         port:gr-osmosdr
-
-    set python_versions { 3.6 3.7 3.8 3.9 }
-    set default_python_variant +python37
 
 }
 
@@ -57,77 +50,17 @@ subport gr37-specest {
         patch-fix_build.37.diff
 
     depends_lib-append \
-        port:gnuradio37 \
         port:gr37-osmosdr
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-}
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
 }
 
 # require a fortran compiler
 #compilers.choose    f77 f90
 compilers.setup     require_fortran
 
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:doxygen \
-    port:cppunit
-
 depends_lib-append \
     port:libxml2 \
-    port:armadillo \
-    port:fftw-3-single \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-packages
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
+    port:armadillo
 
 variant accelerate conflicts atlas openblas description {Use Apple Accelerate Libraries for BLAS} {
     configure.env-append BLA_VENDOR=Apple

--- a/science/gr-tdd/Portfile
+++ b/science/gr-tdd/Portfile
@@ -1,28 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           boost 1.0
+PortGroup           gnuradio 1.0
 
 name                gr-tdd
-categories          science comms
 maintainers         {michaelld @michaelld} openmaintainer
 description         Provides augmented functionality for GNU Radio: test driven development blocks
 long_description    ${description}
 license             GPL-3
-platforms           darwin
-
-# use C++11
-compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         20190521-13ae75ea
     revision        1
     replaced_by     gr37-tdd
     PortGroup       obsolete 1.0
-    set python_versions { 2.7 }
-    set default_python_variant +python27
 }
 
 subport gr37-tdd {
@@ -39,67 +31,4 @@ subport gr37-tdd {
     conflicts \
         gr-tdd
 
-    set python_versions { 2.7 }
-    set default_python_variant +python27
-
-    depends_lib-append \
-        port:gnuradio37
-
 }
-
-# Define the available variants
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    set variant_line {variant python${py_ver_no_dot} description "Build with python ${py_ver} support"}
-    foreach py_over ${python_versions} {
-        if { ${py_ver} == ${py_over} } { continue }
-        set py_over_no_dot [join [split ${py_over} "."] ""]
-        append variant_line " conflicts python${py_over_no_dot}"
-    }
-    append variant_line { { } }
-    eval $variant_line
-    if {[variant_isset python${py_ver_no_dot}]} {
-        if {${default_python_variant} != "+python${py_ver_no_dot}"} {
-            set default_python_variant ""
-        }
-    }
-}
-
-# set default python variant if not selected
-if {${default_python_variant} != ""} {
-    default_variants-append "${default_python_variant}"
-}
-
-# If a python variant is enabled, activate it
-set active_python_version ""
-set active_python_version_no_dot ""
-foreach py_ver ${python_versions} {
-    set py_ver_no_dot [join [split ${py_ver} "."] ""]
-    if {[variant_isset python${py_ver_no_dot}]} {
-        set active_python_version        ${py_ver}
-        set active_python_version_no_dot ${py_ver_no_dot}
-    }
-}
-
-depends_build-append \
-    port:pkgconfig \
-    port:swig-python \
-    port:cppunit \
-    port:doxygen
-
-depends_lib-append \
-    port:python${active_python_version_no_dot}
-
-boost.version 1.71
-
-# specify the Python version to use
-set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${active_python_version}
-configure.args-append \
-    -DPYTHON_EXECUTABLE=${python_framework_dir}/bin/python${active_python_version} \
-    -DPYTHON_INCLUDE_DIR=${python_framework_dir}/Headers \
-    -DPYTHON_LIBRARY=${python_framework_dir}/Python \
-    -DGR_PYTHON_DIR=${python_framework_dir}/lib/python${active_python_version}/site-package
-
-configure.args-append \
-    -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
-    -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen


### PR DESCRIPTION
#### Description

use python 3.9 as default

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
