### PR TITLE
websocketpp: remove architecture restrictions

### DIFF
--- a/net/websocketpp/Portfile
+++ b/net/websocketpp/Portfile
@@ -1,14 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           cmake 1.1
+PortGroup           cmake   1.1
+PortGroup           github  1.0
 
 github.setup        zaphoyd websocketpp 0.8.2
-revision            1
+revision            2
 categories          net devel
 platforms           darwin
-supported_archs     i386 x86_64
 license             BSD
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 


### PR DESCRIPTION
Allow `websocketpp` to build on any arch including `arm64`.

Also, shift to using the OpenSSL portgroup.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
