### PR TITLE
aerc: update to 0.7.1

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                aerc
-version             0.5.2
-revision            1
+version             0.7.1
+revision            0
 categories          mail
 license             MIT
 maintainers         nomaintainer
@@ -15,13 +15,13 @@ long_description    aerc is an email client that runs in your terminal, \
                     and first-class support for working with Git & email.
 platforms           darwin
 homepage            https://aerc-mail.org
-master_sites        https://git.sr.ht/~sircmpwn/aerc/archive/
+master_sites        https://git.sr.ht/~rjarry/aerc/archive/
 distname            ${version}
 worksrcdir          ${name}-${distname}
 
-checksums           rmd160  f935c02ae5bcd37a2100e035bda451045204fa52 \
-                    sha256  87b922440e53b99f260d2332996537decb452c838c774e9340b633296f9f68ee \
-                    size    142415
+checksums           rmd160  13d2b627b7ba7708f51f5028be7e14993cd05192 \
+                    sha256  e149236623c103c8526b1f872b4e630e67f15be98ac604c0ea0186054dbef0cc \
+                    size    168105
 
 depends_build       port:go \
                     port:scdoc
@@ -35,5 +35,5 @@ variant notmuch description {Enable support for notmuch integration} {
 
 build.target
 
-livecheck.url       https://git.sr.ht/~sircmpwn/aerc/refs
+livecheck.url       https://git.sr.ht/~rjarry/aerc/refs
 livecheck.regex     {aerc (\d+(?:\.\d+)*)}


### PR DESCRIPTION
#### Description
The fork was blessed by the original author; [relevant discussion](https://lists.sr.ht/~sircmpwn/aerc/%3CCFBVJ3G1Y4YB.ZI6C02D0MS0S%40diabtop%3E) can be found on the mailing list.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
