### PR TITLE
libbiosig: Update to 1.8.6, fix implicit function declarations, fix license

### DIFF
--- a/science/libbiosig/Portfile
+++ b/science/libbiosig/Portfile
@@ -31,6 +31,8 @@ depends_lib         port:SuiteSparse_CHOLMOD \
                     port:zlib \
                     port:libiconv
 
+patchfiles          implicit.patch
+
 cmake.out_of_source yes
 
 configure.args-append \

--- a/science/libbiosig/Portfile
+++ b/science/libbiosig/Portfile
@@ -4,11 +4,14 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 
 name                libbiosig
-version             1.8.4
-revision            1
+version             1.8.6
+revision            0
+checksums           rmd160  d6bf0c14c42058e3099d63c4cf1475ff66fa85e4 \
+                    sha256  adf1a11260c23c2bf3e6cf89f0344d87ac4e2cc96af931a9670cc87425cd675d \
+                    size    857307
+
 categories          science
-platforms           darwin
-license             GPL-3
+license             GPL-3+
 maintainers         {gmx.de:christsc @neurodroid}
 description         I/O library for biomedical data
 long_description    BioSig is a library for accessing files in several \
@@ -16,14 +19,11 @@ long_description    BioSig is a library for accessing files in several \
                     BrainVision, BCI2000, CFWB, HL7aECG, SCP_ECG (EN1064), \
                     MFER, ACQ, CNT(Neuroscan), DEMG, EGI, EEG1100, FAMOS, \
                     SigmaPLpro, TMS32)
-homepage            http://biosig.sourceforge.net/index.html
-master_sites        sourceforge:biosig
-master_sites.mirror_subdir \
-                    /BioSig%20for%20C_C++/src
+
+homepage            http://biosig.sourceforge.net
+master_sites        sourceforge:project/biosig/BioSig%20for%20C_C%2B%2B/src
 distname            biosig4c++-${version}.src
 worksrcdir          biosig4c++-${version}
-checksums           rmd160  0f242f403f5ea02f76d353b132d86633ec4a5dcb \
-                    sha256  76145dabbf0dd5904e6645ed739284982064f68399e46e472e26c3fbd4c85348
 
 depends_build-append \
                     port:gawk

--- a/science/libbiosig/files/implicit.patch
+++ b/science/libbiosig/files/implicit.patch
@@ -1,0 +1,12 @@
+Fix:
+error: implicitly declaring library function 'finite' with type 'int (double)' [-Werror,-Wimplicit-function-declaration]
+--- t210/sopen_heka_read.c.orig	2017-07-23 15:40:06.000000000 -0500
++++ t210/sopen_heka_read.c	2022-01-24 12:41:34.000000000 -0600
+@@ -22,6 +22,7 @@
+ 
+ #include <assert.h>
+ #include <ctype.h>
++#include <math.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/stat.h>


### PR DESCRIPTION
#### Description

Update to 1.8.6. There are newer versions available including 1.9.x and 2.x but I did not know whether those newer versions would be compatible with the ports that depend on this port so I'm leaving further updates to you for now.

Fix implicit declaration of function. I don't see this [build failure](https://build.macports.org/builders/ports-11_arm64-builder/builds/44996/steps/install-port/logs/stdio) on my system so while I'm fairly sure this fix is correct to fix this implicit declaration of function I don't know whether there are additional implicit declaration of functions remaining to be fixed.

Fix license. The DESCRIPTION file says it is GPL 3 or later, not GPL 3 only.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
