### PR TITLE
py-seaborn: add py310 subport

### DIFF
--- a/python/py-seaborn/Portfile
+++ b/python/py-seaborn/Portfile
@@ -10,7 +10,7 @@ categories-append   science
 license             BSD
 platforms           darwin
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description

py-seaborn: add py310 subport

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.1 21C52 arm64
[CLT](https://trac.macports.org/wiki/ProblemHotlist#reinstall-clt) 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Tested with:

``` python
# Python 3.10.1 (main, Dec 10 2021, 11:21:25) [Clang 13.0.0 (clang-1300.0.29.3)] on darwin

import matplotlib.pyplot as plt
import seaborn as sns
penguins = sns.load_dataset("penguins")
sns.histplot(data=penguins, x="flipper_length_mm", hue="species", multiple="stack")
plt.show()  # because REPL
```
