### PR TITLE
openjdk11-graalvm: update to 22.0.0.2

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -230,7 +230,7 @@ subport openjdk11 {
 }
 
 subport openjdk11-graalvm {
-    version      21.3.0
+    version      22.0.0.2
     revision     0
 
     description  GraalVM Community Edition based on OpenJDK 11
@@ -240,9 +240,9 @@ subport openjdk11-graalvm {
     distname     graalvm-ce-java11-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java11-${version}
 
-    checksums    rmd160  a3d4159e7a9fc118a6595b4aa36225530e9147b9 \
-                 sha256  6c2bf7f6e5fab901e8a2284a0dbec6ce214bde65aa80cfeb90bfef8eabb5f862 \
-                 size    403386940
+    checksums    rmd160  d45ec5d0f9dae092471fe1c9381769f23efb08da \
+                 sha256  8280159b8a66c51a839c8079d885928a7f759d5da0632f3af7300df2b63a6323 \
+                 size    418371142
 }
 
 subport openjdk11-openj9 {


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 22.0.0.2.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?