### PR TITLE
qt5-qtwebengine-gn: fix build on macOS 10.13

### DIFF
--- a/devel/gn-devel/Portfile
+++ b/devel/gn-devel/Portfile
@@ -76,11 +76,13 @@ if {${subport} eq ${name}} {
     compiler.cxx_standard 2014
 
     # see https://github.com/qt/qtwebengine/blob/v5.15.8-lts/src/buildtools/gn.pro#L21
+    if {${configure.sdkroot} ne ""} {
+        configure.post_args-append --isysroot ${configure.sdkroot}
+    }
     pre-configure {
         configure.post_args-append \
             --no-last-commit-position \
             --use-lto \
-            --isysroot ${configure.sdkroot} \
             --cc [compwrap::wrap_compiler cc] \
             --cxx [compwrap::wrap_compiler cxx] \
             --ld [compwrap::wrap_compiler cxx]


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/64688

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6
Xcode 10.1 command line tools
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
