### PR TITLE
py*-google-auth: upgrade to 2.6.0

### DIFF
--- a/python/py-google-auth/Portfile
+++ b/python/py-google-auth/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-google-auth
-version             1.25.0
+version             2.6.0
 revision            0
 
 categories-append   www devel
@@ -18,12 +18,10 @@ description         simplifies using Google's various server-to-server \
 long_description    {*}${description}
 
 homepage            https://pypi.python.org/pypi/${python.rootname}
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 
-checksums           rmd160  077e7c5a61134747ba2879b9fa0710f05615bff4 \
-                    sha256  514e39f4190ca972200ba33876da5a8857c5665f2b4ccc36c8b8ee21228aae80 \
-                    size    121940
+checksums           rmd160  471d535f41aa69f225e62bd74af1779a5fdbed04 \
+                    sha256  ad160fc1ea8f19e331a16a14a79f3d643d813a69534ba9611d2c80dc10439dad \
+                    size    188477
 
 python.versions     27 35 36 37 38 39 310
 
@@ -36,6 +34,14 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-asn1-modules \
                     port:py${python.version}-rsa \
                     port:py${python.version}-six
+
+    if {${python.version} in "27 35"} {
+        version     1.25.0
+        revision    0
+        checksums   rmd160 077e7c5a61134747ba2879b9fa0710f05615bff4 \
+                    sha256 514e39f4190ca972200ba33876da5a8857c5665f2b4ccc36c8b8ee21228aae80 \
+                    size 121940
+    }
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description

* Upgrade py-google-auth from 1.25.0 to 2.6.0.
* Fix exception in starting `python/fava`:`pkg_resources.DistributionNotFound: The 'cachetools<5.0,>=2.0.0' distribution was not found and is required by google-auth`

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

