### PR TITLE
nodejs: deprecate EOL versions

### DIFF
--- a/devel/nodejs10/Portfile
+++ b/devel/nodejs10/Portfile
@@ -3,6 +3,11 @@
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
+PortGroup               deprecated 1.0
+
+# EOL 2021-04-30
+# https://github.com/nodejs/Release
+deprecated.eol_version  yes
 
 # on macOS nodejs only builds against libc++
 # this force is OK as node does not link against any other c++ libs

--- a/devel/nodejs13/Portfile
+++ b/devel/nodejs13/Portfile
@@ -4,6 +4,11 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
+PortGroup               deprecated 1.0
+
+# EOL 2020-06-01
+# https://github.com/nodejs/Release
+deprecated.eol_version  yes
 
 # Peg back to openssl 1.1 release
 openssl.branch          1.1

--- a/devel/nodejs15/Portfile
+++ b/devel/nodejs15/Portfile
@@ -3,6 +3,11 @@
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
+PortGroup               deprecated 1.0
+
+# EOL 2021-06-01
+# https://github.com/nodejs/Release
+deprecated.eol_version  yes
 
 # on macOS nodejs only builds against libc++
 # this force is OK as node does not link against any other c++ libs

--- a/devel/nodejs8/Portfile
+++ b/devel/nodejs8/Portfile
@@ -3,6 +3,11 @@
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
+PortGroup               deprecated 1.0
+
+# EOL 2019-12-31
+# https://github.com/nodejs/Release
+deprecated.eol_version  yes
 
 name                    nodejs8
 version                 8.17.0


### PR DESCRIPTION
#### Description

EOL dates taken from https://github.com/nodejs/Release#end-of-life-releases

Note that nodejs8 currently does not build due to https://trac.macports.org/ticket/64095; this will require a separate fix to keep it pointed at OpenSSL 1.1 (or the port should be removed instead of deprecated).
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
