### PR TITLE
fava: upgrade to 1.20.1

### DIFF
--- a/python/fava/Portfile
+++ b/python/fava/Portfile
@@ -5,11 +5,11 @@ PortGroup               python 1.0
 
 name                    fava
 categories-append       finance
-version                 1.14
+version                 1.20.1
 revision                0
-checksums               rmd160  3584157fff58977d2586b58214065a37f145935e \
-                        sha256  1eb7638252ba110840a94fca5a88fbd3c35057efb0146dce1258a97305be3ea0 \
-                        size    1367651
+checksums               rmd160  0e15595ecf661d42600e39c2acda4376a0dd3cb7 \
+                        sha256  e2d13041acfeab9a63addb2a56678b126476a277badac6a9fec0b2944f61a037 \
+                        size    1725161
 
 license                 MIT
 platforms               darwin
@@ -23,7 +23,7 @@ homepage                https://beancount.github.io/fava/
 master_sites            pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname                ${python.rootname}-${version}
 
-python.versions         37 38
+python.versions         37 38 39 310
 python.default_version  38
 
 depends_build-append    port:py${python.version}-setuptools_scm

--- a/python/fava/Portfile
+++ b/python/fava/Portfile
@@ -20,9 +20,6 @@ description             Beancount web server
 long_description        Fava is a web frontend for the Beancount plain-text accounting system.
 homepage                https://beancount.github.io/fava/
 
-master_sites            pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname                ${python.rootname}-${version}
-
 python.versions         37 38 39 310
 python.default_version  38
 

--- a/python/fava/Portfile
+++ b/python/fava/Portfile
@@ -21,7 +21,6 @@ long_description        Fava is a web frontend for the Beancount plain-text acco
 homepage                https://beancount.github.io/fava/
 
 python.versions         37 38 39 310
-python.default_version  38
 
 depends_build-append    port:py${python.version}-setuptools_scm
 


### PR DESCRIPTION
#### Description

Upgrade fava from 1.14 to 1.20.1.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
