### PR TITLE
git: require C99

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -62,10 +62,12 @@ extract.only        git-${version}${extract.suffix} \
 
 use_configure       no
 
+compiler.c_standard 1999
+
 variant universal   {}
 
-set CFLAGS          "-I. -Wall -O2 -I${prefix}/include [get_canonical_archflags cc]"
-set LDFLAGS         "-L${prefix}/lib [get_canonical_archflags ld]"
+set CFLAGS          "${configure.cflags} -std=gnu99 [get_canonical_archflags cc]"
+set LDFLAGS         "${configure.ldflags} [get_canonical_archflags ld]"
 
 build.args          CFLAGS="${CFLAGS}" \
                     LDFLAGS="${LDFLAGS}" \


### PR DESCRIPTION
#### Description

C99 is now "experimentally required" by git, erroring out if not detected:

https://github.com/git/git/blob/master/git-compat-util.h#L14

Adding `-std=gnu99` fixes the build on Tiger/Leopard. I have also cleaned up the flags being passed to the build.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
