### PR TITLE
ki-shell: update to 0.4.5

### DIFF
--- a/java/ki-shell/Portfile
+++ b/java/ki-shell/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            ki-shell
-version         0.4.4
+version         0.4.5
 revision        0
 
 categories      java
@@ -27,9 +27,9 @@ master_sites    https://search.maven.org/remotecontent?filepath=org/jetbrains/ko
 
 distname        ${name}-${version}-archive
 
-checksums       rmd160  7c592c798d75ad05361235ff41fefbe9b97b2b6d \
-                sha256  0aa28320cc5014883b51c832c0a4f379055eca44ad71d7ee9a08ba539dd81aab \
-                size    61898092
+checksums       rmd160  86787b78af528675b7baa4532b84eeaac88d3ef3 \
+                sha256  9ff35fd15bcec69f91d6f67cb6f4abfc67334d525b24f5cd55986400f9fd389f \
+                size    61967877
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Kotlin Interactive Shell 0.4.5.

###### Tested on

macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?