### PR TITLE
notcurses: update to 3.0.7

### DIFF
--- a/devel/notcurses/Portfile
+++ b/devel/notcurses/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        dankamongmen notcurses 3.0.6 v
+github.setup        dankamongmen notcurses 3.0.7 v
 github.tarball_from archive
 revision            0
 
@@ -27,13 +27,13 @@ master_sites-append https://github.com/dankamongmen/${name}/releases/download/v$
 distfiles-append    ${name}-doc-${version}${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6fc78437d184e92b53532b767e83e1c92d75a06e \
-                    sha256  2113bed52248b048874bceb99f10985ae46019de818fce5cda2a8756b013448b \
-                    size    10146108 \
+                    rmd160  78c32c968f584f6c23408f3e33534012cca075d2 \
+                    sha256  db461c6ba07a8e3735a51a1d2e706d249ae30436519f543fa5931d414019c770 \
+                    size    10145650 \
                     ${name}-doc-${version}${extract.suffix} \
-                    rmd160  5a90f10247a00bb5fcf7bad891b3d28059947938 \
-                    sha256  1cd39b9258bf837e462d6816f48620274ec8ba31663429b3959ef3d4f0eb711d \
-                    size    149044
+                    rmd160  6701964c921bbdb7cf978650354f4092be89e383 \
+                    sha256  51e46198d02f45d302ac7b2ebc9c0f1391cf37f329bd5aa3857c9ccde5f3dac1 \
+                    size    149228
 
 extract.only        ${distname}${extract.suffix}
 


### PR DESCRIPTION
#### Description

Update notcurses to v3.0.7

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?