### PR TITLE
KeePassXC: update devel to latest + fix build on macos <= 10.9

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -62,16 +62,17 @@ if {${subport} eq ${name}} {
                         patch-old-mac.diff
 } else {
     # devel subport
-    github.setup        keepassxreboot keepassxc a0a063b57f6f577bed505ccd652763eeadd1b876
+    github.setup        keepassxreboot keepassxc 456726556dbf288fd881fcf453d7bb13c335f155
     set githash         [string range ${github.version} 0 6]
     version             20211208+git${githash}
     revision            0
 
     conflicts           KeePassXC
 
-    checksums           rmd160  18aa88707b3886cf85eb55c886db2f952f46d791 \
-                        sha256  78ee1c2cbfd3560d576d343c6ad931f225e2e7a95af8b7009d86eae720013692 \
-                        size    10076145
+    checksums           rmd160  84e8cba8ab75f124f9b9ae244a06a7cd4b7f906d \
+                        sha256  d1104c587298c26d1d02ccb01593ee70313c354d049b36ed480d8384a128e986 \
+                        size    10077852
+
 
     gpg_verify.use_gpg_verification \
                         no
@@ -83,6 +84,12 @@ if {${subport} eq ${name}} {
                         devel/patch-quazip.diff
 
     compiler.cxx_standard   2017
+
+    # QTest::addRow was introduced in Qt 5.9
+    # Don't build tests in that case
+    if {[vercmp ${qt5.version} 5.9] < 0} {
+        configure.pre_args-append -DWITH_TESTS=OFF
+    }
 
     post-destroot {
         ln -s ${applications_dir}/KeePassXC.app/Contents/MacOS/keepassxc-proxy \


### PR DESCRIPTION
Build failed because keepassxc-devel now uses QTest::addRow in unit test.
This was introduced in Qt 5.9

So build without tests in case Qt < 5.9

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
