### PR TITLE
lagrange: update to 1.11.1

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.10.5 v
+github.setup        skyjake lagrange 1.11.1 v
 revision            0
 github.tarball_from releases
 categories          net gemini
@@ -18,11 +18,11 @@ license             BSD
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 
 description         A Beautiful Gemini Client
-long_description    ${description}
+long_description    {*}${description}
 
-checksums           rmd160  2d2678736749a821e617a3356b272676ee129bad \
-                    sha256  1ed32cacd3ac779814adb47be669e9bd92d4407b223c3d8e59831a31816f35ce \
-                    size    8670258
+checksums           rmd160  b4715ac9b1735b36f9c49bbdf8e1407469980e5d \
+                    sha256  a303f62b6e7372396d334f25eeaaa745827c28ac926dc12305b2b41596d748e8 \
+                    size    8725112
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
