### PR TITLE
various ports: remove code for earlier MacPorts' releases

### DIFF
--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -14,12 +14,6 @@ if {${os.platform} eq "darwin" && ${os.major} >= 20} {
     if {${version} eq "1.5.0"} {
         incr revision
     }
-    pre-configure {
-        if {[vercmp [macports_version] 2.7.0] < 0} {
-            ui_error "${subport} @${version} requires MacPorts 2.7.0 or greater"
-            return -code error "incompatible MacPorts version"
-        }
-    }
 }
 
 categories          archivers devel

--- a/databases/oracle-instantclient/Portfile
+++ b/databases/oracle-instantclient/Portfile
@@ -24,20 +24,20 @@ if {${os.arch} eq "powerpc"} {
     set library_version 10.1
     supported_archs     ppc
     universal_variant   no
-    
+
     master_sites        http://cmsrep.cern.ch/cmssw/cms/SOURCES/external/oracle/10.2.0.2/
-    
+
     checksums           instantclient-basic-macosx-${version}${extract.suffix} \
                         rmd160  d1f056f8f1b308c5493f4938b29b55fcb32452cf \
                         sha256  55dafdab1b7387b05226fd7eb0d86d52225a702a5e690fc82af42073f49e7725 \
                         instantclient-sdk-macosx-${version}${extract.suffix} \
                         rmd160  c819db7f739b8ca468c8059dfbac31a6a6965938 \
                         sha256  350052656466cc2daecbb8b1c162ff444365def151636ba704f28ae5f05ca411
-    
+
     set my_worksrcdir_format        instantclient%s
     set my_distname_format(ppc)     instantclient-%s-macosx-${version}
     set my_library_prefix(ppc)      /b/729
-    
+
     livecheck.type      none
 } else {
     version             11.2.0.4.0
@@ -45,10 +45,10 @@ if {${os.arch} eq "powerpc"} {
     set library_version 11.1
     supported_archs     x86_64 i386
     variant universal {}
-    
+
     #master_sites        http://astro-wise.org/instantclient/
     master_sites        http://download.oracle.com/otn/mac/instantclient/[join [lrange [split ${version} .] 0 3] ""]/
-    
+
     checksums           instantclient-basic-macos.x32-${version}${extract.suffix} \
                         rmd160  a34edfd79dc3a34026b755bba64499ca74f72f56 \
                         sha256  c1d59a284d7ed8a65fc38c1df08b4ab632aebeb27420f7892e38e0725f1325b4 \
@@ -61,13 +61,13 @@ if {${os.arch} eq "powerpc"} {
                         instantclient-sdk-macos.x64-${version}${extract.suffix} \
                         rmd160  dd54cc83c54bd9d702c0de6cd2219370ca98d2e2 \
                         sha256  aead0663c206a811cf1f61d3b2a533ff81e6e6109dd31544ad850a7ef6eb5d19
-    
+
     set my_worksrcdir_format        instantclient_%s
     set my_distname_format(i386)    instantclient-%s-macos.x32-${version}
     set my_distname_format(x86_64)  instantclient-%s-macos.x64-${version}
     set my_library_prefix(i386)     /ade
     set my_library_prefix(x86_64)   /ade
-    
+
     if {${os.platform} eq "darwin" && ${os.major} < 9} {
         known_fail          yes
         pre-fetch {
@@ -75,7 +75,7 @@ if {${os.arch} eq "powerpc"} {
             return -code error "incompatible Mac OS X version"
         }
     }
-    
+
     livecheck.type          regex
     livecheck.url           http://www.oracle.com/technetwork/topics/intel-macsoft-096467.html
     livecheck.regex         instantclient-basic-macos.x64-(\[0-9.\]+)${extract.suffix}
@@ -133,15 +133,11 @@ extract {
     xinstall -d ${my_build_dir}
     foreach my_arch ${configure.universal_archs} {
         foreach my_distfile_type {basic sdk} {
-if {[vercmp [macports_version] 2.6.99] >= 0} {
             system "${extract.cmd} ${extract.pre_args} ${extract.post_args} [shellescape ${distpath}/[format $my_distname_format(${my_arch}) ${my_distfile_type}]${extract.suffix}]"
-} else {
-            system "${extract.cmd} ${extract.pre_args} ${extract.post_args} '${distpath}/[format $my_distname_format(${my_arch}) ${my_distfile_type}]${extract.suffix}'"
-}
         }
         move ${extract.dir}/[format ${my_worksrcdir_format} [join [lrange [split ${version} .] 0 1] "_"]] ${my_build_dir}/${my_arch}
     }
-    
+
     # Fix permissions.
     fs-traverse f ${my_build_dir} {
         if {[string match "*.dylib.*" ${f}]} {
@@ -171,7 +167,7 @@ build {
         # For each dylib, change the directory of its install_name to ${lib_dir}.
         foreach lib [glob -directory ${workpath}/build/${my_arch} *.dylib*] {
             system "install_name_tool -id ${lib_dir}/[strsed ${lib} /^.*\\///] ${lib}"
-            
+
             # Then for each dependent dylib with a strange install_name that
             # this dylib references, fix the reference to use ${lib_dir}.
             foreach dep [exec otool -L ${lib}] {
@@ -179,7 +175,7 @@ build {
                     system "install_name_tool -change ${dep} ${lib_dir}/[strsed ${dep} /^.*\\///] ${lib}"
                 }
             }
-            
+
             # libociei is special: it's not linked to; it's dynamically loaded at
             # runtime by libclntsh. Oracle says you have to set DYLD_LIBRARY_PATH
             # to include ${lib_dir}, but adding an rpath works too—but rpath only
@@ -200,19 +196,19 @@ destroot {
             {*}[glob -directory ${my_worksrcpath} *.dylib*] \
             {*}[glob -directory ${my_worksrcpath} *.jar] \
             ${my_destroot}${lib_dir}
-        
+
         # You would think the includes should go in ${prefix}/include/oracle, but
         # the "instantclient layout" dictates they must be in ${lib_dir}/sdk/include;
         # ports like php-oracle will expect them there.
         xinstall -d ${my_destroot}${lib_dir}/sdk
         copy ${my_worksrcpath}/sdk/include ${my_destroot}${lib_dir}/sdk
     }
-    
+
     merge ${workpath}/pre-dest
-    
+
     # php-oracle complains without a libclntsh.dylib symlink.
     ln -s libclntsh.dylib.${library_version} ${destroot}${lib_dir}/libclntsh.dylib
-    
+
     # Add a libocci.dylib symlink too for good measure.
     ln -s libocci.dylib.${library_version} ${destroot}${lib_dir}/libocci.dylib
 }

--- a/devel/libretls/Portfile
+++ b/devel/libretls/Portfile
@@ -25,10 +25,7 @@ checksums           rmd160  ef9634114bece359b905185735131c34b83ce91e \
 depends_lib         port:openssl
 
 configure.args      --with-openssl=${prefix}
-
-if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append getpagesize
-}
 
 livecheck.type      regex
 livecheck.url       ${master_sites}

--- a/finance/cpuminer/Portfile
+++ b/finance/cpuminer/Portfile
@@ -25,9 +25,7 @@ depends_lib-append  port:curl \
 patchfiles          arm64.patch
 
 use_autoreconf      yes
-if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append strchr
-}
 
 pre-configure {
     system -W ${worksrcpath} "./nomacro.pl"

--- a/games/mystonline-cider/Portfile
+++ b/games/mystonline-cider/Portfile
@@ -40,7 +40,7 @@ post-extract {
     set my_dmg_mount [my_attach_disk_image ${distpath}/${installer_dmg}]
     copy "${my_dmg_mount}/Myst Online.app" ${worksrcpath}/app
     my_detach_disk_image ${my_dmg_mount}
-    
+
     xinstall -m 644 -W ${filespath} MOUL.sh chown-data.c ${worksrcpath}
 }
 
@@ -60,31 +60,31 @@ build {
     # and replace it with our script (which does that and more)
     delete "${worksrcpath}/app/Contents/MacOS/Uru Live"
     xinstall -W ${worksrcpath} MOUL.sh "${worksrcpath}/app/Contents/MacOS/Uru Live"
-    
+
     # Move the wine prefix and symlink it back to where the app expects it
     set transgaming_dir "${worksrcpath}/app/Contents/Resources/Myst Online.app/Contents/Resources/transgaming"
     move ${transgaming_dir} ${worksrcpath}/wineprefix
     ln -s ${wineprefix} ${transgaming_dir}
-    
+
     # Link "Uru Live" to our assets dir
     set program_files "${worksrcpath}/wineprefix/c_drive/Program Files"
     delete "${program_files}/Uru Live"
     ln -s ${assets_dir} "${program_files}/Uru Live"
-    
+
     file mkdir ${worksrcpath}/assets
     ln -s "${app_package}/Contents/Resources/Myst Online.app/Contents/Resources" ${worksrcpath}/assets/Cider
-    
+
     # Update the URL from which server status messages are obtained
     foreach a {Login Updater} {
         reinplace "s|support.mystonline.com/serverstatus/urulivelive.php|support.cyanworlds.com/serverstatus/moullive.php|g" \
             "${worksrcpath}/app/Contents/Resources/Myst Online.app/Contents/Resources/URU Live ${a}.app/Contents/Info.plist"
     }
-    
+
     # Make sure we show the updated terms and conditions
     set tos "${worksrcpath}/app/Contents/Resources/Myst Online.app/Contents/Resources/URU Live EULA.app/Contents/Resources/TOS.txt"
     delete ${tos}
     ln -s ${assets_dir}/TOS.txt ${tos}
-    
+
     # Build the chown wrapper program
     system -W ${worksrcpath} "${configure.cc} ${configure.cc_archflags} chown-data.c -o chown-data"
 }
@@ -93,13 +93,13 @@ destroot {
     xinstall -d ${destroot}${libexec_dir} \
                 ${destroot}${share_dir} \
                 ${destroot}${applications_dir}
-    
+
     xinstall -m 4755 -W ${worksrcpath} chown-data ${destroot}${libexec_dir}
-    
+
     copy ${worksrcpath}/app ${destroot}${app_package}
-    
+
     copy ${worksrcpath}/assets ${destroot}${assets_dir}
-    
+
     copy ${worksrcpath}/wineprefix ${destroot}${wineprefix}
 }
 
@@ -147,23 +147,14 @@ proc my_attach_disk_image {disk_image} {
     set tmp_disk_image_dir [mkdtemp "${workpath}/.tmp/disk_image.XXXXXXXX"]
     set tmp_disk_image ${tmp_disk_image_dir}/[file tail ${disk_image}].cdr
     set mountpoint [mkdtemp "${workpath}/.tmp/mountpoint.XXXXXXXX"]
-if {[vercmp [macports_version] 2.6.99] >= 0} {
     system "hdiutil convert -quiet -ov -format UDTO -o [shellescape ${tmp_disk_image}] [shellescape ${disk_image}]"
     system "hdiutil attach -quiet [shellescape ${tmp_disk_image}] -mountpoint [shellescape ${mountpoint}] -private -nobrowse -noautoopen -noautofsck -noverify -readonly"
-} else {
-    system "hdiutil convert -quiet -ov -format UDTO -o '${tmp_disk_image}' '${disk_image}'"
-    system "hdiutil attach -quiet '${tmp_disk_image}' -mountpoint '${mountpoint}' -private -nobrowse -noautoopen -noautofsck -noverify -readonly"
-}
     return ${mountpoint}
 }
 
 # Unmounts a disk image.
 proc my_detach_disk_image {mountpoint} {
-if {[vercmp [macports_version] 2.6.99] >= 0} {
     system "hdiutil detach [shellescape ${mountpoint}] -force"
-} else {
-    system "hdiutil detach '${mountpoint}' -force"
-}
     file delete -force ${mountpoint}
 }
 

--- a/graphics/Aseprite/Portfile
+++ b/graphics/Aseprite/Portfile
@@ -117,13 +117,6 @@ proc map {prefix list} {
     return ${result}
 }
 
-# shellescape will be in MacPorts 2.7.0.
-if {[vercmp [macports_version] 2.6.99] < 0} {
-    proc shellescape {arg} {
-        return [regsub -all -- {[^A-Za-z0-9.:@%/+=_-]} $arg {\\&}]
-    }
-}
-
 proc quoted_shellescape {arg} {
     return "\"[shellescape ${arg}]\""
 }

--- a/graphics/gimp2-devel/Portfile
+++ b/graphics/gimp2-devel/Portfile
@@ -104,9 +104,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 
 use_autoreconf      yes
 autoreconf.args     -fvi
-if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append strchr
-}
 
 pre-configure {
     if {[file exists ${prefix}/lib/gtk-2.0/include/gdkconfig.h]} {

--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -104,9 +104,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 
 use_autoreconf      yes
 autoreconf.args     -fvi
-if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append strchr
-}
 
 pre-configure {
     if {[file exists ${prefix}/lib/gtk-2.0/include/gdkconfig.h]} {

--- a/graphics/graphviz-devel/Portfile
+++ b/graphics/graphviz-devel/Portfile
@@ -122,9 +122,7 @@ configure.args                  --disable-silent-rules \
 # Teach glibtool about -stdlib=libc++
 use_autoreconf  yes
 autoreconf.args -fvi
-if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append strchr
-}
 
 platform macosx {
     if {${os.major} > 8} {

--- a/graphics/graphviz/Portfile
+++ b/graphics/graphviz/Portfile
@@ -122,9 +122,7 @@ configure.args                  --disable-silent-rules \
 # Teach glibtool about -stdlib=libc++
 use_autoreconf  yes
 autoreconf.args -fvi
-if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append strchr
-}
 
 platform macosx {
     if {${os.major} > 8} {

--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -79,17 +79,10 @@ depends_lib         port:ncurses
 # GCC 4.2 also fails: https://trac.macports.org/ticket/52507
 compiler.blacklist  {clang < 300} gcc-4.2
 
-# shellescape will be in MacPorts 2.7.0.
-if {[vercmp [macports_version] 2.6.99] < 0} {
-    proc shellescape {arg} {
-        return [regsub -all -- {[^A-Za-z0-9.:@%/+=_-]} $arg {\\&}]
-    }
-}
-
 post-destroot   {
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_html_${version}${extract.suffix}]"
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_man_${version}${extract.suffix}]"
- 
+
     set erts_dir            erts-11.1
     set erl_interface_dir   erl_interface-4.0.1
     set wx_dir              wx-1.9.1

--- a/mail/mail-server/Portfile
+++ b/mail/mail-server/Portfile
@@ -824,16 +824,6 @@ in ${prefix}/etc/dovecot/sieve*/*.sieve are compiled with sievec.
     }
 }
 
-pre-fetch {
-    # The way that startupitems values are quoted was changed in 2.6.3.
-    # This port now relies on those changes. See:
-    # https://github.com/macports/macports-base/pull/191
-    if {[vercmp [macports_version] 2.6.3] < 0} {
-        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
-        return -code error "incompatible MacPorts version"
-    }
-}
-
 startupitem.create      yes
 startupitems \
         name            ${name} \

--- a/net/macos-fortress/Portfile
+++ b/net/macos-fortress/Portfile
@@ -180,16 +180,6 @@ set notes_proxy     "Domain names and a blacklist file are blocked, excluding\
 
 sudo apachectl start"
 
-pre-fetch {
-    # The way that startupitems values are quoted was changed in 2.6.3.
-    # This port now relies on those changes. See:
-    # https://github.com/macports/macports-base/pull/191
-    if {[vercmp [macports_version] 2.6.3] < 0} {
-        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
-        return -code error "incompatible MacPorts version"
-    }
-}
-
 if {${name} eq ${subport}} {
     description     Firewall, Blackhole, and Privatizing Proxy for Trackers, Attackers, Malware, Adware, and Spammers
     long_description \
@@ -245,7 +235,7 @@ if {${name} eq ${subport}} {
                 ${worksrcpath}/macosfortress_setup_check.sh
         }
     }
-    
+
     destroot {
         xinstall -d ${destroot}${prefix}/share/${name} \
                     ${destroot}${prefix}/share/${name}/logrotate.d
@@ -687,7 +677,7 @@ subport ${name}-proxy-squid {
     conflicts       ${name}-proxy
 
     set squid_major_version 5
-    
+
     depends_lib-append \
                     port:${name}-easylistpac \
                     port:${name}-hosts \

--- a/net/wget/Portfile
+++ b/net/wget/Portfile
@@ -82,9 +82,7 @@ depends_lib \
 
 patchfiles              prefix.patch
 
-if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append strchr
-}
 
 configure.perl          ${prefix}/bin/perl${perl_version}
 configure.env-append    POD2MAN=${prefix}/bin/pod2man-${perl_version}

--- a/pure/pure-reduce/Portfile
+++ b/pure/pure-reduce/Portfile
@@ -31,11 +31,7 @@ depends_lib-append              port:gmp
 extract.only                    ${pure_reduce_distfile}
 
 post-extract {
-if {[vercmp [macports_version] 2.6.99] >= 0} {
     system -W ${worksrcpath} "tar xjf [shellescape ${distpath}/${reduce_distfile}]"
-} else {
-    system -W ${worksrcpath} "tar xjf '${distpath}/${reduce_distfile}'"
-}
 }
 
 patchfiles                      patch-Makefile.diff

--- a/sysutils/clamav-server/Portfile
+++ b/sysutils/clamav-server/Portfile
@@ -43,16 +43,6 @@ set logPath ${prefix}/var/log/clamav
 set runPath ${prefix}/var/run/clamav
 set sharePath ${prefix}/share/clamav
 
-pre-fetch {
-    # The way that startupitems values are quoted was changed in 2.6.3.
-    # This port now relies on those changes. See:
-    # https://github.com/macports/macports-base/pull/191
-    if {[vercmp [macports_version] 2.6.3] < 0} {
-        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
-        return -code error "incompatible MacPorts version"
-    }
-}
-
 startupitem.create     yes
 startupitems \
     name               clamd \

--- a/sysutils/file/Portfile
+++ b/sysutils/file/Portfile
@@ -40,20 +40,18 @@ depends_lib         port:zlib
 # We patch Makefile.am files.
 use_autoreconf      yes
 autoreconf.args     -fvi
-if {[vercmp [macports_version] 2.6.99] >= 0} {
 configure.checks.implicit_function_declaration.whitelist-append strchr
-}
 
 if {${name} eq ${subport}} {
     revision            0
 
     depends_lib-append port:libmagic
-    
+
     destroot {
         xinstall -W ${worksrcpath}/src/.libs file ${destroot}${prefix}/bin
         xinstall -m 0644 -W ${worksrcpath}/doc file.1 ${destroot}${prefix}/share/man/man1
     }
-    
+
     livecheck.type      regex
     livecheck.url       ftp://ftp.astron.com/pub/${name}/
     livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}

--- a/www/adblock2privoxy/Portfile
+++ b/www/adblock2privoxy/Portfile
@@ -65,16 +65,6 @@ set adblock2privoxy_css_server \
 # relative paths to ${prefix}
 set ab2p_datadir    share/${name}
 
-pre-fetch {
-    # The way that startupitems values are quoted was changed in 2.6.3.
-    # This port now relies on those changes. See:
-    # https://github.com/macports/macports-base/pull/191
-    if {[vercmp [macports_version] 2.6.3] < 0} {
-        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
-        return -code error "incompatible MacPorts version"
-    }
-}
-
 post-extract {
     # Fix for cabal data-files hardcoded path in binary
     # See:

--- a/www/privoxy/Portfile
+++ b/www/privoxy/Portfile
@@ -78,16 +78,6 @@ proc plutil_startup {plcmds label} {
     }
 }
 
-pre-fetch {
-    # The way that startupitems values are quoted was changed in 2.6.3.
-    # This port now relies on those changes. See:
-    # https://github.com/macports/macports-base/pull/191
-    if {[vercmp [macports_version] 2.6.3] < 0} {
-        ui_error "${name} @${version} requires MacPorts 2.6.3 or later"
-        return -code error "incompatible MacPorts version"
-    }
-}
-
 # bash commands to generate patch files from new upstream configuration files
 ## export prefix=${prefix:-/opt/local}
 ## mkdir privoxy-orig privoxy-new
@@ -147,7 +137,7 @@ post-destroot {
             "1 s|^(#!)/usr/bin/perl|\\1${perl5.bin}|" \
             ${pl}
     }
-    
+
     xinstall -d ${destroot}${prefix}/var/run
     # Install and fixup startup script (if non-Darwin)
     if {${os.platform} ne "darwin"} {


### PR DESCRIPTION
#### Description
MacPorts v2.7.0 was released on May 19, 2021 - remove compatibility code / checks for earlier versions of `base`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
