### PR TITLE
boost*: Enable context/coroutines on 10.6

### DIFF
--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -6,7 +6,7 @@ PortGroup       active_variants 1.1
 PortGroup       compiler_blacklist_versions 1.0
 
 version         1.69.0
-revision        5
+revision        6
 
 set branch      [join [lrange [split ${version} .] 0 1] .]
 set tag         [string map {. {}} ${branch}]
@@ -126,7 +126,8 @@ if {[string match *gcc* ${configure.compiler}]} {
     configure.args-append --with-toolset=gcc
 }
 
-if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+# makecontext/swapcontext introduced in 10.6
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
     configure.args-append   --without-libraries=context \
                             --without-libraries=coroutine
 }

--- a/devel/boost171/Portfile
+++ b/devel/boost171/Portfile
@@ -137,7 +137,8 @@ if {[string match *gcc* ${configure.compiler}]} {
     configure.args-append --with-toolset=gcc
 }
 
-if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+# makecontext/swapcontext introduced in 10.6
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
     configure.args-append   --without-libraries=context \
                             --without-libraries=coroutine
 }
@@ -326,7 +327,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 2
+    revision 3
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost173/Portfile
+++ b/devel/boost173/Portfile
@@ -130,7 +130,8 @@ if {[string match *gcc* ${configure.compiler}]} {
     configure.args-append --with-toolset=gcc
 }
 
-if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+# makecontext/swapcontext introduced in 10.6
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
     configure.args-append   --without-libraries=context \
                             --without-libraries=coroutine
 }
@@ -317,7 +318,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 0
+    revision 1
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -165,7 +165,8 @@ if {[string match *gcc* ${configure.compiler}]} {
     configure.args-append --with-toolset=gcc
 }
 
-if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+# makecontext/swapcontext introduced in 10.6
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
     configure.args-append   --without-libraries=context \
                             --without-libraries=coroutine
 }
@@ -354,7 +355,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 2
+    revision 3
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost177/Portfile
+++ b/devel/boost177/Portfile
@@ -166,7 +166,8 @@ if {[string match *gcc* ${configure.compiler}]} {
     configure.args-append --with-toolset=gcc
 }
 
-if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+# makecontext/swapcontext introduced in 10.6
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
     configure.args-append   --without-libraries=context \
                             --without-libraries=coroutine
 }
@@ -355,7 +356,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 0
+    revision 1
 
     patchfiles-append patch-disable-numpy-extension.diff
 


### PR DESCRIPTION
#### Description

`makecontext`/`swapcontext` were introduced in 10.6; Boost context and coroutine modules compile just fine on that platform, but are excluded across all Boost versions. I'm guessing the `<=` rather than `<` was an oversight in an old Portfile. Update the logic and rev-bump so that 10.6 gets access to these modules.

Tested 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
