### PR TITLE
onedpl: new port

### DIFF
--- a/devel/onedpl/Portfile
+++ b/devel/onedpl/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        oneapi-src oneDPL 2021.6.0 oneDPL- -release
+github.tarball_from archive
+
+name                onedpl
+revision            0
+categories          devel parallel
+platforms           darwin
+license             Apache-2
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         oneAPI DPC++ Library
+
+long_description    oneAPI DPC++ Library (oneDPL) provides high-productivity \
+                    APIs to developers, which can minimize Data Parallel C++ \
+                    (DPC++) programming efforts across devices for high \
+                    performance parallel applications.
+
+checksums           rmd160  82cc1afa2baa3ebae8ad6d8053286a085bcf6680 \
+                    sha256  c05738365b359e662234a25d7093314ba550f79ac8eb918e87116246b934470b \
+                    size    3671693
+
+depends_lib-append  port:onetbb
+
+post-extract {
+    reinplace "s|\${OUTPUT_DIR}|\$ENV{DESTDIR}\${OUTPUT_DIR}|g" \
+        ${worksrcpath}/cmake/scripts/generate_config.cmake
+}
+
+build {}


### PR DESCRIPTION
#### Description

oneAPI DPC++ Library

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?