### PR TITLE
libdbi{,-drivers}: autoreconf to fix build on arm64

### DIFF
--- a/databases/libdbi-drivers/Portfile
+++ b/databases/libdbi-drivers/Portfile
@@ -23,6 +23,18 @@ patchfiles          configure.patch
 configure.args      --with-dbi-incdir=${prefix}/include --with-dbi-libdir=${prefix}/lib \
                     --disable-docs
 
+platform darwin arm {
+    depends_build-append    port:automake
+
+    post-patch {
+        # Use newer config.guess and config.sub to support Apple Silicon.
+        set automake_dirs [glob -directory ${prefix}/share automake-*]
+        set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+        copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+            ${worksrcpath}
+    }
+}
+
 if {![variant_isset mysql5] && ![variant_isset postgresql83] &&
 	![variant_isset sqlite2] && ![variant_isset sqlite3]} {
 	default_variants     +sqlite3

--- a/databases/libdbi/Portfile
+++ b/databases/libdbi/Portfile
@@ -19,6 +19,18 @@ configure.args      --disable-docs
 
 patchfiles          endian.patch cflags.patch
 
+platform darwin arm {
+    depends_build-append    port:automake
+
+    post-patch {
+        # Use newer config.guess and config.sub to support Apple Silicon.
+        set automake_dirs [glob -directory ${prefix}/share automake-*]
+        set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+        copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+            ${worksrcpath}
+    }
+}
+
 variant docs description "Build the documentation" {
         configure.args-delete --disable-docs
 


### PR DESCRIPTION
#### Description
Builds libdbi{,-drivers} with `use_autoreconf yes`. This is required
to update `config.guess` and `config.sub` to know about aarch64.

Closes: https://trac.macports.org/ticket/63382

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.1 21C52 arm64
Xcode 13.2.1 13C100

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
