### PR TITLE
yq: Update to version 4.16.1

### DIFF
--- a/textproc/yq/Portfile
+++ b/textproc/yq/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mikefarah/yq 4.15.1 v
+go.setup            github.com/mikefarah/yq 4.16.1 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  299e9a32b49a6ad7568130a94fbf7b7a3fad5cfc \
-                        sha256  a21ef79bcee6ed575d5679a6dc555c8cbcc6df7ecaeaf8ce0871a01a04465a0a \
-                        size    150395
+                        rmd160  9a90d0525ae621e28719ae4672d2fe4bf189c93d \
+                        sha256  e96eb45992849d2e90f2f96b39dc713c345adafb6db551644118e58192565dd9 \
+                        size    156581
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    496545a6307b \
@@ -110,10 +110,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
                         size    8553 \
                     github.com/jinzhu/copier \
-                        lock    v0.3.2 \
-                        rmd160  8352650b072143b2b26b17357ee3842a81968581 \
-                        sha256  e1ccc5a648c6bfd18e055e78cbac485483ba25dad698f33fcf5b15ae83d3cd50 \
-                        size    12947 \
+                        lock    v0.3.4 \
+                        rmd160  920be6aeddc986ac4e8d96beb866a9030b5af2a1 \
+                        sha256  d9dab8f37ec21201e281ed18155b3785d5aa62ef6a3cebbe05cd3c2172e5c834 \
+                        size    13084 \
                     github.com/inconshreveable/mousetrap \
                         lock    v1.0.0 \
                         rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
