### PR TITLE
py-jupyter_client: update to 7.1.2

### DIFF
--- a/python/py-jupyter_client/Portfile
+++ b/python/py-jupyter_client/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jupyter_client
-version             6.1.12
+version             7.1.2
 revision            0
 platforms           darwin
 license             BSD
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://jupyter.org
 
-checksums           rmd160  1e2bf8a6a8ec37e0744a7d5cb85895224636b43e \
-                    sha256  c4bca1d0846186ca8be97f4d2fa6d2bae889cce4892a167ffa1ba6bd1f73e782 \
-                    size    301499
+checksums           rmd160  f65e01f7c2715624a05e0366bb90f18aa9ff5ba0 \
+                    sha256  4ea61033726c8e579edb55626d8ee2e6bf0a83158ddf3751b8dd46b2c5cd1e96 \
+                    size    326163
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \


### PR DESCRIPTION
#### Description

Update py-jupyter_client to 7.1.2

This is a small step of the big plan of https://github.com/macports/macports-ports/pull/13717 (a recent version of py-jupyter_client is a necessary condition to have a working spyder). See also https://trac.macports.org/ticket/64453 .

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
