### PR TITLE
py-hkdf: add python 3.10 variant

### DIFF
--- a/python/py-hkdf/Portfile
+++ b/python/py-hkdf/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  655173ded611e8c58a3d05225bc18aa2c6896bd7 \
                     sha256  622a31c634bc185581530a4b44ffb731ed208acf4614f9c795bdd70e77991dca \
                     size    3959
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-hkdf: add python 3.10 variant

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? No tests found
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
