### PR TITLE
openssl3, openssl11: Fix CVE-2022-0788

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            2
+revision            3
 
 categories          devel security
 platforms           darwin

--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -8,7 +8,7 @@ name                openssl[string map {. {}} $short_v]
 
 # The revision of the openssl shim port should be bumped whenever
 # the version or revision is changed here.
-version             ${short_v}.1m
+version             ${short_v}.1n
 revision            0
 
 # Please revbump these ports when updating OpenSSL.
@@ -44,9 +44,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  ed6e8fe6c0f3e3912853c888a2af50d37d28f5c6 \
-                    sha256  f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96 \
-                    size    9847315
+checksums           rmd160  34bded200174b0fdbec22584688869332130ea0c \
+                    sha256  40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a \
+                    size    9850712
 
 platform darwin 8 {
     # No Availability.h on Tiger

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 8
 
 set major_v         3
 name                openssl$major_v
-version             ${major_v}.0.1
+version             ${major_v}.0.2
 revision            0
 
 # Please revbump these ports when updating the openssl3 version/revision
@@ -47,9 +47,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  d4be29c790cd56aaac15fb6107982b419a6dd290 \
-                    sha256  c311ad853353bce796edad01a862c50a8a587f62e7e2100ef465ab53ec9b06d1 \
-                    size    15011207
+checksums           rmd160  e85a309de8dbb06553f24c297635539ffa09c643 \
+                    sha256  98e91ccead4d4756ae3c9cde5e09191a8e586d9f4d50838e7ec09d6411dfdb63 \
+                    size    15038141
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             8.9p1
-revision            2
+revision            3
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                5
+revision                6
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.3 20G415 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
