### PR TITLE
cmake: update to 3.22.1

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -32,11 +32,11 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup    cmake   cmake 3.21.4 v
-checksums       rmd160  bd08dd00a6a8ffff6d3d21b80f39d4afe6dd4e70 \
-                sha256  069cfdbb57d9f22dc8706f1fb71ae79249ab37f2c1d2afc3fdf6232073840748 \
-                size    7418791
-revision        0
+gitlab.setup        cmake   cmake 3.22.1 v
+checksums           rmd160  155cf1c291b614df3f02d0e2d158f03df566e116 \
+                    sha256  8a90e425df91e3ecf8432735538238b5ee1c8702c776733b7ccd2119b19cc22d \
+                    size    7532759
+revision            0
 
 gitlab.livecheck.regex {([0-9.]+)}
 compiler.cxx_standard 2011

--- a/devel/cmake/files/patch-cmake-leopard-tiger.diff
+++ b/devel/cmake/files/patch-cmake-leopard-tiger.diff
@@ -10,7 +10,7 @@
  #  error "This file may be included only if CMake_USE_MACH_PARSER is enabled."
 --- Utilities/cmlibuv/src/unix/core.c
 +++ Utilities/cmlibuv/src/unix/core.c
-@@ -530,10 +530,24 @@
+@@ -533,10 +533,24 @@
   * will unwind the thread when it's in the cancel state. Work around that
   * by making the system call directly. Musl libc is unaffected.
   */
@@ -36,7 +36,7 @@
  #if defined(__LP64__) || TARGET_OS_IPHONE
    extern int close$NOCANCEL(int);
    return close$NOCANCEL(fd);
-@@ -541,7 +555,11 @@
+@@ -544,7 +558,11 @@
    extern int close$NOCANCEL$UNIX2003(int);
    return close$NOCANCEL$UNIX2003(fd);
  #endif
@@ -48,7 +48,7 @@
  #elif defined(__linux__)
    return syscall(SYS_close, fd);
  #else
-@@ -1352,8 +1370,12 @@
+@@ -1355,8 +1373,12 @@
    if (name == NULL)
      return UV_EINVAL;
  


### PR DESCRIPTION
#### Description

Update cmake to 3.22.1 from 3.21.4. I've been using 3.22.0 and now 3.22.1 since they were released with no issues that I know of. These cmake major version updates generally are backwards compatible with prior possibly requiring specific settings to be ON or OFF to be changed but otherwise they generally work quite well & that's what I'm seeing. Posting this as a PR for others to comment / test. If no great reason to not merge by Friday Dec 17 then I'll do so then if nobody has already.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G306
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
