### PR TITLE
openjdk: rename to openjdk-distributions

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem       1.0
 
-name             openjdk
+name             openjdk-distributions
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -11,8 +11,9 @@ license          GPL-2 NoMirror
 # These ports use prebuilt binaries for a particular architecture, they are not universal binaries
 universal_variant no
 
-# Latest Long Term Support (LTS) major version
-version          17
+# Note: This is the version/revision for the parent stub only
+version          1.0
+revision         0
 
 set long_description_corretto \
    "No-cost, multiplatform, production-ready distribution of OpenJDK."
@@ -40,8 +41,8 @@ set long_description_zulu \
     verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
     respective Java SE version."
 
-# Dummy default values for the obsoleted openjdk port
-set build        0
+# Dummy default values
+set build          0
 set openj9_version 0
 
 set obsoleted_ports {
@@ -60,11 +61,35 @@ set obsoleted_ports {
 if {${subport} in ${obsoleted_ports}} {
     PortGroup    obsolete 1.0
 
+    replaced_by  openjdk-distributions
+    description
+    long_description
+    homepage
+    master_sites
 }
 
-if {${subport} eq "openjdk"} {
-    # The openjdk port is not installable, but recommends users to install the latest Long Term Support (LTS) subport
-    replaced_by  openjdk${version}
+if {${subport} eq ${name}} {
+    set meta true
+    description          "Meta port encompassing binary OpenJDK releases"
+    long_description     {*}${description}
+    homepage
+    master_sites
+
+    distfiles
+    patchfiles
+    supported_archs      noarch
+    use_configure        no
+    build {}
+    destroot {
+        set docdir ${destroot}${prefix}/share/doc/${subport}
+        xinstall -d ${docdir}
+        system "echo $subport is a stub port > ${docdir}/README"
+    }
+
+    notes {
+        The openjdk-distributions port is not installable, but recommends users to install\
+        the latest Long Term Support (LTS) subport
+    }
 }
 
 subport openjdk7-zulu {
@@ -799,7 +824,7 @@ livecheck.type  none
 use_configure    no
 build {}
 
-if {![info exists meta]} {
+if {!(${subport} in ${obsoleted_ports}) && ![info exists meta]} {
     if {![string match *-temurin ${subport}]} {
         variant BundledApp \
             description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}


### PR DESCRIPTION
#### Description

Renaming the (non-installable) `openjdk` port to `openjdk-distributions` to make it easy to distinguish between the vendor-provided OpenJDK distributions and the builds from source which is planned to be introduced via https://github.com/macports/macports-ports/pull/14185.

This PR doesn't change anything for the subports in this portfile, which is are the actually interesting ports for MacPorts users.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?