### PR TITLE
doctest: update version to 2.4.7

### DIFF
--- a/devel/doctest/Portfile
+++ b/devel/doctest/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        onqtam doctest 2.4.6
+github.setup        onqtam doctest 2.4.7
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ description         Fast header-only C++ unit testing
 long_description    doctest is a light and feature-rich C++98 / C++11 \
                     single-header testing framework for unit tests and TDD.
 
-checksums           rmd160  75316f7456d093e07b885bd38ff04642870f184c \
-                    sha256  39110778e6baf373ef04342d7cb3fe35da104cb40769103e8a2f0035f5a5f1cb \
-                    size    2277281
+checksums           rmd160  daa6dcd0182440f5438d713f54f3da6e2b14f543 \
+                    sha256  551941e0b08fefdde39e394d484ed7ac6c867022c865e771f68a717cd3ce7d76 \
+                    size    2281756
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description

Update to newest doctest, 2.4.7.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

I'm seeing some unit test failures with `sudo port test`. I seem to recall patching these out on 2.4.6, but see no patch in the port, so I'm investigating.