### PR TITLE
k9s: update to 0.25.9

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.25.8 v
+go.setup            github.com/derailed/k9s 0.25.9 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 platforms           darwin
 
-checksums           rmd160  2b562a37fee070e9b13036c363bb988bf017f9ff \
-                    sha256  56a4939b18a1059b55823e3a34b27fef8863473dca6c901659506a79219dba8e \
-                    size    6255844
+checksums           rmd160  8870faea72926708dede36769b5bda3390cbe093 \
+                    sha256  e7ab31077499b6998a994fef841461dff4d8357c903a013073c127c857739ff1 \
+                    size    6257427
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

Update to k9s 0.25.9.

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?