### PR TITLE
git-tools: init

### DIFF
--- a/devel/git-tools/Portfile
+++ b/devel/git-tools/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            MestreLion git-tools 40f8174bf0f4db100c902be7e883dd70cfd1995f
+version                 20210806
+revision                0
+
+checksums               rmd160  17a570b3644306c3bf1f7fcea7c8d06502f52b70 \
+                        sha256  859504bc65a447352c99d0595a92214d24bd8dd97ebb7e6b3ec3b0c19742dc56 \
+                        size    32998
+
+maintainers             {@telotortium gmail.com:rirelan} openmaintainer
+platforms               darwin
+categories              devel
+supported_archs         noarch
+
+description             Assorted git-related scripts and tools, including git-restore-mtime
+long_description        ${description} -- \
+                        Included tools: git-branches-rename, git-clone-subset, \
+                        git-find-uncommitted-repos, git-rebase-theirs, \
+                        git-restore-mtime, git-strip-merge
+license                 GPL-3
+
+use_configure           no
+
+build {}
+destroot {
+    xinstall -m 0444 {*}[glob ${worksrcpath}/man1/*.1] ${destroot}${prefix}/share/man/man1
+    xinstall -m 0755 {*}[glob ${worksrcpath}/git-*] ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
#### Description

Add the [git-tools](https://github.com/MestreLion/git-tools) package, primarily for `git-restore-mtime`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?