### PR TITLE
openjdk11-sap: more relevant URL for latest version

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -320,7 +320,7 @@ subport openjdk11-openj9-large-heap {
 }
 
 subport openjdk11-sap {
-    # https://github.com/SAP/SapMachine/releases/
+    # https://sap.github.io/SapMachine/latest/11
     supported_archs  x86_64
 
     version      11.0.14.1


### PR DESCRIPTION
#### Description

Change comment for `openjdk11-sap` to a more relevant URL for the latest version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?