### PR TITLE
git: use updated gettext dependencies

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                git
 version             2.34.1
-revision            1
+revision            2
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -40,9 +40,13 @@ perl5.branches          5.28 5.30 5.32
 perl5.default_branch    5.28
 perl5.create_variants   ${perl5.branches}
 
+depends_build-append \
+                    port:gettext
+
 depends_lib-append  port:curl \
                     port:zlib \
                     port:expat \
+                    port:gettext-runtime \
                     port:libiconv
 
 depends_run-append  path:bin/rsync:rsync


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/64363

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
