### PR TITLE
proxmark3-iceman: errata, fix destroot option in variant

### DIFF
--- a/science/proxmark3-iceman/Portfile
+++ b/science/proxmark3-iceman/Portfile
@@ -49,7 +49,8 @@ build.args-append   CC=${configure.cc} \
 
 variant pm3generic description {Build firmware for PM3GENERIC instead of PM3RDV4} {
     build.args-append   PLATFORM=PM3GENERIC
-    destroot.env-append PLATFORM=PM3GENERIC
+    destroot.args-append \
+                        PLATFORM=PM3GENERIC
 }
 
 # buildsystem quirk: "make install" calls "make all" as well


### PR DESCRIPTION
Signed-off-by: İlteriş Yağıztegin Eroğlu <ilteris@asenkron.com.tr>

#### Description

Erratum of the given inconsistency errata:

https://github.com/macports/macports-ports/blob/b01d1d46b99391bd4c6217c78b76541bf69eb2d1/science/proxmark3-iceman/Portfile#L51-L52

As pointed out on https://github.com/macports/macports-ports/commit/edacf2fb4bb8764d0fbf100c429ae28ebb40d1dc#r63855556

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
