### PR TITLE
ecCodes: update to 2.25.0

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -5,7 +5,7 @@ PortGroup cmake     1.1
 PortGroup compilers 1.0
 
 name                ecCodes
-version             2.24.2
+version             2.25.0
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
@@ -18,9 +18,9 @@ homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
 
-checksums           rmd160  6d6fb6ff872d9f52e18c134f1f3c2b5422c4346b \
-                    sha256  c60ad0fd89e11918ace0d84c01489f21222b11d6cad3ff7495856a0add610403 \
-                    size    12428695
+checksums           rmd160  c55660abff98c5b47bf5ba0ae53d3434ff90a82c \
+                    sha256  8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e \
+                    size    12439952
 
 long_description \
     ecCodes is a package developed by ECMWF which provides an application programming interface and \


### PR DESCRIPTION
#### Description

Simple upstream update to version 2.25.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.2.1 21D62 x86_64
Xcode Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
