### PR TITLE
nodejs16, nodejs17: upgrade python dependency from 3.9 to 3.10

### DIFF
--- a/devel/nodejs16/Portfile
+++ b/devel/nodejs16/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs16
 version                 16.14.0
-revision                0
+revision                1
 
 categories              devel net
 platforms               darwin
@@ -40,7 +40,7 @@ distname                node-v${version}
 
 depends_build-append    port:pkgconfig
 
-set py_ver              3.9
+set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 depends_lib-append      port:python${py_ver_nodot} \

--- a/devel/nodejs17/Portfile
+++ b/devel/nodejs17/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs17
 version                 17.6.0
-revision                0
+revision                1
 
 categories              devel net
 platforms               darwin
@@ -40,7 +40,7 @@ distname                node-v${version}
 
 depends_build-append    port:pkgconfig
 
-set py_ver              3.9
+set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 depends_lib-append      port:python${py_ver_nodot} \


### PR DESCRIPTION
#### Description

nodejs16, nodejs17: upgrade python dependency from 3.9 to 3.10, bump version to 16.4.0
EDIT: it appears nodejs16 was upgraded to 16.4.0 since this PR was opened, I removed the duplicate commit from this PR

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? No tests available
- [x] tried a full install with `sudo port -vst install`? NOTE: I had to rerun the build several times as "too many files open" seems to be a recurring issue
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
