### PR TITLE
josm: update to 18387

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 
 name                JOSM
-version             18360
+version             18387
 categories          gis editors java
 platforms           darwin
 license             GPL-2+
 supported_archs     i386 x86_64
 
-maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 
 description         An extensible editor for OpenStreetMap
 long_description    ${name} is a feature-rich editor for the \
@@ -19,9 +19,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  042c11eef63eb31baf5ce2c47a9cd92bef28de91 \
-                    sha256  642c9b81a2f03df4151b6809f9db4494863b6c66547bd47c6bfd01e902bcc8af \
-                    size    78493316
+checksums           rmd160  1e32d00cbdce0b4eb09fb7de5fed1c4b9ea7dc74 \
+                    sha256  c4e5679d0f9e5246e84fc4eae45e10244a2ed7001a1f088477288428347f7d49 \
+                    size    78606720
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2022-03-06: Stable release 18387](https://josm.openstreetmap.de/wiki/Changelog#stable-release-22.02)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
