### PR TITLE
retroarch: update to 1.10.0

### DIFF
--- a/emulators/retroarch/Portfile
+++ b/emulators/retroarch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        libretro RetroArch 1.9.14 v
+github.setup        libretro RetroArch 1.10.0 v
 revision            0
 
 name                retroarch
@@ -15,9 +15,9 @@ categories          emulators games
 description         Frontend for the libretro API.
 long_description    {*}${description}
 
-checksums           rmd160  98374e3854b4d72666fe41fc72d7a0c076981924 \
-                    sha256  25bb85eb420372cdd59e35cf80c5e3a65d49e798cd99694f695cff4c153e633e \
-                    size    41603561
+checksums           rmd160  668eb765b13c68af14658a7dccd03bdfbb606b97 \
+                    sha256  47e2293e21cdb99c3bfc3e1b1beeee1f3c1085f438f30b7d762c86d413c2f26b \
+                    size    41691246
 
 # See https://github.com/libretro/RetroArch/issues/8641
 patchfiles          patch-${name}-library-dirs.diff


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [x] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
