### PR TITLE
google-cloud-sdk: update to 369.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             368.0.0
+version             369.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1c4037a7aeb3b6fdb210c781a061831a811e6ea6 \
-                    sha256  813ed5808cb94ce70271e12786977e4874ef89ccc82944470eca7ae7445d1791 \
-                    size    97467794
+    checksums       rmd160  f190876405962473a218f0e1e2f276031c4642db \
+                    sha256  af3417354af8b3a2b87507c0b70632af05823f9551c48b071d5a90e4c8396548 \
+                    size    97654677
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  142d0a84b7e0c9a65b70eae545d17063e2fa5da1 \
-                    sha256  05b8a839b5140399fdc05c94b3d6d3e3b9c5f227d3fb7541bfd4150365b70864 \
-                    size    93733059
+    checksums       rmd160  3674f815554c851517cd43a370b93f5dcba074b1 \
+                    sha256  8a09c9de7c415bdb6ad09b513138d0dffe113fb22c708e10163342e87f80b300 \
+                    size    93927369
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c015ae8f77ed0084ce9f43f5bdce04ffe00bae10 \
-                    sha256  d37e86b852475088d4ed9d880f61f174b2535c848c66236bc580e2ea0c98d641 \
-                    size    93665033
+    checksums       rmd160  c3ec839b27434034057c00c8fa59d16edbcacc1e \
+                    sha256  1115475c638df31869f08dd5c176ddf3fdb946d9a9aedcef7c70e2ab551e6663 \
+                    size    93849385
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 369.0.0.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?