### PR TITLE
libretls: update to 3.5.0

### DIFF
--- a/devel/libretls/Portfile
+++ b/devel/libretls/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                libretls
-version             3.4.1
-revision            1
+version             3.5.0
+revision            0
 categories          devel
 platforms           darwin
 license             ISC
@@ -18,9 +18,9 @@ long_description    LibreTLS is a port of libtls from LibreSSL to OpenSSL. \
 homepage            https://git.causal.agency/libretls/about/
 master_sites        https://causal.agency/libretls/
 
-checksums           rmd160  ef9634114bece359b905185735131c34b83ce91e \
-                    sha256  3aa7e5a014c5ecfd75cb3ae21ec91fe203478860a5ef3e0f03cb4fd5d9cdae89 \
-                    size    435404
+checksums           rmd160  bcf1fce599e30d5f3947ef0d4d08f17571fb3cb3 \
+                    sha256  a683387a2ad44214b05011eb722edc65aac81910b1d184cb7de72be4bbf8872e \
+                    size    438466
 
 depends_lib         port:openssl
 

--- a/net/catgirl/Portfile
+++ b/net/catgirl/Portfile
@@ -5,7 +5,7 @@ PortGroup           makefile 1.0
 
 name                catgirl
 version             2.1
-revision            0
+revision            1
 categories          net
 license             GPL-3+
 license_noconflict  openssl libressl

--- a/net/rpki-client/Portfile
+++ b/net/rpki-client/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                rpki-client
 version             7.4
-revision            1
+revision            2
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

And bump revision of dependents since the soname changed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1713 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
