### PR TITLE
qemu: restore `+gtk3` and `+sdl2` variants

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -190,32 +190,15 @@ variant curses description {Use the curses text-only user interface} {
 
 # XXX: gtk/sdl need libepoxy for OpenGL
 
-# XXX: Builds, but does not work as expected at runtime
-#variant gtk3 description {Build GTK+ GUI for GTK+ 3 (experimental)} conflicts cocoa curses gtk2 sdl sdl2 {
-#    configure.args-replace --disable-gtk --enable-gtk
-#    configure.args-append --with-gtkabi=3.0
-#    depends_lib-append     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 port:vte
-#}
+variant gtk3 description {Use the GTK+3 graphical user interface} conflicts cocoa {
+    configure.args-replace --disable-gtk --enable-gtk
+    depends_lib-append     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 port:vte
+}
 
-# XXX: Builds, but user input does not work at runtime
-#variant gtk2 description {Use the GTK+ 2 graphical user interface} conflicts cocoa curses gtk3 sdl sdl2 {
-#    configure.args-replace --disable-gtk --enable-gtk
-#    configure.args-append  --with-gtkabi=2.0
-#    depends_lib-append     path:lib/pkgconfig/gtk+-2.0.pc:gtk2 port:vte
-#}
-
-# XXX: Build broken due to missing X11 symbols
-#variant sdl description {Use the SDL graphical user interface} conflicts cocoa curses gtk2 gtk3 sdl sdl2 {
-#    configure.args-replace --disable-sdl --enable-sdl
-#    depends_lib-append      port:libsdl
-#}
-
-# XXX: Broken at runtime, screen flickers and input does not work
-#variant sdl2 description {Use the SDL 2 graphical user interface} conflicts cocoa curses {
-#    configure.args-replace --disable-sdl --enable-sdl
-#    configure.args-append --with-sdlabi=2.0
-#    depends_lib-append      port:libsdl2
-#}
+variant sdl2 description {Use the SDL 2 graphical user interface} conflicts cocoa {
+    configure.args-replace --disable-sdl --enable-sdl
+    depends_lib-append      port:libsdl2
+}
 
 variant usb description {Support forwarding of USB devices to the guest} {
     configure.args-replace  --disable-libusb --enable-libusb


### PR DESCRIPTION
#### Description

The old warnings no longer seem to apply. SDL and GTK do not conflict with each other, and can be specified at run-time with `-display sdl` or `-display gtk`.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
