### PR TITLE
asciinema: update python dependency from 3.9 to 3.10

### DIFF
--- a/sysutils/asciinema/Portfile
+++ b/sysutils/asciinema/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        asciinema asciinema 2.1.0 v
+revision            1
 
 categories          sysutils
 platforms           darwin
@@ -21,7 +22,7 @@ long_description    Forget screen recording apps and blurry video. \
 homepage            https://asciinema.org
 
 python.default_version \
-                    39
+                    310
 
 depends_lib         port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description

asciinema: bump python dependency from 3.9 to 3.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
