### PR TITLE
syncthing: update to 1.18.5

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.18.4 v
+go.setup            github.com/syncthing/syncthing 1.18.5 v
 revision            0
 categories          net
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  4135ce51b5373d38a5bbad956476425cb72c4564 \
-                        sha256  9b6dbfcfdc2d46cfebbec42395da4029ea1b809a60d3ececc62996e1c3123117 \
-                        size    6168695
+                        rmd160  e99f9fa30a6696dfed2f5ab26046c5540feb965a \
+                        sha256  20586c55e41fd619dc03bd5427b1f517b0af2635c99f1a849ad26a1920cd157f \
+                        size    6168817
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    496545a6307b \


### PR DESCRIPTION
#### Description
Updates syncthing to 1.18.4
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
