### PR TITLE
redeclipse, warzone2100: add supported_archs noarch to game data subports

### DIFF
--- a/games/redeclipse/Portfile
+++ b/games/redeclipse/Portfile
@@ -131,9 +131,9 @@ if {$subport eq "${name}-data"} {
     github.setup        ${name} base ${version} v
     github.tarball_from releases
     use_bzip2           yes
+    supported_archs     noarch
     distfiles           ${name}_${version}_combined${extract.suffix}
     distname            ${name}-${version}
-
     checksums           rmd160  290f3d40c38e8c8b21f7261ab90cecbe99ba73e9 \
                         sha256  5a14ffd5297e8471cbbe5fe77297945c756361e0fd0f3febf94c1d17004b4aa9 \
                         size    906217329

--- a/games/warzone2100/Portfile
+++ b/games/warzone2100/Portfile
@@ -208,6 +208,7 @@ if {$subport eq "${name}-music"} {
     github.setup        Warzone2100 data-music \
                         68e157c79f6db989120aad9e0b7ad6251c0bf721
     version             0.0.0
+    supported_archs     noarch
 
     long_description-append \
                         \n\nThis package ($subport) contains the music \
@@ -229,6 +230,7 @@ if {$subport eq "${name}-music"} {
 
 if {$subport eq "${name}-videos"} {
     version             0.0.0
+    supported_archs     noarch
 
     long_description-append \
                         \n\nThis package ($subport) contains the \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

As suggested by @ryandesign, add `supported_archs noarch` to subports that contain game data files.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
