### PR TITLE
py-jupyterlab and deps: add py310 versions.

### DIFF
--- a/python/py-json5/Portfile
+++ b/python/py-json5/Portfile
@@ -8,7 +8,7 @@ github.setup        dpranke pyjson5 0.9.6 v
 revision            0
 name                py-json5
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 categories-append   devel
 license             Apache-2
 platforms           darwin

--- a/python/py-jupyter_server/Portfile
+++ b/python/py-jupyter_server/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     36 37 38 39
+python.versions     36 37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupyterlab/Portfile
+++ b/python/py-jupyterlab/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     36 37 38 39
+python.versions     36 37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupyterlab_server/Portfile
+++ b/python/py-jupyterlab_server/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     36 37 38 39
+python.versions     36 37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-nbclassic/Portfile
+++ b/python/py-nbclassic/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     36 37 38 39
+python.versions     36 37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description
Add Python 3.10 versions of `py-jupyterlab` and other packages required to install it.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 11.6.2 20G314 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? (no tests)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?