### PR TITLE
librsvg: update to 2.52.6 on 10.7+

### DIFF
--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -32,24 +32,7 @@ license_noconflict  gobject-introspection \
                     rust \
                     vala
 
-# cargo does not build on 10.7 or earlier
-# https://trac.macports.org/ticket/55794
-
-# cargo build also fails on 10.8 due to known SSL/TLS issues with github.com
-# Updating registry `https://github.com/rust-lang/crates.io-index`
-# Downloading shell-escape v0.1.4
-# error: unable to get packages from source
-# Caused by:[35] SSL connect error (error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure)
-# https://trac.macports.org/ticket/56195
-
-# rust @1.30.1 fails to build on 10.10 and earlier
-# https://trac.macports.org/ticket/57768
-# Update - As of rust 1.51.0 it now builds on 10.9 and newer.
-
-# rust does not yet support Apple Silicon
-# https://github.com/rust-lang/rust/issues/73908
-
-set max_darwin_for_rust 13
+set min_darwin_for_rust 11
 
 #----------------------------------------------------------------------------------------
 # Developer-only override, allowing easy testing of desired behavior:
@@ -66,9 +49,7 @@ if {[info exists librsvg.override.fallback]} {
     }
 } else {
     if {${os.platform} eq "darwin" && (
-            ${os.major} < ${max_darwin_for_rust}
-            || ${os.arch} eq "arm"
-            || ${universal_possible} && [variant_isset universal] && "arm64" in ${configure.universal_archs}
+            ${os.major} < ${min_darwin_for_rust}
             || ${build_arch} eq "i386"
             || ${universal_possible} && [variant_isset universal] && "i386" in ${configure.universal_archs}
         )} {
@@ -107,13 +88,13 @@ if {${librsvg_fallback}} {
 } else {
     PortGroup       cargo_fetch 1.0
 
-    version         2.52.4
+    version         2.52.6
     revision        0
     epoch           2
     
-    checksums       rmd160  543cd5c1d33b137b64babfed66230ed1595d9d51 \
-                    sha256  660ec8836a3a91587bc9384920132d4c38d1d1718c67fe160c5213fe4dec2928 \
-                    size    23287420
+    checksums       rmd160  fd30d3a0491de672830ae523bd2955732b17aa1d \
+                    sha256  a3f939a1e6a3a60408244632d0323f8c3b20eb4b7b000536e2e5bd93b8effaad \
+                    size    23662708
 
     # Only needed for linkat on macOS 10.9
     legacysupport.newest_darwin_requires_legacy 13


### PR DESCRIPTION
#### Description

Use the Rust-requiring librsvg on 10.7+, including arm64. This change has been in librsvg-devel for more than 2 weeks; see https://ports.macports.org/port/librsvg-devel/details/

Prior to #14034, librsvg 2.52.6 was not compatible with arm64, but we should be good to go now. (Tested locally on arm64.)

Closes: https://trac.macports.org/ticket/64661
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
