### PR TITLE
vim: fix broken variants python36-39

### DIFF
--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -116,11 +116,12 @@ foreach s ${pythons_suffixes} {
 
 foreach s ${pythons_suffixes} {
     set p python${s}
-    set v [string index ${s} 0].[string range ${s} 1 end]
+    set major [string index ${s} 0]
+    set v ${major}.[string range ${s} 1 end]
     set i [lsearch -exact ${pythons_ports} ${p}]
     set c [lreplace ${pythons_ports} ${i} ${i}]
     variant ${p} description "Enable Python scripting" conflicts {*}${c} "
-        if {${s} < 300} {
+        if {${major} == 2} {
             configure.args-append   --enable-pythoninterp --with-python-command=${prefix}/bin/python${v}
             patchfiles-append       patch-python.diff
         } else {


### PR DESCRIPTION
#### Description

https://github.com/macports/macports-ports/pull/13922#discussion_r811486640 notes that my previous PR broke some vim variants relating to python3.6 to python3.9.
Apologies, I thought I had pushed the fix. It looks like I hadn't.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
