### PR TITLE
onetbb: new port

### DIFF
--- a/devel/onetbb/Portfile
+++ b/devel/onetbb/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        oneapi-src oneTBB 2021.5.0 v
+github.tarball_from archive
+conflicts           tbb
+
+name                onetbb
+revision            0
+categories          devel parallel
+platforms           darwin
+license             Apache-2
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         oneAPI Threading Building Blocks
+
+long_description    oneTBB is a flexible C++ library that simplifies the work \
+                    of adding parallelism to complex applications, even if you \
+                    are not a threading expert.
+
+checksums           rmd160  edc575ac1a9423b12cdcd5e9aeec7c80d38c002e \
+                    sha256  e5b57537c741400cf6134b428fc1689a649d7d38d9bb9c1b6d64f092ea28178a \
+                    size    2463218
+
+depends_lib-append  port:hwloc
+
+compiler.cxx_standard  2011
+
+configure.args-append  -DTBB_TEST=OFF

--- a/devel/tbb/Portfile
+++ b/devel/tbb/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        intel tbb 2020.3 v
+conflicts           onetbb
 revision            0
 
 categories          devel


### PR DESCRIPTION
#### Description

oneAPI Threading Building Blocks

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?