### PR TITLE
py-mkl{-include}: update to 2022.0.0; py-numpy: add mkl variant

### DIFF
--- a/python/py-mkl/Portfile
+++ b/python/py-mkl/Portfile
@@ -7,7 +7,7 @@ name                py-mkl
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
     version         2019.0
 } else {
-    version         2021.4.0
+    version         2022.0.0
 }
 revision            0
 platforms           darwin
@@ -66,12 +66,12 @@ if {${name} ne ${subport}} {
 
         } else {
 
-            master_sites    https://files.pythonhosted.org/packages/96/15/cb0b6d590a7fa8a5df38da43f5909be065eb78b9d7c8187e8ddd4b6ca8eb/
+            master_sites    https://files.pythonhosted.org/packages/fd/83/271dbbdc62f47883bbe8e72dc9f90cdf5674ac366c0cef232dfa5cf7fa31/
             distname        mkl_include-${version}-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64
 
-            checksums       rmd160  e9a2c5199d3997cfcbbe704fc5e4bf2b9a258e3d \
-                            sha256  d8b3ad7254047c952aa1e3059ed2a8c671cf70dc3a8aa7f7195757ee7936b75f \
-                            size    902519
+            checksums       rmd160  0d2ccb9defe9ce76ccbb50c258a9e3cec35c4b29 \
+                            sha256  9ab59bfa9d6b8e03be08587cb0b2c702be9bb76a94967468bd45eda86f612754 \
+                            size    975899
 
         }
 
@@ -89,12 +89,12 @@ if {${name} ne ${subport}} {
                             size    193800193
         } else {
 
-            master_sites    https://files.pythonhosted.org/packages/b6/b2/b8c755092e3881d6b5ea74be49c7bf3758b6174296626aed39c3416a1b02/
+            master_sites    https://files.pythonhosted.org/packages/a9/67/e81d43841eacc42601e0bcbdcc20df9dbf85139c890b1c773d058672be45/
             distname        mkl-${version}-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64
 
-            checksums       rmd160  a0148fc03cb0a6c95a75cdf30dd67e5032345cf2 \
-                            sha256  67460f5cd7e30e405b54d70d1ed3ca78118370b65f7327d495e9c8847705e2fb \
-                            size    186391276
+            checksums       rmd160  ca99413027ef37d105d3a76ee026172e62109803 \
+                            sha256  ab274aa76d4a3535ddf08b566ee0240acd0840f87692f1b8a5e6461cd1d44bdc \
+                            size    159051872
 
         }
 

--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -108,12 +108,23 @@ if {${name} ne ${subport}} {
         destroot.env-append     ARCHFLAGS=[get_canonical_archflags ld]
     }
 
-    variant atlas conflicts openblas description "Use MacPorts ATLAS Libraries" {
+    variant atlas conflicts openblas mkl description "Use MacPorts ATLAS Libraries" {
         depends_lib-append      port:atlas
     }
 
-    variant openblas conflicts atlas description "Use MacPorts OpenBLAS Libraries" {
+    variant openblas conflicts atlas mkl description "Use MacPorts OpenBLAS Libraries" {
         depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS
+    }
+
+    variant mkl conflicts atlas openblas description "Use MacPorts MKL Libraries" {
+        depends_lib-append  port:py${python.version}-mkl \
+                            port:py${python.version}-mkl-include
+
+        # set absolute path to remove references to @rpath/libmkl_rt.2.dylib
+        post-destroot {
+            system "install_name_tool -change @rpath/libmkl_rt.2.dylib ${python.prefix}/lib/libmkl_rt.2.dylib ${destroot}${python.pkgd}/numpy/core/_multiarray_umath.cpython-${python.version}-darwin.so"
+            system "install_name_tool -change @rpath/libmkl_rt.2.dylib ${python.prefix}/lib/libmkl_rt.2.dylib ${destroot}${python.pkgd}/numpy/linalg/lapack_lite.cpython-${python.version}-darwin.so"
+        }
     }
 
     # Make +openblas a default variant, at least temporarily, to
@@ -121,7 +132,8 @@ if {${name} ne ${subport}} {
     # https://trac.macports.org/ticket/56954
     # https://github.com/numpy/numpy/issues/12230
     if {![variant_isset atlas] &&
-        ![variant_isset openblas]} {
+        ![variant_isset openblas] &&
+        ![variant_isset mkl]} {
         default_variants-append +openblas
     }
 
@@ -154,10 +166,12 @@ variant."
 
         # use MacPorts atlas
         build.env-append    OPENBLAS=None \
+                            MKL=None \
                             ATLAS=${prefix}/lib \
                             LAPACK=${prefix}/lib \
                             BLAS=${prefix}/lib
         destroot.env-append OPENBLAS=None \
+                            MKL=None \
                             ATLAS=${prefix}/lib \
                             LAPACK=${prefix}/lib \
                             BLAS=${prefix}/lib
@@ -170,14 +184,28 @@ variant."
         destroot.env-append OPENBLAS=${prefix}/lib \
                             ATLAS=None
 
+    } elseif {[variant_isset mkl]} {
+
+        # use MacPorts MKL
+        post-patch {
+            reinplace "s|mkl_rt|mkl_rt.2|g" ${worksrcpath}/numpy/distutils/system_info.py
+        }
+
+        build.env-append    OPENBLAS=None \
+                            ATLAS=None
+        destroot.env-append OPENBLAS=None \
+                            ATLAS=None
+
     } else {
         # use Accelerate BLAS
         build.env-append    OPENBLAS=None \
                             ATLAS=None \
+                            MKL=None \
                             LAPACK=/usr/lib \
                             BLAS=/usr/lib
         destroot.env-append OPENBLAS=None \
                             ATLAS=None \
+                            MKL=None \
                             LAPACK=/usr/lib \
                             BLAS=/usr/lib
     }


### PR DESCRIPTION
#### Description
This PR updates the MKL library to its latest upstream version and adds a variant to `py-numpy` to use this library. I would probably in favor of defaulting to it instead of `openblas`, but will leave this for discussion first. It will also avoid opportunistic linking as reported before on Trac. 

I did need to do some mucking around with `install_name_tool` to get rid of the "rpath" linking stuff for it to work, otherwise NumPy throws an error when importing. Now it does seem to work correctly:
```
>>> numpy.show_config()
blas_mkl_info:
    libraries = ['mkl_rt.2', 'pthread']
    library_dirs = ['/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib']
    define_macros = [('SCIPY_MKL_H', None), ('HAVE_CBLAS', None)]
    include_dirs = ['/opt/local/include', '/opt/local/Library/Frameworks/Python.framework/Versions/3.10/include']
blas_opt_info:
    libraries = ['mkl_rt.2', 'pthread']
    library_dirs = ['/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib']
    define_macros = [('SCIPY_MKL_H', None), ('HAVE_CBLAS', None)]
    include_dirs = ['/opt/local/include', '/opt/local/Library/Frameworks/Python.framework/Versions/3.10/include']
lapack_mkl_info:
    libraries = ['mkl_rt.2', 'pthread']
    library_dirs = ['/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib']
    define_macros = [('SCIPY_MKL_H', None), ('HAVE_CBLAS', None)]
    include_dirs = ['/opt/local/include', '/opt/local/Library/Frameworks/Python.framework/Versions/3.10/include']
lapack_opt_info:
    libraries = ['mkl_rt.2', 'pthread']
    library_dirs = ['/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib']
    define_macros = [('SCIPY_MKL_H', None), ('HAVE_CBLAS', None)]
    include_dirs = ['/opt/local/include', '/opt/local/Library/Frameworks/Python.framework/Versions/3.10/include']
Supported SIMD extensions in this NumPy install:
    baseline = SSE,SSE2,SSE3
    found = SSSE3,SSE41,POPCNT,SSE42,AVX,F16C,FMA3,AVX2,AVX512F,AVX512CD,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL
    not found = AVX512_KNL
```


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->