### PR TITLE
wireguard-go: update to 0.0.20220117

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20211016
+version             0.0.20220117
 revision            0
-checksums           rmd160  1920b4ac0ea2bff8df27f28cb8768f2ced319df9 \
-                    sha256  25c9ec596adc714fa456f88b61704bb069f17be3604d1c9cfae96579c924361d \
-                    size    97948
+checksums           rmd160  1e2bf8a75c7dc302667006df0a1dab617ce354de \
+                    sha256  f4496b6db6c2f99ebbb744738dd6c93ebdbda0571b56cfb857916d20a696fe80 \
+                    size    109548
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-go: update to 0.0.20220117

###### Tested on
macOS 12.1 21C52 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
