### PR TITLE
openal-soft: Use legacysupport for new TargetConditionals.h macros

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -2,6 +2,11 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.1
+PortGroup               legacysupport 1.1
+
+# For TARGET_OS_OSX, TARGET_OS_IOS & TARGET_OS_TV macros
+legacysupport.newest_darwin_requires_legacy 14
+
 if {${subport} eq "openal-soft" && [variant_isset gui]} {
 PortGroup               qt5 1.0
 }


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/64548

#### Description

From llvm-11 and later undefined targets cause build failures. 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.9.5 13F1911 X86_64
Xcode Command Line Tools

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
