### PR TITLE
lagrange: update to 1.10.5

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,20 +9,20 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.10.4 v
+github.setup        skyjake lagrange 1.10.5 v
 revision            0
 github.tarball_from releases
 categories          net gemini
 platforms           darwin
 license             BSD
-maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 
 description         A Beautiful Gemini Client
 long_description    ${description}
 
-checksums           rmd160  9b3f5a4fad117fe79e79c8814d16f47286563796 \
-                    sha256  59df3a8a298358a3aa8463faf04c2c2c45cb634483ec69fc8f6e459dd220934a \
-                    size    8667290
+checksums           rmd160  2d2678736749a821e617a3356b272676ee129bad \
+                    sha256  1ed32cacd3ac779814adb47be669e9bd92d4407b223c3d8e59831a31816f35ce \
+                    size    8670258
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
