### PR TITLE
goaccess: build with GeoIP support

### DIFF
--- a/www/goaccess/Portfile
+++ b/www/goaccess/Portfile
@@ -5,14 +5,13 @@ PortGroup           openssl 1.0
 
 name                goaccess
 version             1.5.5
-revision            0
+revision            1
 categories          www
 license             MIT
 maintainers         {mps @Schamschula} openmaintainer
 description         GoAccess was designed to be a fast, terminal-based log analyzer.
 long_description    {*}${description} Its core idea is to quickly analyze and view web \
                     server statistics in real time without needing to use your browser.
-platforms           darwin
 homepage            https://goaccess.io/
 master_sites        https://tar.goaccess.io/
 
@@ -22,13 +21,14 @@ checksums           rmd160  515419ac7fe499d0eb5dae2623cbd4ccd0b1f497 \
 
 openssl.branch      1.1
 
-configure.args      --enable-tcb \
+configure.args      --enable-geoip=mmdb \
                     --enable-utf8 \
                     --with-openssl
 
 depends_build       port:gettext
 
 depends_lib         port:gettext-runtime \
+                    port:libmaxminddb \
                     port:ncurses \
                     port:tokyocabinet
 


### PR DESCRIPTION
Also the `--enable-tcb` option is no longer supported:

```
configure: WARNING: unrecognized options: --enable-tcb
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
