### PR TITLE
mysql8: avoid using OpenSSL 3 headers

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -155,6 +155,7 @@ if {$subport eq $name} {
     patchfiles      patch-cmake-install_macros-protobuf-path.cmake.diff \
                     patch-cmake-install_layout.cmake.diff \
                     patch-cmake-sasl-disable-platform-check.diff \
+                    patch-cmake-ssl-include.diff \
                     patch-package_name.cmake.diff \
                     patch-rpcgen.cmake.diff \
                     patch-scripts-cmakelists.diff \

--- a/databases/mysql8/patch-cmake-ssl-include.diff
+++ b/databases/mysql8/patch-cmake-ssl-include.diff
@@ -1,0 +1,17 @@
+https://trac.macports.org/ticket/64115
+OpenSSL 1.1 include path needs to be specified with higher precedence than ${prefix}/include
+since openssl shim port now makes OpenSSL 3 include headers accessible from ${prefix}/include
+
+diff --git a/cmake/ssl.cmake b/cmake/ssl.cmake
+index 293281cf1..96a48d06186 100644
+--- a/cmake/ssl.cmake
++++ b/cmake/ssl.cmake
+@@ -313,7 +313,7 @@ MACRO (MYSQL_CHECK_SSL)
+         SET(SSL_LIBRARIES ${SSL_LIBRARIES} ${LIBDL})
+       ENDIF()
+       MESSAGE(STATUS "SSL_LIBRARIES = ${SSL_LIBRARIES}")
+-      INCLUDE_DIRECTORIES(SYSTEM ${OPENSSL_INCLUDE_DIR})
++      INCLUDE_DIRECTORIES(BEFORE ${OPENSSL_INCLUDE_DIR})
+     ELSE()
+       RESET_SSL_VARIABLES()
+       FATAL_SSL_NOT_FOUND_ERROR(


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/64115

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Build phase without trace mode succeeds.

macOS 12.1
Xcode 13.2 command line tools

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
Does not build with trace mode: https://trac.macports.org/ticket/63455
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
