### PR TITLE
distcc: Update to 3.4

### DIFF
--- a/devel/distcc/Portfile
+++ b/devel/distcc/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        distcc distcc 3.3.3 v
+github.setup        distcc distcc 3.4 v
 revision            0
-checksums           rmd160  42783101ee994811604ec45919de055e980e3abd \
-                    sha256  bead25471d5a53ecfdf8f065a6fe48901c14d5008956c318c700e56bc87bf0bc \
-                    size    1195666
+checksums           rmd160  7d0fbbcffc28ec53e580f0da18d6370daec04b55 \
+                    sha256  2b99edda9dad9dbf283933a02eace6de7423fe5650daa4a728c950e5cd37bd7d \
+                    size    1239519
 
 categories          devel net
 platforms           darwin


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3 21E5222a
Xcode 13.3 13E5104i 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
