### PR TITLE
gitui: Update to version 0.19.0

### DIFF
--- a/devel/gitui/Portfile
+++ b/devel/gitui/Portfile
@@ -5,9 +5,9 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        extrawurst gitui 0.18.0 v
+github.setup        extrawurst gitui 0.19.0 v
 github.tarball_from archive
-revision            2
+revision            0
 
 description         Blazing fast terminal-ui for git written in Rust.
 
@@ -20,9 +20,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  31c46f185eda51430f39b00822236e0337b1fafd \
-                    sha256  7c8d5829fc8e555d02c576ba0325f0a68114c1fd2eadf17166a3bda866f539be \
-                    size    20975515
+                    rmd160  958797b4d5a1425020d11b0c23d89f9782629026 \
+                    sha256  bcbffb592a5ae49658c79ac7b0daefe4bac3d2b988fdbaf0e868b8c308962f0d \
+                    size    21232828
 
 depends_lib-append  path:lib/libssl.dylib:openssl \
                     port:libgit2 \
@@ -35,31 +35,31 @@ destroot {
 }
 
 cargo.crates \
-    addr2line                       0.16.0  3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd \
+    addr2line                       0.17.0  b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
-    ahash                            0.7.4  43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98 \
+    ahash                            0.7.6  fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47 \
     aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
-    anyhow                          1.0.44  61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1 \
+    anyhow                          1.0.51  8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203 \
     arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
-    backtrace                       0.3.61  e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01 \
+    backtrace                       0.3.63  321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6 \
     base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
     bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
     bit-set                          0.5.2  6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de \
     bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
-    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bugreport                        0.4.1  0014b4b2b4f63bfe69c3838470121290cc437fdc79785d408a761a21e8b2404c \
     bytemuck                         1.7.2  72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b \
     bytesize                         1.1.0  6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70 \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
-    cc                              1.0.71  79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd \
+    cc                              1.0.72  22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
-    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
-    cpp_demangle                     0.3.3  8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a \
-    crc32fast                        1.2.1  81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a \
+    clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
+    cpp_demangle                     0.3.4  931ab2a3e6330a07900b8e7ca4e106cdcbb93f2b9a52df55e54ee53d8305b55d \
+    crc32fast                        1.2.2  3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f \
     crossbeam-channel                0.5.1  06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4 \
     crossbeam-deque                  0.8.1  6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e \
     crossbeam-epoch                  0.9.5  4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd \
@@ -74,29 +74,30 @@ cargo.crates \
     easy-cast                        0.4.4  4bd102ee8c418348759919b83b81cdbdc933ffe29740b903df448b4bafaa348e \
     either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
     fancy-regex                      0.7.1  9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf \
+    findshlibs                      0.10.2  40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64 \
     flate2                          1.0.22  1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     form_urlencoded                  1.0.1  5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
     fuzzy-matcher                    0.3.7  54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94 \
     getrandom                        0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
     gh-emoji                         1.0.6  d6af39cf9a679d7195b3370f5454381ba49c4791bc7ce3ae2a7bf1a2a89c7adf \
-    gimli                           0.25.0  f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7 \
+    gimli                           0.26.1  78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4 \
     git-version                      0.3.5  f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899 \
     git-version-macro                0.3.5  fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f \
-    git2                           0.13.23  2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700 \
+    git2                           0.13.25  f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6 \
     hashbrown                       0.11.2  ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e \
     hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
     idna                             0.2.3  418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
     indexmap                         1.7.0  bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5 \
-    inferno                         0.10.7  bfa5bd9a10b38bf5f3c670f9d75c194adbecd2b1573f737668ab8599f41edc87 \
-    instant                         0.1.11  716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd \
-    itertools                       0.10.1  69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf \
+    inferno                         0.10.8  d5e0d042b82d2153d831ad6f4b865ddb06d9941a086eb9974f8f58cf0368b6e3 \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
+    itertools                       0.10.3  a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3 \
     itoa                             0.4.8  b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4 \
     jobserver                       0.1.24  af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                           0.2.103  dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6 \
-    libgit2-sys              0.12.24+1.3.0  ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c \
+    libc                           0.2.108  8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119 \
+    libgit2-sys              0.12.26+1.3.0  19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494 \
     libssh2-sys                     0.2.23  b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca \
     libz-sys                         1.1.3  de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66 \
     line-wrap                        0.1.1  f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9 \
@@ -108,33 +109,33 @@ cargo.crates \
     memmap                           0.7.0  6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b \
     memoffset                        0.6.4  59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9 \
     miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
-    mio                             0.7.13  8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16 \
+    mio                             0.7.14  8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc \
     miow                             0.3.7  b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21 \
-    nix                             0.20.2  f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945 \
+    nix                             0.23.0  f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     ntapi                            0.3.6  3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44 \
     num-format                       0.4.0  bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465 \
     num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
     num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
     num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-    object                          0.26.2  39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2 \
+    object                          0.27.1  67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9 \
     once_cell                        1.8.0  692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56 \
     openssl-probe                    0.1.4  28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a \
-    openssl-src            111.16.0+1.1.1l  7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f \
-    openssl-sys                     0.9.67  69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058 \
+    openssl-src              300.0.2+3.0.0  14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb \
+    openssl-sys                     0.9.71  7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73 \
     output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
     parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
     parking_lot_core                 0.8.5  d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216 \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
     phf                             0.10.0  b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f \
     phf_shared                      0.10.0  b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096 \
-    pkg-config                      0.3.20  7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb \
+    pkg-config                      0.3.22  12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f \
     plist                            1.2.1  a38d026d73eeaf2ade76309d0c65db5a35ecf649e3cec428db316243ea9d6711 \
-    pprof                            0.5.0  c9fb4eee2f2c4f7d48fe5a33008dececbc405d0e58d2a94afe742d4f175bc401 \
-    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    pprof                            0.6.1  9d47237f290398d4cfcd293fcc9dcc53cdb1f9bde65b78fcbfaafa7f8190d9e9 \
+    ppv-lite86                      0.2.15  ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba \
     pretty_assertions                1.0.0  ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc \
     proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
-    proc-macro2                     1.0.29  b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d \
+    proc-macro2                     1.0.32  ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43 \
     quick-xml                       0.22.0  8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b \
     quote                           1.0.10  38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05 \
     rand                             0.8.4  2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8 \
@@ -147,8 +148,8 @@ cargo.crates \
     regex                            1.5.4  d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461 \
     regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
     remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
-    rgb                             0.8.27  8fddb3b23626145d1776addfc307e1a1851f60ef6ca64f376bcb889697144cf0 \
-    ron                              0.6.5  45005aa836116903a49cf3461474da697cfe66221762c6e95871092009ec86d6 \
+    rgb                             0.8.29  a27fa03bb1e3e2941f52d4a555a395a72bf79b0a85fbbaab79447050c97d978c \
+    ron                              0.7.0  1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678 \
     rustc-demangle                  0.1.21  7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342 \
     ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
     safemem                          0.3.3  ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072 \
@@ -156,24 +157,24 @@ cargo.crates \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
     serde                          1.0.130  f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913 \
     serde_derive                   1.0.130  d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b \
-    serde_json                      1.0.68  0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8 \
+    serde_json                      1.0.72  d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527 \
     serial_test                      0.5.1  e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d \
     serial_test_derive               0.5.1  b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5 \
     shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
     signal-hook                     0.3.10  9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1 \
     signal-hook-mio                  0.2.1  29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4 \
     signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
-    simplelog                       0.10.2  85d04ae642154220ef00ee82c36fb07853c10a4f2a0ca6719f9991211d2eb959 \
+    simplelog                       0.11.0  8baa24de25f3092d9697c76f94cf09f67fca13db2ea11ce80c2f055c1aaf0795 \
     siphasher                        0.3.7  533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b \
     smallvec                         1.7.0  1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309 \
     smawk                            0.3.1  f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     str_stack                        0.1.0  9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb \
-    symbolic-common                  8.3.1  9742f64cab90df3b020ac70c814085a8a8bbf97e1706de91f633d3db55e62a15 \
-    symbolic-demangle                8.3.1  2ed2b461bb192e1c97016085c64a0d548e54c76773cfab6881ddeffb8edea0fd \
-    syn                             1.0.80  d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194 \
+    symbolic-common                  8.5.0  cfc8618f0f31ed048f8e66aa2caecedfbdbbca962ff9ad87107ba4171de0742b \
+    symbolic-demangle                8.5.0  8be790f170c892899802aa1d382b7b5b65baf692b1357864c74e92bbbbdabfbe \
+    syn                             1.0.82  8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59 \
     syntect                          4.6.0  8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031 \
-    sys-info                         0.9.0  33fcecee49339531cf6bd84ecf3ed94f9c8ef4a7e700f2a1cac9cc1ca485383a \
+    sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     tempfile                         3.2.0  dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     textwrap                        0.14.2  0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80 \
@@ -181,7 +182,7 @@ cargo.crates \
     thiserror-impl                  1.0.30  aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b \
     thread_local                     1.1.3  8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd \
     time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
-    tinyvec                          1.5.0  f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7 \
+    tinyvec                          1.5.1  2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2 \
     tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
     tui                             0.16.0  39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23 \
     unicode-bidi                     0.3.7  1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f \


### PR DESCRIPTION
#### Description

See: https://github.com/extrawurst/gitui/releases/tag/v0.19.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
