### PR TITLE
supertuxkart: fix build on 10.9 and earlier

### DIFF
--- a/games/supertuxkart/Portfile
+++ b/games/supertuxkart/Portfile
@@ -29,7 +29,9 @@ master_sites        sourceforge:project/${name}/SuperTuxKart/${version}
 # Remove Homebrew and -arch flag cruft
 patchfiles-append   patch-supertuxkart-cmake.diff
 
-compiler.cxx_standard   2011
+# Need a C++14 compatible compiler in order to resolve:
+# error: chosen constructor is explicit in copy-initialization
+compiler.cxx_standard   2014
 platform darwin {
     post-patch {
         reinplace "s|10\.9|${macosx_deployment_target}|g" ${worksrcpath}/data/SuperTuxKart-Info.plist


### PR DESCRIPTION
#### Description

See e.g. https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/174804/steps/install-port/logs/stdio
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
