### PR TITLE
py-txtorcon: add python3.10 subport

### DIFF
--- a/python/py-txtorcon/Portfile
+++ b/python/py-txtorcon/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  bfe72404f5a649addd8b60d0fafe92e1e99dc25f \
                     sha256  122cd081786396f57718adda1c1a5eb01b8e9a4832fcd140918b45c10359377a \
                     size    306139
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-txtorcon: add python3.10 subport
Note that py-txtorcon supports python3.5+, but does not explicitly support python3.10

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? no tests found
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
