### PR TITLE
memtester: update to newer upstream version 4.5.1

### DIFF
--- a/sysutils/memtester/Portfile
+++ b/sysutils/memtester/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 
 name                memtester
 version             4.5.1
+revision            0
 categories          sysutils
 maintainers         nomaintainer
 license             GPL-2
-platforms           darwin
 description         A userspace utility for testing the memory subsystem for \
                     faults.
 long_description    ${description}
 
-homepage            https://pyropus.ca./software/memtester
+homepage            https://pyropus.ca/software/memtester
 master_sites        ${homepage}/old-versions
 
 checksums           rmd160  6c529f24f2a16cd923624ac9eeccbc1ed28e48a6 \

--- a/sysutils/memtester/Portfile
+++ b/sysutils/memtester/Portfile
@@ -14,6 +14,8 @@ long_description    ${description}
 
 homepage            https://pyropus.ca/software/memtester
 master_sites        ${homepage}/old-versions
+# The upstream web server is broken and gets into an infinite redirect loop.
+master_sites        https://fossies.org/linux/misc/
 
 checksums           rmd160  6c529f24f2a16cd923624ac9eeccbc1ed28e48a6 \
                     sha256  1c5fc2382576c084b314cfd334d127a66c20bd63892cac9f445bc1d8b4ca5a47 \

--- a/sysutils/memtester/Portfile
+++ b/sysutils/memtester/Portfile
@@ -3,19 +3,21 @@
 PortSystem          1.0
 
 name                memtester
-version             4.3.0
+version             4.5.1
 categories          sysutils
 maintainers         nomaintainer
+license             GPL-2
 platforms           darwin
 description         A userspace utility for testing the memory subsystem for \
                     faults.
 long_description    ${description}
 
-homepage            http://pyropus.ca/software/memtester/
+homepage            https://pyropus.ca./software/memtester
 master_sites        ${homepage}/old-versions
 
-checksums           rmd160  0fd3148d76f65516601e4d656dc239a164a190a8 \
-                    sha256  f9dfe2fd737c38fad6535bbab327da9a21f7ce4ea6f18c7b3339adef6bf5fd88
+checksums           rmd160  6c529f24f2a16cd923624ac9eeccbc1ed28e48a6 \
+                    sha256  1c5fc2382576c084b314cfd334d127a66c20bd63892cac9f445bc1d8b4ca5a47 \
+                    size    23655
 
 livecheck.url       ${homepage}/old-versions/
 livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
@@ -25,7 +27,7 @@ use_configure       no
 variant universal {}
 
 pre-patch {
-	reinplace "s|/usr/local|${destroot}${prefix}|" ${worksrcpath}/Makefile
-	reinplace "s|man/man|share/man/man|" ${worksrcpath}/Makefile
-	reinplace "s|^cc|${configure.cc} [get_canonical_archflags cc]|g" ${worksrcpath}/conf-cc ${worksrcpath}/conf-ld
+    reinplace "s|/usr/local|${destroot}${prefix}|" ${worksrcpath}/Makefile
+    reinplace "s|man/man|share/man/man|" ${worksrcpath}/Makefile
+    reinplace "s|^cc|${configure.cc} [get_canonical_archflags cc]|g" ${worksrcpath}/conf-cc ${worksrcpath}/conf-ld
 }


### PR DESCRIPTION
Minor changes:
- Add license
- Change from http to https
- Add size in checksums
- Convert tabs to spaces in pre-patch.

#### Description

memtester: update to newer upstream version 4.5.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
