### PR TITLE
dblatex: Fix python3 encoding problem

### DIFF
--- a/textproc/dblatex/Portfile
+++ b/textproc/dblatex/Portfile
@@ -6,7 +6,7 @@ PortGroup           texlive 1.0
 
 name                dblatex
 version             0.3.12
-revision            0
+revision            1
 categories          textproc tex
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-2+
@@ -37,6 +37,8 @@ checksums           sha256  16e82786272ed1806a079d37914d7ba7a594db792dc4cc34c1c3
                     size    1693272
 
 use_bzip2           yes
+
+patchfiles          patch-64720.diff
 
 depends_lib         port:texlive-latex-extra \
                     port:texlive-latex-recommended \

--- a/textproc/dblatex/files/patch-64720.diff
+++ b/textproc/dblatex/files/patch-64720.diff
@@ -1,0 +1,11 @@
+--- lib/dbtexmf/dblatex/rawverb.py.orig	2022-02-24 21:35:36.000000000 +0100
++++ lib/dbtexmf/dblatex/rawverb.py	2022-02-24 21:35:39.000000000 +0100
+@@ -36,7 +36,7 @@
+         n = tex_handler_counter[self._errors]
+         for c in ntext:
+             if ord(c) > 255:
+-                c = str(self.pre) + c + str(self.post)
++                c = self.pre.decode(self.output_encoding) + c + self.post.decode(self.output_encoding)
+                 n += 1
+             text += c
+         tex_handler_counter[self._errors] = n


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/64720

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.4 20G417 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
