### PR TITLE
commitizen: fix depends and automate bash completion generation

### DIFF
--- a/devel/commitizen/Portfile
+++ b/devel/commitizen/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                commitizen
 version             2.20.2
-revision            0
+revision            1
 categories-prepend  devel
 platforms           darwin
 license             MIT
@@ -43,14 +43,17 @@ depends_run-append \
     port:py${python.version}-tomlkit \
     port:py${python.version}-yaml
 
-default_variants    +bash
+default_variants    +bash_completion
 
-variant bash description {Include Bash completion support} {
-    depends_run-append \
-        port:py${python.version}-argcomplete \
-        port:bash
+variant bash_completion {
+    depends_run-append  port:py${python.version}-argcomplete \
+                        path:etc/bash_completion:bash-completion
 
-    notes-append "
-        To use bash completion, run the following:
-            register-python-argcomplete-${python.branch} cz >> ~/.bashrc"
+    post-destroot {
+        set bash-completions ${prefix}/share/bash-completion/completions
+        xinstall -d -m 0755 ${destroot}${bash-completions}
+        foreach cmd [list cz git-cz] {
+            system "register-python-argcomplete-${python.branch} ${cmd} > ${destroot}${bash-completions}/${cmd}"
+        }
+    }
 }


### PR DESCRIPTION
- replace dependency 'bash' with 'bash-completion', which is more specific.
- automate bash completion generation in 'destroot'

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6
xcode-select version 2354

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
