### PR TITLE
dosbox-x: update to version 0.83.22, add sdl1 variant

### DIFF
--- a/emulators/dosbox-x/Portfile
+++ b/emulators/dosbox-x/Portfile
@@ -7,12 +7,12 @@ PortGroup           app 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 
-github.setup        joncampbell123 dosbox-x 0.83.21 dosbox-x-v
+github.setup        joncampbell123 dosbox-x 0.83.22 dosbox-x-v
 revision            0
 
-checksums           rmd160  2ea3e59d95bd6e1f0e570fe76e889da37bb89a60 \
-                    sha256  ec13bf16a9761c755df25f8b780aee589e328bcd490ac372538f8a87846456a2 \
-                    size    64428183
+checksums           rmd160  653142e839326ce5deefa1fb7e60d42fd7cfa5b0 \
+                    sha256  75c5c1eb3b78701a80ad816f414640894cb0b5998a1a4d7f2af064b47a57b8c9 \
+                    size    64487045
 
 categories          emulators
 platforms           darwin
@@ -54,6 +54,27 @@ use_autoreconf      yes
 autoreconf.args     -fvi
 
 configure.args-append --enable-sdl2
+
+# add a SDL v1.x variant because when SDL2 is used dosbox-x
+# may have display issues in high color and true color modes:
+# https://github.com/joncampbell123/dosbox-x/issues/1431
+
+variant sdl1 description {Use the SDL v1.x library} {
+    configure.args-replace --enable-sdl2 --disable-sdl2
+    configure.args-append --enable-sdl
+    depends_lib-delete port:libsdl2
+    depends_lib-delete port:libsdl2_net
+    patchfiles-append patch-build-macosx.diff
+    use_configure no
+    use_autoreconf no
+}
+
+if {[variant_isset sdl1]} {
+   build {
+      system -W "${workpath}/${name}-${version}/" \
+                "PREFIX=${prefix} ./build-macosx"
+   }
+}
 
 # needs "___cpu_model" in compiler.rt
 compiler.blacklist-append {clang < 900}

--- a/emulators/dosbox-x/files/patch-build-macosx.diff
+++ b/emulators/dosbox-x/files/patch-build-macosx.diff
@@ -1,0 +1,18 @@
+--- build-macosx.orig	2022-02-15 11:48:33.000000000 -0800
++++ build-macosx	2022-02-15 11:52:21.000000000 -0800
+@@ -72,9 +72,14 @@
+     export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$brew/lib/pkgconfig"
+ fi
+ 
++if [ X"$PREFIX" == "X" ] ; then 
++   PREFIX=/usr
++   export PREFIX
++fi
++ 
+ # now compile ourself
+ echo Compiling DOSBox-X
+ chmod +x configure
+-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr $opts "$@" || exit 1
++./configure --enable-core-inline --enable-debug=heavy --prefix="$PREFIX" $opts "$@" || exit 1
+ make -j3 || exit 1
+ 

--- a/emulators/dosbox-x/files/patch-futimens.diff
+++ b/emulators/dosbox-x/files/patch-futimens.diff
@@ -1,6 +1,6 @@
---- src/dos/drive_local.cpp.orig	2021-10-12 22:39:22.000000000 -0700
-+++ src/dos/drive_local.cpp	2021-10-12 22:41:38.000000000 -0700
-@@ -107,6 +107,16 @@
+--- src/dos/drive_local.cpp.orig	2022-01-31 18:05:19.000000000 -0800
++++ src/dos/drive_local.cpp	2022-02-14 14:11:35.000000000 -0800
+@@ -92,6 +92,16 @@
  #define MAX_PATH PATH_MAX
  #endif
  
@@ -14,6 +14,6 @@
 +}
 +#endif
 +
- #if defined(WIN32)
- // Windows: Use UTF-16 (wide char)
- // TODO: Offer an option to NOT use wide char on Windows if directed by config.h
+ uint16_t ldid[256];
+ std::string ldir[256];
+ static host_cnv_char_t cpcnv_temp[4096];


### PR DESCRIPTION
#### Description

Update to version 0.83.22 of dosbox-x and add a SDL v1.x variant because dosbox-x may have display issues when the default SDL v2.x variant is used, see, for example:

https://github.com/joncampbell123/dosbox-x/issues/1431

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.3 20G415 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
