### PR TITLE
Remove platforms from ports that judaew maintains

### DIFF
--- a/audio/abcMIDI/Portfile
+++ b/audio/abcMIDI/Portfile
@@ -7,7 +7,6 @@ version             2022.01.13
 revision            0
 
 categories          audio
-platforms           darwin
 maintainers         {judaew @judaew} openmaintainer
 license             GPL-2+
 

--- a/audio/kid3/Portfile
+++ b/audio/kid3/Portfile
@@ -7,7 +7,6 @@ version             3.9.1
 revision            0
 
 categories          audio
-platforms           darwin
 supported_archs     x86_64
 license             GPL
 maintainers         {judaew @judaew} openmaintainer

--- a/audio/xld/Portfile
+++ b/audio/xld/Portfile
@@ -7,7 +7,6 @@ version             20211018
 revision            0
 
 categories          audio
-platforms           darwin
 supported_archs     x86_64 arm64 i386 ppc
 license             GPL-2
 maintainers         {judaew @judaew} openmaintainer

--- a/databases/dbeaver-community/Portfile
+++ b/databases/dbeaver-community/Portfile
@@ -9,7 +9,6 @@ revision            0
 name                dbeaver-community
 
 categories          databases
-platforms           darwin
 supported_archs     x86_64 arm64
 license             Apache-2
 

--- a/devel/abseil/Portfile
+++ b/devel/abseil/Portfile
@@ -18,8 +18,6 @@ long_description    Abseil is an open-source collection of C++ library \
                     Google's own C++ code base, has been extensively \
                     tested and used in production.
 
-platforms           darwin
-
 if {${os.major} < 11} {
 
     # NB this port builds with < darwin 11 if libcxx is installed

--- a/devel/bctoolbox/Portfile
+++ b/devel/bctoolbox/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          devel multimedia
-platforms           darwin
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/bcunit/Portfile
+++ b/devel/bcunit/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          devel
-platforms           darwin
 license             LGPL-2
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/bzrtp/Portfile
+++ b/devel/bzrtp/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          devel
-platforms           darwin
 license             {GPL-3 Commercial}
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/cargo-generate/Portfile
+++ b/devel/cargo-generate/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          devel
-platforms           darwin
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/dialog/Portfile
+++ b/devel/dialog/Portfile
@@ -15,7 +15,6 @@ description         a utility to create nice user interfaces for command-line sc
 long_description    ${name} is {*}${description}. It is non-graphical (it uses \
                     curses) so it can be run in the console or an xterm.
 
-platforms           darwin
 homepage            https://invisible-island.net/dialog/
 master_sites        ftp://ftp.invisible-island.net/pub/dialog/ \
                     https://invisible-mirror.net/archives/dialog/

--- a/devel/entt/Portfile
+++ b/devel/entt/Portfile
@@ -8,7 +8,6 @@ github.setup        skypjack entt 3.9.0 v
 revision            0
 
 categories          devel games
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/git-interactive-rebase-tool/Portfile
+++ b/devel/git-interactive-rebase-tool/Portfile
@@ -8,7 +8,6 @@ github.setup        MitMaro git-interactive-rebase-tool 2.1.0
 revision            0
 
 categories          devel
-platforms           darwin
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/grails/Portfile
+++ b/devel/grails/Portfile
@@ -11,7 +11,6 @@ name                grails
 
 categories          devel java
 license             Apache-2
-platforms           darwin
 maintainers         {judaew @judaew} openmaintainer
 
 description         Groovy on rails, web framework

--- a/devel/jmeter/Portfile
+++ b/devel/jmeter/Portfile
@@ -8,7 +8,6 @@ name            jmeter
 version         5.4.3
 revision        0
 categories      devel benchmarks java net
-platforms       darwin
 license         Apache-2
 supported_archs i386 x86_64
 maintainers     {judaew @judaew} openmaintainer

--- a/devel/libck/Portfile
+++ b/devel/libck/Portfile
@@ -8,7 +8,6 @@ github.setup        concurrencykit ck 0.7.1
 revision            0
 
 categories          devel
-platforms           darwin
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/libedit/Portfile
+++ b/devel/libedit/Portfile
@@ -9,7 +9,6 @@ epoch               20090923
 version             20210910-3.1
 revision            1
 categories          devel
-platforms           darwin
 license             BSD
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} \
                     {judaew @judaew} openmaintainer

--- a/devel/libpoly/Portfile
+++ b/devel/libpoly/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          devel
-platforms           darwin
 license             LGPL-3
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/libwebsockets/Portfile
+++ b/devel/libwebsockets/Portfile
@@ -8,7 +8,6 @@ github.setup        warmcat libwebsockets 4.3.1 v
 github.tarball_from archive
 revision            0
 categories          devel net
-platforms           darwin
 license             LGPL-2.1
 
 maintainers         {gmail.com:slewsys @slewsys} \

--- a/devel/ortp/Portfile
+++ b/devel/ortp/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          devel
-platforms           darwin
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -13,7 +13,6 @@ checksums           rmd160  371135a06b33a8241e4f3148f03e6381b29e8de9 \
 
 conflicts           spdlog0
 categories          devel
-platforms           darwin
 license             MIT
 maintainers         {protomail.com:XNephila @XNephila} \
                     {judaew @judaew} \

--- a/devel/stb/Portfile
+++ b/devel/stb/Portfile
@@ -8,7 +8,6 @@ version             20210910
 revision            0
 
 categories          devel
-platforms           darwin
 license             {public-domain MIT}
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/stgit/Portfile
+++ b/devel/stgit/Portfile
@@ -9,7 +9,6 @@ github.tarball_from releases
 revision            0
 
 categories          devel python
-platforms           darwin
 supported_archs     noarch
 license             GPL-2
 maintainers         {judaew @judaew} openmaintainer

--- a/devel/tinyobjloader/Portfile
+++ b/devel/tinyobjloader/Portfile
@@ -5,7 +5,6 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 categories          devel graphics games
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/devel/yaml-cpp/Portfile
+++ b/devel/yaml-cpp/Portfile
@@ -8,7 +8,6 @@ github.setup        jbeder yaml-cpp 0.7.0 yaml-cpp-
 revision            0
 
 categories          devel
-platforms           darwin
 maintainers         {judaew @judaew} openmaintainer
 license             MIT
 

--- a/devel/yamllint/Portfile
+++ b/devel/yamllint/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            1
 
 categories          devel python
-platforms           darwin
 supported_archs     noarch
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer

--- a/editors/liteide/Portfile
+++ b/editors/liteide/Portfile
@@ -8,7 +8,6 @@ github.setup        visualfc liteide 37.4 x
 revision            0
 
 categories          editors devel
-platforms           darwin
 license             LGPL
 maintainers         {judaew @judaew} openmaintainer
 

--- a/graphics/svgcleaner/Portfile
+++ b/graphics/svgcleaner/Portfile
@@ -8,7 +8,6 @@ github.setup        RazrFalcon svgcleaner 0.9.5 v
 revision            0
 
 categories          graphics
-platforms           darwin
 license             GPL-2
 maintainers         {judaew @judaew} openmaintainer
 

--- a/java/jlatexmath/Portfile
+++ b/java/jlatexmath/Portfile
@@ -8,7 +8,6 @@ version             1.0.7
 revision            0
 
 categories          java tex
-platforms           darwin
 supported_archs     noarch
 license             GPL-2
 maintainers         {judaew @judaew} openmaintainer

--- a/java/plantuml/Portfile
+++ b/java/plantuml/Portfile
@@ -9,7 +9,6 @@ github.tarball_from     archive
 revision                0
 
 categories              java editors
-platforms               darwin
 supported_archs         noarch
 license                 GPL-3+
 maintainers             {judaew @judaew} openmaintainer

--- a/java/pmd/Portfile
+++ b/java/pmd/Portfile
@@ -9,7 +9,6 @@ github.tarball_from releases
 revision            0
 
 categories          java lang
-platforms           darwin
 license             {BSD Apache-2}
 maintainers         {judaew @judaew} openmaintainer
 

--- a/lang/jruby/Portfile
+++ b/lang/jruby/Portfile
@@ -11,7 +11,6 @@ java.version        1.8+
 java.fallback       openjdk17
 
 categories          lang ruby java
-platforms           darwin
 license             {EPL-2 GPL-2 LGPL-2.1}
 supported_archs     noarch
 maintainers         {judaew @judaew} \

--- a/lua/lua-language-server/Portfile
+++ b/lua/lua-language-server/Portfile
@@ -9,7 +9,6 @@ fetch.type          git
 revision            0
 
 categories          lua devel
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/math/libqalculate/Portfile
+++ b/math/libqalculate/Portfile
@@ -10,7 +10,6 @@ github.tarball_from archive
 revision            0
 
 categories          math
-platforms           darwin
 maintainers         {gmail.com:jjstickel @jjstickel} \
                     {judaew @judaew} \
                     openmaintainer

--- a/multimedia/libogg/Portfile
+++ b/multimedia/libogg/Portfile
@@ -7,7 +7,6 @@ version             1.3.5
 revision            1
 categories          multimedia
 license             BSD
-platforms           darwin
 maintainers         {judaew @judaew} openmaintainer
 
 description         Ogg Bitstream Library

--- a/multimedia/spotify-dl/Portfile
+++ b/multimedia/spotify-dl/Portfile
@@ -9,7 +9,6 @@ version             7.6.0
 revision            2
 
 categories          multimedia python
-platforms           darwin
 supported_archs     noarch
 license             GPL-2
 maintainers         {judaew @judaew} openmaintainer

--- a/net/dnsperf/Portfile
+++ b/net/dnsperf/Portfile
@@ -8,7 +8,6 @@ github.tarball_from archive
 revision            0
 
 categories          net sysutils
-platforms           darwin
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer
 

--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -16,7 +16,6 @@ revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 categories          net
-platforms           darwin
 maintainers         {gmail.com:jeremy.mcmillan @aphor} \
                     {judaew @judaew} \
                     openmaintainer

--- a/net/miniserve/Portfile
+++ b/net/miniserve/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          net www
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/net/oha/Portfile
+++ b/net/oha/Portfile
@@ -8,7 +8,6 @@ github.setup        hatoo oha 0.5.0 v
 revision            0
 
 categories          net devel
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/net/xh/Portfile
+++ b/net/xh/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          net www
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/print/lib3mf/Portfile
+++ b/print/lib3mf/Portfile
@@ -10,7 +10,6 @@ revision            1
 
 categories          print graphics devel
 license             BSD
-platforms           darwin
 maintainers         {judaew @judaew} openmaintainer
 
 description         \

--- a/python/podman-compose/Portfile
+++ b/python/podman-compose/Portfile
@@ -8,7 +8,6 @@ version             1.0.3
 revision            0
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             GPL-2
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-Faker/Portfile
+++ b/python/py-Faker/Portfile
@@ -6,7 +6,6 @@ PortGroup           python 1.0
 name                py-Faker
 version             11.3.0
 revision            0
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/python/py-aiofiles/Portfile
+++ b/python/py-aiofiles/Portfile
@@ -5,7 +5,6 @@ PortGroup           python 1.0
 
 name                py-aiofiles
 version             0.8.0
-platforms           darwin
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer
 

--- a/python/py-aws-sam-translator/Portfile
+++ b/python/py-aws-sam-translator/Portfile
@@ -9,7 +9,6 @@ github.setup        awslabs serverless-application-model 1.42.0 v
 github.tarball_from archive
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -9,7 +9,6 @@ version             1.22.37
 revision            0
 
 categories          python devel
-platforms           darwin
 supported_archs     noarch
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-boto3/Portfile
+++ b/python/py-boto3/Portfile
@@ -7,7 +7,6 @@ name                py-boto3
 version             1.20.37
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             Apache-2
 maintainers         {emcrisostomo @emcrisostomo} \

--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -7,7 +7,6 @@ name                py-botocore
 version             1.23.37
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             Apache-2
 maintainers         {judaew @judaew} \

--- a/python/py-bracex/Portfile
+++ b/python/py-bracex/Portfile
@@ -8,7 +8,6 @@ version             2.2.1
 revision            0
 python.versions     37 38 39 310
 
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/python/py-engineio/Portfile
+++ b/python/py-engineio/Portfile
@@ -8,7 +8,6 @@ github.setup        miguelgrinberg python-engineio 4.3.1 v
 name                py-engineio
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-enrich/Portfile
+++ b/python/py-enrich/Portfile
@@ -8,7 +8,6 @@ version             1.2.7
 revision            0
 python.versions     37 38 39 310
 
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/python/py-hcloud/Portfile
+++ b/python/py-hcloud/Portfile
@@ -7,7 +7,6 @@ name                py-hcloud
 version             1.16.0
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-libtmux/Portfile
+++ b/python/py-libtmux/Portfile
@@ -8,7 +8,6 @@ version             0.10.3
 revision            0
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {@egorenar posteo.net:egorenar-dev} \

--- a/python/py-myst-parser/Portfile
+++ b/python/py-myst-parser/Portfile
@@ -9,7 +9,6 @@ revision            0
 name                py-myst-parser
 
 categories-append   textproc devel
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-pyotp/Portfile
+++ b/python/py-pyotp/Portfile
@@ -7,7 +7,6 @@ name                py-pyotp
 version             2.6.0
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-pytest-datadir/Portfile
+++ b/python/py-pytest-datadir/Portfile
@@ -8,7 +8,6 @@ version             1.3.1
 revision            0
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-pytest-regressions/Portfile
+++ b/python/py-pytest-regressions/Portfile
@@ -8,7 +8,6 @@ version             2.3.0
 revision            0
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-sentry-sdk/Portfile
+++ b/python/py-sentry-sdk/Portfile
@@ -7,7 +7,6 @@ name                py-sentry-sdk
 version             1.5.2
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-socketio/Portfile
+++ b/python/py-socketio/Portfile
@@ -8,7 +8,6 @@ github.setup        miguelgrinberg python-socketio 5.5.1 v
 name                py-socketio
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-sphinx-autodoc-typehints/Portfile
+++ b/python/py-sphinx-autodoc-typehints/Portfile
@@ -7,7 +7,6 @@ name                py-sphinx-autodoc-typehints
 version             1.15.2
 revision            0
 categories-append   textproc devel
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-spotipy/Portfile
+++ b/python/py-spotipy/Portfile
@@ -7,7 +7,6 @@ name                py-spotipy
 version             2.19.0
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {judaew @judaew} openmaintainer

--- a/python/py-tenacity/Portfile
+++ b/python/py-tenacity/Portfile
@@ -6,7 +6,6 @@ PortGroup           python 1.0
 
 name                py-tenacity
 version             8.0.1
-platforms           darwin
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer
 

--- a/python/py-tmuxp/Portfile
+++ b/python/py-tmuxp/Portfile
@@ -11,7 +11,6 @@ revision            0
 
 categories-append   devel
 license             MIT
-platforms           darwin
 supported_archs     noarch
 
 maintainers         {@egorenar posteo.net:egorenar-dev} \

--- a/python/py-wcmatch/Portfile
+++ b/python/py-wcmatch/Portfile
@@ -7,7 +7,6 @@ name                py-wcmatch
 version             8.3
 revision            0
 
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 

--- a/python/tmuxp_select/Portfile
+++ b/python/tmuxp_select/Portfile
@@ -6,7 +6,6 @@ PortGroup           select 1.0
 name                tmuxp_select
 version             0.1
 categories          python devel
-platforms           darwin
 supported_archs     noarch
 license             BSD
 maintainers         {judaew @judaew} openmaintainer

--- a/ruby/rb-cri/Portfile
+++ b/ruby/rb-cri/Portfile
@@ -9,7 +9,6 @@ maintainers         {judaew @judaew} openmaintainer
 description         Cri is a library for building easy-to-use commandline tools.
 long_description    \
     ${description}
-platforms           darwin
 supported_archs     noarch
 homepage            http://rubygems.org/gems/cri
 checksums           rmd160  94df025f74a6551a703faa80e5d1921f723f3579 \

--- a/ruby/rb-gettext/Portfile
+++ b/ruby/rb-gettext/Portfile
@@ -8,7 +8,6 @@ ruby.setup          gettext 3.4.2 gem
 revision            0
 
 categories-append   devel
-platforms           darwin
 license             Ruby
 maintainers         {kimuraw @kimuraw} \
                     {judaew @judaew} \

--- a/ruby/rb-locale/Portfile
+++ b/ruby/rb-locale/Portfile
@@ -7,7 +7,6 @@ ruby.branches       3.1 3.0 2.7 2.6 2.5
 ruby.setup          locale 2.1.3 gem
 
 categories-append   devel textproc
-platforms           darwin
 license             Ruby
 maintainers         {judaew @judaew} openmaintainer
 

--- a/ruby/rb-mini_portile2/Portfile
+++ b/ruby/rb-mini_portile2/Portfile
@@ -12,7 +12,6 @@ long_description    Simplistic port-like solution for developers. \
                     It provides a standard and simplified way to compile \
                     against dependency libraries without messing up your system.
 license             MIT
-platforms           darwin
 homepage            https://github.com/flavorjones/mini_portile
 
 checksums           rmd160  1e72ddb4507a3ec74d81f89855889f3e6fdaf94e \

--- a/ruby/rb-mustache/Portfile
+++ b/ruby/rb-mustache/Portfile
@@ -11,7 +11,6 @@ long_description    \
     render logic-free views.
 categories-append   www
 license             MIT
-platforms           darwin
 homepage            https://github.com/mustache/mustache
 
 checksums           rmd160  bad296ce20b6eebd2d75e921ad2f49ae03e70812 \

--- a/ruby/rb-nokogiri/Portfile
+++ b/ruby/rb-nokogiri/Portfile
@@ -18,7 +18,6 @@ long_description    Nokogiri is an HTML, XML, SAX, and Reader parser. \
                     Among Nokogiri's many features is the ability to search \
                     documents via XPath or CSS3 selectors.
 license             MIT
-platforms           darwin
 homepage            https://nokogiri.org
 
 checksums           rmd160  d1bf8c493d312e2b352d04d05c0d5afd50dc5c35 \

--- a/ruby/rb-rmagick/Portfile
+++ b/ruby/rb-rmagick/Portfile
@@ -7,7 +7,6 @@ ruby.branches           3.1 3.0 2.7 2.6 2.5 2.4 2.3
 ruby.setup              rmagick 4.2.4 gem
 revision                0
 categories-append       graphics
-platforms               darwin
 maintainers             {judaew @judaew} openmaintainer
 license                 MIT
 

--- a/ruby/rb-ronn-ng/Portfile
+++ b/ruby/rb-ronn-ng/Portfile
@@ -8,7 +8,6 @@ ruby.branches       3.1 3.0 2.7 2.6 2.5 2.4
 ruby.setup          ronn-ng 0.9.1 fetch
 github.setup        apjanke ronn-ng 0.9.1 v
 categories-append   www devel
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 supported_archs     noarch

--- a/ruby/rb-rubyzip/Portfile
+++ b/ruby/rb-rubyzip/Portfile
@@ -8,7 +8,6 @@ ruby.setup          rubyzip 2.3.2 gem
 revision            0
 
 categories-append   archivers
-platforms           darwin
 license             {Ruby GPL-2}
 maintainers         {judaew @judaew} openmaintainer
 

--- a/ruby/rb-text/Portfile
+++ b/ruby/rb-text/Portfile
@@ -9,7 +9,6 @@ revision            0
 
 maintainers         {judaew @judaew} openmaintainer
 license             MIT
-platforms           darwin
 
 description         A collection of text algorithms
 long_description    ${description}: Levenshtein, Soundex, Metaphone, \

--- a/ruby/rb-zentest/Portfile
+++ b/ruby/rb-zentest/Portfile
@@ -14,5 +14,4 @@ long_description    ZenTest scans your target and unit-test code and writes \
 checksums           rmd160  2f933894e6b699cbb2fc59e71666e1ccd9b783af \
                     sha256  5301757c3ab29dd2222795c1b076dd348f4d92fe0426e97a13ae56fea47a786e \
                     size    48128
-platforms           darwin
 homepage            https://github.com/seattlerb/zentest

--- a/security/exploitdb/Portfile
+++ b/security/exploitdb/Portfile
@@ -8,7 +8,6 @@ github.tarball_from archive
 revision            0
 
 categories          security
-platforms           darwin
 supported_archs     noarch
 license             GPL-2
 maintainers         {judaew @judaew} openmaintainer

--- a/security/pass-otp/Portfile
+++ b/security/pass-otp/Portfile
@@ -8,7 +8,6 @@ github.tarball_from releases
 revision            1
 
 categories          security
-platforms           darwin
 supported_archs     noarch
 license             GPL-3
 maintainers         {loicp.eu:loic-github @lpefferkorn} \

--- a/security/pass-update/Portfile
+++ b/security/pass-update/Portfile
@@ -8,7 +8,6 @@ github.tarball_from releases
 revision            1
 
 categories          security
-platforms           darwin
 supported_archs     noarch
 license             GPL-2
 maintainers         {judaew @judaew} openmaintainer

--- a/security/pass/Portfile
+++ b/security/pass/Portfile
@@ -9,7 +9,6 @@ maintainers         {judaew @judaew} openmaintainer
 categories          security
 description         ${name} is the standard unix password manager
 long_description    ${description}
-platforms           darwin
 supported_archs     noarch
 homepage            https://www.passwordstore.org/
 license             GPL-2+

--- a/security/sniffglue/Portfile
+++ b/security/sniffglue/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          security net
-platforms           darwin
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
 

--- a/security/sqlmap/Portfile
+++ b/security/sqlmap/Portfile
@@ -9,7 +9,6 @@ revision            0
 
 categories          security databases python
 maintainers         {judaew @judaew} openmaintainer
-platforms           darwin
 supported_archs     noarch
 license             GPL-2+
 

--- a/sysutils/ansible-lint/Portfile
+++ b/sysutils/ansible-lint/Portfile
@@ -8,7 +8,6 @@ github.setup        ansible-community ansible-lint 5.3.1 v
 revision            0
 
 categories          sysutils
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         artisancomputer.com:zdw \

--- a/sysutils/git-chglog/Portfile
+++ b/sysutils/git-chglog/Portfile
@@ -7,7 +7,6 @@ go.setup            github.com/git-chglog/git-chglog 0.15.1 v
 revision            0
 
 categories          sysutils
-platforms           darwin
 license             MIT
 maintainers         {judaew @judaew} openmaintainer
 description         git CHANGELOG generator

--- a/sysutils/joshuto/Portfile
+++ b/sysutils/joshuto/Portfile
@@ -9,7 +9,6 @@ github.tarball_from archive
 revision            0
 
 categories          sysutils
-platforms           darwin
 license             LGPL-3
 maintainers         {judaew @judaew} openmaintainer
 

--- a/sysutils/mas/Portfile
+++ b/sysutils/mas/Portfile
@@ -13,7 +13,6 @@ license             MIT
 
 maintainers         {kimuraw @kimuraw} \
                     {judaew @judaew} openmaintainer
-platforms           darwin
 
 checksums           sha256  a4f81f5dbd7357457bf55e39d16a13d840186afc91bf73eb812e9d314c91c8fd \
                     rmd160  dd94da4f9b8438b915cc3866d7720f0b223a8dcb \

--- a/sysutils/navi/Portfile
+++ b/sysutils/navi/Portfile
@@ -8,7 +8,6 @@ github.setup        denisidoro navi 2.18.0 v
 revision            0
 
 categories          sysutils
-platforms           darwin
 license             Apache-2
 maintainers         {judaew @judaew} \
                     openmaintainer

--- a/sysutils/nvimpager/Portfile
+++ b/sysutils/nvimpager/Portfile
@@ -8,7 +8,6 @@ github.tarball_from archive
 revision            0
 
 categories          sysutils
-platforms           darwin
 supported_archs     noarch
 license             BSD
 maintainers         {judaew @judaew} openmaintainer

--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -12,7 +12,6 @@ revision            0
 
 categories          sysutils
 license             Apache-2
-platforms           darwin
 
 description         Tool for managing OCI containers and pods.
 

--- a/textproc/asciidoctorj/Portfile
+++ b/textproc/asciidoctorj/Portfile
@@ -8,7 +8,6 @@ version             2.5.3
 revision            0
 
 categories          textproc java
-platforms           darwin
 license             Apache-2
 supported_archs     noarch
 maintainers         {judaew @judaew} openmaintainer

--- a/textproc/lowdown/Portfile
+++ b/textproc/lowdown/Portfile
@@ -14,7 +14,6 @@ long_description    lowdown translates markdown to either HTML \
 homepage            https://kristaps.bsd.lv/lowdown/
 master_sites        ${homepage}/snapshots/
 maintainers         {judaew @judaew} openmaintainer
-platforms           darwin
 
 checksums           rmd160 0abf71092bfd346f5f715070dfa3228c62422f6a \
                     sha256 b75cad25b10fa72d2c4730020eadf56345860964f4266bbcb18363e7c89c6297 \

--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -8,7 +8,6 @@ PortGroup           haskell_stack 1.0
 github.setup        jgm pandoc 2.17.0.1
 revision            0
 categories          textproc haskell
-platforms           darwin
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
 

--- a/www/doctl/Portfile
+++ b/www/doctl/Portfile
@@ -8,7 +8,6 @@ github.tarball_from archive
 revision            0
 
 categories          www devel
-platforms           darwin
 license             Apache-2
 maintainers         {@kritr gmail.com:krdevmail} \
                     {@judaew judaew} \


### PR DESCRIPTION
#### Description

I understand that commits violate the standard for commit messages. But this is a change in 93 ports, the name of which cannot be specified in one short header.

Since the platforms field is the default in MacPorts 2.7, I would like my ports to be cleaner.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
[skip notification]
