### PR TITLE
skaffold: update to 1.36.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.36.0 v
+github.setup        GoogleContainerTools skaffold 1.36.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  0717b84d36ab4b61e438788994ee9d3ba71bc2ea \
-                    sha256  0e6c3891e7d62d023094c7d985fe5aac86f07ed1e229817d0041d8646b3de833 \
-                    size    21571574
+checksums           rmd160  1c838da3d2461354fc8d84a7eb09e2e5712ce953 \
+                    sha256  b30361c02963d2374f2636f0181808f868834024f99ace74282c9f7416c1646a \
+                    size    21571254
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.36.1.

###### Tested on

macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?