### PR TITLE
py-netcdf4: update to 1.5.8

### DIFF
--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 
 name                py-netcdf4
 python.rootname     netCDF4
-version             1.5.7
+version             1.5.8
 revision            0
 
 categories-append   science
@@ -24,9 +24,9 @@ long_description    netCDF version 4 has many features not found in \
 
 homepage            https://unidata.github.io/netcdf4-python/
 
-checksums           rmd160  eef29c264379e1a8086bdc7aa883f016920b0881 \
-                    sha256  d145f9c12da29da3922d8b8aafea2a2a89501bcb28a219a46b7b828b57191594 \
-                    size    763928
+checksums           rmd160  3164795f291cdba22de9b808096cca6aea36a4d9 \
+                    sha256  ca3d468f4812c0999df86e3f428851fb0c17ac34ce0827115c246b0b690e4e84 \
+                    size    767013
 
 mpi.enforce_variant netcdf
 mpi.setup
@@ -34,7 +34,7 @@ mpi.setup
 build.env-append    USE_NCCONFIG=1
 destroot.env-append USE_NCCONFIG=1
 
-python.versions     27 35 36 37 38 39
+python.versions     27 35 36 37 38 39 310
 
 if {${name} ne ${subport}} {
     if {${python.version} in "27 35"} {


### PR DESCRIPTION
#### Description
Update py-netcdf4 to 1.5.8 and add py310 subport. (The py310 subport is needed to add a py310 subport to py-pymc3, which will be dealt with in a further PR.)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
