### PR TITLE
pgpdump: Update to 0.35

### DIFF
--- a/security/pgpdump/Portfile
+++ b/security/pgpdump/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                pgpdump
-version             0.31
+version             0.35
 categories          security
 platforms           darwin
 license             BSD
@@ -21,8 +21,9 @@ depends_lib         port:bzip2 \
 homepage            http://www.mew.org/~kazu/proj/pgpdump/en/
 master_sites        http://www.mew.org/~kazu/proj/pgpdump/
 
-checksums           rmd160  cfb2882dcc9c08ea15588e21bac92f4a29db5b86 \
-                    sha256  206ae52d4a8bbfa095b6ceefcc8b53ccabcdb75696db3bae5e05c15433729813
+checksums           rmd160  752e135f292e79665f165408c44ca92b54a9f3ad \
+                    sha256  4e02922dbd6309f371d52d336eef8f4dc0cd75d5140d0a3a795ff10185c9544f \
+                    size    77580
 
 build.args          CC='${configure.cc}'
 


### PR DESCRIPTION
#### Description

pgpdump: Update to 0.35

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.3 20G415 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?