### PR TITLE
mysql8: no reason to avoid clang 8-9

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -90,11 +90,6 @@ if {$subport eq $name} {
     # /usr/include/c++/v1/optional:960:34: note: candidate function not viable: no known conversion from 'optional<...>' to 'const optional<...>' for object argument
     compiler.blacklist-append {clang < 1100}
 
-    # clang 8.0+ are too strict to build this port
-    # version:1:1: error: C++ requires a type specifier for all declarations
-    # MYSQL_VERSION_MAJOR=8
-    compiler.blacklist-append {macports-clang-[8-9].0}
-
     # Use default CMake build_types
     if {[variant_isset debug]} {
         cmake.build_type    Debug


### PR DESCRIPTION
I now recognize that the error encountered in https://github.com/macports/macports-ports/pull/5363#issuecomment-533984148 was actually due to the VERSION file in source distribution, when extracted to case-insensitive filesystem, conflicting with the C++20 &lt;version&gt; header—an issue since encountered in many other ports, and not because clang 8-9 are “too strict”. Resolved upstream since 8.0.22 by renaming VERSION to MYSQL_VERSION: https://github.com/mysql/mysql-server/commit/51675ddb41661163c23e802a3e5eedb1344ce023

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
