### PR TITLE
py27-pyqt5: add OpenSSLException

### DIFF
--- a/python/py27-pyqt5/Portfile
+++ b/python/py27-pyqt5/Portfile
@@ -15,7 +15,7 @@ description             PyQt5 is a set of Python bindings for the Qt5 toolkit
 long_description        ${description}. The bindings \
                         are implemented as a set of Python modules and contain over 620 classes.
 homepage                https://www.riverbankcomputing.com/software/pyqt/intro
-license                 GPL-3
+license                 {GPL-3 OpenSSLException}
 
 version                 5.15.4
 revision                0


### PR DESCRIPTION
see: https://www.riverbankcomputing.com/pipermail/pyqt/2021-December/044421.html

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`? **`port lint` gives an error about a PortGroup being included more than once, but it is not true**
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
