### PR TITLE
postgresql96-server: Remove shell from `postgres` user

### DIFF
--- a/databases/postgresql96-server/Portfile
+++ b/databases/postgresql96-server/Portfile
@@ -5,24 +5,19 @@ PortSystem 1.0
 name                postgresql96-server
 version             9.6.24
 categories          databases
-platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
+supported_archs     noarch
 
 set rname           postgresql96
+
 description         run ${rname} as server
 long_description    {*}${description}
-distfiles       
 
 homepage            https://www.postgresql.org/
 master_sites        postgresql
 
-depends_run         port:${rname}
-
-supported_archs     noarch
-
-use_configure       no
-build    {}
+distfiles
 
 set libdir          ${prefix}/lib/${rname}
 set dbdir           ${prefix}/var/db/${rname}/defaultdb
@@ -35,13 +30,16 @@ add_users           ${dbuser} group=${dbgrp} \
                     home=${prefix}/var/db/${rname} \
                     realname=PostgreSQL-96\ Server
 
+depends_run         port:${rname}
+
+use_configure       no
+
+build               {}
+
 startupitem.create  yes
-startupitem.init    \
-    "PGCTL=${libdir}/bin/pg_ctl"
-startupitem.start    \
-    "su ${dbuser} -c \"\${PGCTL} -D \${POSTGRESQL96DATA:=${dbdir}} start -l ${logdir}/postgres.log\""
-startupitem.stop    \
-"su ${dbuser} -c \"\${PGCTL} -D \${POSTGRESQL96DATA:=${dbdir}} stop -s -m fast\""
+startupitem.init    "PGCTL=${libdir}/bin/pg_ctl"
+startupitem.start   "su ${dbuser} -c \"\${PGCTL} -D \${POSTGRESQL96DATA:=${dbdir}} start -l ${logdir}/postgres.log\""
+startupitem.stop    "su ${dbuser} -c \"\${PGCTL} -D \${POSTGRESQL96DATA:=${dbdir}} stop -s -m fast\""
 
 destroot {
     xinstall -m 755 -d ${destroot}${logdir}
@@ -53,10 +51,10 @@ destroot {
 post-activate {
     set dbuser_UserShell \
         [regsub -- {^UserShell:[[:space:]]+} [exec /bin/sh -c "dscl . -read /Users/${dbuser} UserShell || true"] {}]
-    if {${dbuser_UserShell} ne {/usr/bin/false}} {
+    if {${dbuser_UserShell} ne "" && ${dbuser_UserShell} ne {/usr/bin/false}} {
         system "dscl . -change /Users/${dbuser} UserShell ${dbuser_UserShell} /usr/bin/false"
     }
-}    
+}
 
 notes "\nTo create a database instance, after install do\n\
         sudo mkdir -p ${dbdir}\n\

--- a/databases/postgresql96-server/Portfile
+++ b/databases/postgresql96-server/Portfile
@@ -11,7 +11,7 @@ license             Permissive
 
 set rname           postgresql96
 description         run ${rname} as server
-long_description    ${description}
+long_description    {*}${description}
 distfiles       
 
 homepage            https://www.postgresql.org/
@@ -31,9 +31,9 @@ set dbuser          postgres
 set dbgrp           postgres
 set dbhome          ${prefix}/var/db/${rname}
 
-add_users ${dbuser} shell=/bin/sh group=${dbgrp} \
-    home=${prefix}/var/db/${rname} \
-    realname=PostgreSQL-96\ Server
+add_users           ${dbuser} group=${dbgrp} \
+                    home=${prefix}/var/db/${rname} \
+                    realname=PostgreSQL-96\ Server
 
 startupitem.create  yes
 startupitem.init    \
@@ -48,6 +48,15 @@ destroot {
     system "touch ${destroot}${logdir}/postgres.log"
     system "chown ${dbuser}:${dbgrp} ${destroot}${logdir}/postgres.log"
 }
+
+# https://trac.macports.org/ticket/64286
+post-activate {
+    set dbuser_UserShell \
+        [regsub -- {^UserShell:[[:space:]]+} [exec /bin/sh -c "dscl . -read /Users/${dbuser} UserShell || true"] {}]
+    if {${dbuser_UserShell} ne {/usr/bin/false}} {
+        system "dscl . -change /Users/${dbuser} UserShell ${dbuser_UserShell} /usr/bin/false"
+    }
+}    
 
 notes "\nTo create a database instance, after install do\n\
         sudo mkdir -p ${dbdir}\n\


### PR DESCRIPTION
* Fixes: https://trac.macports.org/ticket/64286

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
