### PR TITLE
anjuta: Add python39/python310 variants

### DIFF
--- a/gnome/anjuta/Portfile
+++ b/gnome/anjuta/Portfile
@@ -113,31 +113,43 @@ variant vala description {Enable vala support} {
 
 default_variants +devhelp +glade
 
-variant python27 conflicts python36 python37 python38 description {Use Python 2.7} {
+variant python27 conflicts python36 python37 python38 python39 python310 description {Use Python 2.7} {
     configure.python        ${prefix}/bin/python2.7
     depends_lib-append      port:py27-gobject3
 }
 
-variant python36 conflicts python27 python37 python38 description {Use Python 3.6} {
+variant python36 conflicts python27 python37 python38 python39 python310 description {Use Python 3.6} {
     configure.python        ${prefix}/bin/python3.6
     depends_lib-append      port:py36-gobject3
 }
 
-variant python37 conflicts python27 python36 python38 description {Use Python 3.7} {
+variant python37 conflicts python27 python36 python38 python39 python310 description {Use Python 3.7} {
     configure.python        ${prefix}/bin/python3.7
     depends_lib-append      port:py37-gobject3
 }
 
-variant python38 conflicts python27 python36 python37 description {Use Python 3.8} {
+variant python38 conflicts python27 python36 python37 python39 python310 description {Use Python 3.8} {
     configure.python        ${prefix}/bin/python3.8
     depends_lib-append      port:py38-gobject3
+}
+
+variant python39 conflicts python27 python36 python37 python38 python310 description {Use Python 3.9} {
+    configure.python        ${prefix}/bin/python3.9
+    depends_lib-append      port:py39-gobject3
+}
+
+variant python310 conflicts python27 python36 python37 python38 python39 description {Use Python 3.10} {
+    configure.python        ${prefix}/bin/python3.10
+    depends_lib-append      port:py310-gobject3
 }
 
 if {![variant_isset python27] \
     && ![variant_isset python36] \
     && ![variant_isset python37] \
-    && ![variant_isset python38]} {
-    default_variants-append +python38
+    && ![variant_isset python38] \
+    && ![variant_isset python39] \
+    && ![variant_isset python310]} {
+    default_variants-append +python39
 }
 
 post-activate {


### PR DESCRIPTION

#### Description

Default to python39 because that's the default of the python portgroup.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
