### PR TITLE
Gildas: update to 202202a

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1
 
 name                gildas
-version             202201a
+version             202202a
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 supported_archs     arm64 x86_64
 set my_machine      [if {[string match *arm* ${os.arch}]} {list arm64} {list x86_64}]
@@ -32,9 +32,9 @@ master_sites        https://www.iram.fr/~gildas/dist/ \
 distname            ${name}-src-${my_version}
 use_xz              yes
 
-checksums           rmd160  468294d9d841551776193c65fdc064341be8d135 \
-                    sha256  9fc8f3dd64a9cdcd754f71f65fe1c009f0e0475ecd47098ffb2204acc33a7fcc \
-                    size    43804968
+checksums           rmd160  1cb0d18fb517215821a60e9b6f3974a5a6c24c91 \
+                    sha256  f88c4bb6648bd87f52783c95d8ce4bdf487c7e113ff73f56bb4ed33994bfe742 \
+                    size    43816896
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \


### PR DESCRIPTION
#### Description

Update to Gildas feb22a monthly release

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.0.1 21A559 x86_64
Xcode 13.1 13A1030d

macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
