### PR TITLE
py-hypothesis: update to 6.39.3

### DIFF
--- a/python/py-hypothesis/Portfile
+++ b/python/py-hypothesis/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-hypothesis
-version             6.20.1
+version             6.39.3
 revision            0
 categories-append   devel
 platforms           darwin
@@ -23,9 +23,9 @@ long_description \
 
 homepage            https://pypi.python.org/pypi/hypothesis
 
-checksums           rmd160  4a3ee5ef2377b00d7524c941ef8bb99c668f1132 \
-                    sha256  1057f8f27a9f3e1eac341502ea4a43f5045161f797bb661e176a67b77c5b1795 \
-                    size    303676
+checksums           rmd160  690452e2e01d4bf86ead5316e9936da48c150eb5 \
+                    sha256  f496dd053fb951b6da9611481fb4e54eeab1d37b594da5efe869083fad3ae621 \
+                    size    318341
 
 if {${name} ne ${subport}} {
     depends_build-append  port:py${python.version}-setuptools
@@ -50,6 +50,14 @@ if {${name} ne ${subport}} {
         checksums           rmd160  ba112a0d4a97ffaf0a0aa6e6ab2c135e0dd96d10 \
                             sha256  5cc9073ee5a5c109c8d731a52c304729dbb6affed570eb7d35908bfdd937975e \
                             size    267988
+    }
+
+    if {${python.version} == 36} {
+        version             6.31.6
+        revision            0
+        checksums           rmd160  fa5b58a419eafda77d1b0fe21723034da51c76b3 \
+                            sha256  d54be6a80b160ad5ea4209b01a0d72e31d910510ed7142fa9907861911800771 \
+                            size    316859
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

py-hypothesis: update to 6.39.3
Lock py36-hypothesis at 6.31.6, which is the final version supporting Py36

Prior py*-hypothesis fails with now-current numpy.test(). Updating fixes the issue.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.5 20G517
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
