### PR TITLE
py-pyqrcode: add python3.10 subport

### DIFF
--- a/python/py-pyqrcode/Portfile
+++ b/python/py-pyqrcode/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  1d90520ec82a029d5ec74229d1eeed5cf8131241 \
 
 python.rootname     PyQRCode
 
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

py-pyqrcode: add python3.10 subport

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? No tests found
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
