### PR TITLE
vscode: new port

### DIFF
--- a/editors/vscode/Portfile
+++ b/editors/vscode/Portfile
@@ -1,0 +1,78 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            microsoft vscode 1.63.2
+revision                0
+categories              editors
+maintainers             {@sainnhe gmail.com:sainnhe} \
+                        openmaintainer
+license                 MIT
+supported_archs         x86_64 arm64
+
+description             Visual Studio Code - Open Source (Code - OSS)
+
+long_description \
+    Visual Studio Code combines the simplicity of a code editor with what developers \
+    need for their core edit-build-debug cycle. It provides comprehensive code editing, \
+    navigation, and understanding support along with lightweight debugging, a rich \
+    extensibility model, and lightweight integration with existing tools.
+
+github.tarball_from     archive
+
+checksums               rmd160  179bf6d4b2738022d8fa7ccedf509ee83898bbf9 \
+                        sha256  21fc9bc17ba4cf480b1e006f298363d86215c339c480f8d781cabcfedad2d624 \
+                        size    15411738
+
+depends_build-append    port:nodejs16 \
+                        port:npm8 \
+                        port:yarn
+
+use_configure           no
+
+patchfiles              patch-postinstall-fix.diff
+
+variant stable conflicts insiders description {Patch with features in VSCode stable release} {
+    patchfiles-append   patch-features-stable.diff
+}
+
+variant insiders conflicts stable description {Patch with features in VSCode insiders release} {
+    patchfiles-append   patch-features-insiders.diff
+}
+
+default_variants        +stable
+universal_variant       no
+
+if {${build_arch} eq "arm64"} {
+    set vscode-arch "arm64"
+} else {
+    set vscode-arch "x64"
+}
+
+build {
+    if {[variant_isset stable]} {
+        system "/usr/bin/curl -sL https://github.com/dhanishgajjar/vscode-icons/raw/master/icns/default.icns -o ${worksrcpath}/resources/darwin/code.icns"
+    } elseif {[variant_isset insiders]} {
+        system "/usr/bin/curl -sL https://github.com/dhanishgajjar/vscode-icons/raw/master/icns/default_insider_light.icns -o ${worksrcpath}/resources/darwin/code.icns"
+    }
+    system "export PYTHON=/usr/bin/python3 && cd ${worksrcpath} && yarn && yarn gulp vscode-darwin-${vscode-arch}"
+}
+
+destroot {
+    if {[variant_isset stable]} {
+        set vscode-bundle "Visual Studio Code.app"
+    } elseif {[variant_isset insiders]} {
+        set vscode-bundle "Visual Studio Code - Insiders.app"
+    } else {
+        set vscode-bundle "Code - OSS.app"
+    }
+    copy "${workpath}/VSCode-darwin-${vscode-arch}/${vscode-bundle}" "${destroot}${applications_dir}"
+    ln -s "${applications_dir}/${vscode-bundle}/Contents/Resources/app/bin/code" "${destroot}${prefix}/bin/code"
+    set zsh-completion "${destroot}${prefix}/share/zsh/site-functions"
+    set bash-completion "${destroot}${prefix}/share/bash-completion/completions"
+    xinstall -d "${zsh-completion}"
+    xinstall -d "${bash-completion}"
+    xinstall "${worksrcpath}/resources/completions/zsh/_code" "${zsh-completion}/_code"
+    xinstall "${worksrcpath}/resources/completions/bash/code" "${bash-completion}/code"
+}

--- a/editors/vscode/files/patch-features-insiders.diff
+++ b/editors/vscode/files/patch-features-insiders.diff
@@ -1,0 +1,79 @@
+--- product.json.orig	2022-01-07 17:57:31.838364241 +0800
++++ product.json	2022-01-07 18:58:55.931310103 +0800
+@@ -1,6 +1,55 @@
+ {
+-	"nameShort": "Code - OSS",
+-	"nameLong": "Code - OSS",
++	"quality": "insider",
++	"extensionsGallery": {
++		"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
++		"cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
++		"itemUrl": "https://marketplace.visualstudio.com/items",
++		"resourceUrlTemplate": "https://{publisher}.vscode-unpkg.net/{publisher}/{name}/{version}/{path}",
++		"controlUrl": "https://az764295.vo.msecnd.net/extensions/marketplace.json",
++		"recommendationsUrl": "https://az764295.vo.msecnd.net/extensions/workspaceRecommendations.json.gz"
++	},
++	"linkProtectionTrustedDomains": ["https://*.visualstudio.com", "https://*.microsoft.com", "https://aka.ms", "https://vscode-auth.github.com", "https://client-auth-staging-14a768b.herokuapp.com", "https://*.gallerycdn.vsassets.io", "https://github.com/microsoft/", "https://github.com/MicrosoftDocs/", "https://login.microsoftonline.com"],
++	"documentationUrl": "https://go.microsoft.com/fwlink/?LinkID=533484#vscode",
++	"releaseNotesUrl": "https://go.microsoft.com/fwlink/?LinkId=724002",
++	"keyboardShortcutsUrlMac": "https://go.microsoft.com/fwlink/?linkid=832143",
++	"introductoryVideosUrl": "https://go.microsoft.com/fwlink/?linkid=832146",
++	"tipsAndTricksUrl": "https://go.microsoft.com/fwlink/?linkid=852118",
++	"newsletterSignupUrl": "https://www.research.net/r/vsc-newsletter",
++	"twitterUrl": "https://go.microsoft.com/fwlink/?LinkID=533687",
++	"requestFeatureUrl": "https://go.microsoft.com/fwlink/?LinkID=533482",
++	"reportMarketplaceIssueUrl": "https://github.com/microsoft/vsmarketplace/issues/new",
++	"privacyStatementUrl": "https://go.microsoft.com/fwlink/?LinkId=786907",
++	"npsSurveyUrl": "https://aka.ms/vscode-nps",
++	"cesSurveyUrl": "https://aka.ms/new-to-vscode-feedback",
++	"checksumFailMoreInfoUrl": "https://go.microsoft.com/fwlink/?LinkId=828886",
++	"settingsSearchUrl": "https://bingsettingssearch.trafficmanager.net/api/Search",
++	"commit": "9afbea7caab9dd06592ddd98aa4161b43b126d3f",
++	"date": "2022-01-06T05:15:46.948Z",
++	"extensionSyncedKeys": {
++		"ritwickdey.liveserver": ["liveServer.setup.version"]
++	},
++	"auth": {
++		"loginUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
++		"tokenUrl": "https://login.microsoftonline.com/common/oauth2/token",
++		"redirectUrl": "https://vscode-redirect.azurewebsites.net/",
++		"clientId": "aebc6443-996d-45c2-90f0-388ff96faa56"
++	},
++	"configurationSync.store": {
++		"url": "https://vscode-sync-insiders.trafficmanager.net/",
++		"stableUrl": "https://vscode-sync.trafficmanager.net/",
++		"insidersUrl": "https://vscode-sync-insiders.trafficmanager.net/",
++		"canSwitch": true,
++		"authenticationProviders": {
++			"microsoft": {
++				"scopes": ["openid", "profile", "email", "offline_access"]
++			},
++			"github": {
++				"scopes": ["user:email"]
++			}
++		}
++	},
++	"nameShort": "Code - Insiders",
++	"nameLong": "Visual Studio Code - Insiders",
+ 	"applicationName": "code-oss",
+ 	"dataFolderName": ".vscode-oss",
+ 	"win32MutexName": "vscodeoss",
+@@ -26,12 +75,12 @@
+ 	"reportIssueUrl": "https://github.com/microsoft/vscode/issues/new",
+ 	"urlProtocol": "code-oss",
+ 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-webview.net/insider/c42793d0357ff9c6589cce79a847177fd42852ee/out/vs/workbench/contrib/webview/browser/pre/",
+-	"extensionAllowedProposedApi": [
+-		"ms-vscode.vscode-js-profile-flame",
+-		"ms-vscode.vscode-js-profile-table",
+-		"GitHub.remotehub",
+-		"GitHub.remotehub-insiders"
+-	],
++	"extensionAllowedProposedApi": ["GitHub.codespaces", "GitHub.copilot-nightly", "GitHub.copilot", "GitHub.vscode-pull-request-github-insiders", "GitHub.vscode-pull-request-github", "GitHub.remotehub", "GitHub.remotehub-insiders", "Microsoft.vscode-nmake-tools", "ms-azuretools.vscode-docker", "ms-dotnettools.dotnet-interactive-vscode", "ms-python.gather", "ms-python.python", "ms-toolsai.jupyter", "ms-toolsai.vscode-ai", "ms-toolsai.vscode-ai-remote", "ms-vscode-remote.remote-containers", "ms-vscode-remote.remote-ssh-edit-nightly", "ms-vscode-remote.remote-ssh-edit", "ms-vscode-remote.remote-ssh-nightly", "ms-vscode-remote.remote-ssh-serverless", "ms-vscode-remote.remote-ssh", "ms-vscode-remote.remote-wsl", "ms-vscode-remote.remote-wsl-recommender", "ms-vscode.azure-account", "ms-vscode.azure-sphere-tools-ui", "ms-vscode.azure-sphere-tools", "ms-vscode.js-debug-nightly", "ms-vscode.js-debug", "ms-vscode.lsif-browser", "ms-vscode.vscode-selfhost-test-provider", "ms-vsliveshare.cloudenv-explorer", "ms-vsliveshare.cloudenv", "ms-vsliveshare.vsliveshare", "ms-vsonline.vsonline", "dbaeumer.vscode-eslint", "VisualStudioExptTeam.vscodeintellicode", "VisualStudioExptTeam.vscodeintellicode-insiders", "VisualStudioExptTeam.vscodeintellicode-completions", "ms-azuretools.vscode-azureappservice"],
++	"extensionEnabledApiProposals": {
++		"ms-vscode.anycode": ["languageStatus"],
++		"ms-vscode.vscode-github-issue-notebooks": ["notebookEditor"],
++		"tanhakabir.rest-book": ["notebookEditor"]
++	},
+ 	"builtInExtensions": [
+ 		{
+ 			"name": "ms-vscode.references-view",

--- a/editors/vscode/files/patch-features-stable.diff
+++ b/editors/vscode/files/patch-features-stable.diff
@@ -1,0 +1,78 @@
+--- product.json.orig	2022-01-07 17:57:31.838364241 +0800
++++ product.json	2022-01-07 17:55:13.355025459 +0800
+@@ -1,6 +1,55 @@
+ {
+-	"nameShort": "Code - OSS",
+-	"nameLong": "Code - OSS",
++	"quality": "stable",
++	"extensionsGallery": {
++		"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
++		"cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
++		"itemUrl": "https://marketplace.visualstudio.com/items",
++		"resourceUrlTemplate": "https://{publisher}.vscode-unpkg.net/{publisher}/{name}/{version}/{path}",
++		"controlUrl": "https://az764295.vo.msecnd.net/extensions/marketplace.json",
++		"recommendationsUrl": "https://az764295.vo.msecnd.net/extensions/workspaceRecommendations.json.gz"
++	},
++	"linkProtectionTrustedDomains": ["https://*.visualstudio.com", "https://*.microsoft.com", "https://aka.ms", "https://vscode-auth.github.com", "https://client-auth-staging-14a768b.herokuapp.com", "https://*.gallerycdn.vsassets.io", "https://github.com/microsoft/", "https://github.com/MicrosoftDocs/", "https://login.microsoftonline.com"],
++	"documentationUrl": "https://go.microsoft.com/fwlink/?LinkID=533484#vscode",
++	"releaseNotesUrl": "https://go.microsoft.com/fwlink/?LinkID=533483#vscode",
++	"keyboardShortcutsUrlMac": "https://go.microsoft.com/fwlink/?linkid=832143",
++	"introductoryVideosUrl": "https://go.microsoft.com/fwlink/?linkid=832146",
++	"tipsAndTricksUrl": "https://go.microsoft.com/fwlink/?linkid=852118",
++	"newsletterSignupUrl": "https://www.research.net/r/vsc-newsletter",
++	"twitterUrl": "https://go.microsoft.com/fwlink/?LinkID=533687",
++	"requestFeatureUrl": "https://go.microsoft.com/fwlink/?LinkID=533482",
++	"reportMarketplaceIssueUrl": "https://github.com/microsoft/vsmarketplace/issues/new",
++	"privacyStatementUrl": "https://go.microsoft.com/fwlink/?LinkId=786907",
++	"npsSurveyUrl": "https://aka.ms/vscode-nps",
++	"cesSurveyUrl": "https://aka.ms/new-to-vscode-feedback",
++	"checksumFailMoreInfoUrl": "https://go.microsoft.com/fwlink/?LinkId=828886",
++	"settingsSearchUrl": "https://bingsettingssearch.trafficmanager.net/api/Search",
++	"commit": "899d46d82c4c95423fb7e10e68eba52050e30ba3",
++	"date": "2021-12-15T09:39:46.686Z",
++	"extensionSyncedKeys": {
++		"ritwickdey.liveserver": ["liveServer.setup.version"]
++	},
++	"auth": {
++		"loginUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
++		"tokenUrl": "https://login.microsoftonline.com/common/oauth2/token",
++		"redirectUrl": "https://vscode-redirect.azurewebsites.net/",
++		"clientId": "aebc6443-996d-45c2-90f0-388ff96faa56"
++	},
++	"configurationSync.store": {
++		"url": "https://vscode-sync.trafficmanager.net/",
++		"stableUrl": "https://vscode-sync.trafficmanager.net/",
++		"insidersUrl": "https://vscode-sync-insiders.trafficmanager.net/",
++		"canSwitch": false,
++		"authenticationProviders": {
++			"microsoft": {
++				"scopes": ["openid", "profile", "email", "offline_access"]
++			},
++			"github": {
++				"scopes": ["user:email"]
++			}
++		}
++	},
++	"nameShort": "Code",
++	"nameLong": "Visual Studio Code",
+ 	"applicationName": "code-oss",
+ 	"dataFolderName": ".vscode-oss",
+ 	"win32MutexName": "vscodeoss",
+@@ -26,12 +75,11 @@
+ 	"reportIssueUrl": "https://github.com/microsoft/vscode/issues/new",
+ 	"urlProtocol": "code-oss",
+ 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-webview.net/insider/c42793d0357ff9c6589cce79a847177fd42852ee/out/vs/workbench/contrib/webview/browser/pre/",
+-	"extensionAllowedProposedApi": [
+-		"ms-vscode.vscode-js-profile-flame",
+-		"ms-vscode.vscode-js-profile-table",
+-		"GitHub.remotehub",
+-		"GitHub.remotehub-insiders"
+-	],
++	"extensionAllowedProposedApi": ["GitHub.codespaces", "GitHub.copilot-nightly", "GitHub.copilot", "GitHub.vscode-pull-request-github-insiders", "GitHub.vscode-pull-request-github", "GitHub.remotehub", "GitHub.remotehub-insiders", "Microsoft.vscode-nmake-tools", "ms-dotnettools.dotnet-interactive-vscode", "ms-python.gather", "ms-python.python", "ms-toolsai.jupyter", "ms-toolsai.vscode-ai", "ms-toolsai.vscode-ai-remote", "ms-vscode-remote.remote-containers-nightly", "ms-vscode-remote.remote-containers", "ms-vscode-remote.remote-ssh-edit-nightly", "ms-vscode-remote.remote-ssh-edit", "ms-vscode-remote.remote-ssh-nightly", "ms-vscode-remote.remote-ssh", "ms-vscode-remote.remote-ssh-serverless", "ms-vscode-remote.remote-wsl", "ms-vscode-remote.remote-wsl-recommender", "ms-vscode-remote.vscode-remote-extensionpack-nightly", "ms-vscode-remote.vscode-remote-extensionpack", "ms-vscode.azure-account", "ms-vscode.azure-sphere-tools-ui", "ms-vscode.azure-sphere-tools", "ms-vscode.js-debug-nightly", "ms-vscode.js-debug", "ms-vscode.lsif-browser", "ms-vscode.vscode-selfhost-test-provider", "ms-vsliveshare.cloudenv-explorer", "ms-vsliveshare.cloudenv", "ms-vsliveshare.vsliveshare", "ms-vsonline.vsonline", "dbaeumer.vscode-eslint", "tanhakabir.rest-book", "VisualStudioExptTeam.vscodeintellicode", "VisualStudioExptTeam.vscodeintellicode-insiders", "VisualStudioExptTeam.vscodeintellicode-completions", "vscode.vscode-web-playground", "ms-azuretools.vscode-azureappservice"],
++	"extensionEnabledApiProposals": {
++		"ms-vscode.anycode": ["languageStatus"],
++		"ms-vscode.vscode-github-issue-notebooks": ["notebookEditor"]
++	},
+ 	"builtInExtensions": [
+ 		{
+ 			"name": "ms-vscode.references-view",

--- a/editors/vscode/files/patch-postinstall-fix.diff
+++ b/editors/vscode/files/patch-postinstall-fix.diff
@@ -1,0 +1,10 @@
+--- build/npm/postinstall.js.orig	2022-01-06 22:30:54.000000000 +0800
++++ build/npm/postinstall.js	2022-01-07 17:28:45.000000000 +0800
+@@ -90,5 +90,5 @@
+ 	yarnInstall(watchPath);
+ }
+ 
+-cp.execSync('git config pull.rebase merges');
+-cp.execSync('git config blame.ignoreRevsFile .git-blame-ignore');
++// cp.execSync('git config pull.rebase merges');
++// cp.execSync('git config blame.ignoreRevsFile .git-blame-ignore');


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Add new port [vscode](https://github.com/microsoft/vscode).

The official vscode release contains tracks/telemetry. This port however, compiles from source code and doesn't contain any tracks/telemetry binaries.

There are two available variants:

- `stable` (default): patching product.json to use vscode marketplace, enable settings sync, update extension proposed api to unblock some features in stable release.
- `insiders`: like stable but update extension proposed api to unblock some features in insider release, also the sync url is set to insider channel.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G314 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
