### PR TITLE
armagetronad: Use the right extract commands

### DIFF
--- a/games/armagetronad/Portfile
+++ b/games/armagetronad/Portfile
@@ -6,6 +6,7 @@ PortGroup           boost 1.0
 
 github.setup        ArmagetronAd armagetronad 0.2.9.1.0 v
 github.tarball_from releases
+use_bzip2           yes
 extract.suffix      .tbz
 
 set pretty_name     "Armagetron Advanced"
@@ -44,19 +45,28 @@ subport ${name}-dedicated {
                     running the game.
 }
 
-distfiles           ${distname}${extract.suffix}:${name}
-checksums           ${distname}${extract.suffix} \
+checksums           ${distfiles} \
                     rmd160  76eed9dd9fe6d888eba0fae67696040ec1eccb7d \
                     sha256  59b6c7c01ce3f8cca5437e33f974a637529541a11aa4f52c1a5c17499e26f6a1 \
                     size    1943758
 
+extract.only        ${distfiles}
+distfiles           ${distfiles}:${name}
+master_sites        ${master_sites}:${name}
+
 if {$subport ne "${name}-common"} {
-    master_sites-append http://deb.debian.org/debian/pool/main/a/${name}:debian_pkg
-    distfiles-append    ${name}_${version}-2.debian.tar.xz:debian_pkg
-    checksums-append    ${name}_${version}-2.debian.tar.xz \
+    master_sites-append debian:a/${name}:debian_pkg
+    set debfile         ${name}_${version}-2.debian.tar.xz
+    distfiles-append    ${debfile}:debian_pkg
+    checksums-append    ${debfile} \
                         rmd160  cc1151617b372d61b6b02b647adb699fdfba3ea0 \
                         sha256  28b778440ee2d7a8657fec2a8a468723017645a98259a7afac9fa67841a6c36f \
                         size    29852
+    depends_extract-append \
+                        bin:xz:xz
+    post-extract {
+        system -W ${workpath} "xz -dc [shellescape ${distpath}/${debfile}] | ${portutil::autoconf::tar_command} -xf -"
+    }
 }
 
 depends_build-append    port:autoconf \


### PR DESCRIPTION
#### Description

Extract bzip2 files with bzip2; extract xz files with xz. Fixes extract failure on OS X 10.8 and earlier.

Specify tag for primary distfile's master_sites.

Use debian fetch group.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
