### PR TITLE
bind9: fix build on older systems

### DIFF
--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem      1.0
 PortGroup       legacysupport 1.0
+PortGroup       compiler_blacklist_versions 1.0
 
 name            bind9
 version         9.18.0
@@ -48,10 +49,13 @@ depends_lib     path:lib/libssl.dylib:openssl  \
 universal_variant \
                 no
 
+# Needs working __atomic_* builtins
 compiler.blacklist \
-                gcc-4.2
+                gcc-4.2 \
+                {clang < 500}
 
-patchfiles      configure.patch
+patchfiles      atomics.patch \
+                configure.patch
 
 
 # tests require `sudo bin/tests/system/ifconfig.sh up`

--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -70,7 +70,8 @@ add_users       named group=named
 
 configure.env   STD_CDEFINES=-DDIG_SIGCHASE=1
 
-configure.args  --mandir=${prefix}/share/man \
+configure.args  --disable-silent-rules \
+                --mandir=${prefix}/share/man \
                 --with-openssl=${prefix} \
                 --with-libidn2=${prefix} \
                 --enable-doh

--- a/net/bind9/files/atomics.patch
+++ b/net/bind9/files/atomics.patch
@@ -1,0 +1,40 @@
+Allow use of gcc-style __atomic* builtins in older clang versions.
+
+Avoid use of const pointers with atomic_load because strictly C11
+compliant compilers error on this. Using const became allowed in C17:
+http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2244.htm#dr_459
+--- lib/isc/include/isc/stdatomic.h.orig	2022-01-24 19:28:57.000000000 +1100
++++ lib/isc/include/isc/stdatomic.h	2022-02-19 00:40:48.000000000 +1100
+@@ -21,7 +21,9 @@
+ #endif /* HAVE_UCHAR_H */
+ 
+ /* GCC 4.7.0 introduced __atomic builtins, but not the __GNUC_ATOMICS define */
+-#if !defined(__GNUC_ATOMICS) && __GNUC__ == 4 && __GNUC_MINOR__ >= 7
++/* Clang 3.1 and later have the builtins but none define __GNUC_ATOMICS */
++#if !defined(__GNUC_ATOMICS) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 7) \
++    || defined(__clang__))
+ #define __GNUC_ATOMICS
+ #endif
+ 
+--- ./lib/isc/netmgr/netmgr-int.h.orig	2022-01-24 19:28:57.000000000 +1100
++++ ./lib/isc/netmgr/netmgr-int.h	2022-02-19 02:03:23.000000000 +1100
+@@ -233,7 +233,7 @@ typedef struct isc__networker {
+ #define NMHANDLE_MAGIC ISC_MAGIC('N', 'M', 'H', 'D')
+ #define VALID_NMHANDLE(t)                      \
+ 	(ISC_MAGIC_VALID(t, NMHANDLE_MAGIC) && \
+-	 atomic_load(&(t)->references) > 0)
++	 atomic_load((isc_refcount_t *)&(t)->references) > 0)
+ 
+ typedef void (*isc__nm_closecb)(isc_nmhandle_t *);
+ typedef struct isc_nm_http_session isc_nm_http_session_t;
+--- lib/isc/netmgr/http.c.orig	2022-01-24 19:28:57.000000000 +1100
++++ lib/isc/netmgr/http.c	2022-02-19 02:13:12.000000000 +1100
+@@ -1651,7 +1651,7 @@ find_server_request_handler(const char *
+ 
+ 	REQUIRE(VALID_NMSOCK(serversocket));
+ 
+-	if (atomic_load(&serversocket->listening)) {
++	if (atomic_load((atomic_bool *)&serversocket->listening)) {
+ 		handler = http_endpoints_find(
+ 			request_path, serversocket->h2.listener_endpoints);
+ 	}


### PR DESCRIPTION
#### Description

Make sure a compiler with atomic builtins is used, and fix issues with detecting and using them.

###### Type(s)
- [x] bugfix

###### Tested on
macOS 10.7, 10.9, 10.13
Xcode 4.6.3, 6.2, 10.1
