### PR TITLE
fontforge: update to 20201107

### DIFF
--- a/graphics/fontforge/Portfile
+++ b/graphics/fontforge/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        fontforge fontforge 20200314
-revision            2
+github.setup        fontforge fontforge 20201107
+revision            0
 github.tarball_from releases
 use_xz              yes
 
@@ -24,9 +24,9 @@ long_description    FontForge allows you to edit outline and bitmap fonts.  You 
 
 homepage            https://fontforge.org
 
-checksums           rmd160  c7368a53f6a5b6649f7bc18a957368006870b67b \
-                    sha256  cd190b237353dc3f48ddca7b0b3439da8ec4fcf27911d14cc1ccc76c1a47c861 \
-                    size    13850076
+checksums           rmd160  25ef811489661aa66200c3d49a5e6f8951129d9c \
+                    sha256  68bcba8f602819eddc29cd356ee13fafbad7a80d19b652d354c6791343476c78 \
+                    size    14163424
 
 # don't override cmake build dependencies
 depends_build-append \
@@ -57,16 +57,20 @@ compiler.blacklist-append {clang < 500}
 # fix 32bit builds by masking an old Carbon call to GetTime
 patchfiles-append   patch-fontforge-carbon-gettime-namecollision.diff
 
-# use older noerr macros, and replace missing SRefCon definition
+# use older noerr macros
 if {${os.platform} eq "darwin" && ${os.major} <= 9} {
     patchfiles-append \
-                patch-fontforge-startui-require-noerr-and-SRefCon-fix.diff \
+                patch-fontforge-startui-require-noerr.diff \
 }
 
 # the date command on Tiger is too old for this port, use gnu coreutils dates instead
 platform darwin 8 {
     depends_build-append path:libexec/coreutils/libstdbuf.so:coreutils
     configure.env-append PATH=${prefix}/libexec/gnubin/:$env(PATH)
+
+    # add SRefCon definition, which is missing in the Tiger SDK
+    patchfiles-append \
+                patch-fontforge-startui-SRefCon-tiger.diff \
 }
 
 configure.args-append -DENABLE_GUI=False \

--- a/graphics/fontforge/files/patch-fontforge-startui-SRefCon-tiger.diff
+++ b/graphics/fontforge/files/patch-fontforge-startui-SRefCon-tiger.diff
@@ -1,0 +1,13 @@
+--- fontforgeexe/startui.c.orig
++++ fontforgeexe/startui.c
+@@ -64,6 +64,10 @@ extern uninm_blocks_db blocks_db;
+ 
+ #ifdef __Mac
+ extern void setup_cocoa_app();
++
++/* add missing def on older MacOS systems */
++typedef long SRefCon;
++
+ #endif
+ 
+ #ifdef _NO_LIBPNG

--- a/graphics/fontforge/files/patch-fontforge-startui-require-noerr.diff
+++ b/graphics/fontforge/files/patch-fontforge-startui-require-noerr.diff
@@ -1,20 +1,5 @@
-diff --git ./fontforgeexe/startui.c.orig ./fontforgeexe/startui.c
-index 39ff112..8284db9 100644
 --- ./fontforgeexe/startui.c.orig
 +++ ./fontforgeexe/startui.c
-@@ -64,6 +64,12 @@ extern uninm_blocks_db blocks_db;
- 
- #ifdef __Mac
- extern void setup_cocoa_app();
-+
-+/* replace missing def on older MacOS systems */
-+#ifndef SRefCon
-+#define SRefCon long
-+#endif
-+
- #endif
- 
- #ifdef _NO_LIBPNG
 @@ -545,23 +551,23 @@ static  OSErr install_apple_event_handlers(void) {
  
      err     = AEInstallEventHandler(kCoreEventClass, kAEOpenApplication,


### PR DESCRIPTION
#### Description

Also attempt to address a build issue on 10.5. See: https://trac.macports.org/ticket/60409
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
