### PR TITLE
nco: update to 5.0.4

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,10 +4,12 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.0.3
-revision            3
+github.setup        nco nco 5.0.4
+revision            0
 platforms           darwin
-maintainers         {takeshi @tenomoto}
+maintainers         {takeshi @tenomoto} \
+                    {me.com:remko.scharroo @remkos} \
+                    openmaintainer
 license             GPL-3
 categories          science
 description         The netCDF Operators
@@ -19,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  b9e99cf6906bcfeafe7fe167f930db554d7a09a2 \
-                    sha256  84e6766b384e3825ee1430ab2fe164ec346d94dbe100eb6e937cd5df8facc0cf \
-                    size    5760295
+checksums           rmd160  c849ea2a8ced3683e24189689d804ada01c56225 \
+                    sha256  13242c0efdd2c366e0efd8ca29e5b82d5ba12cd346e0910ba4b0b585d4924dc8 \
+                    size    5768684
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Simple update to upstream version 5.0.4 (from 5.0.3).
I also added myself as maintainer as this port appears abandoned.
Closes: https://trac.macports.org/ticket/64213

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
