### PR TITLE
vale: A syntax-aware linter for prose

### DIFF
--- a/textproc/vale/Portfile
+++ b/textproc/vale/Portfile
@@ -1,0 +1,188 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/errata-ai/vale 2.15.0 v
+checksums           ${distname}${extract.suffix} \
+                        rmd160  8cd83820ef258f46c30406dd5d7918d498bbcda9 \
+                        sha256  022f21796afe202f6b8ab23161e430f6eb0dad9982d27f4a8eef796122a3f263 \
+                        size    10035342
+
+categories          textproc
+maintainers         nomaintainer
+license             MIT BSD Apache-2
+
+description         \
+    A syntax-aware linter for prose built with speed and extensibility in mind.
+long_description    \
+    Vale is a command-line tool that brings code-like linting to prose. It's \
+    fast, and highly customizable.
+
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    496545a6307b \
+                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
+                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
+                        size    90145 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
+                    gopkg.in/neurosnap/sentences.v1 \
+                        lock    v1.0.6 \
+                        rmd160  4a415615db6586abb0a0ee5f12e38dc442f5b972 \
+                        sha256  9dcd6273b4649715b9b1ad79da93f14f613db2e7d7287071be7206fc03e5dce5 \
+                        size    5182021 \
+                    gopkg.in/check.v1 \
+                        lock    20d25e280405 \
+                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
+                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
+                        size    30360 \
+                    golang.org/x/term \
+                        lock    03fcf44c2211 \
+                        rmd160  a1b9592e95373ba617ef579a2f7015cfdc871343 \
+                        sha256  3673415a6d3d106d49b487715e151fc64245502ef547c16e8e13edb6b8f2f492 \
+                        size    14975 \
+                    golang.org/x/sys \
+                        lock    97ac67df715c \
+                        rmd160  83c8eb632907479d99c0b7f369df5c4b53ca9342 \
+                        sha256  ee550d1efab126d2079ad5b16da04e04fd387688f832a07134fb857e692b17c8 \
+                        size    1218712 \
+                    golang.org/x/net \
+                        lock    6772e930b67b \
+                        rmd160  36f15808e8d3637ec66d5ad30499f38836bc33ca \
+                        sha256  cbe102d3c83e636b911b8715e53f384a7bb82efcc1a76c6be7d599b952f0cf14 \
+                        size    1251396 \
+                    github.com/yuin/goldmark \
+                        lock    v1.4.4 \
+                        rmd160  ee19f62cfad64c8865faab73454b775c6ece918d \
+                        sha256  382c9561b609c85f0e61986b4ebc9a6b998605305a3d77dd5fc19fffb3ca0af2 \
+                        size    238003 \
+                    github.com/xo/terminfo \
+                        lock    ca9a967f8778 \
+                        rmd160  5a12122692f833350761f83b3080e9c1bb400424 \
+                        sha256  fe26be04e3e1c60163f79ea8eaf2c432ea540eaca7fd351d8c8f8514d49545fe \
+                        size    35430 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/cast \
+                        lock    v1.3.1 \
+                        rmd160  d4ab928edfe2ad8aafbc3248287b788c65ec155f \
+                        sha256  a33b9fbe9c9dd9cc2bb54f43bcd9a4b5503666c028448bc1b600d46961ffb604 \
+                        size    11103 \
+                    github.com/shogo82148/go-shuffle \
+                        lock    27e6095f230d \
+                        rmd160  934d2131cd8a5b965b8111085b6442b4e1a2eb4d \
+                        sha256  1721a56f83f105b795258ade1aeecf4ab29ba6ab546705272e2ee1cfc7a57f74 \
+                        size    3029 \
+                    github.com/rivo/uniseg \
+                        lock    v0.2.0 \
+                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
+                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
+                        size    44037 \
+                    github.com/remeh/sizedwaitgroup \
+                        lock    v1.0.0 \
+                        rmd160  284f09ac7768fda039f764409c1540f57d47b1d0 \
+                        sha256  a0aedd09f66634620066e4d5f4e0bb3ad94258af917918997b7075f22579363f \
+                        size    2679 \
+                    github.com/pterm/pterm \
+                        lock    v0.12.33 \
+                        rmd160  954d32c8b517b1986935ba77a4ba8a1df13cab0c \
+                        sha256  598eeb67eeaaf7bcc761b73486672f22f112ae585064ce98d8b47fa1ce7a846b \
+                        size    178451 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.4 \
+                        rmd160  750bec232562820a4f3ba47cd2864f4c84e7a767 \
+                        sha256  890daf262aee371899075912bab0b3107313bea32846cf796bca83ef9a1dccf5 \
+                        size    19267 \
+                    github.com/montanaflynn/stats \
+                        lock    v0.6.3 \
+                        rmd160  91bdb709e84cf969d26723ff450b7d02f30e7661 \
+                        sha256  080582f46d18ece3aefa0deaf70859e0f290797bd718721664749cf7c587e029 \
+                        size    47862 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.4.0 \
+                        rmd160  cb52c7a0d564c38b35b37301f49959522e25a553 \
+                        sha256  60a0d18f536e7e993bcc9f5490c57b7d792b95f0236a54336a547521f05a896e \
+                        size    27256 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.13 \
+                        rmd160  e177edb4dc4702ae2b23704934ff31cc6561bbd0 \
+                        sha256  dcd3ccbd956a6f53bc106b79489d0303a237c21d858d23250e3e1d7284b72b86 \
+                        size    17363 \
+                    github.com/jdkato/titlecase \
+                        lock    0158ddd948b8 \
+                        rmd160  45017ca3dd4dc08fee340284c96d95a4fec12c86 \
+                        sha256  b75ef3c7d9bec7c66a59ee346b2bdfd9214205798f96c8db2c0377d6c7ea461d \
+                        size    6602 \
+                    github.com/jdkato/regexp \
+                        lock    v0.1.0 \
+                        rmd160  83b80ae76fa907bb4834b867b0ea21fe215410d0 \
+                        sha256  4b8b3fc64a5784cb810ab965436395108fcf70027f188cb166259413264bf443 \
+                        size    469639 \
+                    github.com/jdkato/prose \
+                        lock    v1.2.1 \
+                        rmd160  0a2280edbb2ff1ad31b966eaefc69855043a4817 \
+                        sha256  bd62f138e17d7df266d013a2d7d72505c58fe23340b0fd5e736927a5de097286 \
+                        size    4572626 \
+                    github.com/gookit/color \
+                        lock    v1.4.2 \
+                        rmd160  d22a396b1d07ebb559315efa1e9555e959a75796 \
+                        sha256  267099d088b8046362007a470b2c8ad028b12873a36e6c65d34b9027c066522c \
+                        size    2177209 \
+                    github.com/gobwas/glob \
+                        lock    v0.2.3 \
+                        rmd160  1f472cf991498a8091446eb788fe85e0c5403185 \
+                        sha256  2de3694ee0ff41a96b66f9aa3eec51048e620cdd09acc8685f18c3abcd6e14ae \
+                        size    25971 \
+                    github.com/errata-ai/regexp2 \
+                        lock    v1.7.0 \
+                        rmd160  f9616c534e0682a297426ee6d8e98bb6c256f9fe \
+                        sha256  d841bc98cda9d320f096860b5a61a2185c99e8f6c34b709f41747375ede7bb0e \
+                        size    206006 \
+                    github.com/errata-ai/ini \
+                        lock    v1.63.0 \
+                        rmd160  94d158dd39a5c75acb6763329a5456f026d1779a \
+                        sha256  6e38e5835f36a0dab20f6a9b0e36b47f822f5465f529ac8462351623f92eb766 \
+                        size    30664 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/d5/tengo \
+                        lock    v2.10.0 \
+                        rmd160  cc21c9a165d0fcf957480e606aff720592dd0b08 \
+                        sha256  b152922e68ec4ffce446d046ae5a512cb1d5e1b11d62caa4ecd95845064a8de9 \
+                        size    170534 \
+                    github.com/atomicgo/cursor \
+                        lock    v0.0.1 \
+                        rmd160  38f81b9b08dad20a6e288f0890b5d6dfd7453142 \
+                        sha256  52473b72f80f9e626d5a49c526daac188fb796a25e7c2b2a5befc0d3035c0ae7 \
+                        size    6311 \
+                    github.com/MarvinJWendt/testza \
+                        lock    v0.2.10 \
+                        rmd160  5da6162eacc93748681bf95abc252762cd8f9118 \
+                        sha256  0b78d24c0aee8eb9710476b863c96d87b9ff4eabd447e4f9566e87530477016a \
+                        size    36242
+
+build.args          ./cmd/${name}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

vale: A syntax-aware linter for prose

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.3 20G415 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?