### PR TITLE
erlang: fix build error on 10.6

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           wxWidgets 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
+
+# strndup, TARGET_OS_OSX
+legacysupport.newest_darwin_requires_legacy 10
 
 name                erlang
 version             24.2

--- a/lang/erlang/files/patch-erts_emulator_sys_unix_ddll.c.diff
+++ b/lang/erlang/files/patch-erts_emulator_sys_unix_ddll.c.diff
@@ -3,9 +3,9 @@
 @@ -50,6 +50,13 @@
  static int num_errcodes = 0;
  static int num_errcodes_allocated = 0;
- 
-+static void call_cf_initialize() __attribute__ ((constructor));
-+
+
++extern void __CFInitialize(void);
++static void call_cf_initialize(void) __attribute__ ((constructor));
 +static void call_cf_initialize()
 +{
 +    __CFInitialize();


### PR DESCRIPTION
#### Description

Add legacysupport for missing symbols and update the "Snow Leopard mystery patch" to fix an implicit declaration error.

See: https://trac.macports.org/ticket/52507
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
