### PR TITLE
tiptop: update to 0.2.5

### DIFF
--- a/python/py-textual/Portfile
+++ b/python/py-textual/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-textual
-version             0.1.15
+version             0.1.17
 revision            0
 
 homepage            https://github.com/willmcgugan/textual
@@ -28,9 +28,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 supported_archs     noarch
 
-checksums           rmd160  9247cfcf8ccf097863e61b10299e45fb345fc8d8 \
-                    sha256  61367cb7cf0dc0e68d3e41c54916d8170f57f50a4705bd407a9feb479873146e \
-                    size    64671
+checksums           rmd160  db39315de91e7bc4b4b0fcaf3923041dbcb2dd48 \
+                    sha256  af6aa1fa34fe6d40689ce55a7bf519a07e48523a75b95cbed572990e0d6b6f84 \
+                    size    76759
 
 python.versions     39 310
 python.pep517       yes
@@ -41,6 +41,4 @@ if {${name} ne ${subport}} {
 
     depends_lib-append      port:py${python.version}-rich \
                             port:py${python.version}-typing_extensions
-
-    livecheck.type  none
 }

--- a/sysutils/tiptop/Portfile
+++ b/sysutils/tiptop/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           python  1.0
 
-github.setup        nschloe tiptop 0.1.3 v
+github.setup        nschloe tiptop 0.2.5 v
 github.tarball_from archive
 revision            0
 
@@ -18,12 +18,12 @@ long_description    \
 
 supported_archs     noarch
 license             MIT
-categories          sysutils
+categories-prepend  sysutils
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-checksums           rmd160  562c8b0084cb93b87d28300a10936c7a619e7ada \
-                    sha256  14032fcb4523e42669e7e3457712d083f13f0e62b0b0000c82bdb7e759708f92 \
-                    size    15028
+checksums           rmd160  180cd84c2b31e0f5afd4755961ce84573b705b1d \
+                    sha256  5392945518abecd41d904af89e2fa7ea8fedd2f008996d541958f1ed9049bb94 \
+                    size    17618
 
 python.default_version  310
 python.pep517           yes
@@ -32,6 +32,7 @@ python.pep517_backend   flit
 depends_run-append  port:py${python.version}-cpuinfo \
                     port:py${python.version}-distro \
                     port:py${python.version}-psutil \
+                    port:py${python.version}-rich \
                     port:py${python.version}-textual
 
 depends_test-append port:py${python.version}-pytest
@@ -39,4 +40,4 @@ depends_test-append port:py${python.version}-pytest
 test.run            yes
 test.cmd            pytest-${python.branch}
 test.target
-test.env-append     PYTHONPATH=./build/lib
+test.env-append     PYTHONPATH=${worksrcpath}/build/lib


### PR DESCRIPTION
#### Description
- update to latest upstream version
- 
###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
