### PR TITLE
imlib2: disable SVG support on 10.6 and earlier

### DIFF
--- a/graphics/imlib2/Portfile
+++ b/graphics/imlib2/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 
 # for strndup
 legacysupport.newest_darwin_requires_legacy 10
@@ -38,7 +38,6 @@ depends_lib         port:bzip2 \
                     port:libid3tag \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
-                    port:librsvg \
                     port:tiff \
                     port:webp \
                     port:xorg-libsm \
@@ -51,6 +50,13 @@ post-patch {
 }
 
 configure.args      --disable-amd64
+
+# New-enough librsvg is not available on 10.6 and earlier (requires Rust)
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    configure.args-append  --without-svg
+} else {
+    depends_lib-append path:lib/pkgconfig/librsvg-2.0.pc:librsvg
+}
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

imlib2 1.8.0 requires a new-ish librsvg, which is currently not available on 10.6 and earlier due to the Rust requirement. See a failing build here:

https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/80405

So pull in librsvg only on 10.7 and later. In the near future we should be able to support 10.6 but this will require some changes to the librsvg and rust ports.

Update: Changing the logic to support 10.7+
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
