### PR TITLE
pgcli: add python310, remove python36 variants

### DIFF
--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        dbcli pgcli 3.2.0 v
-revision            1
+revision            2
 
 categories          databases python
 maintainers         {g5pw @g5pw} {@xeron gmail.com:xeron.oskom} openmaintainer
@@ -21,20 +21,20 @@ checksums           rmd160  0df7f981395f69e47b277d52336b117ecead12a4 \
                     sha256  65669f869766bb3416dc26ea719c65bd3297ba692207aa9e0f2164d26315ca8d \
                     size    444871
 
-variant python36 conflicts python37 python38 python39 description "Use Python 3.6" {}
-variant python37 conflicts python36 python38 python39 description "Use Python 3.7" {}
-variant python38 conflicts python36 python37 python39 description "Use Python 3.8" {}
-variant python39 conflicts python36 python37 python38 description "Use Python 3.9" {}
+variant python37 conflicts python38 python39 python310 description "Use Python 3.7" {}
+variant python38 conflicts python37 python39 python310 description "Use Python 3.8" {}
+variant python39 conflicts python37 python38 python310 description "Use Python 3.9" {}
+variant python310 conflicts python37 python38 python39 description "Use Python 3.10" {}
 
-if {[variant_isset python36]} {
-    python.default_version 36
-} elseif {[variant_isset python37]} {
+if {[variant_isset python37]} {
     python.default_version 37
 } elseif {[variant_isset python38]} {
     python.default_version 38
-} else {
-    default_variants +python39
+} elseif {[variant_isset python39]} {
     python.default_version 39
+} else {
+    default_variants +python310
+    python.default_version 310
 }
 
 depends_lib-append  port:py${python.version}-cli-helpers \

--- a/python/py-pendulum/Portfile
+++ b/python/py-pendulum/Portfile
@@ -15,7 +15,7 @@ long_description    Pendulum is a Python package to ease datetimes \
                     manipulation. It provides classes that are drop-in \
                     replacements for the native ones (they inherit from them).
 
-python.versions     36 37 38 39
+python.versions     37 38 39 310
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 

--- a/python/py-pgspecial/Portfile
+++ b/python/py-pgspecial/Portfile
@@ -15,7 +15,7 @@ description         Meta-commands handler for Postgres Database
 long_description    This package provides an API to execute meta-commands \
                     (AKA “special”, or “backslash commands”) on PostgreSQL.
 
-python.versions     36 37 38 39
+python.versions     37 38 39 310
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 

--- a/python/py-pytzdata/Portfile
+++ b/python/py-pytzdata/Portfile
@@ -14,7 +14,7 @@ maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         The Olson timezone database for Python
 long_description    ${description}
 
-python.versions     27 36 37 38 39
+python.versions     37 38 39 310
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 

--- a/python/py-setproctitle/Portfile
+++ b/python/py-setproctitle/Portfile
@@ -15,7 +15,7 @@ description         A Python module to customize the process title
 long_description    The setproctitle module allows a process to change \
                     its title (as displayed by system tools such as ps and top).
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Adds Python3.10 and removes EOL Python3.6 from `pgcli` and its dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1
Xcode ?.?

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
