### PR TITLE
py-scipy: add mkl variant

### DIFF
--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -149,12 +149,17 @@ if {${name} ne ${subport}} {
         system "chmod -R a+r ${destroot}${prefix}"
     }
 
-    variant atlas conflicts openblas description "Use MacPorts ATLAS libraries" {
+    variant atlas conflicts openblas mkl description "Use MacPorts ATLAS libraries" {
         depends_lib-append  port:atlas
     }
 
-    variant openblas conflicts atlas description "Use MacPorts OpenBLAS Libraries" {
+    variant openblas conflicts atlas mkl description "Use MacPorts OpenBLAS Libraries" {
         depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS
+    }
+
+    variant mkl conflicts atlas openblas description "Use MacPorts MKL Libraries" {
+        depends_lib-append  port:py${python.version}-mkl \
+                            port:py${python.version}-mkl-include
     }
 
     # Make +openblas a default variant, at least temporarily, to
@@ -162,17 +167,20 @@ if {${name} ne ${subport}} {
     # /usr/lib/liblapack.* missing a symbol. see also:
     # https://trac.macports.org/ticket/57829
     if {![variant_isset atlas] &&
-        ![variant_isset openblas]} {
+        ![variant_isset openblas] &&
+        ![variant_isset mkl]} {
         default_variants +openblas
     }
 
     if {[variant_isset atlas]} {
         # use MacPorts atlas
         build.env-append    OPENBLAS=None \
+                            MKLROOT=None \
                             ATLAS=${prefix}/lib \
                             LAPACK=${prefix}/lib \
                             BLAS=${prefix}/lib
         destroot.env-append OPENBLAS=None \
+                            MKLROOT=None \
                             ATLAS=${prefix}/lib \
                             LAPACK=${prefix}/lib \
                             BLAS=${prefix}/lib
@@ -204,9 +212,41 @@ have the +atlas variant active. Please ensure that numpy is activated with the\
     } elseif {[variant_isset openblas]} {
         # use MacPorts OpenBLAS
         build.env-append    OPENBLAS=${prefix}/lib \
-                            ATLAS=None
+                            ATLAS=None \
+                            MKLROOT=None
         destroot.env-append OPENBLAS=${prefix}/lib \
-                            ATLAS=None
+                            ATLAS=None \
+                            MKLROOT=None
+
+    } elseif {[variant_isset mkl]} {
+        # use MacPorts MKL
+        build.env-append    OPENBLAS=None \
+                            ATLAS=None \
+                            MKLROOT=${python.prefix}
+        destroot.env-append OPENBLAS=None \
+                            ATLAS=None \
+                            MKLROOT=${python.prefix}
+
+        pre-fetch {
+            # check that numpy has the mkl variant active
+            if {![catch {set result [active_variants py${python.version}-numpy mkl ""]}]} {
+                if {!$result} {
+
+                    return -code error \
+"You have selected the +mkl variant but py${python.version}-numpy does not\
+have the +mkl variant active. Please ensure that numpy is activated with the\
++mkl variant."
+                }
+            }
+        }
+
+        # set absolute path to remove references to @rpath/libmkl_rt.2.dylib
+        post-destroot {
+            foreach soname [exec find ${destroot}${python.pkgd}/scipy -name "*.so"] {
+                system "install_name_tool -change @rpath/libmkl_rt.2.dylib ${python.prefix}/lib/libmkl_rt.2.dylib ${soname}"
+                }
+        }
+
     } else {
         # use Accelerate BLAS
         build.env-append    OPENBLAS=None \


### PR DESCRIPTION
#### Description
Following-up on the addition of a MKL variant in `py-numpy`, do the same in `py-scipy`. I added the check to make sure that both ports are installed with the same variant as was done for `openblas`. I am not convinced though that this actually works the way it's supposed to be... for example I just got the binary file for `py-scipy` with the `openblas` variant even though I have `py-numpy` installed with the `mkl` variant. It does work when building from source, but the check doesn't catch things when binaries are downloaded (on the buildbot it will only use the default `openblas` variant anyway). I am not sure whether it is possible, and, if so, how to change the logic in the Portfile to accomplish that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
