### PR TITLE
libdeflate: fix install_name of dylib

### DIFF
--- a/archivers/libdeflate/Portfile
+++ b/archivers/libdeflate/Portfile
@@ -6,7 +6,7 @@ PortGroup           makefile    1.0
 
 github.setup        ebiggers libdeflate 1.10 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Heavily optimized library for DEFLATE/zlib/gzip \
                     compression and decompression
@@ -31,4 +31,6 @@ checksums           rmd160  81681b7e53369ebf4fdb11e02dcc179140290b45 \
                     sha256  5c1f75c285cd87202226f4de49985dcb75732f527eefba2b3ddd70a8865f2533 \
                     size    158379
 
-makefile.has_destdir yes
+# https://github.com/ebiggers/libdeflate/issues/167
+# https://github.com/macports/macports-ports/pull/13927#issuecomment-1058731048
+patchfiles          patch-shared_lib_ldflags-variable-fix.diff

--- a/archivers/libdeflate/files/patch-shared_lib_ldflags-variable-fix.diff
+++ b/archivers/libdeflate/files/patch-shared_lib_ldflags-variable-fix.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2022-03-07 14:11:27.000000000 -0600
++++ Makefile	2022-03-07 14:12:16.000000000 -0600
+@@ -124,7 +124,7 @@
+    SHARED_LIB         := libdeflate.$(SOVERSION).dylib
+    SHARED_LIB_SYMLINK := libdeflate.dylib
+    SHARED_LIB_CFLAGS  := -fPIC
+-   SHARED_LIB_LDFLAGS := -install_name $(SHARED_LIB)
++   SHARED_LIB_LDFLAGS := -install_name $(LIBDIR)/$(SHARED_LIB)
+ 
+ # Compiling for Android?
+ else ifneq ($(findstring -android,$(TARGET_MACHINE)),)


### PR DESCRIPTION
#### Description

Fix install_name of dylib

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?