### PR TITLE
python36: mark as EOL

### DIFF
--- a/lang/python36/Portfile
+++ b/lang/python36/Portfile
@@ -3,6 +3,7 @@
 PortSystem 1.0
 PortGroup select 1.0
 PortGroup openssl 1.0
+PortGroup deprecated 1.0
 
 name                python36
 
@@ -10,6 +11,8 @@ epoch               20170717
 # Remember to keep py36-tkinter and py36-gdbm's versions sync'd with this
 version             3.6.15
 revision            2
+
+deprecated.eol_version  yes
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]


### PR DESCRIPTION
#### Description
Python 3.6 reached end-of-life on 2021-12-23, mark the port as such so that people who install it get a warning about this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
