### PR TITLE
py-pygithub: update to 1.55

### DIFF
--- a/python/py-pygithub/Portfile
+++ b/python/py-pygithub/Portfile
@@ -1,31 +1,38 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        PyGithub PyGithub 1.54 v
 name                py-pygithub
-platforms           darwin
+python.rootname     PyGithub
+version             1.55
 license             LGPL-3+
+supported_archs     noarch
 maintainers         {raimue @raimue} \
                     openmaintainer
 
-description         Python module for Github API v3
-long_description    ${description}
+description         Typed interactions with the GitHub API v3
+long_description    PyGitHub is a Python library to access the GitHub REST API. This \
+                    library enables you to manage GitHub resources such as repositories, \
+                    user profiles, and organizations in your Python applications.
 
-checksums           rmd160  2bda7c70a65e453053236f5e7fd29e8f0a036f11 \
-                    sha256  196cab6dd6421b194245dc8943dce5be3ecc4536af1e2f0b5573939e03f65585 \
-                    size    3117724
+homepage            https://pygithub.readthedocs.io/
 
-python.versions     35 36 37 38 39
+checksums           rmd160  9eabb1440224f445ec49014290df6c3214afe374 \
+                    sha256  1bbfff9372047ff3f21d5cd8e07720f3dbfdaf6462fcaed9d815f528f1ba7283 \
+                    size    158046
+
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
 
+    depends_run-append \
+                        port:py${python.version}-deprecated \
+                        port:py${python.version}-jwt \
+                        port:py${python.version}-pynacl \
+                        port:py${python.version}-requests \
+
     livecheck.type      none
-} else {
-    livecheck.url       ${github.homepage}/releases/latest
-    livecheck.regex     {archive/v(1\.[^"]+)\.tar}
 }


### PR DESCRIPTION
#### Description

- Remove py35/36
- Add py310

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.1 20C69 x86_64
xcode-select version 2384.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
