### PR TITLE
Update smooth to 0.9.8, BoCA to 1.0.5, freac to 1.1.5

### DIFF
--- a/aqua/smooth/Portfile
+++ b/aqua/smooth/Portfile
@@ -4,8 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        enzo1982 smooth 0.9.7 v
-github.tarball_from releases
+github.setup        enzo1982 smooth 0.9.8 v
+revision            0
+checksums           rmd160  b8198a8253df694da3a766061c065eea708192c0 \
+                    sha256  a02c3c15fc9f221809bd16ebbe56460f04facb36ed80ba1d0975526896d9fb42 \
+                    size    8569995
 
 categories          aqua
 platforms           darwin
@@ -24,11 +27,9 @@ long_description    ${name} is an object oriented C++ class library for Windows,
                     \n* completely transparent Unicode and software \
                     internationalization support\
                     \n* a libxml2 based XML parser\
-homepage            http://www.smooth-project.org/
 
-checksums           rmd160  bb26cf10840d080b3e9a04302b26c3c7bcb06ce1 \
-                    sha256  bc00a5e5650895eef629d9e4aa0c32e7438552798f1d40624498a9a116d2411d \
-                    size    8084875
+homepage            http://www.smooth-project.org
+github.tarball_from releases
 
 depends_lib         port:bzip2 \
                     port:curl \

--- a/aqua/smooth/files/patch-fix-dylib-install-path.diff
+++ b/aqua/smooth/files/patch-fix-dylib-install-path.diff
@@ -1,6 +1,6 @@
---- Makefile.orig	2020-12-25 17:02:53.000000000 +0100
-+++ Makefile	2021-01-27 12:17:23.000000000 +0100
-@@ -246,7 +246,7 @@
+--- Makefile.orig	2021-03-22 10:35:28.000000000 -0500
++++ Makefile	2021-12-28 18:01:22.000000000 -0600
+@@ -254,7 +254,7 @@
  ifeq ($(BUILD_WIN32),True)
  	LINKER_OPTS += --shared -mwindows -Wl,--dynamicbase,--nxcompat,--kill-at,--out-implib,$(LIBNAME)
  else ifeq ($(BUILD_OSX),True)

--- a/audio/BoCA/Portfile
+++ b/audio/BoCA/Portfile
@@ -5,8 +5,11 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        enzo1982 BoCA 1.0.4 v
-github.tarball_from releases
+github.setup        enzo1982 BoCA 1.0.5 v
+revision            0
+checksums           rmd160  5665880a576d3f90e7754362be6bfd1b414b3c4d \
+                    sha256  9befa4555b5d9a0ecf3b8472f1d8f14c26dee50993d1d66f35a2d0f140a72870 \
+                    size    2634890
 
 categories          audio
 platforms           darwin
@@ -17,11 +20,9 @@ long_description    ${name} provides unified interfaces for components like \
                     encoders, decoders, taggers and extensions as well as code \
                     to support communication between the application \
                     and its components.
-homepage            https://www.freac.org/
 
-checksums           rmd160  1b5d4a94c5c4d9524da04c0d475acd58622606b5 \
-                    sha256  af01549c006ca5beeb3175178136a1598a25a1c856317ddc0c07355b0e713b6b \
-                    size    2616780
+homepage            https://www.freac.org
+github.tarball_from releases
 
 depends_lib         port:expat \
                     port:libcdio \
@@ -34,3 +35,5 @@ patchfiles          patch-set-install-path-runtime.diff \
 
 makefile.prefix_name        prefix
 compiler.blacklist-append   {clang < 600.0.57}
+
+github.livecheck.regex {([0-9.]+)}

--- a/audio/freac/Portfile
+++ b/audio/freac/Portfile
@@ -41,6 +41,8 @@ depends_run         path:bin/ffmpeg:ffmpeg \
                     port:speex \
                     port:wavpack
 
+patchfiles          no-xcodebuild.patch
+
 makefile.prefix_name    prefix
 
 post-destroot {

--- a/audio/freac/Portfile
+++ b/audio/freac/Portfile
@@ -4,9 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        enzo1982 freac 1.1.4 v
-github.tarball_from releases
+github.setup        enzo1982 freac 1.1.5 v
 revision            0
+checksums           rmd160  41510ae25d07b2f1fe8021213995abbafe07095a \
+                    sha256  62c61840a935dba5230fb7295b508370cd4f1e861db9d479f21c858a8aac3470 \
+                    size    3444426
 
 categories          audio
 platforms           darwin
@@ -17,11 +19,9 @@ long_description    ${name} is a free audio converter and CD ripper with support
                     for various popular formats and encoders. It converts freely \
                     between MP3, M4A/AAC, FLAC, WMA, Opus, Ogg Vorbis, Speex, \
                     Monkey's Audio (APE), WavPack, WAV and other formats.
-homepage            https://www.freac.org/
 
-checksums           rmd160  8a3ff9a8c98198fa590daf6655218dd132006c90 \
-                    sha256  7c06ef01e8342dc13fe198fdcc15fc49ba06a76df471949a20a88f7d8cd8e911 \
-                    size    3384189
+homepage            https://www.freac.org
+github.tarball_from releases
 
 depends_lib         port:BoCA \
                     port:smooth

--- a/audio/freac/files/no-xcodebuild.patch
+++ b/audio/freac/files/no-xcodebuild.patch
@@ -1,0 +1,67 @@
+Don't invoke xcodebuild.
+
+This is the relevant (for MacPorts) half of:
+
+https://github.com/enzo1982/freac/commit/1a2f009f0e4bf562449ebb161d5fafae71ac2095
+
+The other half, which makes it use xcodebuild if a release build is
+being done, isn't relevant to us since we're not doing a release build.
+
+Fixes:
+
+https://github.com/enzo1982/freac/issues/256
+--- Makefile-options.orig
++++ Makefile-options
+@@ -111,52 +111,6 @@ else
+ 		SHARED = .dylib
+ 
+ 		BUILD_OSX = True
+-
+-#		Find macOS and Xcode version
+-		XCODEVERSION = $(shell xcodebuild -version | head -n1)
+-		MACOSVERSION = $(MACOSX_DEPLOYMENT_TARGET)
+-
+-		ifeq ($(MACOSVERSION),)
+-			MACOSVERSION = $(shell sw_vers | awk '$$1 == "ProductVersion:" { print $$2 }')
+-		endif
+-
+-		XCODE_LE3   = $(shell bash -c "v='$(XCODEVERSION)'; v=\$${v\#\#* }; if [ \$${v%%.*} -le  3 ]; then echo True; fi")
+-		XCODE_LE9   = $(shell bash -c "v='$(XCODEVERSION)'; v=\$${v\#\#* }; if [ \$${v%%.*} -le  9 ]; then echo True; fi")
+-		XCODE_EQ12  = $(shell bash -c "v='$(XCODEVERSION)'; v=\$${v\#\#* }; if [ \$${v%%.*} -eq 12 ]; then echo True; fi")
+-		XCODE_GE13  = $(shell bash -c "v='$(XCODEVERSION)'; v=\$${v\#\#* }; if [ \$${v%%.*} -ge 13 ]; then echo True; fi")
+-		XCODE_N_GE2 = $(shell bash -c "v='$(XCODEVERSION)'; v=\$${v\#*.};   if [ \$${v%%.*} -ge  2 ]; then echo True; fi")
+-
+-		MACOS_GE11  = $(shell bash -c "v='$(MACOSVERSION)';                 if [ \$${v%%.*} -ge 11 ]; then echo True; fi")
+-
+-#		Build universal binaries
+-		ifneq ($(BUILD_X86_64),False)
+-			BUILD_X86_64 = True
+-		endif
+-		ifeq ($(XCODE_LE9),True)
+-			ifneq ($(BUILD_X86),False)
+-				BUILD_X86 = True
+-			endif
+-
+-			ifeq ($(XCODE_LE3),True)
+-				ifneq ($(BUILD_PPC),False)
+-					BUILD_PPC = True
+-				endif
+-			endif
+-		else ifeq ($(XCODE_EQ12),True)
+-			ifeq ($(XCODE_N_GE2),True)
+-				ifeq ($(MACOS_GE11),True)
+-					ifneq ($(BUILD_ARM64),False)
+-						BUILD_ARM64 = True
+-					endif
+-				endif
+-			endif
+-		else ifeq ($(XCODE_GE13),True)
+-			ifeq ($(MACOS_GE11),True)
+-				ifneq ($(BUILD_ARM64),False)
+-					BUILD_ARM64 = True
+-				endif
+-			endif
+-		endif
+ 	endif
+ endif
+ 


### PR DESCRIPTION
#### Description

Update smooth to 0.9.8, BoCA to 1.0.5, freac to 1.1.5, and fix freac not to use xcodebuild unnecesssarily

Closes: https://trac.macports.org/ticket/64283
Closes: https://trac.macports.org/ticket/64284
Closes: https://trac.macports.org/ticket/64282
Closes: https://trac.macports.org/ticket/64281

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
