### PR TITLE
argyll: fix subdirectory permissions

### DIFF
--- a/graphics/argyll/Portfile
+++ b/graphics/argyll/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    argyll
 version                 2.2.1
-revision                0
+revision                1
 checksums               rmd160  69375947aa45f26558b9c18acef327079b0f4232 \
                         sha256  24cbef0e81a7ce8424957cbcb399cdea2f069f64866536d181e879ce1ed18ff8 \
                         size    14030108
@@ -67,7 +67,8 @@ post-destroot {
         ${destroot}${prefix}/share/doc/${name}
     system "cp -r ${worksrcpath}/doc/* \
         ${destroot}${prefix}/share/doc/${name} && \
-        chmod 0644 ${destroot}${prefix}/share/doc/${name}/*"
+        find ${destroot}${prefix}/share/doc/${name} -type f -print0 | xargs -0 chmod 644 && \
+        find ${destroot}${prefix}/share/doc/${name} -type d -print0 | xargs -0 chmod 755"
     # Install binaries
     delete ${worksrcpath}/bin/License.txt
     xinstall -m 755 {*}[glob ${worksrcpath}/bin/*] \


### PR DESCRIPTION
#### Description

* destroot was failing due to /share/doc/argyll/{ccmxs,ccsss}
  subdirectories having their x permission removed
* instead, remove x permission from files only

###### Type(s)

- [x] bugfix

###### Tested on

macOS 11.1 20C69 x86_64
Xcode 12.3 12C33

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
