### PR TITLE
py-pytest-timeout: update to 2.0.2

### DIFF
--- a/python/py-pytest-timeout/Portfile
+++ b/python/py-pytest-timeout/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        pytest-dev pytest-timeout 2.0.1
+github.setup        pytest-dev pytest-timeout 2.0.2
 revision            0
 name                py-${github.project}
 
-checksums           rmd160  bdd9b9a918c4bca34d83c8715f4b4869be899057 \
-                    sha256  e13482a3d4f9b391e684c8e09ff575b8ae2a2525b39609dd7cacca1421fedda2 \
-                    size    13848
+checksums           rmd160  9c2298ac65125f224a2e819c897bae6ec4df88ac \
+                    sha256  eec66dc2fbea31c547443347efd5be7479431fa36edc9891ea6c17b03d963082 \
+                    size    14076
 
 platforms           darwin
 license             MIT
@@ -41,7 +41,8 @@ if {${name} ne ${subport}} {
     depends_test-append \
                     port:py${python.version}-ipdb \
                     port:py${python.version}-pexpect \
-                    port:py${python.version}-pytest
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-pytest-cov
 
     test.run        yes
     test.cmd        py.test-${python.branch}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->