### PR TITLE
zabbix4/5: 4.0.37/5.0.19; remote 42 and 44

### DIFF
--- a/net/zabbix4/Portfile
+++ b/net/zabbix4/Portfile
@@ -21,10 +21,10 @@ long_description    Zabbix is the ultimate open source availability and \
                     of the best commercial ones.
 
 array set VERSIONS {
-    4  4.0.36
+    4  4.0.37
     42 4.2.8
     44 4.4.10
-    5  5.0.18
+    5  5.0.19
 }
 
 set zver            [regsub -all {[^\d]} ${subport} {}]
@@ -45,26 +45,17 @@ dist_subdir         zabbix${zver}
 if {$zver == 4} {
     livecheck.regex     "zabbix-(4\\.0\\.\[0-9\]+).tar.gz"
     checksums \
-        rmd160  389100bb3577ef125be5122190d36d3066151b3c \
-        sha256  6febee3f41c03832cd5f354f877642699afed86953f19542dc042a633f070d58 \
-        size    17619115
-}
-
-if {$zver == 42 || $zver == 44} {
-    # REMOVE JANUARY 2022
-    revision        2
-    PortGroup       obsolete 1.0
-
-    replaced_by     zabbix5
-    livecheck.type  none
+        rmd160  ef5add293753824391bde89d9ca453f50d7b12d8 \
+        sha256  5ae7b197c236cc0eb78f24d10def1b3123fefa29b048ec5ce0b11d5271fc8e9b \
+        size    17552391
 }
 
 if {$zver == 5} {
     livecheck.regex     "zabbix-(5\\.0\\.\[0-9\]+).tar.gz"
     checksums \
-        rmd160  bc4fe9f12b68dd4552215dabfb4d74452b6a6dee \
-        sha256  7d15c4d683801edc2bdcda3fd94afdf6a7142a1a92aa71f4a9220af8e39d9e0e \
-        size    21377940
+        rmd160  89f59d0c991915019e136870afb350587d3e29e3 \
+        sha256  7ac6bb0dccdd696886f11bbda72f0794e86f8648d5f08423330ba227a17973a1 \
+        size    21367685
 }
 
 patchfiles          log_and_pid_locations.patch


### PR DESCRIPTION
Maintainer updates.