### PR TITLE
onefetch: Update to 2.11.0 and remove platforms

### DIFF
--- a/devel/onefetch/Portfile
+++ b/devel/onefetch/Portfile
@@ -4,26 +4,24 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        o2sh onefetch 2.10.2 v
-revision            2
+github.setup        o2sh onefetch 2.11.0 v
+github.tarball_from archive
+revision            0
 
 description         Git repository summary on your terminal
 
 long_description    ${description}
 
 categories          devel
-platforms           darwin
 maintainers         {gmail.com:smanojkarthick @manojkarthick} \
                     openmaintainer
 license             MIT
 installs_libs       no
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  5141f7e5f981e0eb6e7792a5a6901f60837d9011 \
-                    sha256  6e4d4effcd4fd94ce21625a5e32da5da6446c8874200e40dd791e623b7aff7bb \
-                    size    1370024
-
-github.tarball_from archive
+                    rmd160  190a8cbb74623c29cc8ecc8aa6f6231b6e135302 \
+                    sha256  ffd3cc3bd24e299ede1fada2b2da8bf066d59219da167477e1997c860650c192 \
+                    size    1547400
 
 depends_lib-append  port:libgit2
 
@@ -34,31 +32,29 @@ destroot {
 }
 
 cargo.crates \
-    addr2line                       0.15.2  e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
     adler32                          1.2.0  aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234 \
     aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anyhow                          1.0.48  62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e \
     arrayvec                        0.4.12  cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9 \
-    askalono                         0.4.3  4c12726b90d9c483f418038faf41cb92a76e5d2c50135546574e4479bfd13ef0 \
+    askalono                         0.4.4  8cce6c91a5d31c8fc5d667d5873e0ddb3b93324c232dfeac54411e882a90bb10 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
-    backtrace                       0.3.60  b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282 \
     base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
     block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
     block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
     bstr                            0.2.16  90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279 \
     byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
-    byte-unit                       4.0.12  063197e6eb4b775b64160dedde7a0986bb2836cce140e9492e9e96f28e18bcd8 \
+    byte-unit                       4.0.13  956ffc5b0ec7d7a6949e3f21fd63ba5af4cffdc2ba1e0b7bf62b481458c4ae7f \
     bytecount                        0.6.2  72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e \
     bytemuck                         1.7.0  9966d2ab714d0f785dbac0a0396251a35280aeb42413281617d0209ab4898435 \
     byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
     cc                              1.0.68  4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
-    chrono-humanize                  0.2.1  2eddc119501d583fd930cb92144e605f44e0252c38dd89d9247fffa1993375cb \
     chrono-tz                        0.5.3  2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120 \
     clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
@@ -79,9 +75,6 @@ cargo.crates \
     encoding_rs                     0.8.28  80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065 \
     encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
     env_logger                       0.8.4  a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3 \
-    error-chain                     0.12.4  2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc \
-    failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
-    failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
     fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
     flate2                          1.0.20  cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
@@ -89,13 +82,12 @@ cargo.crates \
     generic-array                   0.12.4  ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd \
     getrandom                        0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
     gif                             0.11.2  5a668f699973d0f573d15749b7002a9ac9e1f9c6b220e7b165601334c173d8de \
-    gimli                           0.24.0  0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189 \
-    git2                           0.13.20  d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba \
-    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    git2                           0.13.24  845e007a28f1fcac035715988a234e8ec5458fd825b20a20c7dec74237ef341f \
     globset                          0.4.8  10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd \
     globwalk                         0.8.1  93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc \
     grep-matcher                     0.1.5  6d27563c33062cd33003b166ade2bb4fd82db1fd6a86db764dfdad132d46c1cc \
     grep-searcher                    0.1.8  7fbdbde90ba52adc240d2deef7b6ad1f99f53142d074b771fe9b7bede6c4c23d \
+    hashbrown                       0.11.2  ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e \
     heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
     hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
     humansize                        1.1.1  02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026 \
@@ -103,15 +95,14 @@ cargo.crates \
     idna                             0.2.3  418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
     ignore                          0.4.18  713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d \
     image                          0.23.14  24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1 \
+    indexmap                         1.7.0  bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5 \
     instant                          0.1.9  61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec \
-    itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
     itoa                             0.4.7  dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736 \
     jobserver                       0.1.22  972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd \
     jpeg-decoder                    0.1.22  229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2 \
-    json                            0.12.4  078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                            0.2.97  12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6 \
-    libgit2-sys              0.12.21+1.1.0  86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825 \
+    libc                           0.2.108  8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119 \
+    libgit2-sys                   0.12.25+1.3.0  8f68169ef08d6519b2fe133ecc637408d933c0174b23b80bb2f79828966fbaab \
     libz-sys                         1.1.3  de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66 \
     linked-hash-map                  0.5.4  7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3 \
     lock_api                         0.4.4  0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb \
@@ -123,7 +114,7 @@ cargo.crates \
     memoffset                        0.6.4  59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9 \
     miniz_oxide                      0.3.7  791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435 \
     miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
-    more-asserts                     0.2.1  0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238 \
+    more-asserts                     0.2.2  7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389 \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     num-format                       0.4.0  bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465 \
     num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
@@ -131,13 +122,12 @@ cargo.crates \
     num-rational                     0.3.2  12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07 \
     num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
     num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-    object                          0.25.3  a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7 \
     once_cell                        1.8.0  692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56 \
     opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
     parking_lot                     0.11.1  6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb \
     parking_lot_core                 0.8.3  fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018 \
     parse-zoneinfo                   0.3.0  c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41 \
-    paste                            1.0.5  acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58 \
+    paste                            1.0.6  0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5 \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
     pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
     pest_derive                      2.1.0  833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0 \
@@ -160,23 +150,22 @@ cargo.crates \
     regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
     rmp                             0.8.10  4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6 \
     rmp-serde                       0.14.4  4ce7d70c926fe472aed493b902010bccc17fa9f7284145cb8772fd22fdb052d8 \
-    rustc-demangle                  0.1.20  dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49 \
+    rustversion                      1.0.5  61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088 \
     ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scoped_threadpool                0.1.9  1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    serde                          1.0.126  ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03 \
-    serde_derive                   1.0.126  963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43 \
-    serde_json                      1.0.64  799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79 \
-    serde_yaml                      0.8.17  15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23 \
+    serde                          1.0.130  f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913 \
+    serde_derive                   1.0.130  d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b \
+    serde_json                      1.0.71  063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19 \
+    serde_yaml                      0.8.21  d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af \
     sha-1                            0.8.2  f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df \
     slug                             0.1.4  b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373 \
     smallvec                         1.6.1  fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    strum                           0.21.0  aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2 \
-    strum_macros                    0.21.1  d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec \
+    strum                           0.23.0  cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb \
+    strum_macros                    0.23.1  5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38 \
     syn                             1.0.73  f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7 \
-    synstructure                    0.12.4  b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701 \
     tera                            1.12.0  7571541dff0e57eaa2e931249f0d7489eb2b24b6b105546f8c2f1a47f15aaa3a \
     term_size                        0.3.2  1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9 \
     termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
@@ -184,6 +173,8 @@ cargo.crates \
     thread_local                     1.1.3  8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd \
     tiff                             0.6.1  9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437 \
     time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+    time                             0.3.5  41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad \
+    time-humanize                    0.1.3  3e32d019b4f7c100bcd5494e40a27119d45b71fba2b07a4684153129279a4647 \
     tinyvec                          1.2.0  5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342 \
     tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
     tokei                           12.1.2  a41f915e075a8a98ad64a5f7be6b7cc1710fc835c5f07e4a3efcaeb013291c00 \
@@ -205,15 +196,14 @@ cargo.crates \
     utf8-width                       0.1.5  7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
-    version_check                    0.9.3  5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe \
     walkdir                          2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
-    wasi     0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
+    wasi                          0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
     weezl                            0.1.5  d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     yaml-rust                        0.4.5  56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85 \
-    zstd                  0.5.4+zstd.1.4.7  69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910 \
-    zstd-safe             2.0.6+zstd.1.4.7  98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e \
-    zstd-sys             1.4.18+zstd.1.4.7  a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81
+    zstd                          0.8.3+zstd.1.5.0  5ea7094c7b4a58fbd738eb0d4a2fc7684a0e6949a31597e074ffe20a07cbc2bf \
+    zstd-safe                     4.1.0+zstd.1.5.0  d30375f78e185ca4c91930f42ea2c0162f9aa29737032501f93b79266d985ae7 \
+    zstd-sys                      1.6.0+zstd.1.5.0  2141bed8922b427761470e6bbfeff255da94fa20b0bbeab0d9297fcaf71e3aa7


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
