### PR TITLE
watchman: update to version 2022.01.10.00

### DIFF
--- a/devel/cpptoml/Portfile
+++ b/devel/cpptoml/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           boost 1.0
+
+github.setup        skystrife cpptoml 0.1.1 v
+checksums           rmd160  8471ec7641bccc67299cef3ddcf1b5f113fd6dbe \
+                    sha256  23af72468cfd4040984d46a0dd2a609538579c78ddc429d6b8fd7a10a6e24403 \
+                    size    47398
+
+categories          devel
+license             MIT
+
+maintainers         nomaintainer
+
+description         A header-only library for parsing TOML configuration files.
+long_description    {*}${description}
+
+github.tarball_from archive
+
+compiler.cxx_standard   2017

--- a/devel/fb303/Portfile
+++ b/devel/fb303/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           boost 1.0
+
+github.setup        facebook fb303 1d687797b77b1256b4efe992524ee6cce0fa3c1f
+version             20220112
+checksums           rmd160  ab70801177b36fc825aa7cd1662236a4f3f717cc \
+                    sha256  d60868204b6ce0ed3be39e4e1a69edd022f3c6b0b6d489fb713282f6cdcd0999 \
+                    size    236987
+
+categories          devel
+license             Apache-2
+
+maintainers         nomaintainer
+
+description         fb303 is a base Thrift service and a common set of functionality for querying stats, options, and other information from a service.
+long_description    {*}${description}
+
+github.tarball_from archive
+
+depends_lib-append  port:bison \
+                    port:python38 \
+                    port:flex \
+                    port:gflags \
+                    port:google-glog \
+                    port:double-conversion \
+                    port:libevent \
+                    port:libsodium \
+                    port:snappy \
+                    path:lib/libssl.dylib:openssl \
+                    port:mstch \
+                    port:wangle \
+                    port:folly \
+                    port:fizz \
+                    port:fbthrift \
+                    port:py38-thrift \
+                    port:zstd \
+                    port:zlib
+
+compiler.cxx_standard   2017
+
+configure.args-append \
+                    -DBUILD_TESTS=OFF \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DPYTHON_EXTENSIONS=OFF

--- a/sysutils/watchman/Portfile
+++ b/sysutils/watchman/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           boost 1.0
 PortGroup           cargo_fetch 1.0
 
-github.setup        facebook watchman 2021.09.20.00 v
+github.setup        facebook watchman 2022.01.10.00 v
 revision            0
 
 categories          sysutils
@@ -24,6 +24,11 @@ depends_build-append \
                     port:pkgconfig
 depends_lib-append  port:pcre \
                     port:folly \
+                    port:fizz \
+                    port:wangle \
+                    port:fbthrift \
+                    port:fb303 \
+                    port:cpptoml \
                     port:libevent \
                     port:python39
 
@@ -47,94 +52,94 @@ compiler.cxx_standard \
                     2017
 
 checksums           ${distname}${extract.suffix}  \
-                    rmd160  4e74142f248561cbec56e5d0a2a3fbbac06fcacf \
-                    sha256  1efc783e4544289aaad90820e7526eb721dcf15780941f7ef02fcaa428e79903 \
-                    size    3753547
+                        rmd160  78ca1ff1b7e60593feecfd15ab9653371d838ee6 \
+                        sha256  269284ae6333560ac68376af79a49d90a6aaf79e9108e7950ddc59fee51c2abd \
+                        size    3767898
+
 
 cargo.crates \
     ahash                            0.3.8  e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217 \
-    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-    anyhow                          1.0.44  61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1 \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anyhow                          1.0.52  84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
     bytes                            1.1.0  c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
+    clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
     const-random                    0.1.13  f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4 \
     const-random-macro              0.1.13  615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40 \
     crossbeam                        0.8.1  4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845 \
-    crossbeam-channel                0.5.1  06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4 \
+    crossbeam-channel                0.5.2  e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa \
     crossbeam-deque                  0.8.1  6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e \
-    crossbeam-epoch                  0.9.5  4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd \
-    crossbeam-queue                  0.3.2  9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9 \
-    crossbeam-utils                  0.8.5  d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db \
+    crossbeam-epoch                  0.9.6  97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762 \
+    crossbeam-queue                  0.3.3  b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110 \
+    crossbeam-utils                  0.8.6  cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
     futures                         0.1.31  3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678 \
-    futures                         0.3.17  a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca \
-    futures-channel                 0.3.17  5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888 \
-    futures-core                    0.3.17  88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d \
-    futures-executor                0.3.17  45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c \
-    futures-io                      0.3.17  522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377 \
-    futures-macro                   0.3.17  18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb \
-    futures-sink                    0.3.17  36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11 \
-    futures-task                    0.3.17  1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99 \
-    futures-util                    0.3.17  36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481 \
+    futures                         0.3.19  28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4 \
+    futures-channel                 0.3.19  ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b \
+    futures-core                    0.3.19  d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7 \
+    futures-executor                0.3.19  29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a \
+    futures-io                      0.3.19  b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2 \
+    futures-macro                   0.3.19  6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c \
+    futures-sink                    0.3.19  e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508 \
+    futures-task                    0.3.19  6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72 \
+    futures-util                    0.3.19  d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164 \
     getrandom                        0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
     heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
     hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
-    instant                         0.1.10  bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
     jwalk                            0.6.0  172752e853a067cbce46427de8470ddf308af7fd8ceaf9b682ef31a5021b6bb9 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.102  a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103 \
+    libc                           0.2.112  1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125 \
     lock_api                         0.4.5  712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109 \
     log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
     maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
     memchr                           2.4.1  308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a \
-    memoffset                        0.6.4  59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9 \
-    mio                             0.7.13  8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16 \
+    memoffset                        0.6.5  5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
+    mio                             0.7.14  8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc \
     miow                             0.3.7  b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21 \
     ntapi                            0.3.6  3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44 \
-    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-    once_cell                        1.8.0  692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56 \
+    num_cpus                        1.13.1  19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1 \
+    once_cell                        1.9.0  da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5 \
     parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
     parking_lot_core                 0.8.5  d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216 \
-    pin-project-lite                 0.2.7  8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443 \
+    pin-project-lite                 0.2.8  e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
-    proc-macro-nested                0.1.7  bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086 \
-    proc-macro2                     1.0.29  b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d \
-    quote                            1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
+    proc-macro2                     1.0.36  c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029 \
+    quote                           1.0.14  47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d \
     rayon                            1.5.1  c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90 \
     rayon-core                       1.9.1  d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e \
     redox_syscall                   0.2.10  8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    serde                          1.0.130  f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913 \
-    serde_derive                   1.0.130  d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b \
+    serde                          1.0.133  97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a \
+    serde_derive                   1.0.133  ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537 \
     signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
-    slab                             0.4.4  c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590 \
-    smallvec                         1.6.1  fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e \
+    slab                             0.4.5  9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5 \
+    smallvec                         1.7.0  1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    structopt                       0.3.23  bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa \
-    structopt-derive                0.4.16  134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba \
-    syn                             1.0.76  c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84 \
+    structopt                       0.3.25  40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c \
+    structopt-derive                0.4.18  dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0 \
+    syn                             1.0.85  a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-    thiserror                       1.0.29  602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88 \
-    thiserror-impl                  1.0.29  bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c \
+    thiserror                       1.0.30  854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417 \
+    thiserror-impl                  1.0.30  aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b \
     tiny-keccak                      2.0.2  2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237 \
-    tokio                           1.12.0  c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc \
-    tokio-macros                     1.3.0  54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110 \
-    tokio-util                       0.6.8  08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd \
+    tokio                           1.15.0  fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838 \
+    tokio-macros                     1.7.0  b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7 \
+    tokio-util                       0.6.9  9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0 \
     unicode-segmentation             1.8.0  8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b \
     unicode-width                    0.1.9  3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973 \
     unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
-    version_check                    0.9.3  5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe \
-    wasi                          0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    wasi     0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f

--- a/sysutils/watchman/files/cmake-python-destdir.diff
+++ b/sysutils/watchman/files/cmake-python-destdir.diff
@@ -1,11 +1,11 @@
 --- CMakeLists.txt
 +++ #<buffer CMakeLists.txt>
-@@ -411,7 +411,7 @@
-         ${CMAKE_COMMAND} -E env
-           CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-           ${Python3_EXECUTABLE} ${SETUP_PY} install
--          --root $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}
-+          --root $ENV{DESTDIR}
-         RESULT_VARIABLE STATUS)
-       if (NOT STATUS STREQUAL 0)
-         message(FATAL_ERROR \"pywatchman install failed\")
+@@ -409,7 +409,7 @@
+       ${CMAKE_COMMAND} -E env
+         CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+         ${Python3_EXECUTABLE} ${SETUP_PY} install
+-        --root $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}
++        --root $ENV{DESTDIR}
+       RESULT_VARIABLE STATUS)
+     if (NOT STATUS STREQUAL 0)
+       message(FATAL_ERROR \"pywatchman install failed\")


### PR DESCRIPTION
#### Description

- add cpptoml and fb303 packages as new dependencies
- update cargo.crates (i.e., Cargo.lock) versions to latest

TODO: watchman is broken due to a bug in folly: https://github.com/Homebrew/homebrew-core/pull/92869, https://github.com/facebook/folly/issues/1705

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.1
Xcode 13.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
  [watchman: Update to 2022.01.03.00](https://trac.macports.org/ticket/64384)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

