### PR TITLE
salt: remove EOL 3.5 and 3.6 python versions

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -22,65 +22,11 @@ long_description  SaltStack is fast, scalable and flexible software for data \
                   to the entire application stack.
 homepage          https://saltstack.com/
 
-    if {![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
+    if {![variant_isset python37]} {
         default_variants +python38
     }
 
-    variant python35 conflicts python36 python37 python38 description {python-3.5 support} {
-        python.default_version 35
-        depends_build       port:py${python.version}-setuptools
-
-        depends_lib-append  port:py${python.version}-asn1 \
-                            port:py${python.version}-cffi \
-                            port:py${python.version}-cherrypy \
-                            port:py${python.version}-cryptography \
-                            port:py${python.version}-dateutil \
-                            port:py${python.version}-distro \
-                            port:py${python.version}-gitpython \
-                            port:py${python.version}-gnupg \
-                            port:py${python.version}-idna \
-                            port:py${python.version}-jinja2 \
-                            port:py${python.version}-mako \
-                            port:py${python.version}-msgpack \
-                            port:py${python.version}-psutil \
-                            port:py${python.version}-pycryptodome \
-                            port:py${python.version}-pyobjc \
-                            port:py${python.version}-setproctitle \
-                            port:py${python.version}-tornado \
-                            port:py${python.version}-yaml \
-                            port:py${python.version}-zmq
-
-        destroot.cmd-append --with-salt-version=${version}
-    }
-
-    variant python36 conflicts python35 python37 python38 description {python-3.6 support} {
-        python.default_version 36
-        depends_build       port:py${python.version}-setuptools
-
-        depends_lib-append  port:py${python.version}-asn1 \
-                            port:py${python.version}-cffi \
-                            port:py${python.version}-cherrypy \
-                            port:py${python.version}-cryptography \
-                            port:py${python.version}-dateutil \
-                            port:py${python.version}-distro \
-                            port:py${python.version}-gitpython \
-                            port:py${python.version}-gnupg \
-                            port:py${python.version}-idna \
-                            port:py${python.version}-jinja2 \
-                            port:py${python.version}-mako \
-                            port:py${python.version}-msgpack \
-                            port:py${python.version}-psutil \
-                            port:py${python.version}-pycryptodome \
-                            port:py${python.version}-pyobjc \
-                            port:py${python.version}-setproctitle \
-                            port:py${python.version}-tornado \
-                            port:py${python.version}-yaml \
-                            port:py${python.version}-zmq
-
-        destroot.cmd-append --with-salt-version=${version}
-    }
-
-    variant python37 conflicts python35 python36 python38 description {python-3.7 support} {
+    variant python37 conflicts python38 description {python-3.7 support} {
         python.default_version 37
         depends_build       port:py${python.version}-setuptools
 
@@ -107,7 +53,7 @@ homepage          https://saltstack.com/
         destroot.cmd-append --with-salt-version=${version}
     }
 
-    variant python38 conflicts python35 python36 python37 description {python-3.8 support} {
+    variant python38 conflicts python37 description {python-3.8 support} {
         python.default_version 38
         depends_build       port:py${python.version}-setuptools
 


### PR DESCRIPTION
Adding python 39 and 310 would be too time consuming at this point.
Removing these EOL will allow other ports to remove theirs.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
