### PR TITLE
OpenCoarrays: Remove maintainer

### DIFF
--- a/science/OpenCoarrays/Portfile
+++ b/science/OpenCoarrays/Portfile
@@ -10,7 +10,7 @@ revision            0
 categories          science parallel devel
 platforms           darwin
 license             BSD
-maintainers         gmail.com:fanfarillo.gcc
+maintainers         nomaintainer
 
 description         Library for multi-image coarray Fortran suppport
 long_description    OpenCoarrays is an open-source software project \

--- a/science/OpenCoarrays/Portfile
+++ b/science/OpenCoarrays/Portfile
@@ -14,14 +14,11 @@ maintainers         nomaintainer
 
 description         Library for multi-image coarray Fortran suppport
 long_description    OpenCoarrays is an open-source software project \
-                    for developing, porting and tuning transport \
-                    layers that support coarray Fortran compilers. \
-                    We target compilers that conform to the coarray \
-                    parallel programming feature set specified in the \
-                    Fortran 2008 standard. We also support several \
-                    features proposed for Fortran 2015 in the draft \
-                    Technical Specification 'TS18508 Additional \
-                    Parallel Features in Fortran'.
+                    that produces an application binary interface (ABI) \
+                    to support coarrays and other Fortran 2018 parallel \
+                    programming features for gfortran in the GNU Compiler \
+                    Collection (GCC).
+
 homepage            http://opencoarrays.org
 
 mpi.setup           require require_fortran \

--- a/science/OpenCoarrays/Portfile
+++ b/science/OpenCoarrays/Portfile
@@ -17,7 +17,8 @@ long_description    OpenCoarrays is an open-source software project \
                     that produces an application binary interface (ABI) \
                     to support coarrays and other Fortran 2018 parallel \
                     programming features for gfortran in the GNU Compiler \
-                    Collection (GCC).
+                    Collection (GCC).  Gfortran has used OpenCoarrays \
+                    since the GCC 5.1.0 release.
 
 homepage            http://opencoarrays.org
 


### PR DESCRIPTION
* Switch from inactive maintainer, to nomaintainer.
* Update the long_description.

Per upstream:
https://github.com/sourceryinstitute/opencoarrays/blob/2.9.2/INSTALL.md#macos

  "MacPorts: An unmaintained OpenCoarrays Portfile exists for the MacPorts package manager. Although the current OpenCoarrays contributors have no plans to update the portfile, new contributors are welcome to asssume the port maintainer role and to submit a pull request to update this INSTALL.md file."

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
* Not tested.  Comment fixes only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
