### PR TITLE
py-botocore: Remove Python 3.6 subport (also for py-{mrjob,s3transger,aiobotocore,aiotertools,s3fs})

### DIFF
--- a/python/py-aiobotocore/Portfile
+++ b/python/py-aiobotocore/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     36 37 38 39
+python.versions     37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-aioitertools/Portfile
+++ b/python/py-aioitertools/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     36 37 38 39
+python.versions     37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  4a3d8993ded1d0e715cf6c38bc698348f9337dbe \
                     sha256  f3077f1ca19e6ab6b7a84c61e01e136a97c7732078a8d806908aee44f1042f5f \
                     size    8728451
 
-python.versions     36 37 38 39 310
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-mrjob/Portfile
+++ b/python/py-mrjob/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  9aa30d419bca2917f8bd495f76e36ead0c123262 \
                     sha256  5fb72ad6f2f1bb13696dc97c918cb59c29d675d7afe5f84307d31856b545c144 \
                     size    1676800
 
-python.versions     36 37
+python.versions     37
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-s3fs/Portfile
+++ b/python/py-s3fs/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     36 37 38 39
+python.versions     37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-s3transfer/Portfile
+++ b/python/py-s3transfer/Portfile
@@ -20,7 +20,7 @@ long_description    ${description}
 
 homepage            https://github.com/boto/${python.rootname}
 
-python.versions     36 37 38 39 310
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

- py-s3fs: Remove Python 3.6 subport
- py-{aiobotocore,aioitertools}: Remove Python 3.6 subport
- py-{mrjob,s3transfer}: Remove Python 3.6 subport
- py-botocore: Remove Python 3.6 subport

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
