### PR TITLE
various Python ports: remove EOL subports

### DIFF
--- a/python/py-GridDataFormats/Portfile
+++ b/python/py-GridDataFormats/Portfile
@@ -6,12 +6,12 @@ PortGroup           python 1.0
 name                py-GridDataFormats
 version             0.6.0
 revision            0
+
 categories-append   science
-platforms           darwin
 license             LGPL-3
 supported_archs     noarch
 
-python.versions     27 36 37 38 39
+python.versions     37 38 39
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -21,9 +21,6 @@ long_description    ${description} \
                     It supports reading from and writing to some common formats (such as OpenDX).
 
 homepage            https://github.com/MDAnalysis/GridDataFormats
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-
-distname            ${python.rootname}-${version}
 
 checksums           rmd160  5555fd8713be27c6b5afe5a7bdf69640ede1c79c \
                     sha256  f14e00e8b795f8021f6069935e1133352224775c9bd97f395beb2bcd64a19b86 \
@@ -38,5 +35,4 @@ if {${name} ne ${subport}} {
     test.run                yes
     test.cmd                py.test-${python.branch}
     test.target
-    livecheck.type          none
 }

--- a/python/py-MDAnalysis/Portfile
+++ b/python/py-MDAnalysis/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  ece8d0a6ab8b0bb8e5625d547ebd821ec0c1ff20 \
                     sha256  aa3079d1a82305eba58cf567fac8fc231940184ed88f9a4451be8433f4a06d3e \
                     size    3436654
 
-python.versions     36 37 38 39
+python.versions     37 38 39
 
 if {${name} ne ${subport}} {
     # OpenMP is disabled now
@@ -41,6 +41,4 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-scipy \
                             port:py${python.version}-threadpoolctl \
                             port:py${python.version}-tqdm
-
-    livecheck.type          none
 }

--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -7,7 +7,6 @@ PortGroup           github 1.0
 github.setup        srnas barnaba 0.1.7
 name                py-barnaba
 
-platforms           darwin
 categories-append   science
 license             GPL-3
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
@@ -24,10 +23,9 @@ checksums           rmd160  f6e4f68d5af8149e9a884e6dc88fbe77545507e6 \
                     sha256  392402230279c710a263062d52a239d5a9cbebd19946f6dd03dbc8453c62dc87 \
                     size    30260068
 
-python.versions     27 36 37
+python.versions     37
 
 if {${name} ne ${subport}} {
-
     depends_build-append    port:py${python.version}-setuptools_scm \
                             port:py${python.version}-setuptools_scm_git_archive
 

--- a/python/py-gsd/Portfile
+++ b/python/py-gsd/Portfile
@@ -6,11 +6,11 @@ PortGroup           github 1.0
 
 github.setup        glotzerlab gsd 2.5.0 v
 name                py-gsd
+
 categories-append   science
-platforms           darwin
 license             BSD
 
-python.versions     27 36 37 38 39 310
+python.versions     37 38 39 310
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -31,24 +31,11 @@ if {${name} ne ${subport}} {
 
     depends_test-append     port:py${python.version}-pytest
 
-    if {${python.version} ne 27} {
-        pre-test {
-            test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-        }
-        test.run            yes
-        test.cmd            py.test-${python.branch}
-        test.target
-    } else {
-        version             1.7.0
-        master_sites        https://github.com/glotzerlab/gsd/archive/
-        distname            v1.7.0
-        worksrcdir          gsd-1.7.0
-        checksums           rmd160  ec92677fb4ed0321205e238c06c8f58ad5054be4 \
-                            sha256  2e6e8d7cd6e9786b3d0594318fc665ab11cd5963d5bac115081eb46a3f4acca7 \
-                            size    247039
-
-        test.run            no
+    pre-test {
+        test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
     }
 
-    livecheck.type      none
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
 }

--- a/python/py-mdtraj/Portfile
+++ b/python/py-mdtraj/Portfile
@@ -6,8 +6,7 @@ PortGroup           github 1.0
 
 github.setup        mdtraj mdtraj 1.9.4
 name                py-mdtraj
-homepage            http://www.mdtraj.org
-platforms           darwin
+homepage            https://www.mdtraj.org
 license             LGPL-2.1+
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -22,10 +21,9 @@ checksums           rmd160  9c35bfe8c0f3e7270be6bd8cba1b113570e9a838 \
                     sha256  59536069ce8f3aecbfccfe5cbe5ad6d0e33d656fcf15d8e43fda86650697b348 \
                     size    21474623
 
-python.versions     27 36 37 38
+python.versions     37 38
 
 if {${name} ne ${subport}} {
-
     depends_build-append    port:py${python.version}-cython
 
     depends_lib-append      port:py${python.version}-astor \
@@ -35,7 +33,4 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-setuptools \
                             port:py${python.version}-scipy \
                             port:py${python.version}-tables
-
-# tests cannot be implemented since they require too many packages
-# not available on MacPorts
 }

--- a/python/py-mmtf-python/Portfile
+++ b/python/py-mmtf-python/Portfile
@@ -6,12 +6,12 @@ PortGroup           python 1.0
 name                py-mmtf-python
 version             1.1.2
 revision            0
+
 categories-append   science
-platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 36 37 38 39 310
+python.versions     37 38 39 310
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -29,7 +29,6 @@ checksums           rmd160  887c43e5a9137b5cdf625377eeea38d9144234c5 \
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-msgpack
-    livecheck.type          none
 
     depends_test-append     port:py${python.version}-nose \
                             port:py${python.version}-numpy

--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -6,9 +6,7 @@ PortGroup           github 1.0
 
 github.setup        plumed plumed2 2.7.1 v
 name                py-plumed
-categories          python
 
-platforms           darwin
 categories-append   science
 license             LGPL-3
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
@@ -16,13 +14,13 @@ maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 description         Python wrappers for plumed.
 long_description    ${description} They allow the plumed library to be directly used from python.
 
-homepage            http://www.plumed.org
+homepage            https://www.plumed.org
 
 checksums           rmd160  2137586dbc890732d0e632c8b4ec483aa0c00598 \
                     sha256  c5ecc6c13eb45a9e009c1fedf07d91f5a02f2600ff29f1cd481f4a0d17e12908 \
                     size    106402240
 
-python.versions     36 37 38 39
+python.versions     37 38 39
 
 # python setup is located in python subdir of plumed repository
 worksrcdir  ${distname}/python

--- a/python/py-slackclient/Portfile
+++ b/python/py-slackclient/Portfile
@@ -7,11 +7,11 @@ PortGroup           github 1.0
 github.setup        slackapi python-slackclient 2.9.3 v
 name                py-slackclient
 categories-append   irc
-platforms           darwin
+
 supported_archs     noarch
 license             MIT
 
-python.versions     36 37 38 39
+python.versions     37 38 39
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -29,6 +29,4 @@ if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-aiohttp
     depends_lib-append      port:py${python.version}-typing_extensions
-
-    livecheck.type none
 }


### PR DESCRIPTION
#### Description
- remove subports for EOL Python versions in various ports maintained by @GiovanniBussi
- general clean-up of unnecessary lines (i.e., setting default values) in the Portfiles 


###### Tested on
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
