### PR TITLE
squish: fix dylib version number

### DIFF
--- a/graphics/squish/Portfile
+++ b/graphics/squish/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 
 name                squish
 version             1.15
-revision            1
+revision            2
 checksums           rmd160  01a380439426f5a40ad8f42ada58a09d2f1d3fbb \
                     sha256  628796eeba608866183a61d080d46967c9dda6723bc0a3ec52324c85d2147269 \
                     size    59199
@@ -29,6 +29,11 @@ extract.suffix      .tgz
 extract.mkdir       yes
 
 patchfiles-append   add-pkgconfig-file.diff
+
+post-patch {
+    reinplace -E "s/(^\[\[:space:]]+VERSION) 0.0/\\1 ${version}/" \
+        ${worksrcpath}/CMakeLists.txt
+}
 
 configure.args      -DBUILD_SHARED_LIBS=ON \
                     -DBUILD_SQUISH_WITH_OPENMP=OFF


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The version-numbered dylib that gets generated is currently hardcoded to `0.0`, which results in a versioned dylib of `libsquish.0.0.dylib`. This commit fixes the incorrect usage of the dylib version number; it will now start generating the versioned dylib as `libsquish.1.15.dylib`. I have left the `SOVERSION 0.0` in place in the `CMakeLists.txt` file, so that `libsquish.0.0.dylib` will still get generated as a (symlink) compatibility version; this means that revbumps to dependent ports are not needed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
