### PR TITLE
ghc: Add depends_skip_archcheck for platform arm

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -202,6 +202,12 @@ if { [variant_isset "prebuilt"] } {
                     sha256  f444012f97a136d9940f77cdff03fda48f9475e2ed0fec966c4d35c4df55f746 \
                     size    23338772
 
+    # build depends upon these x86_64 binaries
+    depends_skip_archcheck-append \
+                    alex \
+                    happy \
+                    HsColour
+
     depends_build-append \
                     port:alex \
                     port:autoconf \


### PR DESCRIPTION
#### Description

Known build issue:
```
:info:build In file included from /opt/local/var/macports/build/_opt_local_ports_lang_ghc/ghc/work/bootstrap/lib/ghc-9.2.1/lib/../lib/aarch64-osx-ghc-9.2.1/rts-1.0.2/include/ffi.h:66:0: error:
:info:build
:info:build /opt/local/var/macports/build/_opt_local_ports_lang_ghc/ghc/work/bootstrap/lib/ghc-9.2.1/lib/../lib/aarch64-osx-ghc-9.2.1/rts-1.0.2/include/ffitarget.h:6:10: error:
:info:build      fatal error: 'ffitarget_arm64.h' file not found
:info:build   |
:info:build 6 | #include "ffitarget_arm64.h"
:info:build   |          ^
:info:build #include "ffitarget_arm64.h"
:info:build          ^~~~~~~~~~~~~~~~~~~
:info:build 1 error generated.
:info:build `clang' failed in phase `C Compiler'. (Exit code: 1)
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2 21D49 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
