### PR TITLE
gitlab-runner: switch to openmaintainer only

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -7,7 +7,7 @@ go.setup            gitlab.com/gitlab-org/gitlab-runner 14.5.1 v
 
 categories          devel
 platforms           darwin
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         nomaintainer
 license             MIT
 
 description         GitLab Runner


### PR DESCRIPTION
I will no longer be maintaining the `gitlab-runner` port.
