### PR TITLE
phantomjs-qt-qtbase: fix error in post-patch

### DIFF
--- a/aqua/phantomjs-qt/Portfile
+++ b/aqua/phantomjs-qt/Portfile
@@ -262,7 +262,7 @@ foreach {module module_info} [array get modules] {
             patchfiles-append patch-find_rez.diff
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_Rez__|[exec xcrun --find Rez]|g" \
+                    "s|__MACPORTS_Rez__|[exec -ignorestderr xcrun --find Rez]|g" \
                     mkspecs/common/mac.conf \
                     mkspecs/features/mac/rez.prf
             }


### PR DESCRIPTION
As done for other Qt 5 qtbase ports in f8007857680a:

> By default, exec will treat any stderr output as failure.

See: https://trac.macports.org/ticket/64668

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Untested
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
