### PR TITLE
ki-shell: update to 0.4.0

### DIFF
--- a/java/ki-shell/Portfile
+++ b/java/ki-shell/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            ki-shell
-version         0.3.3
+version         0.4.0
 revision        0
 
 categories      java
@@ -27,9 +27,9 @@ master_sites    https://search.maven.org/remotecontent?filepath=org/jetbrains/ko
 
 distname        ${name}-${version}-archive
 
-checksums       rmd160  b3443bcfe9f4d78ed3758530fec1c0934f47a37e \
-                sha256  ea7461051589f86c80babd9a54b8c7a6bb29a77ac134498a63f26c54a28508ef \
-                size    60319541
+checksums       rmd160  349b904ed1687f5fdfd7d32eafa72b28284ad746 \
+                sha256  19b7ca5b5d5330cb45cf38022f5d51e87ae46f56558dbb5f0ba683cccd3f0dbf \
+                size    61848043
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Kotlin interactive shell 0.4.0.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?