### PR TITLE
ixion: set compiler.cxx_standard

### DIFF
--- a/devel/ixion/Portfile
+++ b/devel/ixion/Portfile
@@ -23,7 +23,11 @@ checksums           rmd160  c4cd1a3364af2a004b1f802394411b8d52329c13 \
                     sha256  63f3942defc684be82046b9d7454602dadafced9be7b3b60e9e8a5fa63ee91a8 \
                     size    191134
 
+compiler.cxx_standard 2017
+
 use_autoreconf      yes
 configure.args      --disable-debug \
                     --disable-python \
                     --enable-threads
+
+build.post_args V=1


### PR DESCRIPTION
#### Description

Possibly fixes https://trac.macports.org/ticket/64278

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
