### PR TITLE
dbvis: update to 2.1.8, fix livecheck

### DIFF
--- a/databases/dbvis/Portfile
+++ b/databases/dbvis/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   java 1.0
 
 name                        dbvis
-version                     12.1.5
+version                     12.1.8
 categories                  databases
 platforms                   darwin
 supported_archs             x86_64
@@ -22,9 +22,9 @@ master_sites                ${homepage}/product_download/dbvis-${version}/media/
 distname                    dbvis_macos_[strsed $version g/\\./_/]
 extract.suffix              .tgz
 
-checksums                   rmd160  c87027db4e0dd7614df745f771ecc600e62eab96 \
-                            sha256  8dbd2e98b23038f882525eaa38fcb50bc4849a4bb72ef263dcdb9b5bbcc065a1 \
-                            size    103862214
+checksums                   rmd160  a5c77ba23308fda942916ccfc05ec41c8a4f8478 \
+                            sha256  ef07ee9ece1db6c0d56aee70fd03f123c46cc45f8873ccaad0e50a6bad9969b0 \
+                            size    103890595
 
 java.version                1.8+
 java.fallback               openjdk11
@@ -40,5 +40,5 @@ destroot {
 }
 
 livecheck.type              regex
-livecheck.url               ${homepage}/CheckForUpdate/?dbvisVersion=12.0.0&dbvisEdition=Free&channels=feature&channels=maintenance
-livecheck.regex             {dbvis.com/download/([0-9.]+)}
+livecheck.url               ${homepage}/download/
+livecheck.regex             {/product_download/dbvis-([0-9.]+)/media/dbvis_macos_}


### PR DESCRIPTION
###### Tested on

macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
