### PR TITLE
openjdk17-temurin: update to 17.0.2

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -601,13 +601,8 @@ subport openjdk17-temurin {
     # Java 17 is the first Temurin release with arm64 support
     supported_archs  x86_64 arm64
 
-    if {${configure.build_arch} eq "x86_64"} {
-        version 17.0.1
-        set build    12
-    } elseif {${configure.build_arch} eq "arm64"} {
-        version 17
-        set build    35
-    }
+    version 17.0.2
+    set build    8
     revision     0
 
     description  Eclipse Temurin, based on OpenJDK 17
@@ -617,14 +612,14 @@ subport openjdk17-temurin {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-        checksums    rmd160  1db5d0eacd33b7892f41d6579370ee5089a4a265 \
-                     sha256  98a759944a256dbdd4d1113459c7638501f4599a73d06549ac309e1982e2fa70 \
-                     size    192449459
+        checksums    rmd160  90939e1b687b025674faf1f45b1274fe2e420109 \
+                     sha256  3630e21a571b7180876bf08f85d0aac0bdbb3267b2ae9bd242f4933b21f9be32 \
+                     size    192611208
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     OpenJDK17-jdk_aarch64_mac_hotspot_${version}_${build}
-        checksums    rmd160  b879101e8175b93c30dcb33f8bc25440c8227853 \
-                     sha256  910bb88543211c63298e5b49f7144ac4463f1d903926e94a89bfbf10163bbba1 \
-                     size    182381849
+        checksums    rmd160  e4063da6a1139c137af930c8cf5c5988bb75354d \
+                     sha256  157518e999d712b541b883c6c167f8faabbef1d590da9fe7233541b4adb21ea4 \
+                     size    182550014
     }
 
     worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.2.

###### Tested on

macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?