### PR TITLE
google-cloud-sdk: update to 371.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             370.0.0
+version             371.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  5795d261933c8cf0bd4a96603d7053901c5f8703 \
-                    sha256  ffb7c56611b6ec531676eff7f18c22afde7fe35b969eeec1e6154024db3a92b7 \
-                    size    97716958
+    checksums       rmd160  1b29f5332aec3b18e972759e19034512fa245b83 \
+                    sha256  abf96c92243a3ceee0423b7086334acbb81ee822a9c8e7aa011d1bedf7255780 \
+                    size    97835523
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  634bcd779e8e0f786f7d8b7f19ee7117799a23ce \
-                    sha256  e08541e2e319457698b9154cd064edc5efa95653f5a84b94a1f2f3d0f87ee196 \
-                    size    92976616
+    checksums       rmd160  5ea6cfdeffcba1606c6f8bf7b336f458a971d936 \
+                    sha256  190604173fdb97ef7238b80f22f30f1d5032b0864b6af07a22a5f381ecfab1b5 \
+                    size    93098663
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  8871f8c2c6fc0fea2655dd121f62ebb6090a5063 \
-                    sha256  64564808bd06947a164645caab99bae9da90f0c814e6faf2e549512d4ad4dca7 \
-                    size    92444530
+    checksums       rmd160  9253b2f6cbd415e7151af37ff9709d3b96ce8fc8 \
+                    sha256  b47bcd6c6c39f4602727fc94270a114a9a97d6382c1dedbf5df2ce595829f7a1 \
+                    size    92564834
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 371.0.0.

###### Tested on

macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?