### PR TITLE
py-Pillow: update to 9.0.0

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-Pillow
-version             8.4.0
+version             9.0.0
 revision            0
 categories-append   devel
 platforms           darwin
@@ -19,12 +19,14 @@ long_description    ${description}
 
 homepage            https://github.com/python-imaging/Pillow
 
-checksums           rmd160  c20a0bab9a469c3557044793174dd38905ce4be9 \
-                    sha256  b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed \
-                    size    49368411
+checksums           rmd160  6fc017168f32f83acf1a561d23a2b643874caaef \
+                    sha256  ee6e2963e92762923956fe5d3479b1fdc3b76c83f290aad131a2f98c3df0593e \
+                    size    49513779
 
 if {${name} ne ${subport}} {
-    conflicts           py${python.version}-pil
+    if {${python.version} == 27} {
+        conflicts   py${python.version}-pil
+    }
 
     if {${python.version} < 36} {
         version             6.2.1
@@ -35,6 +37,14 @@ if {${name} ne ${subport}} {
                             size    37673162
 
         patchfiles-append   patch-setup.py_v6.2.1.diff
+    } elseif {${python.version} == 36} {
+        version             8.4.0
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  c20a0bab9a469c3557044793174dd38905ce4be9 \
+                            sha256  b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed \
+                            size    49368411
+
+        patchfiles-append   patch-setup.py_v8.4.0.diff
     } else {
         patchfiles-append   patch-setup.py.diff
     }

--- a/python/py-Pillow/files/patch-setup.py_v8.4.0.diff
+++ b/python/py-Pillow/files/patch-setup.py_v8.4.0.diff
@@ -1,6 +1,6 @@
 --- setup.py.orig	2021-10-15 09:26:23.000000000 +0300
 +++ setup.py	2021-10-16 16:06:42.000000000 +0300
-@@ -510,52 +510,9 @@ class pil_build_ext(build_ext):
+@@ -490,62 +490,10 @@
              )
  
          elif sys.platform == "darwin":
@@ -45,13 +45,23 @@
 -                # Homebrew's freetype is missing
 -                _add_directory(library_dirs, "/usr/X11/lib")
 -                _add_directory(include_dirs, "/usr/X11/include")
--
--            sdk_path = self.get_macos_sdk_path()
++            _add_directory(library_dirs, "@prefix@/lib")
++            _add_directory(include_dirs, "@prefix@/include")
+ 
+-            # SDK install path
+-            sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+-            if not os.path.exists(sdk_path):
+-                try:
+-                    sdk_path = (
+-                        subprocess.check_output(["xcrun", "--show-sdk-path"])
+-                        .strip()
+-                        .decode("latin1")
+-                    )
+-                except Exception:
+-                    sdk_path = None
 -            if sdk_path:
 -                _add_directory(library_dirs, os.path.join(sdk_path, "usr", "lib"))
 -                _add_directory(include_dirs, os.path.join(sdk_path, "usr", "include"))
-+            _add_directory(library_dirs, "@prefix@/lib")
-+            _add_directory(include_dirs, "@prefix@/include")
          elif (
              sys.platform.startswith("linux")
              or sys.platform.startswith("gnu")


### PR DESCRIPTION
#### Description

Updated Pillow to 9.0.0 - but not for Python 3.6, since [Pillow 9.0 has dropped support for it.](https://pillow.readthedocs.io/en/stable/installation.html#python-support) The new patch I've added is effectively the same as the existing one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

- There are no existing Trac tickets
- 'Error: Failed to test py-Pillow: py-Pillow has no tests turned on.'