### PR TITLE
notcurses: update to 3.0.5

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        dankamongmen notcurses 3.0.1 v
+github.setup        dankamongmen notcurses 3.0.5 v
 github.tarball_from archive
 revision            0
 
@@ -27,13 +27,13 @@ master_sites-append https://github.com/dankamongmen/${name}/releases/download/v$
 distfiles-append    ${name}-doc-${version}${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6074bb7d0559cdf4ce8da92ef6cd0b5e3d7d3e9d \
-                    sha256  32041c300e92fc0fe56c19e65d1d1e374e824c781dfcd4f959ab0dcdbb90cdb2 \
-                    size    10119898 \
+                    rmd160  b76f3ed4b3408ff68ab5fba5100a5b30ddc9779f \
+                    sha256  accb41b9bad3415017207c0992c791e4d887c505d5aa1b3be0c44456489e537d \
+                    size    10135637 \
                     ${name}-doc-${version}${extract.suffix} \
-                    rmd160  73c5cd260121b378ad9b3644f0f1e378b0a7136c \
-                    sha256  43be760c5f2f4a7b2c9a9527254cd2bbdda8ad7d6f4fc7f841a776f0ee3cdd05 \
-                    size    145503
+                    rmd160  5ac40165cdef2010446e7b5cb02299b9b12b5bb9 \
+                    sha256  2eb05c7d01e32bfcbca4d05e2e42f2492297c456c1a4ee5c9bd024f4018a275b \
+                    size    148376
 
 extract.only        ${distname}${extract.suffix}
 


### PR DESCRIPTION
#### Description

Update notcurses to v3.0.5

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

---

For `sudo port -vst install` to work correctly, it's necessary for libdeflate to have been installed per the changes in PR #13927.