### PR TITLE
elixir: update to version 1.13.3

### DIFF
--- a/lang/elixir/Portfile
+++ b/lang/elixir/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        elixir-lang elixir 1.13.2 v
+github.setup        elixir-lang elixir 1.13.3 v
 github.tarball_from archive
 epoch               1
 categories          lang
@@ -24,9 +24,9 @@ homepage            http://elixir-lang.org/
 
 depends_lib         port:erlang
 
-checksums           rmd160 770de95c0793c4515289bd60f1cbb1e99523f0de \
-                    sha256 03afed42dccf4347c4d3ae2b905134093a3ba2245d0d3098d75009a1d659ed1a \
-                    size   2921295
+checksums           rmd160 74388c2a94d7587aced0fd6a77a3828db08fa7f7 \
+                    sha256 652779f7199f5524e2df1747de0e373d8b9f1d1206df25b2e551cd0ad33f8440 \
+                    size   2922197
 
 # bin/mix
 conflicts           arb


### PR DESCRIPTION
#### Description

Update to version 1.13.3

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
