### PR TITLE
vim, MacVim: add comment to keep patchlevels in sync

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -4,6 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
+# The vim port should always follow the patch level used in the MacVim port. This
+# is because they both share the same set of configuration files and ensures
+# that the user's configuration files will always work with both.
 set vim_version     8.2
 set snapshot        171
 github.setup        macvim-dev macvim ${snapshot} snapshot-

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -3,6 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
+# The vim port should always follow the patch level used in the MacVim port. This
+# is because they both share the same set of configuration files and ensures
+# that the user's configuration files will always work with both.
 set vim_version     8.2
 set vim_patchlevel  4324
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v


### PR DESCRIPTION
#### Description

vim, MacVim: add comment to keep patchlevels in sync

Following my recent PRs #13922 and #14084 to bump vim patchlevels, I was made aware that [vim and MacVim patchlevels should be kept in sync](https://github.com/macports/macports-ports/pull/12530#issuecomment-939512070). Since #13922 was already merged into master, I wanted to update MacVim to the same patchlevel, but it looks like latest MacVim is based on vim 8.2.3455 as of today, so syncing patchlevels isn't possible unless we downgrade vim.

Even if we can't fix things today, the comments that this PR adds will hopefully help prevent this issue from reoccurring.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
