### PR TITLE
openmpi/mpich: enable support for clang12 and clang13

### DIFF
--- a/_resources/port1.0/group/mpi-1.0.tcl
+++ b/_resources/port1.0/group/mpi-1.0.tcl
@@ -322,11 +322,6 @@ proc mpi.setup {args} {
             -gcc49 -gcc5 -gcc6 -gcc8 \
             -gccdevel
 
-        # Disable clang 12/13 unconditionally, as not yet supported for openmpi/mpich
-        lappend ::mpi.disabled_compilers \
-            -clang12 \
-            -clang13
-
         # gcc 9+ only available on OS X 10.7 (Darwin11) and newer
         # However, gcc9+ subports fail to build on 10.7, for both openmpi and mpich.
         # So only enable for 10.8+.

--- a/science/mpi-doc/Portfile
+++ b/science/mpi-doc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 # make sure to keep in sync with mpich
 name                mpi-doc
-version             3.4.2
+version             4.0.1
 revision            0
 
 license             BSD
@@ -21,9 +21,9 @@ long_description    ${description}
 master_sites        ${homepage}static/tarballs/${version}/
 distname            mpich-${version}
 
-checksums           rmd160  334df002a4bf6794d96cdfc187d35601bd6fe40b \
-                    sha256  5c19bea8b84e8d74cca5f047e82b147ff3fba096144270e3911ad623d6c587bf \
-                    size    32850822
+checksums           rmd160  5074ee23bdb6f44b70033ea5d798ebf1c8bea724 \
+                    sha256  66a1fe8052734af2eb52f47808c4dfef4010ceac461cb93c42b99acfb1a43687 \
+                    size    38146191
 
 dist_subdir         mpich
 

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -20,7 +20,7 @@ PortGroup           mpiutil 1.0
 
 # make sure to keep in sync with mpi-doc
 name                mpich
-version             3.4.2
+version             4.0.1
 revision            0
 
 license             BSD
@@ -48,9 +48,9 @@ homepage            https://www.mpich.org/
 master_sites        ${homepage}static/downloads/${version}
 
 checksums \
-                    rmd160  334df002a4bf6794d96cdfc187d35601bd6fe40b \
-                    sha256  5c19bea8b84e8d74cca5f047e82b147ff3fba096144270e3911ad623d6c587bf \
-                    size    32850822
+    rmd160  5074ee23bdb6f44b70033ea5d798ebf1c8bea724 \
+    sha256  66a1fe8052734af2eb52f47808c4dfef4010ceac461cb93c42b99acfb1a43687 \
+    size    38146191
 
 livecheck.type      regex
 livecheck.regex     {href=.([0-9.p]+)/}
@@ -85,12 +85,16 @@ if { ${os.major} >= 11 } {
 if { ${os.arch} eq "arm" } {
     # disable unreliable clang versions for ARM
     dict set clist clang11 {macports-clang-11}
+    dict set clist clang12 {macports-clang-12}
+    dict set clist clang13 {macports-clang-13}
     lappend clist_unsupported \
         clang90 clang10
 } else {
     dict set clist clang90 {macports-clang-9.0}
     dict set clist clang10 {macports-clang-10}
     dict set clist clang11 {macports-clang-11}
+    dict set clist clang12 {macports-clang-12}
+    dict set clist clang13 {macports-clang-13}
 }
 
 # gcc 9+ only available on macOS10.7 (Darwin11) and newer

--- a/science/mpich/files/portselect/mpich-clang12
+++ b/science/mpich/files/portselect/mpich-clang12
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-clang12
+bin/mpichversion-mpich-clang12
+bin/mpicxx-mpich-clang12
+bin/mpiexec-mpich-clang12
+bin/mpirun-mpich-clang12
+-
+-
+bin/parkill-mpich-clang12
+lib/mpich-clang12/pkgconfig/mpich.pc
+-
+-

--- a/science/mpich/files/portselect/mpich-clang12-fortran
+++ b/science/mpich/files/portselect/mpich-clang12-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-clang12
+bin/mpichversion-mpich-clang12
+bin/mpicxx-mpich-clang12
+bin/mpiexec-mpich-clang12
+bin/mpirun-mpich-clang12
+bin/mpif77-mpich-clang12
+bin/mpif90-mpich-clang12
+bin/parkill-mpich-clang12
+lib/mpich-clang12/pkgconfig/mpich.pc
+-
+bin/mpifort-mpich-clang12

--- a/science/mpich/files/portselect/mpich-clang13
+++ b/science/mpich/files/portselect/mpich-clang13
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-clang13
+bin/mpichversion-mpich-clang13
+bin/mpicxx-mpich-clang13
+bin/mpiexec-mpich-clang13
+bin/mpirun-mpich-clang13
+-
+-
+bin/parkill-mpich-clang13
+lib/mpich-clang13/pkgconfig/mpich.pc
+-
+-

--- a/science/mpich/files/portselect/mpich-clang13-fortran
+++ b/science/mpich/files/portselect/mpich-clang13-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-clang13
+bin/mpichversion-mpich-clang13
+bin/mpicxx-mpich-clang13
+bin/mpiexec-mpich-clang13
+bin/mpirun-mpich-clang13
+bin/mpif77-mpich-clang13
+bin/mpif90-mpich-clang13
+bin/parkill-mpich-clang13
+lib/mpich-clang13/pkgconfig/mpich.pc
+-
+bin/mpifort-mpich-clang13

--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -20,7 +20,7 @@ PortGroup           mpiutil 1.0
 #===============================================================================
 
 name                openmpi
-version             4.1.1
+version             4.1.2
 revision            0
 
 license             BSD
@@ -42,9 +42,9 @@ set branch          [join [lrange [split ${version} .] 0 1] .]
 set subdir          ompi/v${branch}/downloads/
 master_sites        https://www.open-mpi.org/software/${subdir}
 
-checksums           rmd160  60fff94c4c7a4bfaaa11285f35d76265516ed8b0 \
-                    sha256  e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda \
-                    size    10052770
+checksums           rmd160  db9b532e22879aab111f5f02d1814ee7a9abaee4 \
+                    sha256  9b78c7cf7fc32131c5cf43dd2ab9740149d9d87cadb2e2189f02685749a6b527 \
+                    size    10084596
 
 use_bzip2           yes
 
@@ -81,12 +81,16 @@ if { ${os.major} >= 11 } {
 if { ${os.arch} eq "arm" } {
     # disable unreliable clang versions for ARM
     dict set clist clang11 {macports-clang-11}
+    dict set clist clang12 {macports-clang-12}
+    dict set clist clang13 {macports-clang-13}
     lappend clist_unsupported \
         clang90 clang10
 } else {
     dict set clist clang90 {macports-clang-9.0}
     dict set clist clang10 {macports-clang-10}
     dict set clist clang11 {macports-clang-11}
+    dict set clist clang12 {macports-clang-12}
+    dict set clist clang13 {macports-clang-13}
 }
 
 # gcc 9+ only available on macOS10.7 (Darwin11) and newer

--- a/science/openmpi/files/portselect/openmpi-clang12
+++ b/science/openmpi/files/portselect/openmpi-clang12
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang12
+-
+bin/mpicxx-openmpi-clang12
+bin/mpiexec-openmpi-clang12
+bin/mpirun-openmpi-clang12
+-
+-
+-
+lib/openmpi-clang12/pkgconfig/ompi.pc
+lib/openmpi-clang12/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/portselect/openmpi-clang12-fortran
+++ b/science/openmpi/files/portselect/openmpi-clang12-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang12
+-
+bin/mpicxx-openmpi-clang12
+bin/mpiexec-openmpi-clang12
+bin/mpirun-openmpi-clang12
+bin/mpif77-openmpi-clang12
+bin/mpif90-openmpi-clang12
+-
+lib/openmpi-clang12/pkgconfig/ompi.pc
+lib/openmpi-clang12/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang12

--- a/science/openmpi/files/portselect/openmpi-clang13
+++ b/science/openmpi/files/portselect/openmpi-clang13
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang13
+-
+bin/mpicxx-openmpi-clang13
+bin/mpiexec-openmpi-clang13
+bin/mpirun-openmpi-clang13
+-
+-
+-
+lib/openmpi-clang13/pkgconfig/ompi.pc
+lib/openmpi-clang13/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/portselect/openmpi-clang13-fortran
+++ b/science/openmpi/files/portselect/openmpi-clang13-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang13
+-
+bin/mpicxx-openmpi-clang13
+bin/mpiexec-openmpi-clang13
+bin/mpirun-openmpi-clang13
+bin/mpif77-openmpi-clang13
+bin/mpif90-openmpi-clang13
+-
+lib/openmpi-clang13/pkgconfig/ompi.pc
+lib/openmpi-clang13/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang13


### PR DESCRIPTION
#### Description

[Maintainer updates] mpich to 3.4.3

Add clang12 and 13 to mpich/openmpi.

See https://trac.macports.org/ticket/63608 ... note I haven't done anything on implicit function declarations here.

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 11.6.2 20G314 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] * tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] * tested basic functionality of all binary files?
* == for mpich
