### PR TITLE
py-barnaba: 0.1.7 stealth update

### DIFF
--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -33,7 +33,7 @@ checksums           rmd160  e57a589dbcaf231e992f0e252517e602495443b6 \
                     sha256  217904208a5efb4dbd04d23910fad1ffe201c3dd7607a8adb08b9583bdd08c58 \
                     size    30260069
 
-python.versions     37
+python.versions     37 38
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools_scm \

--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -7,6 +7,16 @@ PortGroup           github 1.0
 github.setup        srnas barnaba 0.1.7
 name                py-barnaba
 
+# this is due to a harmless stealth update
+# https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
+dist_subdir   ${name}/${version}_1
+# here's the diff between previous and newer untarred directories:
+# diff -r mp/srnas-barnaba-1d02ca7/.git_archival.txt gh/srnas-barnaba-1d02ca7/.git_archival.txt
+# 1c1
+# < ref-names: HEAD -> master, tag: 0.1.7
+# ---
+# > ref-names: tag: 0.1.7
+
 categories-append   science
 license             GPL-3
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
@@ -19,9 +29,9 @@ long_description    ${description} \
 
 supported_archs     noarch
 
-checksums           rmd160  f6e4f68d5af8149e9a884e6dc88fbe77545507e6 \
-                    sha256  392402230279c710a263062d52a239d5a9cbebd19946f6dd03dbc8453c62dc87 \
-                    size    30260068
+checksums           rmd160  e57a589dbcaf231e992f0e252517e602495443b6 \
+                    sha256  217904208a5efb4dbd04d23910fad1ffe201c3dd7607a8adb08b9583bdd08c58 \
+                    size    30260069
 
 python.versions     37
 


### PR DESCRIPTION
#### Description

- Stealth update for barnaba (see [here](https://github.com/macports/macports-ports/pull/14025#issuecomment-1046224934))
-  Added python 38

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
**I didn't test because nose tests are currently not working correctly with MacPorts. Anyway, the package seems to work correctly**
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
