### PR TITLE
py-altair: update to 4.2.0; remove py27/py36, add py310

### DIFF
--- a/python/py-altair/Portfile
+++ b/python/py-altair/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-altair
-version             4.1.0
+version             4.2.0
 revision            0
+
 categories-append   devel graphics
-platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 36 37 38 39
+python.versions     37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -20,9 +20,11 @@ long_description    ${description}
 
 homepage            https://altair-viz.github.io/
 
-checksums           rmd160  e7cda9d1a3685bbd96c6e270d36899fd27589955 \
-                    sha256  3edd30d4f4bb0a37278b72578e7e60bc72045a8e6704179e2f4738e35bc12931 \
-                    size    655843
+checksums           rmd160  8be7078f5e7a406092eef5177f55671b00dd41d9 \
+                    sha256  d87d9372e63b48cd96b2a6415f0cf9457f50162ab79dc7a31cd7e024dd840026 \
+                    size    740777
+
+python.pep517       yes
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-entrypoints \
@@ -31,17 +33,6 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-numpy \
                         port:py${python.version}-pandas \
                         port:py${python.version}-toolz
-
-    if {${python.version} eq 27} {
-        version             3.3.0
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  033f956d480e845d4bc9967ddb85785ad1bfddf5 \
-                            sha256  9f7c521239ac5a207c3cffc29c5bdde0854fff0dec0b5f91f086ba8e5f1de8a9 \
-                            size    536730
-        depends_lib-append  port:py${python.version}-typing \
-                            port:py${python.version}-six
-    }
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update to latest version, remove EOL Python subporrts, add Python 3.10

Closes: https://trac.macports.org/ticket/64489
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->