### PR TITLE
hyperkit: new port, version 0.20210107

### DIFF
--- a/emulators/hyperkit/Portfile
+++ b/emulators/hyperkit/Portfile
@@ -1,0 +1,84 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+
+categories          emulators
+platforms           darwin
+maintainers         nomaintainer
+license             BSD
+
+github.setup        moby hyperkit 0.20210107 v
+github.tarball_from archive
+
+description         HyperKit is a toolkit for embedding hypervisor capabilities in your application.
+
+long_description    HyperKit is a toolkit for embedding hypervisor capabilities in your application. \
+                    It includes a complete hypervisor, based on xhyve/bhyve, which is optimized for \
+                    lightweight virtual machines and container deployment. It is designed to be interfaced \
+                    with higher-level components such as the VPNKit and DataKit.
+
+checksums           rmd160  49a397d86d20a7ea5d09261f3217b634d2a8b712 \
+                    sha256  095f5f5ef550d7cad10e4d13e9c9ce8b58cc319d654a6d837d8d87ee70537835 \
+                    size    1176356
+
+
+depends_build       port:aspcud \
+                    port:ocaml \
+                    port:opam \
+                    port:pkgconfig
+
+depends_lib         port:libev
+
+if {${os.platform} ne "darwin" || ${os.major} < 14} {
+    known_fail  yes
+
+    depends_build
+    depends_lib
+
+    pre-fetch {
+        ui_error "${name} requires Hypervisor.framework from OS X Yosemite or later"
+        return -code error "incompatible OS X version"
+    }
+}
+
+                    # ref: https://github.com/moby/hyperkit/issues/323
+patchfiles          implicit-conversion.patch
+
+use_configure no
+
+build {
+    set opam_libraries "uri \
+                        qcow.0.11.0 \
+                        conduit.2.1.0 \
+                        lwt.5.3.0 \
+                        qcow-tool \
+                        mirage-block-unix.2.12.0 \
+                        conf-libev \
+                        logs \
+                        fmt \
+                        mirage-unix \
+                        prometheus-app"
+
+    set opam_env_file ${workpath}/opam.env
+    set opam_pin ". ${opam_env_file} && opam pin add"
+    set opam_install ". ${opam_env_file} && opam install -j ${build.jobs} -y"
+
+    system -W ${workpath} "opam init -n --disable-sandboxing"
+    system "opam env > ${opam_env_file}"
+
+    system "${opam_pin} qcow.0.11.0 git://github.com/mirage/ocaml-qcow -n"
+    system "${opam_pin} qcow-tool.0.11.0 git://github.com/mirage/ocaml-qcow -n"
+
+    system "${opam_install} ${opam_libraries}"
+    system -W ${worksrcpath} "${build.cmd}"
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/build/hyperkit \
+                    ${destroot}${prefix}/bin/${name}
+
+    xinstall -m 0644 ${worksrcpath}/${name}.1 \
+                     ${destroot}${prefix}/share/man/man1
+}

--- a/emulators/hyperkit/files/implicit-conversion.patch
+++ b/emulators/hyperkit/files/implicit-conversion.patch
@@ -1,0 +1,41 @@
+diff --git src/lib/pci_ahci.c src/lib/pci_ahci.c
+index 4fc96eb..c25f08d 100644
+--- src/lib/pci_ahci.c
++++ src/lib/pci_ahci.c
+@@ -214,8 +214,8 @@ static inline void lba_to_msf(uint8_t *buf, int lba)
+ {
+ 	lba += 150;
+ 	buf[0] = (uint8_t) ((lba / 75) / 60);
+-	buf[1] = (lba / 75) % 60;
+-	buf[2] = lba % 75;
++	buf[1] = (uint8_t) ((lba / 75) % 60);
++	buf[2] = (uint8_t) (lba % 75);
+ }
+ 
+ /*
+diff --git src/lib/vmm/io/vatpit.c src/lib/vmm/io/vatpit.c
+index 1ecca35..ea84e07 100644
+--- src/lib/vmm/io/vatpit.c
++++ src/lib/vmm/io/vatpit.c
+@@ -200,7 +200,7 @@ pit_update_counter(struct vatpit *vatpit, struct channel *c, bool latch)
+ 
+ 	delta_ticks = (sbinuptime() - c->now_sbt) / vatpit->freq_sbt;
+ 
+-	lval = c->initial - delta_ticks % c->initial;
++	lval = (uint16_t) (c->initial - delta_ticks % c->initial);
+ 
+ 	if (latch) {
+ 		c->olbyte = 2;
+diff --git src/lib/vmm/vmm_instruction_emul.c src/lib/vmm/vmm_instruction_emul.c
+index 3f277c6..f80d79b 100644
+--- src/lib/vmm/vmm_instruction_emul.c
++++ src/lib/vmm/vmm_instruction_emul.c
+@@ -1376,7 +1376,7 @@ emulate_bittest(void *vm, int vcpuid, uint64_t gpa, struct vie *vie,
+ 	 * "Range of Bit Positions Specified by Bit Offset Operands"
+ 	 */
+ 	bitmask = vie->opsize * 8 - 1;
+-	bitoff = vie->immediate & bitmask;
++	bitoff = (int) (vie->immediate & bitmask);
+ 
+ 	/* Copy the bit into the Carry flag in %rflags */
+ 	if (val & (1UL << bitoff))


### PR DESCRIPTION
#### Description

This is a Portfile submission for HyperKit from the Moby project, a hypervisor based on xhyve/bhyve.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] submission

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
