### PR TITLE
64550 Add 'at_quick_exit' to 10.14 whitelist

### DIFF
--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.10.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.10.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.11.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.11.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.12.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.12.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.13.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.13.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.14.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.14.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.4u.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.4u.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.5.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.5.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.6.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.6.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.7.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.7.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.8.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.8.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom

--- a/_resources/port1.0/checks/implicit_function_declaration/macosx10.9.sdk.list
+++ b/_resources/port1.0/checks/implicit_function_declaration/macosx10.9.sdk.list
@@ -1,4 +1,5 @@
 accept4
+at_quick_exit
 eventfd
 fallocate
 getrandom


### PR DESCRIPTION
Apple clang version 11.0.0 (clang-1100.0.33.12) appears to lack the C11 language feature 'at_quick_exit' when compiling for macOS X 10.14. This causes the compiler to generate a `-Wimplicit-function-declaration` error message, even for correct configuration code, which correctly has a `#include <stdlib.h>` directive. MacPorts elevates this to the main.log. But it is a false positive. The configuration code is not implicitly declaring 'at_quick_exit'. So, this function name belongs in the whitelist.

An example of configuration code which demonstrates this condition is:

	#include <stdlib.h>
	static void func(void)
	{}

	int
	main (void)
	{
	 at_quick_exit(func);
	  ;
	  return 0;
	}

The verbose compiler output from my test of this code on macOS X 10.14.6 Mojave, using the macOS X 10.14 SDK, is:

	% /usr/bin/clang -v -o conftest -std=c11 -Werror -Wall -Wpointer-arith -Wcast-align -Wno-tautological-compare  conftest.c  -liconv                                                                
	Apple clang version 11.0.0 (clang-1100.0.33.12)
	Target: x86_64-apple-darwin18.7.0
	Thread model: posix
	InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
	 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" -cc1 -triple x86_64-apple-macosx10.14.0 -Wdeprecated-objc-isa-usage -Werror=deprecated-objc-isa-usage -emit-obj -mrelax-all -disable-free -disable-llvm-verifier -discard-value-names -main-file-name conftest.c -mrelocation-model pic -pic-level 2 -mthread-model posix -mdisable-fp-elim -fno-strict-return -masm-verbose -munwind-tables -target-sdk-version=10.14 -target-cpu penryn -dwarf-column-info -debugger-tuning=lldb -ggnu-pubnames -target-linker-version 520 -v -resource-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/11.0.0 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include -Werror -Wall -Wpointer-arith -Wcast-align -Wno-tautological-compare -Wno-framework-include-private-from-public -Wno-atimport-in-framework-header -Wno-extra-semi-stmt -Wno-quoted-include-in-framework-header -std=c11 -fdebug-compilation-dir /Users/jdlh/workspace/freeciv_overall/freeciv_S2_6 -ferror-limit 19 -fmessage-length 132 -stack-protector 1 -mdarwin-stkchk-strong-link -fblocks -fencode-extended-block-signature -fregister-global-dtors-with-atexit -fobjc-runtime=macosx-10.14.0 -fmax-type-align=16 -fdiagnostics-show-option -fcolor-diagnostics -o /var/folders/5p/zmlrjq6c8xj84s0059bnypz80000gp/T/conftest-901715.o -x c conftest.c
	clang -cc1 version 11.0.0 (clang-1100.0.33.12) default target x86_64-apple-darwin18.7.0
	ignoring nonexistent directory "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/local/include"
	ignoring nonexistent directory "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/Library/Frameworks"
	#include "..." search starts here:
	#include <...> search starts here:
	 /usr/local/include
	 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/11.0.0/include
	 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include
	 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
	 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks (framework directory)
	End of search list.
	conftest.c:99:2: error: implicit declaration of function 'at_quick_exit' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
	 at_quick_exit(func);
	 ^
	1 error generated.

Detected while diagnosing ticket  [#64550 _freeciv @2.6.6: at_quick_exit gives -Wimplicit-function-declaration warning, false positive_](https://trac.macports.org/ticket/64550 ).

#### Description

Apple clang version 11.0.0 (clang-1100.0.33.12) appears to lack the C11 language feature 'at_quick_exit' when compiling for macOS X 10.14. This causes the compiler to generate a `-Wimplicit-function-declaration` error message, even for correct configuration code, which correctly has a `#include <stdlib.h>` directive. MacPorts elevates this to the main.log. But it is a false positive. The configuration code is not implicitly declaring 'at_quick_exit'. So, this function name belongs in the whitelist. Because Apple rarely removes compiler features once introduced, it's a good guess that all macOS X versions before 10.4 (i.e. 10.4u through 10.13), also lack the 'at_quick_exit' feature. Thus this PR adds 'at_quick_exit' to whitelists for all of these macOS X versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.2.1 11B500

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] (sort of) followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
