### PR TITLE
netperf: Fix implicit func decls and wrong code

### DIFF
--- a/net/netperf/Portfile
+++ b/net/netperf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        HewlettPackard netperf 2.7.0 netperf-
-revision            1
+revision            2
 categories          net
 license             Noncommercial BSD BSD-old
 platforms           darwin
@@ -22,7 +22,9 @@ long_description    Netperf is a benchmark that can be used to measure \
 homepage            https://hewlettpackard.github.io/netperf/
 github.tarball_from archive
 
-patchfiles          40c8a0fb873ac07a95f0c0253b2bd66109aa4c51.diff
+patchfiles          40c8a0fb873ac07a95f0c0253b2bd66109aa4c51.diff \
+                    implicit.patch \
+                    mach.patch
 
 # openmaintainer does not apply to the configure argument. Talk with me before touching them.
 configure.args      --enable-demo

--- a/net/netperf/files/implicit.patch
+++ b/net/netperf/files/implicit.patch
@@ -1,0 +1,21 @@
+Fix:
+
+net_uuid.c:158:5: error: implicit declaration of function 'read' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+net_uuid.c:159:5: error: implicit declaration of function 'close' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+Part of:
+
+https://github.com/HewlettPackard/netperf/commit/0b0cbbef75021134c83be0c3dd21878467e11144
+--- src/net_uuid.c.orig
++++ src/net_uuid.c
+@@ -29,6 +29,10 @@
+ #include <string.h>
+ #include <fcntl.h>
+ 
++#if defined(HAVE_UNISTD_H)
++#include <unistd.h>
++#endif
++
+ #if defined(HAVE_INTTYPES_H)
+ #include <inttypes.h>
+ #endif

--- a/net/netperf/files/mach.patch
+++ b/net/netperf/files/mach.patch
@@ -1,0 +1,26 @@
+Fix:
+
+netcpu_osx.c:73:3: error: implicit declaration of function 'mach_port_deallocate' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+netcpu_osx.c:73:37: error: too few arguments to function call, expected 2, have 1
+
+https://github.com/HewlettPackard/netperf/pull/67
+--- src/netcpu_osx.c.orig	2015-07-20 12:39:35.000000000 -0500
++++ src/netcpu_osx.c	2022-01-06 12:22:50.000000000 -0600
+@@ -48,7 +48,7 @@
+    SnowLeopard (10.6) happy, we hope it does not anger previous
+    versions */
+ #include <mach/mach_host.h>
+-/* #include <mach/mach_port.h> */
++#include <mach/mach_port.h>
+ 
+ #include "netsh.h"
+ #include "netlib.h"
+@@ -70,7 +70,7 @@
+ void
+ cpu_util_terminate(void)
+ {
+-  mach_port_deallocate(lib_host_port);
++  mach_port_deallocate(mach_task_self(), lib_host_port);
+   return;
+ }
+ 


### PR DESCRIPTION
#### Description

Fix implicit declaration of functions which caused build failure with Xcode 12 and later.

Fix invocation of `mach_port_deallocate` which was called with 1 argument but needs 2. I assume this change is correct but I don't know.

Closes: https://trac.macports.org/ticket/62219

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
