### PR TITLE
whitebox-tools: update to 2.0.0

### DIFF
--- a/gis/whitebox-tools/Portfile
+++ b/gis/whitebox-tools/Portfile
@@ -5,114 +5,138 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        jblindsay whitebox-tools 1.4.0
+github.setup        jblindsay whitebox-tools 2.0.0 v
+revision            0
 categories          gis
 platforms           darwin
 maintainers         {@mholling gmail.com:mdholling} openmaintainer
 description         an advanced geospatial data analysis platform
-long_description    an advanced geospatial data analysis platform
+long_description    {*}${description}
 homepage            https://jblindsay.github.io/ghrg/WhiteboxTools/index.html
 license             MIT
 
+patchfiles          patch-Cargo.lock.diff
+
 checksums           ${distname}${extract.suffix} \
-                    rmd160  af2546a2f34f317211970874b319b0cabf20ba32 \
-                    sha256  15abf0c972a5eb6cac90265b9357864da722281ee8508b8875099fd57d91f236 \
-                    size    15797799
+                    rmd160  5b5ee28ed2020d4583f7bffd5e3052a5359e7f61 \
+                    sha256  b7e87307b13a80b3fce2d03bbdfadc61f9a77e6e1f7a58202d085a043fdd28d8 \
+                    size    34083798
 
 # When updating Portfile version, see instructions in cargo_fetch
 # PortGroup file for updating crate versions and checksums:
 
 cargo.crates \
-                    adler32 1.0.4 5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2 \
-                    alga 0.9.3 4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2 \
-                    approx 0.3.2 f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3 \
-                    autocfg 0.1.7 1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
-                    autocfg 1.0.0 f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
-                    bitflags 1.2.1 cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-                    byteorder 1.3.4 08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
-                    bzip2 0.3.3 42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
-                    bzip2-sys 0.1.8+1.0.8 05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038 \
-                    cc 1.0.52 c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d \
-                    cfg-if 0.1.10 4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
-                    chrono 0.4.15 942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b \
-                    cloudabi 0.0.3 ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-                    crc32fast 1.2.0 ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1 \
-                    crossbeam-deque 0.7.3 9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285 \
-                    crossbeam-epoch 0.8.2 058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
-                    crossbeam-queue 0.2.3 774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570 \
-                    crossbeam-utils 0.7.2 c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
-                    either 1.5.3 bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3 \
-                    flate2 1.0.14 2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42 \
-                    fuchsia-cprng 0.1.1 a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
-                    generic-array 0.12.3 c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec \
-                    getrandom 0.1.14 7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
-                    hermit-abi 0.1.12 61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4 \
-                    itoa 0.4.5 b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e \
-                    kdtree 0.6.0 80ee359328fc9087e9e3fc0a4567c4dd27ec69a127d6a70e8d9dd22845b8b1a2 \
-                    late-static 0.3.0 fa0fc01ae4c505cff39f8bf927b37a4799ef3309bb865f8cffad2fa3250439c2 \
-                    lazy_static 1.4.0 e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-                    libc 0.2.69 99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005 \
-                    libm 0.2.1 c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a \
-                    lzw 0.10.0 7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084 \
-                    matrixmultiply 0.2.3 d4f7ec66360130972f34830bfad9ef05c6610a43938a467bcc9ab9369ab3478f \
-                    maybe-uninit 2.0.0 60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
-                    memoffset 0.5.5 c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f \
-                    miniz_oxide 0.3.6 aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5 \
-                    msdos_time 0.1.6 aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729 \
-                    nalgebra 0.18.1 aaa9fddbc34c8c35dd2108515587b8ce0cab396f17977b8c738568e4edb521a2 \
-                    num-complex 0.2.4 b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95 \
-                    num-integer 0.1.42 3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba \
-                    num-rational 0.2.4 5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
-                    num-traits 0.2.11 c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
-                    num_cpus 1.13.0 05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-                    pdqselect 0.1.0 4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27 \
-                    podio 0.1.6 780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd \
-                    ppv-lite86 0.2.6 74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b \
-                    proc-macro2 1.0.12 8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319 \
-                    quote 1.0.4 4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7 \
-                    rand 0.3.23 64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c \
-                    rand 0.4.6 552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
-                    rand 0.6.5 6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
-                    rand 0.7.3 6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
-                    rand_chacha 0.1.1 556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
-                    rand_chacha 0.2.2 f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
-                    rand_core 0.3.1 7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
-                    rand_core 0.4.2 9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
-                    rand_core 0.5.1 90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
-                    rand_distr 0.2.2 96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2 \
-                    rand_hc 0.1.0 7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
-                    rand_hc 0.2.0 ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
-                    rand_isaac 0.1.1 ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
-                    rand_jitter 0.1.4 1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
-                    rand_os 0.1.3 7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
-                    rand_pcg 0.1.2 abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
-                    rand_pcg 0.2.1 16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
-                    rand_xorshift 0.1.1 cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
-                    rawpointer 0.2.1 60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3 \
-                    rayon 1.3.1 62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080 \
-                    rayon-core 1.7.1 e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280 \
-                    rdrand 0.4.0 678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
-                    rstar 0.7.1 0650eaaa56cbd1726fd671150fce8ac6ed9d9a25d1624430d7ee9d196052f6b6 \
-                    ryu 1.0.4 ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1 \
-                    scopeguard 1.1.0 d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-                    serde 1.0.110 99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c \
-                    serde_derive 1.0.110 818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984 \
-                    serde_json 1.0.53 993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2 \
-                    statrs 0.9.0 7d8c8660e3867d1a0578cbf7fd9532f1368b7460bd00b080e2d4669618a9bec7 \
-                    syn 1.0.19 e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7 \
-                    time 0.1.43 ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
-                    typenum 1.12.0 373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33 \
-                    unicode-xid 0.2.0 826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c \
-                    wasi 0.9.0+wasi-snapshot-preview1 cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
-                    winapi 0.3.8 8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6 \
-                    winapi-i686-pc-windows-gnu 0.4.0 ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-                    winapi-x86_64-pc-windows-gnu 0.4.0 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-                    zip 0.3.3 77ce0ceee93c995954a31f77903925a6a8bb094709445238e344f2107910e29e
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    adler32                          1.2.0  aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234 \
+    alga                             0.9.3  4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2 \
+    alloc-no-stdlib                  2.0.3  35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3 \
+    alloc-stdlib                     0.2.1  697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2 \
+    approx                           0.3.2  f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3 \
+    autocfg                          0.1.7  1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    brotli                           3.3.2  71cb90ade945043d3d53597b2fc359bb063db8ade2bcffe7997351d0756e9d50 \
+    brotli-decompressor              2.3.2  59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80 \
+    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
+    bzip2                            0.3.3  42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b \
+    bzip2-sys                     0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
+    cc                              1.0.72  22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    crc32fast                        1.3.0  738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836 \
+    crossbeam-channel                0.5.1  06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4 \
+    crossbeam-deque                  0.8.1  6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e \
+    crossbeam-epoch                  0.9.5  4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd \
+    crossbeam-utils                  0.8.5  d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db \
+    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    fasteval                         0.2.4  4f4cdac9e4065d7c48e30770f8665b8cef9a3a73a63a4056a33a5f395bc7cf75 \
+    flate2                          1.0.22  1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    generic-array                   0.12.4  ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd \
+    getrandom                       0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    itoa                             0.4.8  b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4 \
+    kdtree                           0.6.0  80ee359328fc9087e9e3fc0a4567c4dd27ec69a127d6a70e8d9dd22845b8b1a2 \
+    las                              0.7.5  80dd11fe6e333400f08bd3a17c20146bfe4f719bb92545b388be9d21e69644b1 \
+    laz                              0.6.0  4d7a69934a6239f0b4ebb431afe9554df2ec63ef8325a9696b0e94735f554960 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                           0.2.110  b58a4469763e4e3a906c4ed786e1c70512d16aa88f84dded826da42640fc6a1c \
+    libm                             0.2.1  c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a \
+    log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
+    lzw                             0.10.0  7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084 \
+    matrixmultiply                   0.2.4  916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1 \
+    memoffset                        0.6.5  5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
+    miniz_oxide                      0.3.7  791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435 \
+    miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
+    msdos_time                       0.1.6  aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729 \
+    nalgebra                        0.18.1  aaa9fddbc34c8c35dd2108515587b8ce0cab396f17977b8c738568e4edb521a2 \
+    num                              0.4.0  43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606 \
+    num-bigint                       0.4.3  f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f \
+    num-complex                      0.2.4  b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95 \
+    num-complex                      0.4.0  26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085 \
+    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-iter                        0.1.42  b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59 \
+    num-rational                     0.2.4  5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
+    num-rational                     0.4.0  d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a \
+    num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
+    pdqselect                        0.1.1  7778906d9321dd56cde1d1ffa69a73e59dcf5fda6d366f62727adf2bd4193aee \
+    pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
+    pkg-config                      0.3.23  d1a3ea4f0dd7f1f3e512cf97bf100819aa547f36a6eccac8dbaae839eb92363e \
+    podio                            0.1.7  b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19 \
+    ppv-lite86                      0.2.15  ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba \
+    proc-macro2                     1.0.33  fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a \
+    quote                           1.0.10  38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05 \
+    rand                            0.3.23  64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c \
+    rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    rand                             0.6.5  6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.1.1  556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_distr                       0.2.2  96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2 \
+    rand_hc                          0.1.0  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    rand_isaac                       0.1.1  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
+    rand_jitter                      0.1.4  1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
+    rand_os                          0.1.3  7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
+    rand_pcg                         0.1.2  abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
+    rand_pcg                         0.2.1  16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
+    rand_xorshift                    0.1.1  cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
+    rawpointer                       0.2.1  60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3 \
+    rayon                            1.5.1  c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90 \
+    rayon-core                       1.9.1  d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    rstar                            0.7.1  0650eaaa56cbd1726fd671150fce8ac6ed9d9a25d1624430d7ee9d196052f6b6 \
+    rustc_version                    0.3.3  f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee \
+    ryu                              1.0.6  3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    semver                          0.11.0  f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6 \
+    semver-parser                   0.10.2  00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7 \
+    serde                          1.0.131  b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1 \
+    serde_derive                   1.0.131  b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2 \
+    serde_json                      1.0.72  d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527 \
+    statrs                           0.9.0  7d8c8660e3867d1a0578cbf7fd9532f1368b7460bd00b080e2d4669618a9bec7 \
+    syn                             1.0.82  8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59 \
+    thiserror                       1.0.30  854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417 \
+    thiserror-impl                  1.0.30  aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b \
+    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
+    typenum                         1.14.0  b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec \
+    ucd-trie                         0.1.3  56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c \
+    unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
+    uuid                             0.8.2  bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7 \
+    wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi                          0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    zip                              0.3.3  77ce0ceee93c995954a31f77903925a6a8bb094709445238e344f2107910e29e
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/whitebox_tools ${destroot}${prefix}/bin/
     xinstall -d ${destroot}${prefix}/share/doc/${name}/manual/img
     xinstall -m 644 -W ${worksrcpath} README.md LICENSE.txt ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 {*}[glob ${worksrcpath}/manual/WhiteboxToolsManual.*] ${destroot}${prefix}/share/doc/${name}/manual
-    xinstall -m 644 {*}[glob ${worksrcpath}/manual/img/*] ${destroot}${prefix}/share/doc/${name}/manual/img
 }

--- a/gis/whitebox-tools/files/patch-Cargo.lock.diff
+++ b/gis/whitebox-tools/files/patch-Cargo.lock.diff
@@ -1,0 +1,544 @@
+--- Cargo.lock
++++ Cargo.lock
+@@ -4,9 +4,9 @@ version = 3
+ 
+ [[package]]
+ name = "adler"
+-version = "0.2.3"
++version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
++checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+ 
+ [[package]]
+ name = "adler32"
+@@ -27,9 +27,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "alloc-no-stdlib"
+-version = "2.0.1"
++version = "2.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5192ec435945d87bc2f70992b4d818154b5feede43c09fb7592146374eac90a6"
++checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+ 
+ [[package]]
+ name = "alloc-stdlib"
+@@ -63,15 +63,15 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+ 
+ [[package]]
+ name = "bitflags"
+-version = "1.2.1"
++version = "1.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
++checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+ 
+ [[package]]
+ name = "brotli"
+-version = "3.3.0"
++version = "3.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7f29919120f08613aadcd4383764e00526fc9f18b6c0895814faeed0dd78613e"
++checksum = "71cb90ade945043d3d53597b2fc359bb063db8ade2bcffe7997351d0756e9d50"
+ dependencies = [
+  "alloc-no-stdlib",
+  "alloc-stdlib",
+@@ -80,9 +80,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "brotli-decompressor"
+-version = "2.3.1"
++version = "2.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1052e1c3b8d4d80eb84a8b94f0a1498797b5fb96314c001156a1c761940ef4ec"
++checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+ dependencies = [
+  "alloc-no-stdlib",
+  "alloc-stdlib",
+@@ -90,9 +90,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "byteorder"
+-version = "1.4.2"
++version = "1.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
++checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+ 
+ [[package]]
+ name = "bzip2"
+@@ -106,9 +106,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "bzip2-sys"
+-version = "0.1.10+1.0.8"
++version = "0.1.11+1.0.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17fa3d1ac1ca21c5c4e36a97f3c3eb25084576f6fc47bf0139c1123434216c6c"
++checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -117,9 +117,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.66"
++version = "1.0.72"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
++checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+ 
+ [[package]]
+ name = "cfg-if"
+@@ -149,26 +149,20 @@ dependencies = [
+  "bitflags",
+ ]
+ 
+-[[package]]
+-name = "const_fn"
+-version = "0.4.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+-
+ [[package]]
+ name = "crc32fast"
+-version = "1.2.1"
++version = "1.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
++checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+ dependencies = [
+  "cfg-if",
+ ]
+ 
+ [[package]]
+ name = "crossbeam-channel"
+-version = "0.5.0"
++version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
++checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+ dependencies = [
+  "cfg-if",
+  "crossbeam-utils",
+@@ -176,9 +170,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-deque"
+-version = "0.8.0"
++version = "0.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
++checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+ dependencies = [
+  "cfg-if",
+  "crossbeam-epoch",
+@@ -187,12 +181,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-epoch"
+-version = "0.9.1"
++version = "0.9.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
++checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+ dependencies = [
+  "cfg-if",
+- "const_fn",
+  "crossbeam-utils",
+  "lazy_static",
+  "memoffset",
+@@ -201,11 +194,10 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-utils"
+-version = "0.8.1"
++version = "0.8.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
++checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+ dependencies = [
+- "autocfg 1.0.1",
+  "cfg-if",
+  "lazy_static",
+ ]
+@@ -216,16 +208,22 @@ version = "1.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+ 
++[[package]]
++name = "fasteval"
++version = "0.2.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4f4cdac9e4065d7c48e30770f8665b8cef9a3a73a63a4056a33a5f395bc7cf75"
++
+ [[package]]
+ name = "flate2"
+-version = "1.0.20"
++version = "1.0.22"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
++checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+ dependencies = [
+  "cfg-if",
+  "crc32fast",
+  "libc",
+- "miniz_oxide 0.4.3",
++ "miniz_oxide 0.4.4",
+ ]
+ 
+ [[package]]
+@@ -236,9 +234,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+ 
+ [[package]]
+ name = "generic-array"
+-version = "0.12.3"
++version = "0.12.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
++checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+ dependencies = [
+  "typenum",
+ ]
+@@ -256,18 +254,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "hermit-abi"
+-version = "0.1.18"
++version = "0.1.19"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
++checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+ dependencies = [
+  "libc",
+ ]
+ 
+ [[package]]
+ name = "itoa"
+-version = "0.4.7"
++version = "0.4.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
++checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+ 
+ [[package]]
+ name = "kdtree"
+@@ -280,9 +278,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "las"
+-version = "0.7.4"
++version = "0.7.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1c0c61a3595a942582db0ae4ac8367bba6cad29afc6387db9d7315c05890d14c"
++checksum = "80dd11fe6e333400f08bd3a17c20146bfe4f719bb92545b388be9d21e69644b1"
+ dependencies = [
+  "byteorder",
+  "chrono",
+@@ -295,9 +293,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "laz"
+-version = "0.5.2"
++version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "01192c65789af53929798b55be28a65379028e2f822939e2fe887e8a694f5562"
++checksum = "4d7a69934a6239f0b4ebb431afe9554df2ec63ef8325a9696b0e94735f554960"
+ dependencies = [
+  "byteorder",
+  "num-traits",
+@@ -311,9 +309,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.86"
++version = "0.2.110"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
++checksum = "b58a4469763e4e3a906c4ed786e1c70512d16aa88f84dded826da42640fc6a1c"
+ 
+ [[package]]
+ name = "libm"
+@@ -347,9 +345,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "memoffset"
+-version = "0.6.1"
++version = "0.6.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
++checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+ dependencies = [
+  "autocfg 1.0.1",
+ ]
+@@ -365,9 +363,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "miniz_oxide"
+-version = "0.4.3"
++version = "0.4.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
++checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+ dependencies = [
+  "adler",
+  "autocfg 1.0.1",
+@@ -402,23 +400,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "num"
+-version = "0.3.1"
++version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
++checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+ dependencies = [
+  "num-bigint",
+- "num-complex 0.3.1",
++ "num-complex 0.4.0",
+  "num-integer",
+  "num-iter",
+- "num-rational 0.3.2",
++ "num-rational 0.4.0",
+  "num-traits",
+ ]
+ 
+ [[package]]
+ name = "num-bigint"
+-version = "0.3.2"
++version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
++checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+ dependencies = [
+  "autocfg 1.0.1",
+  "num-integer",
+@@ -437,9 +435,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "num-complex"
+-version = "0.3.1"
++version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
++checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+ dependencies = [
+  "num-traits",
+ ]
+@@ -478,9 +476,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "num-rational"
+-version = "0.3.2"
++version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
++checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+ dependencies = [
+  "autocfg 1.0.1",
+  "num-bigint",
+@@ -510,9 +508,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pdqselect"
+-version = "0.1.0"
++version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
++checksum = "7778906d9321dd56cde1d1ffa69a73e59dcf5fda6d366f62727adf2bd4193aee"
+ 
+ [[package]]
+ name = "pest"
+@@ -525,9 +523,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pkg-config"
+-version = "0.3.19"
++version = "0.3.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
++checksum = "d1a3ea4f0dd7f1f3e512cf97bf100819aa547f36a6eccac8dbaae839eb92363e"
+ 
+ [[package]]
+ name = "podio"
+@@ -537,24 +535,24 @@ checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
+ 
+ [[package]]
+ name = "ppv-lite86"
+-version = "0.2.10"
++version = "0.2.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
++checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.24"
++version = "1.0.33"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
++checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
+ dependencies = [
+  "unicode-xid",
+ ]
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.8"
++version = "1.0.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
++checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -756,9 +754,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+ 
+ [[package]]
+ name = "rayon"
+-version = "1.5.0"
++version = "1.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
++checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+ dependencies = [
+  "autocfg 1.0.1",
+  "crossbeam-deque",
+@@ -768,9 +766,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rayon-core"
+-version = "1.9.0"
++version = "1.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
++checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+ dependencies = [
+  "crossbeam-channel",
+  "crossbeam-deque",
+@@ -809,9 +807,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ryu"
+-version = "1.0.5"
++version = "1.0.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
++checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+ 
+ [[package]]
+ name = "scopeguard"
+@@ -839,18 +837,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde"
+-version = "1.0.123"
++version = "1.0.131"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
++checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
+ dependencies = [
+  "serde_derive",
+ ]
+ 
+ [[package]]
+ name = "serde_derive"
+-version = "1.0.123"
++version = "1.0.131"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
++checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -859,9 +857,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde_json"
+-version = "1.0.64"
++version = "1.0.72"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
++checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+ dependencies = [
+  "itoa",
+  "ryu",
+@@ -879,9 +877,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "syn"
+-version = "1.0.60"
++version = "1.0.82"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
++checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -890,18 +888,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "thiserror"
+-version = "1.0.26"
++version = "1.0.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
++checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+ dependencies = [
+  "thiserror-impl",
+ ]
+ 
+ [[package]]
+ name = "thiserror-impl"
+-version = "1.0.26"
++version = "1.0.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
++checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -921,9 +919,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "typenum"
+-version = "1.12.0"
++version = "1.14.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
++checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+ 
+ [[package]]
+ name = "ucd-trie"
+@@ -933,9 +931,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+ 
+ [[package]]
+ name = "unicode-xid"
+-version = "0.2.1"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
++checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+ 
+ [[package]]
+ name = "uuid"
+@@ -961,6 +959,7 @@ version = "1.5.0"
+ dependencies = [
+  "byteorder",
+  "nalgebra",
++ "num-traits",
+  "rand 0.7.3",
+  "rstar",
+  "rustc_version",
+@@ -986,7 +985,9 @@ dependencies = [
+ name = "whitebox_plugins"
+ version = "1.5.0"
+ dependencies = [
++ "fasteval",
+  "num_cpus",
++ "rand 0.7.3",
+  "whitebox_common",
+  "whitebox_raster",
+  "whitebox_vector",


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/jblindsay/whitebox-tools/releases/tag/v2.0.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
