### PR TITLE
gitqlient: new port

### DIFF
--- a/devel/gitqlient/Portfile
+++ b/devel/gitqlient/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           app 1.0
+PortGroup           github 1.0
+PortGroup           qmake5 1.0
+
+github.setup        francescmm gitqlient 1.4.3 v
+github.tarball_from archive
+revision            0
+categories          devel
+license             LGPL-2.1
+
+maintainers         {harens @harens} openmaintainer
+
+description         Multi-platform Git client written with Qt
+long_description    GitQlient, pronounced as git+client, is a multi-platform Git \
+                    client originally forked from QGit. Nowadays it goes beyond of just a fork and \
+                    adds a lot of new functionality.
+
+# Don't use ${name} in homepage - different url.
+homepage            https://francescmm.github.io/GitQlient/
+
+checksums           rmd160  7e35fde124bc36ae07346f0578cb3f8ca7111e79 \
+                    sha256  28de5df9866a6ad6639b0f4b46cac0066a30e27a4898c92c25d4e191c23e035a \
+                    size    4477433
+
+qt5.depends_component \
+                    qtwebengine
+
+configure.args-append \
+                    ${name}.pro \
+                    VERSION=${version}
+
+depends_run         port:git
+
+# Generate app from executable since bundled app has some runtime issues.
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name}.app/Contents/MacOS/${name} ${destroot}${prefix}/bin/
+}
+
+app.name            GitQlient
+app.icon            src/resources/icon.icns
+app.identifier      org.${name}.${name}
+app.retina          yes


### PR DESCRIPTION
#### Description
[GitQlient](https://github.com/francescmm/GitQlient) is a multi-platform git client written with Qt.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
xcode-select version 2384

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
