### PR TITLE
lagrange: update to 1.10.2

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.10.0 v
+github.setup        skyjake lagrange 1.10.2 v
 revision            0
 github.tarball_from releases
 categories          net gemini
@@ -20,9 +20,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  e834f5d32673298cb2f9fabef9ce428fa2a76a79 \
-                    sha256  382c4880bd45d30b9ccd7bb6279b2f8f47db28b41700dbed45b8e4e4ef954f7f \
-                    size    8649852
+checksums           rmd160  2cff37c455098916dc13861e3689e1a4ff95ca44 \
+                    sha256  76b5a866ce535ea4b2250b232d5148e30aba16d44c26f9a9ca3dceea0075bbff \
+                    size    8659158
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
