### PR TITLE
py-geopandas: remove subports for EOL Python versions

### DIFF
--- a/python/py-geopandas/Portfile
+++ b/python/py-geopandas/Portfile
@@ -8,9 +8,8 @@ version             0.9.0
 revision            0
 categories-append   science
 license             BSD
-platforms           darwin
 
-python.versions     27 35 36 37 38 39
+python.versions     37 38 39
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -19,7 +18,7 @@ description         Geographic pandas extensions
 long_description    GeoPandas is a project to add support for geographic data \
                     to pandas objects.
 
-homepage            http://geopandas.org
+homepage            https://geopandas.org
 
 checksums           rmd160  ac2f47cef558a17c3dce0c2ab647512058f36ed2 \
                     sha256  63972ab4dc44c4029f340600dcb83264eb8132dd22b104da0b654bef7f42630a \
@@ -33,15 +32,6 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-shapely \
                         port:py${python.version}-fiona \
                         port:py${python.version}-pyproj
-
-    if {${python.version} < 36} {
-        version             0.8.2
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  28566e35e048d1e164908b60d63acdf28e4e4d6f \
-                            sha256  aa9ae82e4e6b52efa244bd4b8bd2363d66693e5592ad1a0f52b6afa8c36348cb \
-                            size    961168
-    }
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
Several ports had EOL Python subports removed so that the `py-geopandas` failed to build; remove the EOL versions here as well as they have no dependents.

Closes: https://trac.macports.org/ticket/64474

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
