### PR TITLE
py-emcee: add py310 subport

### DIFF
--- a/python/py-emcee/Portfile
+++ b/python/py-emcee/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        dfm emcee 2.2.1 v
+revision            0
 name                py-emcee
 
 maintainers         {aronnax @lpsinger} openmaintainer
@@ -26,7 +27,7 @@ checksums           rmd160  9d877a80ce5a19b8c442d225a27a57fe548a14f0 \
                     sha256  afb252b304051ca7a936e81adfa69c92b37fdafd8d3be95e920059f08dcf2d00 \
                     size    769439
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     if {${python.version} >= 36} {


### PR DESCRIPTION
#### Description
Add py310 subport of `py-emcee`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
