### PR TITLE
py-kivy: delete py35 subport

### DIFF
--- a/python/py-kivy/Portfile
+++ b/python/py-kivy/Portfile
@@ -9,7 +9,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 35 36
+python.versions     27 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
This is the only dependent blocking removal of py35-game. If py-kivy is still useful, it should probably be updated to use non-EOL python versions?