### PR TITLE
lanHEP: fix compiler selection and require C99

### DIFF
--- a/science/lanHEP/Portfile
+++ b/science/lanHEP/Portfile
@@ -39,12 +39,12 @@ worksrcdir          lanhep${short_version}
 
 use_configure       no
 
-compilers.choose    fc
-compilers.setup     require_fortran
+compiler.require_fortran yes
+compiler.c_standard 1999
 
 pre-build {
     build.args      CC=${configure.cc} \
-                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                    CFLAGS="${configure.cflags} -std=c99 [get_canonical_archflags cc]" \
                     LD=${configure.cc} \
                     LOPT="${configure.ldflags} [get_canonical_archflags ld]" \
                     FC=${configure.fc} \


### PR DESCRIPTION
#### Description

Tested locally through build.

Closes: https://trac.macports.org/ticket/64576

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trxc ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
