### PR TITLE
gopass: update to 1.14.0

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.13.1 v
+go.setup            github.com/gopasspw/gopass 1.14.0 v
+revision            0
 categories          security
-maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 license             MIT
 
 description         The slightly more awesome Standard Unix Password Manager for Teams
@@ -15,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  271dbc76f875bf3396857ec1742e57befc95281e \
-                        sha256  e868cac64120abac70ad9f427bad49c3813f8aba4d505c784c79d9cff70616e5 \
-                        size    2183377
+                        rmd160  995a213908b3a1c055549eaff1e20ad9dde47154 \
+                        sha256  bece68def504fba984758106580e5e9df80975a1cbd417989cc40b4a8f4d991c \
+                        size    2209420
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -64,35 +65,57 @@ go.vendors          rsc.io/qr \
                         sha256  3673415a6d3d106d49b487715e151fc64245502ef547c16e8e13edb6b8f2f492 \
                         size    14975 \
                     golang.org/x/sys \
-                        lock    0c823b97ae02 \
-                        rmd160  6e5330d53b301f41301f0552aa201d6fcec9d3f6 \
-                        sha256  1f3d4258b21bf5daec3ca25193d6d5190ca7dd95e9d2f58f4587147aff7bb123 \
-                        size    1224733 \
+                        lock    b874c991c1a5 \
+                        rmd160  04252786eec583af7d21b0ad662307bfdc8a6a8c \
+                        sha256  076a4ddff9240d08b1ead640a98f1eacc7122a859044e0628498621adede14c6 \
+                        size    1288590 \
                     golang.org/x/oauth2 \
-                        lock    d3ed0bb246c8 \
-                        rmd160  d66bbada6578d17da9208ee8c215d4e1ead6aef7 \
-                        sha256  7a0c986063c9580fed9223411152d3ea8126d54597be8184fe613097b95d7489 \
-                        size    87604 \
+                        lock    6242fa91716a \
+                        rmd160  ea459b0a4691cf8f07da62298ed90326cb9e4782 \
+                        sha256  3bf873e3378b4c1ced4ac94845f07527b4b61a310fbed7233ddf217f044888af \
+                        size    88419 \
                     golang.org/x/net \
-                        lock    69e39bad7dc2 \
-                        rmd160  722be2fbb86549a951d74beb4d35f882de120354 \
-                        sha256  f66db35109dbd76aac9039afbcbe891513580ff8edf986d1ed8773bcc0511d49 \
-                        size    1263978 \
+                        lock    27dd8689420f \
+                        rmd160  d7b9477ec487c7f547c2d6669088f0b77c4ecd3f \
+                        sha256  53a566616d208e83a2ec4a58651a450187a3bef980128571a04b01f6231e162d \
+                        size    1229543 \
+                    golang.org/x/exp \
+                        lock    20fd27f61765 \
+                        rmd160  525b884a0c777811f5d3534552ed856a5b348d57 \
+                        sha256  3c8d4c635b272d8ba0c1b023f17ea58d3b99aa34b5156ae64162b356fedea671 \
+                        size    1761087 \
                     golang.org/x/crypto \
-                        lock    ceb1ce70b4fa \
-                        rmd160  6c45c79b117cc3d8ea5c69497553774c26427b76 \
-                        sha256  f67aa2bec7215eb0a6c3f0863612a1a59ea0a103245748f4d9c81b9784350a3f \
-                        size    1732118 \
+                        lock    6068a2e6cfdc \
+                        rmd160  df9e47447ba5bb41d298e658cd038c9ddbdc068a \
+                        sha256  5d083db4aee3736c9c126eef94549651359b2eb494427014043cfab22760602f \
+                        size    1628196 \
+                    go.uber.org/multierr \
+                        repo    github.com/uber-go/multierr \
+                        lock    v1.8.0 \
+                        rmd160  b09e4eae9a41c2b84204346c264e0749998272f5 \
+                        sha256  b172f7c7e805cfd8e7ec423e19e4ed47fab099fb9ff42b0910876098f557f8ee \
+                        size    15600 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.9.0 \
+                        rmd160  7705959c7053aa8e405560f5ffef3fbca414ee69 \
+                        sha256  8baccde94a6ecaea185ef40b9bdecbd3dd8d8df7cbc50c89856b58c5cd897e40 \
+                        size    21353 \
                     github.com/xrash/smetrics \
                         lock    039620a65673 \
                         rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.3.0 \
-                        rmd160  fec9e73bc45d02b2afe43e8d9c76398722494e4b \
-                        sha256  3138857026c9564559b3e734b9b8abfeda57354fc4aa87717879882bff68ef09 \
-                        size    3408338 \
+                        lock    v2.4.0 \
+                        rmd160  08728bda2dd6a9bc445ea4bc7dff4a5184953560 \
+                        sha256  3a3f761b8571fea2a1f38cbed051a70e167bc959774dc32b6413289f65ba578b \
+                        size    3410417 \
+                    github.com/twpayne/go-pinentry \
+                        lock    v0.2.0 \
+                        rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
+                        sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
+                        size    11986 \
                     github.com/stretchr/testify \
                         lock    v1.7.0 \
                         rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
@@ -113,11 +136,16 @@ go.vendors          rsc.io/qr \
                         rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
                         sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
                         size    92950 \
+                    github.com/rs/zerolog \
+                        lock    v1.26.1 \
+                        rmd160  fa1b98732bdf2fd4dd00ac52f9a9dc08a299ff70 \
+                        sha256  9cf189d730c31839de68fc87a2ce52d393cae5bf9b0144880f922abd68067245 \
+                        size    164666 \
                     github.com/rogpeppe/go-internal \
-                        lock    v1.8.0 \
-                        rmd160  22e8b4dadfbeefb32fd38f3ebab26c94d4b165c5 \
-                        sha256  c7ab367e516959a51525f8152a62df0acc9a32ca153a502da967f072ae69d899 \
-                        size    129032 \
+                        lock    86f73c517451 \
+                        rmd160  12ae7289b3b9f3f0339d1ffe90bfefdd28944914 \
+                        sha256  243fd03669a7f2563d066de31a537dc3e99fb3180fcf36f1b492f84e3c8dbd76 \
+                        size    131803 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -148,16 +176,21 @@ go.vendors          rsc.io/qr \
                         rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
                         sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
                         size    3366 \
+                    github.com/mattn/go-tty \
+                        lock    v0.0.4 \
+                        rmd160  aeef24ae0b469f8a83cd43f40843ba3dc58f057d \
+                        sha256  a9ee7c2dc5fcaf640eb3be20fbeab1cebd6fc56a160296c815d1129a0ff0091f \
+                        size    7735 \
                     github.com/mattn/go-isatty \
                         lock    v0.0.14 \
                         rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
                         sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
                         size    4705 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.11 \
-                        rmd160  8c86c57e575979c1544343e23053b73be022cfe5 \
-                        sha256  4b8c7305e79232b627217d894382b7c3cd35371347e3fc7231fbce13500d0a38 \
-                        size    9808 \
+                        lock    v0.1.12 \
+                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
+                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
+                        size    9805 \
                     github.com/martinhoefling/goxkcdpwgen \
                         lock    7dc3d102eca3 \
                         rmd160  f8b32dbe86765d33f5f6e57cc3047f6951bd6957 \
@@ -179,10 +212,10 @@ go.vendors          rsc.io/qr \
                         sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
                         size    4335 \
                     github.com/jsimonetti/pwscheme \
-                        lock    76804708ecad \
-                        rmd160  88e53d2efe5fafd457fd5a101b6ba9b58353a1bf \
-                        sha256  8c8946c5aa3ad151a1536b92376811d7b3e69bcd98d7fa0640f3dac0156bd079 \
-                        size    3871 \
+                        lock    4d9895f5db73 \
+                        rmd160  0485fd6bd45cb7670f2d87b00e951e73bba7c19b \
+                        sha256  abf5851434a001a0c50e05aaf9ce0014472f70c887a1d31f49ced68be3293f4c \
+                        size    4284 \
                     github.com/hashicorp/golang-lru \
                         lock    v0.5.4 \
                         rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
@@ -198,11 +231,6 @@ go.vendors          rsc.io/qr \
                         rmd160  25e655fc958685dd949900eea8c3d97f33d85eab \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
-                    github.com/gopasspw/pinentry \
-                        lock    v0.0.2 \
-                        rmd160  c15d7e73f53a29be1322a9e8858caeb9f4cb3ff9 \
-                        sha256  6f7d313a77b7f38c904bced510cadaa5f82f8a005325519797778212a70215cc \
-                        size    3133 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -214,15 +242,20 @@ go.vendors          rsc.io/qr \
                         sha256  a053e731deda2d4baf00b362a8f55f7eeac5528115468013aeccb4acf05f2bd3 \
                         size    397048 \
                     github.com/google/go-cmp \
-                        lock    v0.5.6 \
-                        rmd160  b93086d92bddc7a3b593fb637776f055c022049f \
-                        sha256  fa1ca0f00fe02f645c4ed12ef753ff6c46b6621db01e09d96599cf1fd990aebe \
-                        size    104422 \
+                        lock    v0.5.7 \
+                        rmd160  f8dffbbc09f05eff889202ab37f473e314ae1b09 \
+                        sha256  7fba30fac1ae84c4dc8c8592936e3fb4ada1f1985803005225e7d61d4159bcff \
+                        size    104517 \
                     github.com/golang/protobuf \
                         lock    v1.5.2 \
                         rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
                         sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
                         size    171736 \
+                    github.com/golang/mock \
+                        lock    v1.6.0 \
+                        rmd160  ed853462703f04ce365bb17b8c88a92994aa5006 \
+                        sha256  4b107f6d26db03f8a36ae38f7b017399ed56571cdbf7b7ebc7bff0006c7dffb5 \
+                        size    69263 \
                     github.com/gokyle/twofactor \
                         lock    v1.0.1 \
                         rmd160  639cb3e1e214c43cd212bbec6faae070a2acbc4c \
@@ -299,7 +332,12 @@ go.vendors          rsc.io/qr \
                         lock    v1.0.0 \
                         rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
                         sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
-                        size    59693
+                        size    59693 \
+                    bitbucket.org/creachadair/stringset \
+                        lock    v0.0.10 \
+                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
+                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
+                        size    19241
 
 set go_ldflags      "-s -w -X main.version=${version}"
 build.args          -ldflags \"${go_ldflags}\"


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.14.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
