### PR TITLE
quassel: add urlpreview variant

### DIFF
--- a/irc/quassel/Portfile
+++ b/irc/quassel/Portfile
@@ -23,7 +23,7 @@ depends_lib-append \
                 path:lib/libssl.dylib:openssl \
                 port:zlib
 
-qt5.depends_component qtmultimedia qtwebengine
+qt5.depends_component qtmultimedia
 qt5.depends_build_component qttools
 
 compiler.cxx_standard \
@@ -36,10 +36,18 @@ configure.args  -DWANT_CORE=OFF \
                 -DWANT_QTCLIENT=OFF \
                 -DWANT_MONO=OFF \
                 -DWITH_KDE=OFF \
+                -DWITH_WEBENGINE=OFF \
                 -DUSE_CCACHE=OFF \
                 -DUSE_QT5=ON \
                 -DBUNDLE=ON \
                 -DENABLE_SHARED=OFF
+
+variant urlpreview description "Support for showing URL thumbnails" {
+    qt5.depends_component qtwebengine
+    configure.args-replace -DWITH_WEBENGINE=OFF -DWITH_WEBENGINE=ON
+}
+
+default_variants +urlpreview
 
 if {${name} eq ${subport}} {
     description \


### PR DESCRIPTION
#### Description

~~On macOS Monterey and above, build without URL previewing support since QtWebEngine does not build on it.~~ No longer true.

Revbump because of changed `default_variants`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
