### PR TITLE
rdfind: Update to upstream version 1.5.0

### DIFF
--- a/sysutils/rdfind/Portfile
+++ b/sysutils/rdfind/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        pauldreik rdfind 1.4.1 releases/
+github.setup        pauldreik rdfind 1.5.0 releases/
 
 revision            0
 categories          sysutils
@@ -15,9 +15,9 @@ long_description    finds and optionally deletes, or symlinks equal files \
 homepage            https://rdfind.pauldreik.se
 platforms           darwin
 
-checksums           rmd160  014778800de9e36ae116d09b5bceb47d4cb98c2e \
-                    sha256  b3e2beeef30b623d75f8b054a514b32183c3ad919f582b23a45506b53095a51e \
-                    size    53719
+checksums           rmd160  f3fda757e3200818fdd9b50333326701ef75f357 \
+                    sha256  d389da9d4a5b99dd77fd6c907827fb96b2954ab10a70c588ed43fba9b8c5904f \
+                    size    55225
 
 use_automake        yes
 automake.cmd        ./bootstrap.sh
@@ -30,11 +30,5 @@ depends_build-append \
 
 depends_lib         port:nettle
 
-post-extract {
-    # Avoid conflict with C++20 version header.
-    # https://github.com/pauldreik/rdfind/issues/77
-    move ${worksrcpath}/VERSION ${worksrcpath}/VERSION.txt
-}
-
-configure.args      CPPFLAGS=-I${prefix}/include/ \
+configure.args      CPPFLAGS='-I${prefix}/include/ -std=c++11'\
                     LDFLAGS=-L${prefix}/lib


### PR DESCRIPTION
Details:
- The post-extract is not required any longer, because the file's name is now Version.txt.
- Added: CPPFLAGS=-std=c++11

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)

- [ ] bugfix
- [*] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
