### PR TITLE
various Python ports: remove replaced_by statement for subports

### DIFF
--- a/python/py-asn1/Portfile
+++ b/python/py-asn1/Portfile
@@ -42,8 +42,3 @@ if {${name} ne ${subport}} {
     test.run            yes
     test.env            PYTHONPATH=${worksrcpath}/build/lib
 }
-
-subport py34-${python.rootname} {
-    replaced_by py35-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -43,10 +43,3 @@ if {${name} ne ${subport}} {
     test.cmd                nosetests-${python.branch}
     test.target
 }
-
-foreach {old new} {34 36 35 36} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -122,11 +122,3 @@ if {${name} ne ${subport}} {
         cindex.set_library_(path|file)().
     }
 }
-
-foreach {old} {36} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${python.default_version}-${python.rootname}
-        PortGroup obsolete 1.0
-
-    "
-}

--- a/python/py-ctypeslib2/Portfile
+++ b/python/py-ctypeslib2/Portfile
@@ -41,11 +41,3 @@ if {${name} ne ${subport}} {
         }
     }
 }
-
-foreach {old} {27 34 35 36} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${python.default_version}-${python.rootname}
-        PortGroup obsolete 1.0
-
-    "
-}

--- a/python/py-django-htmlmin/Portfile
+++ b/python/py-django-htmlmin/Portfile
@@ -49,8 +49,3 @@ port select --set ${select.group} [file tail ${select.file}]
 
     livecheck.type  none
 }
-
-subport py34-${python.rootname} {
-    replaced_by py35-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-django-nose/Portfile
+++ b/python/py-django-nose/Portfile
@@ -42,8 +42,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none
 }
-
-subport py34-${python.rootname} {
-    replaced_by py35-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-fiona/Portfile
+++ b/python/py-fiona/Portfile
@@ -40,11 +40,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 }
-
-# Note: py27 subport requires missing py27-orderdict port and py34 subport is no longer supported
-foreach {old new} {27 35} {
-    subport py${old}-fiona "
-        replaced_by py${new}-fiona
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-flask/Portfile
+++ b/python/py-flask/Portfile
@@ -39,8 +39,3 @@ if {${name} ne ${subport}} {
     livecheck.url       https://pypi.python.org/pypi/Flask/json
     livecheck.regex     {Flask-(\d+(?:\.\d+)*)\.[tz]}
 }
-
-subport py34-${python.rootname} {
-    replaced_by py35-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-gensim/Portfile
+++ b/python/py-gensim/Portfile
@@ -54,10 +54,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 }
-
-foreach {old new} {27 38 35 38 36 38} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-geopandas/Portfile
+++ b/python/py-geopandas/Portfile
@@ -45,9 +45,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 }
-
-# py27 subport no longer available (dependency on obsoleted py27-fiona)
-subport py27-${python.rootname} {
-    replaced_by py36-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -13,7 +13,6 @@ platforms           darwin
 license             GPL-2+
 
 python.versions     37 38 39 310
-set old_versions    [list 36]
 
 maintainers         {snc @nerdling} {gmail.com:szhorvat @szhorvat} openmaintainer
 
@@ -98,12 +97,4 @@ if {${name} ne ${subport}} {
     test.target
 
     livecheck.type          none
-}
-
-foreach old_subport ${old_versions} {
-    subport py${old_subport}-${python.rootname} {
-        PortGroup obsolete 1.0
-
-        replaced_by py${python.default_version}-${python.rootname}
-    }
 }

--- a/python/py-jmespath-terminal/Portfile
+++ b/python/py-jmespath-terminal/Portfile
@@ -40,8 +40,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 }
-
-subport py34-${python.rootname} {
-    replaced_by py35-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-jupyterlab/Portfile
+++ b/python/py-jupyterlab/Portfile
@@ -57,10 +57,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 }
-
-foreach {old new} {27 38 35 38} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-jupyterlab_server/Portfile
+++ b/python/py-jupyterlab_server/Portfile
@@ -37,8 +37,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 }
-
-subport py35-${python.rootname} {
-    replaced_by py36-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-ldap3/Portfile
+++ b/python/py-ldap3/Portfile
@@ -36,10 +36,3 @@ if {${name} ne ${subport}} {
 } else {
     livecheck.type  pypi
 }
-
-foreach {old new} {27 37 36 37} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-mdtraj/Portfile
+++ b/python/py-mdtraj/Portfile
@@ -39,10 +39,3 @@ if {${name} ne ${subport}} {
 # tests cannot be implemented since they require too many packages
 # not available on MacPorts
 }
-
-foreach {old new} {34 36 35 36} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-metakernel/Portfile
+++ b/python/py-metakernel/Portfile
@@ -28,11 +28,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none
 }
-
-foreach {old new} {36 38 37 38} {
-	#	remove 2022-12-02
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-mitmproxy/Portfile
+++ b/python/py-mitmproxy/Portfile
@@ -87,9 +87,3 @@ if {${name} ne ${subport}} {
 } else {
     livecheck.type  pypi
 }
-
-subport py36-${python.rootname} {
-    replaced_by py37-${python.rootname}
-    PortGroup obsolete 1.0
-
-}

--- a/python/py-nuitka/Portfile
+++ b/python/py-nuitka/Portfile
@@ -41,10 +41,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 }
-
-foreach {old new} {27 37 35 37 36 37} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-oct2py/Portfile
+++ b/python/py-oct2py/Portfile
@@ -40,10 +40,3 @@ if {${name} ne ${subport}} {
     test.target
     test.env            PYTHONPATH=${worksrcpath}/build/lib
 }
-
-foreach {old new} {34 36 35 36} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-octave_kernel/Portfile
+++ b/python/py-octave_kernel/Portfile
@@ -45,11 +45,3 @@ cp ${prefix}/share/${subport}/kernel.json ~/Library/Jupyter/kernels/octave/
 
     livecheck.type  none
 }
-
-# remove 27 34 35 36 after 2023-01-04
-foreach {old new} {27 37 34 37 35 37 36 37} {
-    subport py${old}-${python.rootname} "
-        replaced_by py${new}-${python.rootname}
-        PortGroup obsolete 1.0
-    "
-}

--- a/python/py-openpyxl/Portfile
+++ b/python/py-openpyxl/Portfile
@@ -50,8 +50,3 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 }
-
-subport py35-${python.rootname} {
-    replaced_by py38-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-openslide/Portfile
+++ b/python/py-openslide/Portfile
@@ -64,8 +64,3 @@ if {${name} ne ${subport}} {
         file copy ${worksrcpath}/examples ${destroot}${docdir}
     }
 }
-
-subport py34-${python.rootname} {
-    replaced_by py35-${python.rootname}
-    PortGroup obsolete 1.0
-}

--- a/python/py-passlib/Portfile
+++ b/python/py-passlib/Portfile
@@ -7,7 +7,6 @@ name                    py-passlib
 version                 1.7.4
 revision                1
 python.versions         37 38 39 310
-set old_versions        [list 35 36]
 python.pep517           yes
 categories-append       www security
 maintainers             {snc @nerdling} openmaintainer
@@ -39,12 +38,4 @@ livecheck.type          none
 } else {
     livecheck.name          passlib
     livecheck.regex         passlib-(\\d+(\\.\\d+)+)${extract.suffix}
-}
-
-foreach old_subport ${old_versions} {
-    subport py${old_subport}-${python.rootname} {
-        PortGroup obsolete 1.0
-
-        replaced_by py${python.default_version}-${python.rootname}
-    }
 }

--- a/python/py-pytest-asyncio/Portfile
+++ b/python/py-pytest-asyncio/Portfile
@@ -43,8 +43,3 @@ if {${name} ne ${subport}} {
 } else {
     livecheck.type  pypi
 }
-
-subport py35-${python.rootname} {
-    replaced_by py36-${python.rootname}
-    PortGroup obsolete 1.0
-}


### PR DESCRIPTION
#### Description
Replacing pXY-<package> with a newer XY version wasn't deemed to be that useful as it will change the Python interpreter version. Since the retirement of the py-graveyard port (1f65d2919352023f4662f1bf9f8023c29b57e2cd)
there is no reason to do this anymore; just drop the subport, provided of course that there are no dependents.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

Not actually tested; it removes only code that doesn't affect the build so whatever worked before will do so now and things that failed before will still fail.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->