### PR TITLE
emacs{,-app}-devel: update to 20220213

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -96,19 +96,27 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     legacysupport.newest_darwin_requires_legacy 13
 
-    set date        2022-01-11
+    set date        2022-02-13
     epoch           5
     version         [string map {- {}} ${date}]
     revision        0
 
     fetch.type      git
     git.url         --shallow-since=${date}T00:00:00 https://github.com/emacs-mirror/emacs.git
-    git.branch      e35194866706e5632db3070f4e32950ecc0a58f4
+    git.branch      a4dd94de8018e75fc5c000cff5f57b4a53f05042
 
     # --shallow-since needs a newer version of git than on some older systems
     # So use MacPorts version
     depends_fetch-append port:git
     git.cmd         ${prefix}/bin/git
+
+    configure.args-append \
+        --with-sqlite3 \
+        --with-webp
+
+    depends_lib-append \
+        port:sqlite3 \
+        port:webp
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
@@ -125,8 +133,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
         compiler.library_path-prepend \
                                  ${prefix}/lib/gcc11
 
-        build.args-append        NATIVE_FULL_AOT=1 \
-            {BYTE_COMPILE_EXTRA_FLAGS='--eval "(setq comp-speed 2)"'}
+        build.args-append        NATIVE_FULL_AOT=1
     }
 
     default_variants-append +nativecomp


### PR DESCRIPTION
#### Description

Update to a recent commit and fix up build stuff:

- Emacs 29 added support for sqlite3 and webp libraries; currently the port opportunistically links with these, so we need to either make the dependencies explicit or avoid using them. I thought these libraries were reasonable to depend on by default.
- `comp-speed` was renamed to `native-comp-speed`, so that bit wasn't taking effect. The default value of `native-comp-speed` is 2, so we don't need to set it at all.

In terms of interesting new changes to Emacs, there is the `'overlay` and `'child-frame` options for `show-paren-context-when-offscreen`. I like `'overlay`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
