### PR TITLE
frightcrawler: new port

### DIFF
--- a/games/frightcrawler/Portfile
+++ b/games/frightcrawler/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        charlesrocket frightcrawler 0.3.3
+revision            0
+
+categories          games
+license             MIT
+maintainers         @charlesrocket \
+                    openmaintainer
+
+description         MtG deck legality validator.
+long_description    Frightcrawler is a deck legality validator for MtG. It \
+                    reads CSV card lists from Helvault or AetherHub against provided \
+                    game format.
+
+depends_lib         port:crystal \
+                    port:shards
+
+checksums           rmd160  c8943ef7737817a515da9cdafba3b72d6ba2ed41 \
+                    sha256  bc5bf50045a00546bee17ad55a72fc46c381a4f808e8aa5a973c79299b686286 \
+                    size    18694
+
+use_configure       no
+
+build.cmd           ${prefix}/bin/shards --production --verbose install && ${build.cmd}
+
+destroot.destdir    PREFIX=${destroot}${prefix}
+
+test.run            yes


### PR DESCRIPTION
#### Description

MtG deck legality validator.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2.1 21D62
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
