### PR TITLE
glade: update to 3.38.1

### DIFF
--- a/devel/glade/Portfile
+++ b/devel/glade/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           gobject_introspection 1.0
 PortGroup           active_variants 1.1
+PortGroup           meson 1.0
 
 name                glade
-version             3.36.0
-revision            2
+version             3.38.1
+revision            0
 license             LGPL-2+ GPL-2+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Glade is a RAD tool to enable quick & easy development of user interfaces \
@@ -20,9 +20,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  577ca6641931a066fc9d5cdcc083fc78c221fabc \
-                    sha256  19b546b527cc46213ccfc8022d49ec57e618fe2caa9aa51db2d2862233ea6f08 \
-                    size    4466808
+checksums           rmd160  9273f48aede0604f3b0a10df922970006761246b \
+                    sha256  171a50be4930d4806fc8ce7f5ce3a75b49e9916f9d3037a5b50d35799bd0cfcd \
+                    size    2708852
 
 depends_skip_archcheck devhelp
 
@@ -32,13 +32,15 @@ depends_build       port:pkgconfig \
                     port:libxslt \
                     port:gtk-doc
 
-depends_lib         path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
+depends_lib         port:gobject-introspection \
+                    path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:libxml2
 
 depends_run         port:desktop-file-utils
 
-gobject_introspection yes
+# error: redefinition of typedef 'GladeWidgetAdaptor'
+compiler.blacklist-append *gcc-3* *gcc-4*
 
 #
 # disable optimization which (at least with clang)
@@ -48,17 +50,17 @@ gobject_introspection yes
 
 configure.optflags  -O0
 
-configure.args      --enable-gladeui \
-                    --enable-debug \
-                    --disable-python \
-                    --disable-webkit2gtk \
-                    --disable-silent-rules
+configure.args      -Dgladeui=true \
+                    -Dintrospection=true \
+                    -Dgjs=disabled \
+                    -Dpython=disabled \
+                    -Dwebkit2gtk=disabled
 
 configure.cflags-append \
                     -Wno-format-nonliteral
 
 variant python38 conflicts python39 python310 description {Build Python 3.8 widgets support} {
-    configure.args-replace      --disable-python --enable-python
+    configure.args-replace      -Dpython=disabled -Dpython=enabled
     configure.python            ${prefix}/bin/python3.8
     set python_framework        ${frameworks_dir}/Python.framework/Versions/3.8
     configure.env-append        "PYTHON_LIBS=-L${python_framework}/lib -lpython3.8" \
@@ -68,7 +70,7 @@ variant python38 conflicts python39 python310 description {Build Python 3.8 widg
 }
 
 variant python39 conflicts python38 python310 description {Build Python 3.9 widgets support} {
-    configure.args-replace      --disable-python --enable-python
+    configure.args-replace      -Dpython=disabled -Dpython=enabled
     configure.python            ${prefix}/bin/python3.9
     set python_framework        ${frameworks_dir}/Python.framework/Versions/3.9
     configure.env-append        "PYTHON_LIBS=-L${python_framework}/lib -lpython3.9" \
@@ -78,7 +80,7 @@ variant python39 conflicts python38 python310 description {Build Python 3.9 widg
 }
 
 variant python310 conflicts python38 python39 description {Build Python 3.10 widgets support} {
-    configure.args-replace      --disable-python --enable-python
+    configure.args-replace      -Dpython=disabled -Dpython=enabled
     configure.python            ${prefix}/bin/python3.10
     set python_framework        ${frameworks_dir}/Python.framework/Versions/3.10
     configure.env-append        "PYTHON_LIBS=-L${python_framework}/lib -lpython3.10" \
@@ -94,7 +96,7 @@ if {![variant_isset python38] && \
 }
 
 variant webkit2gtk description {Enable WebKit widgets catalog} {
-    configure.args-replace  --disable-webkit2gtk --enable-webkit2gtk
+    configure.args-replace  -Dwebkit2gtk=disabled -Dwebkit2gtk=enabled
     depends_lib-append      path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
     depends_run-append      port:devhelp
 }

--- a/gnome/libhandy/Portfile
+++ b/gnome/libhandy/Portfile
@@ -5,7 +5,7 @@ PortGroup           meson 1.0
 
 name                libhandy
 version             1.2.0
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome
 license             LGPL-2.1+


### PR DESCRIPTION
#### Description

Update glade and migrate it to the meson-based build system (the autotools system is no longer supported). The `gobject_introspection` PG does not play well with meson, so enable introspection manually. Revbump `libhandy` so it picks up the updated dylib name.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
