### PR TITLE
cdo: update to 2.0.4

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   mpi 1.0
 
 name                        cdo
-version                     2.0.3
+version                     2.0.4
 revision                    0
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
@@ -12,11 +12,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/26676
+master_sites                https://code.mpimet.mpg.de/attachments/download/26761
 
-checksums           rmd160  f00d10bfefaa49e2d5dbb148476c92dc857b9e39 \
-                    sha256  25520260ccb4e5324c27fa2160dfafc8152b180dd7f0133bd80425df3ef7c65a \
-                    size    11781699
+checksums           rmd160  53081d368fd774bfa3c579161e9f20d2ea908a36 \
+                    sha256  73c0c1e5348632e6e8452ea8e617c35499bc55c845ee2c1d42b912a7e00e5533 \
+                    size    11777977
 
 long_description \
     CDO is a collection of command line Operators               \


### PR DESCRIPTION
#### Description

Simple upstream update to 2.0.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2.1 21D62 x86_64
Xcode Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
