### PR TITLE
google-cloud-sdk: update to 375.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             374.0.0
+version             375.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  5587002e7c9a3aa4392261bb2f263734a9b560e3 \
-                    sha256  8f4073ebb6bb5b330712c1f6b5f9c1a87aa7e2c9ec58adcf5c0f4e83ec7c4793 \
-                    size    97984389
+    checksums       rmd160  3aa3222dd9a12ad532540b43fe32837aaf8b305d \
+                    sha256  7c8d67ad97a56eb23652cef803b3ba64de2b01ce570770b0a08c98182e22dd0e \
+                    size    98009743
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  bde3773231859c8481f2f1fdbc2eae1c5e134c66 \
-                    sha256  7ce57346f48736d96c640964adaa1e9ec977b592e3a589a9dfac5b6dde8c4aaa \
-                    size    93217849
+    checksums       rmd160  f7764f722c6c38bebed59d784ff5b007216c58de \
+                    sha256  d4344e21c63eaa38bed6a54e81a401fa7f5feeead905b2ed89ff91b08d629f8c \
+                    size    93252132
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  71e6227a67dbf4c2332f0c3d8cfaa00d90285ece \
-                    sha256  a47ac6e2508e7c87110aced102c1926b76d7f125ed6ae9cfb369dedf9b78cd49 \
-                    size    92688757
+    checksums       rmd160  79718e67d1108fa4dfe7d1db9cf4f8402abcf941 \
+                    sha256  f1081ea9cdae0a69ffc03bd97de9e3f08bac17c66cc947f34b9240ea278f5e7d \
+                    size    92717882
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 375.0.0.

###### Tested on

macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?