### PR TITLE
julia: update to 1.7.0

### DIFF
--- a/lang/julia/Portfile
+++ b/lang/julia/Portfile
@@ -10,7 +10,7 @@ compilers.choose    fc f77 f90
 compilers.setup     require_fortran -g95
 compiler.blacklist-append {clang < 900}
 
-github.setup        JuliaLang julia 1.6.2 v
+github.setup        JuliaLang julia 1.7.0 v
 revision            0
 categories-append   lang math science
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -28,9 +28,9 @@ github.tarball_from releases
 distfiles           ${name}-${version}-full${extract.suffix}
 
 checksums           ${name}-${version}-full${extract.suffix} \
-                    rmd160  efc0b88d1d91781774f8793b652ca47f83f4f0ca \
-                    sha256  01241120515cb9435b96179cf301fbd2c24d4405f252588108d13ceac0f41c0a \
-                    size    153647142
+                    rmd160  a0fb271921592088d61f19a5feb1887d4bbcdef0 \
+                    sha256  d40d83944f8e1709de1d6f7544e1a6721e091f70ba06b44c25b89bdba754dfa6 \
+                    size    255670801
 
 extract.only        ${distfiles}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
Update to 1.7.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1
Xcode- none
Command line tools: 13.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
