### PR TITLE
Influxdb: update to 2.1.1

### DIFF
--- a/sysutils/influx-cli/Portfile
+++ b/sysutils/influx-cli/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/influxdata/influx-cli 2.2.1 v
+go.package          github.com/influxdata/influx-cli/v2
+github.tarball_from archive
+revision            0
+
+description         CLI for managing resources in InfluxDB v2
+long_description    {*}${description}
+
+categories          sysutils
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  c971f053d4de68d2f0086ba3eb6474b9e1fece82 \
+                    sha256  52ea58f3195aaf7848d2df7c9fba151ecde01ef1171b587c47727bb0913349d3 \
+                    size    373793
+
+# Allow Go to fetch deps at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+# All gopath/bin to PATH
+build.env-append    PATH=$env(PATH):${gopath}/bin
+
+build.cmd           make
+build.pre_args-append \
+                    VERSION=${version}
+build.args          influx
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/bin/${goos}/influx \
+        ${destroot}${prefix}/bin/
+}

--- a/sysutils/influxdb/Portfile
+++ b/sysutils/influxdb/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   golang 1.0
 
-go.setup                    github.com/influxdata/influxdb 2.0.7 v
+go.setup                    github.com/influxdata/influxdb 2.1.1 v
 revision                    0
 
 homepage                    https://influxdata.com
@@ -18,10 +18,8 @@ long_description            InfluxDB is an open source time series platform. \
                             visualizing and exploring the data and more.
 
 categories                  sysutils net
-platforms                   darwin
-license                     MIT
 installs_libs               no
-
+license                     MIT
 maintainers                 {gmail.com:herby.gillot @herbygillot} \
                             openmaintainer
 
@@ -31,10 +29,15 @@ fetch.type                  git
 # Allow fetching dependencies during build time
 build.env-delete            GO111MODULE=off GOPROXY=off
 
-depends_build-append        bin:node:nodejs15 \
+# Add local gopath/bin to PATH
+build.env-append            PATH=$env(PATH):${gopath}/bin
+
+depends_build-append        bin:node:nodejs16 \
                             bin:npm:npm6 \
                             port:cargo \
+                            port:coreutils \
                             port:pkgconfig \
+                            bin:protoc:protobuf3-cpp \
                             port:rust \
                             port:yarn
 
@@ -62,6 +65,9 @@ post-extract {
     copy ${filespath}/org.macports.influxdb.plist ${influxdb_plist_src}
 
     copy ${filespath}/config.toml.example ${workpath}/
+}
+
+patch {
     reinplace "s|@DATA_DIR@|${influxdb_data_dir}|g" \
         ${workpath}/config.toml.example
 
@@ -71,31 +77,39 @@ post-extract {
     reinplace "s|@PREFIX@|${prefix}|g"                ${influxdb_plist_src}
     reinplace "s|@CONF_FILE@|${influxdb_conf_file}|g" ${influxdb_plist_src}
     reinplace "s|@LOGFILE@|${influxdb_log_file}|g"    ${influxdb_plist_src}
+
+    foreach _script {
+        scripts/fetch-ui-assets.sh
+        scripts/ci/test-downgrade.sh
+        scripts/ci/install-rust.sh
+    } {
+        reinplace -E "s|sha256sum|${prefix}/bin/gsha256sum|g" \
+            ${worksrcpath}/${_script}
+    }
 }
 
 destroot {
 
-    copy {*}[glob ${worksrcpath}/bin/darwin/*] ${destroot}${prefix}/bin/
+    copy {*}[glob ${worksrcpath}/bin/${goos}/*] ${destroot}${prefix}/bin/
 
-
-    xinstall  -d -m 755 ${destroot}${influxdb_conf_dir}
-    xinstall  -d -m 755 ${destroot}${influxdb_share_dir}
-    xinstall  -d -m 755 -o ${influxdb_user} -g ${influxdb_user} \
+    xinstall  -d -m 0755 ${destroot}${influxdb_conf_dir}
+    xinstall  -d -m 0755 ${destroot}${influxdb_share_dir}
+    xinstall  -d -m 0755 -o ${influxdb_user} -g ${influxdb_user} \
               ${destroot}${influxdb_data_dir}
-    xinstall  -d -m 755 -g ${influxdb_user} ${destroot}${influxdb_log_dir}
+    xinstall  -d -m 0755 -g ${influxdb_user} ${destroot}${influxdb_log_dir}
 
     copy ${workpath}/config.toml.example ${destroot}${influxdb_example_conf}
 
     touch ${destroot}${influxdb_log_file}
     file attributes ${destroot}${influxdb_log_file} -owner ${influxdb_user}
 
-    xinstall -d -m 755 \
+    xinstall -d -m 0755 \
         ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
 
     xinstall -m 0644 -o root -W ${workpath} org.macports.${name}.plist \
         ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
 
-    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+    xinstall -d -m 0755 ${destroot}/Library/LaunchDaemons
 
     ln -s ${prefix}/etc/LaunchDaemons/org.macports.${name}/org.macports.${name}.plist \
         ${destroot}/Library/LaunchDaemons/org.macports.${name}.plist
@@ -112,10 +126,13 @@ post-activate {
 }
 
 notes "
+ATTENTION: the InfluxDB CLI is no longer packaged as part of InfluxDB.
+Please install the influx-cli port.
+
 To start the InfluxDB service, use `port load`:
 
     \$ sudo port load ${name}
-    \$ influx
+    \$ influx # if you installed the CLI via the influx-cli port
 
 `port unload` will stop and remove the service:
 


### PR DESCRIPTION
(PR to test in CI)

Includes new port for `influx-cli` as the CLI has been split off from the main InfluxDB codebase.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
