### PR TITLE
google-cloud-sdk: update to 368.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             367.0.0
+version             368.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  7dcea5a11cb2b5df0ce32889c45b8f3e3b328d79 \
-                    sha256  0793754d58f1aca3a7f7b726714fe49817789b57a26eb84d98135da86b208ed5 \
-                    size    97372275
+    checksums       rmd160  1c4037a7aeb3b6fdb210c781a061831a811e6ea6 \
+                    sha256  813ed5808cb94ce70271e12786977e4874ef89ccc82944470eca7ae7445d1791 \
+                    size    97467794
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  46589b463e1233bf7e74219e55b7a3e068a4090c \
-                    sha256  870ca3ca68b0a98af934cb4eae3f8910d1cd971b052eead53397325d9f140233 \
-                    size    93636198
+    checksums       rmd160  142d0a84b7e0c9a65b70eae545d17063e2fa5da1 \
+                    sha256  05b8a839b5140399fdc05c94b3d6d3e3b9c5f227d3fb7541bfd4150365b70864 \
+                    size    93733059
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  7bb1e7b972097d81018b3503bd6699f1bed72a45 \
-                    sha256  1689b401444887ee527a5fe5c02cab8b4220e120b432c9244b94582d0ee7e002 \
-                    size    93568866
+    checksums       rmd160  c015ae8f77ed0084ce9f43f5bdce04ffe00bae10 \
+                    sha256  d37e86b852475088d4ed9d880f61f174b2535c848c66236bc580e2ea0c98d641 \
+                    size    93665033
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 368.0.0.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?