### PR TITLE
twine: update to 3.7.1

### DIFF
--- a/python/py-pkginfo/Portfile
+++ b/python/py-pkginfo/Portfile
@@ -4,8 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pkginfo
-version             1.7.1
-platforms           darwin
+version             1.8.2
+revision            0
+
 license             MIT
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 supported_archs     noarch
@@ -18,13 +19,18 @@ long_description \
 
 homepage            https://pypi.python.org/pypi/pkginfo
 
-checksums           rmd160  7ab4420729f4b3ffdc55d282f086bef12ba0db65 \
-                    sha256  e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd \
-                    size    34280
+checksums           rmd160  68c8c2dba495b74d2f681f44ad1de71c9e7bac11 \
+                    sha256  542e0d0b6750e2e21c20179803e40ab50598d8066d51097a0e382cba9eb02bff \
+                    size    374689
 
 python.versions     27 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
+
+    if {${python.version} < 38} {
+        depends_run-append  port:py${python.version}-importlib-metadata
+    }
+
     livecheck.type          none
 }

--- a/python/py-twine/Portfile
+++ b/python/py-twine/Portfile
@@ -2,49 +2,17 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           obsolete 1.0
 
 name                py-twine
+replaced_by         twine
 version             3.1.1
-revision            1
-platforms           darwin
-supported_archs     noarch
-license             apache
-maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
-
-homepage            https://twine.readthedocs.io
-description         Twine is a utility for interacting with PyPI.
-long_description    ${description}
-
-checksums           rmd160  b2687dcbae3d817251d3ced75eb8564f9a0d886a \
-                    sha256  d561a5e511f70275e5a485a6275ff61851c16ffcb3a95a602189161112d9f160 \
-                    size    146258
+revision            2
 
 python.versions     27 36 37 38
 
-if {${name} ne ${subport}} {
-    if {${python.version} < 36} {
-        version     1.15.0
-
-        checksums   rmd160  32f9a8e1acd7f03011b3703687e2e9aa7eea1fb0 \
-                    sha256  a3d22aab467b4682a22de4a422632e79d07eebd07ff2a7079effb13f8a693787 \
-                    size    139576
-    } elseif {${python.version} < 38} {
-        depends_run-append \
-            port:py${python.version}-importlib-metadata
-    }
-
-    if {${python.version} >= 36} {
-        depends_build-append \
-            port:py${python.version}-setuptools_scm
-    }
-
-    depends_lib-append \
-        port:py${python.version}-setuptools
-    depends_run-append \
-        port:py${python.version}-keyring \
-        port:py${python.version}-readme_renderer \
-        port:py${python.version}-requests-toolbelt \
-        port:py${python.version}-tqdm \
-        port:py${python.version}-pkginfo
-
+foreach pver ${python.versions} {
+    replaced_by         twine
 }
+
+# remove after January 5, 2023

--- a/python/twine/Portfile
+++ b/python/twine/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                twine
+version             3.7.1
+revision            0
+
+categories-append   devel
+supported_archs     noarch
+license             Apache-2.0
+maintainers         {gmail.com:jjstickel @jjstickel} \
+                    {reneeotten @reneeotten} openmaintainer
+
+description         Collection of utilities for publishing packages on PyPI
+long_description    {*}${description}
+
+homepage            https://twine.readthedocs.io/
+
+checksums           rmd160  5661938a81ffc1762d7309abc3daf4d52b40060b \
+                    sha256  28460a3db6b4532bde6a5db6755cf2dce6c5020bada8a641bb2c5c7a9b1f35b8 \
+                    size    231946
+
+python.default_version  310
+python.pep517       yes
+
+depends_build-append \
+                    port:py${python.version}-setuptools_scm
+
+depends_lib-append  port:py${python.version}-colorama \
+                    port:py${python.version}-importlib-metadata \
+                    port:py${python.version}-keyring \
+                    port:py${python.version}-pkginfo \
+                    port:py${python.version}-readme_renderer \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-requests-toolbelt \
+                    port:py${python.version}-rfc3986 \
+                    port:py${python.version}-tqdm
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} AUTHORS README.rst \
+        LICENSE ${destroot}${docdir}
+}


### PR DESCRIPTION
#### Description
Change from `py-twine` to `twine`; as far as I can tell this is just a program that happens to be written in Python; not intended to be imported as module. So just provide the `twine` port with one Python version and set the previous Python subports to `replaced_by` and obsolete the old port.

- update `twine` to latest upstream version (3.7.1) 
- update `py-pkgconfig` to latest version as required

Closes: https://trac.macports.org/ticket/64337

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? 
- [x] tried a full install with `sudo port -vst install`? 
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
