### PR TITLE
cpi: new port

### DIFF
--- a/lang/cpi/Portfile
+++ b/lang/cpi/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+PortGroup           qmake5  1.0
+
+github.setup        treefrogframework cpi 2.0.4 v
+github.tarball_from archive
+revision            0
+
+homepage            https://treefrogframework.github.io/cpi
+
+description         Cpi is a tiny interpreter for C++11, C++14 or C++17.
+long_description    {*}${description}
+
+categories          lang devel
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  60f9295f958feb31a240a22a3374fd930675bf28 \
+                    sha256  55e98b851976d258c1211d3c04d99ce2ec104580cc78f5d30064accef6e3d952 \
+                    size    11054
+
+use_xcode           yes
+
+post-configure {
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/Makefile
+}


### PR DESCRIPTION
#### Description

[cpi](https://github.com/treefrogframework/cpi) is a tiny _interpreter_ (not compiler) for C++11, C++14 or C++17.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
