### PR TITLE
samba4: Update to 4.15.5

### DIFF
--- a/net/samba4/Portfile
+++ b/net/samba4/Portfile
@@ -8,11 +8,11 @@ legacysupport.newest_darwin_requires_legacy 13
 
 name                samba4
 conflicts           samba3
-version             4.15.3
+version             4.15.5
 revision            0
-checksums           rmd160  0d4a2443d6e3f53268389e3504ef97765ac8b9be \
-                    sha256  519399404391550345846768ea4dd0fe7fcb04e20c2b891b5eeb02e5554137db \
-                    size    19272345
+checksums           rmd160  0f16f05626b8b146f150292f89a7bbdfafc13548 \
+                    sha256  69115e33831937ba5151be0247943147765aece658ba743f44741672ad68d17f \
+                    size    19279071
 
 categories          net
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description

See https://www.samba.org/samba/history/samba-4.15.5.html

CVE: CVE-2021-44141, CVE-2021-44142, CVE-2022-0336

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 11.6.3 20G415 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
