### PR TITLE
py-py7zr: update to 0.17.0

### DIFF
--- a/python/py-py7zr/Portfile
+++ b/python/py-py7zr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-py7zr
-version             0.16.3
+version             0.17.0
 revision            0
 
 platforms           darwin
@@ -16,9 +16,9 @@ long_description    ${description}
 
 homepage            https://github.com/miurahr/py7zr
 
-checksums           rmd160  12db8522337b13257cd9e32445d0d3fa0d5233da \
-                    sha256  9ae93b801470c554dc1546a297aafb1dd4dfa799224aa929ad02c443607b9844 \
-                    size    3047256
+checksums           rmd160  b34fd11fdd1405c78e0801f48a15846ef04adda1 \
+                    sha256  a06fba6ab9ac15228b4dd23f5f00e7c4578807bc07ccb9c851f5f5e54cfa0d57 \
+                    size    3265043
 
 python.versions     38 39 310
 

--- a/python/py-pyppmd/Portfile
+++ b/python/py-pyppmd/Portfile
@@ -5,10 +5,9 @@ PortGroup           python 1.0
 
 name                py-pyppmd
 version             0.17.3
-revision            0
+revision            1
 
 platforms           darwin
-supported_archs     noarch
 license             LGPL-2.1+
 maintainers         {@catap korins.ky:kirill} openmaintainer
 


### PR DESCRIPTION
#### Description

It also made py-pyppmd platform specified because it contains `.so` and current buld can't be used:

``` sh
Python 3.10.0 (default, Nov 12 2021, 18:16:44) [Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyppmd
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pyppmd/__init__.py", line 9, in <module>
    from .c.c_ppmd import (  # noqa
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pyppmd/c/c_ppmd.py", line 1, in <module>
    from ._ppmd import (
ImportError: dlopen(/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pyppmd/c/_ppmd.cpython-310-darwin.so, 0x0002): tried: '/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pyppmd/c/_ppmd.cpython-310-darwin.so' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64h')), '/usr/local/lib/_ppmd.cpython-310-darwin.so' (no such file), '/usr/lib/_ppmd.cpython-310-darwin.so' (no such file)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pyppmd/__init__.py", line 20, in <module>
    from .cffi.cffi_ppmd import (  # noqa
ModuleNotFoundError: No module named 'pyppmd.cffi'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pyppmd/__init__.py", line 31, in <module>
    raise ImportError(msg)
ImportError: pyppmd module: Neither C implementation nor CFFI implementation can be imported.
>>> ^D
```


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->