### PR TITLE
redeclipse: fix licenses

### DIFF
--- a/games/redeclipse/Portfile
+++ b/games/redeclipse/Portfile
@@ -7,7 +7,6 @@ name                redeclipse
 set pretty_name     "Red Eclipse"
 version             1.6.0
 categories          games
-license             zlib CC-BY-SA-3
 maintainers         @jasonliu--
 
 homepage            https://www.${name}.net
@@ -30,6 +29,7 @@ if {$subport eq ${name}} {
     PortGroup       app 1.0
 
     github.setup    ${name} base ${version} v
+    license         zlib
 
     checksums       rmd160  2a36e97ebe3e151c835cffdfee12515d83d4d8c8 \
                     sha256  56106b819f32f4d82709ebb3bfc6e8648e88c7fc191f6f0a287a31f3f7612aad \
@@ -131,7 +131,9 @@ if {$subport eq "${name}-data"} {
     github.setup        ${name} base ${version} v
     github.tarball_from releases
     use_bzip2           yes
+    license             CC-BY-SA-3
     supported_archs     noarch
+
     distfiles           ${name}_${version}_combined${extract.suffix}
     distname            ${name}-${version}
     checksums           rmd160  290f3d40c38e8c8b21f7261ab90cecbe99ba73e9 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The source code of Red Eclipse is licensed zlib and the game data is licensed CC, so this commit splits up the `license` line so that they apply to the individual subports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
