### PR TITLE
oof2: update to 2.2.2

### DIFF
--- a/science/oof2/Portfile
+++ b/science/oof2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           active_variants 1.1
 
 name                oof2
-version             2.2.1
+version             2.2.2
 revision            0
 
 license             public-domain
@@ -20,9 +20,9 @@ long_description    OOF2 computes properties of materials with complex \
 homepage            https://www.ctcms.nist.gov/oof/oof2
 master_sites        ${homepage}/source
 
-checksums           rmd160 35f299b7a4f3658c0dedf77dd0ddb3cc51986860 \
-                    sha256 3b6d19e5360a65487a12d8d6dc55f92bb812aa9f3e7260abf445e989bab686e5 \
-                    size 15103683
+checksums           rmd160 235ea0522056af5ac930e822ed4cd028196c6365 \
+                    sha256 b461dc614c2e7785b63cb52dbe2c59ddc230c06e27479623c281665a39b35ea1 \
+                    size 15103836
 
 python.default_version 27
 


### PR DESCRIPTION
This *should* fix the last of the build problems caused by
buffer overflows in our ancient build tools.  I finally figured
out how to test it in situ, using the full path names used by
macports, and not the shorter ones that it uses when building
from a local repository.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G314 x86_64
Xcode 13.2 13C90


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
