### PR TITLE
go-licenses: Reports on licenses used by a Go pkg; golang-1.0: Do not fail when pkgs conflict on prefix

### DIFF
--- a/devel/go-licenses/Portfile
+++ b/devel/go-licenses/Portfile
@@ -1,0 +1,223 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/google/go-licenses 1.0.0 v
+
+categories          devel
+maintainers         nomaintainer
+license             Apache-2 BSD MIT
+
+description         Reports on the licenses used by a Go package and its dependencies.
+long_description \
+    go-licenses analyzes the dependency tree of a Go package/binary. It can \
+    output a report on the libraries used and under what license they can be \
+    used. It can also collect all of the license documents, copyright notices \
+    and source code into a directory in order to comply with license terms on \
+    redistribution.
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  5802587291a1f523baba759167bceb316f467ba4 \
+                        sha256  3629c5108e7ce5e0f19220dcb4effd7adad9b0ae740bb12180441e527428e058 \
+                        size    53099
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    496545a6307b \
+                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
+                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
+                        size    90145 \
+                    gopkg.in/warnings.v0 \
+                        lock    v0.1.2 \
+                        rmd160  e0245ded51f41ce8051ae561d1a0b844f4b8f181 \
+                        sha256  547803dff3ec1c7adb69c411e7b3846595c3265d22a8888001661504d23bd4fb \
+                        size    3772 \
+                    gopkg.in/src-d/go-git.v4 \
+                        lock    v4.13.1 \
+                        rmd160  5fee27daad2048b683389eed98bcc313e380285e \
+                        sha256  7d778311e93226b0cf7e24febf676599e848be4b2caee1016abc20654ffc75d6 \
+                        size    434964 \
+                    gopkg.in/src-d/go-git-fixtures.v3 \
+                        lock    v3.5.0 \
+                        rmd160  cc539a6f1c735df5d31e34ae661a09a3d00b6b70 \
+                        sha256  037c29f438905932553e626423d0d5f28e01730ca6b1f5bcb16bf59087affcb7 \
+                        size    48427284 \
+                    gopkg.in/src-d/go-billy.v4 \
+                        lock    v4.3.2 \
+                        rmd160  2a253d253ea17bfdbd8765f43cc1d5f1da3c79ef \
+                        sha256  d85b42827fdd2cd1cf24163b734f8520ea8915a8df87aae7747c51ed0416f550 \
+                        size    28036 \
+                    gopkg.in/check.v1 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
+                    golang.org/x/xerrors \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
+                    golang.org/x/tools \
+                        lock    v0.1.5 \
+                        rmd160  1bbd33096e15d2084ba543ddbfd86936e5dd09cb \
+                        sha256  66907da0a219e6a27e504acc4c1c58fd9521585de0d6729a43694c950aef1670 \
+                        size    2843627 \
+                    golang.org/x/text \
+                        lock    v0.3.7 \
+                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
+                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
+                        size    8356115 \
+                    golang.org/x/term \
+                        lock    7de9c90e9dd1 \
+                        rmd160  bd573c74337fdd8e57417c03c825a315b2c208f9 \
+                        sha256  5b01bffc3bc94976e27cecbe6d9c403eefc597dc2b03ddd3ad083931c0981fa4 \
+                        size    15244 \
+                    golang.org/x/sys \
+                        lock    97ca703d548d \
+                        rmd160  62cb1461f2ec5a3e4122987ceb7372c372d6702c \
+                        sha256  6962de450bbf6c998d9db8d3323f41cea8f6e92dabf82ed5f775f17744403477 \
+                        size    1253930 \
+                    golang.org/x/net \
+                        lock    60bc85c4be6d \
+                        rmd160  6a1bf501fae3881bd457e46d247c367c7c2b2346 \
+                        sha256  f1afa9c0e0e64fb09daf3555848517d902a0612da836d04c49fa01b5960e5b2e \
+                        size    1253009 \
+                    golang.org/x/mod \
+                        lock    v0.5.0 \
+                        rmd160  6c7b3c96d3cefdca2eeea202030f5408f47abba4 \
+                        sha256  d92a2136622f2e581a7ab9eab737d51f55d174d4f331be39905d01433016c789 \
+                        size    111969 \
+                    golang.org/x/crypto \
+                        lock    32db794688a5 \
+                        rmd160  02ab581de5510ce94205e0fe5a58aacd2cd375b8 \
+                        sha256  2276178323ee1992d2e845e78ffb8fdce625ef24602b97719428fddaf9f2192f \
+                        size    1732601 \
+                    github.com/xanzy/ssh-agent \
+                        lock    v0.2.1 \
+                        rmd160  356547460413381067ab37d9a8ce904dc91e5d9b \
+                        sha256  0e439b2a0962200a2e7872fb8cfe8f9be6942aa66a89230c805aac3ddc456664 \
+                        size    7623 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
+                    github.com/src-d/gcfg \
+                        lock    v1.4.0 \
+                        rmd160  9bc031184466bc7f0c704cd98af4556061a0c370 \
+                        sha256  d94bfbb72f6219a5f24688f4b346fe08d1a00e4426d14565d40f32f76c30a77d \
+                        size    28541 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/cobra \
+                        lock    v1.3.0 \
+                        rmd160  b396e2179691a23f82eae5bb5af09fef218dadf9 \
+                        sha256  173024e7070e355d6c597b648b7096120a36aad4edba2c4b4d54fbc4d074feba \
+                        size    169548 \
+                    github.com/sergi/go-diff \
+                        lock    v1.2.0 \
+                        rmd160  0ee3ab8df694f8b9d8aeea2309da3512aa6ade66 \
+                        sha256  c01c182c57692b98bc38d787e7428c63a11338a8f1a1931427ab184bbdf59df0 \
+                        size    1333604 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.8.1 \
+                        rmd160  a33afa0fbe2e76b7a621d25bdb4bf0b964b18bb5 \
+                        sha256  1ec95b0705f5ac6ea502266b4e6bf177041b7832148a4bf090686243b0f9aa59 \
+                        size    11018 \
+                    github.com/otiai10/mint \
+                        lock    v1.3.2 \
+                        rmd160  274a71c9e46d219d2bbd884a10d5c90dc9654aaa \
+                        sha256  321c67c846f87c56aadbc6af6c8685ccd2e8ef9eb7ba7c35f5a351a55b62d9c7 \
+                        size    5981 \
+                    github.com/otiai10/copy \
+                        lock    v1.6.0 \
+                        rmd160  5c263942d87169c5c9c6d58a307dbc19e940f304 \
+                        sha256  0d2f35268fe488f5b9802b5b4487dce491cb2e3381db497bf913ade59d1864ff \
+                        size    12248 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/kr/text \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
+                    github.com/kr/pretty \
+                        lock    v0.2.0 \
+                        rmd160  45bbf0be7a3328e33186718ab12cb506c0f5a073 \
+                        sha256  35fb1f8788552fc7df2120bc06dd34e00aa3284d23c250fc1f143eef51d08586 \
+                        size    8762 \
+                    github.com/kevinburke/ssh_config \
+                        lock    01f96b0aa0cd \
+                        rmd160  c962defaa545cfeafa69e015b409607091fa81ee \
+                        sha256  d1c0dd1bc30b97aa5fbbd5092aa90acb4f456aba9cc4f1843cb6d54f1265aacc \
+                        size    17343 \
+                    github.com/jbenet/go-context \
+                        lock    d14ea06fba99 \
+                        rmd160  37097898ecea5e875655fde48f48f126e0331246 \
+                        sha256  ce27afd2576a5bc82565c8aa2ef108b1bb3c4dd80ebb4939455cab2495b74a2f \
+                        size    5943 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
+                    github.com/google/licenseclassifier \
+                        lock    3043a050f148 \
+                        rmd160  98a4ca5b767ed01112be2e2e95d7d8a041890235 \
+                        sha256  3a2cc2ce1571fb8d77568e444f7877423d84ce9da760aa5c988d67d6fd1627df \
+                        size    7058192 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.6 \
+                        rmd160  b93086d92bddc7a3b593fb637776f055c022049f \
+                        sha256  fa1ca0f00fe02f645c4ed12ef753ff6c46b6621db01e09d96599cf1fd990aebe \
+                        size    104422 \
+                    github.com/golang/glog \
+                        lock    23def4e6c14b \
+                        rmd160  b5bd9166cd1e073a035b5bbd3c4d9febf2c917a7 \
+                        sha256  2826d20759090e909ba0f8771def236ad6433fc3e44bdc28374b309efe3e57cf \
+                        size    19662 \
+                    github.com/gliderlabs/ssh \
+                        lock    v0.2.2 \
+                        rmd160  1fef7211bf32e04b3daa1f2dcfb5e56afcff6cd1 \
+                        sha256  fab13a77bd8c2ec9e8f441b81515016f2783fa348405676d9952f2ad78412ca2 \
+                        size    21484 \
+                    github.com/emirpasic/gods \
+                        lock    v1.12.0 \
+                        rmd160  5633e4a005c1e335bc00708aefebb0f475d30774 \
+                        sha256  c379f9a4fae5a2defdaa314deab1e201228e866a502afa8948117e52cf644ce2 \
+                        size    76836 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/armon/go-socks5 \
+                        lock    e75332964ef5 \
+                        rmd160  22c2f6c6cfb6fc9e445df5d6e3d7d41d96984e02 \
+                        sha256  30b0b6e33f090505354e6f86d4da39d93d9d31221d354f3166b676f4db30a387 \
+                        size    8583 \
+                    github.com/anmitsu/go-shlex \
+                        lock    648efa622239 \
+                        rmd160  2cd39571128de9ea259f8ebafc292db77bfbc33e \
+                        sha256  ce0cf5fc33466e610f1605683f2e2bcb1e8212cece926074095a80f1326ed15f \
+                        size    3862 \
+                    github.com/alcortesm/tgz \
+                        lock    9c5fe88206d7 \
+                        rmd160  8871d33b125cb1f85571855293f6b9131496aa51 \
+                        sha256  b834470efd98946b981c77fcfcfb6ac181e675a4599b5799257347e7b7ea4d04 \
+                        size    4129
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

A port that has both `gopkg.in/src-d/go-git.v4` and `gopkg.in/src-d/go-git-fixtures.v3` in its `go.vendors` would previously fail, because no `sha1_short` was given for such ports, and `src-d-go-git` is a prefix of `src-d-go-git-fixtures`. This caused the glob expression in the post-extract to match both folders, move both folders, and then fail when processing the second package.

Resolve this by only choosing the match from the glob expression that does not contain dashes in the part that matched the wildcard.

This allows building the go-licenses port, which triggers this exact situation.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.3 20G415 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?