### PR TITLE
py-pytrie: add python3.10 subport

### DIFF
--- a/python/py-pytrie/Portfile
+++ b/python/py-pytrie/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  6e7f2877c6c199bbca0017604900f108d20497f6 \
                     sha256  8f4488f402d3465993fb6b6efa09866849ed8cda7903b50647b7d0342b805379 \
                     size    95139
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-pytrie: add python3.10 subport
Note that pytrie supports python3 but does not explicitly support python3.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
