### PR TITLE
MachO-Explorer: added miscapitalization patch

### DIFF
--- a/sysutils/MachO-Explorer/Portfile
+++ b/sysutils/MachO-Explorer/Portfile
@@ -34,7 +34,8 @@ post-fetch {
     system -W ${worksrcpath} "git submodule update --init --recursive"
 }
 
-patchfiles          no-code-sign.diff
+patchfiles          MachOKit-miscapitalization.diff \
+                    no-code-sign.diff
 
 destroot {
     copy ${worksrcpath}/build/Release/MachOExplorer.app ${destroot}${applications_dir}

--- a/sysutils/MachO-Explorer/files/MachOKit-miscapitalization.diff
+++ b/sysutils/MachO-Explorer/files/MachOKit-miscapitalization.diff
@@ -1,0 +1,11 @@
+--- External/MachO-Kit/MachOKit/Core/Description/Type/MKFieldType.h
++++ External/MachO-Kit/MachOKit/Core/Description/Type/MKFieldType.h
+@@ -26,7 +26,7 @@
+ //----------------------------------------------------------------------------//
+ 
+ #import <MachOKit/MKNodeFieldType.h>
+-#import <machOKit/MKNodeFieldContainerType.h>
++#import <MachOKit/MKNodeFieldContainerType.h>
+ #import <MachOKit/MKNodeFieldBooleanType.h>
+ #import <MachOKit/MKNodeFieldNumericType.h>
+ #import <MachOKit/MKNodeFieldEnumerationType.h>


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/64137

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->