### PR TITLE
poetry: relax dependency requirements

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    poetry
 version                 1.1.12
-revision                0
+revision                1
 categories-append       devel
 platforms               darwin
 license                 MIT
@@ -26,6 +26,8 @@ homepage                https://python-poetry.org/
 checksums               rmd160  2c3b8a3137d0433188de89f91a8b156f4d2baced \
                         sha256  5c66e2357fe37b552462a88b7d31bfa2ed8e84172208becd666933c776252567 \
                         size    135789
+
+patchfiles              patch-requirements.diff
 
 variant python37 conflicts python38 python39 python310 description {Use Python 3.7} {}
 variant python38 conflicts python37 python39 python310 description {Use Python 3.8} {}

--- a/python/poetry/files/patch-requirements.diff
+++ b/python/poetry/files/patch-requirements.diff
@@ -1,0 +1,20 @@
+--- setup.py	2021-11-28 01:15:55.939190600 -0500
++++ setup.py	2022-01-15 13:45:23.034762064 -0500
+@@ -41,7 +41,7 @@
+  'cleo>=0.8.1,<0.9.0',
+  'clikit>=0.6.2,<0.7.0',
+  'html5lib>=1.0,<2.0',
+- 'packaging>=20.4,<21.0',
++ 'packaging>=20.4',
+  'pexpect>=4.7.0,<5.0.0',
+  'pkginfo>=1.4,<2.0',
+  'poetry-core>=1.0.7,<1.1.0',
+@@ -64,7 +64,7 @@
+  ':python_version >= "3.5" and python_version < "3.6"': ['keyring>=20.0.1,<21.0.0'],
+  ':python_version >= "3.6" and python_version < "4.0"': ['crashtest>=0.3.0,<0.4.0',
+                                                          'cachecontrol[filecache]>=0.12.9,<0.13.0',
+-                                                         'keyring>=21.2.0,<22.0.0']}
++                                                         'keyring>=21.2.0']}
+
+ entry_points = \
+ {'console_scripts': ['poetry = poetry.console:main']}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/64429

#### Description

Poetry port appears to be working ok although I was not able to reproduce the original issue.

@ryandesign I am no longer using poetry day-to-day at the job, although I've gone back and forth on using it as I've moved between employers. If you're using it actively please feel free to add yourself as maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
