### PR TITLE
magic-wormhole: bump python dependency from 3.9 to 3.10

### DIFF
--- a/net/magic-wormhole/Portfile
+++ b/net/magic-wormhole/Portfile
@@ -31,7 +31,7 @@ checksums           rmd160  bbb9d49f4520e5168f95b35264a4fce7ce4732a7 \
                     sha256  1b0fd8a334da978f3dd96b620fa9b9348cabedf26a87f74baac7a37052928160 \
                     size    262269
 
-python.default_version  39
+python.default_version  310
 
 depends_build-append port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2 21D49 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
