### PR TITLE
rust: fix compiler_builtins version mis-match

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -423,6 +423,10 @@ if {${subport} ne "${ccwrap}" && ${subport} ne "rust-src"} {
     post-extract {
         # enable offline mode for cargo at bootstrap
         system -W ${worksrcpath} "patch -p0 < ${filespath}/offline-bootstrap.patch"
+
+        # user newer compiler_builtins to fix librsvg on arm64
+        # https://github.com/rust-lang/compiler-builtins/pull/444
+        system -W ${worksrcpath} "patch -p0 < ${filespath}/compiler_builtins.diff"
     }
 
     if { ${os.platform} eq "darwin" && ${os.major} < 12 } {

--- a/lang/rust/files/compiler_builtins.diff
+++ b/lang/rust/files/compiler_builtins.diff
@@ -1,0 +1,11 @@
+--- library/std/Cargo.toml.orig
++++ library/std/Cargo.toml
+@@ -16,7 +16,7 @@
+ panic_abort = { path = "../panic_abort" }
+ core = { path = "../core" }
+ libc = { version = "0.2.106", default-features = false, features = ['rustc-dep-of-std'] }
+-compiler_builtins = { version = "0.1.53" }
++compiler_builtins = { version = "0.1.69" }
+ profiler_builtins = { path = "../profiler_builtins", optional = true }
+ unwind = { path = "../unwind" }
+ hashbrown = { version = "0.11", default-features = false, features = ['rustc-dep-of-std'] }


### PR DESCRIPTION
#### Description

#14011 broke the Rust build; this change is intended to fix it. Please verify CI before merging.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
