### PR TITLE
matterhorn: update to 50200.15.0

### DIFF
--- a/net/matterhorn/Portfile
+++ b/net/matterhorn/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           haskell_cabal 1.0
 
 name                matterhorn
-version             50200.14.1
+version             50200.15.0
 revision            0
-checksums           rmd160  4f0b95b7e474d273b5594154e94d07bb83b95682 \
-                    sha256  e2c0cee0f2e24da07cc0798a18f946e00833a6ceaa332532e7d7df801029bf2f \
-                    size    964313
+checksums           rmd160  73d6e5a5fcb12916c2745bbcf5229779f762bf05 \
+                    sha256  aad5d0d5b7d89bd39814f9be080c060f767edc825b43a048389a7e175d68c342 \
+                    size    964876
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
 


### PR DESCRIPTION
#### Description
matterhorn: update to 50200.15.0

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
