### PR TITLE
GPXSee: update to 10.3

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 10.2
+github.setup        tumic0 GPXSee 10.3
 revision            0
 
-checksums           rmd160  d28f3ccc1fb042b13ec8fb62ec57ed213c2cf8a8 \
-                    sha256  06c5239f287cc5c5546b57dfbe3be86523c967e1d91ae3b5ea811dda766c757e \
-                    size    5120076
+checksums           rmd160  9c6182297bb9e91625c4b5abe69860246e420b71 \
+                    sha256  965ff0ba437d85d9321463975cf131dbc621b3a6ac4ed047ab003e1b0806de20 \
+                    size    5119941
 
 categories          gis graphics
 platforms           darwin


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
