### PR TITLE
pipenv: update to 2022.1.8, move to python 3.10

### DIFF
--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                pipenv
-version             2021.11.23
+version             2022.1.8
 revision            0
 categories-append   devel
 platforms           darwin
@@ -34,11 +34,11 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  6a8de514f46d24e82154aace733b6cb0437fb3b9 \
-                    sha256  1bde859e8bbd1d21d503fd995bc0170048d6da7686ab885f074592c99a16e8f3 \
-                    size    5002449
+checksums           rmd160  4e80087a4aadfc34c85c2620c52bcc26a6a37a7a \
+                    sha256  f84d7119239b22ab2ac2b8fbc7d619d83cf41135206d72a17c4f151cda529fd0 \
+                    size    5002974
 
-python.default_version 39
+python.default_version 310
 
 depends_lib-append \
     port:py${python.version}-pip \


### PR DESCRIPTION
#### Description

Tested with a `pipenv update`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
