### PR TITLE
py-pyside2: update to 5.15.3 and add py310

### DIFF
--- a/python/py-pyside2/Portfile
+++ b/python/py-pyside2/Portfile
@@ -4,8 +4,8 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-pyside2
-version                 5.15.2
-revision                1
+version                 5.15.3
+revision                0
 categories-append       devel aqua
 platforms               darwin
 maintainers             {pmetzger @pmetzger} {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -18,16 +18,24 @@ master_sites            https://download.qt.io/official_releases/QtForPython/pys
 distname                pyside-setup-opensource-src-${version}
 use_xz                  yes
 
-checksums               rmd160  09c0517e0fe07722e799a32c0248cd7bf8b3a581 \
-                        sha256  b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418 \
-                        size    3472624
+checksums               rmd160  e47a57c7d372862a286c7f1fa362896bff2e3b41 \
+                        sha256  7ff5f1cc4291fffb6d5a3098b3090abe4d415da2adec740b4e901893d95d7137 \
+                        size    3572248
 
-python.versions         27 36 37 38 39
+
+python.versions         36 37 38 39 310
 
 set llvm_version        13
 
 if {${name} ne ${subport}} {
     PortGroup           qt5 1.0
+
+    # fix error related to _Py_Mangle, which was half-patched in this version
+    # see: https://bugzilla.redhat.com/show_bug.cgi?id=1990768#c9
+    patchfiles-append   patch-py-mangle.diff
+
+    # fix error with shiboken2 doc building
+    patchfiles-append   patch-shiboken2-docs.diff
 
     # see https://trac.macports.org/ticket/62135#comment:4
     qt5.min_version     5.12

--- a/python/py-pyside2/files/patch-py-mangle.diff
+++ b/python/py-pyside2/files/patch-py-mangle.diff
@@ -1,0 +1,18 @@
+--- sources/shiboken2/libshiboken/pep384impl.cpp	2022-03-16 09:18:06.000000000 +0100
++++ sources/shiboken2/libshiboken/pep384impl.cpp.patched	2022-03-16 09:17:41.000000000 +0100
+@@ -751,9 +751,6 @@
+ #endif // IS_PY2
+     Shiboken::AutoDecRef privateobj(PyObject_GetAttr(
+         reinterpret_cast<PyObject *>(Py_TYPE(self)), Shiboken::PyMagicName::name()));
+-#ifndef Py_LIMITED_API
+-    return _Py_Mangle(privateobj, name);
+-#else
+     // PYSIDE-1436: _Py_Mangle is no longer exposed; implement it always.
+     // The rest of this function is our own implementation of _Py_Mangle.
+     // Please compare the original function in compile.c .
+@@ -789,7 +786,6 @@
+     if (amount > big_stack)
+         free(resbuf);
+     return result;
+-#endif // else Py_LIMITED_API
+ }

--- a/python/py-pyside2/files/patch-shiboken2-docs.diff
+++ b/python/py-pyside2/files/patch-shiboken2-docs.diff
@@ -1,0 +1,17 @@
+--- sources/shiboken2/doc/index.rst	2022-01-05 14:26:23.000000000 +0100
++++ sources/shiboken2/doc/index.rst.patch	2022-03-16 09:44:13.000000000 +0100
+@@ -1,13 +1,8 @@
+ Shiboken
+ ********
+
+-.. ifconfig:: output_format == 'html'
+
+-   Shiboken is a fundamental piece on the `Qt for Python <../index.html>`__ project that serves two purposes:
+-
+-.. ifconfig:: output_format == 'qthelp'
+-
+-   Shiboken is a fundamental piece on the `Qt for Python <../pyside2/index.html>`__ project that serves two purposes:
++Shiboken is a fundamental piece on the `Qt for Python <../pyside2/index.html>`__ project that serves two purposes:
+
+
+ * Generator_: Extract information from C or C++ headers and generate CPython_ code that allow


### PR DESCRIPTION
#### Description

- updated pyside2 to 5.15.2.1
- added py310
- added a patch related to _Py_Mangle missing in the 5.15.2.1 source archive
- suppressed `ifconfig` directives from shiboken2 documentation which were generating an error

Note:
- this would be a major step to migrate #14251 to python 3.10
- there is a possible interaction with #14204 (?), which would probably best be merged before

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.2.1 21D62 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
