### PR TITLE
miniflux: update to 2.0.36

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.35
+go.setup            github.com/miniflux/v2 2.0.36
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,16 +16,16 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  3219304311fdc9ce6f51954ffd389da10faac058 \
-                        sha256  96b7deba40dd2800ee68ffd0a1308d587ae97572fb89deb0c7d30a050fdd1a0e \
-                        size    535973
+                        rmd160  5ecf1e61d67058adf85a4fbe22a723f876be7c46 \
+                        sha256  8b9def8ac294ae920facd8b8dd82b0744141194ed2775f64d55e53fb96e4f15e \
+                        size    548685
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
-                        lock    v2.3.0 \
-                        rmd160  e30d99a1030f46dd80e3531c7eabbcbd563ff1af \
-                        sha256  e22975a7c55cb3e78c3ab0a74660054cee6b898267afd78c4dfe0f8deae21e16 \
-                        size    21186 \
+                        lock    v2.4.0 \
+                        rmd160  7273a8af3153a595e51a8631a103749bc8d18da2 \
+                        sha256  eca62cdf7aeb8edb0effeedb68cb160fc3440e9f8c061e735d738b3cd2afb7ec \
+                        size    26252 \
                     gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
                         rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
@@ -38,10 +38,10 @@ go.vendors          mvdan.cc/xurls \
                         size    308121 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.26.0-rc.1 \
-                        rmd160  30b1bef41e8bb6a456be9548b7b3b9b8b080fb6f \
-                        sha256  12a733d740730c0cd0a171b040d812d453ae55bef0f4fd08c5f2f19887d3f65c \
-                        size    1270384 \
+                        lock    v1.26.0 \
+                        rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
+                        sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
+                        size    1270531 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.6 \
@@ -49,25 +49,25 @@ go.vendors          mvdan.cc/xurls \
                         sha256  084ba3a248eccd0c7606dc6cff3918326a0adb2e8d30babcbaf6f1c00e1d28f9 \
                         size    333013 \
                     golang.org/x/xerrors \
-                        lock    9bdfabe68543 \
-                        rmd160  eee9929ac1c0380402c45b388077c5c505f13311 \
-                        sha256  dc1be1d7efb43643507e87352ae7161883c48cb5116a20a1739ab93ab558bccf \
-                        size    13661 \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
                     golang.org/x/text \
                         lock    v0.3.6 \
                         rmd160  e3da48fcc60d98e202458228188bf6dac408e309 \
                         sha256  6b2d69df22b5ba1634bc6730c3f03404db499536a96c48b8016da80ced804450 \
                         size    8356058 \
                     golang.org/x/sys \
-                        lock    0f9fa26af87c \
-                        rmd160  b5e5b546cddec0ad97bccbc3a19fe3630792097b \
-                        sha256  e9ff4a07a3cc01341990da0d8ecd1cfa05643a2db423bb1efcf62f577901ea77 \
-                        size    1202158 \
+                        lock    da31bd327af9 \
+                        rmd160  d8b0df85d70b8cbb71b19b9cc280f0c8f7b855b5 \
+                        sha256  64217c9d7c5d88f4c9ce502dd660576d70fc89ad31c22916ab2616123fa58d02 \
+                        size    1257082 \
                     golang.org/x/oauth2 \
-                        lock    bf48bf16ab8d \
-                        rmd160  c1d307776adc90ce1a323b0a6cacab759bf1671e \
-                        sha256  ff3e74cdfe9c0b13d9d8e6f04551460efc01ca58b2332ebeb6f93b6c09c789bc \
-                        size    47023 \
+                        lock    f6687ab2804c \
+                        rmd160  4e0869428be254c38f749258d27e213b203b86f1 \
+                        sha256  b7fe336b0f84961c2f652bac01f0fa40e7e0345c2ad64bc5c75bbea3f3911379 \
+                        size    79623 \
                     golang.org/x/net \
                         lock    12bc252f5db8 \
                         rmd160  103c09b86c8fc108f36ae479f64a14dd8ef5f016 \
@@ -94,10 +94,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  48626fece66259b874a79e0ad78bfc99e855349ffc4c0c133237bd37e5081224 \
                         size    101529 \
                     github.com/tdewolff/minify \
-                        lock    v2.9.28 \
-                        rmd160  edf6f0e0430d3ad004499f46958bb69b6c04341a \
-                        sha256  a6e8595e109b28a710baa66b8e67572ad2956a67318e6c71abb176ab4662c746 \
-                        size    4888164 \
+                        lock    v2.10.0 \
+                        rmd160  a0c6274f0f46f370981b7c83d3b56b29a85ecf98 \
+                        sha256  cbc1369eed7f5be7a2df83495790cf7a0ff24ffbed1b1172951bc5a256f6f401 \
+                        size    5202480 \
                     github.com/stretchr/testify \
                         lock    v1.6.1 \
                         rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
@@ -109,25 +109,25 @@ go.vendors          mvdan.cc/xurls \
                         sha256  79003ca68407b3b358db8ef8e073dbec1f7aaab3cafd44f21818d6bc0e08c326 \
                         size    22092 \
                     github.com/prometheus/procfs \
-                        lock    v0.6.0 \
-                        rmd160  ae0e0bcf1c664eacc18c03ec77973f0212dce472 \
-                        sha256  4ffc099c6f2ce85a7681e09462e465b140556743a248f4b3bdc665498f3380b1 \
-                        size    169970 \
+                        lock    v0.7.3 \
+                        rmd160  22af59de47369bf8ac95300e14ef8b1d370712a5 \
+                        sha256  40015c2a7a52b34e6502d2fc17458c30c3ee23f9c2246269d878ab0f96ca3177 \
+                        size    179014 \
                     github.com/prometheus/common \
-                        lock    v0.26.0 \
-                        rmd160  6767da5e89b5aa9e4872df991afdd96abbb0c872 \
-                        sha256  7f1004d8c389191b2c918e267807b6fee0e24d0073de5fa87e47e0798ef13644 \
-                        size    116913 \
+                        lock    v0.32.1 \
+                        rmd160  a6acf4fa8fde63b73fdce283bf384bf0ef1beae8 \
+                        sha256  a6f193ddcbff86669bc3b3b88681dc45e456042b8d54bbd318a708c8761d7110 \
+                        size    146608 \
                     github.com/prometheus/client_model \
                         lock    v0.2.0 \
                         rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
                         sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
                         size    10985 \
                     github.com/prometheus/client_golang \
-                        lock    v1.11.0 \
-                        rmd160  96f9efe7bff3d325ea9f2a3a2caecf1dbebc77c2 \
-                        sha256  fcad11001028f3cecfc6e7f5221a361f0f5ea49cf6ab29a2baf70cf5e005d5a5 \
-                        size    168768 \
+                        lock    v1.12.1 \
+                        rmd160  70ab16c13d6f53cf3433dcba4e590cd93b637998 \
+                        sha256  ef1b1e7e68e01cf67193b25d1207bc7771919d81283976b109ec0d56a1e566f0 \
+                        size    194237 \
                     github.com/pquerna/cachecontrol \
                         lock    1555304b9b35 \
                         rmd160  0a0f37cba23e467f89c717d93a37c5b34005b64e \
@@ -164,10 +164,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  be284023d91976ef03d13cb5670e338c09a0a0da9925d7de457f44e33aebb724 \
                         size    102365 \
                     github.com/golang/protobuf \
-                        lock    v1.4.3 \
-                        rmd160  f07e841d9c9706e08d3ec3b6440a6b7e42d54392 \
-                        sha256  a53f353ad911974ab0483ae25d4f0cdb4f0ea508b69a786062e4743df2ab3959 \
-                        size    171996 \
+                        lock    v1.5.2 \
+                        rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
+                        sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
+                        size    171736 \
                     github.com/golang/gddo \
                         lock    721e228c7686 \
                         rmd160  ff883ee0f935243223b9eb7568045d0d2d8503ab \
@@ -194,10 +194,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  cb7f8f625e511034f24505efeee92be610f2cbd957114d9c591aea9f29afa22c \
                         size    24141 \
                     github.com/cespare/xxhash \
-                        lock    v2.1.1 \
-                        rmd160  0c0da0840864215209db2afcd2ee92a52ca2d4d1 \
-                        sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
-                        size    9300 \
+                        lock    v2.1.2 \
+                        rmd160  aa8f44c877aeb7a980aba19d9d84e6b20e52560d \
+                        sha256  4bc66a9c435d9fa48cc9f8cb72c402a863943d594c1b1f8b5f421541c58150d2 \
+                        size    11252 \
                     github.com/beorn7/perks \
                         lock    v1.0.1 \
                         rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.36)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
