### PR TITLE
nco: update to 5.0.5

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.0.4
+github.setup        nco nco 5.0.5
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
@@ -21,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  c849ea2a8ced3683e24189689d804ada01c56225 \
-                    sha256  13242c0efdd2c366e0efd8ca29e5b82d5ba12cd346e0910ba4b0b585d4924dc8 \
-                    size    5768684
+checksums           rmd160  dc7c586410eac9d303998e62f8e22d79fbee5888 \
+                    sha256  e8896858bae97a4f8849369210ffdb87698dfd594a803d48e16b92d07f2f60a7 \
+                    size    5772489
 
 homepage            http://nco.sourceforge.net/
 long_description \
@@ -101,6 +101,4 @@ variant esmf description {use ESMF (Earth System Modeling Framework)} {
     depends_lib-append      port:esmf
 }
 
-livecheck.type              regex
-livecheck.url               ${homepage}
-livecheck.regex             {nco-([0-9]+\.[0-9]+\.[0-9]+).tar.gz}
+github.livecheck.regex      {([^"rba]+)}


### PR DESCRIPTION
#### Description

Update to upstream version 5.0.5.
Also, changed livecheck to directly poll the Github repository, rather than the website that ultimately links to the repository. In the last few weeks the website already suggested 5.0.5 existed (and so did livecheck) but it was not available on Github. Hence polling Github directly is safer and cleaner (beta versions are skipped).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
