### PR TITLE
sshpass: update to 1.09

### DIFF
--- a/sysutils/sshpass/Portfile
+++ b/sysutils/sshpass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                sshpass
-version             1.06
+version             1.09
 categories          sysutils
 license             GPL-2
 platforms           darwin
@@ -30,5 +30,6 @@ long_description    SSH's (secure shell) most common authentication mode is \
 homepage            http://sourceforge.net/projects/sshpass/
 master_sites        sourceforge:project/${name}/${name}/${version}
 
-checksums           rmd160  4759f5b23506537bf95619dd023cdc3178fc3ff3 \
-                    sha256  c6324fcee608b99a58f9870157dfa754837f8c48be3df0f5e2f3accf145dee60
+checksums           rmd160  f8f2e8864346e994a73fd7f06965e3a731f17477 \
+                    sha256  71746e5e057ffe9b00b44ac40453bf47091930cba96bbea8dc48717dedc49fb7 \
+                    size    112857


### PR DESCRIPTION
#### Description
Update sshpass to 1.09

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
