### PR TITLE
hub: fix installation for zsh completion

### DIFF
--- a/devel/hub/Portfile
+++ b/devel/hub/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        github hub 2.14.2 v
+revision            1
 categories          devel
 platforms           darwin
 license             MIT
@@ -39,18 +40,18 @@ post-extract {
 }
 
 destroot {
-    xinstall -W ${worksrcpath} bin/hub ${destroot}${prefix}/bin
+    xinstall -m 0755 -W ${worksrcpath} bin/hub ${destroot}${prefix}/bin
     set man-pages ${destroot}${prefix}/share/man/man1
     xinstall -d ${man-pages}
     foreach m [glob -directory ${worksrcpath}/share/man/man1 *.1] {
-        xinstall -W ${worksrcpath} ${m} ${man-pages}/
+        xinstall -m 0644 -W ${worksrcpath} ${m} ${man-pages}/
     }
     set bash-completions ${destroot}${prefix}/share/bash-completion/completions
     xinstall -d ${bash-completions}
-    xinstall -W ${worksrcpath} etc/hub.bash_completion.sh ${bash-completions}/hub
+    xinstall -m 0644 -W ${worksrcpath} etc/hub.bash_completion.sh ${bash-completions}/hub
     set site-functions ${destroot}${prefix}/share/zsh/site-functions
     xinstall -d ${site-functions}
-    xinstall -W ${worksrcpath} etc/hub.zsh_completion ${site-functions}/
+    xinstall -m 0644 -W ${worksrcpath} etc/hub.zsh_completion ${site-functions}/_hub
 }
 
 notes "


### PR DESCRIPTION
Force pushed once to standardize the file permission for `_hub`, the zsh completion file, whose file perm was set 755 before.

---

#### Description

hub's zsh completion file is not installed correctly and completion doesn't work. Fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14
xcode-select version 2354

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
