### PR TITLE
macos-fortress: Update to version 2021.12.26

### DIFF
--- a/net/macos-fortress/Portfile
+++ b/net/macos-fortress/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                macos-fortress
-version             2021.11.10
+version             2021.12.26
 revision            0
 
 categories          net security
@@ -198,6 +198,7 @@ if {${name} eq ${subport}} {
 
     if { [variant_isset "https_inspection"] } {
         set proxy_subport ${name}-proxy
+        require_active_variants ${proxy_subport} https_inspection
     } else {
         # proxy chain without HTTPS inspection
         set proxy_subport ${name}-proxy-squid
@@ -209,19 +210,6 @@ if {${name} eq ${subport}} {
 
     pre-build {
         xinstall -d ${worksrcpath}
-
-        if { [variant_isset "https_inspection"] } {
-            if { [catch {set result [registry_active ${name}-proxy]}]
-                 || [lindex [lindex ${result} 0] 3] \
-                     ne "+https_inspection" } {
-                ui_error "${name}-proxy not installed with https_inspection.\
-    Please install:
-
-    sudo port -pN install ${name}-proxy +https_inspection"
-                # this will exit with error if the port is not installed at all
-                registry_active ${name}-proxy
-            }
-        }
     }
 
     build {
@@ -457,6 +445,11 @@ subport ${name}-dshield {
     long_description \
                     {*}${description}
 
+    set perl5_major_min 5.28
+    if {${perl5.major} eq "" || ${perl5.major} < ${perl5_major_min}} {
+        perl5.major ${perl5_major_min}
+    }
+
     depends_run-append \
                     port:gnupg2 \
                     port:p${perl5.major}-data-validate-ip \
@@ -585,24 +578,13 @@ subport ${name}-proxy {
                     port:privoxy
 
     variant https_inspection \
-        description {Use Privoxy HTTPS inspection.} {}
+        description {Use Privoxy HTTPS inspection.} {
+            require_active_variants privoxy https_inspection
+            require_active_variants adblock2privoxy https_inspection
+        }
+
     default_variants-append \
                     +https_inspection
-
-    pre-build {
-        if { [variant_isset "https_inspection"] } {
-            if { [catch {set result [registry_active privoxy]}]
-                 || [lindex [lindex ${result} 0] 3] \
-                     ne "+https_inspection" } {
-                ui_error "Privoxy not installed with https_inspection. \
-    Please install:
-
-    sudo port -pN install privoxy +https_inspection"
-                # this will exit with error if the port is not installed at all
-                registry_active privoxy
-            }
-        }
-    }
 
     # privoxy patch file creation
     ## mkdir privoxy-orig privoxy-new
@@ -956,6 +938,11 @@ subport ${name}-hosts {
                     hosts file that allows an additional layer of \
                     protection against access to ad, tracking, and \
                     malicious websites.
+
+    set perl5_major_min 5.28
+    if {${perl5.major} eq "" || ${perl5.major} < ${perl5_major_min}} {
+        perl5.major ${perl5_major_min}
+    }
 
     depends_run-append \
                     port:gnupg2 \

--- a/net/macos-fortress/files/macosfortress_setup_check.sh
+++ b/net/macos-fortress/files/macosfortress_setup_check.sh
@@ -272,11 +272,11 @@ EOF
 fi
 
 # blackhole on proxy server
-if [[ `"${CURL}" -s --head "http://${PROXY_HOSTNAME}:8119/" | "${HEAD}" -n 1 | "${GREP}" "HTTP/1.[01] [23]\d\d"` ]]; then
-    echo "[✅] Blackhole server for http://${PROXY_HOSTNAME}:8119/ is running properly"
+if [[ `"${CURL}" -s --head "https://${PROXY_HOSTNAME}:8119/" | "${HEAD}" -n 1 | "${GREP}" "HTTP/1.[01] [23]\d\d"` ]]; then
+    echo "[✅] Blackhole server for https://${PROXY_HOSTNAME}:8119/ is running properly"
 else
     "${CAT}" <<EOF
-[❌] Blackhole server for http://${PROXY_HOSTNAME}:8119/ isn't running properly! Troubleshooting:
+[❌] Blackhole server for https://${PROXY_HOSTNAME}:8119/ isn't running properly! Troubleshooting:
 
 sudo ps -f \`cat @PREFIX@/var/run/nginx/nginx-adblock2privoxy.pid\`
 sudo port reload org.macports.adblock2privoxy-nginx


### PR DESCRIPTION
* Update to version 2021.12.26
* Add https_inspection for adblock2privoxy
* Fix active_variants usage
* Specify perl5.major minimum version

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
