### PR TITLE
go: add go-devel subport for Go unstable branch, version 1.18beta1

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -12,6 +12,12 @@ epoch               2
 version             1.17.5
 revision            0
 
+# Subport for Go Unstable Version
+subport ${name}-devel {
+    version         1.18beta1
+    revision        0
+}
+
 homepage            https://golang.org
 
 categories          lang
@@ -31,11 +37,27 @@ long_description    \
     language that feels like a dynamically typed, interpreted language. Go \
     is developed by Google Inc.
 
-set go_src_dist     ${name}${version}.src${extract.suffix}
-set go_armbin_dist  ${name}${version}.darwin-arm64${extract.suffix}
-set go_amdbin_dist  ${name}${version}.darwin-amd64${extract.suffix}
+set go_src_dist     go${version}.src${extract.suffix}
+set go_armbin_dist  go${version}.darwin-arm64${extract.suffix}
+set go_amdbin_dist  go${version}.darwin-amd64${extract.suffix}
 
-checksums           ${go_src_dist} \
+if {$subport eq "${name}-devel"} {
+    # Go (DEVEL / UNSTABLE)
+    checksums       ${go_src_dist} \
+                    rmd160  d37a45365b7df68498764b3924efad7d90a95935 \
+                    sha256  418c028db14699cb5b2d4907ad3a419d79f789b31916ef8764867e4a78e653a1 \
+                    size    22750283 \
+                    ${go_armbin_dist} \
+                    rmd160  b9cdfa3db99e16c85a7753c5f9e6b702d890e99e \
+                    sha256  09b7718f2354acb9826eef27f8257ac41c77df6389b14e91af09b90f79f200e8 \
+                    size    137381896 \
+                    ${go_amdbin_dist} \
+                    rmd160  d65ca3fbba38b938674d0993384884c700f9c3e0 \
+                    sha256  013d6d427a9591711d6e05defc46c4086e2fb9dffbc41c9a0fce09192e6e8ede \
+                    size    143162528
+} else {
+    # Go (RELEASE)
+    checksums       ${go_src_dist} \
                     rmd160  306df91a527008768e41b7ed55d3588f0bf2a27e \
                     sha256  3defb9a09bed042403195e872dcbc8c6fae1485963332279668ec52e80a95a2d \
                     size    22186577 \
@@ -47,10 +69,11 @@ checksums           ${go_src_dist} \
                     rmd160  31ea569528efb343584ec9cd557574503d10dbf5 \
                     sha256  2db6a5d25815b56072465a2cacc8ed426c18f1d5fc26c1fc8c4f5a7188658264 \
                     size    136774992
+}
 
 master_sites        https://storage.googleapis.com/golang/
 distfiles           ${go_src_dist}
-worksrcdir          ${name}
+worksrcdir          ${subport}
 
 maintainers         {ciserlohn @ci42} \
                     {gmail.com:herby.gillot @herbygillot} \
@@ -59,7 +82,7 @@ maintainers         {ciserlohn @ci42} \
 extract.only        ${go_src_dist}
 
 set GOROOT          ${worksrcpath}
-set GOROOT_FINAL    ${prefix}/lib/${name}
+set GOROOT_FINAL    ${prefix}/lib/${subport}
 
 supported_archs     arm64 i386 x86_64
 
@@ -150,7 +173,7 @@ if {${configure.build_arch} eq "arm64"} {
 
     # Use a temporary installation of the binary ARM64 Go distribution to
     # build Go for ARM64
-    set go_bin_path         ${workpath}/go_prebuilt
+    set go_bin_path         ${workpath}/${subport}_prebuilt
 
     build.env-append        GOROOT_BOOTSTRAP=${go_bin_path}/go
 
@@ -166,7 +189,7 @@ if {${configure.build_arch} eq "arm64"} {
 
     # Use a temporary installation of the binary AMD64 Go distribution to
     # build Go for AMD64 on macOS 12 since go-1.4 fails to build
-    set go_bin_path         ${workpath}/go_prebuilt
+    set go_bin_path         ${workpath}/${subport}_prebuilt
 
     build.env-append        GOROOT_BOOTSTRAP=${go_bin_path}/go
 
@@ -190,12 +213,24 @@ post-build {
     delete ${worksrcpath}/pkg/bootstrap
 }
 
+if {$subport eq "${name}-devel"} {
+    set bin_suffix "-devel"
+
+    notes "
+        go-devel binaries are installed with a ${bin_suffix} suffix:
+        - go${bin_suffix}
+        - gofmt${bin_suffix}
+    "
+} else {
+    set bin_suffix ""
+}
+
 destroot {
 
     delete ${worksrcpath}/src/cmd/vendor/github.com/google/pprof/internal/binutils/testdata/malformed_macho
 
     set grfdir ${destroot}${GOROOT_FINAL}
-    set docdir ${destroot}${prefix}/share/doc/${name}
+    set docdir ${destroot}${prefix}/share/doc/${subport}
 
     xinstall -d ${grfdir}
     xinstall -d ${docdir}
@@ -205,7 +240,7 @@ destroot {
     }
 
     foreach f {go gofmt} {
-        system -W ${destroot}${prefix}/bin/ "ln -s ../lib/${name}/bin/$f ./$f"
+        system -W ${destroot}${prefix}/bin/ "ln -s ../lib/${subport}/bin/$f ./${f}${bin_suffix}"
     }
 
     xinstall -m 0644 -W ${worksrcpath} \
@@ -224,7 +259,7 @@ destroot {
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     known_fail yes
     pre-fetch {
-        ui_error "${name} @${version} requires OS X 10.6 or greater."
+        ui_error "${subport} @${version} requires OS X 10.6 or greater."
         return -code error "incompatible Mac OS X version"
     }
 }


### PR DESCRIPTION
#### Description

This change adds a subport, `go-devel`, which can be installed side-by-side next to the standard `go` port.

```
➜  ~ go version
go version go1.17.5 darwin/arm64
➜  ~ go-devel version
go version go1.18beta1 darwin/arm64
```

This makes it possible to try Go 1.18 Beta 1 via MacPorts. 1.18 will be introducing a major change to the language: generics (as detailed here: **https://go.dev/blog/go1.18beta1**)


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
