### PR TITLE
elixir: add livecheck

### DIFF
--- a/lang/elixir/Portfile
+++ b/lang/elixir/Portfile
@@ -39,3 +39,5 @@ destroot.args       PREFIX=${prefix}
 
 # various tests have been removed using above patch
 test.run            yes
+
+github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

Added livecheck. 

###### Type(s)
[x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?