### PR TITLE
py-sympy: add sympy15 variant for octave-symbolic

### DIFF
--- a/python/py-sympy/Portfile
+++ b/python/py-sympy/Portfile
@@ -31,11 +31,15 @@ checksums           rmd160  dab0deb41a610a6581d7c3829f4867563bc0adf9 \
                     sha256  c7a880e229df96759f955d4f3970d4cabce79f60f5b18830c08b90ce77cd5fdc \
                     size    6929669
 
+variant sympy15 description {Build sympy 1.5, needed for octave-symbolic} {
+    # See: https://octave.discourse.group/t/symbolic-package-in-macos/1178
+}
+
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \
                         port:py${python.version}-mpmath
 
-    if {${python.version} <= 35} {
+    if {${python.version} <= 35 || [variant_isset sympy15]} {
         version             1.5.1
         revision            0
         distname            ${python.rootname}-${version}


### PR DESCRIPTION
See: https://octave.discourse.group/t/symbolic-package-in-macos/1178

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G314 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
