### PR TITLE
gobject-introspection{,-devel}: bump python dependency to 3.10

### DIFF
--- a/gnome/gobject-introspection-devel/Portfile
+++ b/gnome/gobject-introspection-devel/Portfile
@@ -9,7 +9,7 @@ conflicts           gobject-introspection
 set my_name         gobject-introspection
 
 version             1.70.0
-revision            0
+revision            1
 
 categories          gnome
 platforms           darwin
@@ -32,7 +32,7 @@ checksums           rmd160  5d13fba531e1f1d1260722aacb524f1da650302e \
                     sha256  902b4906e3102d17aa2fcb6dad1c19971c70f2a82a159ddc4a94df73a3cafc4a \
                     size    1029372
 
-set py_ver          3.9
+set py_ver          3.10
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build       port:pkgconfig \

--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -9,7 +9,7 @@ conflicts           gobject-introspection-devel
 set my_name         gobject-introspection
 
 version             1.70.0
-revision            0
+revision            1
 
 categories          gnome
 platforms           darwin
@@ -32,7 +32,7 @@ checksums           rmd160  5d13fba531e1f1d1260722aacb524f1da650302e \
                     sha256  902b4906e3102d17aa2fcb6dad1c19971c70f2a82a159ddc4a94df73a3cafc4a \
                     size    1029372
 
-set py_ver          3.9
+set py_ver          3.10
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build       port:pkgconfig \


### PR DESCRIPTION
#### Description

It appears that when bumping gobject-introspection versions a few days ago (see 3eec87eed585dfa681320de08bf4c71421152e00), the python dependency was downgraded from 3.10 to 3.9. I'm not sure if this was an accident or if there was a reason for doing so. @mascguy could you please confirm this was intentional? 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? no tests found
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
