### PR TITLE
lighttpd: update dependencies

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -5,7 +5,7 @@ PortGroup                   legacysupport 1.0
 
 name                        lighttpd
 version                     1.4.63
-revision                    0
+revision                    1
 checksums                   rmd160  f8b13b883825626ed04c3349ec5f2330c49a6a37 \
                             sha256  2aef7f0102ebf54a1241a1c3ea8976892f8684bfb21697c9fffb8de0e2d6eab9 \
                             size    1023568
@@ -32,8 +32,9 @@ depends_build-append        port:pkgconfig
 
 depends_lib                 port:brotli \
                             port:bzip2 \
-                            port:pcre \
+                            port:pcre2 \
                             port:spawn-fcgi \
+                            port:xxhashlib \
                             port:zlib \
                             port:zstd
 
@@ -56,7 +57,8 @@ configure.args-append       CC_FOR_BUILD="${configure.cc}" \
                             CFLAGS_FOR_BUILD="${configure.cflags}" \
                             --with-brotli \
                             --with-bzip2 \
-                            --with-pcre \
+                            --with-pcre2 \
+                            --with-xxhash \
                             --with-zlib \
                             --with-zstd \
                             ac_cv_prog_AWK=/usr/bin/awk


### PR DESCRIPTION
Use the xxhashlib port instead of the bundled copy of xxhash. Switch to
PCRE2 since classic PCRE is EOL.

###### Tested on
macOS 11.6.1 20G224 x86_64
Xcode 13.2 13C90
