### PR TITLE
unshield: update to 1.5.1

### DIFF
--- a/archivers/unshield/Portfile
+++ b/archivers/unshield/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           openssl 1.0
 
-github.setup        twogood unshield 1.4.3
+github.setup        twogood unshield 1.5.1
 revision            0
 github.tarball_from archive
 
@@ -22,9 +22,9 @@ long_description \
 depends_lib         port:libiconv \
                     port:zlib
 
-checksums           sha256  aa8c978dc0eb1158d266eaddcd1852d6d71620ddfc82807fe4bf2e19022b7bab \
-                    rmd160  0f26f1c0d3637762fa06a3c2d60253046f0ed085 \
-                    size    58822
+checksums           sha256  34cd97ff1e6f764436d71676e3d6842dc7bd8e2dd5014068da5c560fe4661f60 \
+                    rmd160  fe9c5f3717efa433a864e614068406fd83b974a5 \
+                    size    67454
 
 configure.ldflags-append -liconv
 


### PR DESCRIPTION
#### Description

Update to unshield v. 1.5.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
