### PR TITLE
Remove eol cherrypy

### DIFF
--- a/python/py-cheroot/Portfile
+++ b/python/py-cheroot/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  40b2beea7207bf3f75710ad4e7bc396878e61dab \
                     sha256  5b525b3e4a755adf78070ab54c1821fb860d4255a9317dba2b88eb2df2441cff \
                     size    89470
 
-python.versions     27 35 36 37 38 39 310
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools_scm_git_archive
@@ -35,10 +35,6 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-more-itertools \
                             port:py${python.version}-setuptools \
                             port:py${python.version}-six
-
-    if {${python.version} eq 27} {
-        depends_lib-append  port:py${python.version}-backports-functools_lru_cache
-    }
 
     livecheck.type  none
 }

--- a/python/py-cherrypy/Portfile
+++ b/python/py-cherrypy/Portfile
@@ -32,7 +32,7 @@ checksums           rmd160  71b02055af4fda92b928977643525db456591ed5 \
                     sha256  683e687e7c7b1ba31ef86a113b1eafd0407269fed175bf488d3c839d37d1cc60 \
                     size    685192
 
-python.versions     27 35 36 37 38
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools_scm
@@ -43,20 +43,6 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-portend \
                             port:py${python.version}-setuptools \
                             port:py${python.version}-zc-lockfile
-
-    if {${python.version} eq 27} {
-        # Last version that will support python 2.7
-        version             17.4.2
-        revision            0
-        # Need to set distname again for some reason
-        distname            CherryPy-${version}
-
-        checksums           rmd160  67837d0f745052f156843df9fa48b75c4cf449a4 \
-                            sha256  ef1619ad161f526745d4f0e4e517753d9d985814f1280e330661333d2ba05cdf \
-                            size    684366
-
-        depends_lib-append  port:py${python.version}-six
-    }
 
     post-destroot {
         xinstall -m 644 -W ${worksrcpath} \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
