### PR TITLE
plumed: update to 2.8.0

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.7.3 v
+github.setup        plumed plumed2 2.8.0 v
 name                plumed
 revision            0
 
@@ -26,13 +26,10 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  25b9e84980d08583c782780281b241f5eca47e55 \
-                    sha256  5d7f052697b05d0a2c3b934606d8890b2655b68070fa3a22009d83f8aea5a73f \
-                    size    106492582
+checksums           rmd160  841a9a9c06fe3b0af921839b9e8fa1de509939da \
+                    sha256  b2bafea1c763c1cf65b6b1a3ede5b9c6d82b80ff7e41e0b8517a1fcd5f5e6fde \
+                    size    107835309
 
-# Enable optional features.
-# --enable-asmjit:        Compile internal asmjit. Notice that internal asmjit is protected in
-#                         PLUMED namespace so will not collide with other asmjit implementations.
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
 # --disable-libsearch:    Avoid searching libraries using their default names.
@@ -49,10 +46,6 @@ configure.args-append \
                     --disable-static-patch \
                     --disable-mpi \
                     --disable-python
-
-if {${configure.build_arch} eq "x86_64"} {
-    configure.args-append --enable-asmjit
-}
 
 # install bash completions
 configure.args-append BASH_COMPLETION_DIR=${prefix}/share/bash-completion/completions
@@ -88,11 +81,10 @@ configure.cxxflags-replace -Os -O3
 # Library names are specified here to make sure that
 # only requested packages are linked.
 configure.ldflags-append \
-                    -lxdrfile -lz -lgsl -lfftw3
+                    -lz -lgsl -lfftw3
 depends_lib-append  port:fftw-3 \
                     port:gawk \
                     port:gsl \
-                    port:xdrfile \
                     port:zlib
 
 # C++ library
@@ -120,18 +112,15 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 ef90a2cd5e5c2ccd51dc48c3462c37967ef73910
-    version             2.8-20211201
+    github.setup        plumed plumed2 7e0337ac43a834c59fc5552f5746eae1dde1b541
+    version             2.9-20220222
     revision            0
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  c5b0dbcb7ab6cf26092a57fd91d2eb739dc91bea \
-                        sha256  f689ddb2b4931de6ded67061d7e7d4501e3dd5d6d40785b107a675d17cf545ec \
-                        size    107893701
-    configure.ldflags-delete -lxdrfile
-    depends_lib-delete       port:xdrfile
-    configure.args-delete    --enable-asmjit
+    checksums           rmd160  8a0300ff023d7fe839a9fa06c646d5506bb5f65b \
+                        sha256  48df9b5c970e2eb3ef581300babc16644683b8e268c0c25f62a068650d6d5133 \
+                        size    111048258
 }
 
 # Allow running tests from MacPorts


### PR DESCRIPTION
#### Description

Update plumed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
