### PR TITLE
google-cloud-sdk: update to 373.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             372.0.0
+version             373.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  117e83ad50f0da48511d0343504fd4d549cd6336 \
-                    sha256  f123cd052c763dbf71145505151e7eacd6cf5510bb5b40767992a80fae521811 \
-                    size    97887195
+    checksums       rmd160  f40d4c07af8ceea80c46a1b2c0ad5a74fadecb22 \
+                    sha256  2b45ef3303ff7b086318bec64cdd0822a0500e6308b959d3c66f5eed7fbfc28f \
+                    size    98045331
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8f08cc1c51c4348ca050e746f6478aeef100e4f5 \
-                    sha256  eedce5af110f820fdfea071366aee661369e71e19e7642fdd91ee6dd0660feca \
-                    size    93117511
+    checksums       rmd160  cca819f0298d1179ef20f539703e49048f7dd62d \
+                    sha256  3e0f98c2595594c95d6898b02bcfc3ced8a363199bdf823580d097dc9b1c8962 \
+                    size    93278243
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  ffc91436ce09ef990cfb9fe7aa21a8f61b0fcab1 \
-                    sha256  c8ccd20e5a879ca822670a05c2adc59e958b5e1b56f63ca002ef301dd089dbd1 \
-                    size    92586564
+    checksums       rmd160  3b81e244d64b7359da530334ad1c9f7a33975e26 \
+                    sha256  f16c3fbbbd41fd6775011537d1235aba5d5b1af0e43f91f4a027f03561286562 \
+                    size    92754641
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 373.0.0.

###### Tested on

macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?