### PR TITLE
Add php-pcov pecl port

### DIFF
--- a/php/php-pcov/Portfile
+++ b/php/php-pcov/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               php 1.1
+
+name                    php-pcov
+version                 1.0.11
+categories-append       devel
+maintainers             {ryandesign @ryandesign} openmaintainer
+license                 PHP-3.01
+
+php.branches            7.1 7.2 7.3 7.4 8.0 8.1
+php.pecl                yes
+
+description             A self contained php-code-coverage compatible driver for PHP.
+
+long_description        ${description}
+
+checksums               rmd160  abbf80ccb3883ccfd3a3ce411ede7785ac08bcd6 \
+                        sha256  ad22e64cd3af065330182ac142c1c3ab40de934482cd400f8bd76064130ac242 \
+                        size    25300


### PR DESCRIPTION
#### Description

This adds the PECL port of the php-pcov extension to MacPorts. Note that I'm a noob and have tried to build the Portfile by comparing with other ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.4 20G417 x86_64
Xcode 13.2.1 13C100

Have tested the PHP 7.3 / 7.4 and 8.0 ports. All them working ok.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? (although I don't have much is tested there)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? With PHP 73/74/80

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
