### PR TITLE
fluent-bit: update to 1.8.12

### DIFF
--- a/sysutils/fluent-bit/Portfile
+++ b/sysutils/fluent-bit/Portfile
@@ -11,10 +11,9 @@ PortGroup           legacysupport               1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 name                fluent-bit
-version             1.8.11
+version             1.8.12
 revision            0
 categories          sysutils
-platforms           darwin
 license             Apache-2
 
 homepage            https://fluentbit.io
@@ -35,9 +34,14 @@ maintainers         {l2dy @l2dy} \
 set branch          [join [lrange [split ${version} .] 0 1] .]
 master_sites        ${homepage}/releases/${branch}/
 
-checksums           rmd160  f246c6478a6a9561207c1286d3a63bf489bd825c \
-                    sha256  8dc5f2423e3357ffafb064d8e941fe842781cbd656dc1ffaa844fbc0d2f82462 \
-                    size    14811466
+checksums           rmd160  b49fa3956d67a7da292c93adc77e8785263c8aea \
+                    sha256  97bc8f2bc2f9d443c08e57ddf7863cac5549571e7c96c32c482a075bbd219d86 \
+                    size    14827047
+
+if {${os.platform} eq "darwin" && ${configure.build_arch} eq "arm64"} {
+    patchfiles      patch-monkey-remove-malloc-h.diff \
+                    patch-monkey-flib_libco-memalign.diff
+}
 
 # /usr/bin/ranlib: unknown option character `n' in: -no_warning_for_no_symbols
 compiler.blacklist-append   {clang < 700}

--- a/sysutils/fluent-bit/files/patch-monkey-flib_libco-memalign.diff
+++ b/sysutils/fluent-bit/files/patch-monkey-flib_libco-memalign.diff
@@ -1,0 +1,15 @@
+--- ./lib/monkey/deps/flb_libco/aarch64.c.orig	2022-02-10 15:21:51.000000000 -0500
++++ ./lib/monkey/deps/flb_libco/aarch64.c	2022-02-10 15:22:11.000000000 -0500
+@@ -68,12 +68,8 @@
+ {
+    size = (size + 1023) & ~1023;
+    cothread_t handle = 0;
+-#if HAVE_POSIX_MEMALIGN >= 1
+    if (posix_memalign(&handle, 1024, size + 512) < 0)
+       return 0;
+-#else
+-   handle = memalign(1024, size + 512);
+-#endif
+ 
+    if (!handle)
+       return handle;

--- a/sysutils/fluent-bit/files/patch-monkey-remove-malloc-h.diff
+++ b/sysutils/fluent-bit/files/patch-monkey-remove-malloc-h.diff
@@ -1,0 +1,13 @@
+--- ./lib/monkey/deps/flb_libco/aarch64.c	2021-12-11 00:09:25.000000000 -0500
++++ ./lib/monkey/deps/flb_libco/aarch64.c	2021-12-11 00:09:34.000000000 -0500
+@@ -12,10 +12,6 @@
+ #include <string.h>
+ #include <stdint.h>
+ 
+-#ifndef IOS
+-#include <malloc.h>
+-#endif
+-
+ #ifdef __cplusplus
+ extern "C" {
+ #endif


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2 21D49 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
