### PR TITLE
openjdk11-zulu: update to 11.54.25

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -297,10 +297,10 @@ subport openjdk11-temurin {
 subport openjdk11-zulu {
     # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 
-    version      11.54.23
+    version      11.54.25
     revision     0
 
-    set openjdk_version 11.0.14
+    set openjdk_version 11.0.14.1
 
     description  Azul Zulu Community OpenJDK 11 (Long Term Support)
     long_description ${long_description_zulu}
@@ -309,14 +309,14 @@ subport openjdk11-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  2d37a548a89ff67bdbd957cbb1d066c404a88cef \
-                     sha256  f7ec731200318e194aab6b9c3b70fdfc18175abd7ce70df32e6d58b6388e8cca \
-                     size    193386455
+        checksums    rmd160  1b144473c0ec1086ab295b3d7601a8e7611ce59e \
+                     sha256  fbfe3da2024a170b77efd94946aeb95ffe54377134403f92c682376e1f06e8f5 \
+                     size    193388486
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  ea067dd34655ddd6276001461c5efb8925e8a9dc \
-                     sha256  c7659bf049d2adcbf65222942f88ae0a4a0cbd48230f3dc977e7a907f3af4e26 \
-                     size    176885323
+        checksums    rmd160  1b0182a86c1ae1a42741de3ae5e885b15186a924 \
+                     sha256  2076f8ce51c0e9ad7354e94b79513513b1697aa222f9503121d800c368b620a3 \
+                     size    176884357
     }
 
     worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 11.54.25 (OpenJDK 11.0.14.1).

###### Tested on

macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?