### PR TITLE
ki-shell: update to 0.4.3

### DIFF
--- a/java/ki-shell/Portfile
+++ b/java/ki-shell/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            ki-shell
-version         0.4.1
+version         0.4.3
 revision        0
 
 categories      java
@@ -27,9 +27,9 @@ master_sites    https://search.maven.org/remotecontent?filepath=org/jetbrains/ko
 
 distname        ${name}-${version}-archive
 
-checksums       rmd160  ded388ab2c6ce0c540f0591bd66248137d7d3df1 \
-                sha256  062adbecfc8ed185eeaa038379f80a5198a68d7a69a60f898067e1889267e80c \
-                size    61848572
+checksums       rmd160  0d3b1f88988764c6c0fa299183af31a4ca5ea9f4 \
+                sha256  64f283007e461f1647adcb9a6369b3fcc2f82f31f64b8610873956c41366ca66 \
+                size    65514620
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Kotlin Interactive Shell 0.4.3.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?