### PR TITLE
terraform-1.1: update to 1.1.4

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -17,18 +17,51 @@ maintainers             {emcrisostomo @emcrisostomo} \
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
 set latestVersion       terraform-1.1
 
+set armAvailable        no
+
+proc terraformBaseVersion {} {
+    global subport
+    return [lindex [split ${subport} "-"] 1]
+}
+
+proc terraformVersion {} {
+    global patchNumber
+    return [terraformBaseVersion].${patchNumber}
+}
+
+proc terraformDistBase {} {
+    global name
+    return ${name}_[terraformVersion]_darwin
+}
+
 subport terraform-1.1 {
-    set patchNumber     3
-    checksums           rmd160  d20a8b2a80c45637162297874e35848ad41edae8 \
-                        sha256  c54022e514a97e9b96dae24a3308227d034989ecbafb65e3293eea91f2d5edfb \
-                        size    20098660
+    set patchNumber     4
+
+    set armAvailable    yes
+
+    checksums           [terraformDistBase]_amd64.zip \
+                        rmd160  9c8b6601dfc3f6bdebc7f952f7d7f369f6914771 \
+                        sha256  c2b2500835d2eb9d614f50f6f74c08781f0fee803699279b3eb0188b656427f2 \
+                        size    20098620 \
+                        [terraformDistBase]_arm64.zip \
+                        rmd160  54a54c5b4937a1a2060f6e0e84ea3633ef753729 \
+                        sha256  a753e6cf402beddc4043a3968ff3e790cf50cc526827cda83a0f442a893f2235 \
+                        size    19248286
 }
 
 subport terraform-1.0 {
     set patchNumber     11
-    checksums           rmd160  a8ea8e4ec4087d753801f19c5f5625204cfcc098 \
+
+    set armAvailable    yes
+
+    checksums           [terraformDistBase]_amd64.zip \
+                        rmd160  a8ea8e4ec4087d753801f19c5f5625204cfcc098 \
                         sha256  92f2e7eebb9699e23800f8accd519775a02bd25fe79e1fe4530eca123f178202 \
-                        size    19340098
+                        size    19340098 \
+                        [terraformDistBase]_arm64.zip \
+                        rmd160  5194880e62164b3991d14e8ef39ef6f5e5a05c5c \
+                        sha256  0f38af81641b00a2cbb8d25015d917887a7b62792c74c28d59e40e56ce6f265c \
+                        size    18498208
 }
 
 subport terraform-0.15 {
@@ -72,7 +105,7 @@ if {${subport} eq ${name}} {
     PortGroup           obsolete 1.0
 
     replaced_by         ${latestVersion}
-    version             1.1.3
+    version             1.1.4
     revision            0
 
 } elseif {${subport} eq "terraform_select"} {
@@ -99,11 +132,22 @@ if {${subport} eq ${name}} {
     livecheck.type     none
 
 } else {
-    set baseVersion     [lindex [split ${subport} "-"] 1]
+    set baseVersion     [terraformBaseVersion]
     set baseName        terraform${baseVersion}
 
-    version             ${baseVersion}.${patchNumber}
+    version             [terraformVersion]
+
+    distname            [terraformDistBase]_amd64
     supported_archs     x86_64
+
+    if ${armAvailable} {
+        supported_archs x86_64 arm64
+
+        if {${build_arch} eq "arm64"} {
+            distname    [terraformDistBase]_arm64
+        }
+    }
+
     depends_run         port:terraform_select
 
     description         A tool for building, changing, and versioning \
@@ -116,7 +160,6 @@ if {${subport} eq ${name}} {
                         the infrastructure in a service provider such as AWS.
 
     master_sites        https://releases.hashicorp.com/${name}/${version}
-    distname            ${name}_${version}_darwin_amd64
 
     use_configure       no
     use_zip             yes


### PR DESCRIPTION
- add ARM64 support for Terraform 1.1 & 1.0

Fixes: https://trac.macports.org/ticket/64222

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
