### PR TITLE
Bug fix for oof2 version 2.2.1

### DIFF
--- a/science/oof2/Portfile
+++ b/science/oof2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           active_variants 1.1
 
 name                oof2
-version             2.2.0
+version             2.2.1
 revision            0
 
 license             public-domain
@@ -20,15 +20,13 @@ long_description    OOF2 computes properties of materials with complex \
 homepage            https://www.ctcms.nist.gov/oof/oof2
 master_sites        ${homepage}/source
 
-checksums           rmd160 18dcbac75d39f72350d175abc01fd8338808587e \
-                    sha256 94f6581e884bd51a011a28ce3724587c79121760b1ec004c6db5aa4eadb24dcd \
-                    size 15104880
+checksums           rmd160 35f299b7a4f3658c0dedf77dd0ddb3cc51986860 \
+                    sha256 3b6d19e5360a65487a12d8d6dc55f92bb812aa9f3e7260abf445e989bab686e5 \
+                    size 15103683
 
 python.default_version 27
 
 compiler.cxx_standard 2011
-
-##destroot.args       --prefix=${prefix} --port-dir=${prefix} --skip-build
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
Fixed buffer overflows in legacy code.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G314 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
