### PR TITLE
python PG: switch off livecheck in subports

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -419,3 +419,27 @@ default python.link_binaries_suffix {[python_get_defaults binary_suffix]}
 
 default python.move_binaries no
 default python.move_binaries_suffix {[python_get_defaults binary_suffix]}
+
+# python._first_version: keep track of the first version line in the port.
+global python._first_version
+option_proc version python._set_version
+
+proc python._set_version {option action args} {
+    if {"set" ne ${action}} {
+        return
+    }
+
+    global python._first_version
+
+    if {![info exists python._first_version]} {
+        set python._first_version [option ${option}]
+    }
+}
+
+# If a subport has not changed the version, disable livecheck.
+pre-livecheck {
+    global name subport version python._first_version
+    if {${name} ne ${subport} && ${version} eq ${python._first_version}} {
+        livecheck.type  none
+    }
+}


### PR DESCRIPTION
#### Description
The Python ports should only have the `livecheck` enabled in the `py-<packagname>` stubport. So currently all ports should add ```    livecheck.type  none``` to their ```if {${subport} ne ${name}} {``` block and we often request this change in PRs. It seems to me we can just switch this off by default in the `python` PG and then in few possible cases where it would be desirable to have it running in the subports as well, the maintainer needs to do a bit more work.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
