### PR TITLE
py-numpydoc: update to 1.2

### DIFF
--- a/python/py-numpydoc/Portfile
+++ b/python/py-numpydoc/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-numpydoc
-version             1.1.0
+version             1.2
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             BSD
 maintainers         {mojca @mojca} openmaintainer
@@ -19,20 +18,13 @@ long_description    Numpydoc inserts a hook into Sphinx’s autodoc \
 
 homepage            https://github.com/numpy/numpydoc
 
-checksums           rmd160  3c2db859114cd75285f3b619a39edabe793d53df \
-                    sha256  c36fd6cb7ffdc9b4e165a43f67bf6271a7b024d0bb6b00ac468c9e2bfc76448e \
-                    size    609482
+checksums           rmd160  09d3f9809e47eaa06ad3108b2479c88bb67f9eb1 \
+                    sha256  0cec233740c6b125913005d16e8a9996e060528afcb8b7cad3f2706629dfd6f7 \
+                    size    69659
 
-python.versions     27 35 36 37 38 39 310
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
-    if {${python.version} == 27} {
-        version     0.9.2
-        checksums   rmd160  de791bad34fe958841e1df7101931c1149d3453f \
-                    sha256  9140669e6b915f42c6ce7fef704483ba9b0aaa9ac8e425ea89c76fe40478f642 \
-                    size    27555
-    }
-
     depends_build-append \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-sphinx \
@@ -42,8 +34,7 @@ if {${name} ne ${subport}} {
 
     test.run            yes
     test.cmd            py.test-${python.branch}
+    test.args           -o addopts=''
     test.target
     test.env            PYTHONPATH=${worksrcpath}/build/lib
-
-    livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update to latest upstream version

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
