### PR TITLE
smartmontools: update to 7.3

### DIFF
--- a/sysutils/smartmontools/Portfile
+++ b/sysutils/smartmontools/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                smartmontools
-version             7.2
+version             7.3
 categories          sysutils
 license             GPL-2+
 platforms           darwin
@@ -22,9 +22,9 @@ long_description \
 homepage            http://smartmontools.sourceforge.net/
 master_sites        sourceforge:project/smartmontools/smartmontools/${version}/
 
-checksums           rmd160  51a00e9ac83c5f16af20f220b129180c953385a9 \
-                    sha256  5cd98a27e6393168bc6aaea070d9e1cd551b0f898c52f66b2ff2e5d274118cd6 \
-                    size    992256
+checksums           rmd160  2b07b544d418396a529039c589408ab172e69ac3 \
+                    sha256  a544f8808d0c58cfb0e7424ca1841cb858a974922b035d505d4e4c248be3a22b \
+                    size    1043932
 
 configure.args      --without-savestates \
                     --without-attributelog \


### PR DESCRIPTION
#### Description

Update to smartmontools v.7.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
