### PR TITLE
gopass: update to 1.13.1

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.13.0 v
+go.setup            github.com/gopasspw/gopass 1.13.1 v
 categories          security
 maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 license             MIT
@@ -15,9 +15,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  cddf1ab2afc9747c5fd72dd2cd214a03c650a7a7 \
-                        sha256  9d8daa667c5d568e5a887c2292c12bad6093cfd9bbfeba58e3711a78962a4516 \
-                        size    2182239
+                        rmd160  271dbc76f875bf3396857ec1742e57befc95281e \
+                        sha256  e868cac64120abac70ad9f427bad49c3813f8aba4d505c784c79d9cff70616e5 \
+                        size    2183377
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.13.1)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
