### PR TITLE
pspp-devel: set PYTHON3 during configure

### DIFF
--- a/math/pspp-devel/Portfile
+++ b/math/pspp-devel/Portfile
@@ -92,6 +92,7 @@ configure.args-append   --disable-rpath \
                         --with-packager=snc \
                         --with-packager-version=${version}-${buildstamp} \
                         --with-packager-bug-reports=[lindex ${maintainers} 0 0]
+configure.env-append    PYTHON3=${configure.python}
 
 set nif_compilers {macports-llvm-gcc-4.2 llvm-gcc-4.2}
 if {[lsearch -exact ${nif_compilers} ${configure.compiler}] > -1} {


### PR DESCRIPTION
#### Description

In the absence of `PYTHON3` configure will find `/usr/bin/python`, which does not always meet the minimum Python version requirement (3.4). Configuration succeeds with this change in place.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
