### PR TITLE
py-pycryptodome{,x}: update to 3.14.0

### DIFF
--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 # also update py-pycryptodomex
 name                py-pycryptodome
-version             3.12.0
+version             3.14.0
 revision            0
 
 homepage            https://www.pycryptodome.org
@@ -23,11 +23,9 @@ long_description    PyCryptodome is a self-contained Python package of \
 
 python.versions     27 35 36 37 38 39 310
 
-use_zip             yes
-
-checksums           rmd160  07ce4029f23972ad6713436caed4a27a3a1a7e8b \
-                    sha256  12c7343aec5a3b3df5c47265281b12b611f26ec9367b6129199d67da54b768c1 \
-                    size    3717073
+checksums           rmd160  aea0f9985cc506d6ba4cdb284caca2defa692fb7 \
+                    sha256  ceea92a4b8ba6c50d8d70f2efbb4ea14b002dac4160ce4dda33f1b7442f8158a \
+                    size    3372364
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pycryptodomex/Portfile
+++ b/python/py-pycryptodomex/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 # also update py-pycryptodome
 name                py-pycryptodomex
-version             3.12.0
+version             3.14.0
 revision            0
 
 license             BSD
@@ -17,11 +17,9 @@ long_description    ${description}
 
 homepage            https://www.pycryptodome.org
 
-use_zip             yes
-
-checksums           rmd160  bf9ba66791c40b790f346baf54735a913cf77b80 \
-                    sha256  922e9dac0166e4617e5c7980d2cff6912a6eb5cb5c13e7ece222438650bd7f66 \
-                    size    3721260
+checksums           rmd160  aca7cef5261ece5e7cb0c9fab7d76746c5a0eb7a \
+                    sha256  2d8bda8f949b79b78b293706aa7fc1e5c171c62661252bfdd5d12c70acd03282 \
+                    size    3372515
 
 python.versions     38 39 310
 


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->