### PR TITLE
warzone2100: add license_noconflict

### DIFF
--- a/games/warzone2100/Portfile
+++ b/games/warzone2100/Portfile
@@ -73,6 +73,15 @@ if {$subport eq ${name}} {
     depends_run-append      port:${name}-music \
                             port:${name}-videos
 
+    # This (sub)port is getting flagged with a '"warzone2100" is not
+    # distributable because its license "gpl" conflicts with license
+    # "OpenSSL" of dependency "openssl11"' on the buildbot builders.
+    # However, warzone2100 is in fact NOT dependent on openssl11; the
+    # curl port has already been transitioned to using openssl3, and the
+    # port that is still dependent on openssl11 is asciidoctor, one of
+    # the tools that warzone2100 is using during the build process.
+    license_noconflict      openssl
+
     compiler.cxx_standard   2011
 
     post-patch {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The warzone2100 subport is getting flagged with a `"warzone2100" is not distributable because its license "gpl" conflicts with license "OpenSSL" of dependency "openssl11"` on the buildbot builders. However, warzone2100 is in fact *not* dependent on `openssl11`; the `curl` port has already been transitioned to using `openssl3`, and the port that is still dependent on `openssl11` is `asciidoctor`, one of the tools that warzone2100 is using during the build process (i.e., `asciidoctor` is a `depends_build`, not a `depends_lib`).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
