### PR TITLE
gn-devel: build tests only during test phase

### DIFF
--- a/devel/gn-devel/Portfile
+++ b/devel/gn-devel/Portfile
@@ -34,7 +34,7 @@ configure.pre_args
 
 build.dir           ${worksrcpath}/out
 build.cmd           ${prefix}/bin/ninja
-build.target
+build.target        gn
 # Build verbosely
 build.args          -v
 
@@ -43,5 +43,6 @@ destroot {
 }
 
 test.run            yes
-test.cmd            ${worksrcpath}/out/gn_unittests
-test.target
+test.target         gn_unittests
+test.args           {*}${build.args}
+test.post_args      && ${worksrcpath}/out/gn_unittests


### PR DESCRIPTION
#### Description
No revision bump because this does not affect installed files.

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1
Xcode 13.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
