### PR TITLE
rust: update compiler_builtins to 0.1.69

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy     15
 name                rust
 version             1.58.1
 # rust-src has increased revision. Keep it in mind
-revision            0
+revision            1
 
 if { ${subport} eq ${name} } {
     PortGroup       openssl         1.0
@@ -378,7 +378,7 @@ livecheck.url       https://github.com/rust-lang/rust/tags
 livecheck.regex     refs/tags/(\[\\d\\.\]+).zip
 
 subport rust-src {
-    revision        [ expr ${revision} + 1 ]
+    revision        [ expr ${revision} + 0 ]
 
     # do not unpack bootsrap dependency
     distfiles       ${distname}${extract.suffix}
@@ -492,7 +492,7 @@ if {${subport} ne "${ccwrap}" && ${subport} ne "rust-src"} {
         colored                          2.0.0  b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd \
         commoncrypto                     0.2.0  d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007 \
         commoncrypto-sys                 0.2.0  1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2 \
-        compiler_builtins               0.1.53  2467ff455350a4df7d02f1ed1449d0279605a763de5d586dcf6aa7d732508bcb \
+        compiler_builtins               0.1.69  ac0d1d6b2307c15fd27af2bb41234b4ebddeae69f33714bfbdb44b3b5a6e3efe \
         compiletest_rs                   0.7.1  29843cb8d351febf86557681d049d1e1652b81a086a190fa1173c07fd17fbf83 \
         core-foundation                  0.9.0  3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb \
         core-foundation-sys              0.8.0  9a21fa21941700a3cd8fcb4091f361a6a712fac632f85d9f487cc892045d55c6 \


### PR DESCRIPTION
#### Description

This update is designed to fix the building of librsvg 2.52+ on arm64.

See: https://github.com/rust-lang/compiler-builtins/issues/443
See: https://github.com/rust-lang/compiler-builtins/pull/444
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
