### PR TITLE
balena-cli: new port, version 12.55.2

### DIFF
--- a/devel/balena-cli/Portfile
+++ b/devel/balena-cli/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        balena-io balena-cli 12.55.2 v
+github.tarball_from releases
+revision            0
+categories          devel
+platforms           darwin
+supported_archs     x86_64
+license             Apache-2
+maintainers         { ether.org.za:light @dylanbr } openmaintainer
+
+description         The official balena Command Line Interface.
+long_description    The balena CLI is a Command Line Interface for  \
+                    balenaCloud or openBalena. It builds on the balena API and \
+                    the balena SDK, and can also be directly imported in \
+                    Node.js applications.
+homepage            https://www.balena.io/
+distname            ${name}-v${version}-macOS-x64-standalone
+
+checksums           rmd160  24a1d9b190fa80c5b65bc6fd941ab28b18f8c6c1 \
+                    sha256  cbef0ef7c46dd81bb410ab1953f1bf130772d1f28361ccfb5f532179e92323da \
+                    size    62587811
+
+use_zip             yes
+use_configure       no
+
+build {}
+
+destroot {
+    xinstall -d -m 755 ${destroot}${prefix}/libexec/${name}
+    copy {*}[glob ${worksrcpath}/*] ${destroot}${prefix}/libexec/${name}
+    ln -s ${prefix}/libexec/${name}/balena ${destroot}${prefix}/bin/balena
+}
+


### PR DESCRIPTION
#### Description
Add balena-cli, version 12.55.2

###### Type(s)
- [x] submission

###### Tested on
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
