### PR TITLE
reposurgeon: new port (version 4.31)

### DIFF
--- a/devel/reposurgeon/Portfile
+++ b/devel/reposurgeon/Portfile
@@ -1,0 +1,70 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            gitlab.com/esr/reposurgeon 4.31
+revision            0
+
+homepage            http://www.catb.org/esr/reposurgeon
+
+description         \
+    A tool for editing version-control repositories and translating among \
+    different systems. Supports git, bzr, Subversion, darcs, and fossil \
+    directly.
+
+
+long_description    \
+    {*}${description} ${name} enables risky operations that version-control \
+    systems don’t want to let you do, such as \(a\) editing past comments and \
+    metadata, \(b\) excising commits, \(c\) coalescing commits, and \(d\) \
+    removing files and subtrees from repo history. The original motivation \
+    for ${name} was to clean up artifacts created by repository conversions.
+
+categories          devel
+installs_libs       no
+license             BSD
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  c322295f6b6850a2470baddc0ba2bb65fa07f569 \
+                    sha256  e72e774da2313e3be656bf447a180be496e6bde19e05539be648aaa7def0b292 \
+                    size    1604141
+
+depends_build-append \
+                    port:gawk \
+                    port:asciidoctor
+
+# Allow Go to fetch dependencies at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
+build.cmd           make
+build.target        all
+
+use_parallel_build  no
+
+patch {
+    # Don't build HTML pages (remove HTML pages build target from "all" target)
+    reinplace -E {s|(all:.*)\$\(HTMLFILES\)$|\1|} ${worksrcpath}/Makefile
+
+    # Use gawk
+    reinplace -E "s|AWK = awk|AWK = ${prefix}/bin/gawk|g" \
+        ${worksrcpath}/Makefile
+}
+
+destroot {
+
+    foreach _repobin {
+        repobench
+        repocutter
+        repomapper
+        reposurgeon
+        repotool
+    } {
+        xinstall -m 0755 ${worksrcpath}/${_repobin} \
+            ${destroot}${prefix}/bin/
+
+        xinstall -m 0644 ${worksrcpath}/${_repobin}.1 \
+            ${destroot}${prefix}/share/man/man1/
+    }
+
+}


### PR DESCRIPTION
#### Description

New port for Eric S. Raymond's [reposurgeon](http://www.catb.org/esr/reposurgeon)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
