### PR TITLE
font-spleen: new port

### DIFF
--- a/x11/font-spleen/Portfile
+++ b/x11/font-spleen/Portfile
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                font-spleen
+github.setup        fcambus spleen 1.9.1
+github.tarball_from releases
+revision            0
+categories          x11 x11-font graphics fonts
+maintainers         {@ryanakca debian.org:rak} openmaintainer
+license             BSD
+description         monospaced bitmapped font
+long_description    ${description} available in six sizes: 5x8, 6x12, 8x16 \
+                    12x24, 16x32, 32x64. All font sizes contain all ISO/IEC \
+                    8859-1 characters (Basic Latin and Latin-1 Supplement \
+                    Unicode block), Latin Extended-A characters, as well \
+                    as Box Drawing, Block Elements, and Braille Patterns \
+                    Unicode blocks, except for the 5x8 and the 6x12 versions.
+
+checksums           rmd160 31e639ff9f61bb634ccbca8f8e992014739b17fa \
+                    sha256 7ef59c4e02a45e9dded6bca18b539cdf0f0eb49e6cbcb257858da56ac5daa622 \
+                    size 425960
+
+supported_archs     noarch
+
+depends_build       bin:gzip:gzip
+depends_lib         port:fontconfig port:mkfontscale
+
+set x11fontdir      ${prefix}/share/fonts/misc
+set otffontdir      ${prefix}/share/fonts/OTF
+
+set otfsizes        {6x12 8x16 12x24 16x32 32x64}
+set x11sizes        {5x8 6x12 8x16 12x24 16x32 32x64}
+
+use_configure       no
+
+build {
+    foreach size ${x11sizes} {
+        system "gzip -9 ${worksrcpath}/spleen-${size}.pcf"
+    }
+}
+
+destroot {
+    xinstall -d -m 0755 ${destroot}/${x11fontdir} ${destroot}/${otffontdir}
+    foreach size ${x11sizes} {
+        xinstall ${worksrcpath}/spleen-${size}.pcf.gz ${destroot}/${x11fontdir}
+    }
+    foreach size ${otfsizes} {
+        xinstall ${worksrcpath}/spleen-${size}.otf ${destroot}/${otffontdir}
+    }
+}
+
+post-activate {
+    system "mkfontscale ${x11fontdir}"
+    system "mkfontdir ${x11fontdir}"
+    system "fc-cache ${x11fontdir} ${otffontdir}"
+}
+
+post-deactivate {
+    system "mkfontscale ${x11fontdir}"
+    system "mkfontdir ${x11fontdir}"
+    system "fc-cache ${x11fontdir} ${otffontdir}"
+}


### PR DESCRIPTION
#### Description

Provides the Spleen monospace font, which is the default console font on OpenBSD.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
