### PR TITLE
py-xraylarch: add Python3.10 variant

### DIFF
--- a/python/py-hdf5plugin/Portfile
+++ b/python/py-hdf5plugin/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  3c1b023c69a27f3ba72e08043a8737fd8ed6d479 \
 
 compiler.cxx_standard 2011
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-monty/Portfile
+++ b/python/py-monty/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  269b60978d925ea557d0ad98ec94840d4e140569 \
                     sha256  d4d5b85566bda80360e275e6ffb72228d203de68c5155446a0e09f19c63e8540 \
                     size    38323
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-palettable/Portfile
+++ b/python/py-palettable/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  3c5616dd0e5bc09cf975007065e628750dc2a83c \
                     sha256  72feca71cf7d79830cd6d9181b02edf227b867d503bec953cf9fa91bf44896bd \
                     size    105475
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-plotly/Portfile
+++ b/python/py-plotly/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  679e2ce0095eb3b9e250ed2d6b100120a4613bc1 \
                     sha256  6598393e898a9c5ae78397f76f07002ec41fd92e5f746d3b9806248d53885643 \
                     size    7296601
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pymatgen/Portfile
+++ b/python/py-pymatgen/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  da02e284efbdd35b8af26d33afbb881849e80682 \
                     sha256  03d24ebafc21becab376c26de09437dd5cfb7bda7099046194e95b4c9fa35209 \
                     size    3336765
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pyshortcuts/Portfile
+++ b/python/py-pyshortcuts/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  aa5e642300259a5f736b5587a173a24edad0bc72 \
                     sha256  1e66467a0b7c15f42e2d616abeb2d80aa81d9e0ccca50991dc79bdb99f39d8c1 \
                     size    933679
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-silx/Portfile
+++ b/python/py-silx/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  1494d7c1d58044218986a95f369ac4e79476df03 \
                     sha256  494cf5caa6267bebeb6aa19f3aee9e5c2f86ceba253b133f0709fbe0d47a84cc \
                     size    13751586
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-spglib/Portfile
+++ b/python/py-spglib/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  679bc2296b16ae5627dddbd66718cf3249452fea \
                     sha256  9fd2fefbd83993b135877a69c498d8ddcf20a9980562b65b800cfb4cdadad003 \
                     size    723682
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-wxmplot/Portfile
+++ b/python/py-wxmplot/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  331be7ac970b45e26fb7c11bb91c1cc495028209 \
                     sha256  a70a662b0ff10a230bd2c800d2bc0cf69176881f09a5de014abe9a394121ac6b \
                     size    8250117
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-wxutils/Portfile
+++ b/python/py-wxutils/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  51ee95e8f84b51a2ba35d8fee338bf2b918dfff7 \
                     sha256  6b4ae621b6a0ad0d0e4b8b822bd982413ba053d6e11cd97f021632716e175eac \
                     size    33928
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-xraydb/Portfile
+++ b/python/py-xraydb/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  69c27b973ef79603e9c7a5016e7efe7a121e863a \
                     sha256  f133e0e1cc7d55b9d1e3fdd00ae92fe9ed7bc7ba31153b933930819627206f67 \
                     size    3854588
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-xraylarch/Portfile
+++ b/python/py-xraylarch/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  820a4e60bc8066aa20e38dcb52403da0b05da919 \
                     sha256  057f2db8a5bef5a7a6212196a4af4ad80264d913db722ee4f75521f12d912fd2 \
                     size    37055039
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
Adds Python3.10 variant to larch and 11 of its dependencies.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 11.6.2 20G314 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
