### PR TITLE
libtermkey: use unibilium

### DIFF
--- a/devel/libtermkey/Portfile
+++ b/devel/libtermkey/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libtermkey
 version             0.22
-revision            0
+revision            1
 categories          devel
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -29,7 +29,7 @@ patchfiles          patch-Makefile.diff
 depends_build       port:libtool \
                     port:pkgconfig
 
-depends_lib         port:ncurses
+depends_lib         port:unibilium
 
 use_configure no
 

--- a/devel/libtermkey/files/patch-Makefile.diff
+++ b/devel/libtermkey/files/patch-Makefile.diff
@@ -16,8 +16,8 @@
 -else
 -  override LDFLAGS+=-lncurses
 -endif
-+override CFLAGS +=$(call pkgconfig, --cflags ncursesw)
-+override LDFLAGS+=$(call pkgconfig, --libs   ncursesw)
++override CFLAGS +=$(call pkgconfig, --cflags unibilium) -DHAVE_UNIBILIUM
++override LDFLAGS+=$(call pkgconfig, --libs   unibilium)
  
  OBJECTS=termkey.lo driver-csi.lo driver-ti.lo
  LIBRARY=libtermkey.la

--- a/editors/neovim-devel/Portfile
+++ b/editors/neovim-devel/Portfile
@@ -7,7 +7,7 @@ PortGroup               cmake 1.1
 github.setup            neovim neovim 7229afcd60b6a3ad2f0b58ca270f11936f4a7d1b
 name                    neovim-devel
 version                 20211130
-revision                0
+revision                1
 categories              editors
 platforms               darwin
 maintainers             {l2dy @l2dy} \

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -6,7 +6,7 @@ PortGroup github 1.0
 PortGroup cmake 1.0
 
 github.setup            neovim neovim 0.6.0 v
-revision                0
+revision                1
 categories              editors
 platforms               darwin
 maintainers             {raimue @raimue} \

--- a/editors/vis/Portfile
+++ b/editors/vis/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        martanne vis 0.5 v
+revision            1
 categories          editors
 platforms           darwin
 maintainers         {en.sent.com:macports @Raimondi} openmaintainer


### PR DESCRIPTION
#### Description
This PR reverts the decision to use `ncursesw` instead of `unibilium`. libtermkey upstream prefers `unibilium`, but was patched to prefer `ncursesw` in `patch-Makefile.diff`.

See: https://trac.macports.org/ticket/64159
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1615
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
