### PR TITLE
libcxx: bootstrap with +emulated_tls on 10.6

### DIFF
--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -1,13 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               active_variants 1.1
 
 name                    libcxx
 epoch                   1
 version                 5.0.1
-revision                4
+revision                5
 categories              lang
 platforms               darwin
 license                 MIT NCSA
@@ -71,7 +70,7 @@ platform darwin {
                     # The Tiger SDK has an u after the version number,
                     set sdk_name MacOSX10.4u.sdk
                 } else {
-                    set sdk_name MacOSX[join [lrange [split ${macosx_version} .] 0 1] .].sdk
+                    set sdk_name MacOSX${macos_version_major}.sdk
                 }
                 lappend dirs ${developer_dir}/SDKs/${sdk_name}
             }
@@ -94,58 +93,17 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
         configure.universal_archs i386 x86_64
     }
 
+    # Use clang-11-bootstrap as bootstrap compiler
+    depends_build-append port:clang-11-bootstrap
+    depends_skip_archcheck-append \
+                        port:clang-11-bootstrap
+    configure.cc        ${prefix}/libexec/clang-11-bootstrap/bin/clang
+    configure.cxx       ${prefix}/libexec/clang-11-bootstrap/bin/clang++
+
     if {${os.major} < 11} {
         variant emulated_tls description {build libcxxabi and libcxx with support for emulated thread_local storage} {}
 
-        # only selected clang versions support emulated_tls, and the emulated_tls variant
-        # needs to be enabled to build libcxx with emulated_tls support
-        set emutls_clangs [list]
-        foreach clang_c ${compiler.fallback} {
-            if {[string match macports-clang-* $clang_c]} {
-                # Extract version number from macports clang compiler name
-                set clang_v [lindex [split $clang_c -] 2]
-                if {${clang_v} >= 5.0 && [file exists ${prefix}/bin/clang-mp-${clang_v}]
-                        && [active_variants clang-${clang_v} emulated_tls]} {
-                    ui_debug "Adding ${clang_c} to list of compilers supporting emulated_tls"
-                    lappend emutls_clangs ${clang_c}
-                }
-            }
-        }
-        if {[llength $emutls_clangs] > 0} {
-            default_variants-append +emulated_tls
-        } else {
-            if {![info exists registry_open]} {
-                registry::open [file join ${registry.path} registry registry.db]
-                set registry_open yes
-            }
-            foreach ent [registry::entry search name $name version $version revision $revision] {
-                if {[string match *+emulated_tls* [$ent variants]]} {
-                    # this version of the port is already installed with +emulated_tls, so keep defaulting to it
-                    default_variants-append +emulated_tls
-                    break
-                }
-            }
-        }
-        if {[variant_isset emulated_tls]} {
-            compiler.whitelist-prepend [lindex $emutls_clangs end]
-        }
-
-    }
-
-    compiler.blacklist *gcc* {clang < 500}
-
-    # clang 3.5 and newer are conditionally blacklisted to prevent dependency cycles
-    foreach clang_c ${compiler.fallback} {
-        if {[string match macports-clang-* $clang_c]} {
-            # Extract version number from macports clang compiler name
-            set clang_v [lindex [split $clang_c -] 2]
-            if { ${clang_v} >= 3.5 } {
-                if {![file exists ${prefix}/bin/clang-mp-${clang_v}]} {
-                    ui_debug "Adding ${clang_c} to compiler blacklist"
-                    compiler.blacklist-append ${clang_c}
-                }
-            }
-        }
+        default_variants-append +emulated_tls
     }
 
     post-extract {
@@ -158,6 +116,9 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
             # cmake doesn't include this for darwin builds, so nuke it here as well
             # however, this file is essential for emulated-tls to function
             delete ${libcxxabi_worksrcpath}/src/cxa_thread_atexit.cpp
+        } else {
+            require_active_variants \
+                    port:clang-11-bootstrap emulated_tls
         }
 
         file mkdir ${workpath}/build
@@ -247,19 +208,6 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
         system -W ${destroot}${roots_path}/${root_name} "tar czf ../${root_name}.tgz ."
         delete ${destroot}${roots_path}/${root_name}
     }
-
-    if {![variant_isset emulated_tls] && ${os.major} < 11} {
-    notes "
-    The libcxx you have installed is functional but does not have thread_local support.\
-    To rebuild libcxx with full thread_local support, please install clang-9.0 or any\
-    macports-clang >= clang-5.0 and then rebuild libcxx like this:
-
-    sudo port -v -n upgrade --force --enforce-variants libcxx +emulated_tls
-
-    and you will have a fully-functional libcxx installation.
-    "
-    }
-
 } else {
     supported_archs noarch
     distfiles


### PR DESCRIPTION
#### Description

Here a new port `gcc10-bootstrap` which can be built without any dependencies on macOS 10.6+.

This port allows to build `clang-11-bootstrap` without any dependicies outside of `*-bootstrap` ports.

Which leads to `libcxx` with `+emulated_tls` without rebuilding.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

macOS 12.0.1 21A559 arm64
Xcode 13.1 13A1030d

macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->