### PR TITLE
py-awscli2: new port

### DIFF
--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -25,6 +25,8 @@ checksums           rmd160  0bc0921d368ee03571976e44b392820208fdbfdf \
 python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
+    conflicts           py${python.version}-awscli2
+
     depends_build-append \
                         port:py${python.version}-setuptools
 

--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -1,0 +1,95 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           select 1.0
+PortGroup           github 1.0
+
+name                py-awscli2
+github.setup        aws aws-cli 2.4.21
+revision            0
+
+categories          python devel
+platforms           darwin
+license             Apache-2
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         Universal Command Line Environment for Amazon Web Services.
+long_description    {*}${description}
+
+homepage            https://aws.amazon.com/cli/
+
+checksums           rmd160  05334ad34cea05884eff7c758076e80785dddf2e \
+                    sha256  e34b68a65733f86f487af93248d9b37b002410595056e4e6c58557cc77b971a5 \
+                    size    10243310
+
+# This is what Amazon currently supports and there
+# are hard errors with later Pythons right now.
+python.versions     37 38
+
+if {${name} ne ${subport}} {
+    conflicts           py${python.version}-awscli
+
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    depends_lib-append \
+                        port:py${python.version}-awscrt \
+                        port:py${python.version}-colorama \
+                        port:py${python.version}-cryptography \
+                        port:py${python.version}-dateutil \
+                        port:py${python.version}-distro \
+                        port:py${python.version}-docutils \
+                        port:py${python.version}-jmespath \
+                        port:py${python.version}-prompt_toolkit \
+                        port:py${python.version}-ruamel-yaml \
+                        port:py${python.version}-ruamel-yaml-clib \
+                        port:py${python.version}-urllib3 \
+                        port:py${python.version}-wcwidth
+
+    depends_run-append  port:awscli_select
+
+    select.group        awscli
+    select.file         ${worksrcpath}/py${python.version}-awscli2
+
+    post-extract {
+        copy -force ${filespath}/awscli2 ${worksrcpath}/py${python.version}-awscli2
+    }
+
+    patch.pre_args      -p1
+    patchfiles          patch-requirements.diff
+
+    post-patch {
+        reinplace \
+            "s,@PYTHON_BRANCH@,${python.branch},g" \
+             ${worksrcpath}/${subport}
+    }
+
+    post-destroot {
+        move ${worksrcpath}/scripts/gen-ac-index ${worksrcpath}
+        system -W ${worksrcpath} "${prefix}/bin/python${python.branch} ./gen-ac-index --include-builtin-index --index-location ${destroot}${python.pkgd}/awscli/data/ac.index"
+
+        delete ${destroot}${prefix}/bin/aws.cmd-${python.branch}
+
+        set bash_compl_path ${prefix}/share/bash-completion/completions
+        xinstall -d ${destroot}${bash_compl_path}
+        xinstall -m 0644 ${worksrcpath}/bin/aws_bash_completer \
+            ${destroot}${bash_compl_path}/aws-${python.branch}
+
+        set zsh_compl_path ${prefix}/share/zsh/site-functions
+        xinstall -d ${destroot}${zsh_compl_path}
+        xinstall -m 0644 ${worksrcpath}/bin/aws_zsh_completer.sh \
+            ${destroot}${zsh_compl_path}/aws_zsh_completer.sh-${python.branch}
+        xinstall -m 0644 ${filespath}/_aws \
+            ${destroot}${zsh_compl_path}/_aws-${python.branch}
+    }
+
+    notes "
+To make the Python ${python.branch} version of AWS CLI the one that is run when\
+you execute the commands without a version suffix, e.g. 'aws', run:
+
+port select --set ${select.group} [file tail ${select.file}]
+"
+
+    livecheck.type      none
+}

--- a/python/py-awscli2/files/_aws
+++ b/python/py-awscli2/files/_aws
@@ -1,0 +1,6 @@
+#compdef aws
+_aws () {
+    local e
+    e=$(dirname ${funcsourcetrace[1]%:*})/aws_zsh_completer.sh
+    if [[ -f $e ]]; then source $e; fi
+}

--- a/python/py-awscli2/files/awscli2
+++ b/python/py-awscli2/files/awscli2
@@ -1,0 +1,6 @@
+bin/aws-@PYTHON_BRANCH@
+bin/aws_completer-@PYTHON_BRANCH@
+bin/aws_zsh_completer.sh-@PYTHON_BRANCH@
+share/bash-completion/completions/aws-@PYTHON_BRANCH@
+share/zsh/site-functions/_aws-@PYTHON_BRANCH@
+share/zsh/site-functions/aws_zsh_completer.sh-@PYTHON_BRANCH@

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,0 +1,34 @@
+Keep awscrt pinned. This is the only user, and presumably
+Amazon has a good reason for not bumping the version yet.
+
+diff -ru aws-cli-2.4.21-orig/setup.cfg aws-cli-2.4.21/setup.cfg
+--- aws-cli-2.4.21-orig/setup.cfg	2022-02-24 16:06:48.000000000 -0500
++++ aws-cli-2.4.21/setup.cfg	2022-02-24 18:15:19.211941180 -0500
+@@ -28,17 +28,17 @@
+ python_requires = >=3.7
+ include_package_data = True
+ install_requires =
+-    colorama>=0.2.5,<0.4.4
+-    docutils>=0.10,<0.16
+-    cryptography>=3.3.2,<37.0.0
+-    ruamel.yaml>=0.15.0,<0.16.0
+-    wcwidth<0.2.0
+-    prompt-toolkit>=3.0.24,<3.1.0
+-    distro>=1.5.0,<1.6.0
++    colorama
++    docutils
++    cryptography
++    ruamel.yaml
++    wcwidth
++    prompt-toolkit
++    distro
+     awscrt==0.12.4
+-    python-dateutil>=2.1,<3.0.0
+-    jmespath>=0.7.1,<1.0.0
+-    urllib3>=1.25.4,<1.27
++    python-dateutil
++    jmespath
++    urllib3
+
+ [options.packages.find]
+ exclude =

--- a/python/py-awscrt/Portfile
+++ b/python/py-awscrt/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-awscrt
+# This is only used by awscli2. Bump when Amazon bumps
+# their pinned version in awscli2's setup.cfg.
+version             0.12.4
+revision            0
+
+categories-append   devel
+platforms           darwin
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+license             Apache-2
+
+description         A common runtime for AWS Python projects
+long_description    {*}${description}
+
+homepage            https://aws.amazon.com/cli/
+# The /packages/source/ redirect is not working for older tarballs of awscrt,
+# so when updating this package, you're either removing this line entirely
+# or changing the master_sites
+master_sites        https://files.pythonhosted.org/packages/e3/62/aaf36ad07eb01e36d6a0b5bfe2782ab1b2577e59421b351063e5b2c0a77f
+
+checksums           rmd160  011654ef4d2bc5896ef36d8fb0a0517cd82b9dc2 \
+                    sha256  6ad69336bc5277f501bd7e33f82e11db2665370c7d279496ee39fe2f369baeb2 \
+                    size    18445291
+
+python.versions     37 38 39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        path:bin/cmake:cmake
+    depends_lib-append  port:py${python.version}-setuptools
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

Although Amazon is very aggressive on their version pinning I found that things work fine on the latest versions with the exception of py-prompt_toolkit. So I've added a py-prompt_toolkit2 to backport the old version. I expect Amazon will clean up the dependency at some point and that package can be dropped / the Portfile dependencies can use the main version.

To test this thing out, I did a couple of s3 and ec2 commands. Not exhaustive, but then again, it's AWS. I had the test suite running under MacPorts but there's an unfortunate hang and other breakage that I couldn't troubleshoot, although most stuff was passing. Running the test suite outside of a MacPorts environment (but using the MacPorts python dependencies) had every single test passing, except for the command-line autocompleter.

The command-line autocompleter works, or at least it does under Bash. In order to get it to work you have to get it to build this sqlite3 database and ship that in the package. The autocompleter tests didn't pass because a plain tarball of the source isn't going to have the database in it. However I have this Portfile packaging the right database in the right place and things seem to work pretty well.

Note that if this packaging is unacceptable for MacPorts (and I don't think it should be, it is doing a good job of using the dependencies in the MacPorts tree instead of vendoring), it is still possible to ship an awscli2 from the *installation* tarball, which is a normal Autotools ./configure && install, and has a feature where it creates a self-contained virtualenv and installs that to the destroot, which I am pretty sure will have a clean Portfile and work just fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
