### PR TITLE
various Python ports: set supported_archs noarch

### DIFF
--- a/devel/vulture/Portfile
+++ b/devel/vulture/Portfile
@@ -5,8 +5,10 @@ PortGroup           python 1.0
 
 name                vulture
 version             2.3
+revision            0
+
 categories          devel python
-platforms           darwin
+supported_archs     noarch
 license             MIT
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
 
@@ -23,5 +25,3 @@ python.default_version  39
 
 depends_build-append    port:py${python.version}-setuptools
 depends_run-append      port:py${python.version}-toml
-
-livecheck.type      pypi

--- a/python/py-astor/Portfile
+++ b/python/py-astor/Portfile
@@ -5,7 +5,9 @@ PortGroup           python 1.0
 
 name                py-astor
 version             0.8.1
-platforms           darwin
+revision            0
+
+supported_archs     noarch
 license             BSD
 maintainers         {emcrisostomo @emcrisostomo} openmaintainer
 
@@ -14,8 +16,6 @@ long_description    astor is a python library to easily manipulate Python\
                     source code via ASTs
 
 homepage            https://github.com/berkerpeksag/astor
-master_sites        pypi:a/astor
-distname            astor-${version}
 
 checksums           rmd160  de731d6a42488a90a41acbcd01cd080495baab21 \
                     sha256  6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e \
@@ -28,6 +28,4 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-setuptools
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-backcall/Portfile
+++ b/python/py-backcall/Portfile
@@ -7,7 +7,7 @@ name                py-backcall
 version             0.2.0
 revision            0
 categories-append   devel
-platforms           darwin
+supported_archs     noarch
 license             BSD
 
 python.versions     27 35 36 37 38 39 310

--- a/python/py-distro/Portfile
+++ b/python/py-distro/Portfile
@@ -11,7 +11,7 @@ maintainers         {mps @Schamschula} openmaintainer
 description         distro provides information about the OS distribution it runs on, \
                     such as a reliable machine-readable ID, or version information.
 long_description    {*}${description}
-platforms           darwin
+supported_archs     noarch
 homepage            https://github.com/nir0s/distro
 
 python.versions     27 36 37 38 39 310

--- a/python/py-fonttools/Portfile
+++ b/python/py-fonttools/Portfile
@@ -16,8 +16,8 @@ long_description    TTX is a tool to convert OpenType and TrueType fonts to \
 
 homepage            https://github.com/fonttools/fonttools
 
-platforms           darwin
 categories          python print
+supported_archs     noarch
 license             MIT
 maintainers         {amake @amake} openmaintainer
 

--- a/python/py-mistune/Portfile
+++ b/python/py-mistune/Portfile
@@ -7,7 +7,7 @@ name                py-mistune
 version             0.8.4
 revision            0
 categories-append   devel textproc
-platforms           darwin
+supported_archs     noarch
 license             BSD
 
 python.versions     27 35 36 37 38 39 310

--- a/python/py-mypy_extensions/Portfile
+++ b/python/py-mypy_extensions/Portfile
@@ -7,6 +7,7 @@ name                py-mypy_extensions
 version             0.4.3
 license             MIT
 platforms           darwin
+supported_archs     noarch
 maintainers         {toby @tobypeterson} openmaintainer
 description         Experimental type system extensions for programs checked with the mypy typechecker
 long_description    The “mypy_extensions” module defines experimental extensions to \

--- a/python/py-patsy/Portfile
+++ b/python/py-patsy/Portfile
@@ -7,7 +7,7 @@ name                py-patsy
 version             0.5.2
 revision            0
 categories-append   math
-platforms           darwin
+supported_archs     noarch
 license             BSD
 
 python.versions     27 35 36 37 38 39 310

--- a/python/py-ptyprocess/Portfile
+++ b/python/py-ptyprocess/Portfile
@@ -7,7 +7,7 @@ name                py-ptyprocess
 version             0.7.0
 revision            0
 categories-append   devel
-platforms           darwin
+supported_archs     noarch
 license             ISC
 
 python.versions     27 35 36 37 38 39 310

--- a/python/py-pybind11/Portfile
+++ b/python/py-pybind11/Portfile
@@ -7,7 +7,7 @@ name                py-pybind11
 version             2.9.0
 revision            0
 categories-append   devel
-platforms           darwin
+supported_archs     noarch
 license             BSD
 
 python.versions     27 35 36 37 38 39 310
@@ -17,7 +17,7 @@ maintainers         {stromnov @stromnov} openmaintainer
 description         Seamless operability between C++11 and Python.
 
 long_description    pybind11 is a lightweight header-only library that \
-                    exposes  C++ types in Python and vice versa, mainly \
+                    exposes C++ types in Python and vice versa, mainly \
                     to create Python bindings of existing C++ code.
 
 homepage            https://github.com/pybind/pybind11

--- a/python/py-requests-toolbelt/Portfile
+++ b/python/py-requests-toolbelt/Portfile
@@ -5,10 +5,10 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        requests toolbelt 0.9.1
-
 name                py-requests-toolbelt
-platforms           darwin
-license             apache
+
+supported_archs     noarch
+license             Apache-2
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         Collection of utilities for python-requests

--- a/python/py-terminado/Portfile
+++ b/python/py-terminado/Portfile
@@ -7,7 +7,7 @@ name                py-terminado
 version             0.9.4
 revision            0
 categories-append   devel
-platforms           darwin
+supported_archs     noarch
 license             BSD
 
 python.versions     27 35 36 37 38 39 310

--- a/python/py-zipp/Portfile
+++ b/python/py-zipp/Portfile
@@ -7,7 +7,7 @@ name                py-zipp
 version             3.6.0
 revision            0
 categories-append   devel
-platforms           darwin
+supported_archs     noarch
 license             MIT
 
 # keep version for PY27 and PY34, these are (indirect) dependencies of py-virtualenv

--- a/sysutils/tiptop/Portfile
+++ b/sysutils/tiptop/Portfile
@@ -16,7 +16,7 @@ long_description    \
     displays various interesting system stats, graphs it, and works on Linux \
     and macOS.
 
-platforms           darwin
+supported_archs     noarch
 license             MIT
 categories          sysutils
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
@@ -27,10 +27,6 @@ checksums           rmd160  a4ae261c51af8ebb5b736c6c2cee39a8658837ad \
 
 python.default_version      39
 python.pep517               yes
-
-depends_build-append \
-                    port:py${python.version}-setuptools \
-                    port:py${python.version}-wheel
 
 depends_run-append  port:py${python.version}-cpuinfo \
                     port:py${python.version}-distro \


### PR DESCRIPTION
#### Description
Several Python ports do not compile stuff and thus don't contain contain no Mach-O files --> add `supported_archs noarch`. Additionally remove `platforms` fields, which is the default since MacPorts v2.7 and some other minor clean-up here and there.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->