### PR TITLE
par: add universal support

### DIFF
--- a/textproc/par/Portfile
+++ b/textproc/par/Portfile
@@ -35,7 +35,7 @@ variant i18n description adds support for multibyte characters {
 makefile.override   CC CFLAGS LDFLAGS
 
 build.target
-build.pre_args-append    -f protoMakefile
+build.args          -f protoMakefile
 
 destroot {
     xinstall "${worksrcpath}/${name}" "${destroot}${prefix}/bin/"

--- a/textproc/par/Portfile
+++ b/textproc/par/Portfile
@@ -10,7 +10,7 @@ version             1.52
 revision            3
 categories          textproc
 platforms           darwin
-maintainers         {gmail.com:qbarnes @qbarnes}
+maintainers         {gmail.com:qbarnes @qbarnes} openmaintainer
 description         paragraph reflow for email
 long_description    ${description}
 license             Permissive

--- a/textproc/par/Portfile
+++ b/textproc/par/Portfile
@@ -35,10 +35,7 @@ variant i18n description adds support for multibyte characters {
 makefile.override   CC CFLAGS LDFLAGS
 
 build.target
-
-post-patch {
-    file copy "${worksrcpath}/protoMakefile" "${worksrcpath}/Makefile"
-}
+build.pre_args-append    -f protoMakefile
 
 destroot {
     xinstall "${worksrcpath}/${name}" "${destroot}${prefix}/bin/"
@@ -46,4 +43,4 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.regex     "Par-(\\d+(?:\\.\\d+)(?:\\.\\d+)).tar.gz"
+livecheck.regex     {Par-(\d+(?:\.\d+)*)\.tar\.gz}

--- a/textproc/par/Portfile
+++ b/textproc/par/Portfile
@@ -3,13 +3,14 @@
 # Based on: http://www.openbsd.org/cgi-bin/cvsweb/ports/textproc/par/Makefile
 
 PortSystem          1.0
+PortGroup           makefile 1.0
 
 name                par
 version             1.52
-revision            2
+revision            3
 categories          textproc
 platforms           darwin
-maintainers         gmail.com:qbarnes
+maintainers         {gmail.com:qbarnes @qbarnes}
 description         paragraph reflow for email
 long_description    ${description}
 license             Permissive
@@ -18,26 +19,31 @@ master_sites        ${homepage}
 distname            [string totitle $name][string map {. {}} $version]
 
 checksums           rmd160  253070f319a7f3b3a6f0dad5797882efdbf597bc \
-                    sha256  33dcdae905f4b4267b4dc1f3efb032d79705ca8d2122e17efdecfd8162067082
+                    sha256  33dcdae905f4b4267b4dc1f3efb032d79705ca8d2122e17efdecfd8162067082 \
+                    size    47999
 
 patchfiles          patch-nbspace.diff \
                     patch-ptrdiffwarn.diff \
-                    patch-spelling.diff
-
-use_configure       no
+                    patch-spelling.diff \
+                    patch-protoMakefile.diff
 
 default_variants    +i18n
 variant i18n description adds support for multibyte characters {
     patchfiles-append   patch-i18n.diff
 }
 
-build.args          -f protoMakefile \
-                    CC="${configure.cc} \
-                        -c ${configure.optflags} [get_canonical_archflags cc]" \
-                    LINK1="${configure.cc} [get_canonical_archflags ld]"
+makefile.override   CC CFLAGS LDFLAGS
+
 build.target
+
+post-patch {
+    file copy "${worksrcpath}/protoMakefile" "${worksrcpath}/Makefile"
+}
 
 destroot {
     xinstall "${worksrcpath}/${name}" "${destroot}${prefix}/bin/"
     xinstall -m 444 "${worksrcpath}/${name}.1" "${destroot}${prefix}/share/man/man1/"
 }
+
+livecheck.type      regex
+livecheck.regex     "Par-(\\d+(?:\\.\\d+)(?:\\.\\d+)).tar.gz"

--- a/textproc/par/files/patch-protoMakefile.diff
+++ b/textproc/par/files/patch-protoMakefile.diff
@@ -1,0 +1,33 @@
+--- protoMakefile.orig	2001-03-09 00:53:25.000000000 +0000
++++ protoMakefile	2021-12-29 22:31:06.000000000 +0000
+@@ -47,7 +47,7 @@
+ # Example (for Solaris 2.x with SPARCompiler C):
+ # CC = cc -c -O -s -Xc -DDONTFREE
+ 
+-CC = cc -c
++CC = cc
+ 
+ # Define LINK1 and LINK2 so that the command
+ #
+@@ -61,7 +61,7 @@
+ # LINK1 = cc -s
+ # LINK2 = -o
+ 
+-LINK1 = cc
++LINK1 = $(CC)
+ LINK2 = -o
+ 
+ # Define RM so that the command
+@@ -93,10 +93,10 @@
+ OBJS = buffer$O charset$O errmsg$O par$O reformat$O
+ 
+ .c$O:
+-	$(CC) $<
++	$(CC) -c $(CPPFLAGS) $(CFLAGS) $<
+ 
+ par$E: $(OBJS)
+-	$(LINK1) $(OBJS) $(LINK2) par$E
++	$(LINK1) $(OBJS) $(LINK2) par$E $(LDFLAGS)
+ 
+ buffer$O: buffer.c buffer.h errmsg.h
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

  - use makefile port group (for universal support)
  - add livecheck

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->