### PR TITLE
py-icmplib: new port

### DIFF
--- a/python/py-icmplib/Portfile
+++ b/python/py-icmplib/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-icmplib
+version             3.0.2
+revision            0
+categories-append   net
+platforms           darwin
+license             LGPL-3+
+supported_archs     noarch
+
+python.versions     37 38 39 310
+
+maintainers         nomaintainer
+
+description         Implementation of the ICMP protocol in Python
+long_description    ${description}
+
+homepage            https://github.com/ValentinBELYN/icmplib
+
+checksums           rmd160  263696ec32bde3791d24c6eac22b65cc5898b566 \
+                    sha256  272aa57e9a77731c698e4422715ac09e325e8fe5433510e769468cc23e8323fb \
+                    size    26730
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

Implementation of the ICMP protocol in Python

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6.2 20G314 x86_64
[CLT](https://trac.macports.org/wiki/ProblemHotlist#reinstall-clt) 13.2.0.0.1.1638488800

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

No upstream unit tests.  Tested a subset of functionality in a python39 REPL.  Upstream [advertise](https://github.com/ValentinBELYN/icmplib/blob/a5d3c2b2f675ef475ece73f7d7bc3df5acd1b730/setup.cfg#L23-L28) support for 3.10.

Thank you for MacPorts!