### PR TITLE
glib2: patch universal only

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -12,7 +12,7 @@ name                        glib2
 conflicts                   glib2-devel
 set my_name                 glib
 version                     2.64.6
-revision                    1
+revision                    2
 checksums                   rmd160  27938fd75bdcd4ca0afc8ebce6b137ed3c1fe6a5 \
                             sha256  c36ee07a70164c71f046016fe6aaacd6368333c42590bc0cba47c344ffb853f1 \
                             size    4781576

--- a/devel/glib2/files/universal.patch
+++ b/devel/glib2/files/universal.patch
@@ -114,7 +114,7 @@ here and in config.h.ed.
  @glib_os@
  
 -@glib_vacopy@
-+#ifdef __LP64__
++#if defined(__ppc64__) || defined(__x86_64__)
 +#define G_VA_COPY_AS_ARRAY 1
 +#endif
 +

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -11,7 +11,7 @@ name                gtk3
 conflicts           gtk3-devel
 set my_name         gtk3
 version             3.24.31
-revision            0
+revision            1
 epoch               1
 
 set proj_name       gtk+


### PR DESCRIPTION
#### Description

glib2: move part of universal.patch causing issues on ARM64 to non-ARM patch
gtk3: rev-bump for glib2 patch change

Ref (among others): https://trac.macports.org/ticket/64377

NOTE: this doesn't fix the underlying issue, but since most folks do not install as +universal this will help most users.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Intel:
macOS 11.6.4 20G507
Xcode 12.3 12C33

ARM64:
macOS 11.6.4 20G507
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
