### PR TITLE
notcurses: update to 3.0.6

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        dankamongmen notcurses 3.0.5 v
+github.setup        dankamongmen notcurses 3.0.6 v
 github.tarball_from archive
 revision            0
 
@@ -27,13 +27,13 @@ master_sites-append https://github.com/dankamongmen/${name}/releases/download/v$
 distfiles-append    ${name}-doc-${version}${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b76f3ed4b3408ff68ab5fba5100a5b30ddc9779f \
-                    sha256  accb41b9bad3415017207c0992c791e4d887c505d5aa1b3be0c44456489e537d \
-                    size    10135637 \
+                    rmd160  6fc78437d184e92b53532b767e83e1c92d75a06e \
+                    sha256  2113bed52248b048874bceb99f10985ae46019de818fce5cda2a8756b013448b \
+                    size    10146108 \
                     ${name}-doc-${version}${extract.suffix} \
-                    rmd160  5ac40165cdef2010446e7b5cb02299b9b12b5bb9 \
-                    sha256  2eb05c7d01e32bfcbca4d05e2e42f2492297c456c1a4ee5c9bd024f4018a275b \
-                    size    148376
+                    rmd160  5a90f10247a00bb5fcf7bad891b3d28059947938 \
+                    sha256  1cd39b9258bf837e462d6816f48620274ec8ba31663429b3959ef3d4f0eb711d \
+                    size    149044
 
 extract.only        ${distname}${extract.suffix}
 


### PR DESCRIPTION
#### Description

Update notcurses to v3.0.6

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?