### PR TITLE
cool-retro-term: correct dependency

### DIFF
--- a/aqua/cool-retro-term/Portfile
+++ b/aqua/cool-retro-term/Portfile
@@ -5,7 +5,7 @@ PortGroup           qmake5 1.0
 PortGroup           github 1.0
 
 github.setup        Swordfish90 cool-retro-term 1.2.0
-revision            0
+revision            1
 
 categories          aqua shells
 platforms           darwin
@@ -37,7 +37,7 @@ checksums           ${distname}${extract.suffix} \
                         sha256  97cfb66b845160854783da9d9bbab7540143a29237e50215331ee8dac6c4a901 \
                         size    234929
 
-qt5.depends_component   qtquickcontrols
+qt5.depends_component   qtquickcontrols qtquickcontrols2
 qt5.depends_runtime_component   sqlite-plugin
 
 # Work around "Failed to restore metadata" on file
@@ -53,6 +53,10 @@ post-extract {
     # in the tarball so we put it into place here.
     move [glob ${workpath}/${github.author}-${dep_name}-*] ${worksrcpath}/${dep_name}
 }
+
+# Fixes errors like "Could not resolve SDK Path for 'macosx12' using --show-sdk-path"
+# See https://trac.macports.org/ticket/62934#comment:18
+use_xcode           yes
 
 destroot {
     xinstall -d ${destroot}${applications_dir}


### PR DESCRIPTION
#### Description

Fix dependency I must have had already installed when I last updated the port.

Locally I get the following error, so I'm seeing if CI can build it:

```
DEBUG: system:  cd "/opt/local/var/macports/build/_Users_amake_Code_MacPorts_aqua_cool-retro-term/cool-retro-term/work/cool-retro-term-1.2.0" && /opt/local/libexec/qt5/bin/qmake PREFIX=/opt/local -spec macx-clang 
Project ERROR: Could not resolve SDK Path for 'macosx12' using --show-sdk-path
Command failed:  cd "/opt/local/var/macports/build/_Users_amake_Code_MacPorts_aqua_cool-retro-term/cool-retro-term/work/cool-retro-term-1.2.0" && /opt/local/libexec/qt5/bin/qmake PREFIX=/opt/local -spec macx-clang 
Exit code: 3
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
