### PR TITLE
cdrtools: fix arm64 build by explicitly disabling stack scanning

### DIFF
--- a/sysutils/cdrtools/Portfile
+++ b/sysutils/cdrtools/Portfile
@@ -52,6 +52,7 @@ use_configure       no
 compiler.blacklist  llvm-gcc-4.2 macports-llvm-gcc-4.2 {clang < 300}
 
 configure.cflags-append \
+                    -DNO_SCANSTACK \
                     -Wno-error=implicit-function-declaration
 
 build.cmd           smake


### PR DESCRIPTION
#### Description

avoffset, a helper program run during the cdrtools build, was crashing on arm64 when built with optimization, with `EXC_BREAKPOINT` (`SIGTRAP`), triggered by a `brk` instruction inserted by the compiler in a code path that was provably attempting to dereference a null pointer. Under the same conditions on x86_64, the compiler inserted a `ud2` instruction resulting in `EXC_BAD_INSTRUCTION` (`SIGILL`). On either architecture, when not under optimization, the null pointer dereference resulted in `EXC_BAD_ACCESS` (`SIGSEGV`). avoffset has signal handlers for both `SIGILL` and `SIGSEGV`, and recovered “gracefully” by configuring the build to disable stack scanning and exiting cleanly. Without a `SIGTRAP` handler, the avoffset crash results in a failed build on arm64 under optimization.

It would be easy to add a `SIGTRAP` handler, but a more direct approach is to explicitly disable stack scanning by defining `NO_SCANSTACK` during the build. The stack scanning concept and implementation are both ill-advised, and none of it was working on any architecture or any build configuration on macOS anyway. Even with avoffset “working” (not crashing), all it did on macOS was detect the failure and disable stack scanning for the rest of the build.

Closes: https://trac.macports.org/ticket/63062

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
MacBookPro18,2
macOS 12.1 21C52 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
