### PR TITLE
julius-caesar-3: new port (version 1.7.0)

### DIFF
--- a/games/julius-caesar-3/Portfile
+++ b/games/julius-caesar-3/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake   1.1
+PortGroup           github  1.0
+
+github.setup        bvschaik julius 1.7.0 v
+github.tarball_from archive
+name                julius-caesar-3
+revision            0
+
+description         An open source re-implementation of Caesar III
+
+long_description    \
+    Julius is a fully working open-source version of Caesar 3, with the same \
+    logic as the original, but with some UI enhancements, that can be played \
+    on multiple platforms. Julius will not run without the original Caesar 3 \
+    files. You can buy a digital copy from GOG or Steam, or you can use an \
+    original CD-ROM version. The goal of the project is to have exactly the \
+    same game logic as Caesar 3, with the same look and feel. This means that \
+    the saved games are 100% compatible with Caesar 3, and any gameplay bugs \
+    present in the original Caesar 3 game will also be present in Julius.
+
+categories          games
+installs_libs       no
+license             AGPL-3
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+depends_lib-append  port:libpng         \
+                    port:libsdl2        \
+                    port:libsdl2_mixer  \
+                    port:zlib
+
+checksums   rmd160  fcd4ba2d0d6194016bc265abfcf9f987326f1bf8 \
+            sha256  3ee62699bcbf6c74fe5a9c940c62187141422a9bd98e01747a554fd77483431f \
+            size    6448466
+
+destroot {
+    copy ${cmake.build_dir}/julius.app \
+        ${destroot}${applications_dir}/Julius.app
+}
+
+notes "
+    Julius can be found in the MacPorts Applications directory.
+
+    Follow the instructions at:
+
+        ${homepage}/wiki/Running-Julius-on-macOS
+
+    ...to install the required game data.
+"


### PR DESCRIPTION
#### Description

New port for **[Julius](https://github.com/bvschaik/julius)**, an open-source re-implentation of the classic city-building game Caesar III

<img src="https://github.com/bvschaik/julius/blob/master/res/vita/bg.png?raw=true">

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
