### PR TITLE
warzone2100: add legacysupport for macOS <= 10.10

### DIFF
--- a/games/warzone2100/Portfile
+++ b/games/warzone2100/Portfile
@@ -36,6 +36,7 @@ if {$subport eq ${name} || $subport eq "${name}-music"} {
 }
 if {$subport eq ${name}} {
     PortGroup           cmake 1.1
+    PortGroup           legacysupport 1.1
 
     github.setup        Warzone2100 ${name} 4.2.4
     github.tarball_from releases
@@ -83,6 +84,11 @@ if {$subport eq ${name}} {
     license_noconflict      asciidoctor
 
     compiler.cxx_standard   2011
+
+    # Fix compile errors on macOS <= 10.10 due to files included from
+    # /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1
+    legacysupport.newest_darwin_requires_legacy 14
+    legacysupport.use_mp_libcxx yes
 
     post-patch {
         # Prevent the upstream source from trying to compile these as


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Compiles are failing on the builders for macOS <= 10.10, with errors that look like:

```
In file included from
/opt/local/var/macports/build/.../warzone2100/work/warzone2100_src/lib/framework/wzconfig.h:23:
...
In file included from
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:439:
In file included from
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/algorithm:627:
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/utility:259:9:
error: field has incomplete type 'nlohmann::basic_json<std::map, std::vector,
       std::__1::basic_string<char>, bool, long long, unsigned long long, double, std::allocator,
       adl_serializer, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > >'
    _T2 second;
        ^
```

I don't have a way to test this PR locally, but I'm hoping that adding the `legacysupport.use_mp_libcxx` might be able to resolve these errors.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
