### PR TITLE
py-filelock: update to 3.4.0, revert to 3.2.1 (old Pythons)

### DIFF
--- a/python/py-filelock/Portfile
+++ b/python/py-filelock/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-filelock
-version             3.3.1
-revision            1
+version             3.4.0
+revision            0
 
 platforms           darwin
 supported_archs     noarch
@@ -17,11 +17,11 @@ long_description    This package contains a single module, which implements \
                     a platform independent file lock in Python, which \
                     provides a simple way of inter-process communication:
 
-homepage            https://filelock.readthedocs.io/en/latest/
+homepage            https://py-filelock.readthedocs.io/
 
-checksums           rmd160  f9852c8432196648df2648529d21c14df1d121a1 \
-                    sha256  34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f \
-                    size    205796
+checksums           rmd160  9d2213165c6dfc44a0652124fb8a74ee2bd3ac5b \
+                    sha256  93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4 \
+                    size    206359
 
 # keep version for PY27 and PY34, these are (indirect) dependencies of py-virtualenv
 python.versions     27 34 35 36 37 38 39 310
@@ -29,6 +29,20 @@ python.versions     27 34 35 36 37 38 39 310
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools_scm
+
+    if {${python.version} <= 35} {
+        version     3.2.1
+        revision    0
+        epoch       1
+
+        checksums   rmd160  4438a50fb193ec08f29631a5fbc657a74b5a084d \
+                    sha256  9cdd29c411ab196cf4c35a1da684f7b9da723696cb356efa45bf5eb1ff313ee3 \
+                    size    202950
+
+        depends_build-append \
+                    port:py${python.version}-toml
+
+    }
 
     if {${python.version} ni "34"} {
         depends_test-append \


### PR DESCRIPTION
Also fix install version: without py-toml the library is installed as version 0.0.0, which breaks consumers that have version pins such as virtualenv


#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->