### PR TITLE
py-cvxopt: update to 1.2.7, add py3{9,10}

### DIFF
--- a/python/py-cvxopt/Portfile
+++ b/python/py-cvxopt/Portfile
@@ -7,8 +7,8 @@ PortGroup           linear_algebra  1.0
 
 linalg.setup        noveclibfort
 
-github.setup        cvxopt cvxopt 1.2.5
-revision            1
+github.setup        cvxopt cvxopt 1.2.7
+revision            0
 name                py-cvxopt
 categories-append   math
 platforms           darwin
@@ -29,11 +29,11 @@ long_description    CVXOPT is a free software package for convex \
                     programming language.
 homepage            https://cvxopt.org/
 
-checksums           rmd160  e29d588d74213c7562a181a19a443740343487ca \
-                    sha256  a03c7fff342eecd258769b447e62955f0d34672f5f8fe558aeeaa0339f268b2c \
-                    size    6742604
+checksums           rmd160  4af2fec6a886aa076206de428e5b7ead9447e1d4 \
+                    sha256  e03d8cdd2c952672fa45fd365338857f2d30fbd913df5708747a0535558a51ea \
+                    size    4115655
 
-python.versions     27 35 36 37 38
+python.versions     27 35 36 37 38 39 310
 
 if {${subport} ne ${name}} {
     # ignore empty BLAS and LAPACK inputs
@@ -110,5 +110,5 @@ if {${subport} ne ${name}} {
 
     default_variants +gsl +glpk +fftw +dsdp
 
-    livecheck.type 	none
+    livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update to latest version and add Python subports, patch provided on Trac by bal-agates

Closes: https://trac.macports.org/ticket/64493
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
