### PR TITLE
p5-io-aio: update to 4.76

### DIFF
--- a/perl/p5-io-aio/Portfile
+++ b/perl/p5-io-aio/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.28 5.30 5.32
-perl5.setup         IO-AIO 4.74 ../../authors/id/M/ML/MLEHMANN
+perl5.setup         IO-AIO 4.76 ../../authors/id/M/ML/MLEHMANN
 license             {Artistic-1 GPL}
 platforms           darwin
 maintainers         nomaintainer
@@ -13,9 +13,9 @@ maintainers         nomaintainer
 description         Asynchronous Input/Output
 long_description    ${description}
 
-checksums           rmd160  d0361c31b45c680d55fdcb799df326ee662b274c \
-                    sha256  8d82ba2bd7a7d13adacfa2b02a5fd903779c207a57ad979939e2bdb17c7ff460 \
-                    size    181136
+checksums           rmd160  1345349aba29faea5cf51738569009438512d4a3 \
+                    sha256  39f5044a93ce2114b908afe77a4615881a3d78a0ed53e4502708dd5d4333208f \
+                    size    185929
 
 if {${perl5.major} != ""} {
     depends_build-append \
@@ -25,4 +25,9 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-common-sense
 
     patchfiles      patch-AIO.xs.diff
+
+    # macOS does not implement these
+    configure.checks.implicit_function_declaration.whitelist-append \
+                    posix_close \
+                    posix_fadvise
 }


### PR DESCRIPTION
Ignore implicit declaration of POSIX functions not implemented on macOS

(Implicit declaration of Linux system calls to be ignored by #13319)

#### Description
https://metacpan.org/dist/IO-AIO/changes
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Xcode 12.4 command line tools
Perl 5.34.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
