### PR TITLE
mpv: Set MACOS_SDK_VERSION and use latest SDK

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -262,14 +262,26 @@ platform darwin {
         }
     }
 
-    # Fix for https://trac.macports.org/ticket/61319
-    configure.env-append   MACOS_SDK=${configure.sdkroot}
-
     post-extract {
         xinstall -m 0644 -W "${filespath}" config-maintainer "${worksrcpath}/TOOLS/"
     }
 
     pre-configure {
+        if {${use_xcode}} {
+            configure.sdkroot ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+        }
+        if {${configure.sdkroot} ne ""} {
+            set sdkv [exec /usr/libexec/PlistBuddy -c Print:ProductVersion ${configure.sdkroot}/System/Library/CoreServices/SystemVersion.plist]
+        } else {
+            set sdkv ${configure.sdk_version}
+        }
+        if {[llength [split ${sdkv} .]] < 2} {
+            set sdkv ${sdkv}.0
+        }
+        configure.env-append \
+                        MACOS_SDK=${configure.sdkroot} \
+                        MACOS_SDK_VERSION=${sdkv}
+
         if {[variant_isset network]} {
             reinplace -W "${worksrcpath}/TOOLS" "s/@@NETWORK@@//" config-maintainer
         } else {


### PR DESCRIPTION
#### Description

mpv: Set MACOS_SDK_VERSION and use latest SDK

Fixes build on Mac OS X 10.7 and on Xcode versions where the SDK version does not match the OS version.

Closes: https://trac.macports.org/ticket/61733
Closes: https://trac.macports.org/ticket/61647
Closes: https://trac.macports.org/ticket/62889
Closes: https://trac.macports.org/ticket/63694

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Mac OS X 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
