### PR TITLE
checkssl: update to 0.3.1

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/szazeski/checkssl 0.3 v
+go.setup            github.com/szazeski/checkssl 0.3.1 v
 revision            0
 
 homepage            https://www.checkssl.org
@@ -20,9 +20,9 @@ installs_libs       no
 maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 
-checksums           rmd160  00d066114c7ab8033f422a6f1fd981a4191f66e4 \
-                    sha256  9e436e16bdfaccbc040f8d5240a17709291937336f1d440d3ad98113ca4b24cd \
-                    size    4776593
+checksums           rmd160  c53f2b6f34f9f02f7fe0f45e60cf21685911ace4 \
+                    sha256  1e2db906419b7f91ae3834f62a21fe7892a9e0f1b86f202d70ebf0dde0a8f35f \
+                    size    8156
 
 destroot {
     set doc_dir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to checkssl 0.3.1.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?