### PR TITLE
py35-whoosh: remove obsolete subport

### DIFF
--- a/python/py-whoosh/Portfile
+++ b/python/py-whoosh/Portfile
@@ -42,9 +42,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none
 }
-
-subport py35-whoosh {
-    # remove 2021-12-10
-    replaced_by py36-whoosh
-    PortGroup obsolete 1.0
-}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
