### PR TITLE
www/wml: fix compile errors

### DIFF
--- a/www/wml/Portfile
+++ b/www/wml/Portfile
@@ -64,7 +64,7 @@ configure.args          --with-perl="${perl5.bin}" \
 
 configure.env           CPATH=${prefix}/include LANG=C LC_ALL=C
 
-build.args              CC=${configure.cc} CPP=${configure.cpp}
+build.args              CC="${configure.cc} -Wno-error=implicit-function-declaration" CPP=${configure.cpp} 
 
 build.env               LANG=C LC_ALL=C
 

--- a/www/wml/Portfile
+++ b/www/wml/Portfile
@@ -46,6 +46,7 @@ depends_build           port:lynx
 depends_lib-append      port:gdbm \
                         port:gettext \
                         port:libiconv \
+                        port:libpng \
                         port:p${perl5.major}-getopt-long \
                         port:p${perl5.major}-bit-vector \
                         port:p${perl5.major}-image-size \
@@ -71,4 +72,3 @@ destroot.destdir        prefix=${destroot}${prefix} \
                         mandir=${destroot}${prefix}/share/man
 
 test.run                yes
-


### PR DESCRIPTION
#### Description
Fixes compile errors for port www/wml.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.0.1 21A559 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->