### PR TITLE
pangomm: Fix broken pango includes

### DIFF
--- a/x11/pangomm/Portfile
+++ b/x11/pangomm/Portfile
@@ -23,6 +23,8 @@ checksums       rmd160  f6a26cc1bbdfc388e9df5dad12f75e9c4ec5f24d \
                 sha256  14bf04939930870d5cfa96860ed953ad2ce07c3fd8713add4a1bfe585589f40f \
                 size    882508
 
+patchfiles-append  patch-pango-include.diff
+
 depends_build   port:pkgconfig \
                 port:mm-common
 

--- a/x11/pangomm/files/patch-pango-include.diff
+++ b/x11/pangomm/files/patch-pango-include.diff
@@ -1,0 +1,12 @@
+https://gitlab.gnome.org/GNOME/pangomm/-/commit/f065a2967e22658565f4228b73b1511d291e343f
+--- pango/pangomm/attributes.h.orig	2022-01-25 14:42:31.000000000 -0500
++++ pango/pangomm/attributes.h	2022-01-25 14:40:44.000000000 -0500
+@@ -21,7 +21,7 @@
+ #include <pangomm/rectangle.h>
+ #include <pangomm/color.h>
+ #include <pangomm/fontdescription.h>
+-#include <pango/pango-attributes.h>
++#include <pango/pango.h>
+ #include <glibmm/slisthandle.h>
+ 
+ _DEFS(pangomm,pango)


### PR DESCRIPTION
Changes includes in order to fix build errors caused by header
rearrangements in pango.

These are the pango changes which broken pangomm's build: https://gitlab.gnome.org/GNOME/pango/-/commit/d8df0da73752284dff28952224258b1884ed200c
This patch backports this commit in upstream pangomm: https://gitlab.gnome.org/GNOME/pangomm/-/commit/f065a2967e22658565f4228b73b1511d291e343f

Closes: https://trac.macports.org/ticket/64430

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [N/A] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
