### PR TITLE
openjdk-source: switch to ga builds from ea builds

### DIFF
--- a/java/openjdk-source/Portfile
+++ b/java/openjdk-source/Portfile
@@ -67,9 +67,10 @@ subport openjdk8-adoption-boot {
 
 subport openjdk8u {
     # https://github.com/openjdk/jdk8u/tags
-    # remove 'jdk' from tag and add to version
-    set u 332
-    version             8u${u}-b04
+    # use tags having '-ga' at end
+    # remove 'jdk' from begining of the tag, '-ga' from the end of the tag and add to it the version
+    set u 322
+    version             8u${u}
     revision            0
     set jver 1.8.0_${u}
     set tpath /Library/Java
@@ -80,10 +81,11 @@ subport openjdk8u {
     supported_archs     x86_64
     fetch.type          git
     git.url             https://github.com/openjdk/jdk8u
-    git.branch             jdk${version}
+    git.branch             jdk${version}-ga
     worksrcdir          jdk8u
+    # remove pre-patch phase after jdk8u341-ga tag
     pre-patch {
-        reinplace "s|JDK_UPDATE_VERSION=|JDK_UPDATE_VERSION=332|g" ${worksrcpath}/common/autoconf/version-numbers
+        reinplace "s|JDK_UPDATE_VERSION=|JDK_UPDATE_VERSION=${u}|g" ${worksrcpath}/common/autoconf/version-numbers
     }
     patchfiles          patch-openjdk8u-xcode-configure1.diff \
                         patch-openjdk8u-xcode-configure2.diff
@@ -130,11 +132,11 @@ subport openjdk11-boot {
 
 subport openjdk11u {
     # https://github.com/openjdk/jdk11u/tags
-    # remove 'jdk-' from tag and add to version
-    version             11.0.15+5
+    # use tags having '-ga' at end
+    # remove 'jdk-' from the begining of the tag, '-ga' from the end of the tag and add to it the version
+    version             11.0.14.1
     revision            0
     set tpath /Library/Java
-    set jver 11.0.15
     description         Openjdk 11 updates
     long_description    Openjdk 11 updates of Openjdk, Open-Source implementation \
                         of the Java Platform, Standard Edition, and related projects.
@@ -153,7 +155,7 @@ subport openjdk11u {
                         --with-conf-name=openjdk${version}
     fetch.type          git
     git.url             https://github.com/openjdk/jdk11u
-    git.branch             jdk-${version}
+    git.branch             jdk-${version}-ga
     worksrcdir          jdk11u
     build.type          gnu
     build.target        images
@@ -162,9 +164,9 @@ subport openjdk11u {
     depends_build       port:autoconf \
                         port:gmake
     depends_lib         port:openjdk11-boot
-    set jdkn jdk-${jver}.jdk
+    set jdkn jdk-${version}.jdk
     set bundle_dir /build/openjdk${version}/images/jdk-bundle/${jdkn}/Contents
-    set openjdkn openjdk-${version}.jdk
+    set openjdkn open${jdkn}
 }
 
 subport openjdk13-boot {
@@ -190,11 +192,11 @@ subport openjdk13-boot {
 
 subport openjdk13u {
     # https://github.com/openjdk/jdk13u/tags
-    # remove 'jdk-' from tag and add to version
-    version             13.0.11+2
+    # use tags having '-ga' at end
+    # remove 'jdk-' from the begining of the tag, '-ga' from the end of the tag and add to it the version
+    version             13.0.10
     revision            0
     set tpath /Library/Java
-    set jver 13.0.11
     description         Openjdk 13 updates
     long_description    Openjdk 13 updates of Openjdk, Open-Source implementation \
                         of the Java Platform, Standard Edition, and related projects.
@@ -213,7 +215,7 @@ subport openjdk13u {
                         --with-conf-name=openjdk${version}
     fetch.type          git
     git.url             https://github.com/openjdk/jdk13u
-    git.branch             jdk-${version}
+    git.branch             jdk-${version}-ga
     worksrcdir          jdk13u
     build.type          gnu
     build.target        images
@@ -222,9 +224,9 @@ subport openjdk13u {
     depends_build       port:autoconf \
                         port:gmake
     depends_lib         port:openjdk13-boot
-    set jdkn jdk-${jver}.jdk
+    set jdkn jdk-${version}.jdk
     set bundle_dir /build/openjdk${version}/images/jdk-bundle/${jdkn}/Contents
-    set openjdkn openjdk-${version}.jdk
+    set openjdkn open${jdkn}
 }
 
 subport openjdk15-boot {
@@ -250,11 +252,11 @@ subport openjdk15-boot {
 
 subport openjdk15u {
     # https://github.com/openjdk/jdk15u/tags
-    # remove 'jdk-' from tag and add to version
-    version             15.0.7+2
+    # use tags having '-ga' at end
+    # remove 'jdk-' from the begining of the tag, '-ga' from the end of the tag and add to it the version
+    version             15.0.6
     revision            0
     set tpath /Library/Java
-    set jver 15.0.7
     description         Openjdk 15 updates
     long_description    Openjdk 15 updates of Openjdk, Open-Source implementation \
                         of the Java Platform, Standard Edition, and related projects.
@@ -274,7 +276,7 @@ subport openjdk15u {
                         --with-conf-name=openjdk${version}
     fetch.type          git
     git.url             https://github.com/openjdk/jdk15u
-    git.branch             jdk-${version}
+    git.branch             jdk-${version}-ga
     worksrcdir          jdk15u
     build.type          gnu
     build.target        images
@@ -283,9 +285,9 @@ subport openjdk15u {
     depends_build       port:autoconf \
                         port:gmake
     depends_lib         port:openjdk15-boot
-    set jdkn jdk-${jver}.jdk
+    set jdkn jdk-${version}.jdk
     set bundle_dir /build/openjdk${version}/images/jdk-bundle/${jdkn}/Contents
-    set openjdkn openjdk-${version}.jdk
+    set openjdkn open${jdkn}
 }
 
 subport openjdk17-boot {
@@ -316,11 +318,11 @@ subport openjdk17-boot {
 
 subport openjdk17u {
     # https://github.com/openjdk/jdk17u/tags
-    # remove 'jdk-' from tag and add to version
-    version             17.0.3+4
+    # use tags having '-ga' at end
+    # remove 'jdk-' from the begining of the tag, '-ga' from the end of the tag and add to it the version
+    version             17.0.2
     revision            0
     set tpath /Library/Java
-    set jver 17.0.3
     description         Openjdk 17 updates
     long_description    Openjdk 17 updates of Openjdk, Open-Source implementation \
                         of the Java Platform, Standard Edition, and related projects.
@@ -340,7 +342,7 @@ subport openjdk17u {
                         --with-conf-name=openjdk${version}
     fetch.type          git
     git.url             https://github.com/openjdk/jdk17u
-    git.branch             jdk-${version}
+    git.branch             jdk-${version}-ga
     worksrcdir          jdk17u
     build.type          gnu
     build.target        images
@@ -349,9 +351,9 @@ subport openjdk17u {
     depends_build       port:autoconf \
                         port:gmake
     depends_lib         port:openjdk17-boot
-    set jdkn jdk-${jver}.jdk
+    set jdkn jdk-${version}.jdk
     set bundle_dir /build/openjdk${version}/images/jdk-bundle/${jdkn}/Contents
-    set openjdkn openjdk-${version}.jdk
+    set openjdkn open${jdkn}
 }
 
 if {[string match *-boot ${subport}]} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.13.6 17G65 x86_64
Xcode Command Line Tool Only

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
