### PR TITLE
p5-extutils-makemaker: fix Makefile generation on Tiger

### DIFF
--- a/perl/p5-extutils-makemaker/Portfile
+++ b/perl/p5-extutils-makemaker/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32
 perl5.setup         ExtUtils-MakeMaker 7.64
-revision            0
+revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Create a module Makefile
@@ -23,6 +23,9 @@ if {${perl5.major} != ""} {
     # See https://trac.macports.org/ticket/61630
     patchfiles-append \
                     patch-want-implicit-errors.diff
+
+    patchfiles-append \
+                    patch-extutils-makemaker-rpath.diff
 
     depends_lib-append \
                     port:p${perl5.major}-cpan-meta-requirements \

--- a/perl/p5-extutils-makemaker/files/patch-extutils-makemaker-rpath.diff
+++ b/perl/p5-extutils-makemaker/files/patch-extutils-makemaker-rpath.diff
@@ -1,0 +1,28 @@
+Work around lack of @rpath on Tiger.
+
+--- lib/ExtUtils/MM_Unix.pm.orig
++++ lib/ExtUtils/MM_Unix.pm
+@@ -38,9 +38,12 @@
+                    grep( $^O eq $_, qw(bsdos interix dragonfly) )
+                   );
+     $Is{Android} = $^O =~ /android/;
+-    if ( $^O eq 'darwin' && $^X eq '/usr/bin/perl' ) {
++    if ( $^O eq 'darwin' ) {
+       my @osvers = split /\./, $Config{osvers};
+-      $Is{ApplCor} = ( $osvers[0] >= 18 );
++      if ( $^X eq '/usr/bin/perl' ) {
++        $Is{ApplCor} = ( $osvers[0] >= 18 );
++      }
++      $Is{AppleRPath} = ( $osvers[0] >= 9 );
+     }
+ }
+ 
+@@ -1054,7 +1057,7 @@
+         if ( $Is{IRIX} ) {
+             $ldrun = qq{-rpath "$self->{LD_RUN_PATH}"};
+         }
+-        elsif ( $^O eq 'darwin' ) {
++        elsif ( $^O eq 'darwin' && $Is{AppleRPath} ) {
+             # both clang and gcc support -Wl,-rpath, but only clang supports
+             # -rpath so by using -Wl,-rpath we avoid having to check for the
+             # type of compiler


### PR DESCRIPTION
#### Description

Without this patch, ExtUtils::MakeMaker produces Makefiles that will not compile on Tiger. Tested by building `p5-locale-gettext`, which will not build with unmodified MakeMaker.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
