### PR TITLE
wasmtime: new port (version 0.33.0)

### DIFF
--- a/devel/wasmtime/Portfile
+++ b/devel/wasmtime/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        bytecodealliance wasmtime 0.33.0 v
+github.tarball_from archive
+revision            0
+
+homepage            https://wasmtime.dev
+
+description         Standalone JIT-style runtime for WebAssembly, using \
+                    Cranelift
+
+long_description    {*}${description}
+
+categories          devel
+installs_libs       no
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+fetch.type          git
+
+build.pre_args      --release -v -j${build.jobs}
+
+post-extract {
+    system -W ${worksrcpath} "git submodule update --init --recursive"
+}
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for [wasmtime](https://wasmtime.dev/), a runtime for WebAssembly

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
