### PR TITLE
py-tabulate: add py310 subport

### DIFF
--- a/python/py-tabulate/Portfile
+++ b/python/py-tabulate/Portfile
@@ -12,14 +12,14 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Pretty-print tabular data
 long_description    ${description}
 
-homepage            https://bitbucket.org/astanin/python-tabulate
+homepage            https://github.com/astanin/python-tabulate
 
 checksums           rmd160  5d30a2a3762bda0efb657491ff92f260a18eedc8 \
                     sha256  eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7 \


### PR DESCRIPTION
#### Description

py-tabulate: add py310 subport

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.1 21C52 arm64
[CLT](https://trac.macports.org/wiki/ProblemHotlist#reinstall-clt) 13.2.0.0.1.1638488800

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?