### PR TITLE
py-gitpython: update to 3.1.26

### DIFF
--- a/python/py-gitpython/Portfile
+++ b/python/py-gitpython/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        gitpython-developers GitPython 3.1.14
+github.setup        gitpython-developers GitPython 3.1.26
 name                py-gitpython
 revision            0
 
@@ -18,11 +18,11 @@ long_description    GitPython provides object model access to your git \
                     repository. Once you have created a repository object, you \
                     can traverse it to find parent commit(s), trees, blobs, etc.
 
-checksums           rmd160  73ddde7f2b63737ea58bbdca58df09e19045d050 \
-                    sha256  9267df553ae8735db91e24a2058b915387c07f85c556552477f54bb6abf64963 \
-                    size    449261
+checksums           rmd160  fa3f9b45475caa3f0c4142d8836df1bbf5a2a720 \
+                    sha256  37e3104b6dd89a830e9ac9f7dfa0a89723c325b04dca768cbb58738a27dabb98 \
+                    size    469774
 
-python.versions     27 36 37 38 39 310
+python.versions     27 37 38 39 310
 
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {


### PR DESCRIPTION
Drop Python 3.6 subport; unsupported as of 3.1.23

#### Description
https://gitpython.readthedocs.io/en/stable/changes.html
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7
Python 3.10.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
Enabling tests is not trivial. See https://github.com/gitpython-developers/GitPython/issues/914
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
