### PR TITLE
emacs-mac-app{,-devel}: fix up dependencies

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -9,7 +9,7 @@ set emacs_mac_ver   8.3
 bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ver}
 name                emacs-mac-app
 version             ${emacs_mac_ver}
-revision            1
+revision            2
 categories          aqua editors
 maintainers         {amake @amake} openmaintainer
 
@@ -28,7 +28,6 @@ checksums           rmd160  3544f2607e6002e066bcdd967c88aa7162ef6451 \
 depends_lib         port:ncurses \
                     port:libxml2 \
                     port:gnutls \
-                    port:dbus \
                     port:lcms2 \
                     port:gmp \
                     port:jansson
@@ -58,14 +57,24 @@ depends_build       port:autoconf \
                     port:texinfo
 
 # The Mac port uses CoreText instead of HarfBuzz
-configure.args      --with-mac \
+configure.args      --disable-silent-rules \
+                    --with-mac \
                     --enable-mac-app=${worksrcpath} \
                     --enable-mac-self-contained \
-                    --with-modules \
-                    --without-rsvg \
-                    --without-imagemagick \
+                    --without-dbus \
+                    --without-gconf \
+                    --without-libotf \
+                    --without-m17n-flt \
                     --without-harfbuzz \
-                    --with-json
+                    --without-imagemagick \
+                    --without-rsvg \
+                    --without-xaw3d \
+                    --with-libgmp \
+                    --with-gnutls \
+                    --with-xml2 \
+                    --with-json \
+                    --with-lcms2 \
+                    --with-modules \
 
 if {${os.major} >= 11 && ${os.platform} eq "darwin"} {
     configure.cflags-append -fobjc-arc
@@ -76,7 +85,7 @@ subport ${name}-devel {
     set date            2022-01-29
 
     version         [string map {- {}} ${date}]
-    revision        0
+    revision        1
 
     long_description \
         ${name} is the \"Mac port\" of GNU Emacs ${emacs_version}. \


### PR DESCRIPTION
Harmonize with emacs-app:

- No longer compile with dbus support (proper support needs a patch?)
- Specify appropriate configure args

(Opening PR to run CI checks)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
