### PR TITLE
mbtileserver: new port

### DIFF
--- a/gis/mbtileserver/Portfile
+++ b/gis/mbtileserver/Portfile
@@ -1,0 +1,165 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/consbio/mbtileserver 0.8.0 v
+revision            0
+categories          gis
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+license             ISC
+
+description         A simple Go-based server for map tiles stored in mbtiles format
+long_description    ${description}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  024779ee63481a981e40758df938dda817737d3c \
+                        sha256  dc495edfffd2875733f81b5876a6bebd921bb23f16a574666281b9b9b1af1d57 \
+                        size    1622813
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    496545a6307b \
+                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
+                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
+                        size    90145 \
+                    golang.org/x/time \
+                        lock    f0f3c7e86c11 \
+                        rmd160  12c83458da614277c6fb69ccda7b68e0302c82d8 \
+                        sha256  05cf5c1700d05a7e4732ba7f4ca0b238babad5c8d0bdbe57e5e224f8fbe8f697 \
+                        size    9629 \
+                    golang.org/x/text \
+                        lock    v0.3.7 \
+                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
+                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
+                        size    8356115 \
+                    golang.org/x/sys \
+                        lock    3b038e5940ed \
+                        rmd160  4f3add590457b00d70a590f8bbef1d617dbf5d56 \
+                        sha256  82f37d083589f99d7566a6dc8f32edd3812f92afc77d7f89c4565d7380b8ef78 \
+                        size    1254461 \
+                    golang.org/x/net \
+                        lock    491a49abca63 \
+                        rmd160  7671d08ec00027d57f4b9084dd0919b94bb88bb1 \
+                        sha256  347578522032cd741e84d0dfea82616dedae730416182c2ddb2351d5a6d500be \
+                        size    1226710 \
+                    golang.org/x/crypto \
+                        lock    4570a0811e8b \
+                        rmd160  603e958324fa5cbb605116b2e880297145f33efb \
+                        sha256  183fef0e64ee865da967f48f41bfecdd70ef1402a623539cbd53af7342a72713 \
+                        size    1734498 \
+                    github.com/valyala/fasttemplate \
+                        lock    v1.2.1 \
+                        rmd160  f825fd5196461afd7ac55c99ed2d55260b5c40d4 \
+                        sha256  ba85d4a0984ed43285a9cf853be7a3f2760426933bd5afdc0ae32d6d226538af \
+                        size    11551 \
+                    github.com/valyala/bytebufferpool \
+                        lock    v1.0.0 \
+                        rmd160  32bddf2031e54e583df580e989cfd9be2f51bda8 \
+                        sha256  849a2f097cc06fb40219bd350225e99bfdeb1e9105b428d72f07953f44808531 \
+                        size    5031 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/cobra \
+                        lock    v1.3.0 \
+                        rmd160  b396e2179691a23f82eae5bb5af09fef218dadf9 \
+                        sha256  173024e7070e355d6c597b648b7096120a36aad4edba2c4b4d54fbc4d074feba \
+                        size    169548 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.8.1 \
+                        rmd160  aeb4e5f2ea8112e787a72fba611605c4c87f42b5 \
+                        sha256  931c31f624d05136760b41a63f6bc146b79ac91776b4642cbd2026c2792e3aca \
+                        size    47184 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.14 \
+                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
+                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
+                        size    4705 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.12 \
+                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
+                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
+                        size    9805 \
+                    github.com/labstack/gommon \
+                        lock    v0.3.1 \
+                        rmd160  a4b2b3ca840130825eb90ba5160219e09044ad28 \
+                        sha256  4452d88fcb76c2bd8394cf412c12b9a4200db8390bde005198503aeb7e36db3a \
+                        size    12430 \
+                    github.com/labstack/echo \
+                        lock    v4.6.1 \
+                        rmd160  a4fcb11f9c65ddd1dd5941e3f7854e043e12f3ae \
+                        sha256  1d15f525c1306822db676f25d8e95f0f0dbbf658c9da5d7ce3840ff1a1a6e213 \
+                        size    357676 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/golang-jwt/jwt \
+                        lock    v3.2.2 \
+                        rmd160  358c4daf19c2fba8917970b6dfa258ba7a834123 \
+                        sha256  b9c616a2b0c17f2e9454a0807c03a3c6ff335bb097487633327283f969c53598 \
+                        size    39914 \
+                    github.com/getsentry/raven-go \
+                        lock    v0.2.0 \
+                        rmd160  c564a8e9061642f60d401b6ab5b26961feec3212 \
+                        sha256  690d7813db5510d0dc739335dc950519c6664cc47ce49029e9c817f4a0c896c1 \
+                        size    19245 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.5.1 \
+                        rmd160  c99fbad44a371ce38eb2bd5c6ef70fb4537952e3 \
+                        sha256  699405dfda2fe02a305bee66f58046adb43f426ac905f85d80710e36846b3768 \
+                        size    32714 \
+                    github.com/evalphobia/logrus_sentry \
+                        lock    v0.8.2 \
+                        rmd160  d51b09200a328f2f66ee9f12c7973b9c9abcfb70 \
+                        sha256  eab8b4b04abc22adc5afcb7f8d7483bf3c9759053ce2eb4e188546dbcd6c9476 \
+                        size    15461 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/certifi/gocertifi \
+                        lock    431795d63e8d \
+                        rmd160  2abdbe7f2c77cbf012637de9cb3a5ea42173b6ae \
+                        sha256  a06bb1869b1ef9fa2253eaaffc738deed98535e65c04b5fea6e03cbfb5879ec0 \
+                        size    121737 \
+                    github.com/brendan-ward/mbtiles-go \
+                        lock    553bc514bbdf \
+                        rmd160  e691ca4df079d3455b0707e21fb3bdba4dc9f7ff \
+                        sha256  998930ed8d4195df958090cdf9f23127e80d182810d1909ecc142c947546a49c \
+                        size    1231688 \
+                    crawshaw.io/sqlite \
+                        repo    github.com/crawshaw/sqlite \
+                        lock    v0.3.2 \
+                        rmd160  5f846e34da9e2193a7c52521f7f4e46509cb62bf \
+                        sha256  e92f48bb73aac61970219ec27c1c704f6e2baf0f61d095b08577ad76bbbbb832 \
+                        size    2308450 \
+                    crawshaw.io/iox \
+                        repo    github.com/crawshaw/iox \
+                        lock    c51c3df30797 \
+                        rmd160  6984ed21526199be83eb7f67c50f992289fda316 \
+                        sha256  d460cf405998a953839488826c13b94e179b8e6bb26ed0d81863a8add58c1a5b \
+                        size    13301
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
[**mbtileserver**](https://github.com/consbio/mbtileserver) is a simple Go-based server for map tiles stored in mbtiles format.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
