### PR TITLE
onedpl: update to 2021.6.1

### DIFF
--- a/devel/onedpl/Portfile
+++ b/devel/onedpl/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        oneapi-src oneDPL 2021.6.0 oneDPL- -release
+github.setup        oneapi-src oneDPL 2021.6.1 oneDPL- -release
 name                onedpl
-revision            1
+revision            0
 
 categories          devel parallel
 platforms           darwin
@@ -23,12 +23,9 @@ long_description    oneAPI DPC++ Library (oneDPL) provides high-productivity \
 
 github.tarball_from archive
 
-checksums           rmd160  82cc1afa2baa3ebae8ad6d8053286a085bcf6680 \
-                    sha256  c05738365b359e662234a25d7093314ba550f79ac8eb918e87116246b934470b \
-                    size    3671693
-
-# Port provides headers and cmake files only, with no binaries
-installs_libs       no
+checksums           rmd160  d13dff4b3d788e6d5a7dee2456021c6558704ca3 \
+                    sha256  4995fe2ed2724b89cdb52c4b6c9af22e146b48d2561abdafdaaa06262dbd67c4 \
+                    size    3682780
 
 depends_lib-append  port:onetbb
 


### PR DESCRIPTION
###### Tested on
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?