### PR TITLE
openjdk: Azul Zulu OpenJDK Q1 2022 updates

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -80,10 +80,10 @@ if {${subport} eq "openjdk"} {
 subport openjdk7-zulu {
     # https://www.azul.com/downloads/?version=java-7-lts&os=macos&package=jdk
 
-    version      7.50.0.11
+    version      7.52.0.11
     revision     0
 
-    set openjdk_version 7.0.322
+    set openjdk_version 7.0.332
 
     description  Azul Zulu Community OpenJDK 7 (Long Term Support)
     long_description ${long_description_zulu}
@@ -91,9 +91,9 @@ subport openjdk7-zulu {
     master_sites https://cdn.azul.com/zulu/bin/
 
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  6052a3fb3917e0dbf0bbeea711529cf39c5a670d \
-                 sha256  085af056bfa3cbba63992a388c4eadebb1e3ae6f88822bee17520488592d7726 \
-                 size    68505097
+    checksums    rmd160  ad2a8a147e47327854ce5adfd7c9ae9da3f363e6 \
+                 sha256  c677a720a1e06fbf6fe20a8d15ea54a184fb783ece7a6707efe67ab6376846ae \
+                 size    68509988
 
     worksrcdir   ${distname}/zulu-7.jdk
 
@@ -173,10 +173,10 @@ subport openjdk8-temurin {
 subport openjdk8-zulu {
     # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
 
-    version      8.58.0.13
+    version      8.60.0.21
     revision     0
 
-    set openjdk_version 8.0.312
+    set openjdk_version 8.0.322
 
     description  Azul Zulu Community OpenJDK 8 (Long Term Support)
     long_description ${long_description_zulu}
@@ -185,14 +185,14 @@ subport openjdk8-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  30a02522f89b4d454617b1a819a4b657f226fa14 \
-                     sha256  e8088937f8df77a4e18c690cfe3d602ff50af3446b1a5420438ec811b0cf50ea \
-                     size    108079078
+        checksums    rmd160  01ca97a28d979f5468542fc4ff53a1185d54d119 \
+                     sha256  dece2b4105501353adf58fdd04a8ae959e2112e6ff9a743cbf222598f8ebc2ca \
+                     size    108226544
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  7d1629220e44a2e77ff4a7cc2bb0024692c49d62 \
-                     sha256  304251193046120487e6ee4b3172349118911f58e84fb8449e1ca14e03924db9 \
-                     size    105844180
+        checksums    rmd160  063f83e35c5c8057c95333f65647461f636cf626 \
+                     sha256  87410301c7e0e33ece61b4404c3c8ebfc3e75dd9f74d3ebae30833631e2dff60 \
+                     size    105912737
     }
 
     worksrcdir   ${distname}/zulu-8.jdk
@@ -297,10 +297,10 @@ subport openjdk11-temurin {
 subport openjdk11-zulu {
     # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 
-    version      11.52.13
+    version      11.54.23
     revision     0
 
-    set openjdk_version 11.0.13
+    set openjdk_version 11.0.14
 
     description  Azul Zulu Community OpenJDK 11 (Long Term Support)
     long_description ${long_description_zulu}
@@ -309,14 +309,14 @@ subport openjdk11-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  5e5eee2f151bcf166e0d4025b35a66d070160988 \
-                     sha256  e27a11a6e970ba6f597ecc957c0cdb502ff8990c243a6abd9df1e3413a0a3e44 \
-                     size    195746537
+        checksums    rmd160  2d37a548a89ff67bdbd957cbb1d066c404a88cef \
+                     sha256  f7ec731200318e194aab6b9c3b70fdfc18175abd7ce70df32e6d58b6388e8cca \
+                     size    193386455
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  d8184893aea25d7a5a6c0c6ff9ae18c837c7adab \
-                     sha256  eb8d593a61a9461a554e7bb1d67bca0f94242273f1d01a13f58c20c269b35fe5 \
-                     size    179324731
+        checksums    rmd160  ea067dd34655ddd6276001461c5efb8925e8a9dc \
+                     sha256  c7659bf049d2adcbf65222942f88ae0a4a0cbd48230f3dc977e7a907f3af4e26 \
+                     size    176885323
     }
 
     worksrcdir   ${distname}/zulu-11.jdk
@@ -367,10 +367,10 @@ subport openjdk13-openj9-large-heap {
 subport openjdk13-zulu {
     # https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
 
-    version      13.44.13
+    version      13.46.15
     revision     0
 
-    set openjdk_version 13.0.9
+    set openjdk_version 13.0.10
 
     description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
     long_description ${long_description_zulu}
@@ -379,14 +379,14 @@ subport openjdk13-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  9ce25f37b5c2951c0669a1858f246e2095bb5191 \
-                     sha256  a8600f9a1c82c6ac60c8138a51ff1c60d055f59c78aa082b22ed711097ed56b1 \
-                     size    200299583
+        checksums    rmd160  c37417003a010428e69a0b53e8800d9997e87577 \
+                     sha256  ed9142deef3d230928207ab64456ca0285213939afe78cd914c5b6689269e87d \
+                     size    200591500
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  fb87f09ab81c1bc7de8c604bbbe116a295ef48bd \
-                     sha256  f600d120ae43cfe906c71eea10b26c7df01a0c343041cddfc1278f95f10cb4c3 \
-                     size    179657257
+        checksums    rmd160  6a0bcb3c4485dbdb768e54ea7a7165c0a2199431 \
+                     sha256  92eb552b109a1e68809c319df6dc29798fdd64a07098bd5821387e8b298657e5 \
+                     size    179912266
     }
 
     worksrcdir   ${distname}/zulu-13.jdk
@@ -436,10 +436,10 @@ subport openjdk15-openj9-large-heap {
 subport openjdk15-zulu {
     # https://www.azul.com/downloads/?version=java-15-mts&os=macos&package=jdk
 
-    version      15.36.13
+    version      15.38.17
     revision     0
 
-    set openjdk_version 15.0.5
+    set openjdk_version 15.0.6
 
     description  Azul Zulu Community OpenJDK 15 (Medium Term Support)
     long_description ${long_description_zulu}
@@ -448,14 +448,14 @@ subport openjdk15-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  a4963a7f164be6b40e30c33105554de9d232d906 \
-                     sha256  e89e4b1ad499b59bfc74edef0975654a4033cdb9887a646c98cb35f41de72c06 \
-                     size    202001319
+        checksums    rmd160  3a46d9f2b822667113a3fe400300dcd56466f218 \
+                     sha256  59a2e0fac951fb48ccd11a39d16752bf7e375871d5fe92d3a63f032ddfbe8b44 \
+                     size    202445259
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  d8878abda897736555a4c6265133ab2a7e1a6771 \
-                     sha256  b58b4385752c2439edd78f88b7206c5ff71880862e849e0700c7fc1e4bf91b60 \
-                     size    176400196
+        checksums    rmd160  5f413443e65273dc53b059cea7965b2e6f8ed95b \
+                     sha256  3a0b2e6b36af26d996b5ec73418203e462be233da021f41c1834196e3bc2e60d \
+                     size    176748838
     }
 
     worksrcdir   ${distname}/zulu-15.jdk
@@ -610,10 +610,10 @@ subport openjdk17-temurin {
 subport openjdk17-zulu {
     # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 
-    version      17.30.15
+    version      17.32.13
     revision     0
 
-    set openjdk_version 17.0.1
+    set openjdk_version 17.0.2
 
     description  Azul Zulu Community OpenJDK 17 (Long Term Support)
     long_description ${long_description_zulu}
@@ -622,14 +622,14 @@ subport openjdk17-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  cc97b9d3487261caa7ab7f6c38fad54ce41a4d72 \
-                     sha256  09d64fe576373b4314422811bc8402fbb7700176822b0e1e2bf2ff8a6cad10eb \
-                     size    193015661
+        checksums    rmd160  3eced1f7701de4306f1fa24bc204cc56679afb03 \
+                     sha256  89d04b2d99b05dcb25114178e65f6a1c5ca742e125cab0a63d87e7e42f3fcb80 \
+                     size    193143505
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  92bb19ff065f2d9527e00a5e2de65bdd7be34d9f \
-                     sha256  ce10425ce9cefdfb23ebeabebc0944cfb41531114a2d5bd89e3c19cc5cfa9913 \
-                     size    190776969
+        checksums    rmd160  ec8b93727a88ab77a692aac411a7cb63ce0ff709 \
+                     sha256  54247dde248ffbcd3c048675504b1c503b81daf2dc0d64a79e353c48d383c977 \
+                     size    190938303
     }
 
     worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu:
* 7.52.0.11 (OpenJDK 7u332)
* 8.60.0.21 (OpenJDK 8u322)
* 11.54.23 (OpenJDK 11.0.14)
* 13.46.15 (OpenJDK 13.0.10)
* 15.38.17 (OpenJDK 15.0.6)
* 17.32.13 (OpenJDK 17.0.2)

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?