### PR TITLE
cwm: new port

### DIFF
--- a/x11/cwm/Portfile
+++ b/x11/cwm/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        leahneukirchen cwm 6.7 v
+github.tarball_from archive
+revision            0
+categories          x11
+platforms           darwin
+license             ISC
+maintainers         {@ryanakca debian.org:rak} openmaintainer
+description         OpenBSD's cwm --- calm window manager
+long_description    cwm is a window manager for X11 which contains many \
+                    features that concentrate on the efficiency and \
+                    transparency of window management. cwm also aims to \
+                    maintain the simplest and most pleasant aesthetic.
+
+checksums           rmd160  ace3484da689214c6c12a9d9cc66f6aef898df91 \
+                    sha256  fdd3d5b4fe9b1b03e1fc270d3dd5a031218589a8e40170e8438d2b9c44a35f08 \
+                    size    53172
+
+depends_lib         port:pkgconfig \
+                    port:Xft2 \
+                    port:xorg-libXinerama \
+                    port:xrandr


### PR DESCRIPTION
#### Description

calm window manager from openbsd

###### Type(s)


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.0.1 21A559 x86_64
Xcode 13.2.1 13C100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
