### PR TITLE
gscan2pdf: new port + its perl dependencies

### DIFF
--- a/graphics/gscan2pdf/Portfile
+++ b/graphics/gscan2pdf/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+name                gscan2pdf
+version             2.12.4
+revision            0
+
+categories          graphics
+maintainers         nomaintainer
+license             GPL-3
+description         A GUI to produce PDFs or DjVus from scanned documents
+long_description    ${description}
+
+homepage            http://gscan2pdf.sourceforge.net
+master_sites        sourceforge
+use_xz              yes
+
+checksums           rmd160  d800f0f54214763dacf0847f5eece92dcd076b65 \
+                    sha256  52b06dd1091293b20fe26658168c4534943542671be7709e9af9587ecc6367fb \
+                    size    503792
+
+depends_lib         port:ImageMagick \
+                    port:librsvg \
+                    port:p${perl5.major}-config-general \
+                    port:p${perl5.major}-date-calc \
+                    port:p${perl5.major}-filesys-df \
+                    port:p${perl5.major}-goocanvas2 \
+                    port:p${perl5.major}-gtk3 \
+                    port:p${perl5.major}-gtk3-imageview \
+                    port:p${perl5.major}-gtk3-simplelist \
+                    port:p${perl5.major}-image-sane \
+                    port:p${perl5.major}-ipc-system-simple \
+                    port:p${perl5.major}-list-moreutils \
+                    port:p${perl5.major}-locale-gettext \
+                    port:p${perl5.major}-log-log4perl \
+                    port:p${perl5.major}-pdf-builder \
+                    port:p${perl5.major}-perlmagick \
+                    port:p${perl5.major}-proc-processtable \
+                    port:p${perl5.major}-readonly \
+                    port:p${perl5.major}-set-intspan \
+                    port:p${perl5.major}-sub-override \
+                    port:p${perl5.major}-try-tiny \
+                    port:sane-backends \
+                    port:tiff \
+
+configure.cmd       ${perl5.bin}
+configure.pre_args  Makefile.PL --prefix=${prefix}
+
+post-destroot {
+    ln -s ${prefix}/libexec/perl${perl5.major}/sitebin/gscan2pdf \
+        ${destroot}${prefix}/bin/
+    file delete ${destroot}${prefix}/lib/perl5/${perl5.major}/darwin-thread-multi-2level/perllocal.pod
+}
+
+notes "
+gscan2pdf can also use any of these optional packages you may install:
+- sane-frontends (for scanadf frontend)
+- djvulibre (for djvu format support)
+- any of tesseract, gocr, cuneiform (for OCR)
+- pdftk (for encrypted PDF)
+- unpaper (post-processing tool for scanned pages)
+- xdg-utils (to send Pdf per e-mail)
+"

--- a/perl/p5-carp-always/Portfile
+++ b/perl/p5-carp-always/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Carp-Always 0.16
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         Carp::Always - Warns and dies noisily with stack backtraces
+long_description    ${description}
+
+checksums           rmd160  dd5a577595679c9a39a6045cfc7fda7ae8771e7c \
+                    sha256  98aa11492171c016fb0827581ab1fa5ed01b1e99c6357489ddf3a827315866f1 \
+                    size    13386
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-test-base
+
+    supported_archs noarch
+}

--- a/perl/p5-filesys-df/Portfile
+++ b/perl/p5-filesys-df/Portfile
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Filesys-Df 0.92
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         Filesys::Df - Perl extension for filesystem disk space information.
+long_description    ${description}
+
+checksums           rmd160  8baf50df114f3b5af70df8b9c0cb005b5558ee67 \
+                    sha256  fe89cbb427e0e05f1cd97c2dd6d3866ac6b21bc7a85734ede159bdc35479552a \
+                    size    7113
+
+if {${perl5.major} != ""} {
+    supported_archs noarch
+}

--- a/perl/p5-goocanvas2/Portfile
+++ b/perl/p5-goocanvas2/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         GooCanvas2 0.06 ../../authors/id/P/PE/PERLMAX
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         GooCanvas2 - Perl binding for GooCanvas2 widget using Glib::Object::Introspection
+long_description    ${description}
+
+checksums           rmd160  cd23f89e0ec69a46c675d105f7b83123754e83a8 \
+                    sha256  e24c87873e19063dd4d5e2c709caacf8c0ae8881044395bb865dc2b4fdd63b50 \
+                    size    4684
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-gtk3 \
+                    port:p${perl5.major}-glib-object-introspection \
+                    port:p${perl5.major}-test-base \
+                    port:goocanvas2
+
+    supported_archs noarch
+}

--- a/perl/p5-graphics-tiff/Portfile
+++ b/perl/p5-graphics-tiff/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Graphics-TIFF 18
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         Graphics::TIFF - Perl extension for the libtiff library
+long_description    ${description}
+
+checksums           rmd160  04d0eb33bd3c4ca2ab951ec873b20ab596291f59 \
+                    sha256  6d070045097deaa9c7706c958ab868d0b8e6622218bf06ab737d085c8659a514 \
+                    size    42102
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-extutils-depends \
+                    port:p${perl5.major}-extutils-pkgconfig \
+                    port:p${perl5.major}-readonly \
+                    port:p${perl5.major}-test-deep \
+                    port:p${perl5.major}-test-requires \
+                    port:p${perl5.major}-test-simple \
+                    port:tiff
+
+    supported_archs noarch
+}

--- a/perl/p5-gtk3-imageview/Portfile
+++ b/perl/p5-gtk3-imageview/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Gtk3-ImageView 10 ../../authors/id/A/AS/ASOKOLOV
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         Gtk3::ImageView - Image viewer widget for Gtk3
+long_description    ${description}
+
+checksums           rmd160  f16303312f5f0842b2ddc29ddf665c9490b8c3db \
+                    sha256  bc77e706069e64f2bb84181970fd4a8dea46f88bec0c4dd7c2b1fd538c6837e6 \
+                    size    28165
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-cairo \
+                    port:p${perl5.major}-carp-always \
+                    port:p${perl5.major}-glib \
+                    port:p${perl5.major}-gtk3 \
+                    port:p${perl5.major}-perlmagick \
+                    port:p${perl5.major}-readonly \
+                    port:p${perl5.major}-scalar-list-utils \
+                    port:p${perl5.major}-test-deep \
+                    port:p${perl5.major}-test-mockobject \
+                    port:p${perl5.major}-test-simple \
+                    port:p${perl5.major}-try-tiny \
+                    port:xauth
+
+    supported_archs noarch
+}

--- a/perl/p5-gtk3-simplelist/Portfile
+++ b/perl/p5-gtk3-simplelist/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Gtk3-SimpleList 0.21 ../../authors/id/T/TV/TVIGNAUD
+license             LGPL-2.1
+maintainers         nomaintainer
+description         Gtk3::SimpleList - A simple interface to Gtk3's complex MVC list widget
+long_description    ${description}
+
+checksums           rmd160  bfb3aeb74e4122d42359e9cdb5eb7bf12173324e \
+                    sha256  1d4465100bf3bc0474a29469a406fd033562b6e3736188121000372ab2ada884 \
+                    size    19124
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-gtk3
+
+    supported_archs noarch
+}

--- a/perl/p5-image-png-libpng/Portfile
+++ b/perl/p5-image-png-libpng/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Image-PNG-Libpng 0.57
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         Image::PNG::Libpng is a Perl library for accessing the contents of \
+                    PNG (Portable Network Graphics) images.
+long_description    ${description}
+
+checksums           rmd160  2f3b5be4ff3a092a3e3927a829e485d50a5318e9 \
+                    sha256  909b1c4118eab82c812104602a1c4784cdb0efd400e410bda6710994b85ee8a0 \
+                    size    870387
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:libpng \
+                    port:zlib
+
+    supported_archs noarch
+}

--- a/perl/p5-image-sane/Portfile
+++ b/perl/p5-image-sane/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Image-Sane 5
+license             LGPL-2.1
+maintainers         nomaintainer
+description         Image::Sane - Perl extension for the SANE (Scanner Access Now Easy) Project
+long_description    ${description}
+
+checksums           rmd160  f313d74d543823d613938306067ae4670f6bbdd9 \
+                    sha256  229aa0e9f049efa760f3c2f6e61d9d539af43d8f764b50a6e03064b4729a35ff \
+                    size    47781
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:ImageMagick \
+                    port:p${perl5.major}-exception-class \
+                    port:p${perl5.major}-extutils-depends \
+                    port:p${perl5.major}-extutils-pkgconfig \
+                    port:p${perl5.major}-readonly \
+                    port:p${perl5.major}-test-requires \
+                    port:p${perl5.major}-try-tiny \
+                    port:sane-backends
+
+    supported_archs noarch
+}

--- a/perl/p5-pdf-builder/Portfile
+++ b/perl/p5-pdf-builder/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         PDF-Builder 3.023
+license             LGPL-2.1
+maintainers         nomaintainer
+description         PDF::Builder - Facilitates the creation and modification of PDF files
+long_description    ${description}
+
+checksums           rmd160  5ee169f2e6538ab16cac6a9dd83c1eafbad90000 \
+                    sha256  6baaaa1949a42281886568ec699c302ccd11daa6c0ad4fe3911374ccca5eb49a \
+                    size    7561436
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:ghostscript \
+                    port:ImageMagick \
+                    port:p${perl5.major}-font-ttf \
+                    port:p${perl5.major}-gd \
+                    port:p${perl5.major}-graphics-tiff \
+                    port:p${perl5.major}-image-png-libpng \
+                    port:p${perl5.major}-io-compress \
+                    port:p${perl5.major}-test-exception \
+                    port:p${perl5.major}-test-memory-cycle \
+
+    supported_archs noarch
+}

--- a/perl/p5-set-intspan/Portfile
+++ b/perl/p5-set-intspan/Portfile
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Set-IntSpan 1.19
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         Set::IntSpan - Manages sets of integers
+long_description    ${description}
+
+checksums           rmd160  1b46da5ef90168c600f8874e7633a74aacdc8c3b \
+                    sha256  11b7549b13ec5d87cc695dd4c777cd02983dd5fe9866012877fb530f48b3dfd0 \
+                    size    26640
+
+if {${perl5.major} != ""} {
+    supported_archs noarch
+}


### PR DESCRIPTION
I'm not sure if it is accepted to commit all the dependencies at the same time. But since these dependencies are nested I thought it would be better that way.

gscan2pdf: A GUI to produce PDFs or DjVus from scanned documents

Perl dependencies: new ports:
- p5-carp-always
- p5-filesys-df
- p5-goocanvas2
- p5-graphics-tiff
- p5-gtk3-imageview
- p5-gtk3-simplelist
- p5-image-png-libpng
- p5-image-sane
- p5-pdf-builder
- p5-set-intspan

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
