### PR TITLE
erlang: disable Java interface

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                erlang
 version             24.2
-revision            0
+revision            1
 
 categories          lang erlang
 maintainers         {ciserlohn @ci42}
@@ -63,6 +63,7 @@ configure.args      --prefix=${prefix}       \
                     --enable-smp-support     \
                     --without-ssl            \
                     --without-odbc           \
+                    --without-javac          \
                     --without-wx
 
 depends_build       port:gawk


### PR DESCRIPTION
#### Description

By default, the Java interface is built if `javac` is found on the system. This results in an unpredictable build which fails when an out-of-date Java is present. Pass `--without-javac` to disable the feature altogether.

If someone is sufficiently motivated, they may want to add a `+java` variant in the future. It's a pretty rare use-case, however.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
