### PR TITLE
openjdk17-temurin: Fix typo in arm64 download link

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -616,7 +616,7 @@ subport openjdk17-temurin {
                      sha256  3630e21a571b7180876bf08f85d0aac0bdbb3267b2ae9bd242f4933b21f9be32 \
                      size    192611208
     } elseif {${configure.build_arch} eq "arm64"} {
-        distname     OpenJDK17-jdk_aarch64_mac_hotspot_${version}_${build}
+        distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
         checksums    rmd160  e4063da6a1139c137af930c8cf5c5988bb75354d \
                      sha256  157518e999d712b541b883c6c167f8faabbef1d590da9fe7233541b4adb21ea4 \
                      size    182550014


### PR DESCRIPTION
#### Description

The arm64 link was missing a "U" and 404ing.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3 21E5196i
Xcode 13.3 13E5086k 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
