### PR TITLE
nodejs8: require OpenSSL 1.1

### DIFF
--- a/devel/nodejs8/Portfile
+++ b/devel/nodejs8/Portfile
@@ -39,8 +39,10 @@ distname                node-v${version}
 
 depends_build-append    port:pkgconfig
 
+# Require OpenSSL 1.1 and not generic OpenSSL
+# https://trac.macports.org/ticket/64095
 depends_lib-append      port:python27 \
-                        path:lib/libssl.dylib:openssl
+                        port:openssl11
 
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
@@ -81,8 +83,9 @@ if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
 configure.args-append   --without-npm
 configure.args-append   --with-intl=small-icu
 configure.args-append   --shared-openssl
-configure.args-append   --shared-openssl-includes=${prefix}/include/openssl
-configure.args-append   --shared-openssl-libpath=${prefix}/lib
+configure.args-append   --shared-openssl-includes=${prefix}/include/openssl-1.1
+configure.args-append   --shared-openssl-libname=crypto.1.1,ssl.1.1
+configure.args-append   --shared-openssl-libpath=${prefix}/lib/openssl-1.1
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64


### PR DESCRIPTION
#### Description

Builds are failing across the board, see https://ports.macports.org/port/nodejs8/builds/

Closes: https://trac.macports.org/ticket/64095
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
