### PR TITLE
py-utidylib: update to 0.8

### DIFF
--- a/python/py-utidylib/Portfile
+++ b/python/py-utidylib/Portfile
@@ -1,9 +1,11 @@
 PortSystem 1.0
 PortGroup python 1.0
+PortGroup github 1.0
 
-name			py-utidylib
-version			0.2
-revision		2
+github.setup            nijel utidylib 0.8 v
+github.tarball_from     archive
+name                    py-${github.project}
+revision		0
 platforms		darwin
 supported_archs	noarch
 license			MIT
@@ -14,33 +16,19 @@ long_description	Python interface to html tidy, the html and xml \
 
 homepage		http://utidylib.berlios.de/
 
-python.versions	27
+python.versions	        36 37 38 39
+python.pep517           yes
 
 if {${name} ne ${subport}} {
-    master_sites		http://download.berlios.de/utidylib/
-    distname		uTidylib-${version}
-    checksums		md5 c9f16988f92ef660f46523192ef37462
-    use_zip			yes
+    checksums           rmd160  37c195115b06524a15f811fdc6fada5bef6d2ef7 \
+                        sha256  9342ae5c99b17c37d15850c2dbcdb9c1a991a12de7f0ec61f06c246d5688db68 \
+                        size    15285
 
-    patchfiles		patch-lib.py.diff patch-lib.py-64bit.diff
-
-    depends_lib-append	port:tidy \
-			port:py${python.version}-epydoc
+    depends_lib-append	port:tidy
+    depends_build-append port:py${python.version}-sphinx
 
     post-patch	{
         reinplace "s|__TIDYLIB__|${prefix}/lib/libtidy.dylib|g" \
             ${worksrcpath}/tidy/lib.py
-    }
-
-    post-build	{
-        system -W ${worksrcpath} "${python.bin} gendoc.py"
-        file rename ${worksrcpath}/apidoc ${worksrcpath}/doc
-    }
-
-    post-destroot	{
-        file delete -force ${destroot}${prefix}/share/doc/${subport}
-        file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 644 -W ${worksrcpath} INSTALL.txt README.path README.txt \
-            ${destroot}${prefix}/share/doc/${subport}
     }
 }


### PR DESCRIPTION
#### Description

py-utidylib update in an effort to drop py27 packages

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6.4 20G417 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?