### PR TITLE
parallel: update to 20211222

### DIFF
--- a/sysutils/parallel/Portfile
+++ b/sysutils/parallel/Portfile
@@ -3,14 +3,13 @@
 PortSystem          1.0
 
 name                parallel
-version             20211122
+version             20211222
 revision            0
-checksums           rmd160  9f168eedfb18506b9c2e7550a00a733819fc020c \
-                    sha256  48b256322c56a4cb1a7818fe0894fdde575dab0e0f925c6a2289517b6bd8962e \
-                    size    2267617
+checksums           rmd160  2237e35275f89000d8083cb86e07819ac7717da6 \
+                    sha256  058491cf4c52a4855977bde803c63688b2ca9c5991be10e7b8b0c0aede46d19c \
+                    size    2267909
 
 categories          sysutils
-platforms           darwin
 license             GPL-3+
 maintainers         {ciserlohn @ci42}
 supported_archs     noarch

--- a/sysutils/parallel/Portfile
+++ b/sysutils/parallel/Portfile
@@ -11,7 +11,7 @@ checksums           rmd160  2237e35275f89000d8083cb86e07819ac7717da6 \
 
 categories          sysutils
 license             GPL-3+
-maintainers         {ciserlohn @ci42}
+maintainers         {ciserlohn @ci42} openmaintainer
 supported_archs     noarch
 
 description         GNU parallel: Shell command parallelization utility


### PR DESCRIPTION
Is there a reason why `parallel` doesn't have the `openmaintainer` policy? Added a commit that adds that, can remove if there is some actual reason why.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
