### PR TITLE
typescript: new port

### DIFF
--- a/lang/typescript/Portfile
+++ b/lang/typescript/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                typescript
+version             4.6.2
+revision            0
+checksums           rmd160  d26bc3d25644998ea8a45f013bfcef2c5353fa65 \
+                    sha256  30afe4c71ff164ba41560e0770e0f8c48f9c03959cbcdcc7c410ab052bf2f6d6 \
+                    size    11410610
+
+categories          lang
+maintainers         @goranmoomin openmaintainer
+license             Apache-2
+description         TypeScript is JavaScript with syntax for types
+long_description    TypeScript is a strongly typed programming language that \
+                    builds on JavaScript, giving you better tooling at any \
+                    scale.
+
+homepage            https://www.typescriptlang.org
+master_sites        https://registry.npmjs.org/${name}/-
+
+distfiles          ${distname}.tgz
+
+platforms           darwin
+
+depends_lib-append  path:bin/node:nodejs16
+depends_build-append \
+                    path:bin/npm:npm8
+
+use_configure       no
+
+extract.mkdir       yes
+extract {
+    copy ${distpath}/${distname}.tgz ${worksrcpath}/${distname}.tgz
+}
+
+build {}
+
+destroot {
+    system -W ${worksrcpath} "npm install --global --prefix [shellescape ${destroot}${prefix}] ${distname}.tgz"
+}
+
+livecheck.type      regex
+livecheck.url       https://registry.npmjs.org/${name}
+livecheck.regex     {"latest":"(.*?)"}


### PR DESCRIPTION
#### Description

This PR adds a new `lang/typescript` port.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
