### PR TITLE
flyctl: Add shell completions

### DIFF
--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/superfly/flyctl 0.0.302 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          devel
 installs_libs       no
@@ -42,6 +42,14 @@ destroot {
     xinstall -m 0755 ${worksrcpath}/_bin/${name} ${destroot}${prefix}/bin/
 
     ln -s ${prefix}/bin/${name} ${destroot}${prefix}/bin/fly
+
+    # Shell completion
+    xinstall -d "${destroot}${prefix}/etc/bash_completion.d"
+    xinstall -d "${destroot}${prefix}/share/zsh/site-functions"
+    xinstall -d "${destroot}${prefix}/share/fish/completions"
+    system "${destroot}${prefix}/bin/${name} completion bash > ${destroot}${prefix}/etc/bash_completion.d/${name}"
+    system "${destroot}${prefix}/bin/${name} completion zsh > ${destroot}${prefix}/share/zsh/site-functions/_${name}"
+    system "${destroot}${prefix}/bin/${name} completion fish > ${destroot}${prefix}/share/fish/completions/${name}.fish"
 }
 
 # Only match releases. Pre-releaes have a "-pre-N" suffix


### PR DESCRIPTION
#### Description

This PR adds shell completions to the `flyctl` port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
