### PR TITLE
py-argcomplete: update to 2.0.0

### DIFF
--- a/python/py-argcomplete/Portfile
+++ b/python/py-argcomplete/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-argcomplete
-version             1.12.3
+version             2.0.0
 platforms           darwin
 license             Apache-2
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 
 homepage            https://kislyuk.github.io/argcomplete
 
-checksums           rmd160  feddf82662fb2d13c57b01f2f6265d073f257dd9 \
-                    sha256  2c7dbffd8c045ea534921e63b0be6fe65e88599990d8dc408ac8c542b72a5445 \
-                    size    76128
+checksums           rmd160  8b2287463686c297936e40164fcc2d5afcfd1601 \
+                    sha256  6372ad78c89d662035101418ae253668445b391755cfe94ea52f1b9d22425b20 \
+                    size    54164
 
 python.versions     36 37 38 39 310
 


### PR DESCRIPTION
###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?