### PR TITLE
nodejs[8-14]: fix build on 10.10 and earlier

### DIFF
--- a/devel/nodejs10/Portfile
+++ b/devel/nodejs10/Portfile
@@ -116,7 +116,7 @@ build.args-append   CC=${configure.cc} \
                     CPP=${configure.cpp} \
                     CFLAGS="${configure.cflags}" \
                     CXXFLAGS="${configure.cxxflags}" \
-                    LDFLAGS="${configure.ldflags}" \
+                    LDFLAGS="${configure.ldflags} [legacysupport::get_library_link_flags]" \
                     PYTHON=${configure.python} \
                     V=1
 

--- a/devel/nodejs12/Portfile
+++ b/devel/nodejs12/Portfile
@@ -122,7 +122,7 @@ build.args-append   CC=${configure.cc} \
                     CPP=${configure.cpp} \
                     CFLAGS="${configure.cflags}" \
                     CXXFLAGS="${configure.cxxflags}" \
-                    LDFLAGS="${configure.ldflags}" \
+                    LDFLAGS="${configure.ldflags} [legacysupport::get_library_link_flags]" \
                     PYTHON=${configure.python} \
                     V=1
 

--- a/devel/nodejs13/Portfile
+++ b/devel/nodejs13/Portfile
@@ -119,7 +119,7 @@ build.args-append   CC=${configure.cc} \
                     CPP=${configure.cpp} \
                     CFLAGS="${configure.cflags}" \
                     CXXFLAGS="${configure.cxxflags}" \
-                    LDFLAGS="${configure.ldflags}" \
+                    LDFLAGS="${configure.ldflags} [legacysupport::get_library_link_flags]" \
                     PYTHON=${configure.python} \
                     V=1
 

--- a/devel/nodejs14/Portfile
+++ b/devel/nodejs14/Portfile
@@ -121,7 +121,7 @@ build.args-append   CC=${configure.cc} \
                     CPP=${configure.cpp} \
                     CFLAGS="${configure.cflags}" \
                     CXXFLAGS="${configure.cxxflags}" \
-                    LDFLAGS="${configure.ldflags}" \
+                    LDFLAGS="${configure.ldflags} [legacysupport::get_library_link_flags]" \
                     PYTHON=${configure.python} \
                     V=1
 

--- a/devel/nodejs8/Portfile
+++ b/devel/nodejs8/Portfile
@@ -114,7 +114,7 @@ build.args-append   CC=${configure.cc} \
                     CPP=${configure.cpp} \
                     CFLAGS="${configure.cflags}" \
                     CXXFLAGS="${configure.cxxflags}" \
-                    LDFLAGS="${configure.ldflags}" \
+                    LDFLAGS="${configure.ldflags} [legacysupport::get_library_link_flags]" \
                     PYTHON=${configure.python} \
                     V=1
 


### PR DESCRIPTION
#### Description

See failing builds e.g. https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/174170/steps/install-port/logs/stdio

The legacysupport dynamic library needs to be linked in explicitly (this is already the case with nodejs15 and later).

Tested locally with nodejs14.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
