### PR TITLE
ignore more implicitly declared Linux syscalls, POSIX functions not implemented on macOS

### DIFF
--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.10.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.10.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.10.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.10.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.11.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.11.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.11.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.11.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.12.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.12.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.12.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.12.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.13.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.13.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.13.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.13.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.14.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.14.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.14.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.14.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.15.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.15.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.15.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.15.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.4u.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.4u.sdk.list
@@ -1,6 +1,16 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.4u.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.4u.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.5.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.5.sdk.list
@@ -1,6 +1,16 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.5.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.5.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.6.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.6.sdk.list
@@ -1,6 +1,16 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.6.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.6.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.7.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.7.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.7.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.7.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.8.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.8.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.8.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.8.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.9.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.9.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.9.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.9.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx11.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx11.sdk.list
@@ -1,7 +1,17 @@
+accept4
 eventfd
+fallocate
 getrandom
 ioctlsocket
 le64toh
+memfd_create
+pipe2
+readahead
 sem_timedwait
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx11.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx11.sdk.list
@@ -6,6 +6,8 @@ ioctlsocket
 le64toh
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 sem_timedwait
 setns

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx12.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx12.sdk.list
@@ -1,3 +1,14 @@
+accept4
+fallocate
+getrandom
 ioctlsocket
+memfd_create
+pipe2
+readahead
+setns
+splice
 statx
+sync_file_range
+tee
 vec_splat_u32
+vmsplice

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx12.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx12.sdk.list
@@ -4,6 +4,8 @@ getrandom
 ioctlsocket
 memfd_create
 pipe2
+posix_close
+posix_fadvise
 readahead
 setns
 splice

--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -153,9 +153,6 @@ if {$subport eq $name} {
 #       -DROUTER_INSTALL_LIBDIR="lib/${name_mysql}" \
 #       -DROUTER_INSTALL_PLUGINDIR="lib/${name_mysql}/mysqlrouter"
 
-    # setns() is a Linux system call
-    configure.checks.implicit_function_declaration.whitelist-append setns
-
     patch.pre_args  -p1
     patchfiles      patch-cmake-install_macros-protobuf-path.cmake.diff \
                     patch-cmake-install_layout.cmake.diff \

--- a/perl/p5-io-aio/Portfile
+++ b/perl/p5-io-aio/Portfile
@@ -25,9 +25,4 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-common-sense
 
     patchfiles      patch-AIO.xs.diff
-
-    # macOS does not implement these
-    configure.checks.implicit_function_declaration.whitelist-append \
-                    posix_close \
-                    posix_fadvise
 }


### PR DESCRIPTION
mysql8 implicitly declares `setns()`

p5-io-aio implicitly declares `accept4()`, `fallocate()`, `memfd_create()`, `pipe2()`, `readahead()`, `splice()`, `sync_file_range()`, `tee()`, `vmsplice()`, `posix_close()`, `posix_fadvise()`

expat implicitly declares `getrandom()`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
