### PR TITLE
git: do not overwrite system-wide gitconfig, when adding configuration for the osxkeychain credential helper

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -110,7 +110,8 @@ pre-destroot {
     xinstall -m 644 ${worksrcpath}/contrib/subtree/git-subtree.1 ${workpath}/man1
 }
 
-set docdestroot ${destroot}${prefix}/share/doc/git-doc
+set docdestroot         ${destroot}${prefix}/share/doc/git-doc
+set system_gitconfig    ${prefix}/etc/gitconfig
 
 post-destroot {
     foreach f {1 5 7} {
@@ -227,22 +228,37 @@ variant credential_osxkeychain description {Install git credential-osxkeychain u
     }
 
     post-destroot {
-        xinstall -m 755 "${worksrcpath}/contrib/credential/osxkeychain/git-credential-osxkeychain" \
+        xinstall -m 0755 \
+            "${worksrcpath}/contrib/credential/osxkeychain/git-credential-osxkeychain" \
             "${destroot}${prefix}/libexec/git-core/"
+    }
 
-        # Create a global gitconfig file that sets credential.helper to
-        # osxkeychain. This can be overriden on a per-user basis in the user's
-        # own git config file
-        set f [open ${destroot}${prefix}/etc/gitconfig w 0644]
-        puts ${f} "\[credential]\n\thelper = osxkeychain"
-        close ${f}
+    pre-activate {
+        set osxkc_config        "\[credential]\n\thelper = osxkeychain"
+
+        # Ensure the osxkeychain credential helper is configured in the
+        # system-wide gitconfig.  If the gitconfig file already exists,
+        # then append the configuration to the pre-existing file only
+        # if the file is currently missing the desired config.
+
+        if { ![file exists ${system_gitconfig}] } {
+            set f [open ${system_gitconfig} w 0644]
+            puts ${f} ${osxkc_config}
+            close ${f}
+        } else {
+            if { [catch {exec grep "helper = osxkeychain" ${system_gitconfig}} result] } {
+                set f [open ${system_gitconfig} a]
+                puts ${f} ${osxkc_config}
+                close ${f}
+            }
+        }
     }
 
     notes "
-A gitconfig file has been created at ${prefix}/etc/gitconfig to enable the
-osxkeychain credential helper. If you do not wish to use this credential
-helper, you can override this setting in your own personal git config file
-\(\$HOME/.gitconfig\) with e.g.
+Configuration to enable the osxkeychain credential helper has been added to
+the system-wide gitconfig at ${system_gitconfig}. If you do not wish to use
+this credential helper, you can override this setting in your own personal
+git config file \(\$HOME/.gitconfig\) with e.g.
 
     \[credential]
             helper = some_other_credential_helper
@@ -250,12 +266,6 @@ helper, you can override this setting in your own personal git config file
 For more information, run
 
     git help credentials
-
-NOTE: ${prefix}/etc/gitconfig will be over-written on port upgrades, and
-      thus it is NOT recommended to place any personal customisations in
-      this file. Instead use your personal configuration file
-         \(\$HOME/.gitconfig\)
-      for any additional modifications you wish to make.
 "
 }
 


### PR DESCRIPTION
Do not overwrite the system-wide gitconfig when adding configuration for the osxkeychain credential helper

If the gitconfig does not exist, then it will be created. But if it *does*
exist, then the file will be checked to see whether it already contains the
desired config, and if it doesn't, the configuration will be appended to the
already existing file.

Fixes: https://trac.macports.org/ticket/63953

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
