### PR TITLE
lagrange: update to 1.10.0

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.9.5 v
+github.setup        skyjake lagrange 1.10.0 v
 revision            0
 github.tarball_from releases
 categories          net gemini
@@ -20,9 +20,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  744503e22cb200e592c317a62f6f44abc21a1d32 \
-                    sha256  10d75283f1d235c2d8865ebb9ccba6b1b2821c44e9aa20a60619ab6c32f49ca0 \
-                    size    8594827
+checksums           rmd160  e834f5d32673298cb2f9fabef9ce428fa2a76a79 \
+                    sha256  382c4880bd45d30b9ccd7bb6279b2f8f47db28b41700dbed45b8e4e4ef954f7f \
+                    size    8649852
 
 depends_build-append \
                     port:pkgconfig \
@@ -39,9 +39,6 @@ depends_lib-append  port:fribidi \
 
 compiler.c_standard 2011
 compiler.blacklist-append {clang < 800}
-
-# OpenSSL 3.0 deprecations, see https://codeberg.org/skyjake/the_Foundation/issues/9
-configure.cppflags-append -Wno-deprecated-declarations
 
 destroot {
     copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
