### PR TITLE
tomcat-native: Update to 1.2.31

### DIFF
--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                tomcat-native
-version             1.2.28
+version             1.2.31
 revision            1
 categories          java www
 maintainers         {thebishops.org:matt @mattbishop} openmaintainer
@@ -18,9 +18,9 @@ long_description    This port provides access to native apr and other \
 homepage            https://tomcat.apache.org/
 master_sites        apache:tomcat/tomcat-connectors/native/${version}/source/
 
-checksums           rmd160  91aea13355ff3f4dd91b9cadcfe18a3cf12043de \
-                    sha256  6001129bbefa40ba92268d722c8c101e3c5c9fd969534799f682bb0e0bce6c6a \
-                    size    423848
+checksums           rmd160  d4b768b042f7c6c6c7096628f9ba3c3a4e2b2d44 \
+                    sha256  acc0e6e342fbdda54b029564405322823c93d83f9d64363737c1cbcc3af1c1fd \
+                    size    428057
 
 distname            ${name}-${version}-src
 worksrcdir          ${distname}/native


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0 Beta (21A5506j)
Xcode 13.0 beta 5 (13A5212g)

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Fixes:
https://bz.apache.org/bugzilla/show_bug.cgi?id=65441
```
:info:build src/sslutils.c:998:9: error: implicit declaration of function 'OCSP_HTTP_parse_url' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
:info:build     if (OCSP_HTTP_parse_url(url,&hostname, &c_port, NULL, &path, &use_ssl) == 0 )
:info:build         ^
:info:build src/sslutils.c:998:9: note: did you mean 'OSSL_HTTP_parse_url'?
:info:build /opt/local/include/openssl/http.h:100:5: note: 'OSSL_HTTP_parse_url' declared here
:info:build int OSSL_HTTP_parse_url(const char *url, int *pssl, char **puser, char **phost,
:info:build     ^
```