### PR TITLE
munt-mt32emu: update to 2.5.3

### DIFF
--- a/audio/munt-mt32emu/Portfile
+++ b/audio/munt-mt32emu/Portfile
@@ -10,12 +10,11 @@ checksums           rmd160  f79f8befdb16d9a698a00c8bb08dce20ffe0d6d7 \
                     sha256  062d110bbdd7253d01ef291f57e89efc3ee35fd087587458381f054bac49a8f5 \
                     size    527698
 
-name                munt-mt32emu
-version             [string map {_ .} ${github.version}]
-
 description         Munt library
 long_description    mt32emu is a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules.
 
+name                munt-mt32emu
+version             [string map {_ .} ${github.version}]
 categories          audio emulators
 license             LGPL-2.1
 maintainers         nomaintainer

--- a/audio/munt-mt32emu/Portfile
+++ b/audio/munt-mt32emu/Portfile
@@ -6,20 +6,22 @@ PortGroup           github 1.0
 
 github.setup        munt munt 2_5_3 libmt32emu_
 revision            0
-checksums           rmd160  93b62d029f9877d4051050d64f1953260b16878c \
-                    sha256  455ba7a16f4e9c73aaa21f19f8252bc3480ac3a22856e3a22d33d270358a0d06 \
-                    size    527730
+checksums           rmd160  f79f8befdb16d9a698a00c8bb08dce20ffe0d6d7 \
+                    sha256  062d110bbdd7253d01ef291f57e89efc3ee35fd087587458381f054bac49a8f5 \
+                    size    527698
 
 name                munt-mt32emu
 version             [string map {_ .} ${github.version}]
-homepage            http://munt.sourceforge.net/
+
 description         Munt library
 long_description    mt32emu is a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules.
 
 categories          audio emulators
 license             LGPL-2.1
-
 maintainers         nomaintainer
+
+homepage            http://munt.sourceforge.net
+github.tarball_from archive
 
 configure.args-append \
                     -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE \

--- a/audio/munt-mt32emu/Portfile
+++ b/audio/munt-mt32emu/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           github 1.0
 
 name                munt-mt32emu
-version             2.4.0
+github.setup        munt munt libmt32emu_2_5_3
 revision            0
 
 homepage            http://munt.sourceforge.net/
@@ -17,13 +18,9 @@ license             LGPL-2.1
 
 maintainers         nomaintainer
 
-master_sites        sourceforge:project/munt/munt/${version}
-
-distname            munt-${version}
-
-checksums           rmd160  9f3c76daf60294613e4e2646eba9e76d506c85ff \
-                    sha256  b4f7054df1d3f89e2cc683ff6182c4d0a272daceffc4d27fd968b6eaebcdc9ed \
-                    size    474789
+checksums           rmd160  93b62d029f9877d4051050d64f1953260b16878c \
+                    sha256  455ba7a16f4e9c73aaa21f19f8252bc3480ac3a22856e3a22d33d270358a0d06 \
+                    size  527730
 
 configure.args-append \
                     -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE \

--- a/audio/munt-mt32emu/Portfile
+++ b/audio/munt-mt32emu/Portfile
@@ -4,23 +4,22 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-name                munt-mt32emu
-github.setup        munt munt libmt32emu_2_5_3
+github.setup        munt munt 2_5_3 libmt32emu_
 revision            0
+checksums           rmd160  93b62d029f9877d4051050d64f1953260b16878c \
+                    sha256  455ba7a16f4e9c73aaa21f19f8252bc3480ac3a22856e3a22d33d270358a0d06 \
+                    size    527730
 
+name                munt-mt32emu
+version             [string map {_ .} ${github.version}]
 homepage            http://munt.sourceforge.net/
 description         Munt library
 long_description    mt32emu is a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules.
 
 categories          audio emulators
-platforms           darwin
 license             LGPL-2.1
 
 maintainers         nomaintainer
-
-checksums           rmd160  93b62d029f9877d4051050d64f1953260b16878c \
-                    sha256  455ba7a16f4e9c73aaa21f19f8252bc3480ac3a22856e3a22d33d270358a0d06 \
-                    size  527730
 
 configure.args-append \
                     -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE \


### PR DESCRIPTION
* added PortGroup github 1.0 as there are now only github releases for munt
* removed SourceForge specific entries

#### Description

Updated munt-mt32emu to 2.5.3.
Since there are now only github release tags for munt and no longer SourceForge releases I fixed that.

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

