### PR TITLE
bash: update to 5.1.16

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                bash
 set bash_version    5.1
-set bash_patchlevel 12
+set bash_patchlevel 16
 subport bash50 {
     # used by bashdb port
     set bash_version    5.0
@@ -94,7 +94,23 @@ if {${subport} eq ${name}} {
                         bash51-012 \
                         rmd160  ddd681c0b2fa328157528532388615a3f4abc16a \
                         sha256  10f189c8367c4a15c7392e7bf70d0ff6953f78c9b312ed7622303a779273ab98 \
-                        size    6372
+                        size    6372 \
+                        bash51-013 \
+                        rmd160  234a8702a0a229bda181a4173bc28e5373a7d547 \
+                        sha256  c7acb66df435d284304c16ca83a5265f9edd9368612095b01a733d45c77ed5ad \
+                        size    1277 \
+                        bash51-014 \
+                        rmd160  1a75aec5dacce12a0a9925a518585097cb9e9a1c \
+                        sha256  6a4ee0c81b437b96279a792c1efcec4ba56f009195a318083db6b53b096f83d0 \
+                        size    1456 \
+                        bash51-015 \
+                        rmd160  69e2623becfa0670077216f787cd2dc7da0e7851 \
+                        sha256  1b37692ef1f6cc3dcec246773443276066e6b1379868f8c14e01f4dfd4df80f0 \
+                        size    1409 \
+                        bash51-016 \
+                        rmd160  b82ce6e4bce59b290961c4ac682e5b527e9e87cb \
+                        sha256  8899144f76a5db1fb41a89ed881c9f19add95728dd71db324f772ef225c5384f \
+                        size    2122
 } elseif {${subport} eq "bash50"} {
    checksums           ${distname}${extract.suffix} \
                        rmd160  a081428a896d617855499376b670eca3433a27c1 \


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
