### PR TITLE
gjs: update to 1.64.5

### DIFF
--- a/gnome/gjs/Portfile
+++ b/gnome/gjs/Portfile
@@ -1,13 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           meson 1.0
 PortGroup           gobject_introspection 1.0
 
 name                gjs
 conflicts           gjs-devel
 set my_name         gjs
 
-version             1.54.3
+version             1.64.5
 revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
@@ -25,36 +26,48 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  6b6ef5e4812d393237be264dffc6f6ee4a87f8e6 \
-                    sha256  76b30dcc3ce9836c053aee531aa9f1d9d3f94b8503adf0a5a7bd176c492ba6b1 \
-                    size    647704
+checksums           rmd160  c4f03a6d3717efba782d2b92c3248e0100d3d011 \
+                    sha256  883b7c2bfe06716f0c44d6a447728f93e7fb810e18a1c48567914bb7d102949e \
+                    size    422548
 
 depends_build       port:pkgconfig \
-                    port:gettext
+                    port:python310
 
 depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
-                    port:gnome-js-common \
                     port:libffi \
                     path:lib/pkgconfig/cairo.pc:cairo \
-                    port:mozjs60 \
+                    port:mozjs68 \
                     port:readline
 
-# Teach glibtool about -stdlib=libc++
-use_autoreconf      yes
-autoreconf.args     -fvi
-
-compiler.cxx_standard 2014
+compiler.cxx_standard \
+                    2017
 
 # Fix gsize/size_t mismatch on 32-bit systems
-patchfiles          patch-gjs-gsize.diff
+patchfiles-append   patch-gjs-gsize.diff
+
+# Fix gint64/int64_t mismatch on x86_64
+patchfiles-append   patch-gjs-gint64.diff
+
+# LD_LIBRARY_PATH => DYLD_LIBRARY_PATH
+patchfiles-append   patch-gjs-test.diff
+
+configure.python    ${prefix}/bin/python3.10
 
 # profiler currently only supported on Linux
-configure.args      --disable-profiler \
-                    --disable-silent-rules
+configure.args-append \
+                    -Dprofiler=disabled \
+                    -Dbsymbolic_functions=false \
+                    -Dpython=${prefix}/bin/python3.10
 
-use_parallel_build  no
+#use_parallel_build  no
 
 gobject_introspection yes
+
+# Note that a few tests will fail because the "macports" user
+# does not have permission to open a display, issuing warnings like:
+# Gtk-WARNING **: 07:57:17.013: cannot open display: /tmp/launch-vBCmUl/org.macports:0
+test.run            yes
+test.target         test
 
 livecheck.type      gnome
 livecheck.name      ${my_name}

--- a/gnome/gjs/files/patch-gjs-gint64.diff
+++ b/gnome/gjs/files/patch-gjs-gint64.diff
@@ -1,0 +1,18 @@
+Undefined symbols for architecture x86_64:
+  "_gjs_profiler_add_mark(_GjsProfiler*, long long, long long, char const*, char const*, char const*)", referenced from:
+      GjsContextPrivate::set_sweeping(bool) in gjs_context.cpp.o
+ld: symbol(s) not found for architecture x86_64
+
+--- gjs/profiler.cpp.orig
++++ gjs/profiler.cpp
+@@ -673,8 +673,8 @@
+     self->filename = g_strdup(filename);
+ }
+ 
+-void _gjs_profiler_add_mark(GjsProfiler* self, gint64 time_nsec,
+-                            gint64 duration_nsec, const char* group,
++void _gjs_profiler_add_mark(GjsProfiler* self, int64_t time_nsec,
++                            int64_t duration_nsec, const char* group,
+                             const char* name, const char* message) {
+     g_return_if_fail(self);
+     g_return_if_fail(group);

--- a/gnome/gjs/files/patch-gjs-gsize.diff
+++ b/gnome/gjs/files/patch-gjs-gsize.diff
@@ -29,12 +29,13 @@ https://gitlab.gnome.org/GNOME/gjs/-/merge_requests/680
          /* First, let's handle the case where we're passed an instance
 --- gi/function.cpp.orig
 +++ gi/function.cpp
-@@ -840,12 +840,12 @@
-         GjsAutoChar name = format_function_name(function, is_method);
-         JS_ReportWarningUTF8(context, "Too many arguments to %s: expected %d, "
-                              "got %" G_GSIZE_FORMAT, name.get(),
--                             function->expected_js_argc, args.length());
-+                             function->expected_js_argc, (gsize)args.length());
+@@ -856,13 +856,13 @@
+                           "Too many arguments to %s: expected %d, "
+                           "got %" G_GSIZE_FORMAT,
+                           name.get(), function->expected_js_argc,
+-                          args.length()))
++                          (gsize)args.length()))
+             return false;
      } else if (args.length() < function->expected_js_argc) {
          GjsAutoChar name = format_function_name(function, is_method);
          gjs_throw(context, "Too few arguments to %s: "
@@ -75,25 +76,14 @@ https://gitlab.gnome.org/GNOME/gjs/-/merge_requests/680
      GjsAutoUnref<GFile> file = g_file_new_for_commandline_arg(filename);
  
      if (!g_file_load_contents(file, nullptr, &script, &script_len, nullptr,
---- gjs/global.cpp.orig
-+++ gjs/global.cpp
-@@ -55,7 +55,7 @@
-            .setSourceIsLazy(true);
- 
-     JS::RootedScript compiled_script(cx);
--    size_t script_len;
-+    gsize script_len;
-     auto script = static_cast<const char *>(g_bytes_get_data(script_bytes.get(),
-                                             &script_len));
-     if (!JS::Compile(cx, options, script, script_len, &compiled_script))
 --- gjs/module.cpp.orig
 +++ gjs/module.cpp
-@@ -123,7 +123,7 @@
-         size_t script_len = 0;
-         int start_line_number = 1;
+@@ -145,7 +145,7 @@
+     {
+         GError *error = nullptr;
+         char *unowned_script;
+-        size_t script_len = 0;
++        gsize script_len = 0;
  
--        if (!(g_file_load_contents(file, nullptr, &unowned_script, &script_len,
-+        if (!(g_file_load_contents(file, nullptr, &unowned_script, nullptr,
-                                    nullptr, &error))) {
-             gjs_throw_g_error(cx, error);
-             return false;
+         if (!(g_file_load_contents(file, nullptr, &unowned_script, &script_len,
+                                    nullptr, &error)))

--- a/gnome/gjs/files/patch-gjs-test.diff
+++ b/gnome/gjs/files/patch-gjs-test.diff
@@ -1,0 +1,13 @@
+Darwin uses DYLD_LIBRARY_PATH, not LD_LIBRARY_PATH
+
+--- meson.build.orig	2022-03-02 07:44:45.000000000 -0500
++++ meson.build	2022-03-02 07:44:52.000000000 -0500
+@@ -574,7 +574,7 @@
+ tests_environment.set('GJS_PATH', '')
+ tests_environment.prepend('GI_TYPELIB_PATH', meson.current_build_dir(),
+     js_tests_builddir)
+-tests_environment.prepend('LD_LIBRARY_PATH', meson.current_build_dir(),
++tests_environment.prepend('DYLD_LIBRARY_PATH', meson.current_build_dir(),
+     js_tests_builddir)
+ tests_environment.set('G_FILENAME_ENCODING', 'latin1')
+ tests_environment.set('LSAN_OPTIONS', 'exitcode=23,suppressions=@0@'.format(


### PR DESCRIPTION
#### Description

Slowly nudge gjs into the future now that we have `mozjs68` and an updated `gobject-introspection`. The dylib name is unchanged, so reverse dependencies should not require a rev-bump. Migrate to meson and add tests along with a note as to why some of the tests fail when executed by the "macports" user.

The 32-bit patch is retained with modifications even though mozjs68 currently does not build on 32-bit systems; this reflects my optimism that we'll eventually get there.

gjs is still several versions behind current, but the next updates will require `mozjs78` and `mozjs91` ports, which we don't have.

CC @mascguy 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
