### PR TITLE
Wireshark3: add python3.10 variant

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -168,7 +168,7 @@ variant chmodbpf description {Enable Wireshark to access macOS capture devices} 
     depends_run             port:wireshark-chmodbpf
 }
 
-set pythons_suffixes {36 37 38 39}
+set pythons_suffixes {36 37 38 39 310}
 
 set pythons_ports {}
 foreach py_ver_nodot ${pythons_suffixes} {
@@ -193,10 +193,10 @@ foreach py_ver_nodot ${pythons_suffixes} {
         break
     }
 }
-## if no python3* variant is specified, add +python38
+## if no python3* variant is specified, add +python310
 ## XYZZY: it would be better to detect which python3* is already installed and use that...
 if {!${python_isset}} {
-    default_variants-append +python39
+    default_variants-append +python310
 }
 
 

--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -99,6 +99,7 @@ configure.args-append \
 
 variant qt5 conflicts no_gui description {Build wireshark with a qt5 GUI} {
     PortGroup               qt5 1.0
+
     configure.args-replace  -DENABLE_APPLICATION_BUNDLE=OFF -DENABLE_APPLICATION_BUNDLE=ON
     configure.args-replace  -DBUILD_wireshark=OFF -DBUILD_wireshark=ON
     configure.args-append   -DENABLE_QT5=ON
@@ -167,21 +168,37 @@ variant chmodbpf description {Enable Wireshark to access macOS capture devices} 
     depends_run             port:wireshark-chmodbpf
 }
 
-variant python36 conflicts python37 python38 python39 description {Use python36 during build} {
-    depends_build-append    port:python36
+set pythons_suffixes {36 37 38 39}
+
+set pythons_ports {}
+foreach py_ver_nodot ${pythons_suffixes} {
+    lappend pythons_ports python${py_ver_nodot}
 }
 
-variant python37 conflicts python36 python38 python39 description {Use python37 during build} {
-    depends_build-append    port:python37
+foreach py_ver_nodot ${pythons_suffixes} {
+    set py_port python${py_ver_nodot}
+    set py_ver [string index ${py_ver_nodot} 0].[string range ${py_ver_nodot} 1 end]
+    set i [lsearch -exact ${pythons_ports} ${py_port}]
+    set py_conflicts [lreplace ${pythons_ports} ${i} ${i}]
+    variant ${py_port} description "Use python ${py_ver} during build" conflicts {*}${py_conflicts} "
+        depends_build-append      port:${py_port}
+    "
 }
 
-variant python38 conflicts python36 python37 python39 description {Use python38 during build} {
-    depends_build-append    port:python38
+# make sure one of the +python* variants is set
+set python_isset false
+foreach py_ver_nodot ${pythons_suffixes} {
+    if { [variant_isset python${py_ver_nodot}] } {
+        set python_isset true
+        break
+    }
+}
+## if no python3* variant is specified, add +python38
+## XYZZY: it would be better to detect which python3* is already installed and use that...
+if {!${python_isset}} {
+    default_variants-append +python39
 }
 
-variant python39 conflicts python36 python37 python38 description {Use python39 during build} {
-    depends_build-append    port:python39
-}
 
 default_variants +zlib +libsmi +gnutls +geoip +kerberos5 +chmodbpf
 
@@ -191,13 +208,6 @@ if {![variant_isset qt5] && ![variant_isset no_gui]} {
 
 if {![variant_isset adns] && ![variant_isset cares]} {
     default_variants-append +cares
-}
-
-## if no python3* variant is specified, add +python38
-## XYZZY: it would be better to detect which python3* is already installed and use that...
-if {![variant_isset python36] && ![variant_isset python37] && \
-    ![variant_isset python38] && ![variant_isset python39] } {
-    default_variants-append +python39
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

wireshark3: add python310 variant

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode 13.1 13A1030d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
