### PR TITLE
py-plumed: update to 2.8.0 and added python 310

### DIFF
--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        plumed plumed2 2.7.1 v
+github.setup        plumed plumed2 2.8.0 v
 name                py-plumed
 
 categories-append   science
@@ -16,14 +16,17 @@ long_description    ${description} They allow the plumed library to be directly 
 
 homepage            https://www.plumed.org
 
-checksums           rmd160  2137586dbc890732d0e632c8b4ec483aa0c00598 \
-                    sha256  c5ecc6c13eb45a9e009c1fedf07d91f5a02f2600ff29f1cd481f4a0d17e12908 \
-                    size    106402240
+checksums           rmd160  841a9a9c06fe3b0af921839b9e8fa1de509939da \
+                    sha256  b2bafea1c763c1cf65b6b1a3ede5b9c6d82b80ff7e41e0b8517a1fcd5f5e6fde \
+                    size    107835309
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 # python setup is located in python subdir of plumed repository
 worksrcdir  ${distname}/python
+
+patchfiles          0001-Fix-python-version-file.patch
+patch.pre_args      -p1
 
 if {${name} ne ${subport}} {
 

--- a/python/py-plumed/files/0001-Fix-python-version-file.patch
+++ b/python/py-plumed/files/0001-Fix-python-version-file.patch
@@ -1,0 +1,68 @@
+From 8c6fddffa94a5242bf64957bda2b51b6e3526f07 Mon Sep 17 00:00:00 2001
+From: Giovanni Bussi <giovanni.bussi@gmail.com>
+Date: Wed, 23 Feb 2022 11:38:51 +0100
+Subject: [PATCH] Fix python version file
+
+---
+ python/MANIFEST.in | 2 +-
+ python/Makefile    | 5 +++--
+ python/setup.py    | 4 ++--
+ 3 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/MANIFEST.in b/MANIFEST.in
+index 60433df7c..2004b38cd 100644
+--- a/MANIFEST.in
++++ b/MANIFEST.in
+@@ -1,4 +1,4 @@
+-include VERSION
++include PLUMED_VERSION
+ include include/Plumed.h
+ include plumed.pyx
+ include cplumed.pxd
+diff --git a/Makefile b/Makefile
+index ffb746b66..967955d2d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,7 +29,7 @@ all:
+ endif
+ 
+ pip:
+-	cp ../VERSION .
++	cp ../VERSION ./PLUMED_VERSION
+ 	mkdir -p include
+ 	cp ../src/wrapper/Plumed.h include/
+ 
+@@ -44,6 +44,7 @@ pypi:
+ 	mkdir -p pypi/include
+ 	cp -r test pypi/
+ 	cp ../src/wrapper/Plumed.h pypi/include/
+-	cp README.rst MANIFEST.in cplumed.pxd plumed.pyx setup.py ../VERSION pypi/
++	cp README.rst MANIFEST.in cplumed.pxd plumed.pyx setup.py pypi/
++	cp ../VERSION pypi/PLUMED_VERSION
+ 	cd pypi ; $(python_bin) setup.py sdist
+ 	echo "now use: $(python_bin) -m twine upload dist/plumed-$(VERSION).tar.gz"
+diff --git a/setup.py b/setup.py
+index 7ad0903d4..cd3b30e83 100644
+--- a/setup.py
++++ b/setup.py
+@@ -40,7 +40,7 @@ def is_platform_mac():
+     return sys.platform == 'darwin'
+ 
+ if os.getenv("plumed_macports") is not None:
+-    copyfile("../VERSION","VERSION")
++    copyfile("../VERSION","PLUMED_VERSION")
+     try:
+         os.mkdir("include")
+     except OSError:
+@@ -53,7 +53,7 @@ if plumedname is None:
+ 
+ plumedversion = os.getenv("plumed_version")
+ if plumedversion is None:
+-    plumedversion = subprocess.check_output(['grep','-v','#','./VERSION']).decode("utf-8").rstrip()
++    plumedversion = subprocess.check_output(['grep','-v','#','./PLUMED_VERSION']).decode("utf-8").rstrip()
+ 
+ print( "Module name " + plumedname )
+ print( "Version number " + plumedversion )
+-- 
+2.35.1
+


### PR DESCRIPTION
#### Description


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
