### PR TITLE
openfst: update to 1.7.2

### DIFF
--- a/devel/openfst/Portfile
+++ b/devel/openfst/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                openfst
-version             1.5.2
+version             1.7.2
 categories          devel
 maintainers         nomaintainer
 
@@ -19,8 +19,9 @@ license             Apache-2
 
 master_sites        ${homepage}twiki/pub/FST/FstDownload/
 
-checksums           rmd160  39de985c50ade986ad2e39bcf7050dfe9d709683 \
-                    sha256  944b9ae654d62345f51b9c2f728eee2751af32f90caeb35283bb7a5262d19cf2
+checksums           rmd160  bc5a3ccc1aaa97837d3e5753d88ee11707b487a8 \
+                    sha256  21c3758ff8574dedaf22b0a6b88c2829bbf3b2e59fbf04740ce2cf92029a0f3b \
+                    size    1269292
 
 if {${os.platform} eq "darwin" && ${os.major} < 12} {
     version         1.3.4


### PR DESCRIPTION
#### Description

This PR updates the openfst port to 1.7.2. While the latest version is 1.8.2, I'm trying to use openfst for [Kaldi](https://github.com/kaldi-asr/kaldi), which will not work with 1.8.2.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
