### PR TITLE
geckodriver: build is prefixed with aarch64

### DIFF
--- a/www/geckodriver/Portfile
+++ b/www/geckodriver/Portfile
@@ -189,6 +189,6 @@ cargo.crates \
 
 destroot {
     xinstall -m 755 \
-        [glob ${worksrcpath}/target/${build_arch}-*-${os.platform}/release/geckodriver] \
+        [glob ${worksrcpath}/target/[regsub {^arm64$} $build_arch aarch64]-*-${os.platform}/release/geckodriver] \
         ${destroot}${prefix}/bin
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

geckodriver couldn't be installed on amd64, because the build directory is prefixed with `aarch64` and not `arm64` (`${build_arch}`).

This PR uses `aarch64` instead of `arm64` when looking for the `geckodriver` binary.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G314 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
