### PR TITLE
wireshark3: add missing minizip dep

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -31,7 +31,7 @@ long_description    A network analyzer that lets you capture and \
 
 if {${os.major} >= 16} {
     version         3.4.9
-    revision        1
+    revision        2
 
     checksums       sha256  c6525e829bd24525ee699aa207ecd27c50646d64263a669671badfb71cd99620 \
                     rmd160  7fd30ef3b906fa2301b6a77bd4623633d0b46f23 \
@@ -43,7 +43,7 @@ if {${os.major} >= 16} {
     livecheck.regex "Stable Release \\((\\d+(?:\\.\\d+)*)"
 } else {
     version         3.4.1
-    revision        4
+    revision        5
 
     checksums       sha256  f8165211f5b4a4f6708df73ef9be51df917927f2da78348b32d3a6eb5fc458a3 \
                     rmd160  1b5e1fee340c149b70dbe8e8cf935518b06656e8 \
@@ -90,6 +90,7 @@ configure.args-append \
                     -DENABLE_LIBXML2=OFF \
                     -DENABLE_LUA=OFF \
                     -DENABLE_LZ4=ON \
+                    -DENABLE_MINIZIP=OFF \
                     -DENABLE_NETLINK=OFF \
                     -DENABLE_SMI=OFF \
                     -DENABLE_SNAPPY=OFF \
@@ -124,6 +125,11 @@ variant adns conflicts cares description {use adns library for async. dns resolu
 variant zlib description {Build with zlib compression support} {
     configure.args-replace  -DENABLE_ZLIB=OFF -DENABLE_ZLIB=ON
     depends_lib-append      port:zlib
+}
+
+variant minizip description {Build with minizip support} {
+    configure.args-replace -DENABLE_MINIZIP=OFF -DENABLE_MINIZIP=ON
+    depends_lib-append      port:minizip
 }
 
 variant lua description {Build with Lua dissector support} {

--- a/net/wireshark30/Portfile
+++ b/net/wireshark30/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                wireshark30
 version             3.0.9
-revision            2
+revision            3
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         {darkart.com:opendarwin.org @ghosthound}
@@ -56,6 +56,7 @@ configure.args-append \
                     -DENABLE_LIBXML2=OFF \
                     -DENABLE_LUA=OFF \
                     -DENABLE_LZ4=ON \
+                    -DENABLE_MINIZIP=OFF \
                     -DENABLE_NETLINK=OFF \
                     -DENABLE_SMI=OFF \
                     -DENABLE_SNAPPY=OFF \
@@ -90,6 +91,11 @@ variant adns conflicts cares description {use adns library for async. dns resolu
 variant zlib description {Build with zlib compression support} {
     configure.args-replace  -DENABLE_ZLIB=OFF -DENABLE_ZLIB=ON
     depends_lib-append      port:zlib
+}
+
+variant minizip description {Build with minizip support} {
+    configure.args-replace -DENABLE_MINIZIP=OFF -DENABLE_MINIZIP=ON
+    depends_lib-append      port:minizip
 }
 
 variant lua description {Build with Lua dissector support} {


### PR DESCRIPTION
#### Description

- wireshark3: add required minizip dep
- wireshark30: add required minizip dep

Maybe related to https://trac.macports.org/ticket/61414 where Wireshark's system will detect libraries available and enable things based on their presence. In general, I think it's better to just include minizip support, because a package may have a bdep that uses minizip but then it would cleaned out with `port clean`. Then by surprise Wireshark will fail to start.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
