### PR TITLE
expat: Fix CVE-2022-23852, CVE-2022-23990

### DIFF
--- a/textproc/expat/Portfile
+++ b/textproc/expat/Portfile
@@ -7,7 +7,7 @@ PortGroup           muniversal 1.0
 
 name                expat
 version             2.4.3
-revision            0
+revision            1
 checksums           rmd160  c313bd1e965fdf6325e395412cfecd7b7a5051f0 \
                     sha256  6f262e216a494fbf42d8c22bc841b3e117c21f2467a19dc4c27c991b5622f986 \
                     size    559674
@@ -30,6 +30,10 @@ master_sites        sourceforge:project/${name}/${name}/${version}
 # port since that causes a dependency cycle on older OS versions since
 # e.g. clang-3.4 depends on python27-bootstrap which depends on expat.
 use_bzip2           yes
+
+patch.pre_args      -p2
+patchfiles          847a645152f5ebc10ac63b74b604d0c1a79fae40.patch \
+                    ede41d1e186ed2aba88a06e84cac839b770af3a1.patch
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/textproc/expat/files/847a645152f5ebc10ac63b74b604d0c1a79fae40.patch
+++ b/textproc/expat/files/847a645152f5ebc10ac63b74b604d0c1a79fae40.patch
@@ -1,0 +1,27 @@
+From 847a645152f5ebc10ac63b74b604d0c1a79fae40 Mon Sep 17 00:00:00 2001
+From: Samanta Navarro <ferivoz@riseup.net>
+Date: Sat, 22 Jan 2022 17:48:00 +0100
+Subject: [PATCH] lib: Detect and prevent integer overflow in XML_GetBuffer
+ (CVE-2022-23852)
+
+Upstream-Status: Backport [https://github.com/libexpat/libexpat/commit/847a645152f5ebc10ac63b74b604d0c1a79fae40]
+---
+ expat/lib/xmlparse.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/expat/lib/xmlparse.c b/expat/lib/xmlparse.c
+index d54af683..5ce31402 100644
+--- ./expat/lib/xmlparse.c
++++ ./expat/lib/xmlparse.c
+@@ -2067,6 +2067,11 @@ XML_GetBuffer(XML_Parser parser, int len) {
+     keep = (int)EXPAT_SAFE_PTR_DIFF(parser->m_bufferPtr, parser->m_buffer);
+     if (keep > XML_CONTEXT_BYTES)
+       keep = XML_CONTEXT_BYTES;
++    /* Detect and prevent integer overflow */
++    if (keep > INT_MAX - neededSize) {
++      parser->m_errorCode = XML_ERROR_NO_MEMORY;
++      return NULL;
++    }
+     neededSize += keep;
+ #endif /* defined XML_CONTEXT_BYTES */
+     if (neededSize

--- a/textproc/expat/files/ede41d1e186ed2aba88a06e84cac839b770af3a1.patch
+++ b/textproc/expat/files/ede41d1e186ed2aba88a06e84cac839b770af3a1.patch
@@ -1,0 +1,43 @@
+From ede41d1e186ed2aba88a06e84cac839b770af3a1 Mon Sep 17 00:00:00 2001
+From: Sebastian Pipping <sebastian@pipping.org>
+Date: Wed, 26 Jan 2022 02:36:43 +0100
+Subject: [PATCH] lib: Prevent integer overflow in doProlog (CVE-2022-23990)
+
+The change from "int nameLen" to "size_t nameLen"
+addresses the overflow on "nameLen++" in code
+"for (; name[nameLen++];)" right above the second
+change in the patch.
+
+Upstream-Status: Backport [https://github.com/libexpat/libexpat/commit/ede41d1e186ed2aba88a06e84cac839b770af3a1]
+---
+ expat/lib/xmlparse.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/expat/lib/xmlparse.c b/expat/lib/xmlparse.c
+index 5ce31402..d1d17005 100644
+--- ./expat/lib/xmlparse.c
++++ ./expat/lib/xmlparse.c
+@@ -5372,7 +5372,7 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
+       if (dtd->in_eldecl) {
+         ELEMENT_TYPE *el;
+         const XML_Char *name;
+-        int nameLen;
++        size_t nameLen;
+         const char *nxt
+             = (quant == XML_CQUANT_NONE ? next : next - enc->minBytesPerChar);
+         int myindex = nextScaffoldPart(parser);
+@@ -5388,7 +5388,13 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
+         nameLen = 0;
+         for (; name[nameLen++];)
+           ;
+-        dtd->contentStringLen += nameLen;
++
++        /* Detect and prevent integer overflow */
++        if (nameLen > UINT_MAX - dtd->contentStringLen) {
++          return XML_ERROR_NO_MEMORY;
++        }
++
++        dtd->contentStringLen += (unsigned)nameLen;
+         if (parser->m_elementDeclHandler)
+           handleDefault = XML_FALSE;
+       }


### PR DESCRIPTION
#### Description

Fix CVE-2022-23852, CVE-2022-23990.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.2 20G314 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
