### PR TITLE
mod_tile: Correct path to `osm2pgsql-lua` executable

### DIFF
--- a/gis/mod_tile/Portfile
+++ b/gis/mod_tile/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 
 github.setup        openstreetmap mod_tile 0.5
 github.tarball_from archive
-revision            1
+revision            2
 
 categories-append   gis
 platforms           darwin

--- a/gis/mod_tile/files/openstreetmap-tiles-update-expire.diff
+++ b/gis/mod_tile/files/openstreetmap-tiles-update-expire.diff
@@ -1,5 +1,5 @@
---- openstreetmap-tiles-update-expire.orig	2021-09-16 18:07:30.000000000 +0100
-+++ openstreetmap-tiles-update-expire	2021-09-22 19:07:57.000000000 +0100
+--- openstreetmap-tiles-update-expire.orig	2022-01-10 19:07:49.000000000 +0000
++++ openstreetmap-tiles-update-expire	2022-01-10 19:09:24.000000000 +0000
 @@ -4,13 +4,33 @@
  
  #*************************************************************************
@@ -24,7 +24,7 @@
 +#------------------------------------------------------------------------------
 +ACCOUNT="${GIS_USER:-nobody}"
 +OSMOSIS_BIN=${PREFIX}/bin/osmosis
-+OSM2PGSQL_BIN=${PREFIX}/bin/osm2pgsql
++OSM2PGSQL_BIN=${PREFIX}/bin/osm2pgsql-lua
 +OSM2PGSQL_RAM="${OSM2PGSQL_RAM:-4096}"
 +OSM2PGSQL_CPUS="${OSM2PGSQL_CPUS:-4}"
 +DBNAME="${GIS_DB:-gis}"


### PR DESCRIPTION
#### Description

The patched script refers to the wrong variant of the `osm2pgsql` binary.  The `lua` variant of `osm2pgsql` installs the binary as `osm2pgsql-lua`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 11.6.3 20G415 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
