### PR TITLE
libpano13: update to 2.9.21

### DIFF
--- a/graphics/libpano13/Portfile
+++ b/graphics/libpano13/Portfile
@@ -1,34 +1,45 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
+PortSystem            1.0
+PortGroup             cmake 1.1
 
-name                libpano13
-version             2.9.19
-revision            1
-categories          graphics
-platforms           darwin
-maintainers         {gmail.com:freespace @freespace}
-license             GPL-2+
+name                  libpano13
+version               2.9.21
+revision              0
+categories            graphics
+platforms             darwin
+maintainers           {gmail.com:freespace @freespace}
+license               GPL-2+
 
-description         The cross-platform library behind Panorama Tools
+description           The cross-platform library behind Panorama Tools
 
-long_description    The panorama tools are mainly used to build panoramic images from a set of overlapping images. The usability extends beyond "just" building panoramas by far though. You can, for instance, use them to render an average of multiple images to broaden the dynamic range of the images or average out noise. You can also build object movies with them, morph between images and much more.
+long_description      The panorama tools are mainly used to build panoramic images from a set of overlapping images. The usability extends beyond "just" building panoramas by far though. You can, for instance, use them to render an average of multiple images to broaden the dynamic range of the images or average out noise. You can also build object movies with them, morph between images and much more.
 
-homepage            http://panotools.sourceforge.net/
-master_sites        sourceforge:project/panotools/libpano13/libpano13-${version}/
+homepage              http://panotools.sourceforge.net/
+master_sites          sourceforge:project/panotools/libpano13/libpano13-${version}/
 
-checksums           rmd160  88b8770815d3a8bd41cfe367ae19daffcf2ec76a \
-                    sha256  037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8
+checksums             rmd160  a2e4529112f09f24a2ff6bacee5031261965f279 \
+                      sha256  79e5a1452199305e2961462720ef5941152779c127c5b96fc340d2492e633590 \
+                      size    2801535
 
-depends_lib         path:include/turbojpeg.h:libjpeg-turbo \
-                    port:tiff \
-                    port:libpng \
-                    port:zlib
+cmake.generator       Ninja
+configure.args-append -DJPEG_INCLUDE_DIR=${prefix}/include \
+                      -DJPEG_LIBRARY=${prefix}/lib/libjpeg.dylib \
+                      -DPNG_INCLUDE_DIR=${prefix}/include \
+                      -DPNG_LIBRARY=${prefix}/lib/libpng.dylib \
+                      -DSUPPORT_JAVA_PROGRAMS=OFF \
+                      -DTIFF_INCLUDE_DIR=${prefix}/include \
+                      -DZLIB_ROOT=${prefix}
+patchfiles-append     patch-endian-detection.diff
 
-configure.args      --with-jpeg=${prefix} \
-                    --with-tiff=${prefix} \
-                    --with-png=${prefix} \
-                    --with-zlib=${prefix} \
-                    --without-java
+depends_build-append  port:pkgconfig
 
-livecheck.regex     /${name}-(\[0-9.\]+)${extract.suffix}
+depends_lib           port:libjpeg-turbo \
+                      port:libpng \
+                      port:tiff \
+                      port:zlib
+
+test.run              yes
+test.cmd              ctest --output-on-failure
+
+livecheck.regex       /${name}-(\[0-9.\]+)${extract.suffix}

--- a/graphics/libpano13/files/patch-endian-detection.diff
+++ b/graphics/libpano13/files/patch-endian-detection.diff
@@ -1,0 +1,38 @@
+--- panorama.h.orig	2022-01-22 10:22:19.000000000 +0100
++++ panorama.h	2022-01-22 10:22:34.000000000 +0100
+@@ -45,7 +45,16 @@
+ 
+ // If you need PT_BIGENDIAN, and don't use MacOS, define it here:
+ //#define PT_BIGENDIAN                  1
+-#if defined(__GNUC__) && !defined(__MINGW32__)
++#if !defined(__Mac_OSX__) && defined(__APPLE_CC__)
++        #define __Mac_OSX__ 1
++#endif
++#ifdef __Mac_OSX__
++    #if (defined(__ppc__) || defined(__ppc64__))
++        #define PT_BIGENDIAN		1
++    #elif defined(__i386__)
++        #undef PT_BIGENDIAN
++    #endif
++#elif defined(__GNUC__) && !defined(__MINGW32__)
+ #if defined(__FreeBSD__)
+ // special check for FreeBSD because it follow its own rules
+ #include <sys/endian.h>
+@@ -75,17 +84,6 @@
+   #endif
+ #endif
+ 
+-#ifndef __Mac_OSX__
+-    #if defined(__APPLE_CC__)
+-        #define __Mac_OSX__			1
+-        #if (defined(__ppc__) || defined(__ppc64__))
+-            #define PT_BIGENDIAN		1
+-        #elif defined(__i386__)
+-            #undef PT_BIGENDIAN
+-        #endif
+-    #endif
+-#endif
+-
+ // Use FSSpec on Macs as Path-specifyers, else strings
+ #define PATH_SEP							'/'
+ 


### PR DESCRIPTION
#### Description
Update libpano13 from 2.9.19 to 2.9.21. Migrate to using CMake to build.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 12.1 21C52 x86_64
Xcode not installed, I just have the latest commandline tools.

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?