### PR TITLE
gdb: update to 11.2, provide patch to avoid lock-ups

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -90,6 +90,14 @@ post-destroot {
     }
 }
 
+# These patches should be removed once they get merged into mainstream.
+# Fingers crossed they get merged in for gdb 11.3
+# https://sourceware.org/bugzilla/show_bug.cgi?id=24069
+platform darwin {
+    patchfiles-append \
+        patch-darwin-nat.c.diff
+}
+
 set pythons_suffixes {27 35 36 37 38 39 310}
 
 set pythons_ports {}

--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            gdb
-version         11.1
+version         11.2
 revision        0
 categories      devel
 license         GPL-3+
@@ -33,9 +33,9 @@ supported_archs x86_64 i386
 
 master_sites    gnu
 
-checksums       rmd160  cdc4f037e9513d3502963ff51ed4ac1172aa47fe \
-                sha256  cc2903474e965a43d09c3b263952d48ced39dd22ce2d01968f3aa181335fcb9c \
-                size    37854893
+checksums       rmd160  fa6438443a42a5bb06ef61dd3b31f92bd1ea2676 \
+                sha256  b558b66084835e43b6361f60d60d314c487447419cdf53adf83a87020c367290 \
+                size    37839607
 
 # these dependencies are listed under depends_lib rather than depends_build
 # because gdb will link with libraries they provide if installed.

--- a/devel/gdb/files/patch-darwin-nat.c.diff
+++ b/devel/gdb/files/patch-darwin-nat.c.diff
@@ -1,0 +1,36 @@
+diff --git a/gdb/darwin-nat.c b/gdb/darwin-nat.c
+index 6388567..c20db68 100644
+--- gdb/darwin-nat.c
++++ gdb/darwin-nat.c
+@@ -1096,18 +1096,28 @@ darwin_nat_target::decode_message (mach_msg_header_t *hdr,
+ 		{
+ 		  status->kind = TARGET_WAITKIND_EXITED;
+ 		  status->value.integer = WEXITSTATUS (wstatus);
++          inferior_debug (4, _("darwin_wait: pid=%d exit, status=0x%x\n"),
++                  res_pid, wstatus);
++        }
++          else if (WIFSTOPPED (wstatus))
++        {
++            status->kind = TARGET_WAITKIND_IGNORE;
++            inferior_debug (4, _("darwin_wait: pid %d received WIFSTOPPED\n"), res_pid);
++            return minus_one_ptid;
+ 		}
+ 	      else
+ 		{
+ 		  status->kind = TARGET_WAITKIND_SIGNALLED;
+ 		  status->value.sig = gdb_signal_from_host (WTERMSIG (wstatus));
++          inferior_debug (4, _("darwin_wait: pid=%d received signal %d\n"),
++                  res_pid, status->value.sig);
+ 		}
+ 
+-	      inferior_debug (4, _("darwin_wait: pid=%d exit, status=0x%x\n"),
+-			      res_pid, wstatus);
++	      //inferior_debug (4, _("darwin_wait: pid=%d exit, status=0x%x\n"),
++			 //     res_pid, wstatus);
+ 
+ 	      /* Looks necessary on Leopard and harmless...  */
+-	      wait4 (inf->pid, &wstatus, 0, NULL);
++	      // wait4 (inf->pid, &wstatus, 0, NULL);
+ 
+ 	      return ptid_t (inf->pid);
+ 	    }


### PR DESCRIPTION
#### Description

Upgrade GDB to version 11.2

Workaround for this bug https://sourceware.org/bugzilla/show_bug.cgi?id=24069 which causes GDB to hang when running a binary.
While the root cause is still unknown and the patch included here is only a workaround, the patch has reportedly a near-100% success rate in preventing lock-ups so it's still an improvement on the status quo.

Let's keep an eye on the bug and revert this commit once one of 2 things
happen:
  - this patch gets merged into master
  - the root cause is debugged and the proper fix is shipped from upstream

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
