### PR TITLE
rust-src: put sources in the right place

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -11,6 +11,7 @@ legacysupport.newest_darwin_requires_legacy     15
 # keep in mind that you also need to update cargo.crates at the end of this file
 name                rust
 version             1.57.0
+# rust-src has increased revision. Keep it in mind
 revision            1
 
 if { ${subport} eq ${name} } {
@@ -168,7 +169,7 @@ if {${os.platform} eq "darwin" && ${os.major} < ${min_darwin}} {
 set rust_platform       ${arch}-apple-${os.platform}
 set rust_root           ${worksrcpath}/build/stage0-${arch}
 
-if { ${subport} ne ${ccwrap} } {
+if { ${subport} ne ${ccwrap} && ${subport} ne "rust-src" } {
     if {${os.platform} eq "darwin" && ${os.major} < 13} {
         depends_build-append \
                         port:curl
@@ -376,6 +377,11 @@ livecheck.url       https://github.com/rust-lang/rust/tags
 livecheck.regex     refs/tags/(\[\\d\\.\]+).zip
 
 subport rust-src {
+    revision        2
+
+    # do not unpack bootsrap dependency
+    distfiles       ${distname}${extract.suffix}
+
     # remove dependencies
     depends_build
     depends_lib
@@ -387,19 +393,20 @@ subport rust-src {
 
     use_configure no
 
+    post-extract {
+        # delete the test directories (which for some god awful reason contains binaries)
+        system -W ${worksrcpath} "find src/llvm-project -type d -name test -print0 | xargs -0 rm -rf"
+    }
+
     build {}
 
     destroot {
         xinstall -d ${rust_source_dir}
-        move ${worksrcpath}/src ${rust_source_dir}/src
-        move ${worksrcpath}/library ${rust_source_dir}/library
+        move {*}[glob ${worksrcpath}/*] ${rust_source_dir}
 
         # correct the permissions
-        system -W ${rust_source_dir} "find . -type d -exec chmod 755 {} \\;"
-        system -W ${rust_source_dir} "find . -type f -exec chmod 644 {} \\;"
-
-        # delete the test directories (which for some god awful reason contains binaries)
-        system -W ${rust_source_dir} "find . -type d -name test -print0 | xargs -0 rm -rf"
+        system -W ${rust_source_dir} "find . -type d -perm -755 -print0 | xargs -0 chmod 755"
+        system -W ${rust_source_dir} "find . -type f -perm -644 -print0 | xargs -0 chmod 644"
     }
 }
 


### PR DESCRIPTION
#### Description

Before sources was installed to the wrong place and `cargo build --release -Z build-std --target=x86_64-apple-darwin` fails as:
```
error: "/opt/local/lib/rustlib/src/rust/Cargo.lock" does not exist, unable to build with the standard library, try:
        rustup component add rust-src
```

now it works as expected.

-------


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->