### PR TITLE
go-tools: update to 0.1.8

### DIFF
--- a/devel/go-tools/Portfile
+++ b/devel/go-tools/Portfile
@@ -3,22 +3,21 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golang/tools 0.1.7 v
+go.setup            github.com/golang/tools 0.1.8 v
 epoch               7
-revision            1
+revision            0
 
 
 name                go-tools
 categories          devel
-platforms           darwin freebsd linux
 license             BSD
 maintainers         {ciserlohn @ci42} {@enckse voidedtech.com:enckse} openmaintainer
 description         Various packages and tools that support the Go programming language.
 long_description    $description
 
-checksums           rmd160  71a1a020b05829115088d3bb575100d38e51ca48 \
-                    sha256  b88cae9ca14fc3f18ff714c8014929c8c2c63d15805416d49d88b51f201e9fbf \
-                    size    2884220
+checksums           rmd160  b0f01c5169b12cb2aa3e73fa4842cbeb916e3e71 \
+                    sha256  f4449b1bc8aea5864bffadf507f4b690edae12b707c07c2f7497d6d5ff8497ec \
+                    size    2929454
 
 github.tarball_from archive
 
@@ -33,7 +32,11 @@ destroot {
     set dp_bin ${destroot}${prefix}/bin
     xinstall -m 755 {*}[glob ${worksrcpath}/bin/*] ${dp_bin}
 
-    # Remove internal Go utility 'bundle', to avoid conflict with Ruby
+    # Rename bundle binary to avoid conflict with Ruby
     # See: https://trac.macports.org/ticket/57787
-    delete ${dp_bin}/bundle
+    move ${dp_bin}/bundle ${dp_bin}/gotools-bundle
 }
+
+notes "
+    The go-tools bundle binary is available as gotools-bundle
+"


### PR DESCRIPTION
CC: @mascguy - this PR also _restores_ the `bundle` binary.  Instead of wholesale _deleting_ a binary from a port to prevent conflict, we should seek to just rename it instead. In this way users of the port will still have all the binaries that they expect would be there, while at the same time avoiding path conflicts. 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
