### PR TITLE
podman: Fix `podman machine` for M1

### DIFF
--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -7,6 +7,12 @@ go.setup            github.com/containers/podman 3.4.3 v
 github.tarball_from archive
 revision            0
 
+platform arm {
+    if {${version} eq "3.4.3"} {
+        incr revision
+    }
+}
+
 categories          sysutils
 license             Apache-2
 platforms           darwin
@@ -33,6 +39,9 @@ post-extract {
 
 patchfiles          patch-defaultHelperBinariesDir-for-MacPorts.diff \
                     patch-getEdk2CodeFd-for-MacPorts.diff
+
+# See https://trac.macports.org/ticket/64131#comment:3
+patchfiles-append   patch-remove-hvf-accel-option-for-qemu.diff
 
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" \

--- a/sysutils/podman/files/patch-remove-hvf-accel-option-for-qemu.diff
+++ b/sysutils/podman/files/patch-remove-hvf-accel-option-for-qemu.diff
@@ -1,0 +1,11 @@
+--- pkg/machine/qemu/options_darwin_arm64.go.orig	2021-12-07 02:28:38.000000000 +0200
++++ pkg/machine/qemu/options_darwin_arm64.go	2021-12-07 02:28:44.000000000 +0200
+@@ -13,7 +13,6 @@
+ func (v *MachineVM) addArchOptions() []string {
+ 	ovmfDir := getOvmfDir(v.ImagePath, v.Name)
+ 	opts := []string{
+-		"-accel", "hvf",
+ 		"-accel", "tcg",
+ 		"-cpu", "cortex-a57",
+ 		"-M", "virt,highmem=off",
+


### PR DESCRIPTION
Closed: https://trac.macports.org/ticket/64131

CHANGES:
* Add patch `patch-remove-hvf-accel-option-for-qemu.diff` for remove the `hvf` option from the list for `arm64`. Thus, the `podman machine` for M1 should work correctly.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
