### PR TITLE
google-cloud-sdk: update to 370.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             369.0.0
+version             370.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f190876405962473a218f0e1e2f276031c4642db \
-                    sha256  af3417354af8b3a2b87507c0b70632af05823f9551c48b071d5a90e4c8396548 \
-                    size    97654677
+    checksums       rmd160  5795d261933c8cf0bd4a96603d7053901c5f8703 \
+                    sha256  ffb7c56611b6ec531676eff7f18c22afde7fe35b969eeec1e6154024db3a92b7 \
+                    size    97716958
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3674f815554c851517cd43a370b93f5dcba074b1 \
-                    sha256  8a09c9de7c415bdb6ad09b513138d0dffe113fb22c708e10163342e87f80b300 \
-                    size    93927369
+    checksums       rmd160  634bcd779e8e0f786f7d8b7f19ee7117799a23ce \
+                    sha256  e08541e2e319457698b9154cd064edc5efa95653f5a84b94a1f2f3d0f87ee196 \
+                    size    92976616
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c3ec839b27434034057c00c8fa59d16edbcacc1e \
-                    sha256  1115475c638df31869f08dd5c176ddf3fdb946d9a9aedcef7c70e2ab551e6663 \
-                    size    93849385
+    checksums       rmd160  8871f8c2c6fc0fea2655dd121f62ebb6090a5063 \
+                    sha256  64564808bd06947a164645caab99bae9da90f0c814e6faf2e549512d4ad4dca7 \
+                    size    92444530
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 370.0.0.

###### Tested on

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?