### PR TITLE
jreleaser: update to version v1.0.0-M3

### DIFF
--- a/devel/jreleaser/Portfile
+++ b/devel/jreleaser/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# Generated with JReleaser 1.0.0-SNAPSHOT at 2022-02-13T12:11:01.494659Z
+# Generated with JReleaser 1.0.0-SNAPSHOT at 2022-03-05T15:54:17.031894Z
 
 PortSystem       1.0
 PortGroup        github 1.0
 PortGroup        java 1.0
 
-github.setup     jreleaser jreleaser 1.0.0-M2 v
+github.setup     jreleaser jreleaser 1.0.0-M3 v
 revision         0
 
 categories       devel java
@@ -29,9 +29,9 @@ homepage         https://jreleaser.org
 github.tarball_from releases
 use_zip          yes
 
-checksums        rmd160 3972f2480350e996811483dcbd8c1fdb4dc05160 \
-                 sha256 7ca27efc21c34c091a7d96aefbd3a78175d440f7673f0c705ca670a946b60541 \
-                 size   21920573
+checksums        rmd160 956cf308c8582149813a1b9603274483efbc381e \
+                 sha256 167b99bdf927453ff6bb03d409c193a5308848911bf553c0fc840b28c413ddbd \
+                 size   21953620
 
 java.version     1.8+
 


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
