### PR TITLE
openjdk8-temurin: update to 8u322

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -153,10 +153,10 @@ subport openjdk8-openj9 {
 subport openjdk8-temurin {
     # https://adoptium.net/releases.html?variant=openjdk8&jvmVariant=hotspot
 
-    version      8u312
+    version      8u322
     revision     0
 
-    set build    07
+    set build    06
 
     description  Eclipse Temurin, based on OpenJDK 8
     long_description ${long_description_temurin}
@@ -165,9 +165,9 @@ subport openjdk8-temurin {
     distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  aa3258067243f32db66d0ab4c3f8154589837d57 \
-                 sha256  2428e7fbd0dfb7416783df89398c0ccc0fa883f4fabce0e9b83388bc2109268e \
-                 size    107991615
+    checksums    rmd160  335f1bfa3cee50eee7da9d78514dd28e665ae553 \
+                 sha256  96a3124bf0f5ca777954239893cc89ea34c4bc9a9b7c1559aa2c69baa0ee84e3 \
+                 size    108075347
 }
 
 subport openjdk8-zulu {


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u322.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?