### PR TITLE
hugo: update to 0.91.0

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.90.1 v
+go.setup            github.com/gohugoio/hugo 0.91.0 v
 revision            0
-checksums           rmd160  3d0dba9f310a22ae2205631575b1b1c42984e068 \
-                    sha256  0752dc3ad2dbc329024db16cf5b8c0ed08a87f5e21c8cc42a10a32c78c0851c9 \
-                    size    36244007
+checksums           rmd160  203e11bd3c3e9a8db8f073aad089d6713e103e00 \
+                    sha256  8778d0ae7f5345e590df2581d58ac946e7c07f298255fdef4d1df565eb154677 \
+                    size    28287213
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.91.0

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.0 12A7209

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?