### PR TITLE
godot: remove conditional around legacysupport PG

### DIFF
--- a/games/godot/Portfile
+++ b/games/godot/Portfile
@@ -23,10 +23,7 @@ long_description    Godot Engine is a cross-platform game engine for \
                     (Android, iOS) and web-based (HTML5) platforms.
 
 if {$subport eq ${name}} {
-    if {${os.platform} eq "darwin" && ${os.major} <= 15} {
-        PortGroup legacysupport 1.1
-
-    }
+    PortGroup legacysupport 1.1
 
     github.setup    godotengine ${name} 3.3.4 "" -stable
 
@@ -37,6 +34,13 @@ if {$subport eq ${name}} {
     # Godot fails to build for Xcode Clang < 802,
     # but builds fine using MacPorts Clang
     compiler.blacklist-append {clang < 802}
+
+    legacysupport.newest_darwin_requires_legacy 15
+    # Using macports-libcxx is needed in order to lower the minimum
+    # macOS version specified in -mmacosx-version-min. Otherwise the
+    # compile will fail, complaining that 'shared_time_mutex' was
+    # introduced in macOS 10.12.
+    legacysupport.use_mp_libcxx yes
 }
 
 subport ${name}-3.2 {
@@ -111,14 +115,10 @@ post-patch {
 if {$subport eq ${name} && \
     ${os.platform} eq "darwin" && ${os.major} <= 15} \
 {
-    # Using macports-libcxx is needed in order to lower the minimum
-    # macOS version specified in -mmacosx-version-min. Otherwise the
-    # compile will fail, complaining that 'shared_time_mutex' was
-    # introduced in macOS 10.12.
-    legacysupport.use_mp_libcxx yes
-
     post-patch {
-        # Tell the build to use macports-libcxx
+        # Tell the build to use macports-libcxx. We have to do it
+        # manually here in the Portfile, because SCons ignores most/all
+        # of the environment variables set by MacPorts.
         reinplace "/LINKFLAGS.*isysroot.*MACOS_SDK_PATH/a\\
 \\
 \\        env.Append(CXXFLAGS=\[\"-nostdinc++\", \"-I${prefix}/include/libcxx/v1\"\])\\


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Remove conditional around legacysupport PortGroup statement and use `legacysupport.newest_darwin_requires_legacy` instead, [as suggested by](https://github.com/macports/macports-ports/commit/58beac661126853dafe8df2331df3833c7b64d90#r61789057) @ryandesign.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
