### PR TITLE
xar: Fix to-stdout functionality

### DIFF
--- a/archivers/xar/Portfile
+++ b/archivers/xar/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 name                xar
 set apple_version   452
 version             1.8.0.${apple_version}
-revision            3
+revision            4
 
 categories          archivers sysutils
 platforms           darwin freebsd linux

--- a/archivers/xar/files/patch-stdout.diff
+++ b/archivers/xar/files/patch-stdout.diff
@@ -1,22 +1,100 @@
---- src/xar.c.orig	2022-03-09 07:52:07.000000000 -0600
-+++ src/xar.c	2022-03-09 19:29:08.000000000 -0600
-@@ -53,8 +53,15 @@
- #include "config.h"
- #include "../lib/filetree.h"
- #include "util.h"
+Add the capability to extract to stdout. Relevant parts from:
+https://github.com/mackyle/xar/commit/312a71a77dff76c4bf6ebc8d7a9e64ca1322d8dd 2012-09-15T07:10
+https://github.com/mackyle/xar/commit/ba57887b34af69e786b35b34762ab06f17135e2b 2012-09-15T07:29
+https://github.com/mackyle/xar/commit/ddea2e4b53b6b2cfdd0d13c6beaac0978330c2a2 2012-09-15T07:33
+--- include/xar.h.in.orig	2019-02-14 18:05:37.000000000 -0600
++++ include/xar.h.in	2022-03-10 06:07:31.000000000 -0600
+@@ -134,6 +134,8 @@
+ #define XAR_OPT_VAL_TRUE       "true"
+ #define XAR_OPT_VAL_FALSE      "false"
+ 
++#define XAR_OPT_EXTRACTSTDOUT  "extract-stdout" /* Extract data to stdout instead of file (true/false) */
 +
-+#define MIN_XAR_NEW_OPTIONS 0x01060180
-+
- #define SYMBOLIC 1
- #define NUMERIC  2
-+
-+static unsigned long xar_lib_version = 0;
-+static int xar_lib_version_fetched = 0;
-+
- static int Perms = 0;
- static int Local = 0;
- static char *Subdoc = NULL;
-@@ -73,6 +80,7 @@
+ /* xar signing algorithms */
+ #define XAR_SIG_SHA1RSA		1
+ 
+--- lib/archive.c.orig	2022-03-10 05:12:27.000000000 -0600
++++ lib/archive.c	2022-03-10 06:17:03.000000000 -0600
+@@ -876,6 +876,9 @@
+ 	if( (strcmp(option, XAR_OPT_TOCCKSUM) == 0) ) {
+ 		XAR(x)->heap_offset = xar_io_get_toc_checksum_length_for_type(value);
+ 	}
++	if ((strcmp(option, XAR_OPT_EXTRACTSTDOUT) == 0)) {
++		XAR(x)->tostdout = strcmp(value, XAR_OPT_VAL_TRUE) == 0;
++	}
+ 	
+ 	/*	This was an edit from xar-1.4
+ 		Looks like we would only allow one definition for a particular key in this list
+@@ -1488,26 +1491,39 @@
+ 	char *tmp1, *dname;
+ 	xar_file_t tmpf;
+ 	
+-	if( (strstr(XAR_FILE(f)->fspath, "/") != NULL) && (stat(XAR_FILE(f)->fspath, &sb)) && (XAR_FILE(f)->parent_extracted == 0) ) {
+-		tmp1 = strdup(XAR_FILE(f)->fspath);
+-		dname = xar_safe_dirname(tmp1);
+-		tmpf = xar_file_find(XAR(x)->files, dname);
+-		if( !tmpf ) {
+-			xar_err_set_string(x, "Unable to find file");
+-			xar_err_callback(x, XAR_SEVERITY_NONFATAL, XAR_ERR_ARCHIVE_EXTRACTION);
+-			return -1;
+-		}
+-		free(dname);
+-		free(tmp1);
+-		XAR_FILE(f)->parent_extracted++;
+-		int32_t result = xar_extract(x, tmpf);
+-		
+-		if (result < 0)
++	if (XAR(x)->tostdout) {
++		char *buffer = NULL;
++		size_t bsize = 0;
++		int32_t result;
++		if ((result = xar_extract_tobuffersz(x, f, &buffer, &bsize)) != 0)
+ 			return result;
++		if (bsize && buffer && fwrite(buffer, bsize, 1, stdout) != 1)
++			result = -1;
++		free(buffer);
++		return result;
++	}
++	else {
++		if( (strstr(XAR_FILE(f)->fspath, "/") != NULL) && (stat(XAR_FILE(f)->fspath, &sb)) && (XAR_FILE(f)->parent_extracted == 0) ) {
++			tmp1 = strdup(XAR_FILE(f)->fspath);
++			dname = xar_safe_dirname(tmp1);
++			tmpf = xar_file_find(XAR(x)->files, dname);
++			if( !tmpf ) {
++				xar_err_set_string(x, "Unable to find file");
++				xar_err_callback(x, XAR_SEVERITY_NONFATAL, XAR_ERR_ARCHIVE_EXTRACTION);
++				return -1;
++			}
++			free(dname);
++			free(tmp1);
++			XAR_FILE(f)->parent_extracted++;
++			int32_t result = xar_extract(x, tmpf);
+ 			
++			if (result < 0)
++				return result;
++				
++		}
++		
++		return xar_extract_tofile(x, f, XAR_FILE(f)->fspath);
+ 	}
+-	
+-	return xar_extract_tofile(x, f, XAR_FILE(f)->fspath);
+ }
+ 
+ int32_t xar_verify_progress(xar_t x, xar_file_t f, xar_progress_callback p) {
+--- lib/archive.h.orig	2022-03-10 05:12:27.000000000 -0600
++++ lib/archive.h	2022-03-10 05:45:47.000000000 -0600
+@@ -101,6 +101,7 @@
+ 	int toc_hash_size;			/* size of toc hash that was copied during archive open */
+ 	void *toc_hash;				/* copy of the toc hash copied during archive open */
+ 	int skipwarn;
++	int tostdout;
+ 	struct stat sbcache;
+ };
+ 
+--- src/xar.c.orig	2022-03-10 05:12:27.000000000 -0600
++++ src/xar.c	2022-03-10 05:39:41.000000000 -0600
+@@ -73,6 +73,7 @@
  static int LinkSame = 0;
  static int NoOverwrite = 0;
  static int SaveSuid = 0;
@@ -24,7 +102,17 @@
  
  struct lnode {
  	char *str;
-@@ -457,24 +465,27 @@
+@@ -383,6 +384,9 @@
+ 	if( SaveSuid ) {
+ 		xar_opt_set(x, XAR_OPT_SAVESUID, XAR_OPT_VAL_TRUE);
+ 	}
++	if (ToStdout) {
++		xar_opt_set(x, XAR_OPT_EXTRACTSTDOUT, XAR_OPT_VAL_TRUE);
++	}
+ 	
+ 	iter = xar_iter_new();
+ 	if( !iter ) {
+@@ -457,24 +461,28 @@
  		
  		if( matched ) {
  			struct stat sb;
@@ -36,12 +124,13 @@
  				int deferred = 0;
  				if( xar_prop_get(f, "type", &prop) == 0 && prop != NULL ) {
  					if( strcmp(prop, "directory") == 0 ) {
-+						if (!ToStdout) {
- 						struct lnode *tmpl = calloc(sizeof(struct lnode),1);
+-						struct lnode *tmpl = calloc(sizeof(struct lnode),1);
 -						tmpl->str = (char *)f;
 -						tmpl->next = dirs;
 -						dirs = tmpl;
 -						deferred = 1;
++						if (!ToStdout) {
++							struct lnode *tmpl = calloc(sizeof(struct lnode),1);
 +							tmpl->str = (char *)f;
 +							tmpl->next = dirs;
 +							dirs = tmpl;
@@ -51,7 +140,7 @@
  				}
  				if( ! deferred ) {
 -					files_extracted++;
--					print_file(x, f);
+ 					print_file(x, f);
 -					xar_extract(x, f);
 +					if (xar_extract(x, f) == 0)
 +						files_extracted++;
@@ -60,7 +149,7 @@
  				}
  			}
  		}
-@@ -859,6 +870,8 @@
+@@ -859,6 +867,8 @@
  	fprintf(stderr, "\t                      to a document in cwd named <name>.xml\n");
  	fprintf(stderr, "\t--exclude        POSIX regular expression of files to \n");
  	fprintf(stderr, "\t                      ignore while archiving.\n");
@@ -69,15 +158,15 @@
  	fprintf(stderr, "\t--rsize          Specifies the size of the buffer used\n");
  	fprintf(stderr, "\t                      for read IO operations in bytes.\n");
  	fprintf(stderr, "\t--coalesce-heap  When archived files are identical, only store one copy\n");
-@@ -917,6 +953,7 @@
+@@ -917,6 +927,7 @@
  		{"keep-existing",    no_argument,       0, 15},
  		{"keep-setuid",      no_argument,       0, 16},
  		{"compression-args", required_argument, 0, 17},
-+		{"to-stdout",        no_argument, 		0, 'O'},
++		{"to-stdout",        no_argument,       0, 'O'},
  		{ 0, 0, 0, 0}
  	};
  
-@@ -925,7 +962,7 @@
+@@ -925,7 +936,7 @@
  		exit(1);
  	}
  
@@ -86,17 +175,13 @@
  		switch(c) {
  		case  1 : // toc-cksum
  			if( !optarg ) {
-@@ -1150,6 +1187,13 @@
+@@ -1150,6 +1161,9 @@
  		case 'l': // stay on local device
  			Local = 1;
  			break;
 +		case 'O':
-+ 			if (xar_lib_version < MIN_XAR_NEW_OPTIONS) {
-+ 				fprintf(stderr, "--to-stdout requires a newer xar library\n");
-+ 				exit(1);
-+ 			}
-+ 			ToStdout = 1;
-+ 			break;
++			ToStdout = 1;
++			break;
  		case 'n': // provide subdocument name
  			SubdocName = optarg;
  			break;


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/64775

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
