### PR TITLE
lcms2: update to 2.13.1

### DIFF
--- a/graphics/lcms2/Portfile
+++ b/graphics/lcms2/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               muniversal 1.0
 
 name                    lcms2
-version                 2.13
+version                 2.13.1
 revision                0
 worksrcdir              lcms2-${version}
 categories              graphics
@@ -26,9 +26,9 @@ homepage                http://www.littlecms.com/
 master_sites            sourceforge:project/lcms/lcms/${version}/ \
                         ${homepage}
 
-checksums               rmd160  419839b9c50f0304f6baaf627db0c6d3d525e5d0 \
-                        sha256  0c67a5cc144029cfa34647a52809ec399aae488db4258a6a66fba318474a070f \
-                        size    7259337
+checksums               rmd160  5f7e4a15bbaf13ba946e4387aee8224ff6923683 \
+                        sha256  d473e796e7b27c5af01bd6d1552d42b45b43457e7182ce9903f38bb748203b88 \
+                        size    7276499
 
 depends_lib             path:include/turbojpeg.h:libjpeg-turbo \
                         port:tiff \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Updated lcms2 to 2.13.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
- There are no existing Trac tickets
- There are no binary files that I can see