### PR TITLE
godot: use external libs

### DIFF
--- a/games/godot/Portfile
+++ b/games/godot/Portfile
@@ -27,6 +27,7 @@ if {$subport eq ${name}} {
 
     github.setup    ${name}engine ${name} 3.4 "" -stable
     version         3.4.0
+    revision        1
 
     checksums       rmd160  b06648c75e9c4c08a0f7163efb575f270cab71d7 \
                     sha256  c5abd7fd9e603a4fae55e34f950f0568064a7ec406a12af6c01c218cddb46908 \
@@ -76,13 +77,38 @@ if {${os.platform} eq "darwin" && ${os.major} <= 11} {
     }
 }
 
-depends_build       port:scons \
-                    port:yasm
+depends_build-append    port:scons \
+                        port:yasm \
+                        port:pkgconfig
+depends_lib-append      port:freetype \
+                        port:libpng \
+                        port:zlib \
+                        port:zstd \
+                        port:libtheora \
+                        port:libogg \
+                        port:libvorbis \
+                        port:libopus \
+                        port:opusfile \
+                        port:miniupnpc \
+                        port:pcre2
+# Some dependencies that are available in MacPorts can't be used. See
+# the "Important note" in the build.args-append section below.
+#                       port:bullet \
+#                       port:assimp \
+#                       port:libenet \
+#                       port:squish \
+#                       port:libvpx \
+#                       port:webp \
+#                       port:mbedtls \
+#                       port:minizip \
+#                       port:embree
+
+patchfiles-append       add-external_libs-support.diff
 
 if {$subport eq "${name}-3.2" && \
     ${os.platform} eq "darwin" && ${os.major} <= 15} \
 {
-    patchfiles      legacy-osx-defines.diff
+    patchfiles-append legacy-osx-defines.diff
 }
 
 if {$subport eq ${name} && ${os.platform} eq "darwin"} {
@@ -196,6 +222,28 @@ build.cmd           ${prefix}/bin/scons
 build.env-append    BUILD_NAME=macports_build
 build.target        platform=osx arch=${build_arch} \
                     target=release_debug verbose=yes warnings=extra
+build.args-append   builtin_freetype=no \
+                    builtin_libpng=no \
+                    builtin_zlib=no \
+                    builtin_zstd=no \
+                    builtin_libtheora=no \
+                    builtin_libogg=no \
+                    builtin_libvorbis=no \
+                    builtin_opus=no \
+                    builtin_miniupnpc=no \
+                    builtin_pcre2=no
+# Important note: I am only turning off built-in for libraries that
+# don't have any references to "godot" in them (i.e.,
+# 'grep -Ri godot ${worksrcpath}/thirdparty' doesn't return anything).
+# The other libraries have some sort of modification that has been made
+# by the Godot devs.
+#                   builtin_assimp=no \
+#                   builtin_enet=no \
+#                   builtin_squish=no \
+#                   builtin_libvpx=no \
+#                   builtin_libwebp=no \
+#                   builtin_mbedtls=no \
+#                   builtin_embree=no
 
 destroot {
     if {$subport eq "${name}-3.2"} {

--- a/games/godot/files/add-external_libs-support.diff
+++ b/games/godot/files/add-external_libs-support.diff
@@ -1,0 +1,111 @@
+--- platform/osx/detect.py.orig	2021-11-04 20:06:19.000000000 -0400
++++ platform/osx/detect.py	2021-12-22 20:42:13.000000000 -0500
+@@ -146,10 +146,107 @@
+ 
+     ## Dependencies
+ 
+-    if env["builtin_libtheora"]:
++    # freetype depends on libpng and zlib, so bundling one of them while keeping others
++    # as shared libraries leads to weird issues
++    if (
++        env["builtin_freetype"] or
++        env["builtin_libpng"] or
++        env["builtin_zlib"]
++    ):
++        env["builtin_freetype"] = True
++        env["builtin_libpng"] = True
++        env["builtin_zlib"] = True
++
++    if not env["builtin_freetype"]:
++        env.ParseConfig("pkg-config freetype2 --cflags --libs")
++
++    if not env["builtin_libpng"]:
++        env.ParseConfig("pkg-config libpng16 --cflags --libs")
++
++    if not env["builtin_zlib"]:
++        env.ParseConfig("pkg-config zlib --cflags --libs")
++
++    if not env["builtin_bullet"]:
++        # We need at least version 2.90
++        min_bullet_version = "2.90"
++
++        import subprocess
++
++        bullet_version = subprocess.check_output(["pkg-config", "bullet", "--modversion"]).strip()
++        if str(bullet_version) < min_bullet_version:
++            # Abort as system bullet was requested but too old
++            print(
++                "Bullet: System version {0} does not match minimal requirements ({1}). Aborting.".format(
++                    bullet_version, min_bullet_version
++                )
++            )
++            sys.exit(255)
++        env.ParseConfig("pkg-config bullet --cflags --libs")
++
++    if False:  # not env['builtin_assimp']:
++        # FIXME: Add min version check
++        env.ParseConfig("pkg-config assimp --cflags --libs")
++
++    if not env["builtin_enet"]:
++        env.ParseConfig("pkg-config libenet --cflags --libs")
++
++    if not env["builtin_squish"]:
++        # No pkgconfig file so far, hardcode expected lib name.
++        env.Append(LIBS=["squish"])
++        #env.ParseConfig("pkg-config libsquish --cflags --libs")
++
++    if not env["builtin_zstd"]:
++        env.ParseConfig("pkg-config libzstd --cflags --libs")
++
++    # Sound and video libraries
++    # Keep the order as it triggers chained dependencies (ogg needed by others, etc.)
++
++    if not env["builtin_libtheora"]:
++        env["builtin_libogg"] = False  # Needed to link against system libtheora
++        env["builtin_libvorbis"] = False  # Needed to link against system libtheora
++        env.ParseConfig("pkg-config theora theoradec --cflags --libs")
++    else:
+         if env["arch"] != "arm64":
+             env["x86_libtheora_opt_gcc"] = True
+ 
++
++    if not env["builtin_libvpx"]:
++        env.ParseConfig("pkg-config vpx --cflags --libs")
++
++    if not env["builtin_libvorbis"]:
++        env["builtin_libogg"] = False  # Needed to link against system libvorbis
++        env.ParseConfig("pkg-config vorbis vorbisfile --cflags --libs")
++
++    if not env["builtin_opus"]:
++        env["builtin_libogg"] = False  # Needed to link against system opus
++        env.ParseConfig("pkg-config opus opusfile --cflags --libs")
++
++    if not env["builtin_libogg"]:
++        env.ParseConfig("pkg-config ogg --cflags --libs")
++
++    if not env["builtin_libwebp"]:
++        env.ParseConfig("pkg-config libwebp --cflags --libs")
++
++    if not env["builtin_mbedtls"]:
++        # mbedTLS does not provide a pkgconfig config yet. See https://github.com/ARMmbed/mbedtls/issues/228
++        env.Append(LIBS=["mbedtls", "mbedcrypto", "mbedx509"])
++
++    if not env["builtin_wslay"]:
++        env.ParseConfig("pkg-config libwslay --cflags --libs")
++
++    if not env["builtin_miniupnpc"]:
++        env.ParseConfig("pkg-config miniupnpc --cflags --libs")
++
++    # On Linux wchar_t should be 32-bits
++    # 16-bit library shouldn't be required due to compiler optimisations
++    if not env["builtin_pcre2"]:
++        env.ParseConfig("pkg-config libpcre2-32 --cflags --libs")
++
++    # Embree is only used in tools build on x86_64 and aarch64.
++    if env["tools"] and not env["builtin_embree"]:
++        # No pkgconfig file so far, hardcode expected lib name.
++        env.Append(LIBS=["embree3"])
++
+     ## Flags
+ 
+     env.Prepend(CPPPATH=["#platform/osx"])


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This commit adds support for compiling Godot using external dependencies. It is nearly identical to the patch that has been implemented by one of the maintainers of the Godot package for Homebrew, as discussed here:

https://github.com/godotengine/godot-proposals/issues/1796

I will be submitting an upstream PR to get this feature incorporated into the Godot code base.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
