### PR TITLE
armagetronad: fix error "use of undeclared identifier 'finite'" on arm64

### DIFF
--- a/games/armagetronad/Portfile
+++ b/games/armagetronad/Portfile
@@ -108,6 +108,19 @@ post-patch {
         {/socktype = socktype_/,/socktype |= SOCK_CLOEXEC/s/ndef WIN32/def SOCK_CLOEXEC/} \
         ${worksrcpath}/src/network/nSocket.cpp
 
+    # Avoid "error: use of undeclared identifier 'finite'; did you mean
+    # 'isfinite'?" on Apple arm64 (Reference: see Ryan's comment
+    # "[2018-10-16 01:07 UTC] php-bugs-2018 at ryandesign dot com" at
+    # https://bugs.php.net/bug.php?id=76826)
+    if {${os.platform} eq "darwin" && ${build_arch} eq "arm64" || \
+        ${os.major} <= 11} \
+    {
+        reinplace "/#include.*math.h/a\\
+            #define finite isfinite\\
+        " \
+            ${worksrcpath}/src/tools/tMath.h
+    }
+
     # Fix "Internal Error: Language British English not found."
     # Reference: https://forums3.armagetronad.net/viewtopic.php?t=24632
     reinplace "/include definition for top source directory/a\\


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
