### PR TITLE
godot: mark 3.2 subport as obsolete

### DIFF
--- a/games/godot/Portfile
+++ b/games/godot/Portfile
@@ -37,17 +37,28 @@ if {$subport eq ${name}} {
 }
 
 subport ${name}-3.2 {
-    github.setup    godotengine ${name} 3.2.3 "" -stable
+    PortGroup       obsolete 1.0
 
-    checksums       rmd160  4ff4f9c4798d67cf6cf4d63c38bed84d400daa8e \
-                    sha256  6cd925cc4c23e2c4b0bf36458a83e03484184d8d5311b8eb2339319df7c0c26c \
-                    size    22460848
+    version         3.2.3
+    revision        1
+    replaced_by     ${name}
 
-    long_description-append \
-                    \n\n(Note: Godot ${version} is the last version of \
-                    Godot that is officially supported on macOS \
-                    10.9-10.11.)
+    # 2021-12-09: I believe that it would be safe to completely remove
+    # this subport without needing to wait for the traditional one-year
+    # waiting period. The only reason I originally created this subport
+    # was because Godot 3.3+ was failing to compile for macOS <= 10.10.
+    # Now that we have been able to get the source code to compile and
+    # run successfully on older macOSes, this subport is no longer
+    # necessary. In addition, based on the statistics, it looks like
+    # no one has ever installed this subport.
 }
+
+# Note: We continue to keep the subport syntax, because we will need to
+# use it in the future. When Godot 4 is released, we will still need to
+# maintain a Godot 3.x subport, because Godot Engine is being rewritten
+# to use Vulkan in Godot 4. This means that Godot 4 will only have the
+# possibility of being executable back to macOS 10.11, because MoltenVK
+# requires Metal, which was introduced in macOS 10.11.
 
 if {${os.platform} eq "darwin" && ${os.major} <= 11} {
     known_fail      yes


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

When I originally created the `godot-3.2` subport, it was because I wasn't able to get Godot 3.3 to compile on macOS <= 10.10. Now that we have the build working on older macOSes, the `godot-3.2` subport is no longer necessary.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
