### PR TITLE
ticket #64816: luit: Update to 2.0.20220111

### DIFF
--- a/x11/luit/Portfile
+++ b/x11/luit/Portfile
@@ -1,31 +1,30 @@
 PortSystem          1.0
 
 name                luit
-version             1.1.1
+version             2.0.20220111
 categories          x11
 license             X11
 platforms           darwin
-maintainers         {jeremyhu @jeremyhu} openmaintainer
-description         X.org luit
-long_description    Convert terminal i/o from legacy encodings to UTF-8
+maintainers         {invisible-island.net:dickey @ThomasDickey} openmaintainer
+description         filter that converts legacy encodings to/from UTF-8
+long_description    ${name} is a filter that converts terminal I/O \
+                    between legacy encodings and UTF-8.
 
-homepage            https://www.x.org/
-master_sites        xorg:individual/app/
+homepage            https://invisible-island.net/${name}/
+master_sites        https://invisible-mirror.net/archives/${name}/current/
 
-checksums           sha1    3130c14d7267cecce0ba2280643844b48cca49b0 \
-                    rmd160  571ec95ef3be0f761810e50272071ed4273afc16 \
-                    sha256  30b0e787cb07a0f504b70f1d6123930522111ce9d4276f6683a69b322b49c636
+extract.suffix      .tgz
 
-use_bzip2	    yes
+checksums           rmd160  82bd24c29a30d48a12ec3d91d58027f68813ffdc \
+                    sha256  6f2a424573da01e26bced5a0fb4ff2cce722eb7b4bc493242faec38920aaf985 \
+                    size    204924
+
 use_parallel_build  yes
 
 depends_build \
 	port:pkgconfig
 
-depends_lib \
-	port:xorg-libX11 \
-	port:xorg-libfontenc
-
-livecheck.type  regex
-livecheck.url   https://xorg.freedesktop.org/archive/individual/app/?C=M&O=D
-livecheck.regex ${name}-(\\d+(?:\\.\\d+)*)
+livecheck.type    regex
+livecheck.regex   ${name}-(\\d+(?:\\.\\d+)*)
+livecheck.url     https://invisible-mirror.net/archives/luit/current/?C=M&O=D
+livecheck.version ${name}-${version}${extract.suffix}


### PR DESCRIPTION
Signed-off-by: Thomas E. Dickey <dickey@invisible-island.net>

#### Description

update luit to 2.0.20220111 (current release), which allows both the font-encoding files supported in luit 1.x, as well as encodings derived from the installed system locales.

###### Type(s)
- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.4 20G417 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ x] tried a full install with `sudo port -vst install`?
- [ x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
