### PR TITLE
mapnik: Comment Portfile to synchronize boost.version with mod_tile port

### DIFF
--- a/gis/mapnik/Portfile
+++ b/gis/mapnik/Portfile
@@ -37,6 +37,9 @@ checksums           rmd160  14ec14c48ab790c8c3a2d30d51f8dd23b4dcd470 \
                     sha256  4b1352e01f7ce25ab099e586d7ae98e0b74145a3bf94dd365cb0a2bdab3b9dc2 \
                     size    10110103
 
+# When changing `boost.version`, please update the `mod_tile` port
+# correspondingly with the same version of Boost.  Also increase the
+# `mod_tile` `revision` attribute.
 boost.version       1.69
 
 depends_build-append \


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The `mod_tile` port depends on `mapnik` and must be built with the same version of Boost.

This change simply adds a comment to the `mapnik` Portfile to that effect.
See PR #13425 for details of the `mod_tile` update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
