### PR TITLE
yubico-pam: Update to 2.27

### DIFF
--- a/security/yubico-pam/Portfile
+++ b/security/yubico-pam/Portfile
@@ -3,10 +3,10 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    Yubico yubico-pam 2.26
-checksums       rmd160  831d608fbcb2146d80b33d8b5e0e0d7d37d6b1d5 \
-                sha256  fdab8ee7b373799a9eae813ec9c19b62cca8ea1b0c654b1753b70c286d8d894f \
-                size    75294
+github.setup    Yubico yubico-pam 2.27
+checksums       rmd160  535104ee7a68d048de604a9ba3d89a92c661eb72 \
+                sha256  77700a2e5619aeeda5a30019c37acfa146f2716a9d346495d59d8bcb9feb8379 \
+                size    81401
 
 
 # I'm explicitly not marking this openmaintainer


### PR DESCRIPTION
#### Description

yubico-pam: Update to 2.27

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.2 20G314 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
