### PR TITLE
virt-manager: prepend ${prefix}/bin and ${prefix}/sbin to app's PATH

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           app 1.0
 
 github.setup        virt-manager virt-manager 3.2.0 v
-revision            2
+revision            3
 categories          gnome emulators
 supported_archs     noarch
 maintainers         nomaintainer
@@ -78,13 +78,14 @@ post-patch {
     }
     unset f
 
-    reinplace "s|@PREFIX@|${prefix}|" \
+    reinplace "s|@PREFIX@|${prefix}|g" \
         ${worksrcpath}/virtManager/createconn.py
 }
 
 pre-configure {
     copy ${filespath}/virt-manager.sh ${workpath}
-    reinplace s+@PREFIX@+${prefix}+ ${workpath}/virt-manager.sh
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${workpath}/virt-manager.sh
 }
 
 set virtmgr_deps_validate \

--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -39,13 +39,16 @@ patchfiles-append   patch-setup.py-rst2man.diff
 
 python.default_version  39
 
+# Note: 'gettext' only needed at build time. No need for a runtime dep on
+# 'gettext-runtime', as this port utilizes Python's built-in 'gettext' support.
 depends_build \
+    port:gettext \
     port:intltool \
     path:lib/pkgconfig/gtk+-2.0.pc:gtk2 \
     port:python${python.version} \
     port:py${python.version}-docutils \
-    bin:podman:perl5 \
     path:lib/pkgconfig/glib-2.0.pc:glib2
+
 depends_run \
     port:py${python.version}-gobject3 \
     port:py${python.version}-libvirt \

--- a/gnome/virt-manager/files/virt-manager.sh
+++ b/gnome/virt-manager/files/virt-manager.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+PATH=@PREFIX@/bin:@PREFIX@/sbin:${PATH:-$(/usr/bin/getconf PATH)}
 exec @PREFIX@/bin/virt-manager --no-fork "$@"


### PR DESCRIPTION
#### Description

Makes virt-manager prefer MacPorts' binaries, e.g. /opt/local/bin/ssh.
Thus fixing errors that may occur because virt-manager is using macOS shipped binaries lacking some options present in the (mostly newer) MacPorts versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
