### PR TITLE
qsv: new port (version 0.34.1)

### DIFF
--- a/textproc/qsv/Portfile
+++ b/textproc/qsv/Portfile
@@ -1,0 +1,457 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        jqnatividad qsv 0.34.1
+github.tarball_from archive
+revision            0
+
+description         Ultra-fast CSV data-wrangling CLI toolkit
+
+long_description    \
+    qsv is a command line program for indexing, slicing, analyzing, \
+    splitting, enriching, validating & joining CSV files.  Commands are \
+    simple, fast and composable.
+
+categories          textproc
+installs_libs       no
+license             Unlicense
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  aefa061a36cbebcd7df26fe65ef8826f00eb9edb \
+                    sha256  9a1e2021944c8e697e8a30bcfc3a4645c7069e87f4896aeebfb954921727191f \
+                    size    280922
+
+build.env-append    PATH=${workpath}/bin:$env(PATH)
+
+depends_lib-append  port:python310
+
+build.pre_args-append \
+                    --all-features
+
+post-extract {
+    file mkdir ${workpath}/bin
+    file link -symbolic ${workpath}/bin/python3 ${prefix}/bin/python3.10
+}
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    actix-codec                      0.3.0  78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570 \
+    actix-connect                    2.0.0  177837a10863f15ba8d3ae3ec12fac1099099529ed20083a27fdfe247381d0dc \
+    actix-governor                   0.2.6  dff68e30e5839d33afc5f3567e31a89cbfb04877b1629af41a6665fa3d60f1e5 \
+    actix-http                       2.2.2  2be6b66b62a794a8e6d366ac9415bb7d475ffd1e9f4671f38c1d8a8a5df950b3 \
+    actix-macros                     0.1.3  b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655 \
+    actix-router                     0.2.7  2ad299af73649e1fc893e333ccf86f377751eb95ff875d095131574c6f43452c \
+    actix-rt                         1.1.1  143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227 \
+    actix-server                     1.0.4  45407e6e672ca24784baa667c5d32ef109ccdd8d5e0b5ebb9ef8a67f4dfb708e \
+    actix-service                    1.0.6  0052435d581b5be835d11f4eb3bce417c8af18d87ddf8ace99f8e67e595882bb \
+    actix-testing                    1.0.1  47239ca38799ab74ee6a8a94d1ce857014b2ac36f242f70f3f75a66f691e791c \
+    actix-threadpool                 0.3.3  d209f04d002854b9afd3743032a27b066158817965bf5d036824d19ac2cc0e30 \
+    actix-tls                        2.0.0  24789b7d7361cf5503a504ebe1c10806896f61e96eca9a7350e23001aca715fb \
+    actix-utils                      2.0.0  2e9022dec56632d1d7979e59af14f0597a28a830a9c1c7fec8b2327eb9f16b5a \
+    actix-web                        3.3.3  b6534a126df581caf443ba2751cab42092c89b3f1d06a9d829b1e17edfe3e277 \
+    actix-web-codegen                0.4.0  ad26f77093333e0e7c6ffe54ebe3582d908a104e448723eec6d43d08b07143fb \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    ahash                            0.3.8  e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217 \
+    ahash                            0.7.6  fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47 \
+    aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
+    alloc-no-stdlib                  2.0.3  35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3 \
+    alloc-stdlib                     0.2.1  697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2 \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anyhow                          1.0.55  159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd \
+    assert-json-diff                 2.0.1  50f1c3703dd33532d7f0ca049168930e9099ecac238e23cf932f3a69c42f06da \
+    async-attributes                 1.1.2  a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5 \
+    async-channel                    1.6.1  2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319 \
+    async-executor                   1.4.1  871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965 \
+    async-global-executor            2.0.3  c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a \
+    async-io                         1.6.0  a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b \
+    async-lock                       2.5.0  e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6 \
+    async-mutex                      1.4.0  479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e \
+    async-process                    1.3.0  83137067e3a2a6a06d67168e49e68a0957d215410473a740cea95a2425c0b7c6 \
+    async-rwlock                     1.3.0  261803dcc39ba9e72760ba6e16d0199b1eef9fc44e81bffabbebb9f5aea3906c \
+    async-std                       1.10.0  f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952 \
+    async-task                       4.2.0  30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9 \
+    async-trait                     0.1.52  061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3 \
+    atomic-waker                     1.0.0  065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    awc                              2.0.3  b381e490e7b0cfc37ebc54079b0413d8093ef43d14a4e4747083f7fa47a9e691 \
+    base-x                           0.2.8  a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b \
+    base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
+    bit-set                          0.5.2  6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de \
+    bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    block-buffer                     0.7.3  c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b \
+    block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
+    block-padding                    0.1.5  fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5 \
+    blocking                         1.1.0  046e47d4b2d391b1f6f8b407b1deb8dee56c1852ccd868becf2710f601b5f427 \
+    brotli                           3.3.3  f838e47a451d5a8fa552371f80024dd6ace9b7acdf25c4c3d0f9bc6816fb1c39 \
+    brotli-decompressor              2.3.2  59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80 \
+    bstr                            0.2.17  ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223 \
+    bumpalo                          3.9.1  a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899 \
+    byte-tools                       0.3.1  e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7 \
+    bytecount                        0.6.2  72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e \
+    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
+    bytes                            0.5.6  0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38 \
+    bytes                            1.1.0  c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8 \
+    bytestring                       1.0.0  90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d \
+    cache-padded                     1.2.0  c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c \
+    cached                          0.33.0  f66c8f6ae13abbdc12268879b8070a441777b69157fb7653b4c7da7f2610c25d \
+    cached_proc_macro               0.11.0  dc8de7b947777686ee8f3c11f4c3e58c296d6bc598d9b2286a80a9404a538ff8 \
+    cached_proc_macro_types          0.1.0  3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663 \
+    cc                              1.0.73  2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11 \
+    censor                           0.2.0  5563d2728feef9a6186acdd148bccbe850dad63c5ba55a3b3355abc9137cb3eb \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
+    clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
+    combine                          4.6.3  50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062 \
+    concurrent-queue                 1.2.2  30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3 \
+    console                         0.15.0  a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31 \
+    const_fn                         0.4.9  fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935 \
+    convert_case                     0.4.0  6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e \
+    cookie                          0.14.4  03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951 \
+    cookie                          0.15.1  d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d \
+    cookie_store                    0.15.1  b3f7034c0932dc36f5bd8ec37368d971346809435824f277cb3b8299fc56167c \
+    copyless                         0.1.5  a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536 \
+    cpufeatures                      0.2.1  95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469 \
+    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
+    crossbeam                        0.8.1  4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845 \
+    crossbeam-channel                0.5.2  e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa \
+    crossbeam-deque                  0.8.1  6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e \
+    crossbeam-epoch                  0.9.7  c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9 \
+    crossbeam-queue                  0.3.4  4dd435b205a4842da59efd07628f921c096bc1cc0a156835b4fa0bcb9a19bcce \
+    crossbeam-utils                  0.8.7  b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6 \
+    csv                              1.1.6  22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1 \
+    csv-core                        0.1.10  2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
+    csv-index                        0.1.6  f274135fcb98bd7e6e47a9e0b44639ec53b3e5d6c1930e2a9e6a014f90470404 \
+    ctor                            0.1.21  ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa \
+    darling                         0.13.1  d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4 \
+    darling_core                    0.13.1  7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324 \
+    darling_macro                   0.13.1  72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b \
+    dashmap                          5.1.0  c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c \
+    dateparser                       0.1.6  81dcee48ba66b79ba92dab399f218228f98c5d601ca85127fbc1ad60caf237d8 \
+    derive_more                    0.99.17  4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321 \
+    digest                           0.8.1  f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5 \
+    digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
+    discard                          1.0.4  212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0 \
+    docopt                           1.1.1  7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f \
+    dtoa                             0.4.8  56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0 \
+    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    encoding_rs                     0.8.30  7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df \
+    enum-as-inner                    0.3.4  570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4 \
+    eudex                            0.1.1  95cb9bf0969366245682aedd5197be1491f2a044fc99c45564710b22b0e9ac87 \
+    event-listener                   2.5.2  77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71 \
+    fake-simd                        0.1.2  e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed \
+    fancy-regex                      0.7.1  9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf \
+    fastrand                         1.7.0  c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf \
+    filetime                        0.2.15  975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98 \
+    fixedbitset                      0.4.1  279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e \
+    flate2                          1.0.22  1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f \
+    flexi_logger                    0.22.3  969940c39bc718475391e53a3a59b0157e64929c80cf83ad5dde5f770ecdc423 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    form_urlencoded                  1.0.1  5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
+    fraction                         0.9.0  aba3510011eee8825018be07f08d9643421de007eaf62a3bde58d89b058abfa7 \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    futures                         0.3.21  f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e \
+    futures-channel                 0.3.21  c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010 \
+    futures-core                    0.3.21  0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3 \
+    futures-executor                0.3.21  9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6 \
+    futures-io                      0.3.21  fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b \
+    futures-lite                    1.12.0  7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48 \
+    futures-macro                   0.3.21  33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512 \
+    futures-sink                    0.3.21  21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868 \
+    futures-task                    0.3.21  57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a \
+    futures-timer                    3.0.2  e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c \
+    futures-util                    0.3.21  d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a \
+    fxhash                           0.2.1  c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c \
+    generic-array                   0.12.4  ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd \
+    generic-array                   0.14.5  fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803 \
+    getrandom                       0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
+    getrandom                        0.2.5  d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77 \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    gloo-timers                      0.2.3  4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e \
+    governor                         0.4.2  19775995ee20209163239355bc3ad2f33f83da35d9ef72dea26e5af753552c87 \
+    grex                             1.3.0  3616b65969ace16c2092a553702e2db26cad939dbbb920335a5b6b482b36d86f \
+    h2                               0.2.7  5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535 \
+    h2                              0.3.11  d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e \
+    hashbrown                        0.7.2  96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf \
+    hashbrown                       0.11.2  ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e \
+    hashbrown                       0.12.0  8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758 \
+    heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
+    heck                             0.4.0  2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9 \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    hlua                             0.4.1  ed9db71fff2e55b83d24bbbdd9ad13f0d1ff79bc265f544370f39ee0825d54e4 \
+    hostname                         0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
+    http                             0.2.6  31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03 \
+    http-body                        0.4.4  1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6 \
+    httparse                         1.6.0  9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4 \
+    httpdate                         1.0.2  c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421 \
+    hyper                          0.14.17  043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd \
+    hyper-rustls                    0.23.0  d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
+    idna                             0.2.3  418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
+    indexmap                         1.8.0  282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223 \
+    indicatif                       0.16.2  2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b \
+    indoc                            1.0.4  e7906a9fababaeacb774f72410e497a1d18de916322e33797bb2cd29baa23c9e \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
+    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
+    ipconfig                         0.2.2  f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7 \
+    ipnet                            2.3.1  68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9 \
+    iso8601                          0.4.1  0a59a3f2be6271b2a844cd0dd13bf8ccc88a9540482d872c7ce58ab1c4db9fab \
+    itertools                       0.10.3  a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3 \
+    itoa                             0.4.8  b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4 \
+    itoa                             1.0.1  1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35 \
+    jql                              3.1.1  3258fc2346586f11b67c3372d9fc94b71cf61f2f070789b06af4e55bd3687ec0 \
+    js-sys                          0.3.56  a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04 \
+    jsonschema                      0.15.0  d4be404426c47c9b868fc9b6ddda07f84e2885d12b17066036717db2cd4e5d77 \
+    kdtree                           0.6.0  80ee359328fc9087e9e3fc0a4567c4dd27ec69a127d6a70e8d9dd22845b8b1a2 \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    kv-log-macro                     1.0.7  0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f \
+    language-tags                    0.2.2  a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    levenshtein                      1.0.5  db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760 \
+    libc                           0.2.119  1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4 \
+    libmimalloc-sys                 0.1.24  7705fc40f6ed493f73584abbb324e74f96b358ff60dfe5659a0f8fc12c590a69 \
+    linked-hash-map                  0.5.4  7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3 \
+    lock_api                         0.4.6  88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b \
+    log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
+    lru-cache                        0.1.2  31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c \
+    lua52-sys                        0.1.2  d451db153c94e455dc817d388f9674f6232425c28db3509e90251c55b8df2f94 \
+    mach                             0.3.2  b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa \
+    maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
+    match_cfg                        0.1.0  ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4 \
+    matches                          0.1.9  a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f \
+    matrixmultiply                   0.3.2  add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84 \
+    memchr                           2.4.1  308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a \
+    memoffset                        0.6.5  5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
+    mimalloc                        0.1.28  b0dfa131390c2f6bdb3242f65ff271fcdaca5ff7b6c08f28398be7f2280e3926 \
+    mime                            0.3.16  2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d \
+    minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
+    miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
+    mio                             0.6.23  4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4 \
+    mio                              0.8.0  ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2 \
+    mio-uds                          0.6.8  afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0 \
+    miow                             0.2.2  ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d \
+    miow                             0.3.7  b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21 \
+    ndarray                         0.15.4  dec23e6762830658d2b3d385a75aa212af2f67a4586d4442907144f3bb6a1ca8 \
+    net2                            0.2.37  391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae \
+    no-std-compat                    0.4.1  b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c \
+    nom                              7.1.0  1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109 \
+    nonzero_ext                      0.3.0  38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21 \
+    ntapi                            0.3.7  c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f \
+    num                              0.2.1  b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36 \
+    num                              0.4.0  43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606 \
+    num-bigint                       0.2.6  090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304 \
+    num-bigint                       0.4.3  f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f \
+    num-cmp                          0.1.0  63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa \
+    num-complex                      0.2.4  b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95 \
+    num-complex                      0.4.0  26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085 \
+    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-iter                        0.1.42  b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59 \
+    num-rational                     0.2.4  5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef \
+    num-rational                     0.4.0  d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a \
+    num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    num_cpus                        1.13.1  19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1 \
+    num_threads                      0.1.3  97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15 \
+    number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
+    once_cell                       1.10.0  87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9 \
+    opaque-debug                     0.2.3  2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c \
+    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
+    parking                          2.0.0  427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72 \
+    parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
+    parking_lot                     0.12.0  87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58 \
+    parking_lot_core                 0.8.5  d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216 \
+    parking_lot_core                 0.9.1  28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954 \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pest                             2.1.3  10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53 \
+    pest_derive                      2.1.0  833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0 \
+    pest_generator                   2.1.3  99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55 \
+    pest_meta                        2.1.3  54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d \
+    petgraph                         0.6.0  4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f \
+    pin-project                     0.4.29  9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909 \
+    pin-project                     1.0.10  58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e \
+    pin-project-internal            0.4.29  044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a \
+    pin-project-internal            1.0.10  744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb \
+    pin-project-lite                0.1.12  257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777 \
+    pin-project-lite                 0.2.8  e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pkg-config                      0.3.24  58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe \
+    polling                          2.2.0  685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259 \
+    ppv-lite86                      0.2.16  eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872 \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro-hack                 0.5.19  dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5 \
+    proc-macro2                     1.0.36  c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029 \
+    psl-types                       2.0.10  e8eda7c62d9ecaafdf8b62374c006de0adf61666ae96a96ba74a37134aa4e470 \
+    publicsuffix                     2.1.1  292972edad6bbecc137ab84c5e36421a4a6c979ea31d3cc73540dd04315b33e1 \
+    pyo3                            0.16.0  9d1a3df45cb95bd954fac00bd9609062640fd7fb9e9946a660092c9e015421fb \
+    pyo3-build-config               0.16.0  386a68f0f5f2f9932815068bc8049a56989f2437d96dbb31d1fb11b63ce90364 \
+    pyo3-ffi                        0.16.0  a9a4e2f74dc77eea5ce11d19f0afaeb632b6590f8cbb1d5ee2f1330b766803e8 \
+    pyo3-macros                     0.16.0  dbff3a1579934968a53bcc78ac33663ed2577accda05d484097679cc8d28e52d \
+    pyo3-macros-backend             0.16.0  90644126c8c1ac7b47f794dd20a5729f8646b91c49edb31689c90f8cb3c33ea9 \
+    qsv-stats                        0.3.6  f3cff8f4bef94fd92ec65ff9c88fba0d7c44b08f4f581eda9096ae6998084c20 \
+    qsv_currency                     0.5.0  6ec34fb9bfedc869a4726d8f1a39047736c8d843910f0788c107e202d418ccf3 \
+    quanta                           0.9.3  20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8 \
+    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+    quick-xml                       0.20.0  26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd \
+    quickcheck                       1.0.3  588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6 \
+    quote                           1.0.15  864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145 \
+    r2d2                             0.8.9  545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_core                        0.6.3  d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    raw-cpuid                       10.2.0  929f54e29691d4e6a9cc558479de70db7aa3d98cd6fe7ab86d7507aa2886b9d2 \
+    rawpointer                       0.2.1  60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3 \
+    rayon                            1.5.1  c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90 \
+    rayon-core                       1.9.1  d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e \
+    redis                           0.21.5  1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852 \
+    redox_syscall                   0.2.11  8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c \
+    regex                            1.5.4  d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461 \
+    regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
+    regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    reqwest                         0.11.9  87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525 \
+    resolv-conf                      0.7.0  52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00 \
+    reverse_geocoder                 3.0.0  7e2c7983a04230d15e83a3079765d370628e04a2474d585b712d7c46e17e9ab0 \
+    ring                           0.16.20  3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
+    rustls                          0.20.4  4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921 \
+    rustls-pemfile                   0.2.1  5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9 \
+    rustversion                      1.0.6  f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f \
+    ryu                              1.0.9  73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f \
+    scheduled-thread-pool            0.2.5  dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    sct                              0.7.0  d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4 \
+    self_update                     0.28.0  5bc3e89793fe56c82104ddc103c998e4e94713cb975202207829e61031eb4be6 \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver                          0.11.0  f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6 \
+    semver                           1.0.6  a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    semver-parser                   0.10.2  00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7 \
+    serde                          1.0.136  ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789 \
+    serde_derive                   1.0.136  08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9 \
+    serde_json                      1.0.79  8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95 \
+    serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    serde_yaml                      0.8.23  a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0 \
+    sha-1                            0.8.2  f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df \
+    sha-1                            0.9.8  99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6 \
+    sha1                             0.6.1  c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770 \
+    sha1_smol                        1.0.0  ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012 \
+    signal-hook                     0.3.13  647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d \
+    signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
+    slab                             0.4.5  9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5 \
+    smallvec                         1.8.0  f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83 \
+    socket2                         0.3.19  122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e \
+    socket2                          0.4.4  66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    standback                       0.2.17  e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff \
+    stdweb                          0.4.20  d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5 \
+    stdweb-derive                    0.5.3  c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef \
+    stdweb-internal-macros           0.2.9  58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11 \
+    stdweb-internal-runtime          0.1.5  213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0 \
+    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    structopt                       0.3.26  0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10 \
+    structopt-derive                0.4.18  dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0 \
+    syn                             1.0.86  8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b \
+    tabwriter                        1.2.1  36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111 \
+    tempfile                         3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
+    terminal_size                   0.1.17  633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df \
+    test-data-generation             0.3.4  640e18df4252c8ccb6c1c3abd1e48c9f2c674a61eb3136936811b79b9b7f58d6 \
+    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thiserror                       1.0.30  854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417 \
+    thiserror-impl                  1.0.30  aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b \
+    thousands                        0.2.0  3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820 \
+    threadpool                       1.8.1  d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa \
+    time                            0.1.43  ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438 \
+    time                            0.2.27  4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242 \
+    time                             0.3.7  004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d \
+    time-macros                      0.1.1  957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1 \
+    time-macros                      0.2.3  25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6 \
+    time-macros-impl                 0.1.2  fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f \
+    tinyvec                          1.5.1  2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2 \
+    tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
+    titlecase                        1.1.0  f565e410cfc24c2f2a89960b023ca192689d7f77d3f8d4f4af50c2d8affe1117 \
+    tokio                           0.2.25  6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092 \
+    tokio                           1.17.0  2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee \
+    tokio-macros                     1.7.0  b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7 \
+    tokio-rustls                    0.23.2  a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b \
+    tokio-util                       0.3.1  be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499 \
+    tokio-util                       0.6.9  9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0 \
+    tower-service                    0.3.1  360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6 \
+    tracing                         0.1.31  f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f \
+    tracing-core                    0.1.22  03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23 \
+    tracing-futures                  0.2.5  97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2 \
+    trust-dns-proto                 0.19.7  1cad71a0c0d68ab9941d2fb6e82f8fb2e86d9945b94e1661dd0aaea2b88215a9 \
+    trust-dns-resolver              0.19.7  710f593b371175db53a26d0b38ed2978fafb9e9e8d3868b1acd753ea18df0ceb \
+    try-lock                         0.2.3  59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642 \
+    typenum                         1.15.0  dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987 \
+    ucd-trie                         0.1.3  56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c \
+    unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \
+    unic-char-range                  0.9.0  0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc \
+    unic-common                      0.9.0  80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc \
+    unic-ucd-category                0.9.0  1b8d4591f5fcfe1bd4453baaf803c40e1b1e69ff8455c47620440b46efef91c0 \
+    unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
+    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
+    unicode-bidi                     0.3.7  1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f \
+    unicode-normalization           0.1.19  d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9 \
+    unicode-segmentation             1.9.0  7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99 \
+    unicode-width                    0.1.9  3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973 \
+    unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
+    unindent                         0.1.8  514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8 \
+    untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
+    url                              2.2.2  a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c \
+    uuid                             0.8.2  bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7 \
+    vader_sentiment                  0.1.1  7f79fb65bbfaf53d62afa05b1d162ff245cda71257d094e5d2de022fa5cff112 \
+    value-bag                1.0.0-alpha.8  79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f \
+    vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    waker-fn                         1.1.0  9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca \
+    want                             0.3.0  1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0 \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    wasi     0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
+    wasm-bindgen                    0.2.79  25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06 \
+    wasm-bindgen-backend            0.2.79  8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca \
+    wasm-bindgen-futures            0.4.29  2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395 \
+    wasm-bindgen-macro              0.2.79  2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01 \
+    wasm-bindgen-macro-support      0.2.79  bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc \
+    wasm-bindgen-shared             0.2.79  3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2 \
+    web-sys                         0.3.56  c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb \
+    webpki                          0.22.0  f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd \
+    webpki-roots                    0.22.2  552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449 \
+    wepoll-ffi                       0.1.2  d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb \
+    whatlang                        0.13.0  349357fdf0f049dcb402da4a4c5a5aae80a7f6b3e5976b38475ce4ac18e5cd2f \
+    widestring                       0.4.3  c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows-sys                     0.32.0  3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6 \
+    windows_aarch64_msvc            0.32.0  d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5 \
+    windows_i686_gnu                0.32.0  6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615 \
+    windows_i686_msvc               0.32.0  146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172 \
+    windows_x86_64_gnu              0.32.0  c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc \
+    windows_x86_64_msvc             0.32.0  504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316 \
+    winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9 \
+    winreg                           0.7.0  0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69 \
+    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
+    yaml-rust                        0.4.5  56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85 \
+    zip                             0.5.13  93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815


### PR DESCRIPTION
New port for [qsv](https://github.com/jqnatividad/qsv), a CSV analysis toolkit

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
