### PR TITLE
jreleaser: cleanup

### DIFF
--- a/devel/jreleaser/Portfile
+++ b/devel/jreleaser/Portfile
@@ -46,14 +46,10 @@ destroot {
     xinstall -m 755 -d ${target}
 
     # Copy over the needed elements of our directory tree
-    foreach f [glob -dir ${worksrcpath} *] {
-        copy ${f} ${target}
-    }
+    copy {*}[glob -dir ${worksrcpath} *] ${target}
 
     # Remove extraneous files
-    foreach f [glob -directory ${target}/bin *.bat] {
-        delete ${f}
-    }
+    delete {*}[glob -directory ${target}/bin *.bat]
 
     ln -s ../share/${name}/bin/jreleaser ${destroot}${prefix}/bin/jreleaser
 }

--- a/devel/jreleaser/Portfile
+++ b/devel/jreleaser/Portfile
@@ -26,7 +26,6 @@ long_description JReleaser is a release automation tool. Its goal is to simplify
 
 homepage         https://jreleaser.org
 github.tarball_from releases
-distname         ${name}-${version}
 use_zip          yes
 
 checksums        rmd160 226bb019e05a094752692b5cb71f5f75c9dd391a \

--- a/devel/jreleaser/Portfile
+++ b/devel/jreleaser/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        github 1.0
 PortGroup        java 1.0
 
-name             jreleaser
-version          0.10.0
+github.setup     jreleaser jreleaser 0.10.0 v
 revision         0
 
 categories       devel java
@@ -25,8 +25,7 @@ long_description JReleaser is a release automation tool. Its goal is to simplify
                  may be announced in a variety of channels such as Twitter, Zulip, SDKMAN!, and more.
 
 homepage         https://jreleaser.org
-
-master_sites     https://github.com/jreleaser/jreleaser/releases/download/v${version}
+github.tarball_from releases
 distname         ${name}-${version}
 use_zip          yes
 
@@ -58,7 +57,3 @@ destroot {
 
     ln -s ../share/${name}/bin/jreleaser ${destroot}${prefix}/bin/jreleaser
 }
-
-livecheck.type   regex
-livecheck.url    https://jreleaser.org/releases/latest/download/VERSION
-livecheck.regex  (\[0-9.\]+\\.\[0-9.\]+\\.\[0-9.\]+)


### PR DESCRIPTION
Use github portgroup

Don't use `foreach` where it's unnecessary

Remove `distname ${name}-${version}` since that'd the default