### PR TITLE
hugo: update to 0.90.1

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.89.4 v
+go.setup            github.com/gohugoio/hugo 0.90.1 v
 revision            0
-checksums           rmd160  ddc5481eb7abb0ad52efd699e40ca773755805a5 \
-                    sha256  a4b0246abc310f032b324f80983c6cb8ab4bbf3bb8b6da740b35735ae8514565 \
-                    size    37375481
+checksums           rmd160  3d0dba9f310a22ae2205631575b1b1c42984e068 \
+                    sha256  0752dc3ad2dbc329024db16cf5b8c0ed08a87f5e21c8cc42a10a32c78c0851c9 \
+                    size    36244007
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.90.1

###### Tested on
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?