### PR TITLE
afio: Update to 2.5.2

### DIFF
--- a/archivers/afio/Portfile
+++ b/archivers/afio/Portfile
@@ -1,10 +1,18 @@
-PortSystem          1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name                afio
-version             2.5.1
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        kholtman afio 2.5.2 v
+revision            0
+checksums           rmd160  a0da5fafb6cee3fac054bbbb74eacc8e24cd7c7f \
+                    sha256  c64ca14109df547e25702c9f3a9ca877881cd4bf38dcbe90fbd09c8d294f42b9 \
+                    size    194030
+
 categories          archivers
-platforms           darwin
 maintainers         {puffin.lb.shuttle.de:michael.klein @mklein-de}
+
 description         Archiver & backup program with builtin compression
 
 long_description    Afio makes cpio-format archives. It deals somewhat \
@@ -12,32 +20,20 @@ long_description    Afio makes cpio-format archives. It deals somewhat \
                     multi-volume archives during interactive operation, and \
                     can make compressed archives that are much safer than \
                     compressed tar or cpio archives. Afio is best used as \
-                    an `archive engine' in a backup script.
+                    an \"archive engine\" in a backup script.
 
-homepage            http://members.chello.nl/~k.holtman/afio.html
-master_sites        http://members.brabant.chello.nl/~k.holtman \
-                    http://www.ibiblio.org/pub/Linux/system/backup/
-extract.suffix      .tgz
+github.tarball_from archive
 
-checksums           sha256  363457a5d6ee422d9b704ef56d26369ca5ee671d7209cfe799cab6e30bf2b99a \
-                    rmd160  923981a9e6766781705ceedecd3d86afa5b9abae
+patchfiles          Makefile.patch \
+                    implicit.patch
 
-post-patch {
-    reinplace -E "s|/usr(/local)?|\$(DESTDIR)${prefix}|" ${worksrcpath}/Makefile
-}
+makefile.override-append \
+                    PREFIX
 
-configure {
-    reinplace -E "/^CFLAGS/s|\$| [join ${configure.cflags} " "]|" ${worksrcpath}/Makefile
-    reinplace -E "/^LDFLAGS/s|\$| [join ${configure.ldflags} " "]|" ${worksrcpath}/Makefile
-}
+build.target
 
 post-destroot {
-    set docdir ${prefix}/share/doc/${name}-${version}
+    set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} ANNOUNCE-${version} HISTORY README SCRIPTS ${destroot}${docdir}
 }
-
-build.target            afio
-
-livecheck.type          regex
-livecheck.regex         "afio-(\\d(?:\\.\\d)+)${extract.suffix}"

--- a/archivers/afio/files/Makefile.patch
+++ b/archivers/afio/files/Makefile.patch
@@ -1,0 +1,22 @@
+https://github.com/kholtman/afio/pull/16
+--- Makefile.orig
++++ Makefile
+@@ -83,6 +83,7 @@ CC=gcc
+ CFLAGS += $(CFLAGS1) $1 $2 $3 $4 $5 $6 $7 $8 $9 $a $b $c $d $e $(e2) $f $g $I
+ LDFLAGS +=
+ CPPFLAGS +=
++PREFIX = /usr/local
+
+ afio : afio.o compfile.o exten.o match.o $M
+ 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) \
+@@ -95,8 +96,8 @@ clean:
+ 	cd regtest; /bin/sh regtest.clean
+
+ install: afio
+-	cp afio /usr/local/bin
+-	cp afio.1 /usr/share/man/man1
++	cp afio $(DESTDIR)$(PREFIX)/bin
++	cp afio.1 $(DESTDIR)$(PREFIX)/share/man/man1
+
+ # generate default list of -E extensions from manpage
+ # note: on sun, I had to change awk command below to nawk or gawk

--- a/archivers/afio/files/implicit.patch
+++ b/archivers/afio/files/implicit.patch
@@ -1,0 +1,15 @@
+Fix:
+error: implicit declaration of function 'utime' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+error: implicit declaration of function 'kill' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+https://github.com/kholtman/afio/issues/17
+--- afio.c.orig	2018-11-30 08:25:04.000000000 -0600
++++ afio.c	2022-01-26 17:24:28.000000000 -0600
+@@ -162,6 +162,8 @@
+ 
+ #include <stdio.h>
+ #include <errno.h>
++#include <utime.h>
++#include <signal.h>
+ 
+ #ifdef sun
+ #include <sys/types.h>


### PR DESCRIPTION
#### Description

afio: Update to 2.5.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
