### PR TITLE
py-httplib2: upgrade to 0.15.0

### DIFF
--- a/python/py-httplib2/Portfile
+++ b/python/py-httplib2/Portfile
@@ -4,7 +4,7 @@ PortSystem        1.0
 PortGroup         python 1.0
 
 name              py-httplib2
-set realversion   0.11.3
+set realversion   0.20.4
 revision          0
 version           2-${realversion}
 categories-append devel net
@@ -22,9 +22,9 @@ distname          ${python.rootname}-${realversion}
 
 python.versions   27 35 36 37 38 39 310
 
-checksums         rmd160  c8c524c2fd7edca575db197da82b71c23c7f128c \
-                  sha256  e71daed9a0e6373642db61166fa70beecc9bf04383477f84671348c02a04cbdf \
-                  size    215815
+checksums         rmd160  8f76359b0b9676aad0d9d70d3fb26635c038272e \
+                  sha256  58a98e45b4b1a48273073f905d2961666ecf0fbac4250ea5b47aef259eb5c585 \
+                  size    349137
 
 if {${name} ne ${subport}} {
   # Extracted files do not have correct 'group' and 'other' permissions.


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Upgrade to 0.15.0 to fix `pkg_resources.ContextualVersionConflict: (httplib2 0.11.3 (/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages), Requirement.parse('httplib2>=0.15.0'), {'google-auth-httplib2'})` in running `fava @1.20.1_0`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

See #13903, #13878.