### PR TITLE
stlink: compatibility fixes with libusb 1.0.25

### DIFF
--- a/cross/stlink/Portfile
+++ b/cross/stlink/Portfile
@@ -4,7 +4,11 @@ PortSystem              1.0
 PortGroup               cmake 1.1
 PortGroup               github 1.0
 
+# stlink static-links to libusb, which needs clock_gettime
+PortGroup               legacysupport 1.1
+
 github.setup            stlink-org stlink 1.7.0 v
+revision                1
 
 categories              cross devel
 license                 BSD
@@ -21,6 +25,10 @@ checksums               rmd160  40627ba83e3a4749b0a7bbcbb8a66873df346c88 \
                     
 depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb \
                         port:pkgconfig
+
+# stlink static-links to libusb, which needs Security
+patch.pre_args          -p1
+patchfiles              patch-stlink-libusb-Security-framework.diff
 
 variant gui description "Enable st-link GUI" {
     PortGroup           app 1.0

--- a/cross/stlink/files/patch-stlink-libusb-Security-framework.diff
+++ b/cross/stlink/files/patch-stlink-libusb-Security-framework.diff
@@ -1,0 +1,47 @@
+From 468b1d2daa853b975c33ab69876c486734f2c6a7 Mon Sep 17 00:00:00 2001
+From: nightwalker-87 <15526941+Nightwalker-87@users.noreply.github.com>
+Date: Fri, 4 Feb 2022 22:24:42 +0100
+Subject: [PATCH] [libusb] Added Security framework for macOS
+
+---
+ CMakeLists.txt                     | 6 ++++--
+ cmake/packaging/cpack_config.cmake | 2 +-
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 52c00ea2..67f76ec0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -209,7 +209,8 @@ if (APPLE)     # ... with Apple macOS libraries
+     find_library(ObjC objc)
+     find_library(CoreFoundation CoreFoundation)
+     find_library(IOKit IOKit)
+-    target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB} ${ObjC} ${CoreFoundation} ${IOKit})
++    find_library(Security Security)
++    target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB} ${ObjC} ${CoreFoundation} ${IOKit} ${Security})
+ elseif (WIN32) # ... with Windows libraries
+     target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB} wsock32 ws2_32)
+ else ()
+@@ -251,7 +252,8 @@ if (APPLE)     # ... with Apple macOS libraries
+     find_library(ObjC objc)
+     find_library(CoreFoundation CoreFoundation)
+     find_library(IOKit IOKit)
+-    target_link_libraries(${STLINK_LIB_STATIC} ${LIBUSB_LIBRARY} ${SSP_LIB} ${ObjC} ${CoreFoundation} ${IOKit})
++    find_library(Security Security)
++    target_link_libraries(${STLINK_LIB_STATIC} ${LIBUSB_LIBRARY} ${SSP_LIB} ${ObjC} ${CoreFoundation} ${IOKit} ${Security})
+ elseif (WIN32) # ... with Windows libraries
+     target_link_libraries(${STLINK_LIB_STATIC} ${LIBUSB_LIBRARY} ${SSP_LIB} wsock32 ws2_32)
+ else ()
+diff --git a/cmake/packaging/cpack_config.cmake b/cmake/packaging/cpack_config.cmake
+index 587ff5fb..a4f1ae07 100644
+--- a/cmake/packaging/cpack_config.cmake
++++ b/cmake/packaging/cpack_config.cmake
+@@ -17,7 +17,7 @@ set(CPACK_OUTPUT_FILE_PREFIX "${CMAKE_BINARY_DIR}/dist")
+ 
+ if (APPLE)                                                                      # macOS
+     set(CPACK_GENERATOR "ZIP")
+-    set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-macosx-amd64")
++    set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-macos-amd64")
+     set(CPACK_INSTALL_PREFIX "")
+ 
+ elseif (WIN32 AND (NOT EXISTS "/etc/debian_version"))                           # Windows


### PR DESCRIPTION
#### Description

CI is failing in #14082; this is designed to fix it.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
