### PR TITLE
py-awscli2, py-awscrt: disable build on old macOS

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -28,6 +28,13 @@ checksums           rmd160  05334ad34cea05884eff7c758076e80785dddf2e \
 python.versions     37 38
 
 if {${name} ne ${subport}} {
+    if {${os.platform} eq "darwin" && ${os.major} <= 15} {
+        known_fail      yes
+        pre-fetch {
+            ui_error "${name} @${version} requires macOS 10.12 or later."
+            return -code error "incompatible macOS version"
+        }
+    }
     conflicts           py${python.version}-awscli
 
     depends_build-append \

--- a/python/py-awscrt/Portfile
+++ b/python/py-awscrt/Portfile
@@ -30,6 +30,14 @@ checksums           rmd160  011654ef4d2bc5896ef36d8fb0a0517cd82b9dc2 \
 python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
+    if {${os.platform} eq "darwin" && ${os.major} <= 15} {
+        known_fail      yes
+        pre-fetch {
+            ui_error "${name} @${version} requires macOS 10.12 or later."
+            return -code error "incompatible macOS version"
+        }
+    }
+
     depends_build-append \
                         path:bin/cmake:cmake
     depends_lib-append  port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description
kSecAttrKeyTypeECSECPrimeRandom is only available on 10.12+, so disable building on the old macOS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
