### PR TITLE
xxhashlib: Fix C11 build

### DIFF
--- a/devel/xxhash/Portfile
+++ b/devel/xxhash/Portfile
@@ -5,7 +5,6 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 github.setup        Cyan4973 xxhash 0.8.1 v
-revision            0
 categories          devel
 maintainers         {mps @Schamschula} openmaintainer
 description         xxHash is an Extremely fast Hash algorithm, running at RAM speed \
@@ -22,12 +21,11 @@ if {[string match "*gcc-4.*" ${configure.compiler}]} {
     patchfiles      patch-Makefile.diff
 }
 
-# On compilers that default to C11 mode, build fails with
-# Undefined symbols for architecture x86_64: "_static_assert"
-compiler.c_standard 1999
-configure.cflags-append -std=c99
+patchfiles-append   _Static_assert.patch
 
 subport ${name} {
+    revision        1
+
     license         GPL-2+
 
     depends_run     port:${name}lib
@@ -39,6 +37,8 @@ subport ${name} {
 }
 
 subport ${name}lib {
+    revision        1
+
     license         BSD
 
     post-destroot {

--- a/devel/xxhash/Portfile
+++ b/devel/xxhash/Portfile
@@ -45,14 +45,4 @@ subport ${name}lib {
         file delete -force ${destroot}${prefix}/bin
         file delete -force ${destroot}${prefix}/share
     }
-
-    pre-activate {
-        # xxhash previously installed libxxhash.dylib, etc.
-        if {![catch {set installed [lindex [registry_active ${name}] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 0.7.4] < 0} {
-                registry_deactivate_composite ${name} "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }

--- a/devel/xxhash/files/_Static_assert.patch
+++ b/devel/xxhash/files/_Static_assert.patch
@@ -1,0 +1,19 @@
+No longer depend on `<assert.h>` for XXH_STATIC_ASSERT since some
+versions are buggy.
+
+Use `_Static_assert` instead, which is part of the C11 language.
+
+https://github.com/Cyan4973/xxHash/issues/671
+https://github.com/Cyan4973/xxHash/commit/6189ecd3d44a693460f86280ccf49d33cb4b18e1
+--- xxhash.h.orig	2021-11-29 12:34:10.000000000 -0600
++++ xxhash.h	2021-12-28 19:55:42.000000000 -0600
+@@ -1546,8 +1546,7 @@
+ /* note: use after variable declarations */
+ #ifndef XXH_STATIC_ASSERT
+ #  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)    /* C11 */
+-#    include <assert.h>
+-#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
++#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { _Static_assert((c),m); } while(0)
+ #  elif defined(__cplusplus) && (__cplusplus >= 201103L)            /* C++11 */
+ #    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
+ #  else


### PR DESCRIPTION
#### Description

Fixes build failure of xxhashlib and ports that use xxhashlib when clang is in C11 mode, for some versions of clang.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

Mac OS X 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

I verified that xxhash, xxhashlib, and php81 now build successfully on 10.7.5 using MacPorts clang 9.0.1 whereas before they failed.

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
