### PR TITLE
auto-multiple-choice: update to version 1.5.1

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -27,26 +27,26 @@ subport auto-multiple-choice-devel {}
 
 if {${subport} eq ${name}} {
     # release
-    set amc.version.main        1.5.0
-    set amc.version.secondary   1-g7ad0c6c6
-    checksums               rmd160  eec8abdce3b026cdbb4e721d95aeb6037924148d \
-                            sha256  28c1d9ed2ff0b8fa9b8c2e0a9a28d405dbae3121af2bf486624ad5ca546069ff \
-                            size    11190366
+    set amc.version.main        1.5.1
+    version                 ${amc.version.main}
+    checksums               rmd160  e7c260b0ff2f93e70a2e27ec7a33e68c89622805 \
+                            sha256  329b2a0c8f9ad2a8219865acc79ac0441ef7c7179c19b1cb4795fb2186a4760e \
+                            size    11251717
 
     conflicts               auto-multiple-choice-devel
 
 } else {
     # devel
-    set amc.version.main        1.5.0
-    set amc.version.secondary   3-g3f13eaba
-    checksums               rmd160  a340e46fd9ca22ebc27fd867d2641ca4c3da1819 \
-                            sha256  5a18f33bf1155ce2fd85aad75c408122f80fab06980244ae3412773f461bdb58 \
-                            size    11190764
+    set amc.version.main        1.5.1
+    set amc.version.secondary   45-g9d9d622b
+    version                 ${amc.version.main}-${amc.version.secondary}
+    checksums               rmd160  8475cc9834ca61cb8c4b0b6b82c7770ec2698600 \
+                            sha256  0cc0c6c2de0fa4f59b38a9cbcfbd0b2b37ca88c88c427626e7cc729ad2d6835a \
+                            size    12878136
 
     conflicts               auto-multiple-choice
 }
 
-version                 ${amc.version.main}-${amc.version.secondary}
 
 set opencv_ver          4
 depends_lib-append      path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}


### PR DESCRIPTION
auto-multiple-choice: update to version 1.5.1
auto-multiple-choice-devel : update to version 1.5.1-45-g9d9d622b

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2 21D49
Xcode 13.2 13C90 
MacPorts 2.7.1

macOS 10.11.6 (MacPorts 2.7.1, Xcode 8.2.1)
macOS 10.10.5 (MacPorts 2.7.1, Xcode 7.2.1)
macOS 10.9.5 (MacPorts 2.7.1, Xcode 6.2)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
