### PR TITLE
emacs-mac-app-devel: update to 20220113

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -15,8 +15,8 @@ maintainers         {amake @amake} openmaintainer
 
 description         Emacs Mac port
 
-long_description    ${name} is "Mac port" addition to GNU Emacs ${emacs_version}. \
-                    This provides a native GUI support for Mac OS X 10.6 - macOS 10.14.
+long_description    ${name} is the \"Mac port\" of GNU Emacs ${emacs_version}. \
+                    This provides a native GUI with tight OS integration.
 
 platforms           darwin
 license             GPL-3+
@@ -33,12 +33,50 @@ depends_lib         port:ncurses \
                     port:gmp \
                     port:jansson
 
-patchfiles          patch-src_emacs.c.diff \
-                    patch-apple-silicon-arch.diff
+patchfiles          patch-src_emacs.c.diff
 
 if {${subport} eq ${name}} {
     conflicts       emacs-mac-app-devel
 
+    patchfiles-append patch-apple-silicon-arch.diff
+
+    post-destroot {
+        # move files into the app bundle.
+        # https://github.com/railwaycat/emacs-mac-port/blob/master/build-emacs.app.sh
+        set app_dir ${destroot}${applications_dir}/Emacs.app/Contents/Resources
+        foreach d [glob ${destroot}${prefix}/share/emacs/${emacs_version}/*] {
+            move ${d} ${app_dir}
+        }
+        move ${destroot}${prefix}/share/info ${app_dir}
+        move ${destroot}${prefix}/share/man  ${app_dir}
+        move ${destroot}${prefix}/var        ${app_dir}
+        move ${destroot}${prefix}/bin        ${app_dir}/../MacOS
+        xinstall -d ${app_dir}/../MacOS/libexec
+        foreach f [glob ${destroot}${prefix}/libexec/emacs/${emacs_version}/*/*] {
+            move ${f} ${app_dir}/../MacOS/libexec
+        }
+        # Remove everything from ${destroot}${prefix} except ${app_dir}
+        if {0 != [string first ${destroot}${prefix} ${app_dir}]} {
+            # ${app_dir} is not a subdirectory of ${prefix}
+            delete ${destroot}${prefix}
+        } else {
+            foreach d [glob ${destroot}${prefix}/*] {
+                if {0 != [string first ${d} ${app_dir}]} {
+                    delete ${d}
+                }
+            }
+        }
+
+        # make the application binary a hard link.
+        delete ${app_dir}/../MacOS/Emacs
+        file link -hard ${app_dir}/../MacOS/Emacs ${app_dir}/../MacOS/bin/emacs
+
+        # rename the app bundle to avoid a conflict with emacs-app.
+        move ${destroot}${applications_dir}/Emacs.app \
+            ${destroot}${applications_dir}/EmacsMac.app
+
+        post_destroot_common
+    }
 }
 
 post-patch {
@@ -71,70 +109,76 @@ if {${os.major} >= 11 && ${os.platform} eq "darwin"} {
 }
 
 subport ${name}-devel {
-    set emacs_version   27.2
+    set emacs_version   28.0.91
+    set date            2022-01-19
 
-    version         20211113
+    version         [string map {- {}} ${date}]
     revision        0
 
     long_description \
-        ${name} is "Mac port" addition to GNU Emacs ${emacs_version}. \
-        This provides a native GUI support for Mac OS X 10.6 - macOS 10.14.
+        ${name} is the \"Mac port\" of GNU Emacs ${emacs_version}. \
+        This provides a native GUI with tight OS integration.
+
+    if {${os.major} <= 13} {
+        known_fail  yes
+    }
 
     fetch.type      git
-    git.url         --depth=1000 --branch work https://bitbucket.org/mituharu/emacs-mac.git
-    git.branch      6c281ea549a9085a7ac68300a58c977945b0c12b
+    git.url         --shallow-since=${date}T00:00:00 --branch work https://bitbucket.org/mituharu/emacs-mac.git
+    git.branch      379a15c67ad253bf0bd014ba25c135c293719562
+
+    # --shallow-since needs a newer version of git than on some older systems,
+    # so use MacPorts version
+    depends_fetch-append port:git
+    git.cmd         ${prefix}/bin/git
 
     conflicts       emacs-mac-app
 
-    # Bitbucket doesn't seem to have a good way to get the latest commit on a
-    # branch
-    livecheck.type  none
+    patchfiles-append patch-selfcontained.diff
+
+    post-patch {
+        # Rename the app bundle to avoid a conflict with the emacs-app port.
+        # patch-selfcontained.diff handles everything but this directory rename.
+        move ${worksrcpath}/mac/Emacs.app ${worksrcpath}/mac/EmacsMac.app
+    }
+
+    configure.args-append --enable-mac-self-contained
+
+    post-destroot {
+        post_destroot_common
+    }
+
+    variant nativecomp description {Builds emacs with native compilation support} {
+        depends_lib-append       port:gcc11
+
+        configure.args-append    --with-native-compilation
+
+        compiler.cpath-prepend   ${prefix}/include/gcc11
+        compiler.library_path-prepend \
+                                 ${prefix}/lib/gcc11
+
+        build.args-append        NATIVE_FULL_AOT=1
+    }
 
     variant metal description {Enable experimental Metal support} {
         configure.args-append  --with-mac-metal
     }
+
+    default_variants-append +nativecomp
+
+    # Bitbucket doesn't seem to have a good way to get the latest commit on a
+    # branch
+    livecheck.type  none
 }
 
-post-destroot {
-    # move files into the app bundle.
-    # https://github.com/railwaycat/emacs-mac-port/blob/master/build-emacs.app.sh
-    set app_dir ${destroot}${applications_dir}/Emacs.app/Contents/Resources
-    foreach d [glob ${destroot}${prefix}/share/emacs/${emacs_version}/*] {
-        move ${d} ${app_dir}
-    }
-    move ${destroot}${prefix}/share/info ${app_dir}
-    move ${destroot}${prefix}/share/man  ${app_dir}
-    move ${destroot}${prefix}/var        ${app_dir}
-    move ${destroot}${prefix}/bin        ${app_dir}/../MacOS
-    xinstall -d ${app_dir}/../MacOS/libexec
-    foreach f [glob ${destroot}${prefix}/libexec/emacs/${emacs_version}/*/*] {
-        move ${f} ${app_dir}/../MacOS/libexec
-    }
-    # Remove everything from ${destroot}${prefix} except ${app_dir}
-    if {0 != [string first ${destroot}${prefix} ${app_dir}]} {
-        # ${app_dir} is not a subdirectory of ${prefix}
-        delete ${destroot}${prefix}
-    } else {
-        foreach d [glob ${destroot}${prefix}/*] {
-            if {0 != [string first ${d} ${app_dir}]} {
-                delete ${d}
-            }
-        }
-    }
-
-    # make the application binary a hard link.
-    delete ${app_dir}/../MacOS/Emacs
-    file link -hard ${app_dir}/../MacOS/Emacs ${app_dir}/../MacOS/bin/emacs
+proc post_destroot_common {} {
+    global destroot applications_dir site_lisp filespath prefix worksrcpath
 
     # install site-start.el.
-    set site_lisp ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp
+    set site_lisp ${destroot}${applications_dir}/EmacsMac.app/Contents/Resources/site-lisp
     xinstall -d ${site_lisp}
     file copy ${filespath}/site-start.el ${site_lisp}
     reinplace "s|__PREFIX__|${prefix}|g" ${site_lisp}/site-start.el
-
-    # rename the app bundle to avoid a conflict with emacs-app.
-    move ${destroot}${applications_dir}/Emacs.app \
-        ${destroot}${applications_dir}/EmacsMac.app
 
     # install emacs-module.h header file
     xinstall -m 0755 -d ${destroot}${prefix}/include/emacs-mac

--- a/aqua/emacs-mac-app/files/patch-selfcontained.diff
+++ b/aqua/emacs-mac-app/files/patch-selfcontained.diff
@@ -1,0 +1,276 @@
+diff --git Makefile.in Makefile.in
+index 3f78b0d968..f6447239ce 100644
+--- Makefile.in
++++ Makefile.in
+@@ -104,23 +104,23 @@ USE_STARTUP_NOTIFICATION =
+ 
+ # ==================== Where To Install Things ====================
+ 
+-# Location to install Emacs.app on macOS
++# Location to install EmacsMac.app on macOS
+ mac_appdir=@mac_appdir@
+ mac_appbindir=@mac_appbindir@
+ mac_applibexecdir=@mac_applibexecdir@
+ mac_appresdir=@mac_appresdir@
+ mac_applibdir=@mac_applibdir@
+-# Either yes or no depending on whether this is a relocatable Emacs.app.
++# Either yes or no depending on whether this is a relocatable EmacsMac.app.
+ mac_self_contained=@mac_self_contained@
+ 
+-# Location to install Emacs.app under GNUstep / macOS.
++# Location to install EmacsMac.app under GNUstep / macOS.
+ # Later values may use these.
+ ns_appdir=@ns_appdir@
+ ns_appbindir=@ns_appbindir@
+ ns_applibexecdir=@ns_applibexecdir@
+ ns_appresdir=@ns_appresdir@
+ ns_applibdir=@ns_applibdir@
+-# Either yes or no depending on whether this is a relocatable Emacs.app.
++# Either yes or no depending on whether this is a relocatable EmacsMac.app.
+ ns_self_contained=@ns_self_contained@
+ 
+ # The default location for installation.  Everything is placed in
+@@ -355,8 +355,8 @@ BIN_DESTDIR=
+ ELN_DESTDIR = ${ns_applibdir}/
+ endif
+ else
+-BIN_DESTDIR='${mac_appbindir}/'
+-ELN_DESTDIR = ${mac_applibdir}/
++BIN_DESTDIR='$(DESTDIR)${mac_appbindir}/'
++ELN_DESTDIR = $(DESTDIR)${mac_applibdir}/
+ endif
+ 
+ all: ${SUBDIR} info
+@@ -438,7 +438,7 @@ epaths-force-w32:
+ # bundle root itself with the relative path.
+ epaths-force-mac-self-contained: epaths-force
+ 	@(sed < src/epaths.h > epaths.h.$$$$		\
+-	  -e 's;${mac_appdir}/Emacs.app/;;') &&			\
++	  -e 's;${mac_appdir}/EmacsMac.app/;;') &&			\
+ 	${srcdir}/build-aux/move-if-change epaths.h.$$$$ src/epaths.h
+ 
+ epaths-force-ns-self-contained: epaths-force
+@@ -541,9 +541,9 @@ install-arch-dep:
+ 	umask 022; ${MKDIR_P} "$(DESTDIR)${bindir}"
+ 	$(MAKE) -C lib-src install
+ 	if test "$(realpath $(DESTDIR)${mac_appdir})" != "`cd mac && /bin/pwd`"; then \
+-	  umask 022; ${MKDIR_P} $(DESTDIR)${mac_appdir}/Emacs.app; \
+-	  (cd mac/Emacs.app; (tar -chf - . | \
+-		(cd $(DESTDIR)${mac_appdir}/Emacs.app; umask 022; tar -xvf - \
++	  umask 022; ${MKDIR_P} $(DESTDIR)${mac_appdir}/EmacsMac.app; \
++	  (cd mac/EmacsMac.app; (tar -chf - . | \
++		(cd $(DESTDIR)${mac_appdir}/EmacsMac.app; umask 022; tar -xvf - \
+ 			&& cat > /dev/null))) || exit 1; \
+ 	fi
+ ifeq (${mac_self_contained},no)
+@@ -562,8 +562,8 @@ install-arch-dep:
+ 	rm -rf ${ns_appresdir}/share
+ endif
+ else
+-	subdir=${mac_appresdir}/site-lisp && ${write_subdir}
+-	rm -rf ${mac_appresdir}/share
++	subdir=$(DESTDIR)${mac_appresdir}/site-lisp && ${write_subdir}
++	rm -rf $(DESTDIR)${mac_appresdir}/share
+ endif
+ 
+ ### Windows-specific install target for installing programs produced
+diff --git configure.ac configure.ac
+index 6c09f86725..9792c534c4 100644
+--- configure.ac
++++ configure.ac
+@@ -536,7 +536,7 @@ AC_DEFUN
+ 
+ AC_ARG_ENABLE(mac-app,
+ [AS_HELP_STRING([--enable-mac-app@<:@=DIR@:>@],
+-                [specify install directory for Emacs.app on macOS
++                [specify install directory for EmacsMac.app on macOS
+ 		 [DIR=/Application]])],
+ [ mac_appdir_x=${enableval}])
+ 
+@@ -1910,10 +1910,10 @@ AC_DEFUN
+     esac
+   fi
+ 
+-  mac_appbindir=${mac_appdir}/Emacs.app/Contents/MacOS
+-  mac_applibexecdir=${mac_appdir}/Emacs.app/Contents/MacOS/libexec/${configuration}
+-  mac_applibdir=${mac_appdir}/Emacs.app/Contents/Frameworks
+-  mac_appresdir=${mac_appdir}/Emacs.app/Contents/Resources
++  mac_appbindir=${mac_appdir}/EmacsMac.app/Contents/MacOS
++  mac_applibexecdir=${mac_appdir}/EmacsMac.app/Contents/MacOS/libexec/${configuration}
++  mac_applibdir=${mac_appdir}/EmacsMac.app/Contents/Frameworks
++  mac_appresdir=${mac_appdir}/EmacsMac.app/Contents/Resources
+ 
+   if test "${with_native_image_api}" = yes; then
+      AC_DEFINE(HAVE_NATIVE_IMAGE_API, 1, [Define to use native OS APIs for images.])
+@@ -1937,7 +1937,7 @@ AC_DEFUN
+   # Even a headless Emacs can build macuvs.h, so this should let you bootstrap.
+   if test "${opsys}" = darwin && test -f "$srcdir/src/macuvs.h"; then
+      NS_IMPL_COCOA=yes
+-     ns_appdir=`pwd`/nextstep/Emacs.app
++     ns_appdir=`pwd`/nextstep/EmacsMac.app
+      ns_appbindir=${ns_appdir}/Contents/MacOS
+      ns_applibexecdir=${ns_appdir}/Contents/MacOS/libexec
+      ns_applibdir=${ns_appdir}/Contents/Frameworks
+@@ -1996,7 +1996,7 @@ AC_DEFUN
+      fi
+   fi
+   if test $NS_IMPL_GNUSTEP = yes; then
+-     ns_appdir=`pwd`/nextstep/Emacs.app
++     ns_appdir=`pwd`/nextstep/EmacsMac.app
+      ns_appbindir=${ns_appdir}
+      ns_applibexecdir=${ns_appdir}/libexec
+      ns_applibdir=${ns_appdir}/Frameworks
+@@ -4204,7 +4204,7 @@ AC_DEFUN
+   # We also have mouse menus.
+   HAVE_MENUS=yes
+   # Tell src/Makefile.in to create files in the macOS application
+-  # bundle mac/Emacs.app.
++  # bundle mac/EmacsMac.app.
+   OTHER_FILES=macosx-app
+ fi
+ 
+@@ -6162,7 +6162,7 @@ AC_DEFUN
+    echo
+    AS_ECHO(["Run '${MAKE-make}' to build Emacs, then run 'src/emacs' to test it.
+ Run '${MAKE-make} install' in order to build an application bundle.
+-The application will go to nextstep/Emacs.app and can be run or moved
++The application will go to nextstep/EmacsMac.app and can be run or moved
+ from there."])
+    if test "$EN_NS_SELF_CONTAINED" = "yes"; then
+       echo "The application will be fully self-contained."
+@@ -6194,8 +6194,8 @@ AC_DEFUN
+ 
+ MAC_TEMPLATE_FILES=
+ if test "$HAVE_MACGUI" = "yes"; then
+-    AC_CONFIG_FILES([mac/Emacs.app/Contents/Info.plist:mac/templates/Info.plist.in \
+-    mac/Emacs.app/Contents/Resources/English.lproj/InfoPlist.strings:mac/templates/InfoPlist.strings.in])
++    AC_CONFIG_FILES([mac/EmacsMac.app/Contents/Info.plist:mac/templates/Info.plist.in \
++    mac/EmacsMac.app/Contents/Resources/English.lproj/InfoPlist.strings:mac/templates/InfoPlist.strings.in])
+     MAC_TEMPLATE_FILES="mac/templates/Info.plist.in mac/templates/InfoPlist.strings.in"
+ fi
+ AC_SUBST(MAC_TEMPLATE_FILES)
+diff --git lib-src/Makefile.in lib-src/Makefile.in
+index 338ba0d576..9aa30193cc 100644
+--- lib-src/Makefile.in
++++ lib-src/Makefile.in
+@@ -49,6 +49,8 @@ top_builddir =
+ 
+ # ==================== Where To Install Things ====================
+ 
++mac_applibexecdir=@mac_applibexecdir@
++
+ # Location to install Emacs.app under GNUstep / macOS.
+ # Later values may use this.
+ ns_appbindir=@ns_appbindir@
+diff --git mac/Emacs.app/Contents/MacOS/Emacs.sh mac/EmacsMac.app/Contents/MacOS/Emacs.sh
+similarity index 100%
+rename from mac/Emacs.app/Contents/MacOS/Emacs.sh
+rename to mac/EmacsMac.app/Contents/MacOS/Emacs.sh
+diff --git mac/Emacs.app/Contents/PkgInfo mac/EmacsMac.app/Contents/PkgInfo
+similarity index 100%
+rename from mac/Emacs.app/Contents/PkgInfo
+rename to mac/EmacsMac.app/Contents/PkgInfo
+diff --git mac/Emacs.app/Contents/Resources/Emacs.icns mac/EmacsMac.app/Contents/Resources/Emacs.icns
+similarity index 100%
+rename from mac/Emacs.app/Contents/Resources/Emacs.icns
+rename to mac/EmacsMac.app/Contents/Resources/Emacs.icns
+diff --git mac/Emacs.app/Contents/Resources/document.icns mac/EmacsMac.app/Contents/Resources/document.icns
+similarity index 100%
+rename from mac/Emacs.app/Contents/Resources/document.icns
+rename to mac/EmacsMac.app/Contents/Resources/document.icns
+diff --git mac/Makefile.in mac/Makefile.in
+index e1663c1a8f..7e1cdea452 100644
+--- mac/Makefile.in
++++ mac/Makefile.in
+@@ -33,9 +33,9 @@ mac_self_contained=
+ 
+ ifeq ($(DUMPING),pdumper)
+ ifeq (${mac_self_contained},no)
+-bundle_pdmp := Emacs.app/Contents/MacOS/Emacs.pdmp
++bundle_pdmp := EmacsMac.app/Contents/MacOS/Emacs.pdmp
+ else
+-bundle_pdmp := Emacs.app/Contents/MacOS/libexec/${configuration}/Emacs.pdmp
++bundle_pdmp := EmacsMac.app/Contents/MacOS/libexec/${configuration}/Emacs.pdmp
+ endif
+ else
+ bundle_pdmp :=
+@@ -44,31 +44,31 @@ bundle_pdmp :=
+ lprojs = English Dutch French German Italian Japanese Spanish \
+   ar ca cs da el en_AU en_GB es_419 es_MX fi fr_CA he hi hr hu id ko ms no \
+   pl pt pt_BR pt_PT ro ru sk sv th tr uk vi zh_CN zh_HK zh_TW
+-lprojdirs = $(patsubst %,Emacs.app/Contents/Resources/%.lproj,${lprojs})
++lprojdirs = $(patsubst %,EmacsMac.app/Contents/Resources/%.lproj,${lprojs})
+ 
+ ${lprojdirs}:
+ 	${MKDIR_P} $@
+ 
+ ifneq ($(CURDIR), $(realpath ${srcdir}))
+-Emacs.app/Contents/MacOS/Emacs.sh: ${srcdir}/Emacs.app/Contents/MacOS/Emacs.sh
+-	${MKDIR_P} Emacs.app/Contents/MacOS
++EmacsMac.app/Contents/MacOS/Emacs.sh: ${srcdir}/EmacsMac.app/Contents/MacOS/Emacs.sh
++	${MKDIR_P} EmacsMac.app/Contents/MacOS
+ 	cp $< $@
+-Emacs.app/Contents/PkgInfo: ${srcdir}/Emacs.app/Contents/PkgInfo
++EmacsMac.app/Contents/PkgInfo: ${srcdir}/EmacsMac.app/Contents/PkgInfo
+ 	cp $< $@
+-Emacs.app/Contents/Resources/Emacs.icns: ${srcdir}/Emacs.app/Contents/Resources/Emacs.icns
+-	${MKDIR_P} Emacs.app/Contents/Resources
++EmacsMac.app/Contents/Resources/Emacs.icns: ${srcdir}/EmacsMac.app/Contents/Resources/Emacs.icns
++	${MKDIR_P} EmacsMac.app/Contents/Resources
+ 	cp $< $@
+-Emacs.app/Contents/Resources/document.icns: ${srcdir}/Emacs.app/Contents/Resources/document.icns
+-	${MKDIR_P} Emacs.app/Contents/Resources
++EmacsMac.app/Contents/Resources/document.icns: ${srcdir}/EmacsMac.app/Contents/Resources/document.icns
++	${MKDIR_P} EmacsMac.app/Contents/Resources
+ 	cp $< $@
+ endif
+ 
+-macosx-bundle: ${lprojdirs} Emacs.app/Contents/MacOS/Emacs.sh \
+-	Emacs.app/Contents/PkgInfo Emacs.app/Contents/Resources/Emacs.icns \
+-	Emacs.app/Contents/Resources/document.icns
+-macosx-app: macosx-bundle Emacs.app/Contents/MacOS/Emacs $(bundle_pdmp)
+-Emacs.app/Contents/MacOS/Emacs: ../src/emacs${EXEEXT}
+-	${MKDIR_P} Emacs.app/Contents/MacOS
++macosx-bundle: ${lprojdirs} EmacsMac.app/Contents/MacOS/Emacs.sh \
++	EmacsMac.app/Contents/PkgInfo EmacsMac.app/Contents/Resources/Emacs.icns \
++	EmacsMac.app/Contents/Resources/document.icns
++macosx-app: macosx-bundle EmacsMac.app/Contents/MacOS/Emacs $(bundle_pdmp)
++EmacsMac.app/Contents/MacOS/Emacs: ../src/emacs${EXEEXT}
++	${MKDIR_P} EmacsMac.app/Contents/MacOS
+ 	rm -f $@
+ 	cp $< $@
+ ifeq ($(DUMPING),pdumper)
+@@ -86,12 +86,12 @@ .PHONY:
+ 
+ clean:
+ 	rm -rf ${lprojdirs}
+-	rm -f Emacs.app/Contents/MacOS/Emacs $(bundle_pdmp)
++	rm -f EmacsMac.app/Contents/MacOS/Emacs $(bundle_pdmp)
+ 
+ distclean: clean
+ 	rm -f Makefile
+-	rm -f Emacs.app/Contents/Info.plist \
+-	  Emacs.app/Contents/Resources/English.lproj/InfoPlist.strings
++	rm -f EmacsMac.app/Contents/Info.plist \
++	  EmacsMac.app/Contents/Resources/English.lproj/InfoPlist.strings
+ 
+ bootstrap-clean maintainer-clean: distclean
+ 
+diff --git src/emacs.c src/emacs.c
+index c0df96f828..d598e8d48c 100644
+--- src/emacs.c
++++ src/emacs.c
+@@ -531,10 +531,10 @@ init_cmdargs (int argc, char **argv, int skip_args, char const *original_pwd)
+ #elif defined HAVE_MACGUI
+       /* If we are running from the build directory, set DIR to the
+ 	 src subdirectory of the Emacs tree.  */
+-      if (SBYTES (dir) > sizeof ("/mac/Emacs.app/Contents/MacOS/") - 1
++      if (SBYTES (dir) > sizeof ("/mac/EmacsMac.app/Contents/MacOS/") - 1
+ 	  && 0 == strcmp ((SSDATA (dir) + SBYTES (dir)
+-			   - sizeof ("/mac/Emacs.app/Contents/MacOS/") + 1),
+-			  "/mac/Emacs.app/Contents/MacOS/"))
++			   - sizeof ("/mac/EmacsMac.app/Contents/MacOS/") + 1),
++			  "/mac/EmacsMac.app/Contents/MacOS/"))
+ 	{
+ 	  if (NILP (Vpurify_flag))
+ 	    {


### PR DESCRIPTION
#### Description

I am the maintainer of this port, but I can't get this to work so I am hoping for help from anyone knowledgeable.

Upstream has merged in emacs-28.0.91, which means that in principle we should be able to use nativecomp in this port.

However there are problems with paths: `${prefix}/lib/emacs/28.0.91/native-lisp` needs to go somewhere in the app bundle in order to be located, so I have moved it to `EmacsMac.app/Contents/native-lisp` (indicated by the error message shown when the dir is *not* present there).

However doing so reveals other missing paths; the errors now shown are:

```
% /Applications/MacPorts/EmacsMac.app/Contents/MacOS/Emacs -Q
Warning: arch-dependent data dir '/opt/local/libexec/emacs/28.0.91/x86_64-apple-darwin21.2.0/': No such file or directory
Warning: arch-independent data dir '/opt/local/share/emacs/28.0.91/etc/': No such file or directory
Warning: Lisp directory '/opt/local/share/emacs/28.0.91/lisp': No such file or directory
Error: /opt/local/share/emacs/28.0.91/etc/charsets: No such file or directory
Emacs will not function correctly without the character map files.
Please check your installation!
```

Note: This port (temporarily) conflicts with the emacs{,-devel} port because I commented out some deletions for debugging purposes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->