### PR TITLE
gqrx-devel: remove obsolete subport

### DIFF
--- a/science/gqrx/Portfile
+++ b/science/gqrx/Portfile
@@ -21,17 +21,6 @@ long_description    Gqrx is a software defined radio receiver for Funcube \
     source software and anyone is invited to hack the source code to suit \
     their needs.
 
-# this can be removed after 20211105
-subport gqrx-devel {
-    # releases happen here often enough to not require this port
-    replaced_by gqrx
-    PortGroup obsolete 1.0
-
-    # final version of the devel, with +1 rev bump
-    version   20201016-19772b1a
-    revision  1
-}
-
 homepage            https://gqrx.dk
 
 if {${subport} eq ${name}} {


### PR DESCRIPTION
Replaced by `gqrx` in 01dafe3a190 over a year ago

#### Description
The rest of portfile was left alone, including the `if {${subport} eq ${name}} {…}` block even though there are no other subports.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
