### PR TITLE
py-taskw: add python3.{7,8,9,10} subport

### DIFF
--- a/python/py-taskw/Portfile
+++ b/python/py-taskw/Portfile
@@ -19,7 +19,7 @@ long_description    ${description} It contains two implementations: \
 platforms           darwin
 license             GPL-3
 
-python.versions     27 35 36
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

py-taskw: add python3.{7,8,9,10} subport

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? No tests found
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
