### PR TITLE
openjdk: added openjdk17-oracle

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -24,6 +24,9 @@ set long_description_ibm_semeru \
     "The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications built with\
 the OpenJDK class libraries and the Eclipse OpenJ9 JVM."
 
+set long_description_oracle \
+    "Open-source Oracle builds of OpenJDK, the Java Development Kit, an implementation of the Java SE Platform."
+
 set long_description_temurin \
     "Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes."
 
@@ -541,6 +544,34 @@ subport openjdk17-graalvm {
                  size    415089299
 }
 
+subport openjdk17-oracle {
+    # https://jdk.java.net/17/
+
+    supported_archs  x86_64 arm64
+
+    version      17.0.2
+    revision     0
+
+    description  Oracle OpenJDK 17
+    long_description ${long_description_oracle}
+
+    master_sites https://download.java.net/java/GA/jdk${version}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/
+
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     openjdk-${version}_macos-x64_bin
+        checksums    rmd160  3c89d3464a2c5e5e62af2153101d19f6023f1410 \
+                     sha256  b85c4aaf7b141825ad3a0ea34b965e45c15d5963677e9b27235aa05f65c6df06 \
+                     size    184480668
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     openjdk-${version}_macos-aarch64_bin
+        checksums    rmd160  79b88f39a4321cafe5b652b1c9fe6a92966b0de8 \
+                     sha256  602d7de72526368bb3f80d95c4427696ea639d2e0cc40455f53ff0bbb18c27c8 \
+                     size    182209404
+    }
+
+    worksrcdir   jdk-${version}.jdk
+}
+
 subport openjdk17-temurin {
     # https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
 
@@ -636,6 +667,8 @@ if {[string match *-graalvm ${subport}]} {
     homepage     https://www.azul.com/downloads/
 } elseif {[string match *-temurin ${subport}]} {
     homepage     https://adoptium.net
+} elseif {[string match *-oracle ${subport}]} {
+    homepage     https://jdk.java.net
 }
 
 livecheck.type  none


### PR DESCRIPTION
#### Description

Add a subport for Oracle OpenJDK 17.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?