### PR TITLE
josm: update to 18360

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18303
+version             18360
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  5aa6488f7115a93e5661be101252f3815779a954 \
-                    sha256  b3c32e5dc0e5f83c235ceb5fea5b69c5849e084f51dbfc7d889b360686478173 \
-                    size    77640118
+checksums           rmd160  042c11eef63eb31baf5ce2c47a9cd92bef28de91 \
+                    sha256  642c9b81a2f03df4151b6809f9db4494863b6c66547bd47c6bfd01e902bcc8af \
+                    size    78493316
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2022-01-03: Stable release 18360](https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.12)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
