### PR TITLE
binwalk: update python dependency from 3.9 to 3.10

### DIFF
--- a/cross/binwalk/Portfile
+++ b/cross/binwalk/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        ReFirmLabs binwalk 2.3.3 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          cross
 platforms           darwin
@@ -20,7 +20,7 @@ checksums           rmd160  38243ba7717e723d868b1032fa748cd409abdc0c \
                     sha256  7e32b94dc77632b51d18732b5456e2a3ef85e4521d7d4a54410e36f93859501f \
                     size    39723775
 
-python.default_version  39
+python.default_version  310
 
 depends_lib-append  port:py${python.default_version}-setuptools \
                     port:py${python.default_version}-pylzma

--- a/python/py-pylzma/Portfile
+++ b/python/py-pylzma/Portfile
@@ -10,7 +10,7 @@ categories-append   archivers
 platforms           darwin
 license             LGPL-2.1+
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description

binwalk: bump python dependency from 3.9 to 3.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
