### PR TITLE
spin: update to 6.5.2

### DIFF
--- a/devel/spin/Portfile
+++ b/devel/spin/Portfile
@@ -1,11 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-
-name            spin
-version         6.4.3
-set version_no_dot [join [split ${version} .] ""]
-distname        ${name}${version_no_dot}
+PortGroup       github 1.0
+github.setup    nimble-code spin 6.5.2 version-
 categories      devel
 platforms       darwin
 maintainers     {jann @roederja} openmaintainer
@@ -17,34 +14,28 @@ long_description \
     distributed software (software design) in a rigorous and \
     mostly automated fashion.
 
+notes           "The ispin command needs an X server. Either from the xorg-server port or from\
+                 www.xquartz.org"
+
 homepage        http://spinroot.com
-master_sites    http://spinroot.com/spin/Src/
-checksums           md5     17eb7f14df3616e25635691967786996 \
-                    sha1    9f562f330851da47518f4405b1778b044d655b9c \
-                    rmd160  6d7eac3f6c44ef1e3232ddc032920dc8399e95d4
+checksums       rmd160  a169571ac0796e36e576330966dfb5c0c071696d \
+                sha256  b3864e69797e556b75fbbb0b2f9c54084a8eccefb9108732e27568c2611975f6 \
+                size    6085037
 depends_lib     port:tk port:tcl
-worksrcdir      Spin/Src${version}
 use_configure   no
 use_parallel_build no
 
 pre-patch   {
-    file rename ${worksrcpath}/../iSpin/ispin.tcl ${worksrcpath}/../iSpin/ispin
+    file rename ${worksrcpath}/optional_gui/ispin.tcl ${worksrcpath}/optional_gui/ispin
 }
 
-build.target    ""
-build.args      CC="${configure.cc} -DNXT" \
-                CFLAGS='${configure.cflags} -ansi -D_POSIX_SOURCE -Wno-format-security -DMAC -DCPP=\"\\\"gcc -E -x c -xassembler-with-cpp\\""'
+build.post_args CC="${configure.cc}" \
+                CFLAGS="${configure.cflags} -O2 -DNXT -DMAC"
 
-destroot    {
-    xinstall -m 0444 ${worksrcpath}/../Man/${name}.1 \
-        ${destroot}${prefix}/share/man/man1
-    xinstall -m 0755 ${worksrcpath}/${name} \
-        ${destroot}${prefix}/bin
-    xinstall -m 0755 ${worksrcpath}/../iSpin/ispin \
+destroot.post_args INSTALL=install \
+                   "${destroot.destdir}/${prefix}"
+
+post-destroot    {
+    xinstall -m 0755 ${worksrcpath}/optional_gui/ispin \
         ${destroot}${prefix}/bin
 }
-
-# spinroot.com returns '406 Not Acceptable'
-livecheck.type  regex
-livecheck.url   http://portsmon.freebsd.org/portoverview.py?category=devel&portname=spin
-livecheck.regex >${name}-(\[.\\d\]+)<


### PR DESCRIPTION
#### Description

Update spin port to version 6.5.2

###### Tested on
macOS 11.6.3 20G415 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
