### PR TITLE
stern: update to 1.21.0

### DIFF
--- a/sysutils/stern/Portfile
+++ b/sysutils/stern/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/stern/stern 1.20.1 v
+go.setup            github.com/stern/stern 1.21.0 v
 maintainers         {breun.nl:nils @breun} openmaintainer
 platforms           darwin
 categories          sysutils
@@ -16,9 +16,9 @@ long_description    Stern allows you to tail multiple pods on Kubernetes and \
                     multiple containers within the pod. Each result is color \
                     coded for quicker debugging.
 
-checksums           rmd160  6cf083e35ba2aba0ecb350ab85a903a7e2b9192b \
-                    sha256  73c1bf3267e654c91befb3981c9a873c68b1c217ae0182f9d947455c02ff3e32 \
-                    size    116272
+checksums           rmd160  e5ff05a447856d97ad8de504cf091615ab5f52ba \
+                    sha256  b95061eca122a65083e81f2f38d439920d8e4b6057419dc3ffa177c47c642106 \
+                    size    124825
 
 set go_ldflags      "-s -w -X ${go.package}/cmd.version=${version}"
 build.args          -ldflags \"${go_ldflags}\" -o bin/${name}


### PR DESCRIPTION
#### Description

Update to Stern 1.21.0.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?