### PR TITLE
ngs: new port, version 0.2.13

### DIFF
--- a/shells/ngs/Portfile
+++ b/shells/ngs/Portfile
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake       1.1
+PortGroup           github      1.0
+
+github.setup        ngs-lang ngs 0.2.13 v
+github.tarball_from archive
+revision            0
+
+homepage            https://ngs-lang.org
+
+description         \
+    Next Generation Shell (NGS)
+
+long_description    \
+    NGS is an alternative shell. At its core is a domain-specific language \
+    that was specifically designed to be a shell language. It is designed \
+    with a focus on Ops and systems engineering. One way to think about NGS \
+    is bash plus data structures plus better syntax and error handling.
+
+checksums           rmd160  ea7335942152c9ae74d3f240077e4063bc592dbe \
+                    sha256  7648761edb3695292d3289b91f9644c204d42269b8af697c765707ce192e45b5 \
+                    size    724109
+
+categories          shells
+installs_libs       no
+license             GPL-3
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+patchfiles          patch-implicit.diff
+
+post-patch {
+    # Replace hard-coded prefixes
+    foreach ftarget {
+        doc/ngstut.1.md
+        doc/ngs.1.md
+        doc/ngslang.1.md
+        lib/autoload/globals/DelimStr.ngs
+        lib/stdlib.ngs
+        CMakeLists.txt
+    } {
+        reinplace -E "s|/usr/local|${prefix}|g" ${worksrcpath}/${ftarget}
+    }
+
+    # Correct man and doc paths
+    reinplace {s|DESTINATION man/man1|DESTINATION share/man/man1|} \
+        ${worksrcpath}/CMakeLists.txt
+
+    reinplace {s|DESTINATION doc/ngs|DESTINATION share/doc/ngs|} \
+        ${worksrcpath}/CMakeLists.txt
+}
+
+depends_build-append \
+                    path:bin/gsed:gsed  \
+                    port:pandoc         \
+                    port:peg            \
+                    port:pkgconfig
+
+depends_lib-append  port:boehmgc    \
+                    port:json-c     \
+                    port:libffi     \
+                    port:pcre2
+
+configure.env-append \
+                    "PKG_CONFIG_PATH=${prefix}/lib/pkgconfig"
+
+build.env-append    "PKG_CONFIG_PATH=${prefix}/lib/pkgconfig"

--- a/shells/ngs/files/patch-implicit.diff
+++ b/shells/ngs/files/patch-implicit.diff
@@ -1,0 +1,10 @@
+--- ./ngs.c	2021-12-10 05:42:18.000000000 -0500
++++ ./ngs.c	2021-12-10 05:42:32.000000000 -0500
+@@ -6,6 +6,7 @@
+ #include <assert.h>
+ #include <errno.h>
+ #include <unistd.h>
++#include <string.h>
+ #include <pcre.h>
+ #include "ngs.h"
+ #include "syntax.include"


### PR DESCRIPTION
New port for [Next Generation Shell](https://github.com/ngs-lang/ngs)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
