### PR TITLE
py-awscli-plugin-endpoint: New port

### DIFF
--- a/python/py-awscli-plugin-endpoint/Portfile
+++ b/python/py-awscli-plugin-endpoint/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-awscli-plugin-endpoint
+version             0.4
+revision            0
+
+supported_archs     noarch
+license             Apache-2
+maintainers         {judaew @judaew} openmaintainer
+
+description         \
+    An awscli plugin to configure service endpoint from aws configure file
+long_description    {*}${description}
+homepage            https://github.com/wbingli/awscli-plugin-endpoint
+
+checksums           rmd160  a322d2a4faff6677d248443a76a7cb6b53ec64d5 \
+                    sha256  9096f01f637f17e7b0c28788a64276acc40c0165f1655a6dc45fec39b96bafd0 \
+                    size    3680
+
+python.versions     37 38 39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_run-append      port:py${python.version}-awscli
+
+    livecheck.type          none
+}

--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -72,6 +72,18 @@ To make the Python ${python.branch} version of AWS CLI the one that is run when\
 you execute the commands without a version suffix, e.g. 'aws', run:
 
 port select --set ${select.group} [file tail ${select.file}]
+
+---
+
+If you use a plugin in your ~/.aws/config, it must be installed. For example,
+Wasabi for S3 uses the awscli_plugin_endpoint plugin. Just install it:
+
+port install py${python.version}-awscli_plugin_endpoint
+
+If your plugin is not in MacPorts, you can install it using the
+py${python.version}-pip port, for example:
+
+pip-${python.branch} install --user <plugin-name>
 "
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

Closed: https://trac.macports.org/ticket/64608

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
