### PR TITLE
cbor, cbor2: add python3.10 variant

### DIFF
--- a/python/py-cbor/Portfile
+++ b/python/py-cbor/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  27191bbc42751d6a305f8ce7f70748f7541e2e9e \
                     sha256  13225a262ddf5615cbd9fd55a76a0d53069d18b07d2e9f19c39e6acb8609bbb6 \
                     size    20096
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-cbor2/Portfile
+++ b/python/py-cbor2/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  3085abd98292c515ffb75e5ec246ba56f3f29f40 \
                     sha256  a33aa2e5534fd74401ac95686886e655e3b2ce6383b3f958199b6e70a87c94bf \
                     size    81467
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

cbor, cbor2: add python3.10 variant
Note that cbor's project homepage is dead and that neither cbor (supports python2.7, 3.4, 3.5) nor cbor2 (supports python3.6+) explicitly support python3.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
