### PR TITLE
Update rtl_433 to the new 21.12 release

### DIFF
--- a/science/rtl_433/Portfile
+++ b/science/rtl_433/Portfile
@@ -5,8 +5,8 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 epoch               1
-github.setup        merbanan rtl_433 21.05
-revision            1
+github.setup        merbanan rtl_433 21.12
+revision            0
 
 categories          science comms
 license             GPL-2
@@ -16,9 +16,9 @@ maintainers         {@ducksauz duksta.org:john} openmaintainer
 description         RTL-SDR 433.92 MHz generic data receiver
 long_description    rtl_433 turns your Realtek RTL2832 based DVB dongle into a 433.92 MHz generic data receiver
 
-checksums           rmd160  d10ab6c0fb91225bf41a75faa47b500f922b3391 \
-                    sha256  35fecc2575ade4ad8a84b221271181de7b2bd8dee5700fb12f05fcf33d9ae592 \
-                    size    915727
+checksums           rmd160  2610e3882d83877c291f9a2cef421e03470135b1 \
+                    sha256  8bc1866f61f8c2b4f6140c7b9ce159187e5ab821ecfba1ae2e35cde34423b8b9 \
+                    size    954737
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

Update rtl_433 to the new 21.12 release

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
