### PR TITLE
py-pyside2: enable verbose build

### DIFF
--- a/python/py-pyside2/Portfile
+++ b/python/py-pyside2/Portfile
@@ -42,6 +42,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-wheel
 
     build.args-append \
+        --verbose-build \
         --qmake=${qt_qmake_cmd} \
         --cmake=${prefix}/bin/cmake \
         --parallel=${build.jobs} \


### PR DESCRIPTION
#### Description
Print full compiler commands, which may help in case of build issues
<!-- Note: it is best to make pull requests from a branch rather than from master -->
Before:
```
[  4%] Building CXX object ApiExtractor/CMakeFiles/apiextractor.dir/abstractmetabuilder.cpp.o
[  7%] Building CXX object ApiExtractor/CMakeFiles/apiextractor.dir/apiextractor.cpp.o
[  7%] Building CXX object ApiExtractor/CMakeFiles/apiextractor.dir/apiextractor_autogen/mocs_compilation.cpp.o
```

After:
```
[  4%] Building CXX object ApiExtractor/CMakeFiles/apiextractor.dir/abstractmetabuilder.cpp.o
cd /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor && /opt/local/bin/ccache /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/compwrap/cxx/usr/bin/clang++ -DCMAKE_CXX_COMPILER=\"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/compwrap/cxx/usr/bin/clang++\" -DHAVE_LIBXSLT -DHAVE_QTXMLPATTERNS -DQT_CORE_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_XMLPATTERNS_LIB -DQT_XML_LIB -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor/apiextractor_autogen/include -I/opt/local/libexec/llvm-13/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/sources/shiboken2/ApiExtractor -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/sources/shiboken2/ApiExtractor/parser -I/opt/local/include -I/opt/local/include/libxml2 -iframework /opt/local/libexec/qt5/lib -isystem /opt/local/libexec/qt5/lib/QtCore.framework/Headers -isystem /opt/local/libexec/qt5/./mkspecs/macx-clang -isystem /opt/local/libexec/qt5/lib/QtXml.framework/Headers -isystem /opt/local/libexec/qt5/lib/QtXmlPatterns.framework/Headers -isystem /opt/local/libexec/qt5/lib/QtNetwork.framework/Headers -arch x86_64 -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -Wall -fvisibility=hidden -Wno-strict-aliasing -D QT_NO_CAST_FROM_ASCII -D QT_NO_CAST_TO_ASCII -O3 -DNDEBUG -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -mmacosx-version-min=12.0   -fPIC -fPIC -std=gnu++11 -MD -MT ApiExtractor/CMakeFiles/apiextractor.dir/abstractmetabuilder.cpp.o -MF CMakeFiles/apiextractor.dir/abstractmetabuilder.cpp.o.d -o CMakeFiles/apiextractor.dir/abstractmetabuilder.cpp.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/sources/shiboken2/ApiExtractor/abstractmetabuilder.cpp
[  7%] Building CXX object ApiExtractor/CMakeFiles/apiextractor.dir/apiextractor.cpp.o
cd /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor && /opt/local/bin/ccache /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/compwrap/cxx/usr/bin/clang++ -DCMAKE_CXX_COMPILER=\"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/compwrap/cxx/usr/bin/clang++\" -DHAVE_LIBXSLT -DHAVE_QTXMLPATTERNS -DQT_CORE_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_XMLPATTERNS_LIB -DQT_XML_LIB -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor/apiextractor_autogen/include -I/opt/local/libexec/llvm-13/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/sources/shiboken2/ApiExtractor -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/sources/shiboken2/ApiExtractor/parser -I/opt/local/include -I/opt/local/include/libxml2 -iframework /opt/local/libexec/qt5/lib -isystem /opt/local/libexec/qt5/lib/QtCore.framework/Headers -isystem /opt/local/libexec/qt5/./mkspecs/macx-clang -isystem /opt/local/libexec/qt5/lib/QtXml.framework/Headers -isystem /opt/local/libexec/qt5/lib/QtXmlPatterns.framework/Headers -isystem /opt/local/libexec/qt5/lib/QtNetwork.framework/Headers -arch x86_64 -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -Wall -fvisibility=hidden -Wno-strict-aliasing -D QT_NO_CAST_FROM_ASCII -D QT_NO_CAST_TO_ASCII -O3 -DNDEBUG -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -mmacosx-version-min=12.0   -fPIC -fPIC -std=gnu++11 -MD -MT ApiExtractor/CMakeFiles/apiextractor.dir/apiextractor.cpp.o -MF CMakeFiles/apiextractor.dir/apiextractor.cpp.o.d -o CMakeFiles/apiextractor.dir/apiextractor.cpp.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/sources/shiboken2/ApiExtractor/apiextractor.cpp
[  7%] Building CXX object ApiExtractor/CMakeFiles/apiextractor.dir/apiextractor_autogen/mocs_compilation.cpp.o
cd /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor && /opt/local/bin/ccache /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/compwrap/cxx/usr/bin/clang++ -DCMAKE_CXX_COMPILER=\"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/compwrap/cxx/usr/bin/clang++\" -DHAVE_LIBXSLT -DHAVE_QTXMLPATTERNS -DQT_CORE_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_XMLPATTERNS_LIB -DQT_XML_LIB -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor/apiextractor_autogen/include -I/opt/local/libexec/llvm-13/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/sources/shiboken2/ApiExtractor -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/sources/shiboken2/ApiExtractor/parser -I/opt/local/include -I/opt/local/include/libxml2 -iframework /opt/local/libexec/qt5/lib -isystem /opt/local/libexec/qt5/lib/QtCore.framework/Headers -isystem /opt/local/libexec/qt5/./mkspecs/macx-clang -isystem /opt/local/libexec/qt5/lib/QtXml.framework/Headers -isystem /opt/local/libexec/qt5/lib/QtXmlPatterns.framework/Headers -isystem /opt/local/libexec/qt5/lib/QtNetwork.framework/Headers -arch x86_64 -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -Wall -fvisibility=hidden -Wno-strict-aliasing -D QT_NO_CAST_FROM_ASCII -D QT_NO_CAST_TO_ASCII -O3 -DNDEBUG -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -mmacosx-version-min=12.0   -fPIC -fPIC -std=gnu++11 -MD -MT ApiExtractor/CMakeFiles/apiextractor.dir/apiextractor_autogen/mocs_compilation.cpp.o -MF CMakeFiles/apiextractor.dir/apiextractor_autogen/mocs_compilation.cpp.o.d -o CMakeFiles/apiextractor.dir/apiextractor_autogen/mocs_compilation.cpp.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-pyside2/py39-pyside2/work/pyside-setup-opensource-src-5.15.2/pyside3_build/py3.9-qt5.15.2-64bit-release/shiboken2/ApiExtractor/apiextractor_autogen/mocs_compilation.cpp
```
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1
Xcode 13.2 beta 2
Python 3.9.9
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
