### PR TITLE
pipenv: update to 2021.11.23

### DIFF
--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                pipenv
-version             2021.5.29
+version             2021.11.23
 revision            0
 categories-append   devel
 platforms           darwin
@@ -29,22 +29,19 @@ long_description    ${description} \
                     ever-important Pipfile.lock, which is used to \
                     produce deterministic builds.
 
-homepage            http://pipenv.org/
+homepage            https://pipenv.pypa.io/en/latest/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  d1efb27850fd4de348c21a9cb72f57f3111aa754 \
-                    sha256  05958fadcd70b2de6a27542fcd2bd72dd5c59c6d35307fdac3e06361fb06e30e \
-                    size    5188489
-
+checksums           rmd160  6a8de514f46d24e82154aace733b6cb0437fb3b9 \
+                    sha256  1bde859e8bbd1d21d503fd995bc0170048d6da7686ab885f074592c99a16e8f3 \
+                    size    5002449
 
 python.default_version 39
 
 depends_lib-append \
     port:py${python.version}-pip \
-    port:py${python.version}-parver \
-    port:py${python.version}-invoke \
     port:py${python.version}-certifi \
     port:py${python.version}-setuptools \
     port:py${python.version}-virtualenv \
@@ -54,17 +51,6 @@ post-destroot {
     xinstall -m 644 \
         ${destroot}${python.pkgd}/${name}/${name}.1 \
         ${destroot}${prefix}/share/man/man1
-}
-
-if {${python.version} < 34} {
-    depends_lib-append \
-        port:py${python.version}-pathlib
-}
-
-if {${python.version} < 30} {
-    depends_lib-append \
-        port:py${python.version}-requests \
-        port:py${python.version}-ordereddict
 }
 
 test.run            yes


### PR DESCRIPTION
#### Description

Tested with a `pipenv update` in a project. The removed dependencies are no longer in setup_requires in pipenv. Pipenv has also dropped pre-3.6 support so that support was removed from the portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
