### PR TITLE
py-slack-sdk: update to 3.15.1 and add py310

### DIFF
--- a/python/py-slack-sdk/Portfile
+++ b/python/py-slack-sdk/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        slackapi python-slack-sdk 3.1.1 v
+github.setup        slackapi python-slack-sdk 3.15.1 v
 name                py-slack-sdk
 categories-append   irc
 platforms           darwin
 supported_archs     noarch
 license             MIT
 
-python.versions     38 39
+python.versions     38 39 310
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -25,9 +25,9 @@ long_description    The Slack platform offers several APIs to build apps. Each S
 
 homepage            https://slack.dev/python-slackclient/
 
-checksums           rmd160  888f11df7d65660a5ce1cb3d7325b553cc273589 \
-                    sha256  858a8545c684ca5395a716dff7e9e379c242971242eb3e5161ebc154a300c37f \
-                    size    2996184
+checksums           rmd160  f5c7979b4d2466ca3c20831840966c92b830b144 \
+                    sha256  1c0bf661ec3dec22341ceb9d76f1bb4ded595d0297749cc57dc810cddba8a3ef \
+                    size    3726306
 
 if {${name} ne ${subport}} {
     conflicts               py${python.version}-slackclient


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
