### PR TITLE
py-sure: Update to 2.0.0 and add Python 3.10 subport

### DIFF
--- a/python/py-rednose/Portfile
+++ b/python/py-rednose/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rednose
+version             1.3.0
+revision            0
+
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         pretty output formatter for python-nosetests
+long_description    \
+    rednose is a nosetests plugin for adding colour (and readability) to \
+    nosetest console results.
+homepage            https://github.com/JBKahn/rednose
+
+checksums           rmd160  548a63d7bc32ae9423660647ecc9fdaaceefd03b \
+                    sha256  6da77917788be277b70259edc0bb92fc6f28fe268b765b4ea88206cc3543a3e1 \
+                    size    10299
+
+python.versions     37 38 39 310
+
+if {${name} ne ${subport}} {
+    depends_lib-append  \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-colorama \
+                    port:py${python.version}-termstyle
+
+    depends_test-append \
+                    port:py${python.version}-six \
+                    port:py${python.version}-nose
+
+    test.run        yes
+    test.cmd        ${python.bin}
+    test.dir        ${worksrcpath}/test_files
+    test.target     new_tests.py
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type      none
+}

--- a/python/py-sure/Portfile
+++ b/python/py-sure/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-sure
-version             1.4.11
+version             2.0.0
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             GPL-3+
 maintainers         nomaintainer
@@ -16,31 +15,29 @@ description         Utility belt for automated testing in python for python
 long_description    ${description}
 
 homepage            http://github.com/gabrielfalcao/sure
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 
-checksums           sha256  3c8d5271fb18e2c69e2613af1ad400d8df090f1456081635bd3171847303cdaa \
-                    rmd160  fb6c37da7c2d005c6874d266fbc8d2edcb21d833 \
-                    size    45933
+checksums           sha256  34ae88c846046742ef074036bf311dc90ab152b7bc09c342b281cebf676727a2 \
+                    rmd160  5a20615bf48f287c322c9b17f651ffd8ac680a1b \
+                    size    46747
 
-python.versions     37
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    post-extract {
-        system "find ${worksrcpath} -type d -print0 | xargs -0 chmod a+rx"
-        system "find ${worksrcpath} -type f -print0 | xargs -0 chmod a+r"
-    }
+    # See https://github.com/gabrielfalcao/sure/issues/169
+    patchfiles      patch-fix-python310.diff
 
     depends_run-append \
                     port:py${python.version}-mock \
                     port:py${python.version}-six
 
     depends_test-append \
+                    port:py${python.version}-coverage \
                     port:py${python.version}-mock \
                     port:py${python.version}-nose \
+                    port:py${python.version}-rednose \
                     port:py${python.version}-six
 
     test.run        yes

--- a/python/py-sure/files/patch-fix-python310.diff
+++ b/python/py-sure/files/patch-fix-python310.diff
@@ -1,0 +1,11 @@
+--- sure/__init__.py.Orig
++++ sure/__init__.py
+@@ -126,7 +126,7 @@ class CallBack(object):
+             err = traceback.format_exc().splitlines()[-1]
+             err = err.replace("{0}:".format(exc_klass.__name__), "").strip()
+ 
+-            if err.startswith(self.callback_name) and (
++            if self.callback_name in err and (
+                 "takes no arguments (1 given)" in err
+                 or "takes 0 positional arguments but 1 was given" in err
+             ):

--- a/python/py-termstyle/Portfile
+++ b/python/py-termstyle/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-termstyle
+version             0.1.11
+revision            0
+
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         console colouring for python
+long_description    {*}${description}
+homepage            https://github.com/timbertson/termstyle
+
+checksums           rmd160  6525c56a3c3b57bf3fd7af4220c0de416948fc08 \
+                    sha256  ef74b83698ea014112040cf32b1a093c1ab3d91c4dd18ecc03ec178fd99c9f9f \
+                    size    4580
+
+python.versions     37 38 39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    test.run        yes
+    test.cmd        ${python.bin}
+    test.target     test3.py
+    
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

- py-{rednose,termstyle}: New ports
- py-sure: Update to 2.0.0, add py37-310 subports

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
