### PR TITLE
asciidoc: Update to 10.1.1

### DIFF
--- a/textproc/asciidoc/Portfile
+++ b/textproc/asciidoc/Portfile
@@ -3,12 +3,13 @@
 PortSystem          1.0
 
 PortGroup           github 1.0
+PortGroup           python 1.0
 
-github.setup        asciidoc asciidoc-py3 9.1.0
-revision            1
-checksums           rmd160  4fef2148ed93859afe13031e0c953bbe0dabba29 \
-                    sha256  98941741bcef1b172bce735c9393255c095fe88642ac725a43a32afda0d73a4a \
-                    size    1131368
+github.setup        asciidoc asciidoc-py3 10.1.1
+revision            0
+checksums           rmd160  422997f6e8997f8603561cb98ad6d3ee4010ba05 \
+                    sha256  e5024d8e92dbcc16214caa9b3fffab3cc80112c6af205b927170a0f6dda96e50 \
+                    size    1133017
 name                asciidoc
 
 categories          textproc
@@ -28,37 +29,47 @@ platforms           darwin
 supported_archs     noarch
 installs_libs       no
 
-homepage            http://asciidoc.org/
+homepage            https://asciidoc-py.github.io/
 
+# Need autoconf to generate and install docs; python 1.0 PG disables configure, we can just re-enable it
 use_autoreconf      yes
-depends_lib         port:python39 \
+use_configure       yes
+
+python.versions     310
+python.default_version \
+                    310
+depends_build-append \
+                    port:py${python.version}-setuptools
+depends_lib         port:python${python.version} \
                     port:libxml2 \
                     port:libxslt \
                     port:docbook-xml-4.5 \
                     port:docbook-xsl-nons
 depends_run         port:fop
+depends_test        port:py${python.version}-pytest \
+                    port:py${python.version}-pytest-mock
 # Other runtime dependencies include dblatex, w3m and epubcheck, but those are
 # rarely used and large. See #52758.
 
-configure.python    ${prefix}/bin/python3.9
-
 pre-configure {
-    reinplace "s:^\tpython3 :\t${configure.python} :" \
-        ${worksrcpath}/Makefile.in
-    reinplace "s:#!/usr/bin/env python3:#!${configure.python}:" \
-        ${worksrcpath}/asciidoc.py \
-        ${worksrcpath}/a2x.py
+    reinplace -W ${worksrcpath} \
+        "s|python3|${python.bin}|g" \
+        Makefile.in
 }
 
-destroot.target install docs vimdir=${prefix}/share/vim/vimfiles/
-
-pre-destroot {
-    xinstall -d ${destroot}${prefix}/share/vim/vimfiles
+post-build {
+    system -W ${worksrcpath} "make manpages"
 }
 
-platform darwin {
-    # Avoid hidden dependency on gsed
-    configure.env-append SED=/usr/bin/sed
+post-destroot {
+    system -W ${worksrcpath} "make docs DESTDIR='${destroot}'"
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 -W ${worksrcpath} \
+        doc/a2x.1 \
+        doc/asciidoc.1 \
+        ${destroot}${prefix}/share/man/man1
 }
 
 test.run            yes
+test.cmd            make
+test.target         test


### PR DESCRIPTION
#### Description

asciidoc is now a python module, so switch to the python portgroup to build it. Note that for a few other bits and pieces (docs and manpages, for example), we still need to invoke the old autoconf-based build system.

Switch to Python 3.10 as the new default python.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.2 20G314 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
