### PR TITLE
oui: new port

### DIFF
--- a/net/oui/Portfile
+++ b/net/oui/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+revision            0
+
+go.setup            github.com/thatmattlove/oui 0.1.8 v
+
+homepage            https://github.com/thatmattlove/oui
+
+categories          net
+
+description         MAC Address CLI Toolkit
+
+long_description    Look up MAC Address vendors and convert MAC Addresses \
+                    to other formats — offline and at the console.
+
+maintainers         {stunninglyclear.com:matt @thatmattlove} openmaintainer
+
+license             BSD
+
+depends_build-append \
+                    port:goreleaser
+
+fetch.type          git
+
+build.env-delete    GO111MODULE=off GOPROXY=off
+build.cmd           goreleaser
+build.pre_args      build
+build.args          --single-target
+
+github.livecheck.regex  {([0-9.]+)}
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/dist/${name}_${goos}_${goarch}/${name} \
+        ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

oui is a MAC Address CLI toolkit written in go

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
