### PR TITLE
python-snappy: add python3.10 subport

### DIFF
--- a/python/py-python-snappy/Portfile
+++ b/python/py-python-snappy/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  0cb60f12d4246798cbcb7eeff3052b8a1963077a \
                     sha256  168a98d3f597b633cfeeae7fe1c78a8dfd81f018b866cf7ce9e4c56086af891a \
                     size    21344
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

python-snappy: add python3.10 subport
Note that snappy "Supports Python 2.7 and Python 3"  but does not explicitly support python3.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? no tests found
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
