### PR TITLE
libstdcxx-docs: new port

### DIFF
--- a/lang/libstdcxx-docs/Portfile
+++ b/lang/libstdcxx-docs/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libstdcxx-docs
+version             11.2.0
+categories          lang
+platforms           darwin
+supported_archs     noarch
+license             GPL-3+
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         libstdc++ manpages
+
+long_description    Manpages for the C++ library.
+
+homepage            https://gcc.gnu.org/onlinedocs/libstdc++/
+
+depends_build       port:doxygen port:graphviz
+
+master_sites        gnu:gcc/gcc-${version}
+distname            gcc-${version}
+
+checksums           rmd160  0fdd0b2c0954ccbd32e24f027d7b55fd26dcc627 \
+                    sha256  d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b \
+                    size    80888824
+
+use_xz              yes
+
+configure.dir       ${workpath}/build
+configure.cmd       ${worksrcpath}/libstdc++-v3/configure
+
+build.dir           ${configure.dir}
+build.target        man
+
+destroot.dir        ${configure.dir}
+destroot.target     install-man


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/64237

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?