### PR TITLE
grass7: update to version 7.8.7

### DIFF
--- a/gis/grass7/Portfile
+++ b/gis/grass7/Portfile
@@ -5,10 +5,10 @@ PortGroup           wxWidgets 1.0
 PortGroup           github 1.0
 PortGroup           debug 1.0
 
-github.setup        OSGeo grass 7.8.6
+github.setup        OSGeo grass 7.8.7
 name                grass7
 set main_version    [join [lrange [split ${version} "."] 0 1] ""]
-revision            4
+revision            0
 set realVersion     ${version}
 #distname           grass-${version}
 distname            grass-${realVersion}
@@ -24,9 +24,9 @@ long_description    GRASS is a Geographic Information System (GIS) used for \
 homepage            http://grass.osgeo.org/
 master_sites        ${homepage}grass[join [lrange [split ${realVersion} .] 0 1] {}]/source/
 
-checksums           rmd160  4393641be9fe3821f3fbd11a79d86ea07f088e00 \
-                    sha256  d85e17b0a717e344cdda8f6c5bdeb86763e48d1ee74a62ab471dc8e1293993be \
-                    size    66331264
+checksums           rmd160  ae1e1b2b775cc8e4a513bc42fbe40ed1ea8326d9 \
+                    sha256  4fff7be556d820ed81704bb27fe3ed913c173076bb3ed036bcc3a49bd4027f69 \
+                    size    66333084
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \
@@ -295,8 +295,6 @@ post-configure {
     file copy ${prefix}/include/ogr_core.h ${worksrcpath}/lib/python/ctypes
     file copy ${prefix}/include/gdal_version.h ${worksrcpath}/lib/python/ctypes
     file copy ${prefix}/include/cpl_port.h ${worksrcpath}/lib/python/ctypes
-    reinplace -E "s|#include <x86intrin.h>|/* #include <x86intrin.h> */|" \
-        ${worksrcpath}/lib/python/ctypes/cpl_port.h
     reinplace -E "s|\\\$\\\(CPPFLAGS)|-I${worksrcpath}/lib/python/ctypes \$(CPPFLAGS) \
         \\\\\"-Drestrict=\\\\\" \\\\\"-D__attribute__(x)=\\\\\" \\\\\"-D_Nonnull=\\\\\" \
         \\\\\"-Dint8_t=char\\\\\" \\\\\"-DCF_INLINE=\\\\\" \\\\\"-D_Null_unspecified=\\\\\" \


### PR DESCRIPTION
#### Description

Bump to GRASS version 7.8.7.




###### Tested on

macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
