### PR TITLE
*-w64-mingw32-gcc: Add dependency zstd

### DIFF
--- a/cross/i686-w64-mingw32-gcc/Portfile
+++ b/cross/i686-w64-mingw32-gcc/Portfile
@@ -11,7 +11,7 @@ set mingw_target    ${mingw_arch}-${mingw_name}
 crossgcc.setup      ${mingw_target} 11.2.0
 crossgcc.languages  {c c++ fortran objc obj-c++}
 dist_subdir         gcc[lindex [split ${version} .] 0]
-revision            1
+revision            2
 
 maintainers         {mojca @mojca} openmaintainer
 
@@ -73,7 +73,8 @@ subport ${mingw_target}-gcc-nothreads {
 # Final phase
 if {${subport} eq ${name}} {
     depends_lib-append      port:${mingw_target}-crt \
-                            port:${mingw_target}-winpthreads
+                            port:${mingw_target}-winpthreads  \
+                            port:zstd
 
     depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads
 

--- a/cross/x86_64-w64-mingw32-gcc/Portfile
+++ b/cross/x86_64-w64-mingw32-gcc/Portfile
@@ -11,7 +11,7 @@ set mingw_target    ${mingw_arch}-${mingw_name}
 crossgcc.setup      ${mingw_target} 11.2.0
 crossgcc.languages  {c c++ fortran objc obj-c++}
 dist_subdir         gcc[lindex [split ${version} .] 0]
-revision            1
+revision            2
 
 maintainers         {mojca @mojca} openmaintainer
 
@@ -70,7 +70,8 @@ subport ${mingw_target}-gcc-nothreads {
 # Final phase
 if {${subport} eq ${name}} {
     depends_lib-append      port:${mingw_target}-crt \
-                            port:${mingw_target}-winpthreads
+                            port:${mingw_target}-winpthreads \
+                            port:zstd
 
     depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads
 


### PR DESCRIPTION
Opportunistic links `zstd` for LTO byte code compression, so might as well add it.

#### Description
After https://github.com/macports/macports-ports/commit/52cf3d239d60402dcd3843f927810e9b57a7c63f the rebuilt packages now link `zstd` but doesn't get installed so *-w64-mingw32-gcc packages are currently broken without manually installing `zstd`

```
dyld: Library not loaded: /opt/local/lib/libzstd.1.dylib
  Referenced from: /opt/local/libexec/gcc/x86_64-w64-mingw32/11.2.0/cc1
  Reason: image not found
x86_64-w64-mingw32-gcc: internal compiler error: Abort trap: 6 signal terminated program cc1
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
