### PR TITLE
py-httplib2: Add missing dependency py-parsing

### DIFF
--- a/python/py-httplib2/Portfile
+++ b/python/py-httplib2/Portfile
@@ -5,7 +5,7 @@ PortGroup         python 1.0
 
 name              py-httplib2
 set realversion   0.20.4
-revision          0
+revision          1
 version           2-${realversion}
 categories-append devel net
 license           MIT
@@ -35,6 +35,9 @@ if {${name} ne ${subport}} {
 
   depends_build-append \
                     port:py${python.version}-setuptools
+
+  depends_lib-append \
+                    port:py${python.version}-parsing
 
   livecheck.type    none
 } else {


### PR DESCRIPTION
#### Description

The `py-httplib2` Portfile is missing a dependency on the pyparsing module (port `py-parsing`). It is used in the auth.py file.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1713 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
