### PR TITLE
GPXSee: update to 10.0

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 9.12
+github.setup        tumic0 GPXSee 10.0
 revision            0
 
-checksums           rmd160  e5cc8b3f5b8f9feaf36b2821e08dff9cf44e4ed8 \
-                    sha256  44cf2ad2b79ac4d56244fe96b7e707907865f1784a8595c21ceb55bf5faf313f \
-                    size    4978321
+checksums           rmd160  7cba0b1387f3f5f6170a4f732df557d39c2e9beb \
+                    sha256  1ebd1d43aab58ae1e6bf0a8a7d12d94b55a4fcbcbe7d06c3165d599b13d8fad7 \
+                    size    4997439
 
 categories          gis graphics
 platforms           darwin
@@ -24,6 +24,7 @@ homepage            https://www.gpxsee.org/
 
 patchfiles          patch-src_GUI_app_cpp.diff
 
+qt5.depends_component           qtlocation
 qt5.depends_build_component     qttools
 qt5.depends_runtime_component   qtimageformats qttranslations
 


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

cc @cjones051073 

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
