### PR TITLE
fpc: Update to upstream version 3.2.2

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                fpc
-version             3.2.0
+version             3.2.2
 categories          lang
 platforms           darwin
 license             GPL-2 LGPL-2
@@ -23,9 +23,9 @@ set src             ${name}build-${version}.tar.gz
 set pp              x86_64-macosx-10.9-ppcx64.tar.bz2
 distfiles           ${src}:main ${pp}:bootstrap
 checksums           ${src} \
-                    rmd160  c8d56acb409a6d5c186b0aaed38dc02dfa3bcb69 \
-                    sha256  f9b914eace989a023fb953da203dc0d973b44487568b4138c7d5b9613d7d6838 \
-                    size    80698915 \
+                    rmd160  3106b4aff1adc4cd08dfdd39cc3ef4e800888255 \
+                    sha256  85ef993043bb83f999e2212f1bca766eb71f6f973d362e2290475dbaaf50161f \
+                    size    84195619 \
                     ${pp} \
                     rmd160  7c5327aa6f4fd8616d78bc4f708463b9fb3e8844 \
                     sha256  0515ad4251c51fa7e5c0ff9b1d90ea50f41530b56276cc72b73798fae437b3b4 \
@@ -214,7 +214,7 @@ subport "${name}-cross-x86-64-win64" {
 }
 
 if {${subport} eq "${name}"} {
-    revision            1
+    revision            0
 
     installs_libs       yes
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G314 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
