### PR TITLE
glade: remove obsolete reinplace

### DIFF
--- a/devel/glade/Portfile
+++ b/devel/glade/Portfile
@@ -128,14 +128,6 @@ variant quartz conflicts x11 {
 # disable dependency on devhelp at runtime
 # until +quartz problem solved for webkit2-gtk (#52688)
     depends_run-delete port:devhelp
-
-    # compile glade-registration.c as Objective-C file since it includes
-    #    /System/Library/Frameworks/AppKit.framework/Headers/AppKit.h
-    post-configure {
-        reinplace \
-            "s|-o glade-glade-registration.o|-xobjective-c -o glade-glade-registration.o|g" \
-            ${worksrcpath}/src/Makefile
-    }
 }
 
 if {![variant_isset quartz]} {


### PR DESCRIPTION
#### Description

There is no longer a Makefile, and glade no longer includes AppKit.h.

Closes: https://trac.macports.org/ticket/64581

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
