### PR TITLE
anjuta: Fix build with autoconf 2.70/2.71

### DIFF
--- a/gnome/anjuta/Portfile
+++ b/gnome/anjuta/Portfile
@@ -56,6 +56,11 @@ patchfiles          patch-configure.ac.diff \
                     python-ldflags.patch \
                     patch-plugins-python-loader-plugin.c.diff
 
+if {${os.platform} ne "linux"} {
+    patchfiles-append \
+                    shm_open.patch
+}
+
 gobject_introspection yes
 
 # blacklist compilers that do not support C11 (redefinition of typedef ‘GtkSourceTag’ at gtksourceview/gtksourcetag.h:35)

--- a/gnome/anjuta/files/shm_open.patch
+++ b/gnome/anjuta/files/shm_open.patch
@@ -1,0 +1,18 @@
+Remove the check for librt on Linux because as of autoconf 2.70 or 2.71
+the check fails on macOS:
+configure: error: Failed to find library with shm_open()
+https://gitlab.gnome.org/GNOME/anjuta/-/issues/30
+--- configure.ac.orig	2021-12-13 12:13:13.000000000 -0600
++++ configure.ac	2021-12-13 12:13:31.000000000 -0600
+@@ -808,11 +808,6 @@
+ 
+ AC_SUBST(SYMBOL_DB_SHM)
+ 
+-dnl On Linux, need librt for shm_open/shm_unlink
+-bck_LIBS="$LIBS"
+-AC_SEARCH_LIBS(shm_open, rt, [SHM_LIBS="$LIBS"], [AC_MSG_ERROR([Failed to find library with shm_open()])])
+-AC_SUBST(SHM_LIBS)
+-LIBS="$bck_LIBS"
+ 
+ dnl Test using autotest
+ dnl -----------------------------


### PR DESCRIPTION
#### Description

anjuta: Fix build with autoconf 2.70/2.71

Fixes: https://gitlab.gnome.org/GNOME/anjuta/-/issues/30

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
