### PR TITLE
notcurses: update to 3.0.1

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        dankamongmen notcurses 3.0.0 v
+github.setup        dankamongmen notcurses 3.0.1 v
 github.tarball_from archive
 revision            0
 
@@ -26,13 +26,13 @@ master_sites-append https://github.com/dankamongmen/${name}/releases/download/v$
 distfiles-append    ${name}-doc-${version}${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  79b671c905ebe84fa14c1fac57ed7a1cd70a2b2e \
-                    sha256  b4839108ca8f9aef31d2f537485cbd878356bbcd4ad4f7a4dd19e72201d01cee \
-                    size    10101772 \
+                    rmd160  6074bb7d0559cdf4ce8da92ef6cd0b5e3d7d3e9d \
+                    sha256  32041c300e92fc0fe56c19e65d1d1e374e824c781dfcd4f959ab0dcdbb90cdb2 \
+                    size    10119898 \
                     ${name}-doc-${version}${extract.suffix} \
-                    rmd160  be4e3f82bd9dbab32189038ddb59fa63147af8f1 \
-                    sha256  90d48eba21f78fc7eabded6dc21709492d8dc201d085a30909bcda56fc384aeb \
-                    size    141494
+                    rmd160  73c5cd260121b378ad9b3644f0f1e378b0a7136c \
+                    sha256  43be760c5f2f4a7b2c9a9527254cd2bbdda8ad7d6f4fc7f841a776f0ee3cdd05 \
+                    size    145503
 
 extract.only        ${distname}${extract.suffix}
 


### PR DESCRIPTION
#### Description

Your friendly weeklyish Notcurses update.
https://github.com/dankamongmen/notcurses/releases/tag/v3.0.1

###### Type(s)

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
