### PR TITLE
py-humanize: add python 3.10 subport

### DIFF
--- a/python/py-humanize/Portfile
+++ b/python/py-humanize/Portfile
@@ -12,7 +12,7 @@ maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         Python humanize utilities
 long_description    ${description}
 
-python.versions     27 36 37 38 39
+python.versions     27 36 37 38 39 310
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}


### PR DESCRIPTION
#### Description

py-humanize: add python 3.10 subport

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? no tests found
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
