### PR TITLE
apache-solr8: Update to version 8.11.0, log4j vulnerability mitigation

### DIFF
--- a/java/apache-solr8/Portfile
+++ b/java/apache-solr8/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                apache-solr8
-version             8.9.0
+version             8.11.0
 revision            0
 categories          java textproc
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -25,9 +25,13 @@ extract.suffix      .tgz
 
 master_sites        apache:lucene/solr/${version}/
 
-checksums           rmd160  b781608474fb33060740df303a58ec3e428f91a2 \
-                    sha256  c9c970e0603318eac1ca5bae24e9a85e917d012266159237e572e636c5a3da62 \
-                    size    202942547
+checksums           rmd160  7ec0e184f17427877e8ac52e4c9e9807dcd722c1 \
+                    sha256  ba69bffc624e5c1e35b3b2e0929d82f2ba7871d7ba5941f202c2b97945eb730c \
+                    size    217788568
+
+# log4j vulnerability CVE-2021-44228
+# diff -NaurdwB -I '^ *#' ./solr-orig/bin/solr.in.sh ./solr-new/bin/solr.in.sh | sed -E -e 's/\.\/solr-(orig|new)\//\.\//' > patch-solr-in-sh.diff
+patchfiles-append   patch-solr-in-sh.diff
 
 # see https://lucene.apache.org/solr/guide/8_1/solr-system-requirements.html
 java.version        9+

--- a/java/apache-solr8/files/patch-solr-in-sh.diff
+++ b/java/apache-solr8/files/patch-solr-in-sh.diff
@@ -1,0 +1,13 @@
+--- ./bin/solr.in.sh	2021-12-12 10:15:40.000000000 -0500
++++ ./bin/solr.in.sh	2021-12-12 10:17:50.000000000 -0500
+@@ -100,6 +100,10 @@
+ #SOLR_OPTS="$SOLR_OPTS -Dsolr.autoSoftCommit.maxTime=3000"
+ #SOLR_OPTS="$SOLR_OPTS -Dsolr.autoCommit.maxTime=60000"
+ 
++# log4j vulnerability CVE-2021-44228
++# https://github.com/apache/solr/pull/454#issuecomment-991169501
++SOLR_OPTS="$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true"
++
+ # Location where the bin/solr script will save PID files for running instances
+ # If not set, the script will create PID files in $SOLR_TIP/bin
+ #SOLR_PID_DIR=


### PR DESCRIPTION
* Update to version 8.11.0
* Addresses log4j vulnerability CVE-2021-44228
* See https://solr.apache.org/security.html#apache-solr-affected-by-apache-log4j-cve-2021-44228

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
