### PR TITLE
py-terminaltables: update to 3.1.10

### DIFF
--- a/python/py-terminaltables/Portfile
+++ b/python/py-terminaltables/Portfile
@@ -4,24 +4,23 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-terminaltables
-version             3.1.0
+version             3.1.10
 revision            0
 
 license             MIT
-platforms           darwin
 supported_archs     noarch
 maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         Generate simple tables in terminals from a nested list of strings
 long_description    Easily draw tables in terminal/console applications from \
                     a list of lists of strings. Supports multi-line rows.
 
-python.versions     27 36 37 38 39
+python.versions     37 38 39 310
 
-homepage            https://pypi.python.org/pypi/${python.rootname}/
+homepage            https://robpol86.github.io/${python.rootname}/
 
-checksums           rmd160  3978da76ff2bc1fec403cc29f36427834151305b \
-                    sha256  f3eb0eb92e3833972ac36796293ca0906e998dc3be91fbe1f8615b331b853b81 \
-                    size    12478
+checksums           rmd160  9d02523f89d32c890ae9c40212155e221584e279 \
+                    sha256  ba6eca5cb5ba02bba4c9f4f985af80c54ec3dccf94cfcd190154386255e47543 \
+                    size    12264
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
- Add py310
- Remove py36 which was recently EOL, and py27 which has been unsupported for a while. Neither appears to have any dependants.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
