### PR TITLE
*-w64-mingw32-binutils: Update to 2.38

### DIFF
--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -7,10 +7,13 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.37
+crossbinutils.setup ${mingw_target} 2.38
 revision            0
 
 maintainers         {mojca @mojca} openmaintainer
+
+# Upstream patch remove binutils 2.39
+patchfiles-append   patch-dlltool-fix.diff
 
 configure.args-append \
                     --disable-multilib \

--- a/cross/i686-w64-mingw32-binutils/files/patch-dlltool-fix.diff
+++ b/cross/i686-w64-mingw32-binutils/files/patch-dlltool-fix.diff
@@ -1,0 +1,21 @@
+X-Git-Url: https://sourceware.org/git/?p=binutils-gdb.git;a=blobdiff_plain;f=binutils%2Fdlltool.c;h=89871510b459a78ba1076368e3752c677f8daaf6;hp=d95bf3f5470b999fa3b30bc887791859f48d81d1;hb=d65c0ddddd85645cab6f11fd711d21638a74489f;hpb=a2757c4ed693cef4ecc4dcdcb2518353eb6b3c3f
+
+diff --git binutils/dlltool.c binutils/dlltool.c
+index d95bf3f5470..89871510b45 100644
+--- binutils/dlltool.c
++++ binutils/dlltool.c
+@@ -3992,10 +3992,11 @@ main (int ac, char **av)
+   if (tmp_prefix == NULL)
+     {
+       /* If possible use a deterministic prefix.  */
+-      if (dll_name)
++      if (imp_name || delayimp_name)
+         {
+-          tmp_prefix = xmalloc (strlen (dll_name) + 2);
+-          sprintf (tmp_prefix, "%s_", dll_name);
++          const char *input = imp_name ? imp_name : delayimp_name;
++          tmp_prefix = xmalloc (strlen (input) + 2);
++          sprintf (tmp_prefix, "%s_", input);
+           for (i = 0; tmp_prefix[i]; i++)
+             if (!ISALNUM (tmp_prefix[i]))
+               tmp_prefix[i] = '_';

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -7,10 +7,13 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.37
+crossbinutils.setup ${mingw_target} 2.38
 revision            0
 
 maintainers         {mojca @mojca} openmaintainer
+
+# Upstream patch remove binutils 2.39
+patchfiles-append   patch-dlltool-fix.diff
 
 configure.args-append \
                     --disable-multilib \

--- a/cross/x86_64-w64-mingw32-binutils/files/patch-dlltool-fix.diff
+++ b/cross/x86_64-w64-mingw32-binutils/files/patch-dlltool-fix.diff
@@ -1,0 +1,21 @@
+X-Git-Url: https://sourceware.org/git/?p=binutils-gdb.git;a=blobdiff_plain;f=binutils%2Fdlltool.c;h=89871510b459a78ba1076368e3752c677f8daaf6;hp=d95bf3f5470b999fa3b30bc887791859f48d81d1;hb=d65c0ddddd85645cab6f11fd711d21638a74489f;hpb=a2757c4ed693cef4ecc4dcdcb2518353eb6b3c3f
+
+diff --git binutils/dlltool.c binutils/dlltool.c
+index d95bf3f5470..89871510b45 100644
+--- binutils/dlltool.c
++++ binutils/dlltool.c
+@@ -3992,10 +3992,11 @@ main (int ac, char **av)
+   if (tmp_prefix == NULL)
+     {
+       /* If possible use a deterministic prefix.  */
+-      if (dll_name)
++      if (imp_name || delayimp_name)
+         {
+-          tmp_prefix = xmalloc (strlen (dll_name) + 2);
+-          sprintf (tmp_prefix, "%s_", dll_name);
++          const char *input = imp_name ? imp_name : delayimp_name;
++          tmp_prefix = xmalloc (strlen (input) + 2);
++          sprintf (tmp_prefix, "%s_", input);
+           for (i = 0; tmp_prefix[i]; i++)
+             if (!ISALNUM (tmp_prefix[i]))
+               tmp_prefix[i] = '_';


### PR DESCRIPTION
#### Description
Update `crossbinutils-1.0.tcl`, `i686-w64-mingw32-binutils` & `x86_64-w64-mingw32-binutils`

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] Update

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
