### PR TITLE
py-numpy: update to 1.22.1

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -9,15 +9,14 @@ PortGroup               compiler_blacklist_versions 1.0
 name                    py-numpy
 categories-append       math
 license                 BSD
-platforms               darwin
 maintainers             {michaelld @michaelld} openmaintainer
 description             The core utilities for the scientific library scipy for Python
 long_description        ${description}
 
-github.setup            numpy numpy 1.22.0 v
-checksums               rmd160  13fc81b3a2ac2922c1aa964394a996f5242b54ff \
-                        sha256  f2be14ba396780a6f662b8ba1a24466c9cf18a6a386174f614668e58387a13d7 \
-                        size    10362528
+github.setup            numpy numpy 1.22.1 v
+checksums               rmd160  c9fce11f3964b7d0bc1d19568745450a17660d81 \
+                        sha256  dd1968402ae20dfd59b34acd799b494be340c774f6295e9bf1c2b9842a5e416d \
+                        size    10522216
 revision                0
 
 if {${name} ne ${subport}} {
@@ -91,6 +90,10 @@ if {${name} ne ${subport}} {
         livecheck.regex     {(1\.21(?:\.\d+)+)}
     } else {
         github.tarball_from releases
+
+        # remove capping of setuptools; it appears tests fail with >= 60.0.0
+        # see: https://github.com/numpy/numpy/issues/20692
+        patchfiles-append       patch-setuptools_setup.py.diff
     }
 
     patchfiles-append       patch-numpy_core_setup.py${PATCH_PY_EXT}.diff \

--- a/python/py-numpy/files/patch-setuptools_setup.py.diff
+++ b/python/py-numpy/files/patch-setuptools_setup.py.diff
@@ -1,0 +1,14 @@
+--- setup.py.orig	2022-01-26 15:41:52.000000000 -0500
++++ setup.py	2022-01-26 15:42:05.000000000 -0500
+@@ -79,11 +79,6 @@
+ # However, we need to run the distutils version of sdist, so import that first
+ # so that it is in sys.modules
+ import numpy.distutils.command.sdist
+-import setuptools
+-if int(setuptools.__version__.split('.')[0]) >= 60:
+-    raise RuntimeError(
+-        "Setuptools version is '{}', version < '60.0.0' is required. "
+-        "See pyproject.toml".format(setuptools.__version__))
+ 
+ # Initialize cmdclass from versioneer
+ from numpy.distutils.core import numpy_cmdclass


### PR DESCRIPTION
#### Description
- update to latest upstream version
 
- ###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
