### PR TITLE
discord-rpc: new port

### DIFF
--- a/games/discord-rpc/Portfile
+++ b/games/discord-rpc/Portfile
@@ -1,0 +1,73 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        discord discord-rpc 3.4.0 v
+categories          games devel
+license             MIT
+maintainers         nomaintainer
+
+description         simple RPC client for Discord
+long_description    Discord RPC is a library for interfacing your game \
+                    with a locally running Discord desktop client.
+
+checksums           rmd160  5162c62ba2484098f683c1bb82ef1a2704f61b19 \
+                    sha256  d814e86f214790a2fcc4a740ab5bdcf259ac2a09b22ff641b2a3ace911fd244c \
+                    size    2107652
+
+compiler.cxx_standard 2014
+
+depends_lib-append  port:rapidjson
+
+# Patch the CMakeLists.txt file to add a CMake find module
+# and a pkg-config file to the final output products.
+patchfiles-append   add-package-locator-files.diff
+
+# Patch the src/CMakeLists.txt file so that CMake
+# builds both the static and dynamic libraries.
+patchfiles-append   create-both-lib-types.diff
+
+post-patch {
+    file mkdir ${worksrcpath}/cmake
+    copy ${filespath}/DiscordRPCConfig.cmake ${worksrcpath}/cmake/
+    copy ${filespath}/FindDiscordRPC.cmake.in \
+         ${filespath}/discord-rpc.pc.in \
+         ${worksrcpath}/
+
+    # Add the version number from this Portfile. The upstream
+    # source code doesn't seem to contain any references to the
+    # version number, other than the version number in the file name
+    # of the source tarball.
+    reinplace "/project.*DiscordRPC/s/)/ VERSION ${version})/" \
+        ${worksrcpath}/CMakeLists.txt
+
+    # Force the source code to use the MacPorts-provided RapidJSON
+    # instead of its own copy of the header files.
+    reinplace {/find_file.RAPIDJSONTEST/,/add_library.rapidjson/d} \
+        ${worksrcpath}/CMakeLists.txt
+    reinplace {/target_include_directories.*RAPIDJSON/d} \
+        ${worksrcpath}/src/CMakeLists.txt
+    reinplace -E {s/(#include )"(rapidjson.*)"/\1<\2>/} \
+        ${worksrcpath}/src/serialization.h
+}
+
+configure.args-append   BUILD_SHARED_LIBS=ON
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}$docdir
+    xinstall -m 644 -W ${worksrcpath} README.md LICENSE \
+        ${destroot}$docdir
+    copy {*}[glob ${worksrcpath}/documentation/*] ${destroot}$docdir/
+
+    set datadir ${prefix}/share/${name}
+    xinstall -d ${destroot}$datadir
+    copy ${worksrcpath}/examples ${destroot}$datadir/
+    copy ${build.dir}/examples/send-presence/send-presence.app \
+         ${destroot}$datadir/examples/send-presence/
+    fs-traverse f ${destroot}$datadir {
+        if {[file tail $f] eq ".gitignore"} { delete $f }
+    }
+}

--- a/games/discord-rpc/files/DiscordRPCConfig.cmake
+++ b/games/discord-rpc/files/DiscordRPCConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/DiscordRPCTargets.cmake")

--- a/games/discord-rpc/files/FindDiscordRPC.cmake.in
+++ b/games/discord-rpc/files/FindDiscordRPC.cmake.in
@@ -1,0 +1,101 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+# See accompanying file Copyright.txt or https://cmake.org/licensing
+# for details.
+
+#[================================================================[.rst:
+FindDiscordRPC
+-------
+
+Finds the discord-rpc library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``discord-rpc::discord-rpc``
+  The discord-rpc library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``DiscordRPC_FOUND``
+  True if the system has the discord-rpc library.
+``DiscordRPC_VERSION``
+  The version of the discord-rpc library which was found.
+``DiscordRPC_INCLUDE_DIRS``
+  Include directories needed to use discord-rpc.
+``DiscordRPC_LIBRARIES``
+  Libraries needed to link to discord-rpc.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``DiscordRPC_INCLUDE_DIR``
+  The directory containing ``discord_rpc.h``.
+``DiscordRPC_LIBRARY``
+  The path to the discord-rpc library.
+
+#]================================================================]
+
+# The following code was adapted from the instructions provided at
+# https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_DiscordRPC QUIET discord-rpc)
+  find_path(DiscordRPC_INCLUDE_DIR
+    NAMES discord_rpc.h
+    PATHS ${PC_DiscordRPC_INCLUDE_DIRS}
+  )
+  find_library(DiscordRPC_LIBRARY
+    NAMES discord-rpc
+    PATHS ${PC_DiscordRPC_LIBRARY_DIRS}
+  )
+else()
+  find_path(DiscordRPC_INCLUDE_DIR NAMES discord_rpc.h)
+  find_library(DiscordRPC_LIBRARY  NAMES discord-rpc)
+endif(PkgConfig_FOUND)
+
+# Set library version
+if(PC_DiscordRPC_VERSION)
+  set(DiscordRPC_VERSION ${PC_DiscordRPC_VERSION})
+else()
+  set(DiscordRPC_VERSION @VERSION@)
+endif()
+if(${DiscordRPC_VERSION} MATCHES [[([0-9]+)(\.([0-9]+)(\.([0-9]+))?)?]])
+  set(DiscordRPC_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  if(CMAKE_MATCH_2)
+    set(DiscordRPC_VERSION_MINOR "${CMAKE_MATCH_3}")
+  endif()
+  if(CMAKE_MATCH_4)
+    set(DiscordRPC_VERSION_PATCH "${CMAKE_MATCH_5}")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(DiscordRPC
+  FOUND_VAR DiscordRPC_FOUND
+  REQUIRED_VARS
+    DiscordRPC_LIBRARY
+    DiscordRPC_INCLUDE_DIR
+  VERSION_VAR DiscordRPC_VERSION
+)
+
+if(DiscordRPC_FOUND AND NOT TARGET discord-rpc::discord-rpc)
+  add_library(discord-rpc::discord-rpc UNKNOWN IMPORTED)
+  set_target_properties(discord-rpc::discord-rpc PROPERTIES
+    IMPORTED_LOCATION "${DiscordRPC_LIBRARY}"
+    INTERFACE_COMPILE_OPTIONS "${PC_DiscordRPC_CFLAGS_OTHER}"
+    INTERFACE_INCLUDE_DIRECTORIES "${DiscordRPC_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(
+  DiscordRPC_INCLUDE_DIR
+  DiscordRPC_LIBRARY
+)

--- a/games/discord-rpc/files/add-package-locator-files.diff
+++ b/games/discord-rpc/files/add-package-locator-files.diff
@@ -1,0 +1,47 @@
+--- CMakeLists.txt.orig	2018-11-27 12:19:14.000000000 -0500
++++ CMakeLists.txt	2021-12-27 20:27:19.000000000 -0500
+@@ -54,3 +54,44 @@
+ if (BUILD_EXAMPLES)
+     add_subdirectory(examples/send-presence)
+ endif(BUILD_EXAMPLES)
++
++# generate CMake config-file package
++# The following code was adapted from the instructions provided at
++# https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++    ${CMAKE_CURRENT_BINARY_DIR}/cmake/DiscordRPCConfigVersion.cmake
++    COMPATIBILITY AnyNewerVersion
++)
++export(EXPORT discord-rpc
++    FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/DiscordRPCTargets.cmake
++)
++configure_file(cmake/DiscordRPCConfig.cmake
++    ${CMAKE_CURRENT_BINARY_DIR}/cmake/DiscordRPCConfig.cmake
++    COPYONLY
++)
++set(ConfigPackageLocation ${CMAKE_INSTALL_PREFIX}/share/cmake/discord-rpc)
++install(EXPORT discord-rpc
++    FILE DiscordRPCTargets.cmake
++    DESTINATION ${ConfigPackageLocation}
++)
++install(
++    FILES
++        cmake/DiscordRPCConfig.cmake
++        ${CMAKE_CURRENT_BINARY_DIR}/cmake/DiscordRPCConfigVersion.cmake
++    DESTINATION ${ConfigPackageLocation}
++)
++
++# create CMake find module and pkg-config file
++set(PREFIX ${CMAKE_INSTALL_PREFIX})
++set(VERSION ${PROJECT_VERSION})
++configure_file(FindDiscordRPC.cmake.in FindDiscordRPC.cmake @ONLY)
++install(
++    FILES ${CMAKE_CURRENT_BINARY_DIR}/FindDiscordRPC.cmake
++    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cmake/Modules
++)
++configure_file(discord-rpc.pc.in discord-rpc.pc @ONLY)
++install(
++    FILES ${CMAKE_CURRENT_BINARY_DIR}/discord-rpc.pc
++    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pkgconfig
++)

--- a/games/discord-rpc/files/create-both-lib-types.diff
+++ b/games/discord-rpc/files/create-both-lib-types.diff
@@ -1,0 +1,96 @@
+--- src/CMakeLists.txt.orig	2018-11-27 12:19:14.000000000 -0500
++++ src/CMakeLists.txt	2021-12-28 00:36:54.000000000 -0500
+@@ -69,10 +69,21 @@
+         add_definitions(-DDISCORD_LINUX)
+         set(BASE_RPC_SRC ${BASE_RPC_SRC} discord_register_linux.cpp)
+     endif(APPLE)
++endif(UNIX)
+ 
+-    add_library(discord-rpc ${BASE_RPC_SRC})
+-    target_link_libraries(discord-rpc PUBLIC pthread)
+-    target_compile_options(discord-rpc PRIVATE
++foreach(libtype shared static)
++    string(TOUPPER ${libtype} libtype_upper)
++    if(${libtype} STREQUAL "static")
++        set(suffix _${libtype})
++    else()
++        set(suffix "")
++    endif()
++
++if(UNIX)
++    add_library(discord-rpc${suffix} ${libtype_upper} ${BASE_RPC_SRC})
++    set_target_properties(discord-rpc${suffix} PROPERTIES OUTPUT_NAME discord-rpc)
++    target_link_libraries(discord-rpc${suffix} PUBLIC pthread)
++    target_compile_options(discord-rpc${suffix} PRIVATE
+         -g
+         -Wall
+         -Wextra
+@@ -80,10 +91,10 @@
+     )
+ 
+     if (${WARNINGS_AS_ERRORS})
+-      target_compile_options(discord-rpc PRIVATE -Werror)
++      target_compile_options(discord-rpc${suffix} PRIVATE -Werror)
+     endif (${WARNINGS_AS_ERRORS})
+ 
+-    target_compile_options(discord-rpc PRIVATE
++    target_compile_options(discord-rpc${suffix} PRIVATE
+         -Wno-unknown-pragmas # pragma push thing doesn't work on clang
+         -Wno-old-style-cast # it's fine
+         -Wno-c++98-compat # that was almost 2 decades ago
+@@ -95,34 +106,34 @@
+         -Wno-global-constructors
+     )
+ 
+-    if (${BUILD_SHARED_LIBS})
+-        target_compile_options(discord-rpc PRIVATE -fPIC)
+-    endif (${BUILD_SHARED_LIBS})
++    if (${libtype} STREQUAL "shared")
++        target_compile_options(discord-rpc${suffix} PRIVATE -fPIC)
++    endif (${libtype})
+ 
+     if (APPLE)
+-        target_link_libraries(discord-rpc PRIVATE "-framework AppKit")
++        target_link_libraries(discord-rpc${suffix} PRIVATE "-framework AppKit")
+     endif (APPLE)
+ endif(UNIX)
+ 
+-target_include_directories(discord-rpc PRIVATE ${RAPIDJSON}/include)
++target_include_directories(discord-rpc${suffix} PRIVATE ${RAPIDJSON}/include)
+ 
+ if (NOT ${ENABLE_IO_THREAD})
+-    target_compile_definitions(discord-rpc PUBLIC -DDISCORD_DISABLE_IO_THREAD)
++    target_compile_definitions(discord-rpc${suffix} PUBLIC -DDISCORD_DISABLE_IO_THREAD)
+ endif (NOT ${ENABLE_IO_THREAD})
+ 
+-if (${BUILD_SHARED_LIBS})
+-    target_compile_definitions(discord-rpc PUBLIC -DDISCORD_DYNAMIC_LIB)
+-    target_compile_definitions(discord-rpc PRIVATE -DDISCORD_BUILDING_SDK)
+-endif(${BUILD_SHARED_LIBS})
++if (${libtype} STREQUAL "shared")
++    target_compile_definitions(discord-rpc${suffix} PUBLIC -DDISCORD_DYNAMIC_LIB)
++    target_compile_definitions(discord-rpc${suffix} PRIVATE -DDISCORD_BUILDING_SDK)
++endif(${libtype})
+ 
+ if (CLANG_FORMAT_CMD)
+-    add_dependencies(discord-rpc clangformat)
++    add_dependencies(discord-rpc${suffix} clangformat)
+ endif(CLANG_FORMAT_CMD)
+ 
+ # install
+ 
+ install(
+-    TARGETS discord-rpc
++    TARGETS discord-rpc${suffix}
+     EXPORT "discord-rpc"
+     RUNTIME
+         DESTINATION "${CMAKE_INSTALL_BINDIR}"
+@@ -134,6 +145,8 @@
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+ )
+ 
++endforeach(libtype)
++
+ install(
+     FILES
+         "../include/discord_rpc.h"

--- a/games/discord-rpc/files/discord-rpc.pc.in
+++ b/games/discord-rpc/files/discord-rpc.pc.in
@@ -1,0 +1,13 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: discord-rpc
+Description: simple RPC client for Discord
+Version: @VERSION@
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -ldiscord-rpc
+Cflags: -I${includedir}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Originally, I had intended to package the [Discord GameSDK](https://discord.com/developers/docs/game-sdk/sdk-starter-guide), but after stumbling upon discord/discord-rpc#290 and seeing the questions regarding the Discord GameSDK's unclear licensing terms, I went ahead and packaged [discord-rpc](https://github.com/discord/discord-rpc) instead, even though the authors are calling it "deprecated".

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
