### PR TITLE
libomp: unbreak <= 10.6

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -110,6 +110,13 @@ configure.args-delete   -DCMAKE_INSTALL_RPATH=${prefix}/lib \
 configure.args-append   -DCMAKE_INSTALL_RPATH=${prefix}/lib/libomp \
                         -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib/libomp
 
+if {${os.major} <= 10} {
+    set hnames              {omp.h}
+    configure.args-append   -DLIBOMP_OMPT_SUPPORT=FALSE
+} else {
+    set hnames              {omp-tools.h omp.h ompt.h}
+}
+
 variant top_level description \
     "Install (links to) omp.h and libs into ${prefix}/(include|lib)" {}
 
@@ -124,7 +131,7 @@ post-destroot {
     xinstall -d ${instdest}/share/doc/libomp
 
     xinstall -d ${instdest}/include/libomp
-    foreach h {omp-tools.h omp.h ompt.h} {
+    foreach h ${hnames} {
         move ${instdest}/tmp/include/${h} ${instdest}/include/libomp/
     }
 
@@ -134,7 +141,7 @@ post-destroot {
     }
 
     if {[variant_isset top_level]} {
-        foreach h {omp-tools.h omp.h ompt.h} {
+        foreach h ${hnames} {
             system -W ${instdest}/include \
               "ln -s libomp/${h}"
         }


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/64558

Maintainer update. No bump (either worked before, or we're hopefully fixing the broken.)