### PR TITLE
gn-devel: build verbosely, switch to Python 3.10, remove Python runtime dependency

### DIFF
--- a/devel/gn-devel/Portfile
+++ b/devel/gn-devel/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                gn-devel
 version             20200529
+revision            1
 categories          devel
 platforms           darwin
 license             BSD
@@ -17,20 +17,26 @@ fetch.type          git
 git.url             ${homepage}
 git.branch          b175fa5d6ae1640742aad593185780a08f6ba224
 
-python.default_version      38
+set python_branch   3.10
+set python_version  [string map {"." ""} ${python_branch}]
+
 compiler.cxx_standard       2017
 compiler.blacklist-append   {clang < 1001.0.46.4}
 
-depends_build       port:ninja
+depends_build-append \
+                    port:ninja \
+                    port:python${python_version}
 
 use_configure       yes
-configure.cmd       ${python.bin}
+configure.cmd       ${prefix}/bin/python${python_branch}
 configure.args      build/gen.py
 configure.pre_args
 
 build.dir           ${worksrcpath}/out
 build.cmd           ${prefix}/bin/ninja
 build.target
+# Build verbosely
+build.args          -v
 
 destroot {
     copy ${worksrcpath}/out/gn ${destroot}${prefix}/bin


### PR DESCRIPTION
Python is only needed during build, but the python 1.0 PortGroup specifies it as a library dependency.

#### Description
Before:
```
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_devel_gn-devel/gn-devel/work/gn-devel-20200529/out" && /opt/local/bin/ninja -j4 
[1/272] CXX src/base/files/file_enumerator.o
[2/272] CXX src/base/files/file.o
[3/272] CXX src/base/environment.o
[4/272] CXX src/base/command_line.o
[5/272] CXX src/base/files/file_path_constants.o
```

After:
```
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_devel_gn-devel/gn-devel/work/gn-devel-20200529/out" && /opt/local/bin/ninja -j4 -v
[1/272] ccache /usr/bin/clang++ -MMD -MF src/gn/rust_variables.o.d -I../src -I. -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -pipe -Os -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -DNDEBUG -O3 -fdata-sections -ffunction-sections -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -pthread -pipe -fno-exceptions -fno-rtti -fdiagnostics-color -Wall -Wextra -Wno-unused-parameter -std=c++17 -mmacosx-version-min=10.9 -c ../src/gn/rust_variables.cc -o src/gn/rust_variables.o
[2/272] ccache /usr/bin/clang++ -MMD -MF src/gn/scope_per_file_provider.o.d -I../src -I. -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -pipe -Os -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -DNDEBUG -O3 -fdata-sections -ffunction-sections -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -pthread -pipe -fno-exceptions -fno-rtti -fdiagnostics-color -Wall -Wextra -Wno-unused-parameter -std=c++17 -mmacosx-version-min=10.9 -c ../src/gn/scope_per_file_provider.cc -o src/gn/scope_per_file_provider.o
[3/272] ccache /usr/bin/clang++ -MMD -MF src/gn/settings.o.d -I../src -I. -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -pipe -Os -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -DNDEBUG -O3 -fdata-sections -ffunction-sections -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -pthread -pipe -fno-exceptions -fno-rtti -fdiagnostics-color -Wall -Wextra -Wno-unused-parameter -std=c++17 -mmacosx-version-min=10.9 -c ../src/gn/settings.cc -o src/gn/settings.o
[4/272] ccache /usr/bin/clang++ -MMD -MF src/gn/scheduler.o.d -I../src -I. -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -pipe -Os -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -DNDEBUG -O3 -fdata-sections -ffunction-sections -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -pthread -pipe -fno-exceptions -fno-rtti -fdiagnostics-color -Wall -Wextra -Wno-unused-parameter -std=c++17 -mmacosx-version-min=10.9 -c ../src/gn/scheduler.cc -o src/gn/scheduler.o
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1
Xcode 13.2 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
