### PR TITLE
cppcheck: update python dependency from 3.9 to 3.10

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -25,7 +25,7 @@ checksums                   rmd160  4b741a33b0ecce65064710810a546ec3f24c6422 \
                             sha256  7a49ebb7a54356ade09867f466cb41ee4020ebf3732582762669e5c8903f16c8 \
                             size    3880340
 
-set python_branch   3.9
+set python_branch   3.10
 set python_version  [string map {"." ""} ${python_branch}]
 set python_bin      ${prefix}/bin/python${python_branch}
 

--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 
 github.setup                danmar cppcheck 2.6.3
-revision                    0
+revision                    1
 
 categories                  devel
 license                     GPL-3


### PR DESCRIPTION
#### Description

cppcheck: bump python dependency from 3.9 to 3.10

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.1 13A1030d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
