### PR TITLE
ghidra: update to 10.1.1 [CVE-2021-44228]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ Portfile~
 *.patch~
 
 .DS_Store
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Portfile~
 *.patch~
 
 .DS_Store
+*.swp

--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -4,17 +4,17 @@ PortSystem          1.0
 PortGroup           app 1.0
 PortGroup           github 1.0
 
-github.setup        NationalSecurityAgency ghidra 10.1
+github.setup        NationalSecurityAgency ghidra 10.1.1 Ghidra_ _build
+set filedate        20211221
+revision            0
+checksums           rmd160  fa62c4dcf356b27ce9a1f6ad5b41b623171b87b1 \
+                    sha256  d4ee61ed669cec7e20748462f57f011b84b1e8777b327704f1646c0d47a5a0e8 \
+                    size    348978464
+
 homepage            https://ghidra-sre.org/
 github.tarball_from releases
-git.branch          Ghidra_${version}_build
-master_sites-append ${github.homepage}/releases/download/${git.branch} ${homepage}
 use_zip             yes
-distname            ${name}_${version}_PUBLIC_20211210
-checksums           rmd160  067b14d79a0b7c852b303781a57a8dca74d6077b \
-                    sha256  99139c4a63a81135b3b63fe9997a012a6394a766c2c7f2ac5115ab53912d2a6c \
-                    size    348995964
-revision            0
+distname            ${name}_${version}_PUBLIC_${filedate}
 
 categories          devel
 maintainers         {1e0.co.uk:dev @hexagonal-sun} openmaintainer

--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -2,17 +2,19 @@
 
 PortSystem          1.0
 PortGroup           app 1.0
+PortGroup           github 1.0
 
-name                ghidra
+github.setup        NationalSecurityAgency ghidra 10.1
 homepage            https://ghidra-sre.org/
-master_sites        ${homepage}
-version             9.2.2
+github.tarball_from releases
+git.branch          Ghidra_${version}_build
+master_sites-append ${github.homepage}/releases/download/${git.branch} ${homepage}
 use_zip             yes
-distname            ${name}_${version}_PUBLIC_20201229
-checksums           rmd160  2b7a239329ba515010ff52725da08eb656f168f7 \
-                    sha256  8cf8806dd5b8b7c7826f04fad8b86fc7e07ea380eae497f3035f8c974de72cf8 \
-                    size    317805407
-revision            1
+distname            ${name}_${version}_PUBLIC_20211210
+checksums           rmd160  067b14d79a0b7c852b303781a57a8dca74d6077b \
+                    sha256  99139c4a63a81135b3b63fe9997a012a6394a766c2c7f2ac5115ab53912d2a6c \
+                    size    348995964
+revision            0
 
 categories          devel
 maintainers         {1e0.co.uk:dev @hexagonal-sun} openmaintainer


### PR DESCRIPTION
* switch to github portgroup
* fixes log4j vulnerability

Closes: https://trac.macports.org/ticket/64199

###### Type(s)
- [x] security fix

###### Tested on
macOS 11.6.2 20G314 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
- [x] checked your Portfile with `port -v  lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
