### PR TITLE
qemu: use MacPorts smbd, as opposed to macOS version

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -123,6 +123,9 @@ configure.args-append   --disable-cocoa \
                         --disable-dbus-display \
                         --enable-virtfs
 
+# Use 'smbd' installed by samba port, rather than macOS; latter does not work with qemu.
+configure.args-append   --smbd=${prefix}/sbin/smbd
+
 # Hypervisor.framework introduced in 10.10
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     configure.args-replace --enable-hvf --disable-hvf


### PR DESCRIPTION
#### Description

Samba mounts do not work, when the default Samba implementation bundled on macOS is used (/usr/sbin/smbd).

Update port to use the Samba server installed by MacPorts instead, something that cannot be accomplished by simple PATH manipulation.

Complementary to: https://github.com/macports/macports-ports/pull/13305

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 11.6.1 20G224 x86_64
Xcode 12.5.1 12E507

###### Verification 
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
