### PR TITLE
tiptop: new port

### DIFF
--- a/sysutils/tiptop/Portfile
+++ b/sysutils/tiptop/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+PortGroup           python  1.0
+
+github.setup        nschloe tiptop 0.0.16 v
+github.tarball_from archive
+revision            0
+
+description         \
+    Command-line system monitoring
+
+long_description    \
+    tiptop is a command-line system monitoring tool in the spirit of top. It \
+    displays various interesting system stats, graphs it, and works on Linux \
+    and macOS.
+
+platforms           darwin
+license             MIT
+categories          sysutils
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+checksums           rmd160  a4ae261c51af8ebb5b736c6c2cee39a8658837ad \
+                    sha256  73f8a4367f05acc90a118554bfd5bfd9b645a30b1de4985740b1cf6a1a6486c2 \
+                    size    14932
+
+python.default_version      39
+python.pep517               yes
+
+depends_build-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-wheel
+
+depends_run-append  port:py${python.version}-cpuinfo \
+                    port:py${python.version}-distro \
+                    port:py${python.version}-psutil \
+                    port:py${python.version}-textual
+
+depends_test-append port:py${python.version}-pytest
+
+test.run            yes
+test.cmd            pytest-${python.branch}
+test.target
+test.env-append     PYTHONPATH=./build/lib


### PR DESCRIPTION
#### Description

New port for [tiptop](https://github.com/nschloe/tiptop), a system monitoring CLI tool.

<img src="https://raw.githubusercontent.com/nschloe/tiptop/gh-pages/screenshot.png"/>

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
