### PR TITLE
ksh: fix build on 10.5/10.6

### DIFF
--- a/shells/ksh/Portfile
+++ b/shells/ksh/Portfile
@@ -22,6 +22,9 @@ patchfiles-append   dlfcn.c.patch
 
 platform darwin 8 {
     configure.cppflags-append -D__DARWIN_UNIX03
+}
+
+if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     configure.cppflags-append -DF_DUPFD_CLOEXEC=67
 }
 


### PR DESCRIPTION
#### Description

`F_DUPFD_CLOEXEC` was added in 10.7, not 10.5.

Failing buildbot: https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/91080
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
