### PR TITLE
google-cloud-sdk: update to 367.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             366.0.0
+version             367.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a39d296d351e1eaba8d75be4a9caab77df84f9ca \
-                    sha256  8dcc623d320f17f3cb4959ab3b79e08ff602204fc7eacc51b82b1532f24135c5 \
-                    size    97323547
+    checksums       rmd160  7dcea5a11cb2b5df0ce32889c45b8f3e3b328d79 \
+                    sha256  0793754d58f1aca3a7f7b726714fe49817789b57a26eb84d98135da86b208ed5 \
+                    size    97372275
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  6bf389d4ed0b660a829cdd6ba1541cc1cfe425d6 \
-                    sha256  7241cf19d0116f82d4600c2e60c7f63f084c384759b1febabaafe11501ae81fe \
-                    size    93594071
+    checksums       rmd160  46589b463e1233bf7e74219e55b7a3e068a4090c \
+                    sha256  870ca3ca68b0a98af934cb4eae3f8910d1cd971b052eead53397325d9f140233 \
+                    size    93636198
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  8a5d1dc0361160937328484d6c5a10603b7b0091 \
-                    sha256  9ef1d8e5774848e262d64f06ca39302b81d64289a12095a2fe029d8996c1d898 \
-                    size    93520490
+    checksums       rmd160  7bb1e7b972097d81018b3503bd6699f1bed72a45 \
+                    sha256  1689b401444887ee527a5fe5c02cab8b4220e120b432c9244b94582d0ee7e002 \
+                    size    93568866
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 367.0.0.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?