### PR TITLE
ncarg: Escape cflags properly and mark as unsupported on arm64

### DIFF
--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -106,6 +106,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 12} {
     }
 }
 
+supported_archs             i386 ppc ppc64 x86_64
 configure.cflags-append     -Wno-error=implicit-function-declaration
 if {${configure.sdkroot} ne ""} {
     configure.cflags-append     -isysroot ${configure.sdkroot}

--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -169,8 +169,8 @@ pre-configure {
     # run ymake
     system -W ${worksrcpath}/config \
         "CC=${configure.cc} \
-        CFLAGS=${configure.cflags} \
-        make -f Makefile.ini; \
+        CFLAGS=[shellescape ${configure.cflags}] \
+        make -f Makefile.ini && \
         ./ymake -config `pwd`"
 
     # copy triangle.[ch]


### PR DESCRIPTION
#### Description

Escape cflags when building ymake-filter. Also change `;` to `&&` so that failure to build ymake-filter causes the whole build to fail rather than continuing.

Closes: https://trac.macports.org/ticket/62867

Mark as unsupported on arm64

See: https://trac.macports.org/ticket/64710

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1615 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
