### PR TITLE
py-pytest-timeout: fixed tests

### DIFF
--- a/python/py-pytest-timeout/Portfile
+++ b/python/py-pytest-timeout/Portfile
@@ -38,16 +38,24 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
+    if {${python.version} ne 27} {
+        depends_test-append \
                     port:py${python.version}-ipdb \
                     port:py${python.version}-pexpect \
                     port:py${python.version}-pytest \
                     port:py${python.version}-pytest-cov
 
-    test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target     test_pytest_timeout.py
-    test.env        PYTHONPATH=${build.dir}/build/lib
+        test.run    yes
+        test.env    PYTHONPATH=${worksrcpath}/build/lib \
+                    PYTEST_PLUGINS=pytest_timeout
+        test.cmd    py.test-${python.branch}
+        test.target
+
+        pre-test {
+            # See https://docs.pytest.org/en/stable/pythonpath.html
+            delete ${test.dir}/${test.target}/__init__.py
+        }
+    }
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->