### PR TITLE
swi-prolog: Updated to version 8.4.2

### DIFF
--- a/lang/swi-prolog/Portfile
+++ b/lang/swi-prolog/Portfile
@@ -6,14 +6,14 @@ PortGroup           cmake 1.1
 name                swi-prolog
 conflicts           swi-prolog-devel
 epoch               20051223
-version             8.4.1
+version             8.4.2
 revision            0
 
 categories          lang
 platforms           darwin
 universal_variant   no
 license             BSD
-maintainers         {cwi.nl:J.Wielemaker @JanWielemaker} openmaintainer
+maintainers         {swi-prolog.org:jan @JanWielemaker} openmaintainer
 
 description         SWI-Prolog compiler plus extra packages (stable version)
 long_description    ISO/Edinburgh-style Prolog compiler including modules, \
@@ -32,14 +32,14 @@ master_sites        https://www.swi-prolog.org/download/stable/src/
 distname            swipl-${version}
 dist_subdir         swi-prolog
 
-checksums           rmd160  b82405b56ce650774147a8bc1e8b5e78b7f54eeb \
-                    sha256  30bb6542b7767e47b94bd92e8e8a7d7a8a000061044046edf45fc864841b69c4 \
-                    size    11386908
+checksums           rmd160  e571fc6525e08bf87367fed2cc1006d131de28c2 \
+                    sha256  be21bd3d6d1c9f3e9b0d8947ca6f3f5fd56922a3819cae03251728f3e1a6f389 \
+                    size    11396705
 
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:db53 \
+depends_lib-append  port:db62 \
                     port:gmp \
                     port:gperftools \
                     path:include/turbojpeg.h:libjpeg-turbo \


### PR DESCRIPTION
#### Description

Also updated BerkeleyDB dependency to db62 and maintainer email.   

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
