### PR TITLE
neomutt: Add support for lz4 and zstd compression

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        neomutt neomutt 20211029
-revision            0
+revision            1
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -29,8 +29,10 @@ depends_lib         path:bin/perl:perl5 \
                     path:lib/libssl.dylib:openssl \
                     port:gettext \
                     port:libiconv \
+                    port:lz4 \
                     port:ncurses \
-                    port:zlib
+                    port:zlib \
+                    port:zstd
 depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 
 post-patch {
@@ -59,8 +61,10 @@ configure.args      --disable-doc \
                     --disable-idn \
                     --with-ncurses=${prefix} \
                     --with-nls=${prefix} \
+                    --with-lz4=${prefix} \
                     --with-ssl=${prefix} \
-                    --with-zlib=${prefix}
+                    --with-zlib=${prefix} \
+                    --with-zstd=${prefix}
 
 # disable ccache, build issues with autosetup
 configure.ccache     no


### PR DESCRIPTION
###### Description

Adds support for
```
set header_cache_compress_method = "zstd"
```
and
```
set header_cache_compress_method = "lz4"
```

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 arm64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?