### PR TITLE
libstdcxx-docs: fix livecheck

### DIFF
--- a/lang/libstdcxx-docs/Portfile
+++ b/lang/libstdcxx-docs/Portfile
@@ -37,3 +37,5 @@ build.target        man
 
 destroot.dir        ${configure.dir}
 destroot.target     install-man
+
+livecheck.name      gcc


### PR DESCRIPTION
###### Type(s)

- [x] bugfix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?