### PR TITLE
emacs-{,-app}-devel: update to 2021-12-15

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -96,14 +96,14 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     legacysupport.newest_darwin_requires_legacy 13
 
-    set date        2021-11-12
+    set date        2021-12-15
     epoch           5
     version         [string map {- {}} ${date}]
     revision        0
 
     fetch.type      git
     git.url         --shallow-since=${date}T00:00:00 https://github.com/emacs-mirror/emacs.git
-    git.branch      eb4567e5be17e30583baebced562cb83595643e3
+    git.branch      2893cb6a21af3384cf5d6dc2b6bbdd5ebba8e1ad
 
     # --shallow-since needs a newer version of git than on some older systems
     # So use MacPorts version
@@ -124,34 +124,6 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
         compiler.cpath-prepend   ${prefix}/include/gcc11
         compiler.library_path-prepend \
                                  ${prefix}/lib/gcc11
-
-        # gcc11 can't be build on Monterey / arm64, use gcc-devel instead
-        if {${build_arch} eq {arm64} && ${os.platform} eq "darwin" && ${os.major} eq 21} {
-            depends_lib-delete   port:gcc11
-            depends_lib-append   port:gcc-devel
-
-            compiler.cpath-delete \
-                                 ${prefix}/include/gcc11
-            compiler.cpath-prepend \
-                                 ${prefix}/include/gcc-devel
-
-            compiler.library_path-delete \
-                                 ${prefix}/lib/gcc11
-            compiler.library_path-prepend \
-                                 ${prefix}/lib/gcc-devel
-
-            # by some reason compiler.library_path isn't included into `@rpath`
-            configure.env-append "DYLD_LIBRARY_PATH=${prefix}/lib/gcc-devel"
-            build.env-append     "DYLD_LIBRARY_PATH=${prefix}/lib/gcc-devel"
-            pre-destroot {
-                system "install_name_tool -add_rpath ${prefix}/lib/gcc-devel ${worksrcpath}/src/emacs"
-                system "install_name_tool -add_rpath ${prefix}/lib/gcc-devel ${worksrcpath}/src/temacs"
-
-                if {$subport eq "emacs-app-devel"} {
-                    system "install_name_tool -add_rpath ${prefix}/lib/gcc-devel ${worksrcpath}/nextstep/Emacs.app/Contents/MacOS/Emacs"
-                }
-            }
-        }
 
         build.args-append        NATIVE_FULL_AOT=1 \
             {BYTE_COMPILE_EXTRA_FLAGS='--eval "(setq comp-speed 2)"'}


### PR DESCRIPTION
#### Description

Update to latest master branch. Brings in

- `pixel-scroll-precision-mode`: quite nice!
- `mode-line` face inheriting from `variable-pitch` face. Not so nice; disable with

    ```elisp
    (set-face-attribute 'mode-line nil :inherit 'default)
    ```

The date (2021-12-15) is intentionally set to one day before the pinned commit in order to avoid the problem last time where the pinned commit didn't get pulled in despite being within the window.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->