### PR TITLE
chromedriver: update to 97.0.4692.71

### DIFF
--- a/www/chromedriver/Portfile
+++ b/www/chromedriver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                chromedriver
-version             96.0.4664.45
+version             97.0.4692.71
 categories          www
 platforms           darwin
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -42,9 +42,9 @@ destroot {
 set latest_major_version \
                     [lindex [split ${version} .] 0]
 
-checksums           rmd160  fd794e33e44a3c6069c447317a607f45f5b50754 \
-                    sha256  0e88eab13db9bd6ef2def8c2342556c29f739f00846de21258b2a3b61e476b64 \
-                    size    8234174
+checksums           rmd160  c66d93b3c40f6a6801bb14dd39f0c9ab84819a60 \
+                    sha256  7ae949b20216aa9dda278564d877d2c815ded013442cf0b64f429d1676b361ff \
+                    size    8277283
 
 if {${subport} eq ${name}} {
     conflicts       ${name}-${latest_major_version}
@@ -57,6 +57,18 @@ subport ${name}-${latest_major_version} {
             ${prefix}/bin/${name}-${latest_major_version} \
             ${destroot}${prefix}/bin/chromedriver
     }
+}
+
+subport ${name}-96 {
+    version         96.0.4664.45
+
+    checksums       rmd160  fd794e33e44a3c6069c447317a607f45f5b50754 \
+                    sha256  0e88eab13db9bd6ef2def8c2342556c29f739f00846de21258b2a3b61e476b64 \
+                    size    8234174
+
+    master_sites    https://chromedriver.storage.googleapis.com/${version}/
+    dist_subdir     ${name}/${version}
+    livecheck.type  none
 }
 
 subport ${name}-86 {
@@ -144,6 +156,8 @@ subport ${name}-79 {
     livecheck.type  none
 }
 
-livecheck.type      regex
-livecheck.url       http://chromedriver.storage.googleapis.com/LATEST_RELEASE
-livecheck.regex     {^(.*)$}
+if {$subport eq $name} {
+    livecheck.type  regex
+    livecheck.url   http://chromedriver.storage.googleapis.com/LATEST_RELEASE
+    livecheck.regex {^(.*)$}
+}


### PR DESCRIPTION
#### Description

Also fixed livecheck
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->