### PR TITLE
protozero: Update to version 1.7.1

### DIFF
--- a/devel/protozero/Portfile
+++ b/devel/protozero/Portfile
@@ -4,8 +4,9 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        mapbox protozero 1.7.0 v
+github.setup        mapbox protozero 1.7.1 v
 github.tarball_from archive
+revision            0
 
 categories          devel
 platforms           darwin
@@ -24,11 +25,21 @@ long_description    Low-level: this is designed to be a building block \
                     generated with the Google Protobufs protoc \
                     program.
 
-checksums           rmd160  d1f420730e65008ec2c0f394e5a1383a0997dc16 \
-                    sha256  beffbdfab060854fd770178a8db9c028b5b6ee4a059a2fed82c46390a85f3f31 \
-                    size    1114856
+checksums           rmd160  291b36bd4139c30caa08322abd084abaced6f518 \
+                    sha256  27e0017d5b3ba06d646a3ec6391d5ccc8500db821be480aefd2e4ddc3de5ff99 \
+                    size    1123468
 
 compiler.cxx_standard 2011
 
 test.run            yes
 test.cmd            ctest --output-on-failure
+
+configure.args-append \
+                    -DWERROR:BOOL=OFF
+
+variant protobuf description {Use protobuf library to include writer unit test} {
+
+    depends_build-append \
+                        port:protobuf3-cpp
+
+}


### PR DESCRIPTION
#### Description

Re: https://trac.macports.org/ticket/64629

This is a header-only library.

One of the unit tests uses the [Protobuf](https://developers.google.com/protocol-buffers/)
library if it is found.  I've added a `protobuf` variant to allow that test to be run.  Other than that,
the Protobuf library is not required.

I have disabled treating warnings as errors to handle the reported issue.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.6.3 20G415 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
