### PR TITLE
openjdk17-graalvm: update to 22.0.0.2

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -529,7 +529,7 @@ subport openjdk17 {
 }
 
 subport openjdk17-graalvm {
-    version      21.3.0
+    version      22.0.0.2
     revision     0
 
     description  GraalVM Community Edition based on OpenJDK 17
@@ -539,9 +539,9 @@ subport openjdk17-graalvm {
     distname     graalvm-ce-java17-darwin-amd64-${version}
     worksrcdir   graalvm-ce-java17-${version}
 
-    checksums    rmd160  bdbe63ef185db265df38fae5666d0ea64d38d539 \
-                 sha256  60236506920cc84a07ea7602f4514d05da2c07c7176e0634652f8a9c5ad677aa \
-                 size    415089299
+    checksums    rmd160  857dd0491c827e52aabe7891d1aaada29f802570 \
+                 sha256  d54af9d1f4d0d351827395a714ed84d2489b023b74a9c13a431cc9d31d1e8f9a \
+                 size    429797450
 }
 
 subport openjdk17-openj9 {


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 22.0.0.2.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?