### PR TITLE
tectonic: update to version 0.8.2

### DIFF
--- a/tex/tectonic/Portfile
+++ b/tex/tectonic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        tectonic-typesetting tectonic 0.8.0 tectonic@
+github.setup        tectonic-typesetting tectonic 0.8.2 tectonic@
 revision            0
 categories          tex
 platforms           darwin
@@ -15,9 +15,9 @@ long_description    {*}${description}.
 homepage            https://tectonic-typesetting.github.io/
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  483c51f5c9b9d1249e15fdff863a0122bd19a3c3 \
-                    sha256  4c87b7fd0289c6f83bf9e0f3bd80c21598dd9371a7d7568f4f45514d54b42088 \
-                    size    2322144
+                    rmd160  5dd311c6eccd74cbdc47c539919c7e34c05dcfee \
+                    sha256  644f469036d961cb683e5551eaece1439061d6d43292be2f8bf9d1f109f755b5 \
+                    size    2385227
 
 depends_build       port:pkgconfig
 
@@ -37,65 +37,68 @@ destroot {
 }
 
 cargo.crates \
-    addr2line                       0.16.0  3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd \
+    addr2line                       0.17.0  b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
     aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
-    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-    anyhow                          1.0.44  61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1 \
-    app_dirs2                        2.3.2  55db1808b75fbf537160a28c59f868018c480a9a7f05ab6d6a760cba7d4cd303 \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anyhow                          1.0.55  159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd \
+    app_dirs2                        2.4.0  d6f731ef6e0f345c835c86724f619d3a73d8be0a9505b83d5e2fa34fd1d50261 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
-    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
-    backtrace                       0.3.61  e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    backtrace                       0.3.64  5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f \
     base64                          0.10.1  0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
     base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
-    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
     block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
     block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
     bstr                            0.2.17  ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223 \
-    bumpalo                          3.7.1  d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538 \
+    bumpalo                          3.9.1  a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899 \
     byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
-    byte-unit                       4.0.12  063197e6eb4b775b64160dedde7a0986bb2836cce140e9492e9e96f28e18bcd8 \
+    byte-unit                       4.0.13  956ffc5b0ec7d7a6949e3f21fd63ba5af4cffdc2ba1e0b7bf62b481458c4ae7f \
     byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
     bytes                           0.4.12  206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
     bytes                            1.1.0  c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8 \
-    cc                              1.0.71  79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd \
+    cc                              1.0.73  2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11 \
     cesu8                            1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
-    clearscreen                      1.0.7  95325739f550f23c4695b87632378f3738c2e95095531f45dab316678e5a4310 \
+    chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
+    chrono-tz                        0.6.1  58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552 \
+    chrono-tz-build                  0.0.2  db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069 \
+    clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
+    clearscreen                      1.0.9  a7ed49b0e894fe6264a58496c7ec4e9d3c46f66b59efae527cd5bee429d0a418 \
     cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-    combine                          4.6.1  a909e4d93292cd8e9c42e189f61681eff9d67b6541f96b8a1a737f23737bd001 \
-    command-group                    1.0.6  29033dd7a07be0c480c88ae8796b998d85fb2f8788c87687fff2d89af51f7da0 \
-    core-foundation                  0.9.1  0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62 \
-    core-foundation-sys              0.8.2  ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b \
+    combine                          4.6.3  50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062 \
+    command-group                    1.0.8  f7a8a86f409b4a59df3a3e4bee2de0b83f1755fdd2a25e3a9684c396fc4bed2c \
+    core-foundation                  0.9.3  194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146 \
+    core-foundation-sys              0.8.3  5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc \
     cpufeatures                      0.2.1  95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469 \
-    crc32fast                        1.2.1  81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a \
+    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
     crossbeam-deque                  0.7.4  c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed \
     crossbeam-epoch                  0.8.2  058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace \
     crossbeam-queue                  0.2.3  774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570 \
     crossbeam-utils                  0.7.2  c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8 \
-    curl                            0.4.39  aaa3b8db7f3341ddef15786d250106334d4a6c4b0ae4a46cd77082777d9849b9 \
-    curl-sys                      0.4.49+curl-7.79.1  e0f44960aea24a786a46907b8824ebc0e66ca06bf4e4978408c7499620343483 \
-    darling                         0.10.2  0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858 \
+    crossbeam-utils                  0.8.7  b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6 \
+    curl                            0.4.42  7de97b894edd5b5bcceef8b78d7da9b75b1d2f2f9a910569d0bde3dd31d84939 \
+    curl-sys                      0.4.52+curl-7.81.0  14b8c2d1023ea5fded5b7b892e4b8e95f70038a421126a056761a84246a28971 \
     darling                         0.12.4  5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c \
-    darling_core                    0.10.2  f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b \
     darling_core                    0.12.4  8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36 \
-    darling_macro                   0.10.2  d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72 \
     darling_macro                   0.12.4  29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a \
-    derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
     derive_builder                  0.10.2  d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30 \
     derive_builder_core             0.10.2  66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5 \
     derive_builder_macro            0.10.2  58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73 \
+    deunicode                        0.4.3  850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690 \
     digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
     digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
     dirs                             2.0.2  13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3 \
+    dirs                             4.0.0  ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059 \
     dirs-sys                         0.3.6  03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780 \
     either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
-    encoding_rs                     0.8.28  80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065 \
+    encoding_rs                     0.8.30  7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df \
     error-chain                     0.12.4  2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc \
     fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    fastrand                         1.7.0  c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf \
     filetime                        0.2.15  975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98 \
     flate2                          1.0.22  1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
@@ -108,117 +111,129 @@ cargo.crates \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
     fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
     futures                         0.1.31  3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678 \
-    futures-channel                 0.3.17  5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888 \
-    futures-core                    0.3.17  88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d \
+    futures-channel                 0.3.21  c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010 \
+    futures-core                    0.3.21  0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3 \
     futures-cpupool                  0.1.8  ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4 \
-    futures-io                      0.3.17  522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377 \
-    futures-sink                    0.3.17  36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11 \
-    futures-task                    0.3.17  1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99 \
-    futures-util                    0.3.17  36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481 \
+    futures-io                      0.3.21  fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b \
+    futures-sink                    0.3.21  21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868 \
+    futures-task                    0.3.21  57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a \
+    futures-util                    0.3.21  d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a \
     generic-array                   0.12.4  ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd \
-    generic-array                   0.14.4  501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
+    generic-array                   0.14.5  fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803 \
     getrandom                       0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
-    getrandom                        0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
-    gimli                           0.25.0  f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7 \
+    getrandom                        0.2.5  d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77 \
+    gimli                           0.26.1  78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4 \
     glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
     globset                          0.4.6  c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a \
+    globwalk                         0.8.1  93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc \
     h2                              0.1.26  a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462 \
-    h2                               0.3.6  6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964 \
+    h2                              0.3.11  d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e \
     hashbrown                       0.11.2  ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e \
     headers                          0.2.3  882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642 \
     headers-core                     0.1.1  967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237 \
     heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
     hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
     http                            0.1.21  d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0 \
-    http                             0.2.5  1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b \
+    http                             0.2.6  31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03 \
     http-body                        0.1.0  6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d \
-    http-body                        0.4.3  399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5 \
-    httparse                         1.5.1  acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503 \
-    httpdate                         1.0.1  6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440 \
+    http-body                        0.4.4  1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6 \
+    httparse                         1.6.0  9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4 \
+    httpdate                         1.0.2  c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421 \
+    humansize                        1.1.1  02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026 \
     hyper                          0.12.36  5c843caf6296fc1f93444735205af9ed4e109a539005abb2564ae1d6fad34c52 \
-    hyper                          0.14.13  15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593 \
+    hyper                          0.14.17  043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd \
     hyper-tls                        0.5.0  d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905 \
     ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             0.2.3  418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
-    indexmap                         1.7.0  bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5 \
+    ignore                          0.4.17  b287fb45c60bb826a0dc68ff08742b9d88a2fea13d6e0c286b3172065aaf878c \
+    indexmap                         1.8.0  282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223 \
     inotify                          0.7.1  4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
     iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
     ipnet                            2.3.1  68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9 \
     itoa                             0.4.8  b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4 \
+    itoa                             1.0.1  1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35 \
     jni                             0.19.0  c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec \
     jni-sys                          0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
-    js-sys                          0.3.55  7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84 \
+    js-sys                          0.3.56  a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                           0.2.103  dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6 \
+    libc                           0.2.119  1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4 \
     libz-sys                         1.1.3  de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66 \
     lock_api                         0.3.4  c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75 \
     log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
     matches                          0.1.9  a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f \
     maybe-uninit                     2.0.0  60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00 \
     md-5                             0.9.1  7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15 \
     memchr                           2.4.1  308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a \
     memoffset                        0.5.6  043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa \
-    memoffset                        0.6.4  59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9 \
+    memoffset                        0.6.5  5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
     mime                            0.3.16  2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d \
+    minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
     mio                             0.6.23  4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4 \
-    mio                             0.7.13  8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16 \
+    mio                              0.8.0  ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2 \
     mio-extras                       2.0.6  52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19 \
     mio-uds                          0.6.8  afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0 \
     miow                             0.2.2  ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d \
     miow                             0.3.7  b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21 \
     native-tls                       0.2.8  48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d \
-    ndk                              0.3.0  8794322172319b972f528bf90c6b467be0079f1fa82780ffb431088e741a73ab \
-    ndk-glue                         0.3.0  c5caf0c24d51ac1c905c27d4eda4fa0635bbe0de596b8f79235e0b17a4d29385 \
-    ndk-macro                        0.2.0  05d1c6307dc424d0f65b9b06e94f88248e6305726b14729fd67a5e47b2dc481d \
-    ndk-sys                          0.2.1  c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d \
+    ndk-context                      0.1.0  4e3c5cc68637e21fe8f077f6a1c9e0b9ca495bb74895226b476310f613325884 \
     net2                            0.2.37  391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae \
-    nix                             0.22.2  d3bb9a13fa32bc5aeb64150cd3f32d6cf4c748f8f8a417cce5d2eb976a8370ba \
+    nix                             0.22.3  e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf \
     nom                              5.1.2  ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af \
+    nom                              7.1.0  1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109 \
     notify                          4.0.17  ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257 \
-    ntapi                            0.3.6  3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44 \
-    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-    num_enum                         0.5.4  3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f \
-    num_enum_derive                  0.5.4  486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9 \
-    object                          0.26.2  39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2 \
-    once_cell                        1.8.0  692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56 \
+    ntapi                            0.3.7  c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f \
+    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    num_cpus                        1.13.1  19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1 \
+    object                          0.27.1  67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9 \
+    once_cell                        1.9.0  da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5 \
     opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
     opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
     open                             1.7.1  dcea7a30d6b81a2423cc59c43554880feff7b57d12916f231a79f8d6d9470201 \
-    openssl                        0.10.36  8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a \
-    openssl-probe                    0.1.4  28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a \
-    openssl-src                   111.16.0+1.1.1l  7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f \
-    openssl-sys                     0.9.67  69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058 \
+    openssl                        0.10.38  0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95 \
+    openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
+    openssl-src                   111.17.0+1.1.1m  05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4 \
+    openssl-sys                     0.9.72  7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb \
     parking_lot                      0.9.0  f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252 \
     parking_lot_core                 0.6.2  b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b \
+    parse-zoneinfo                   0.3.0  c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41 \
     pathdiff                         0.2.1  8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
+    pest_derive                      2.1.0  833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0 \
+    pest_generator                   2.1.3  99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55 \
+    pest_meta                        2.1.3  54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d \
     phf                              0.8.0  3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12 \
+    phf                             0.10.1  fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259 \
     phf_codegen                      0.8.0  cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815 \
+    phf_codegen                     0.10.0  4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd \
     phf_generator                    0.8.0  17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
+    phf_generator                   0.10.0  5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6 \
     phf_shared                       0.8.0  c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
-    pin-project-lite                 0.2.7  8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443 \
+    phf_shared                      0.10.0  b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096 \
+    pin-project-lite                 0.2.8  e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    pkg-config                      0.3.20  7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb \
-    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
-    proc-macro-crate                 0.1.5  1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785 \
-    proc-macro-crate                 1.1.0  1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83 \
+    pinot                            0.1.4  fe3ae90d2484923177d7f6157cf88d025e8ff0b802932fe2d7431dd2ce03f08f \
+    pkg-config                      0.3.24  58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe \
+    ppv-lite86                      0.2.16  eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872 \
     proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
-    proc-macro2                     1.0.29  b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d \
+    proc-macro2                     1.0.36  c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029 \
     quick-xml                       0.22.0  8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b \
-    quote                           1.0.10  38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05 \
+    quote                           1.0.15  864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145 \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
-    rand                             0.8.4  2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8 \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_core                        0.6.3  d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7 \
     rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
-    rand_hc                          0.3.1  d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7 \
     rand_pcg                         0.2.1  16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
     redox_syscall                   0.2.10  8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff \
@@ -226,45 +241,47 @@ cargo.crates \
     regex                            1.5.4  d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461 \
     regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
     remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
-    reqwest                         0.11.5  51c732d463dd300362ffb44b7b125f299c23d2990411a4253824630ebc7467fb \
+    reqwest                         0.11.9  87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525 \
     rustc-demangle                  0.1.21  7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342 \
     rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
-    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    ryu                              1.0.9  73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.19  8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    security-framework               2.3.1  23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467 \
-    security-framework-sys           2.4.2  a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e \
+    security-framework               2.6.1  2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc \
+    security-framework-sys           2.6.1  0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556 \
     semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
     semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
-    serde                          1.0.130  f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913 \
-    serde_derive                   1.0.130  d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b \
-    serde_json                      1.0.68  0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8 \
-    serde_urlencoded                 0.7.0  edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9 \
+    serde                          1.0.136  ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789 \
+    serde_derive                   1.0.136  08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9 \
+    serde_json                      1.0.79  8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95 \
+    serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha-1                            0.8.2  f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df \
-    sha2                             0.9.8  b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa \
-    siphasher                        0.3.7  533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b \
-    slab                             0.4.4  c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590 \
+    sha2                             0.9.9  4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800 \
+    siphasher                        0.3.9  a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e \
+    slab                             0.4.5  9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5 \
+    slug                             0.1.4  b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373 \
     smallvec                        0.6.14  b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0 \
-    socket2                          0.4.2  5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516 \
+    socket2                          0.4.4  66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0 \
     string                           0.2.1  d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    strsim                           0.9.3  6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c \
     strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
-    structopt                       0.3.23  bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa \
-    structopt-derive                0.4.16  134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba \
-    syn                             1.0.80  d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194 \
-    tempfile                         3.2.0  dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22 \
+    structopt                       0.3.26  0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10 \
+    structopt-derive                0.4.18  dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0 \
+    syn                             1.0.86  8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b \
+    tempfile                         3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
+    tera                            1.15.0  d3cac831b615c25bcef632d1cabf864fa05813baad3d526829db18eb70e8b58d \
     termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
     terminfo                         0.7.3  76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     thiserror                       1.0.30  854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417 \
     thiserror-impl                  1.0.30  aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b \
+    thread_local                     1.1.4  5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180 \
     time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
-    tinyvec                          1.5.0  f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7 \
+    tinyvec                          1.5.1  2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2 \
     tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
     tokio                           0.1.22  5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6 \
-    tokio                           1.12.0  c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc \
+    tokio                           1.17.0  2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee \
     tokio-buf                        0.1.1  8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46 \
     tokio-codec                      0.1.2  25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b \
     tokio-current-thread             0.1.7  b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e \
@@ -279,37 +296,45 @@ cargo.crates \
     tokio-timer                     0.2.13  93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296 \
     tokio-udp                        0.1.6  e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82 \
     tokio-uds                        0.2.7  ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0 \
-    tokio-util                       0.6.8  08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd \
+    tokio-util                       0.6.9  9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0 \
     toml                             0.5.8  a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa \
     tower-service                    0.3.1  360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6 \
-    tracing                         0.1.29  375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105 \
-    tracing-core                    0.1.21  1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4 \
+    tracing                         0.1.31  f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f \
+    tracing-core                    0.1.22  03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23 \
     try-lock                         0.2.3  59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642 \
-    typenum                         1.14.0  b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec \
+    typenum                         1.15.0  dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987 \
+    ucd-trie                         0.1.3  56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c \
+    uncased                          0.9.6  5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0 \
+    unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \
+    unic-char-range                  0.9.0  0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc \
+    unic-common                      0.9.0  80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc \
+    unic-segment                     0.9.0  e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23 \
+    unic-ucd-segment                 0.9.0  2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700 \
+    unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
     unicode-bidi                     0.3.7  1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f \
     unicode-normalization           0.1.19  d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9 \
-    unicode-segmentation             1.8.0  8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b \
+    unicode-segmentation             1.9.0  7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99 \
     unicode-width                    0.1.9  3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973 \
     unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
     url                              2.2.2  a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c \
     utf8-width                       0.1.5  7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
-    version_check                    0.9.3  5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
     walkdir                          2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
     want                             0.2.0  b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230 \
     want                             0.3.0  1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
     wasi                          0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
     wasi                          0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
-    wasm-bindgen                    0.2.78  632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce \
-    wasm-bindgen-backend            0.2.78  a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b \
-    wasm-bindgen-futures            0.4.28  8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39 \
-    wasm-bindgen-macro              0.2.78  d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9 \
-    wasm-bindgen-macro-support      0.2.78  7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab \
-    wasm-bindgen-shared             0.2.78  0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc \
+    wasm-bindgen                    0.2.79  25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06 \
+    wasm-bindgen-backend            0.2.79  8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca \
+    wasm-bindgen-futures            0.4.29  2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395 \
+    wasm-bindgen-macro              0.2.79  2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01 \
+    wasm-bindgen-macro-support      0.2.79  bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc \
+    wasm-bindgen-shared             0.2.79  3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2 \
     watchexec                       1.17.1  c52e0868bc57765fa91593a173323f464855e53b27f779e1110ba0fb4cb6b406 \
-    web-sys                         0.3.55  38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb \
-    which                            4.2.2  ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9 \
+    web-sys                         0.3.56  c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb \
+    which                            4.2.4  2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2 \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
@@ -318,5 +343,5 @@ cargo.crates \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     winreg                           0.7.0  0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69 \
     ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
-    xdg                              2.2.0  d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57 \
+    xdg                              2.4.1  0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6 \
     zip                             0.5.13  93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815


### PR DESCRIPTION
#### Description

Update tectonic to the just released version 0.8.2

###### Type(s)
- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?