### PR TITLE
weechat: update to 3.4.1, remove old python variants

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             3.4
+version             3.4.1
 revision            0
-checksums           rmd160  26d4141ab8e7ab2d3cfbbe9e3e9c33994fd374fb \
-                    sha256  7cd3dcc7029e888de49e13ebbcc3749586ff59c9d97f89f5eeb611067c7bb94c \
-                    size    2617640
+checksums           rmd160  e4eed9dd4ee8e0d61c7ab59a6dbd1d397c279402 \
+                    sha256  7e088109ad5dfbcb08a9a6b1dd70ea8236093fed8a13ee9d9c98881d7b1aeae7 \
+                    size    2617856
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
@@ -75,35 +75,24 @@ configure.args-append \
                     -DENABLE_TCL=OFF \
                     -DENABLE_TESTS=OFF
 
-variant python requires python27 description {Compatibility variant, requires +python27} {}
+variant python requires python310 description {Compatibility variant, requires +python310} {}
 
-variant python27 description "Bindings for Python 2.7 plugins" conflicts python36 python37 python38 python39 python310 {
-    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    configure.args-replace  -DENABLE_PYTHON2=OFF -DENABLE_PYTHON2=ON
-    depends_lib-append      port:python27
-}
-
-variant python36 description "Bindings for Python 3.6 plugins" conflicts python27 python37 python38 python39 python310 {
-    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    depends_lib-append      port:python36
-}
-
-variant python37 description "Bindings for Python 3.7 plugins" conflicts python27 python36 python38 python39 python310 {
+variant python37 description "Bindings for Python 3.7 plugins" conflicts python38 python39 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python37
 }
 
-variant python38 description "Bindings for Python 3.8 plugins" conflicts python27 python36 python37 python39 python310 {
+variant python38 description "Bindings for Python 3.8 plugins" conflicts python37 python39 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python38
 }
 
-variant python39 description "Bindings for Python 3.9 plugins" conflicts python27 python36 python37 python38 python310 {
+variant python39 description "Bindings for Python 3.9 plugins" conflicts python37 python38 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python39
 }
 
-variant python310 description "Bindings for Python 3.10 plugins" conflicts python27 python36 python37 python38 python39 {
+variant python310 description "Bindings for Python 3.10 plugins" conflicts python37 python38 python39 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python310
 }
@@ -111,11 +100,7 @@ variant python310 description "Bindings for Python 3.10 plugins" conflicts pytho
 post-patch {
     set patchfile ${worksrcpath}/cmake/FindPython.cmake
 
-    if {[variant_isset python27]} {
-        reinplace -E "s|PYTHON python2|PYTHON python-2.7|g" ${patchfile}
-    } elseif {[variant_isset python36]} {
-        reinplace -E "s|PYTHON python3|PYTHON python-3.6|g" ${patchfile}
-    } elseif {[variant_isset python37]} {
+    if {[variant_isset python37]} {
         reinplace -E "s|PYTHON python3|PYTHON python-3.7|g" ${patchfile}
     } elseif {[variant_isset python38]} {
         reinplace -E "s|PYTHON python3|PYTHON python-3.8|g" ${patchfile}


### PR DESCRIPTION
#### Description
weechat: update to 3.4.1, remove old python variants
- set default python variant to python310
- remove EOL python27 and python36 variants

###### Tested on
macOS 12.2.1 21D62 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?