### PR TITLE
py-{arviz, semver, theano-pymc}: add py310 subport

### DIFF
--- a/python/py-arviz/Portfile
+++ b/python/py-arviz/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  787d818fc3dba23e3684f93fcc893caa3fe7beca \
                     sha256  01872758eeabb9941479ec5dd378117337bf95d14cc2c298b437cfda1780b436 \
                     size    1506007
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -42,6 +42,4 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} CHANGELOG.md CODE_OF_CONDUCT.md \
             CONTRIBUTING.md LICENSE README.md ${destroot}${docdir}
     }
-
-    livecheck.type  none
 }

--- a/python/py-semver/Portfile
+++ b/python/py-semver/Portfile
@@ -7,12 +7,11 @@ name                py-semver
 version             2.13.0
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             BSD
 maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
 
-description         Python helper for Semantic Versioning (http://semver.org/)
+description         Python helper for Semantic Versioning
 long_description    ${description}
 
 homepage            https://github.com/k-bx/python-semver
@@ -21,7 +20,7 @@ checksums           sha256  fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c
                     rmd160  8e5914920e95e3c7db2ca658ed2915641fb19d57 \
                     size    45816
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_lib-append \
@@ -43,6 +42,4 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} README.rst \
             LICENSE.txt ${destroot}${docdir}
     }
-
-    livecheck.type  none
 }

--- a/python/py-theano-pymc/Portfile
+++ b/python/py-theano-pymc/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  b5b36cbda77dada32128025796350809c132e97c \
                     sha256  5da6c2242ea72a991c8446d7fe7d35189ea346ef7d024c890397011114bf10fc \
                     size    1810180
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     if {${python.version} in "37 38"} {


### PR DESCRIPTION
#### Description

Add py310 subports to dependencies py-arviz, py-semver, py-theano-pymc of py-pymc3.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
