### PR TITLE
beets-{beetcamp,devel} upgrade to 0.12.0 / 20220216

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -232,8 +232,8 @@ subport ${name}-barcode {
 
 subport ${name}-beetcamp {
     python.rootname beetcamp
-    version         0.11.0
-    revision        1
+    version         0.12.0
+    revision        0
 
     license         GPL-2
 
@@ -243,9 +243,9 @@ subport ${name}-beetcamp {
 
     homepage        https://github.com/snejus/beetcamp
 
-    checksums       rmd160  1e1c7e767cd959008f07e5d6189f6616a9f9945c \
-                    sha256  0171236fdc389d86c78671663b765d59824a3dfd6ca316e360a5b5244e7301bf \
-                    size    30755
+    checksums       rmd160  132486984e4ca0536a11cefaa04f9362fa41a81d \
+                    sha256  7a810f337f1e9a34135026d9140fce13442d82a18d967553c5a8cd281185ce2b \
+                    size    32657
 
     depends_lib-append \
                     port:py${python.version}-cached-property \

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,13 +39,13 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets 51e478ed1d1f818775abfd8b9fd086da10a30c2b
-    version         20220130
+    github.setup    beetbox beets 5f45e9e10894ea94d35a885d25c4c4ffffcfaa91
+    version         20220216
     revision        0
 
-    checksums       rmd160  0f24f7193b386866859d98d83cc7ad104dc5f6d5 \
-                    sha256  2ea8de44f74545e45f09931257246b29a1c1f9fa74ac9a54e4ac35b9c0ff3cf7 \
-                    size    1687868
+    checksums       rmd160  559c85a7ba388c633ccec0f830d638214bddef64 \
+                    sha256  58d6f1d01818926857a54be19370dd8bc0c7eb80b2aa3178d1d97c39a9e92e5e \
+                    size    1687910
 
     depends_build-append \
                     port:py${python.version}-sphinx


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.1 21C52 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->