### PR TITLE
vecLibFort: respect CFLAGS

### DIFF
--- a/devel/vecLibFort/Portfile
+++ b/devel/vecLibFort/Portfile
@@ -6,7 +6,7 @@ PortGroup           conflicts_build 1.0
 PortGroup           makefile 1.0
 
 github.setup        mcg1969 vecLibFort 0.4.3
-revision            0
+revision            1
 checksums           rmd160  52429e533071664d0ab94d05f0cbc42795540e59 \
                     sha256  fe9e7e0596bfb4aa713b2273b21e7d96c0d7a6453ee4b214a8a50050989d5586 \
                     size    10689
@@ -33,7 +33,8 @@ platform darwin 8 {
 }
 
 makefile.override-append \
-                    PREFIX
+                    PREFIX \
+                    CFLAGS
 
 test.run            yes
 test.target         check

--- a/devel/vecLibFort/files/patch-Makefile.diff
+++ b/devel/vecLibFort/files/patch-Makefile.diff
@@ -6,6 +6,9 @@ https://github.com/mcg1969/vecLibFort/pull/13
 
 Use LDFLAGS when linking.
 (Not yet submitted upsream.)
+
+Remove extra -O flag
+https://github.com/mcg1969/vecLibFort/pull/16
 --- Makefile.orig	2022-01-22 08:32:18.000000000 -0600
 +++ Makefile	2022-02-09 20:30:04.000000000 -0600
 @@ -1,7 +1,9 @@
@@ -29,7 +32,7 @@ Use LDFLAGS when linking.
  
  $(PRELOAD): $(SOURCE) $(DEPEND)
 -	clang -shared $(CFLAGS) -DVECLIBFORT_INTERPOSE -o $@ -O $(SOURCE) \
-+	$(CC) -shared $(CFLAGS) $(LDFLAGS) -DVECLIBFORT_INTERPOSE -o $@ -O $(SOURCE) \
++	$(CC) -shared $(CFLAGS) $(LDFLAGS) -DVECLIBFORT_INTERPOSE -o $@ $(SOURCE) \
  		-Wl,-reexport_framework -Wl,Accelerate \
  		-install_name $(LIBDIR)/$@
  


### PR DESCRIPTION
#### Description

In researching why the Tiger build was failing, I discovered that `CFLAGS` was not being passed to the compiler. Since new `CFLAGS` changes the resulting binary (optimization level), bump the revision.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
