### PR TITLE
sqlcipher: disable tcl to fix build on old macOS

### DIFF
--- a/databases/sqlcipher/Portfile
+++ b/databases/sqlcipher/Portfile
@@ -56,6 +56,10 @@ if {${subport} eq ${name}} {
                         --enable-tempstore=yes \
                         AWK=/usr/bin/awk
 
+    if {${os.major} <= 16} {
+        configure.args-prepend  --disable-tcl
+    }
+
     # search in worksrcpath for sqlcipher/sqlite3.h first -- don't pick up an installed one!
     configure.cppflags-prepend  -DSQLITE_DISABLE_INTRINSIC \
                                 -DSQLITE_ENABLE_COLUMN_METADATA \


### PR DESCRIPTION
Build on macOS 10.12 and older, will install some tcl libs to
/System/Library/Frameworks, so disable tcl in sqlcipher,
and disable sqlcipher-tools on macOS 10.12 and older.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.2 20G314 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
