### PR TITLE
libssh2: update to 1.10.0

### DIFF
--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -1,16 +1,22 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           muniversal 1.0
+PortGroup           github      1.0
+PortGroup           muniversal  1.0
+PortGroup           openssl     1.0
 
-name                libssh2
-version             1.9.0
-revision            1
+github.setup        libssh2 libssh2 1.10.0 libssh2-
+github.tarball_from releases
+revision            0
+
 categories          devel net
 platforms           darwin
 maintainers         {wohner.eu:normen @Gminfly} openmaintainer
 
+homepage            https://www.libssh2.org/
+
 description         libssh2 is a library implementing the SSH2 protocol
+
 long_description    libssh2 is a library implementing the SSH2 protocol as \
                     defined by Internet Drafts: SECSH-TRANS(22), \
                     SECSH-USERAUTH(25), SECSH-CONNECTION(23), SECSH-ARCH(20), \
@@ -18,19 +24,16 @@ long_description    libssh2 is a library implementing the SSH2 protocol as \
 
 license             BSD
 
-homepage            https://www.libssh2.org/
-master_sites        ${homepage}download/
-
-checksums           rmd160  eb3553a9b2c05d5b6a24159db8a1478f9aea3877 \
-                    sha256  d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd \
-                    size    888551
+checksums           rmd160  b3af89cc5974dbffbcba0dd80dcd521e6e60b39d \
+                    sha256  2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51 \
+                    size    965044
 
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     # remove errant pragmas inside functions no supported on older gcc versions
     patchfiles-append patch-libssh2-pragmas-older-gcc.diff
 }
 
-depends_lib         path:lib/libssl.dylib:openssl port:zlib
+depends_lib-append  port:zlib
 
 configure.args      ac_cv_prog_AWK=/usr/bin/awk
 
@@ -38,5 +41,3 @@ variant debug description {Enable debug mode including tracing support} {
     configure.args-append \
         --enable-debug
 }
-
-livecheck.regex     libssh2-(\\d(?:\\.\\d)+)${extract.suffix}


### PR DESCRIPTION
- use `openssl` portgroup

Fixes: https://trac.macports.org/ticket/64151

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
