### PR TITLE
vim: bump patchlevel, add python310 variant

### DIFF
--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -107,50 +107,31 @@ variant perl description {Enable Perl scripting} {
     depends_lib-append      path:bin/perl:perl5
 }
 
-variant python27 description {Enable Python scripting} {
-    configure.args-append   --enable-pythoninterp --with-python-command=${prefix}/bin/python2.7
-    patchfiles-append       patch-python.diff
-    depends_lib-append      port:python27
+set pythons_suffixes {27 36 37 38 39}
 
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
+set pythons_ports {}
+foreach s ${pythons_suffixes} {
+    lappend pythons_ports python${s}
 }
-variant python36 conflicts python37 python38 python39 description {Enable Python scripting} {
-    configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python3.6
-    patchfiles-append       patch-python3.diff
-    depends_lib-append      port:python36
 
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
-}
-variant python37 conflicts python36 python38 python39 description {Enable Python scripting} {
-    configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python3.7
-    patchfiles-append       patch-python3.diff
-    depends_lib-append      port:python37
-
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
-}
-variant python38 conflicts python36 python37 python39 description {Enable Python scripting} {
-    configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python3.8
-    patchfiles-append       patch-python3.diff
-    depends_lib-append      port:python38
-
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
-}
-variant python39 conflicts python36 python37 python38 description {Enable Python scripting} {
-    configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python3.9
-    patchfiles-append       patch-python3.diff
-    depends_lib-append      port:python39
-
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
+foreach s ${pythons_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string range ${s} 1 end]
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    variant ${p} description "Enable Python scripting" conflicts {*}${c} "
+        if {${s} < 300} {
+            configure.args-append   --enable-pythoninterp --with-python-command=${prefix}/bin/python${v}
+            patchfiles-append       patch-python.diff
+        } else {
+            configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python${v}
+            patchfiles-append       patch-python3.diff
+        }
+        depends_lib-append      port:${p}
+        use_autoconf yes
+        # overwriting autoconf.cmd above removes dependency, add it again
+        depends_build-append port:autoconf
+    "
 }
 
 variant ruby requires ruby18 description {Compatibility variant, requires +ruby18} {}

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -107,7 +107,7 @@ variant perl description {Enable Perl scripting} {
     depends_lib-append      path:bin/perl:perl5
 }
 
-set pythons_suffixes {27 36 37 38 39}
+set pythons_suffixes {27 36 37 38 39 310}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 set vim_version     8.2
-set vim_patchlevel  2683
+set vim_patchlevel  4324
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v
 revision            0
 
@@ -20,9 +20,9 @@ long_description    Vim is an advanced text editor that seeks to provide the\
 
 homepage            https://www.vim.org/
 
-checksums           rmd160  117ecc6a7932b76ecfe53948172f5056b6ffb028 \
-                    sha256  15f869b640a50d0a3552c2b120536892bd5626c6c1bc25d8bb24af24f81e9b66 \
-                    size    15459857
+checksums           rmd160  ca008ee7734fd1753bbc7e91a2d498a5177ae642 \
+                    sha256  a2b842f258fda87446504df911c27fa4ea54084e5112722d419a8b63b2bd8027 \
+                    size    15981311
 
 depends_lib         port:ncurses \
                     port:gettext \


### PR DESCRIPTION
#### Description

This PR:
 - updates vim to patch level 4324: needed as current vim patchlevel (2683) [has a bug when compiling with python3.10]( https://github.com/vim/vim/issues/6183)
 - refactors the python variants code in the portfile
 - adds a python3.10 variant

There is an issue with the `vim` port:
 - `sudo port install -vs ./editors/vim` [works](https://github.com/macports/macports-ports/files/8019818/success_vim8.2.4324_build_log.txt), `sudo port install -vst ./editors/vim` does not, both for the [existing patchlevel](https://github.com/macports/macports-ports/files/8019801/failure_vim8.2.2683_build_log.txt) and for the [new patchlevel](https://github.com/macports/macports-ports/files/8019811/failure_vim8.2.4324_build_log.txt) introduced in this PR. I have tried finding out is going on, I'm afraid debugging trace mode is beyond me ([failure_vim8.2.4324_main.log](https://github.com/macports/macports-ports/files/8019815/failure_vim8.2.4324_main.log) and [failure_vim8.2.4324_manual_configure_cmd_run.txt](https://github.com/macports/macports-ports/files/8019817/failure_vim8.2.4324_manual_configure_cmd_run.txt))
 - `port variants vim` lists python variants in alphabetical order rather than numeric order. I'm not sure if anything can be done about that.
 - tests fail both for patchlevels both current (2683) and updated (4324)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`? FAIL
- [ ] tried a full install with `sudo port -vst install`? FAIL
- [x] tested basic functionality of all binary files?
