### PR TITLE
k9s: update to 0.25.8

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.25.7 v
+go.setup            github.com/derailed/k9s 0.25.8 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 platforms           darwin
 
-checksums           rmd160  e924203cc17bb9e216ff41eb0a943d07895a1d64 \
-                    sha256  af24547f4c83492ec92db36e3cc09bdbb27aef44969bb18f393e93eee8c5d3a3 \
-                    size    6254516
+checksums           rmd160  2b562a37fee070e9b13036c363bb988bf017f9ff \
+                    sha256  56a4939b18a1059b55823e3a34b27fef8863473dca6c901659506a79219dba8e \
+                    size    6255844
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

Update to k9s 0.25.8.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?