### PR TITLE
ffmpeg: add libaribb24 to gpl3 variant and revbump

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               0
 version             5.0
-revision            0
+revision            1
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} {mascguy @mascguy} openmaintainer
@@ -365,9 +365,11 @@ variant gpl2 description {Enable GPL code, license will be GPL-2+} {
 
 variant gpl3 requires gpl2 description {Enable GPL code, license will be GPL-3+} {
     configure.args-append   --enable-version3 \
-                            --enable-libsmbclient
+                            --enable-libsmbclient \
+                            --enable-libaribb24
 
-    depends_lib-append      port:samba3
+    depends_lib-append      port:samba3 \
+                            port:libaribb24
 
     license                 GPL-3+
 }

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -368,7 +368,7 @@ variant gpl3 requires gpl2 description {Enable GPL code, license will be GPL-3+}
                             --enable-libsmbclient \
                             --enable-libaribb24
 
-    depends_lib-append      port:samba3 \
+    depends_lib-append      port:samba4 \
                             port:libaribb24
 
     license                 GPL-3+

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg-devel
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               1
 version             4.4.1
-revision            1
+revision            2
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} {mascguy @mascguy} openmaintainer
@@ -373,9 +373,11 @@ variant gpl2 description {Enable GPL code, license will be GPL-2+} {
 
 variant gpl3 requires gpl2 description {Enable GPL code, license will be GPL-3+} {
     configure.args-append   --enable-version3 \
-                            --enable-libsmbclient
+                            --enable-libsmbclient \
+                            --enable-libaribb24
 
-    depends_lib-append      port:samba3
+    depends_lib-append      port:samba3 \
+                            port:libaribb24
 
     license                 GPL-3+
 }

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -376,7 +376,7 @@ variant gpl3 requires gpl2 description {Enable GPL code, license will be GPL-3+}
                             --enable-libsmbclient \
                             --enable-libaribb24
 
-    depends_lib-append      port:samba3 \
+    depends_lib-append      port:samba4 \
                             port:libaribb24
 
     license                 GPL-3+

--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -7,7 +7,7 @@ PortGroup               legacysupport 1.1
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
 github.setup            mpv-player mpv 0.34.1 v
-revision                1
+revision                2
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic} {i0ntempest @i0ntempest} openmaintainer


### PR DESCRIPTION
#### Description
Add the aribb24 library to the gpl3 variant. I also mirror these changes into the ffmpeg-devel port. Since it is requested, I revbump mpv. While mpv was giving me strange swift library linking issues, these changes seem to leave mpv in a functional state, and in my testing, the changes to ffmpeg allow mpv to decode arib subtitles.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
