### PR TITLE
py-soco: fixed tests

### DIFF
--- a/python/py-requests-mock/Portfile
+++ b/python/py-requests-mock/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-requests-mock
-version             1.8.0
+version             1.9.3
 revision            0
 
 platforms           darwin
@@ -18,11 +18,11 @@ long_description    ${python.rootname} provides a building block to stub out the
 
 homepage            https://requests-mock.readthedocs.io/
 
-checksums           sha256  e68f46844e4cee9d447150343c9ae875f99fa8037c6dcf5f15bf1fe9ab43d226 \
-                    rmd160  60952e442286478f73da16567cd0108b29c45cb1 \
-                    size    59794
+checksums           sha256  8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba \
+                    rmd160  cbcbb150f07ab4d5e5c1eadee0bf88782d557ed5 \
+                    size    67988
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-soco/Portfile
+++ b/python/py-soco/Portfile
@@ -34,10 +34,15 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-xmltodict
 
     depends_test-append \
-                    port:py${python.version}-pip \
-                    port:py${python.version}-wheel
+                    port:py${python.version}-pyflakes \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-requests-mock
 
     test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.args       -m 'not integration'
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description

It also updated py-requests-mock to the last version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->