### PR TITLE
groovy: update to 4.0.0

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         3.0.9
+version         4.0.0
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  09b063a87cf11fa994f6bafcb125587ddae68127 \
-                sha256  eb34f4ee229b1a424adb87df5b999f66d1b1285694e5332d0800896744c2e421 \
-                size    44145611
+checksums       rmd160  1ac329d0dacee4caf4db4e6db451febc474ed3d9 \
+                sha256  bd5b8af69c169f41c5c7aea00cb8832a6e232ee697f626e29d8f92adebe30df9 \
+                size    29010898
 
 worksrcdir      ${name}-${version}
 
@@ -61,7 +61,7 @@ destroot {
     xinstall -m 755 -d ${target}
 
     # Copy over the needed elements of our directory tree
-    foreach d { bin conf grooid indy lib } {
+    foreach d { bin conf grooid lib } {
         copy ${worksrcpath}/${d} ${target}
     }
 


### PR DESCRIPTION
#### Description

Update to Groovy 4.0.0.

###### Tested on

macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?