### PR TITLE
sfeed: new port

### DIFF
--- a/net/sfeed/Portfile
+++ b/net/sfeed/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           legacysupport 1.1
+PortGroup           makefile 1.0
+
+name                sfeed
+version             1.1
+revision            0
+license             ISC
+
+categories          net www
+maintainers         {sikmir @sikmir} openmaintainer
+description         RSS and Atom parser (and some format programs)
+long_description    {*}${description}
+
+homepage            https://git.codemadness.org/${name}/
+
+master_sites        https://codemadness.org/releases/${name}/
+
+checksums           rmd160  7434e4fd1908bc94928721649c2a9247c0dc0689 \
+                    sha256  8481e7df07d9ee66d6e50f45f61fcff62b9efe9c4686160ef70883d6083a25ef \
+                    size    60644
+
+depends_lib-append  port:ncurses
+
+legacysupport.newest_darwin_requires_legacy 10
+
+makefile.override   CC PREFIX
+
+compiler.c_standard 1999
+
+configure.cflags-append \
+                    -D_DARWIN_C_SOURCE
+
+build.args          "COMPATOBJ:=" \
+                    "SFEED_CURSES_LDFLAGS:=-lncurses"
+
+destroot.args       ${build.args}
+
+livecheck.type   regex
+livecheck.url    [lindex ${master_sites} 0]
+livecheck.regex  href=\"sfeed-(.*)\\.tar\\.gz\"


### PR DESCRIPTION
#### Description
**[Sfeed](http://codemadness.org/sfeed.html)**: simple RSS and Atom parser.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
