### PR TITLE
python27: fix support for virtualenv on macOS 12

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -9,7 +9,7 @@ name                python27
 epoch               2
 # Remember to keep py27-tkinter and py27-gdbm's versions sync'd with this
 version             2.7.18
-revision            6
+revision            7
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -45,8 +45,11 @@ patchfiles          patch-Makefile.pre.in.diff \
                     darwin20.diff \
                     arm.patch \
                     implicit.patch \
-                    openssl_ver.patch \
-                    patch-getpath.diff
+                    openssl_ver.patch
+
+if {${os.platform} eq "darwin" && ${os.major} >= 21} {
+    patchfiles-append patch-getpath.diff
+}
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \
@@ -65,7 +68,6 @@ openssl.branch      1.1
 
 # This port is used by clang-3.4 to bootstrap libcxx
 subport ${name}-bootstrap {
-    revision                6
     set stdprefix ${prefix}
     prefix ${prefix}/libexec/libcxx-bootstrap
     set frameworks_dir      ${prefix}/Library/Frameworks

--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -9,7 +9,7 @@ name                python27
 epoch               2
 # Remember to keep py27-tkinter and py27-gdbm's versions sync'd with this
 version             2.7.18
-revision            5
+revision            6
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -45,7 +45,8 @@ patchfiles          patch-Makefile.pre.in.diff \
                     darwin20.diff \
                     arm.patch \
                     implicit.patch \
-                    openssl_ver.patch
+                    openssl_ver.patch \
+                    patch-getpath.diff
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \

--- a/lang/python27/files/patch-getpath.diff
+++ b/lang/python27/files/patch-getpath.diff
@@ -1,0 +1,77 @@
+--- Modules/getpath.c.orig
++++ Modules/getpath.c
+@@ -7,7 +7,7 @@
+ #include <string.h>
+ 
+ #ifdef __APPLE__
+-#include <mach-o/dyld.h>
++#include <dlfcn.h>
+ #include <AvailabilityMacros.h>
+ #endif
+ 
+@@ -380,9 +380,10 @@ calculate_path(void)
+     size_t prefixsz;
+     char *defpath = pythonpath;
+ #ifdef WITH_NEXT_FRAMEWORK
+-    NSModule pythonModule;
++    Dl_info addrinfo;
++    int first_pass = 1;
+ #endif
+-#ifdef __APPLE__
++#ifdef notdef
+ #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_4
+     uint32_t nsexeclength = MAXPATHLEN;
+ #else
+@@ -397,7 +398,7 @@ calculate_path(void)
+          */
+         if (strchr(prog, SEP))
+                 strncpy(progpath, prog, MAXPATHLEN);
+-#ifdef __APPLE__
++#ifdef notdef
+      /* On Mac OS X, if a script uses an interpreter of the form
+       * "#!/opt/python2.3/bin/python", the kernel only passes "python"
+       * as argv[0], which falls through to the $PATH search below.
+@@ -410,7 +411,7 @@ calculate_path(void)
+       */
+      else if(0 == _NSGetExecutablePath(progpath, &nsexeclength) && progpath[0] == SEP)
+        ;
+-#endif /* __APPLE__ */
++#endif /* notdef */
+         else if (path) {
+                 while (1) {
+                         char *delim = strchr(path, DELIM);
+@@ -449,9 +450,18 @@ calculate_path(void)
+         ** which is in the framework, not relative to the executable, which may
+         ** be outside of the framework. Except when we're in the build directory...
+         */
+-    pythonModule = NSModuleForSymbol(NSLookupAndBindSymbol("_Py_Initialize"));
+-    /* Use dylib functions to find out where the framework was loaded from */
+-    buf = (char *)NSLibraryNameForModule(pythonModule);
++	/* dladdr() now returns the real path of the dylib, instead of the
++	** path of the symlink.  This breaks virtualenv.  To fix this, we
++	** skip using dladdr() during a first pass, and if that fails, then
++	** we go back and do the dladdr().  It turns out that since we moved
++	** Python.app to inside the Python.framework bundle, the call to
++	** search_for_prefix() will now succeed without needing dladdr().
++	** However, virtualenv copies the wrong binary when the prefix is
++	** /usr, so if progpath begins with /usr/bin/, we skip the first pass.
++	*/
++    if (strncmp(progpath, "/usr/bin/", 9) == 0) first_pass = 0;
++return_here_for_second_pass:
++    buf = first_pass ? NULL : (dladdr("_Py_Initialize", &addrinfo) ? (char *)addrinfo.dli_fname : NULL);
+     if (buf != NULL) {
+         /* We're in a framework. */
+         /* See if we might be in the build directory. The framework in the
+@@ -504,6 +514,12 @@ calculate_path(void)
+     */
+ 
+     if (!(pfound = search_for_prefix(argv0_path, home))) {
++#ifdef WITH_NEXT_FRAMEWORK
++	if (first_pass) {
++	    first_pass = 0;
++	    goto return_here_for_second_pass;
++	}
++#endif
+         if (!Py_FrozenFlag)
+             fprintf(stderr,
+                 "Could not find platform independent libraries <prefix>\n");

--- a/lang/python27/files/patch-getpath.diff
+++ b/lang/python27/files/patch-getpath.diff
@@ -1,5 +1,10 @@
---- Modules/getpath.c.orig
-+++ Modules/getpath.c
+As of macOS 12, dladdr, NSLibraryNameForModule, and similar functions
+will resolve symlinks, which breaks virtualenv. This works around that
+issue by not using those functions if at all possible.
+
+Adapted from https://github.com/apple-oss-distributions/python/blob/python-136.120.2/2.7/fix/getpath.c.ed
+--- Modules/getpath.c.orig	2022-01-08 05:08:48.000000000 +1100
++++ Modules/getpath.c	2022-01-08 05:13:34.000000000 +1100
 @@ -7,7 +7,7 @@
  #include <string.h>
  
@@ -18,7 +23,7 @@
 +    int first_pass = 1;
  #endif
 -#ifdef __APPLE__
-+#ifdef notdef
++#if 0
  #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_4
      uint32_t nsexeclength = MAXPATHLEN;
  #else
@@ -27,7 +32,7 @@
          if (strchr(prog, SEP))
                  strncpy(progpath, prog, MAXPATHLEN);
 -#ifdef __APPLE__
-+#ifdef notdef
++#if 0
       /* On Mac OS X, if a script uses an interpreter of the form
        * "#!/opt/python2.3/bin/python", the kernel only passes "python"
        * as argv[0], which falls through to the $PATH search below.
@@ -41,7 +46,7 @@
                  while (1) {
                          char *delim = strchr(path, DELIM);
 @@ -449,9 +450,18 @@ calculate_path(void)
-         ** which is in the framework, not relative to the executable, which may
+         ** which is in the framework, not relative to the executable, which ma
          ** be outside of the framework. Except when we're in the build directory...
          */
 -    pythonModule = NSModuleForSymbol(NSLookupAndBindSymbol("_Py_Initialize"));


### PR DESCRIPTION
#### Description
<!-- Note: it is best to make pull requests from a branch rather than from master -->

On macOS 12 (Monterey) `NSLibraryNameForModule` returns the real path of the dynamic library instead of the path to the symlink in a virtualenv. This breaks support for virtualenv because then `sys.prefix` points to the path of the Python installation instead of the path of the virtualenv.

By applying the same patch as Apple does for its Python version, which no longer uses the deprecated `NSLibraryNameForModule` function, support for virtualenv is restored.

See also:
https://github.com/apple-oss-distributions/python/blob/python-136.120.2/2.7/fix/getpath.c.ed

Fixes building mozjs60 on x86_64 as well: https://trac.macports.org/ticket/61606#comment:2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (4 tests fail, but these already fail before this change)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
