### PR TITLE
openjdk: remove obsolete subports

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -49,16 +49,6 @@ set obsoleted_ports {
     openjdk8-graalvm
     openjdk8-openj9-large-heap
     openjdk11-openj9-large-heap
-    openjdk12
-    openjdk12-openj9
-    openjdk12-openj9-large-heap
-    openjdk13
-    openjdk13-openj9
-    openjdk13-openj9-large-heap
-    openjdk14
-    openjdk14-openj9
-    openjdk14-openj9-large-heap
-    openjdk15
     openjdk15-openj9
     openjdk15-openj9-large-heap
     openjdk16
@@ -322,46 +312,22 @@ subport openjdk11-zulu {
     worksrcdir   ${distname}/zulu-11.jdk
 }
 
-# Remove after 2022-02-15
-subport openjdk12 {
-    version      12.0.2
-    revision     1
-    replaced_by  openjdk17
-}
-
-# Remove after 2022-02-15
-subport openjdk12-openj9 {
-    version      12.0.2
-    revision     1
-    replaced_by  openjdk16-openj9
-}
-
-# Remove after 2022-02-15
-subport openjdk12-openj9-large-heap {
-    version      12.0.2
-    revision     1
-    replaced_by  openjdk16-openj9
-}
-
-# Remove after 2022-02-15
 subport openjdk13 {
-    version      13.0.2
-    revision     1
-    replaced_by  openjdk17
-}
+    version      13.0.10
+    revision     0
 
-# Remove after 2022-02-15
-subport openjdk13-openj9 {
-    version      13.0.2
-    revision     1
-    replaced_by  openjdk16-openj9
-}
+    set meta true
 
-# Remove after 2022-02-15
-subport openjdk13-openj9-large-heap {
-    version      13.0.2
-    revision     1
-    replaced_by  openjdk16-openj9
+    description  Open Java Development Kit 13 meta port
+    long_description Open Java Development Kit 13 meta port
+
+    distfiles
+    destroot {
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
+    }
+
+    depends_run-append port:openjdk13-zulu
 }
 
 subport openjdk13-zulu {
@@ -392,31 +358,22 @@ subport openjdk13-zulu {
     worksrcdir   ${distname}/zulu-13.jdk
 }
 
-# Remove after 2022-02-15
-subport openjdk14 {
-    version      14.0.2
-    revision     1
-    replaced_by  openjdk17
-}
-
-# Remove after 2022-02-15
-subport openjdk14-openj9 {
-    version      14.0.2
-    revision     1
-    replaced_by  openjdk16-openj9
-}
-
-# Remove after 2022-02-15
-subport openjdk14-openj9-large-heap {
-    version      14.0.2
-    revision     1
-    replaced_by  openjdk16-openj9
-}
-
 subport openjdk15 {
-    version      15.0.4
+    version      15.0.6
     revision     0
-    replaced_by  openjdk15-zulu
+
+    set meta true
+
+    description  Open Java Development Kit 15 meta port
+    long_description Open Java Development Kit 15 meta port
+
+    distfiles
+    destroot {
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
+    }
+
+    depends_run-append port:openjdk15-zulu
 }
 
 # Remove after 2022-03-22


### PR DESCRIPTION
#### Description

Remove subports which were marked as obsolete one year ago:

* openjdk12
* openjdk12-openj9
* openjdk12-openj9-large-heap
* openjdk13-openj9
* openjdk13-openj9-large-heap
* openjdk14
* openjdk14-openj9
* openjdk14-openj9-large-heap

###### Tested on

macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?