### PR TITLE
py-u-msgpack-python: add python3.10 subport

### DIFF
--- a/python/py-u-msgpack-python/Portfile
+++ b/python/py-u-msgpack-python/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  b5a70fb41922b391cc6db4a48ebc0c99515504cf \
                     sha256  b7e7d433cab77171a4c752875d91836f3040306bab5063fb6dbe11f64ea69551 \
                     size    20631
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-u-msgpack-python: add python3.10 subport
Note that py-u-msgpack-python officially supports python3, but does not explicitly support python3.10

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? No tests found
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
