### PR TITLE
catgirl: Use CC and CFLAGS environment variables

### DIFF
--- a/net/catgirl/Portfile
+++ b/net/catgirl/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           makefile 1.0
 
 name                catgirl
 version             2.0
@@ -33,6 +34,7 @@ depends_build       port:pkgconfig
 depends_lib         path:lib/libtls.dylib:libretls \
                     port:ncurses
 
+use_configure       yes
 configure.post_args --prefix=${prefix} \
                     --mandir=${prefix}/share/man
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/64201

#### Description

Use the makefile portgroup to ensure that the right environment variables get used.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
