### PR TITLE
libusb: fix build on 10.11 and earlier

### DIFF
--- a/devel/libusb/Portfile
+++ b/devel/libusb/Portfile
@@ -3,6 +3,10 @@
 PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       compiler_blacklist_versions 1.0
+PortGroup       legacysupport 1.1
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 name            libusb
 categories      devel
@@ -43,8 +47,6 @@ if {${subport} eq ${name}} {
     github.livecheck.regex  {([0-9.]+)}
 
 } else {
-    PortGroup       legacysupport 1.1
-
     # IOKit/USB.h - fixes GCC 4.5+ issue pre-Catalina
     # https://trac.macports.org/ticket/61868
     # (As of 2021-11-07 the fix requires legacy-support-devel - bump


### PR DESCRIPTION
#### Description

Build bots are failing, see e.g. https://build.macports.org/builders/ports-10.11_x86_64-builder/builds/172407
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
