### PR TITLE
tiptop: update to 0.1.3

### DIFF
--- a/python/py-textual/Portfile
+++ b/python/py-textual/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-textual
-version             0.1.12
+version             0.1.15
 revision            0
 
 homepage            https://github.com/willmcgugan/textual
@@ -28,16 +28,15 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 supported_archs     noarch
 
-checksums           rmd160  e22bb60a4088eee2f9101c107392d1ff3914b3c9 \
-                    sha256  fa70b9f2fe43819afeea64dff355aee1610e1d55e9915df1cef5b0d6f86cb20d \
-                    size    61429
+checksums           rmd160  9247cfcf8ccf097863e61b10299e45fb345fc8d8 \
+                    sha256  61367cb7cf0dc0e68d3e41c54916d8170f57f50a4705bd407a9feb479873146e \
+                    size    64671
 
 python.versions     39 310
 python.pep517       yes
 python.pep517_backend   poetry
 
 if {${name} ne ${subport}} {
-
     depends_build-append    port:poetry
 
     depends_lib-append      port:py${python.version}-rich \

--- a/sysutils/tiptop/Portfile
+++ b/sysutils/tiptop/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           python  1.0
 
-github.setup        nschloe tiptop 0.0.16 v
+github.setup        nschloe tiptop 0.1.3 v
 github.tarball_from archive
 revision            0
 
@@ -21,12 +21,13 @@ license             MIT
 categories          sysutils
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  a4ae261c51af8ebb5b736c6c2cee39a8658837ad \
-                    sha256  73f8a4367f05acc90a118554bfd5bfd9b645a30b1de4985740b1cf6a1a6486c2 \
-                    size    14932
+checksums           rmd160  562c8b0084cb93b87d28300a10936c7a619e7ada \
+                    sha256  14032fcb4523e42669e7e3457712d083f13f0e62b0b0000c82bdb7e759708f92 \
+                    size    15028
 
-python.default_version      39
-python.pep517               yes
+python.default_version  310
+python.pep517           yes
+python.pep517_backend   flit
 
 depends_run-append  port:py${python.version}-cpuinfo \
                     port:py${python.version}-distro \


### PR DESCRIPTION
#### Description
- update to latest upstream version, switch to Python 3.10
- update `py-textual` dependency to latest version


###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
