### PR TITLE
discord-rpc: new port

### DIFF
--- a/games/discord-rpc/Portfile
+++ b/games/discord-rpc/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        discord discord-rpc 3.4.0 v
+categories          games devel
+license             MIT
+maintainers         nomaintainer
+
+description         simple RPC client for Discord
+long_description    Discord RPC is a library for interfacing your game \
+                    with a locally running Discord desktop client.
+
+checksums           rmd160  5162c62ba2484098f683c1bb82ef1a2704f61b19 \
+                    sha256  d814e86f214790a2fcc4a740ab5bdcf259ac2a09b22ff641b2a3ace911fd244c \
+                    size    2107652
+
+compiler.cxx_standard 2014
+
+depends_lib-append  port:rapidjson
+
+# Patch the CMakeLists.txt file to have CMake build
+# both the static and dynamic libraries.
+patchfiles-append   create-both-lib-types.diff
+
+post-patch {
+    # Link the example against the dynamic library
+    reinplace -E {s/(discord-rpc)/\1-shared/} \
+        ${worksrcpath}/examples/send-presence/CMakeLists.txt
+
+    # Force the source code to use the MacPorts-provided RapidJSON
+    # instead of its own copy of the header files.
+    reinplace {/find_file.RAPIDJSONTEST/,/add_library.rapidjson/d} \
+        ${worksrcpath}/CMakeLists.txt
+    reinplace {/target_include_directories.*RAPIDJSON/d} \
+        ${worksrcpath}/src/CMakeLists.txt
+    reinplace -E {s/(#include )"(rapidjson.*)"/\1<\2>/} \
+        ${worksrcpath}/src/serialization.h
+}
+
+configure.args-append   BUILD_SHARED_LIBS=ON
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}$docdir
+    foreach f [list README.md LICENSE] {
+        xinstall -m 644 ${worksrcpath}/$f ${destroot}$docdir
+    }
+    copy {*}[glob ${worksrcpath}/documentation/*] ${destroot}$docdir/
+
+    set datadir ${prefix}/share/${name}
+    xinstall -d ${destroot}$datadir
+    copy ${worksrcpath}/examples ${destroot}$datadir/
+    copy ${build.dir}/examples/send-presence/send-presence.app \
+         ${destroot}$datadir/examples/send-presence/
+    reinplace -E {s/(discord-rpc)-shared/\1/} \
+        ${destroot}$datadir/examples/send-presence/CMakeLists.txt
+}

--- a/games/discord-rpc/files/create-both-lib-types.diff
+++ b/games/discord-rpc/files/create-both-lib-types.diff
@@ -1,0 +1,91 @@
+--- src/CMakeLists.txt.orig	2018-11-27 12:19:14.000000000 -0500
++++ src/CMakeLists.txt	2021-12-26 21:05:58.000000000 -0500
+@@ -69,10 +69,16 @@
+         add_definitions(-DDISCORD_LINUX)
+         set(BASE_RPC_SRC ${BASE_RPC_SRC} discord_register_linux.cpp)
+     endif(APPLE)
++endif(UNIX)
++
++foreach(libtype static shared)
++    string(TOUPPER ${libtype} libtype_upper)
+ 
+-    add_library(discord-rpc ${BASE_RPC_SRC})
+-    target_link_libraries(discord-rpc PUBLIC pthread)
+-    target_compile_options(discord-rpc PRIVATE
++if(UNIX)
++    add_library(discord-rpc-${libtype} ${libtype_upper} ${BASE_RPC_SRC})
++    set_target_properties(discord-rpc-${libtype} PROPERTIES OUTPUT_NAME discord-rpc)
++    target_link_libraries(discord-rpc-${libtype} PUBLIC pthread)
++    target_compile_options(discord-rpc-${libtype} PRIVATE
+         -g
+         -Wall
+         -Wextra
+@@ -80,10 +86,10 @@
+     )
+ 
+     if (${WARNINGS_AS_ERRORS})
+-      target_compile_options(discord-rpc PRIVATE -Werror)
++      target_compile_options(discord-rpc-${libtype} PRIVATE -Werror)
+     endif (${WARNINGS_AS_ERRORS})
+ 
+-    target_compile_options(discord-rpc PRIVATE
++    target_compile_options(discord-rpc-${libtype} PRIVATE
+         -Wno-unknown-pragmas # pragma push thing doesn't work on clang
+         -Wno-old-style-cast # it's fine
+         -Wno-c++98-compat # that was almost 2 decades ago
+@@ -95,34 +101,34 @@
+         -Wno-global-constructors
+     )
+ 
+-    if (${BUILD_SHARED_LIBS})
+-        target_compile_options(discord-rpc PRIVATE -fPIC)
+-    endif (${BUILD_SHARED_LIBS})
++    if (${libtype} STREQUAL "shared")
++        target_compile_options(discord-rpc-${libtype} PRIVATE -fPIC)
++    endif (${libtype})
+ 
+     if (APPLE)
+-        target_link_libraries(discord-rpc PRIVATE "-framework AppKit")
++        target_link_libraries(discord-rpc-${libtype} PRIVATE "-framework AppKit")
+     endif (APPLE)
+ endif(UNIX)
+ 
+-target_include_directories(discord-rpc PRIVATE ${RAPIDJSON}/include)
++target_include_directories(discord-rpc-${libtype} PRIVATE ${RAPIDJSON}/include)
+ 
+ if (NOT ${ENABLE_IO_THREAD})
+-    target_compile_definitions(discord-rpc PUBLIC -DDISCORD_DISABLE_IO_THREAD)
++    target_compile_definitions(discord-rpc-${libtype} PUBLIC -DDISCORD_DISABLE_IO_THREAD)
+ endif (NOT ${ENABLE_IO_THREAD})
+ 
+-if (${BUILD_SHARED_LIBS})
+-    target_compile_definitions(discord-rpc PUBLIC -DDISCORD_DYNAMIC_LIB)
+-    target_compile_definitions(discord-rpc PRIVATE -DDISCORD_BUILDING_SDK)
+-endif(${BUILD_SHARED_LIBS})
++if (${libtype} STREQUAL "shared")
++    target_compile_definitions(discord-rpc-${libtype} PUBLIC -DDISCORD_DYNAMIC_LIB)
++    target_compile_definitions(discord-rpc-${libtype} PRIVATE -DDISCORD_BUILDING_SDK)
++endif(${libtype})
+ 
+ if (CLANG_FORMAT_CMD)
+-    add_dependencies(discord-rpc clangformat)
++    add_dependencies(discord-rpc-${libtype} clangformat)
+ endif(CLANG_FORMAT_CMD)
+ 
+ # install
+ 
+ install(
+-    TARGETS discord-rpc
++    TARGETS discord-rpc-${libtype}
+     EXPORT "discord-rpc"
+     RUNTIME
+         DESTINATION "${CMAKE_INSTALL_BINDIR}"
+@@ -134,6 +140,8 @@
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+ )
+ 
++endforeach(libtype)
++
+ install(
+     FILES
+         "../include/discord_rpc.h"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Originally, I had wanted to package the [Discord GameSDK](https://discord.com/developers/docs/game-sdk/sdk-starter-guide), but after stumbling upon discord/discord-rpc#290 and seeing the questions regarding the Discord GameSDK's unclear licensing terms, I went ahead and packaged [discord-rpc](https://github.com/discord/discord-rpc) instead, even though the authors are calling it "deprecated".

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
