### PR TITLE
submission: php-xmlrpc: new port (from PECL)

### DIFF
--- a/php/php-xmlrpc/Portfile
+++ b/php/php-xmlrpc/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               php 1.1
+
+name                    php-xmlrpc
+version                 1.0.0RC3
+categories-append       devel net
+maintainers             {ryandesign @ryandesign} openmaintainer
+license                 PHP-3.01
+
+php.branches            8.0 8.1
+php.pecl                yes
+php.pecl.prerelease     yes
+
+description             Functions to write XML-RPC servers and clients
+
+long_description        ${description}
+
+checksums               rmd160  5c1cd8dec6f9af81d697effc07a981c1bc6f375e \
+                        sha256  65ce03491782f9d9d5e9bc70bfe684255e5afa8486a2960c7a7cab033882a282 \
+                        size    79506


### PR DESCRIPTION
#### Description

Before PHP 8.0, the xmlrpc extension was bundled with PHP, but
now it's moved to PECL.

https://wiki.php.net/rfc/unbundle_xmlprc
https://php.watch/versions/8.0/xmlrpc

Current version (1.0.0RC3) works ok for PHP 8.0 and 8.1. While it's
really using old libraries and the recommendation is to move away
from it to newer/better alternatives, there is still some code out
there using it.

Hence, this provides the extension, built from PECL, for PHP 8.0 and up.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
