### PR TITLE
flyctl: update to 0.0.301

### DIFF
--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -1,15 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        superfly flyctl 0.0.246 v
+go.setup            github.com/superfly/flyctl 0.0.301 v
+github.tarball_from archive
 revision            0
+
 categories          devel
-platforms           darwin
-supported_archs     arm64 x86_64
+installs_libs       no
 license             Apache-2
 maintainers         {netinertia.co.uk:jamesog @jamesog} \
+                    {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 description         Command line tools for fly.io services
@@ -17,27 +19,28 @@ long_description    ${name} is a command-line interface for fly.io.
 
 homepage            https://fly.io
 
-github.tarball_from releases
-distname            ${name}_${version}_macOS_${build_arch}
+checksums           rmd160 0894dc95ddb3d7ebbc9c4030d7e1e20cd8f149b6 \
+                    sha256 7c23749f81159cd037952168b94473ff982fdfac3e8627fb3a0ce8eca26da5ed \
+                    size 1439017
 
-checksums           ${name}_${version}_macOS_x86_64${extract.suffix} \
-                    rmd160  1451bcedc41d8abca79b276dcb06220167d42f79 \
-                    sha256  07ec4507beac246d2c1971215c709b4ceab5d23aaefa627e3039c0105f897b4f \
-                    size    18875569 \
-                    ${name}_${version}_macOS_arm64${extract.suffix} \
-                    rmd160  a764a74f792045aebb41879fa31a04d951b9e515 \
-                    sha256  ff42e1d7e8d1c873daec8aad23ece855599b6f77cfa2ab03db18865e1b55f4a3 \
-                    size    18300962
+# Allow Go to download dependencies at runtime
+build.env-delete    GO111MODULE=off GOPROXY=off
 
-use_configure       no
-installs_libs       no
+build.cmd           "${go.bin} generate ./... && ${go.bin} build"
 
-build {}
-
-extract.mkdir       yes
+# Hard-code the build date to help with build reproducibility
+build.pre_args-append \
+    -o ./_bin/${name} \
+    -ldflags \" \
+        -X ${go.package}/internal/buildinfo.environment=production \
+        -X ${go.package}/internal/buildinfo.buildDate=2022-02-27T00:00:00Z \
+        -X ${go.package}/internal/buildinfo.version=${version} \
+        -X ${go.package}/internal/buildinfo.commit=release \
+    \"
 
 destroot {
-    xinstall -m 0755 -W ${worksrcpath} ${name} ${destroot}${prefix}/bin
+    xinstall -m 0755 ${worksrcpath}/_bin/${name} ${destroot}${prefix}/bin/
+
     ln -s ${prefix}/bin/${name} ${destroot}${prefix}/bin/fly
 }
 


### PR DESCRIPTION
- use Golang portgroup
- switch from pre-built binaries to building from source using goreleaser
- remove arch restrictions (supported_archs) now that we build from source
- add @herbygillot as co-maintainer

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
