### PR TITLE
ecCodes: update to 2.24.0

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -5,10 +5,12 @@ PortGroup cmake     1.1
 PortGroup compilers 1.0
 
 name                ecCodes
-version             2.23.0
+version             2.24.0
 revision            0
 platforms           darwin
-maintainers         {takeshi @tenomoto}
+maintainers         {takeshi @tenomoto} \
+                    {me.com:remko.scharroo @remkos} \
+                    openmaintainer
 license             Apache-2
 categories          science
 description         API and tools for decoding and encoding GRIB, BUFR and GTS formats
@@ -16,9 +18,9 @@ homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
 
-checksums           rmd160  f578bb3cbbdd941ef5d5dda72fe0fa74f1628784 \
-                    sha256  cbdc8532537e9682f1a93ddb03440416b66906a4cc25dec3cbd73940d194bf0c \
-                    size    12037258
+checksums           rmd160  73e1594eb1abae13dfd02a09d9d9e48b2b9a17e8 \
+                    sha256  307ae2b79f4a7d31789824bca1df1412f60cad68f49bfc49bbc1d4780f3e5b96 \
+                    size    12427185
 
 long_description \
     ecCodes is a package developed by ECMWF which provides an application programming interface and \


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.24.0 (from 2.23.0).
I also added myself as maintainer as this port appears to be abandoned. 
Closes: https://trac.macports.org/ticket/64221

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
