### PR TITLE
hugo: update to 0.92.1

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.92.0 v
+go.setup            github.com/gohugoio/hugo 0.92.1 v
 revision            0
-checksums           rmd160  20e80794dae6d52079f5a0c8292a3f008e6ce70f \
-                    sha256  c9169f95a3e6f131c61eacf53e32c2b6ce2734ca77d7061405499af5f2a79de4 \
-                    size    28551833
+checksums           rmd160  ed43ced17ba3b3e8e521cef4eb44e32240e4db48 \
+                    sha256  d42b6cf5c682b4d265da5efb6a2c6fdecebef32ca1e3ca11d80ca3a6e8b09801 \
+                    size    28555230
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
hugo: update to 0.92.1

###### Tested on
macOS 12.1 21C52 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
