### PR TITLE
texlive-bin: fix build error on 10.6/10.7

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -102,6 +102,10 @@ patchfiles-append  \
 patchfiles-append  patch-libs_luajit_configure.diff \
                    patch-texk_web2c_configure.diff
 
+# patch to fix duplicate symbol error on 10.6/10.7
+# remove when TexLive 2022 is released (expected 1-Apr-2022)
+patchfiles-append  patch-texk_xdvik_gui_print-log.h.diff
+
 post-patch {
     reinplace "s|@@TEXMFDIST@@|${texlive_texmfdist}|" ${worksrcpath}/texk/texlive/linked_scripts/Makefile.in
 #    reinplace "s|@@TEXMFDIST@@|${texlive_texmfdist}|" ${worksrcpath}/texk/texlive/tl_scripts/Makefile.in

--- a/tex/texlive-bin/files/patch-texk_xdvik_gui_print-log.h.diff
+++ b/tex/texlive-bin/files/patch-texk_xdvik_gui_print-log.h.diff
@@ -1,0 +1,15 @@
+ld: duplicate symbol _info in libxdvi.a(print-dialog.o) and libxdvi.a(font-open.o) for architecture x86_64
+
+Fixed upstream: https://tug.org/svn/texlive?view=revision&revision=61752
+
+--- texk/xdvik/gui/print-log.h.orig
++++ texk/xdvik/gui/print-log.h
+@@ -23,7 +23,7 @@
+ #ifndef PRINT_LOG_H_
+ #define PRINT_LOG_H_
+ 
+-struct save_or_print_info *info; /* forward declaration */
++struct save_or_print_info; /* forward declaration */
+ 
+ /* printlog access functions */
+ extern void printlog_create(struct save_or_print_info *info,


### PR DESCRIPTION
#### Description

An incorrect forward declaration results in a duplicate symbol error during linking. See e.g. https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/86426

Reported bug upstream, waiting for response.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
