### PR TITLE
Updated for 2.9.13 which fixes a regression in 2.9.12 that was fixed …

### DIFF
--- a/python/py-libxml2/Portfile
+++ b/python/py-libxml2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 # Please keep the version of the libxml2 and py-libxml2 ports the same.
 name                py-libxml2
-version             2.9.12
+version             2.9.13
 revision            0
 
 categories-append   textproc
@@ -18,16 +18,17 @@ long_description    ${description}
 
 homepage            http://xmlsoft.org/python.html
 
-master_sites        http://www.xmlsoft.org/sources/ \
-                    ftp://gd.tuwien.ac.at/pub/libxml/ \
-                    ftp://xmlsoft.org/libxml2/
+master_sites        https://download.gnome.org/sources/libxml2/2.9/
+
 
 distname            libxml2-${version}
 dist_subdir         libxml2
 
-checksums           rmd160  766b9460b9e62b8152f431747c30c88c868c0c7e \
-                    sha256  c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92 \
-                    size    5681632
+checksums           rmd160  dc9922afb45d2e7ba4840d13ce784a48d664687c \
+                    sha256  276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e \
+                    size    3243336
+
+use_xz yes
 
 python.versions     27 35 36 37 38 39 310
 

--- a/textproc/libxml2/Portfile
+++ b/textproc/libxml2/Portfile
@@ -6,8 +6,8 @@ PortGroup           clang_dependency 1.0
 # Please keep the version of the libxml2 and py-libxml2 ports the same.
 
 name                libxml2
-version             2.9.12
-revision            1
+version             2.9.13
+revision            0
 categories          textproc
 platforms           darwin
 license             MIT
@@ -27,12 +27,13 @@ depends_lib         port:libiconv \
                     port:xz \
                     port:zlib
 
-master_sites        ${homepage}sources/ \
-                    ftp://xmlsoft.org/${name}/
+master_sites        https://download.gnome.org/sources/libxml2/2.9/
 
-checksums           rmd160  766b9460b9e62b8152f431747c30c88c868c0c7e \
-                    sha256  c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92 \
-                    size    5681632
+checksums           rmd160  dc9922afb45d2e7ba4840d13ce784a48d664687c \
+                    sha256  276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e \
+                    size    3243336
+
+use_xz yes
 
 set icu_cxx_version 201103L
 


### PR DESCRIPTION
…only in git. Building from source against 2.9.12 caused problems for lxml 4.8.0 but the wheels are fine.

py-libxml2 updated to stay in sync.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
Update to textproc/libxml2 python/py-libxml2

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
