### PR TITLE
MoltenVK: Bump min requirement

### DIFF
--- a/graphics/MoltenVK/Portfile
+++ b/graphics/MoltenVK/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        KhronosGroup MoltenVK 1.1.17 v
+github.setup        KhronosGroup MoltenVK 1.1.7 v
+epoch               1
 
 set sdkversion      1.3.204.0
 categories          graphics
@@ -59,13 +60,13 @@ destroot {
 }
 
 platform darwin {
-    if {${os.major} < 15} {
+    if {${os.major} < 16} {
         archive_sites
         distfiles
         depends_build
         known_fail  yes
         pre-fetch {
-            ui_error "${subport} @${version} requires OS X El Capitan or later"
+            ui_error "${subport} @${version} requires macOS Sierra or later"
             return -code error "incompatible OS X version"
         }
     }


### PR DESCRIPTION
Buildbot was unable to mount the dmg on 10.11 to bump back to 10.12.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
