### PR TITLE
Openjdk early access subports and subport error fix

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -573,12 +573,13 @@ subport openjdk17-oracle {
     supported_archs  x86_64 arm64
 
     version      17.0.2
+    set build    8
     revision     0
 
     description  Oracle OpenJDK 17
     long_description ${long_description_oracle}
 
-    master_sites https://download.java.net/java/GA/jdk${version}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/
+    master_sites https://download.java.net/java/GA/jdk${version}/dfd4a8d0985749f896bed50d7138ee7f/${build}/GPL/
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     openjdk-${version}_macos-x64_bin
@@ -651,6 +652,155 @@ subport openjdk17-zulu {
     }
 
     worksrcdir   ${distname}/zulu-17.jdk
+}
+
+subport openjdk18 {
+    version      18
+    revision     0
+
+    set meta true
+
+    description  Open Java Development Kit 18 meta port
+    long_description Open Java Development Kit 18 meta port
+
+    distfiles
+    destroot {
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
+    }
+
+    depends_run-append port:openjdk18+ea-zulu
+}
+subport openjdk18+ea-oracle {
+    # https://jdk.java.net/18/
+
+    supported_archs  x86_64 arm64
+
+    version      18
+    set build    33
+    revision     0
+
+    description  Oracle OpenJDK 18 early access
+    long_description ${long_description_oracle}
+
+    master_sites https://download.java.net/java/early_access/jdk18/${build}/GPL/
+
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     openjdk-${version}-ea+${build}_macos-x64_bin
+        checksums    rmd160  b89b5b6223a1e9a36a1960e5be44cdd770ceab4b \
+                     sha256  3d8908cbaede6034541cff3474b571b18227ebf0d6cc6d700f443b1e7aa92fa2 \
+                     size    185375374
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     openjdk-${version}-ea+${build}_macos-aarch64_bin
+        checksums    rmd160  49cb208bdaf645977949b91336304432bbcd89b2 \
+                     sha256  960886ff388f24cdeff1e9c7330b10c9bb7c996a97ea37cb0a41b13e68d1d4a7 \
+                     size    183216634
+    }
+
+    worksrcdir   jdk-${version}.jdk
+}
+
+subport openjdk18+ea-zulu {
+    # https://www.azul.com/downloads/?version=java-18-ea&os=macos&package=jdk
+
+    version      18.0.75
+    revision     0
+
+    set openjdk_version 18.0.0
+    set openjdk_build   33
+
+    description  Azul Zulu Community OpenJDK 18 early access
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     zulu${version}-ea-jdk${openjdk_version}-ea.${openjdk_build}-macosx_x64
+        checksums    rmd160  a732d1c1049a9d413199f8485224badd3ecc390b \
+                     sha256  26797f3fd387a01e27175ee93756812c004a264e418579e5db380dc40d91cc27 \
+                     size    197890992
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     zulu${version}-ea-jdk${openjdk_version}-ea.${openjdk_build}-macosx_aarch64
+        checksums    rmd160  9564cec0e43709c346a69f8a6b44bd0013342cad \
+                     sha256  539e4bed871c9f716c99d8f70f2ecbc38948783ea0334f9ace198f8fd030f82f \
+                     size    195624934
+    }
+
+    worksrcdir   ${distname}/zulu-18.jdk
+}
+subport openjdk19 {
+    version      19
+    revision     0
+
+    set meta true
+
+    description  Open Java Development Kit 19 meta port
+    long_description Open Java Development Kit 19 meta port
+
+    distfiles
+    destroot {
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
+    }
+
+    depends_run-append port:openjdk19+ea-zulu
+}
+subport openjdk19+ea-oracle {
+    # https://jdk.java.net/19/
+
+    supported_archs  x86_64 arm64
+
+    version      19
+    set build    7
+    revision     0
+
+    description  Oracle OpenJDK 19 early access
+    long_description ${long_description_oracle}
+
+    master_sites https://download.java.net/java/early_access/jdk19/${build}/GPL/
+
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     openjdk-${version}-ea+${build}_macos-x64_bin
+        checksums    rmd160  1e436d404ef637a93512103bc33a71add85c38d1 \
+                     sha256  76be3a6e233b116d4148b571225620ce89d6e3984e15d54e885b90ef583f0217 \
+                     size    186329308
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     openjdk-${version}-ea+${build}_macos-aarch64_bin
+        checksums    rmd160  457ddf9f6cc45b7cc96fc123c32289cab9518106 \
+                     sha256  85a2f2c0cd5431c751a07eb36ea90cf9dc7a9ded8448135554af012a2628f83b \
+                     size    184261172
+    }
+
+    worksrcdir   jdk-${version}.jdk
+}
+
+subport openjdk19+ea-zulu {
+    # https://www.azul.com/downloads/?version=java-19-ea&os=macos&package=jdk
+
+    version      19.0.75
+    revision     0
+
+    set openjdk_version 19.0.0
+    set openjdk_build   7
+
+    description  Azul Zulu Community OpenJDK 19 early access
+    long_description ${long_description_zulu}
+
+    master_sites https://cdn.azul.com/zulu/bin/
+
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     zulu${version}-ea-jdk${openjdk_version}-ea.${openjdk_build}-macosx_x64
+        checksums    rmd160  45cefc1f502476ef73a783e7a88e8fbec2e770c4 \
+                     sha256  1ed3902ee1fe95a3f0dc08b3f627fb857afc79d25dd1c7df3fdb0a628306f758 \
+                     size    198859286
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     zulu${version}-ea-jdk${openjdk_version}-ea.${openjdk_build}-macosx_aarch64
+        checksums    rmd160  670ba9e763d55e563386b5535901912600dc3ae1 \
+                     sha256  caf45e085f4983ff2075f584938887bd0c6feaaedb723eaf6d588fcf40b3b401 \
+                     size    196662165
+    }
+
+    worksrcdir   ${distname}/zulu-19.jdk
 }
 
 if {${os.platform} eq "darwin"} {

--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -819,13 +819,6 @@ if {${os.platform} eq "darwin"} {
             ui_error "${name} ${version} is only supported on Mac OS X 10.12 Sierra or later."
             return -code error
         }
-    } elseif {[string match *-oracle ${subport}] && ${os.major} < 16} {
-        # See https://openjdk.java.net/groups/build/doc/building.html
-        known_fail yes
-        pre-fetch {
-            ui_error "${name} ${version} is only supported on Mac OS X 10.12 Sierra or later."
-            return -code error
-        }
     } elseif {[string match *-zulu ${subport}] && ${os.major} < 18} {
         # See https://www.azul.com/downloads/?os=macos&package=jdk
         known_fail yes

--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -654,7 +654,7 @@ subport openjdk17-zulu {
     worksrcdir   ${distname}/zulu-17.jdk
 }
 
-subport openjdk18 {
+subport openjdk18-ea {
     version      18
     revision     0
 
@@ -669,9 +669,9 @@ subport openjdk18 {
         system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
     }
 
-    depends_run-append port:openjdk18+ea-zulu
+    depends_run-append port:openjdk18-ea-zulu
 }
-subport openjdk18+ea-oracle {
+subport openjdk18-ea-oracle {
     # https://jdk.java.net/18/
 
     supported_archs  x86_64 arm64
@@ -700,7 +700,7 @@ subport openjdk18+ea-oracle {
     worksrcdir   jdk-${version}.jdk
 }
 
-subport openjdk18+ea-zulu {
+subport openjdk18-ea-zulu {
     # https://www.azul.com/downloads/?version=java-18-ea&os=macos&package=jdk
 
     version      18.0.75
@@ -728,7 +728,7 @@ subport openjdk18+ea-zulu {
 
     worksrcdir   ${distname}/zulu-18.jdk
 }
-subport openjdk19 {
+subport openjdk19-ea {
     version      19
     revision     0
 
@@ -743,9 +743,9 @@ subport openjdk19 {
         system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
     }
 
-    depends_run-append port:openjdk19+ea-zulu
+    depends_run-append port:openjdk19-ea-zulu
 }
-subport openjdk19+ea-oracle {
+subport openjdk19-ea-oracle {
     # https://jdk.java.net/19/
 
     supported_archs  x86_64 arm64
@@ -774,7 +774,7 @@ subport openjdk19+ea-oracle {
     worksrcdir   jdk-${version}.jdk
 }
 
-subport openjdk19+ea-zulu {
+subport openjdk19-ea-zulu {
     # https://www.azul.com/downloads/?version=java-19-ea&os=macos&package=jdk
 
     version      19.0.75

--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -777,7 +777,7 @@ subport openjdk19-ea-oracle {
 subport openjdk19-ea-zulu {
     # https://www.azul.com/downloads/?version=java-19-ea&os=macos&package=jdk
 
-    version      19.0.75
+    version      19.0.23
     revision     0
 
     set openjdk_version 19.0.0
@@ -814,6 +814,13 @@ if {${os.platform} eq "darwin"} {
         }
     } elseif {[string match *-temurin ${subport}] && ${os.major} < 16} {
         # See https://adoptium.net/supported_platforms.html
+        known_fail yes
+        pre-fetch {
+            ui_error "${name} ${version} is only supported on Mac OS X 10.12 Sierra or later."
+            return -code error
+        }
+    } elseif {[string match *-oracle ${subport}] && ${os.major} < 16} {
+        # See https://openjdk.java.net/groups/build/doc/building.html
         known_fail yes
         pre-fetch {
             ui_error "${name} ${version} is only supported on Mac OS X 10.12 Sierra or later."


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G65 x86_64
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
