### PR TITLE
mvnd: repository moved

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    mvndaemon mvnd 0.7.1
+github.setup    apache maven-mvnd 0.7.1
 revision        0
 name            mvnd
 categories      java


### PR DESCRIPTION
#### Description

Maven Wrapper moved to new GitHub URL.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?