### PR TITLE
py-pypng: add python3.10 subport

### DIFF
--- a/python/py-pypng/Portfile
+++ b/python/py-pypng/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  cbc12a8c877ad7161ba3cf541dfe967bd73c2995 \
                     sha256  1032833440c91bafee38a42c38c02d00431b24c42927feb3e63b104d8550170b \
                     size    649538
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-pypng: add python3.10 subport
Note that pypng supports "python3.5 or any compatible higher version" but doesn't explicitly support pyhon3.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? No tests found
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
