### PR TITLE
mozjs68: new port

### DIFF
--- a/lang/mozjs68/Portfile
+++ b/lang/mozjs68/Portfile
@@ -1,0 +1,124 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           muniversal 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime, TARGET_OS_SIMULATOR
+legacysupport.newest_darwin_requires_legacy 15
+
+name                mozjs68
+version             68.4.2
+set version_major   68
+categories          lang
+platforms           darwin
+license             {MPL-2 LGPL-2.1+}
+maintainers         nomaintainer
+description         JavaScript-C Engine
+long_description    SpiderMonkey is Mozilla's JavaScript engine written in C/C++. \
+                    It is used in various Mozilla products, including Firefox, \
+                    and is available under the MPL2.
+
+homepage            https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
+# build from GNOME releng tarball
+master_sites        https://ftp.gnome.org/pub/GNOME/teams/releng/tarballs-needing-help/mozjs/
+
+# For Rust
+supported_archs     x86_64 arm64
+
+distname            mozjs-${version}
+use_bzip2           yes
+
+checksums           rmd160  8f1decdf3b50d6c4cb6f2123497d4ee59b0ebbb8 \
+                    sha256  097fb482aa0e57fb117fde6816fbabfedcb862ee81906990363954f47ce93227 \
+                    size    70569055
+
+depends_build       port:autoconf213 \
+                    port:cargo \
+                    port:pkgconfig \
+                    port:python27 \
+                    port:yasm
+
+depends_lib         port:nspr \
+                    port:xorg-libX11 \
+                    port:xorg-libXt
+
+# requires C++14 compiler to build
+compiler.cxx_standard 2014
+
+# Rust components require a MacPorts clang (i.e. one with llvm-config)
+compiler.blacklist  *gcc* clang macports-clang-3.*
+
+if {[regexp {macports-clang-(.*)} ${configure.compiler} -> llvm_ver]} {
+    configure.env-append \
+                    LLVM_CONFIG=${prefix}/bin/llvm-config-mp-${llvm_ver}
+}
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # Once Snow Leopard gets "real Rust", remove the next 3 lines
+    depends_build-replace port:cargo port:mrustc-rust
+    configure.env-append RUSTC=${prefix}/libexec/mrustc-rust/bin/rustc
+    configure.env-append CARGO=${prefix}/libexec/mrustc-rust/bin/cargo
+
+    depends_build-append port:cctools
+    configure.env-append AR=${prefix}/bin/ar
+}
+
+patchfiles          patch-skip-sdk-check.diff \
+                    patch-virtualenv-arm64-codesign.diff
+
+# Use absolute path for install_name
+post-patch {
+    reinplace "s|@executable_path|${prefix}/lib|g" ${worksrcpath}/config/rules.mk
+}
+
+configure.perl      /usr/bin/perl
+configure.python    ${prefix}/bin/python2.7
+
+# The combination of JS_STANDALONE=1 and --disable-jemalloc are needed
+# to ensure that mozglue is statically linked.
+configure.env-append \
+                    SHELL=/bin/bash \
+                    JS_STANDALONE=1
+
+configure.dir       ${worksrcpath}/js/src/obj
+configure.cmd       ../configure
+
+configure.args      --with-system-nspr \
+                    --disable-jemalloc \
+                    --disable-readline \
+                    --disable-xcode-checks \
+                    --with-macos-sdk=${configure.sdkroot}
+
+configure.universal_args-delete --disable-dependency-tracking
+
+build.env-append    SHELL=/bin/bash
+build.dir           ${worksrcpath}/js/src/obj
+destroot.dir        ${worksrcpath}/js/src/obj
+
+post-destroot {
+    # make static lib name version specific to avoid conflict with other mozjs versions
+    move ${destroot}${prefix}/lib/libjs_static.ajs ${destroot}${prefix}/lib/libjs${version_major}_static.ajs
+}
+if {![info exists universal_possible]} {
+    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
+}
+
+if {${universal_possible} && [variant_isset universal]} {
+    set merger_host(x86_64) x86_64-apple-${os.platform}${os.major}
+    set merger_host(i386) i686-apple-${os.platform}${os.major}
+    set merger_configure_args(x86_64) "--host=x86_64-apple-${os.platform}${os.major} --target=x86_64-apple-${os.platform}${os.major}"
+    set merger_configure_args(i386) "--host=i686-apple-${os.platform}${os.major} --target=i686-apple-${os.platform}${os.major}"
+} else {
+    if {${build_arch} eq "i386"} {
+        configure.args-append \
+            --host=i686-apple-${os.platform}${os.major} \
+            --target=i686-apple-${os.platform}${os.major}
+    } elseif {${build_arch} in "x86_64 ppc ppc64"} {
+        configure.args-append \
+            --host=${build_arch}-apple-${os.platform}${os.major} \
+            --target=${build_arch}-apple-${os.platform}${os.major}
+    }
+}
+
+livecheck.type      none

--- a/lang/mozjs68/files/patch-skip-sdk-check.diff
+++ b/lang/mozjs68/files/patch-skip-sdk-check.diff
@@ -1,0 +1,11 @@
+--- build/moz.configure/toolchain.configure.orig	2021-09-20 18:53:22.000000000 -0400
++++ build/moz.configure/toolchain.configure	2021-09-20 18:53:40.000000000 -0400
+@@ -145,7 +145,7 @@
+         sdk_max_version = Version('10.15.4')
+ 
+         if sdk:
+-            sdk = sdk[0]
++            return sdk[0]
+         elif host.os == 'OSX':
+             sdk = check_cmd_output('xcrun', '--show-sdk-path', onerror=lambda: '').rstrip()
+             if not sdk:

--- a/lang/mozjs68/files/patch-virtualenv-arm64-codesign.diff
+++ b/lang/mozjs68/files/patch-virtualenv-arm64-codesign.diff
@@ -1,0 +1,17 @@
+--- third_party/python/virtualenv/virtualenv.py.orig	2021-02-01 22:20:21.000000000 -0600
++++ third_party/python/virtualenv/virtualenv.py	2021-02-01 22:28:31.000000000 -0600
+@@ -1339,6 +1339,14 @@
+                              "have Apple's development tools installed")
+                 raise
+ 
++        # For macOS on arm64, the copied binary needs to be ad-hoc codesigned.
++
++        if os.uname()[4] == 'arm64':
++            codesign_cmd = ["codesign", "--sign", "-", "--force",
++                           "--preserve-metadata=entitlements,requirements,flags,runtime", py_executable]
++            subprocess.call(codesign_cmd)
++
++
+     if not is_win:
+         # Ensure that 'python', 'pythonX' and 'pythonX.Y' all exist
+         py_exe_version_major = 'python%s' % sys.version_info[0]


### PR DESCRIPTION
#### Description

gjs is out of date; newer versions require an updated mozjs. A gjs update can be prepared after this and #13897 are merged.

One major improvement over the mozjs60 Portfile is that mozglue is now compiled statically. This eliminates the need for two of the patches, and also avoids a file conflict over `libmozglue.dylib` with mozjs60.

After #13817 is merged, this mozjs68 port can be made available on 10.6+ (already compiled and tested locally on 10.6.8 / x86_64). mozjs78 and mozjs91 will be explored later. 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
