### PR TITLE
hugo: update to 0.93.3

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.93.2 v
+go.setup            github.com/gohugoio/hugo 0.93.3 v
 github.tarball_from archive
 revision            0
-checksums           rmd160  7676216e348bc44d798abb7c073d56ade638f6a0 \
-                    sha256  a2cd028ec8072696e22e350f76b6ad076fb95457db87712a181c0e684b143043 \
-                    size    28563091
+checksums           rmd160  5610525d68589e4202e2d1f5863229779826c22e \
+                    sha256  6fbd5b4031c3f8fedda8a888462b93b8dfd1d3f3d8bbc0dac670582c7dc89f4e \
+                    size    27852078
 
 categories          www
 license             Apache-2


### PR DESCRIPTION
#### Description
hugo: update to 0.93.3

###### Tested on
macOS 12.2 21D49 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
