### PR TITLE
google-cloud-sdk: update to 366.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             365.0.1
+version             366.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  180ed4df51e9b5844591f464142e5d0e2494a676 \
-                    sha256  b3b04f7f5577347d5c30277d4bf6aa2d1a182c1ff8f9cc04edf0dee6f0b8c4a9 \
-                    size    96973273
+    checksums       rmd160  a39d296d351e1eaba8d75be4a9caab77df84f9ca \
+                    sha256  8dcc623d320f17f3cb4959ab3b79e08ff602204fc7eacc51b82b1532f24135c5 \
+                    size    97323547
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a214491508a07022d44899ea331f48c11a7057ca \
-                    sha256  4ae8a3274eb9b6fca5761ef2eed713bc3486256d11268575febe3351e9e4d902 \
-                    size    93240163
+    checksums       rmd160  6bf389d4ed0b660a829cdd6ba1541cc1cfe425d6 \
+                    sha256  7241cf19d0116f82d4600c2e60c7f63f084c384759b1febabaafe11501ae81fe \
+                    size    93594071
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e5398b95ac97497da5d06307dcb8b2b120d41427 \
-                    sha256  636591e597730649011f510fc8c78e2b133ef8b417992f8d923a87a528dc6d5e \
-                    size    93164676
+    checksums       rmd160  8a5d1dc0361160937328484d6c5a10603b7b0091 \
+                    sha256  9ef1d8e5774848e262d64f06ca39302b81d64289a12095a2fe029d8996c1d898 \
+                    size    93520490
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 366.0.0.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?