### PR TITLE
fq: new port

### DIFF
--- a/sysutils/fq/Portfile
+++ b/sysutils/fq/Portfile
@@ -1,0 +1,85 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/wader/fq 0.0.2 v
+github.tarball_from archive
+revision            0
+
+description         jq for binary formats
+long_description    \
+    {*}${description}. ${name} is a tool, language and set of decoders for \
+    inspecting binary data. In most cases ${name} works the same way as jq \
+    but instead of reading JSON it reads binary data. The result is a JSON \
+    compatible structures where each value has a bit range, symbolic \
+    interpretations and know how to be presented in a useful way.
+
+categories          sysutils
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+build.pre_args-append \
+    -ldflags \"-s -w -X main.version=${github.tag_prefix}${version}\"
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  5474a774ca80b2dd4873f0414b6418d07e2dabe8 \
+                        sha256  1bb7b968ba4ffe6f0dc8b080a2051719caebb96c244606468aecb2786640937b \
+                        size    1299179
+
+go.vendors          golang.org/x/text \
+                        lock    v0.3.7 \
+                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
+                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
+                        size    8356115 \
+                    golang.org/x/sys \
+                        lock    fe61309f8881 \
+                        rmd160  2c0fdafb1c6c4a5da26d0b1baf1ac34c15e2f664 \
+                        sha256  2c432aadeb689ce92c4c8e991bbba2a5a9770d7ca77d5b96829de88059ee300e \
+                        size    1253691 \
+                    github.com/wader/readline \
+                        lock    5a81f7707bac \
+                        rmd160  f4be465430c7030f175a2c12e6d1b0e5cae130af \
+                        sha256  771edd042e7017f4d9b7395062b89679dd2b1068dc3bfd2e12d9f2acffafcbc7 \
+                        size    38434 \
+                    github.com/wader/gojq \
+                        lock    3894ded312be \
+                        rmd160  963ab07945e5cf8f4d7cfe0c78db96d26fe477c5 \
+                        sha256  3232a5038ae371cfd830061ae52348f6b4da9249a9cd5c10f8c69d3b5e258215 \
+                        size    124814 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.4.3 \
+                        rmd160  0d356c5704da36a626d37a592924b44d283f4096 \
+                        sha256  ec44b30992a4bc81e7141cfe24521538aa693f0b99ff97868b5aa1e8370b49cc \
+                        size    28434 \
+                    github.com/itchyny/timefmt-go \
+                        lock    v0.1.3 \
+                        rmd160  4dd1de3c9370e88eba6fe3ade9048d0215a6184c \
+                        sha256  fa7d0e1fba7cc734d387d791fb4487c26e42a561d0945eb065f7453ea60a0424 \
+                        size    12817 \
+                    github.com/google/gopacket \
+                        lock    v1.1.19 \
+                        rmd160  4f1732d15d1f4057d37f8e8cdb6bbbcbd722cdd2 \
+                        sha256  546027e7edd39388cd5a8f265e30ba921ed452889eceaaecbc1484f20b350a21 \
+                        size    950824 \
+                    github.com/chzyer/test \
+                        lock    a1ea475d72b1 \
+                        rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
+                        sha256  98d0c7d1dec438459e31886d65190bb45f70c4ed73e35f5ab2f3b8de582ea309 \
+                        size    4007 \
+                    github.com/chzyer/logex \
+                        lock    v1.1.10 \
+                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
+                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
+                        size    4351


### PR DESCRIPTION
Port for [fq](https://github.com/wader/fq), a `jq`-like utility for binary formats.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
