### PR TITLE
gitlab-runner: update to 14.5.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 14.5.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 14.5.1 v
 
 categories          devel
 platforms           darwin
@@ -22,9 +22,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  e0b3f366c199349c6d2d04030d301318c64d66de \
-                    sha256  2c3061528f6eb714b5893bc3f5575b52bcface3272074717e0c18b3da783df97 \
-                    size    9143600
+checksums           rmd160  f362a2eed88aa25bfaf15ffc6d378610c02838e9 \
+                    sha256  2700a09e1bb468cee8abc01998f7cd99c51f9218e3d0f5d3dcbf334322669869 \
+                    size    9144873
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 14.5.1.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?