### PR TITLE
ortep3: fix arm platform

### DIFF
--- a/science/ortep3/Portfile
+++ b/science/ortep3/Portfile
@@ -51,6 +51,16 @@ build {
         -o ortep3 ortep.f"
 }
 
+post-build {
+# Preliminary fix of not finding the fortran libraries
+    if { ${os.arch} eq "arm" } {
+        set libgfortran [glob -tails -directory ${prefix}/lib/libgcc libgfortran.*.dylib]
+        set libquadmath [glob -tails -directory ${prefix}/lib/libgcc libquadmath.*.dylib]
+        system -W ${worksrcpath} "install_name_tool -change @rpath/${libgfortran} @executable_path/../lib/libgcc/${libgfortran} ortep3"
+        system -W ${worksrcpath} "install_name_tool -change @rpath/${libquadmath} @executable_path/../lib/libgcc/${libquadmath} ortep3"
+    }
+}
+
 destroot {
     xinstall -m 0755 -W ${worksrcpath} ortep3 \
         ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description

Preliminary fix of not finding the fortran libraries on arm.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
https://trac.macports.org/ticket/63115
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
