### PR TITLE
google-cloud-sdk: update to 376.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             375.0.0
+version             376.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3aa3222dd9a12ad532540b43fe32837aaf8b305d \
-                    sha256  7c8d67ad97a56eb23652cef803b3ba64de2b01ce570770b0a08c98182e22dd0e \
-                    size    98009743
+    checksums       rmd160  479eac3bebe2554853ac305c0503be87ac4c0d74 \
+                    sha256  dc10bb238b270dfb601b007c936a4ced9b5b3a909b36537d2ebc0094b886139f \
+                    size    99102533
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f7764f722c6c38bebed59d784ff5b007216c58de \
-                    sha256  d4344e21c63eaa38bed6a54e81a401fa7f5feeead905b2ed89ff91b08d629f8c \
-                    size    93252132
+    checksums       rmd160  892e6d199b135a5492eb524bd39f3f6d7574eb6d \
+                    sha256  fa785d3415e004fbbddfe2f4237ae1947c478c2311e28ed83ba652fa0e97a5f3 \
+                    size    94340191
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  79718e67d1108fa4dfe7d1db9cf4f8402abcf941 \
-                    sha256  f1081ea9cdae0a69ffc03bd97de9e3f08bac17c66cc947f34b9240ea278f5e7d \
-                    size    92717882
+    checksums       rmd160  8e96f54e9a4078fffdb20b2a9b8fca314ca3a640 \
+                    sha256  5a01e08528d3598fd8c82d8a7e830da8b9d9b6a80050b22695b98291226e5144 \
+                    size    93811409
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 376.0.0.

###### Tested on

macOS 12.2.1 21D62 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?