### PR TITLE
libbonoboui: replace dep to pangox-compat with pango 

### DIFF
--- a/gnome/libbonoboui/Portfile
+++ b/gnome/libbonoboui/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                libbonoboui
 version             2.24.5
-revision            10
+revision            11
 set branch          [join [lrange [split ${version} .] 0 1] .]
 maintainers         nomaintainer
 categories          gnome
@@ -26,7 +26,8 @@ master_sites        gnome:sources/${name}/${branch}/
 use_bzip2           yes
 
 checksums           rmd160  0ebf5618e1564317561b098d6774f0c75ea082f0 \
-                    sha256  fab5f2ac6c842d949861c07cb520afe5bee3dce55805151ce9cd01be0ec46fcd
+                    sha256  fab5f2ac6c842d949861c07cb520afe5bee3dce55805151ce9cd01be0ec46fcd \
+                    size    976250
 
 depends_build       path:libexec/coreutils/libstdbuf.so:coreutils \
                     port:pkgconfig \
@@ -43,7 +44,7 @@ depends_lib         port:desktop-file-utils \
                     port:libffi \
                     port:libgnome \
                     port:libgnomecanvas \
-                    port:pangox-compat
+                    path:lib/pkgconfig/pango.pc:pango
 
 # see #48986
 depends_lib-append path:lib/pkgconfig/gtk+-2.0.pc:gtk2


### PR DESCRIPTION
#### Description

The aim of this four commits is to be able to build and use unison (in its gtk variant) on Monterey machines with M1 CPUs. Therefore, one needs to be able to build the GTK-related dependencies of unison.
By the way, replacing the broken (on Monterey) pangox-compat with pango in the dependencies of libbonoboui is a step on the way of retiring pangox-compat (see https://trac.macports.org/ticket/64228).

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
