### PR TITLE
unison: update to 2.51.5

### DIFF
--- a/net/unison/Portfile
+++ b/net/unison/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        bcpierce00 unison 2.51.4 v
+github.setup        bcpierce00 unison 2.51.5 v
 revision            0
 categories          net
 maintainers         nomaintainer
@@ -18,12 +18,12 @@ long_description    Unison is a file-synchronization tool for Unix and \
 homepage            http://www.cis.upenn.edu/~bcpierce/unison/
 platforms           darwin
 
-checksums           rmd160  231cc9a56e12ef3b79f0517eeaad9db670fa3356 \
-                    sha256  406237c9a1a0c85f8a02a05b22b17ebaa65b87ddb5b3d1f17a43f30f37f534b0 \
-                    size    1373118
+checksums           rmd160  a1024b19350dee2cf952ed924eba1dc921485154 \
+                    sha256  77eb8bc28cec5eaa7ceb2011354f77f4a753fd033589497a56c8cb9306f9459f \
+                    size    1385506
 
 # from ocaml port
-supported_archs     i386 x86_64
+supported_archs     i386 x86_64 arm64
 universal_variant   no
 
 depends_build       port:ocaml


### PR DESCRIPTION
#### Description

Update unison to 2.51.5 and add arm64 as supported arch.

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
