### PR TITLE
libgee: blacklist GCC 3/4

### DIFF
--- a/devel/libgee/Portfile
+++ b/devel/libgee/Portfile
@@ -31,6 +31,10 @@ depends_build       port:pkgconfig \
 
 patchfiles          patch-typelib-use-absolute-sharedlib-path.diff
 
+# error: redefinition of typedef 'GeeHazardPointerNode'
+# https://gitlab.gnome.org/GNOME/libgee/-/issues/42
+compiler.blacklist *gcc-3* *gcc-4*
+
 # autoreconf after patching gee/Makefile.am
 use_autoreconf      yes
 autoreconf.args     -fvi


### PR DESCRIPTION
#### Description

A source-level workaround is not straightforward since the redefinition error arises from generated C code. See https://gitlab.gnome.org/GNOME/libgee/-/issues/42
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
