### PR TITLE
inkscape: update to 1.1.2

### DIFF
--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -8,6 +8,8 @@ cmake.generator     Ninja
 
 name                inkscape
 conflicts           inkscape-devel inkscape-gtk3-devel
+set my_name         inkscape
+
 version             1.1.2
 revision            0
 license             GPL-3+
@@ -24,6 +26,8 @@ long_description    Inkscape is an multi-platform, Open-Source Vector Graphics E
 homepage            https://inkscape.org/
 master_sites        https://inkscape.org/en/gallery/item/31668
 
+distname            ${my_name}-${version}
+dist_subdir         ${my_name}
 use_xz              yes
 
 checksums           rmd160  721d41c1c344dc17f8eb38bd45bc3b3bf85f5b88 \
@@ -106,7 +110,7 @@ if {![variant_isset quartz]} {
 }
 
 post-activate {
-        system "${prefix}/bin/gtk-update-icon-cache -f -t ${prefix}/share/icons/hicolor"
+        system "${prefix}/bin/gtk-update-icon-cache-3.0 -f -t ${prefix}/share/icons/hicolor"
         system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
 }
 

--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
@@ -9,8 +8,8 @@ cmake.generator     Ninja
 
 name                inkscape
 conflicts           inkscape-devel inkscape-gtk3-devel
-version             0.92.5
-revision            9
+version             1.1.2
+revision            0
 license             GPL-3+
 maintainers         {mascguy @mascguy} openmaintainer
 categories          graphics gnome
@@ -23,16 +22,16 @@ long_description    Inkscape is an multi-platform, Open-Source Vector Graphics E
                     ${description}
 
 homepage            https://inkscape.org/
-master_sites        https://inkscape.org/en/gallery/item/18051
+master_sites        https://inkscape.org/en/gallery/item/31668
 
-use_bzip2           yes
+use_xz              yes
 
-checksums           rmd160  360feade19ee48dd081bb43df68189717a63267b \
-                    sha256  81ee7f69e2bd64a97343d8395a4a7a7905b21b861566ed5e5d9179178d519a0b \
-                    size    32175410
+checksums           rmd160  721d41c1c344dc17f8eb38bd45bc3b3bf85f5b88 \
+                    sha256  3ffe54a06d0b25a4cd8b6eb424536ef1ed205be13443a39cd437c8c7b89b96d1 \
+                    size    34222832
 
 set python_major    3
-set python_minor    9
+set python_minor    10
 set python_version  ${python_major}${python_minor}
 
 # this port only uses boost headers during build
@@ -46,48 +45,52 @@ depends_build-append \
                     port:gtest
 
 depends_lib-append  port:desktop-file-utils \
-                    port:popt \
+                    port:libxslt \
+                    port:libsigcxx2 \
+                    port:adwaita-icon-theme \
+                    port:double-conversion \
+                    port:gdl3 \
+                    port:libsoup \
+                    path:lib/pkgconfig/cairo.pc:cairo \
+                    path:include/turbojpeg.h:libjpeg-turbo \
                     port:boehmgc \
-                    path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
                     port:gsl \
-                    port:gtkmm \
+                    port:glibmm \
+                    port:gtkmm3 \
+                    port:gspell \
                     port:dbus-glib \
                     port:lcms2 \
                     port:poppler \
                     port:ImageMagick \
                     port:libcdr-0.1 \
-                    port:libexif \
                     port:libvisio-0.1 \
                     port:libwpg-0.3 \
-                    port:aspell \
-                    port:gtkspell2 \
+                    port:lib2geom \
                     port:potrace \
                     port:python${python_version} \
                     port:py${python_version}-lxml \
                     port:py${python_version}-numpy
 
 post-patch {
-    reinplace "s|\"python-interpreter\", \"python\"|\"python-interpreter\", \"python${python_major}.${python_minor}\"|g" ${worksrcpath}/src/extension/implementation/script.cpp
+    reinplace "s|\"python-interpreter\", *\{\"python3\"|\"python-interpreter\", \{\"python${python_major}.${python_minor}\"|g" ${worksrcpath}/src/extension/implementation/script.cpp
+    reinplace "s|COMMAND python3 |COMMAND ${prefix}/bin/python${python_major}.${python_minor} |g" \
+        ${worksrcpath}/share/filters/CMakeLists.txt \
+        ${worksrcpath}/share/paint/CMakeLists.txt \
+        ${worksrcpath}/share/palettes/CMakeLists.txt \
+        ${worksrcpath}/share/symbols/CMakeLists.txt \
+        ${worksrcpath}/share/templates/CMakeLists.txt
     reinplace "s|^#include \"Object.h\"|#include \"${prefix}/include/poppler/Object.h\"|" ${worksrcpath}/src/extension/internal/pdfinput/pdf-parser.h
     reinplace "s|^#include \"Object.h\"|#include \"${prefix}/include/poppler/Object.h\"|" ${worksrcpath}/src/extension/internal/pdfinput/pdf-parser.cpp
-    reinplace "s|lib/inkscape|lib|" ${worksrcpath}/src/CMakeLists.txt
+    reinplace "s|\"\$\{CMAKE_INSTALL_LIBDIR\}/inkscape\"|\$\{CMAKE_INSTALL_LIBDIR\}|" ${worksrcpath}/src/CMakeLists.txt
 }
 
-# py-numpy is currently not universal (#48263).
-
-universal_variant no
-
-# dependencies require C++11
-compiler.cxx_standard 2011
-
-# clang-425.0.28 cannot handle glibmm's headers
-# allow build with more modern gcc on 10.5 and earlier
-compiler.blacklist-append {clang < 500} *gcc-3.* *gcc-4.*
+compiler.cxx_standard 2017
 
 configure.args-append \
                     -DWITH_DBUS:BOOL=ON \
                     -DWITH_GNOME_VFS=OFF \
-                    -DWITH_OPENMP=OFF
+                    -DWITH_OPENMP=OFF \
+                    -DWITH_MANPAGE_COMPRESSION=OFF
 
 #
 # the following dummy variants are used


### PR DESCRIPTION
#### Description

Update Inkscape to the latest stable version. The Inkscape build is currently broken due to the recent poppler update, which requires C++17.

Depends on #14057 – leaving this PR as Draft until that one is merged.

Closes: https://trac.macports.org/ticket/50210
Closes: https://trac.macports.org/ticket/51287
Closes: https://trac.macports.org/ticket/51407
Closes: https://trac.macports.org/ticket/54944
Closes: https://trac.macports.org/ticket/60927
Closes: https://trac.macports.org/ticket/61404
Closes: https://trac.macports.org/ticket/64660

CC @mascguy 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
