### PR TITLE
jreleaser: update to 0.9.1

### DIFF
--- a/devel/jreleaser/Portfile
+++ b/devel/jreleaser/Portfile
@@ -4,7 +4,7 @@ PortSystem       1.0
 PortGroup        java 1.0
 
 name             jreleaser
-version          0.9.0
+version          0.9.1
 revision         0
 
 categories       devel java
@@ -14,23 +14,24 @@ platforms        darwin
 supported_archs  noarch
 
 description      Release projects quickly and easily with JReleaser
-long_description JReleaser is a release automation tool. Its goal is to simplify creating releases \
-                 and publishing artifacts to multiple package managers while providing customizable options. \
+long_description JReleaser is a release automation tool. Its goal is to simplify creating releases and \
+                 publishing artifacts to multiple package managers while providing customizable options. \
                   \
-                 JReleaser takes inputs from popular builds tools (Ant, Maven, Gradle) such as JAR files, binary \
-                 distributions (.zip, .tar), JLink images, or any other file that you’d like to publish as a Git \
-                 release on popular Git services such as Github or Gitlab. Distribution files can additionally be \
-                 published to be consumed by popular package managers as Homebrew, Snapcraft, or get ready to be \
-                 launched via JBang. Releases may be announced in a variety of channels such as Twitter, Zulip, or SDKMAN!
+                 JReleaser takes inputs from popular builds tools (Ant, Maven, Gradle) such as JAR files, \
+                 binary distributions (.zip, .tar), JLink images, or any other file that you’d like to \
+                 publish as a Git release on popular Git services such as GitHub, GitLab, or Gitea. \
+                 Distribution files may additionally be published to be consumed by popular package managers \
+                 such as Homebrew, Chocolatey, Snapcraft, or get ready to be launched via JBang. Releases \
+                 may be announced in a variety of channels such as Twitter, Zulip, SDKMAN!, and more.
 
 homepage         https://jreleaser.org
 
-master_sites     https://github.com/jreleaser/jreleaser/releases/download/v${version}
+master_sites     https://github.com/jreleaser/jreleaser/releases/download/v${version}/
 use_zip          yes
 
-checksums        rmd160 814b44dcbfe9559c7eb554583b33eca818a13949 \
-                 sha256 2a0e82f59400bfa0e87ed42ca10a824ce830d856df28a944e1ae1467cdad18fa \
-                 size   22229605
+checksums        rmd160 9d2a4280267110c25d35ca3430e45a8d05316ff7 \
+                 sha256 c834816967bf948e90837bb0d10f5f22290b20c617a29c3177a8051d5e74d956 \
+                 size   21428788
 
 java.version     1.8+
 


### PR DESCRIPTION
#### Description

Fix release for JReleaser v0.9.1
https://github.com/jreleaser/jreleaser/issues?q=is%3Aclosed+milestone%3Av0.9.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
