### PR TITLE
py-numpy: fix rpath in all applicable .so files

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -18,7 +18,7 @@ github.setup            numpy numpy 1.21.4 v
 checksums               rmd160  a49a39752d2fbe9db8d151541666566dd4f60432 \
                         sha256  5d412381aa489b8be82ac5c6a9e99c3eb3f754245ad3f90ab5c339d92f25fb47 \
                         size    9766310
-revision                0
+revision                1
 
 if {${name} ne ${subport}} {
     # the python PortGroup puts compiler names in build.env and destroot.env
@@ -54,7 +54,7 @@ if {${name} ne ${subport}} {
         checksums           rmd160  cbb34cf0981ea142ff45722d05a9daad20a134ea \
                             sha256  2dce87065d5de1a83485cfb3de5e4e793787890f5c1dcc3536a9cabf2e1620af \
                             size    4691852
-        revision            2
+        revision            3
         set PATCH_PY_EXT    ".27"
         patchfiles-append   patch-cpu-detection.py.27.patch
         livecheck.url       https://numpy.org/doc/stable/release.html
@@ -64,7 +64,7 @@ if {${name} ne ${subport}} {
         checksums           rmd160  c14f2725afe0f7420d69a6f9ed5744639a2d2b31 \
                             sha256  4a421fdf82dbb3dce7e62400f69c43722b530db109c3321c6c95452f166560d9 \
                             size    5167349
-        revision            1
+        revision            2
         patchfiles-append   patch-cpu-detection.py.35.patch
         set PATCH_PY_EXT    ".35"
         livecheck.url       https://numpy.org/doc/stable/release.html
@@ -74,7 +74,7 @@ if {${name} ne ${subport}} {
         checksums           rmd160 66861032bbd7c1f7e7741d913c9edf6c0b8be68a \
                             sha256 40e0a919cb8741556f8402cb7ec862b3b27903725ba59af44fd5b88620c5a7e1 \
                             size   7037758
-        revision            0
+        revision            1
         # because I pushed 1.20 and it requires Py37+ and so reverting back to 1.19
         epoch               1
         set PATCH_PY_EXT    ".36"
@@ -122,8 +122,11 @@ if {${name} ne ${subport}} {
 
         # set absolute path to remove references to @rpath/libmkl_rt.2.dylib
         post-destroot {
-            system "install_name_tool -change @rpath/libmkl_rt.2.dylib ${python.prefix}/lib/libmkl_rt.2.dylib ${destroot}${python.pkgd}/numpy/core/_multiarray_umath.cpython-${python.version}-darwin.so"
-            system "install_name_tool -change @rpath/libmkl_rt.2.dylib ${python.prefix}/lib/libmkl_rt.2.dylib ${destroot}${python.pkgd}/numpy/linalg/lapack_lite.cpython-${python.version}-darwin.so"
+            foreach dirname [glob -types d ${destroot}${python.pkgd}/numpy/*] {
+                foreach soname [glob -nocomplain -directory ${dirname}/ *.so] {
+                    system "install_name_tool -change @rpath/libmkl_rt.2.dylib ${python.prefix}/lib/libmkl_rt.2.dylib ${soname}"
+                }
+            }
         }
     }
 


### PR DESCRIPTION
#### Description
I missed one occurrence of rpath in a .so file when adding the MKL variant. Instead of specifying the files manually, use `glob` to use `install_name_tool` on all .so files.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
