### PR TITLE
lighttpd: update config; remove mod_cml

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -5,7 +5,7 @@ PortGroup                   legacysupport 1.0
 
 name                        lighttpd
 version                     1.4.63
-revision                    1
+revision                    2
 checksums                   rmd160  f8b13b883825626ed04c3349ec5f2330c49a6a37 \
                             sha256  2aef7f0102ebf54a1241a1c3ea8976892f8684bfb21697c9fffb8de0e2d6eab9 \
                             size    1023568
@@ -31,7 +31,7 @@ use_xz                      yes
 depends_build-append        port:pkgconfig
 
 depends_lib                 port:brotli \
-                            port:bzip2 \
+                            port:lua \
                             port:pcre2 \
                             port:spawn-fcgi \
                             port:xxhashlib \
@@ -56,7 +56,7 @@ compiler.blacklist          *gcc-3.* *gcc-4.*
 configure.args-append       CC_FOR_BUILD="${configure.cc}" \
                             CFLAGS_FOR_BUILD="${configure.cflags}" \
                             --with-brotli \
-                            --with-bzip2 \
+                            --with-lua \
                             --with-pcre2 \
                             --with-xxhash \
                             --with-zlib \
@@ -136,14 +136,6 @@ variant mysql57 description {Enable MySQL 5.7 support} {
 variant ssl description {Enable serving secure web sites with SSL} {
     depends_lib-append      path:lib/libssl.dylib:openssl
     configure.args-append   --with-openssl
-}
-
-variant cml description {Enable Cache Meta-Language (CML)} {
-    depends_lib-append      port:lua \
-                            port:libmemcache \
-                            port:memcached
-    configure.args-append   --with-lua \
-                            --with-memcache
 }
 
 variant davprops description {Enable mod_webdav} {


### PR DESCRIPTION
#### Description

lighttpd config updates; remove mod_cml
- remove mod_cml
  long-deprecated module will be removed from upstream in Jan 2022
- add --with-lua to the core build; mod_magnet is better than mod_cml
- remove bzip2 dependency; seldom used with mod_deflate; brotli better

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?