### PR TITLE
py-execnet: update to 1.9.0

### DIFF
--- a/python/py-execnet/Portfile
+++ b/python/py-execnet/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-execnet
-version             1.8.0
+version             1.9.0
 revision            0
 
 categories-append   devel
@@ -21,18 +21,15 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  2fee2009d7a30282c2286a9c50b85f728f7a57bc \
-                    sha256  b73c5565e517f24b62dea8a5ceac178c661c4309d3aa0c3e420856c072c411b4 \
-                    size    173765
+checksums           rmd160  de3fae0a9a4c7731a11333af8a17f65c17136933 \
+                    sha256  8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
+                    size    173884
 
 python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools_scm
-
-    depends_lib-append \
-                    port:py${python.version}-apipkg
 
     post-destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

Remove apipkg dependency as it is removed in this release

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
