### PR TITLE
mod_tile: Handle conflict with boost port

### DIFF
--- a/gis/mod_tile/Portfile
+++ b/gis/mod_tile/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           active_variants 1.1
+PortGroup           boost 1.0
 PortGroup           github 1.0
 
 github.setup        openstreetmap mod_tile 0.5
@@ -27,6 +28,9 @@ long_description    mod_tile is a system to serve raster tiles for example to us
 checksums           rmd160  e6c2224c6500f695e4a17addc7d05086ce5bebd5 \
                     sha256  d730ec04f9dc01ac7e4f863130480451be849b5d14a632225b23957fe5da0aef \
                     size    182209
+
+# boost.version must follow that of the `mapnik` port.
+boost.version       1.69
 
 depends_build       port:apache2 \
                     port:iniparser


### PR DESCRIPTION
#### Description

The build fails if the `boost` port is installed.

This port depends on the `mapnik` port, which builds with Boost.

This application determines how `mapnik` was built during `configure`
via an M4 macro that makes calls to `mapnik-config` (installed with
the `mapnik` port) and adds appropriate flags for the libs and include
parameters, which will specify the correct Boost version for the
build.

This fix doesn't change the installed files, so I have not incremented the revision number.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.6.1 20G224 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
