### PR TITLE
openjdk: add Amazon Corretto OpenJDK

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -11,14 +11,11 @@ license          GPL-2 NoMirror
 # These ports use prebuilt binaries for a particular architecture, they are not universal binaries
 universal_variant no
 
-if {[regexp {openjdk[0-9]*(-zulu)?$} ${subport}]} {
-    supported_archs  x86_64 arm64
-} else {
-    supported_archs  x86_64
-}
-
 # Latest Long Term Support (LTS) major version
 version          17
+
+set long_description_corretto \
+   "No-cost, multiplatform, production-ready distribution of OpenJDK."
 
 set long_description_ibm_semeru \
     "The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications built with\
@@ -72,6 +69,7 @@ if {${subport} eq "openjdk"} {
 
 subport openjdk7-zulu {
     # https://www.azul.com/downloads/?version=java-7-lts&os=macos&package=jdk
+    supported_archs  x86_64
 
     version      7.52.0.11
     revision     0
@@ -94,6 +92,8 @@ subport openjdk7-zulu {
 }
 
 subport openjdk8 {
+    supported_archs  x86_64 arm64
+
     version      8u322
     revision     0
 
@@ -115,6 +115,26 @@ subport openjdk8 {
     }
 }
 
+subport openjdk8-corretto {
+    # https://github.com/corretto/corretto-8/releases
+    supported_archs  x86_64
+
+    version      8.322.06.1
+    revision     0
+
+    description  Amazon Corretto OpenJDK 8 (Long Term Support)
+    long_description ${long_description_corretto}
+
+    master_sites https://corretto.aws/downloads/resources/${version}/
+
+    distname     amazon-corretto-${version}-macosx-x64
+    checksums    rmd160  98759066ee6e41884e3acbf7f9e7debd6a6d54d0 \
+                 sha256  b86a899aac567b86866fe3cff0b80ee7e7a53f93d9fbe1ec3a2c992376ff1cc6 \
+                 size    118882960
+
+    worksrcdir   amazon-corretto-8.jdk
+}
+
 # Remove after 2022-10-19
 subport openjdk8-graalvm {
     version      21.0.0.2
@@ -123,6 +143,9 @@ subport openjdk8-graalvm {
 }
 
 subport openjdk8-openj9 {
+    # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
+    supported_archs  x86_64
+
     version      8u322
     revision     0
 
@@ -145,6 +168,7 @@ subport openjdk8-openj9 {
 
 subport openjdk8-temurin {
     # https://adoptium.net/releases.html?variant=openjdk8&jvmVariant=hotspot
+    supported_archs  x86_64
 
     version      8u322
     revision     0
@@ -165,6 +189,7 @@ subport openjdk8-temurin {
 
 subport openjdk8-zulu {
     # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
+    supported_archs  x86_64 arm64
 
     version      8.60.0.21
     revision     0
@@ -201,6 +226,8 @@ subport openjdk8-openj9-large-heap {
 }
 
 subport openjdk11 {
+    supported_archs  x86_64 arm64
+
     version      11.0.12
     revision     0
 
@@ -222,7 +249,30 @@ subport openjdk11 {
     }
 }
 
+subport openjdk11-corretto {
+    # https://github.com/corretto/corretto-11/releases
+    supported_archs  x86_64
+
+    version      11.0.14.10.1
+    revision     0
+
+    description  Amazon Corretto OpenJDK 11 (Long Term Support)
+    long_description ${long_description_corretto}
+
+    master_sites https://corretto.aws/downloads/resources/${version}/
+
+    distname     amazon-corretto-${version}-macosx-x64
+    checksums    rmd160  39004f9cabd34ba08af06c37be3c8896bde2176d \
+                 sha256  d4b8e365091ebcadd3c70709c26ab01d7a58aeb57978e0d68a7805f4cee6be71 \
+                 size    187369666
+
+    worksrcdir   amazon-corretto-11.jdk
+}
+
 subport openjdk11-graalvm {
+    # https://github.com/graalvm/graalvm-ce-builds/releases
+    supported_archs  x86_64
+
     version      22.0.0.2
     revision     0
 
@@ -239,6 +289,9 @@ subport openjdk11-graalvm {
 }
 
 subport openjdk11-openj9 {
+    # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
+    supported_archs  x86_64
+
     version      11.0.14.1
     revision     0
 
@@ -268,6 +321,8 @@ subport openjdk11-openj9-large-heap {
 
 subport openjdk11-sap {
     # https://github.com/SAP/SapMachine/releases/
+    supported_archs  x86_64
+
     version      11.0.14.1
     revision     0
     
@@ -286,6 +341,7 @@ subport openjdk11-sap {
 
 subport openjdk11-temurin {
     # https://adoptium.net/releases.html?variant=openjdk11&jvmVariant=hotspot
+    supported_archs  x86_64
 
     version      11.0.14.1
     revision     0
@@ -307,6 +363,7 @@ subport openjdk11-temurin {
 
 subport openjdk11-zulu {
     # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
+    supported_archs  x86_64 arm64
 
     version      11.54.25
     revision     0
@@ -353,6 +410,7 @@ subport openjdk13 {
 
 subport openjdk13-zulu {
     # https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
+    supported_archs  x86_64 arm64
 
     version      13.46.15
     revision     0
@@ -413,6 +471,7 @@ subport openjdk15-openj9-large-heap {
 
 subport openjdk15-zulu {
     # https://www.azul.com/downloads/?version=java-15-mts&os=macos&package=jdk
+    supported_archs  x86_64 arm64
 
     version      15.38.17
     revision     0
@@ -454,6 +513,9 @@ subport openjdk16-graalvm {
 }
 
 subport openjdk16-openj9 {
+    # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
+    supported_archs  x86_64
+
     version      16.0.2
     revision     0
 
@@ -506,7 +568,38 @@ subport openjdk17 {
     depends_run-append port:openjdk17-temurin
 }
 
+subport openjdk17-corretto {
+    # https://github.com/corretto/corretto-17/releases
+    supported_archs  x86_64 arm64
+
+    version      17.0.2.8.1
+    revision     0
+
+    description  Amazon Corretto OpenJDK 17 (Long Term Support)
+    long_description ${long_description_corretto}
+
+    master_sites https://corretto.aws/downloads/resources/${version}/
+
+    distname     amazon-corretto-${version}-macosx-x64
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     amazon-corretto-${version}-macosx-x64
+        checksums    rmd160  8a622fe2c8dd5eba07330804d7b98c3b67b5ee78 \
+                     sha256  eec3acc2d1d303ef23c79ed45a8374002e34c14e34ba0fa931e98cbf6b963345 \
+                     size    187776090
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     amazon-corretto-${version}-macosx-aarch64
+        checksums    rmd160  e5eb0341468193a223ec927abade6f151831da06 \
+                     sha256  b6d3c359bd31a3c1697fe386c927e139bd72572e72cdc12a08b5e1144fe35438 \
+                     size    185518346
+    }
+
+    worksrcdir   amazon-corretto-17.jdk
+}
+
 subport openjdk17-graalvm {
+    # https://github.com/graalvm/graalvm-ce-builds/releases
+    supported_archs  x86_64
+
     version      22.0.0.2
     revision     0
 
@@ -524,6 +617,7 @@ subport openjdk17-graalvm {
 
 subport openjdk17-openj9 {
     # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
+    supported_archs  x86_64
 
     version      17.0.2
     revision     0
@@ -575,7 +669,9 @@ subport openjdk17-oracle {
 }
 
 subport openjdk17-sap {
-    # https://github.com/SAP/SapMachine/releases/
+    # https://sap.github.io/SapMachine/latest/17
+    supported_archs  x86_64 arm64
+
     version      17.0.2
     revision     0
 
@@ -600,6 +696,7 @@ subport openjdk17-sap {
 
 subport openjdk17-temurin {
     # https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
+    supported_archs  x86_64 arm64
 
     # Java 17 is the first Temurin release with arm64 support
     supported_archs  x86_64 arm64
@@ -630,6 +727,7 @@ subport openjdk17-temurin {
 
 subport openjdk17-zulu {
     # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
+    supported_archs  x86_64 arm64
 
     version      17.32.13
     revision     0
@@ -692,6 +790,8 @@ if {[string match *-graalvm ${subport}]} {
     homepage     https://adoptium.net
 } elseif {[string match *-oracle ${subport}]} {
     homepage     https://jdk.java.net
+} elseif {[string match *-corretto ${subport}]} {
+    homepage     https://aws.amazon.com/corretto/
 }
 
 livecheck.type  none


### PR DESCRIPTION
#### Description

Add Amazon Carretto builds for Java 8, 11 and 17, made supported architecture explicit per subport and added missing links for latest versions.

###### Tested on

macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?