### PR TITLE
input-source-switcher: New port

### DIFF
--- a/sysutils/input-source-switcher/Portfile
+++ b/sysutils/input-source-switcher/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        vovkasm input-source-switcher 0.3 v
+revision            0
+
+categories          sysutils
+maintainers         {outlook.de:judaew @judaew} openmaintainer
+license             MIT
+
+description         Command line input source switcher for Mac.
+long_description    \
+    This small utility for Apple OS X allows to easily switch input sources \
+    from a command line. It's main purpose is to be used as a service in \
+    vim-xkbswitch plugin.
+
+checksums           rmd160 ffc4d4264c5a2777e9bf50a6dd18fdfc0d968239 \
+                    sha256 6d481d6d1d326f85e71f44bc2f9bc582678f1c92ad30d7db56f4a3199c3ca320 \
+                    size 4970


### PR DESCRIPTION
#### Description

This small utility for Apple OS X allows to easily switch input sources from a command line. It's main purpose is to be used as a service in vim-xkbswitch plugin.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
