### PR TITLE
ansible: remove adfernandes (self) from the maintainers list

### DIFF
--- a/sysutils/ansible/Portfile
+++ b/sysutils/ansible/Portfile
@@ -13,7 +13,7 @@ distfiles
 version         2.3.2.0.1
 revision        2
 
-maintainers     {adfernandes @adfernandes} {gmail.com:pedro.salgado @steenzout} openmaintainer
+maintainers     {gmail.com:pedro.salgado @steenzout} openmaintainer
 
 license         GPL-3+
 homepage        https://github.com/ansible/ansible


### PR DESCRIPTION
* I am not active enough in the Ansible community currently

Signed-off-by: Andrew Fernandes <andrew@fernandes.org>

