### PR TITLE
weechat: update to 3.4

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -8,13 +8,12 @@ PortGroup           conflicts_build 1.0
 PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
-conflicts           weechat-devel
 name                weechat
-version             3.3
+version             3.4
 revision            0
-checksums           rmd160  f2c74ea964c1d6b09d5123ac8a9577ee3354188f \
-                    sha256  cafeab8af8be4582ccfd3e74fd40e5086a1efa158231f2c26b8b05c3950fcbdf \
-                    size    2564280
+checksums           rmd160  26d4141ab8e7ab2d3cfbbe9e3e9c33994fd374fb \
+                    sha256  7cd3dcc7029e888de49e13ebbcc3749586ff59c9d97f89f5eeb611067c7bb94c \
+                    size    2617640
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
@@ -78,30 +77,35 @@ configure.args-append \
 
 variant python requires python27 description {Compatibility variant, requires +python27} {}
 
-variant python27 description "Bindings for Python 2.7 plugins" conflicts python36 python37 python38 python39 {
+variant python27 description "Bindings for Python 2.7 plugins" conflicts python36 python37 python38 python39 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.args-replace  -DENABLE_PYTHON2=OFF -DENABLE_PYTHON2=ON
     depends_lib-append      port:python27
 }
 
-variant python36 description "Bindings for Python 3.6 plugins" conflicts python27 python37 python38 python39 {
+variant python36 description "Bindings for Python 3.6 plugins" conflicts python27 python37 python38 python39 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python36
 }
 
-variant python37 description "Bindings for Python 3.7 plugins" conflicts python27 python36 python38 python39 {
+variant python37 description "Bindings for Python 3.7 plugins" conflicts python27 python36 python38 python39 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python37
 }
 
-variant python38 description "Bindings for Python 3.8 plugins" conflicts python27 python36 python37 python39 {
+variant python38 description "Bindings for Python 3.8 plugins" conflicts python27 python36 python37 python39 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python38
 }
 
-variant python39 description "Bindings for Python 3.9 plugins" conflicts python27 python36 python37 python38 {
+variant python39 description "Bindings for Python 3.9 plugins" conflicts python27 python36 python37 python38 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python39
+}
+
+variant python310 description "Bindings for Python 3.10 plugins" conflicts python27 python36 python37 python38 python39 {
+    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    depends_lib-append      port:python310
 }
 
 post-patch {
@@ -117,6 +121,8 @@ post-patch {
         reinplace -E "s|PYTHON python3|PYTHON python-3.8|g" ${patchfile}
     } elseif {[variant_isset python39]} {
         reinplace -E "s|PYTHON python3|PYTHON python-3.9|g" ${patchfile}
+    } elseif {[variant_isset python310]} {
+        reinplace -E "s|PYTHON python3|PYTHON python-3.10|g" ${patchfile}
     }
 }
 


### PR DESCRIPTION
#### Description
weechat: update to 3.4
- remove conflict with weechat-devel: weechat-devel port removed in 1a76377c8e698ddb06536001b9d765f91a5f16ed
- add python310 variant

###### Tested on
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
