### PR TITLE
s710: Fix macOS 11+ libtool bug

### DIFF
--- a/comms/s710/Portfile
+++ b/comms/s710/Portfile
@@ -20,6 +20,9 @@ checksums               md5 5cacc616971265881400e18e09c60fa5 \
                         sha1 3b6f703082d19056490c76b22b4ef8158795876c \
                         rmd160 866ed5d0dec77582872123f2762cbc2dfd6c0856
 depends_lib             port:gd2  port:libiconv
+
+patchfiles              dynamic_lookup-11.patch
+
 configure.cflags        "-DS710_SERIAL_ALT_INTER_CHAR_TIMER_IMP -L${prefix}/libs710"
 configure.ldflags       "-lz -liconv"
 configure.args  --with-filedir=${prefix}/var/polar/s710/raw

--- a/comms/s710/files/dynamic_lookup-11.patch
+++ b/comms/s710/files/dynamic_lookup-11.patch
@@ -1,0 +1,40 @@
+Recognize macOS 11 and later.
+https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44605
+--- configure.orig	2022-01-26 03:06:46.000000000 -0600
++++ configure	2022-01-26 03:07:54.000000000 -0600
+@@ -8039,7 +8039,7 @@
+              10.[012])
+                allow_undefined_flag='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
+                ;;
+-             10.*)
++             *)
+                allow_undefined_flag='${wl}-undefined ${wl}dynamic_lookup'
+                ;;
+            esac
+@@ -11102,7 +11102,7 @@
+              10.[012])
+                allow_undefined_flag_CXX='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
+                ;;
+-             10.*)
++             *)
+                allow_undefined_flag_CXX='${wl}-undefined ${wl}dynamic_lookup'
+                ;;
+            esac
+@@ -14615,7 +14615,7 @@
+              10.[012])
+                allow_undefined_flag_F77='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
+                ;;
+-             10.*)
++             *)
+                allow_undefined_flag_F77='${wl}-undefined ${wl}dynamic_lookup'
+                ;;
+            esac
+@@ -17242,7 +17242,7 @@
+              10.[012])
+                allow_undefined_flag_GCJ='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
+                ;;
+-             10.*)
++             *)
+                allow_undefined_flag_GCJ='${wl}-undefined ${wl}dynamic_lookup'
+                ;;
+            esac


### PR DESCRIPTION
#### Description

s710: Fix macOS 11+ libtool bug

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

I have not tested on macOS 11+ but this is the type of fix we typically commit to fix this problem for macOS 11+

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
