### PR TITLE
csfml: new port

### DIFF
--- a/multimedia/csfml/Portfile
+++ b/multimedia/csfml/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+
+name                csfml
+version             2.5.1
+revision            0
+categories          multimedia devel
+maintainers         nomaintainer
+license             zlib
+
+description         C bindings for SFML, the Simple and Fast Multimedia Library
+
+long_description    ${description}. It provides a simple interface to the various \
+                    components of your computer, to ease the development of games and \
+                    multimedia applications. It is composed of five modules: system, \
+                    window, graphics, audio and network.
+
+homepage            https://www.sfml-dev.org
+master_sites        ${homepage}/files/
+distname            CSFML-${version}-sources
+use_zip             yes
+
+checksums           rmd160  5d8eecf7d3be6061e3a749511af9dd1674c1ae97 \
+                    sha256  5453f04ae782a22697ebeb2694a0f7a56bf172c1406ca2b9134143198705ddc7 \
+                    size    324088
+
+worksrcdir          CSFML-${version}
+
+depends_lib-append  port:sfml


### PR DESCRIPTION
#### Description
C bindings for SFML

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2.1 21D62 arm64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->