### PR TITLE
miniflux: new port

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -1,0 +1,225 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/miniflux/v2 2.0.35
+go.package          miniflux.app
+name                miniflux
+revision            0
+categories          net
+maintainers         {sikmir @sikmir} openmaintainer
+license             Apache-2
+
+description         Minimalist and opinionated feed reader
+long_description    {*}${description}
+homepage            https://miniflux.app
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  3219304311fdc9ce6f51954ffd389da10faac058 \
+                        sha256  96b7deba40dd2800ee68ffd0a1308d587ae97572fb89deb0c7d30a050fdd1a0e \
+                        size    535973
+
+go.vendors          mvdan.cc/xurls \
+                        repo    github.com/mvdan/xurls \
+                        lock    v2.3.0 \
+                        rmd160  e30d99a1030f46dd80e3531c7eabbcbd563ff1af \
+                        sha256  e22975a7c55cb3e78c3ab0a74660054cee6b898267afd78c4dfe0f8deae21e16 \
+                        size    21186 \
+                    gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/square/go-jose.v2 \
+                        lock    v2.5.0 \
+                        rmd160  4e33b18c386d9f617a1d18dc8c627add26ae4074 \
+                        sha256  b5dcfcf94e79eaaabd4eaf1cf1e4211c9f443705ae2ac0cfa8775f08690c2ef0 \
+                        size    308121 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.26.0-rc.1 \
+                        rmd160  30b1bef41e8bb6a456be9548b7b3b9b8b080fb6f \
+                        sha256  12a733d740730c0cd0a171b040d812d453ae55bef0f4fd08c5f2f19887d3f65c \
+                        size    1270384 \
+                    google.golang.org/appengine \
+                        repo    github.com/golang/appengine \
+                        lock    v1.6.6 \
+                        rmd160  ee3e5a6d2742607fd310e18634c1268156f39ad4 \
+                        sha256  084ba3a248eccd0c7606dc6cff3918326a0adb2e8d30babcbaf6f1c00e1d28f9 \
+                        size    333013 \
+                    golang.org/x/xerrors \
+                        lock    9bdfabe68543 \
+                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
+                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
+                        size    13661 \
+                    golang.org/x/text \
+                        lock    v0.3.6 \
+                        rmd160  e3da48fcc60d98e202458228188bf6dac408e309 \
+                        sha256  6b2d69df22b5ba1634bc6730c3f03404db499536a96c48b8016da80ced804450 \
+                        size    8356058 \
+                    golang.org/x/sys \
+                        lock    0f9fa26af87c \
+                        rmd160  b5e5b546cddec0ad97bccbc3a19fe3630792097b \
+                        sha256  e9ff4a07a3cc01341990da0d8ecd1cfa05643a2db423bb1efcf62f577901ea77 \
+                        size    1202158 \
+                    golang.org/x/oauth2 \
+                        lock    bf48bf16ab8d \
+                        rmd160  c1d307776adc90ce1a323b0a6cacab759bf1671e \
+                        sha256  ff3e74cdfe9c0b13d9d8e6f04551460efc01ca58b2332ebeb6f93b6c09c789bc \
+                        size    47023 \
+                    golang.org/x/net \
+                        lock    12bc252f5db8 \
+                        rmd160  103c09b86c8fc108f36ae479f64a14dd8ef5f016 \
+                        sha256  36d4043751156a71a051e104685bd53bf2e500fbd14c028a7152fafe25c8b01e \
+                        size    1255149 \
+                    golang.org/x/crypto \
+                        lock    75b288015ac9 \
+                        rmd160  d0df189672060fb880ac1bd440bfe94a5fc3e6d9 \
+                        sha256  290dc7a301e9ad139c8a5bd91bc0fd9936c60e2d7e7f9361eb3766e8b5947e86 \
+                        size    1729939 \
+                    github.com/technoweenie/multipartstreamer \
+                        lock    v1.0.1 \
+                        rmd160  f1ac41924fe0ca28bf79b5737680452a907b70b4 \
+                        sha256  4d7559e4d965a056e8dc4c32f852a23451ad47cd639123bc7a4bf7268ff94861 \
+                        size    3248 \
+                    github.com/tdewolff/test \
+                        lock    v1.0.6 \
+                        rmd160  356ec42d41a32c7db4f4be7fbe5e136236c88162 \
+                        sha256  521e9c769207c752824fb3f241dcb093f99e33e93c14f52882c07b2c7513dc56 \
+                        size    2835 \
+                    github.com/tdewolff/parse \
+                        lock    v2.5.27 \
+                        rmd160  75aa5693e9b515f38bb1d89b580af06225db4f16 \
+                        sha256  48626fece66259b874a79e0ad78bfc99e855349ffc4c0c133237bd37e5081224 \
+                        size    101529 \
+                    github.com/tdewolff/minify \
+                        lock    v2.9.28 \
+                        rmd160  edf6f0e0430d3ad004499f46958bb69b6c04341a \
+                        sha256  a6e8595e109b28a710baa66b8e67572ad2956a67318e6c71abb176ab4662c746 \
+                        size    4888164 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/rylans/getlang \
+                        lock    4c3188ff8a2d \
+                        rmd160  53d360a749a8a7c53b7ed2a88b3ceeb8f4214c17 \
+                        sha256  79003ca68407b3b358db8ef8e073dbec1f7aaab3cafd44f21818d6bc0e08c326 \
+                        size    22092 \
+                    github.com/prometheus/procfs \
+                        lock    v0.6.0 \
+                        rmd160  ae0e0bcf1c664eacc18c03ec77973f0212dce472 \
+                        sha256  4ffc099c6f2ce85a7681e09462e465b140556743a248f4b3bdc665498f3380b1 \
+                        size    169970 \
+                    github.com/prometheus/common \
+                        lock    v0.26.0 \
+                        rmd160  6767da5e89b5aa9e4872df991afdd96abbb0c872 \
+                        sha256  7f1004d8c389191b2c918e267807b6fee0e24d0073de5fa87e47e0798ef13644 \
+                        size    116913 \
+                    github.com/prometheus/client_model \
+                        lock    v0.2.0 \
+                        rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
+                        sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
+                        size    10985 \
+                    github.com/prometheus/client_golang \
+                        lock    v1.11.0 \
+                        rmd160  96f9efe7bff3d325ea9f2a3a2caecf1dbebc77c2 \
+                        sha256  fcad11001028f3cecfc6e7f5221a361f0f5ea49cf6ab29a2baf70cf5e005d5a5 \
+                        size    168768 \
+                    github.com/pquerna/cachecontrol \
+                        lock    1555304b9b35 \
+                        rmd160  0a0f37cba23e467f89c717d93a37c5b34005b64e \
+                        sha256  51832af12991acba3c87afe472abf3e0c44fdc152f88d53d53db36eb2f63eec2 \
+                        size    18999 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/mitchellh/go-server-timing \
+                        lock    feb680ab92c2 \
+                        rmd160  60c6a906372d8486f21905a9bb3382cf32918f08 \
+                        sha256  f614f2e7a905b8865bd3b8070adaf91065c8795d24d091e070bbe7cfadc86e3d \
+                        size    78468 \
+                    github.com/matttproud/golang_protobuf_extensions \
+                        lock    v1.0.1 \
+                        rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
+                        sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
+                        size    37197 \
+                    github.com/lib/pq \
+                        lock    v1.10.4 \
+                        rmd160  e2f0dde65aa624ff4c99c03a60eb50f9256b1381 \
+                        sha256  ed6e9e981845f012fc0b0acd205581ad133431ed8000719dd3f3435b3fe5114c \
+                        size    108160 \
+                    github.com/gorilla/mux \
+                        lock    v1.8.0 \
+                        rmd160  0671fd049b24cb4c682168aef4e176793dd624a7 \
+                        sha256  b94c995107eaf9f5bcaa0a29629fb6c23bab9ec0606071c09070e143fdf323fa \
+                        size    45524 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.5 \
+                        rmd160  5caef57da3ce09c102ed270168afa2a5200c2c47 \
+                        sha256  be284023d91976ef03d13cb5670e338c09a0a0da9925d7de457f44e33aebb724 \
+                        size    102365 \
+                    github.com/golang/protobuf \
+                        lock    v1.4.3 \
+                        rmd160  f07e841d9c9706e08d3ec3b6440a6b7e42d54392 \
+                        sha256  a53f353ad911974ab0483ae25d4f0cdb4f0ea508b69a786062e4743df2ab3959 \
+                        size    171996 \
+                    github.com/golang/gddo \
+                        lock    721e228c7686 \
+                        rmd160  ff883ee0f935243223b9eb7568045d0d2d8503ab \
+                        sha256  1501412a0961f3f93f0b6b200accec9e50ccd4b8ba7574b42d3707bdcaf1e50b \
+                        size    3106988 \
+                    github.com/go-telegram-bot-api/telegram-bot-api \
+                        lock    v4.6.4 \
+                        rmd160  80821ad149f661570509a35adcf2d1d73fcf0c10 \
+                        sha256  98e078b4f8909436790f12c39fcc589ac7b4e9b39e342966d60470aa2f14fad8 \
+                        size    2076483 \
+                    github.com/felixge/httpsnoop \
+                        lock    v1.0.1 \
+                        rmd160  0d3ce8473f93cb8cb901d811b37e765b7a528be3 \
+                        sha256  5a4589657bc09f824b17f1c30ea20b0ef2a1354070d6260a426e7afb4eedd9ec \
+                        size    10725 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/coreos/go-oidc \
+                        lock    v2.2.1 \
+                        rmd160  d91319f3d8e0a3c82d9a2ee16e0fc101208c253f \
+                        sha256  cb7f8f625e511034f24505efeee92be610f2cbd957114d9c591aea9f29afa22c \
+                        size    24141 \
+                    github.com/cespare/xxhash \
+                        lock    v2.1.1 \
+                        rmd160  0c0da0840864215209db2afcd2ee92a52ca2d4d1 \
+                        sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
+                        size    9300 \
+                    github.com/beorn7/perks \
+                        lock    v1.0.1 \
+                        rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
+                        sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
+                        size    10874 \
+                    github.com/andybalholm/cascadia \
+                        lock    v1.3.1 \
+                        rmd160  c9646a2a7dafdeac093fd99a8e27153cf24f5c92 \
+                        sha256  a567b37da6b02ae582740bf015864a29cfd3b44af4815b0ac1680040fe46f67d \
+                        size    33105 \
+                    github.com/PuerkitoBio/goquery \
+                        lock    v1.8.0 \
+                        rmd160  81d239bcf19ee6e8dcadea494b9fc04c96f9480f \
+                        sha256  ea72d407535c049adac1a50fd783a5e3a2563dd6e6b60ddfb8a00691c43d78bd \
+                        size    105214
+
+build.args-append   -ldflags=\"-s -w -X '${go.package}/version.Version=${version}'\"
+
+destroot {
+    set mandir ${prefix}/share/man/man1
+    xinstall -m 755 -d ${destroot}${mandir}
+
+    xinstall -m 755 ${worksrcpath}/${go.package} ${destroot}${prefix}/bin/${name}
+    xinstall -m 644 ${worksrcpath}/${name}.1 ${destroot}${mandir}/
+}


### PR DESCRIPTION
#### Description
**[Miniflux](https://miniflux.app/)** is a minimalist and opinionated feed reader.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
