### PR TITLE
postgresql12: version bump to 12.10

### DIFF
--- a/databases/postgresql12-doc/Portfile
+++ b/databases/postgresql12-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql12-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc \
     postgresql13-doc
-version             12.9
+version             12.10
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -22,9 +22,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql12
 
-checksums           rmd160  7bdb6e85259fbb520a93f66fab82fcedee9fee2c \
-                    sha256  89fda2de33ed04a98548e43f3ee5f15b882be17505d631fe0dd1a540a2b56dce \
-                    size    20904260
+checksums           rmd160  87e6070cfe77a947d32b1b23fe83041ecbe1c127 \
+                    sha256  83dd192e6034951192b9a86dc19cf3717a8b82120e2f11a0a36723c820d2b257 \
+                    size    20990621
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql12-server/Portfile
+++ b/databases/postgresql12-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql12-server
-version             12.9
+version             12.10
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql12/Portfile
+++ b/databases/postgresql12/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql12
-version             12.9
-revision            1
+version             12.10
+revision            0
 
 categories          databases
 platforms           darwin
@@ -27,9 +27,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  7bdb6e85259fbb520a93f66fab82fcedee9fee2c \
-                    sha256  89fda2de33ed04a98548e43f3ee5f15b882be17505d631fe0dd1a540a2b56dce \
-                    size    20904260
+checksums           rmd160  87e6070cfe77a947d32b1b23fe83041ecbe1c127 \
+                    sha256  83dd192e6034951192b9a86dc19cf3717a8b82120e2f11a0a36723c820d2b257 \
+                    size    20990621
 
 use_bzip2           yes
 


### PR DESCRIPTION
#### Description

Update postgresql12 to 12.10

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
