### PR TITLE
hugo: update to 0.91.2

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.91.0 v
+go.setup            github.com/gohugoio/hugo 0.91.2 v
 revision            0
-checksums           rmd160  203e11bd3c3e9a8db8f073aad089d6713e103e00 \
-                    sha256  8778d0ae7f5345e590df2581d58ac946e7c07f298255fdef4d1df565eb154677 \
-                    size    28287213
+checksums           rmd160  785089a58bfc9d973986a6b51ee6b69ef69e098f \
+                    sha256  c52f83d3e3c5a1029dda5cd69a61c64a288685a0edfdc33aec59289df83207d6 \
+                    size    28415983
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.91.2

###### Tested on
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?