### PR TITLE
ghc: Add depends_skip_archcheck for platform arm, Fix prebuilt issues

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -181,6 +181,8 @@ use_parallel_build  no
 # binaries into ${prefix}, not DESTDIR.  Work around this by setting
 # --prefix=${destroot}${prefix} and not setting DESTDIR
 
+depends_lib-append  port:libffi
+
 if { [variant_isset "prebuilt"] } {
     set bootstrap_dir ${destroot}${prefix}
 
@@ -191,6 +193,16 @@ if { [variant_isset "prebuilt"] } {
     # the PATH environment must provide the bootstrap path
     build.env-append \
                     "PATH=$env(PATH):${bootstrap_dir}/bin"
+
+    post-destroot {
+        # avoid conflicts with libffi
+        foreach f {ffi.h ffitarget.h} {
+            if {[file exists ${prefix}/include/${f}] \
+                && [file exists ${destroot}${prefix}/include/${f}]} {
+                delete ${destroot}${prefix}/include/${f}
+            }
+        }
+    }
 } else {
     set bootstrap_dir ${workpath}/bootstrap
 
@@ -220,11 +232,16 @@ if { [variant_isset "prebuilt"] } {
                     port:texlive-latex-extra \
                     port:xz
 
+    # build depends upon these x86_64 binaries
+    depends_skip_archcheck-append \
+                    alex \
+                    happy \
+                    HsColour
+
     # Add these MacPorts dependencies after this issue is fixed:
     # https://gitlab.haskell.org/ghc/ghc/-/issues/18752
     # depends_lib-append \
     #                 port:gmp \
-    #                 port:libffi \
     #                 port:libiconv
 
     post-extract {
@@ -346,9 +363,15 @@ destroot {
 set workpath_destdir_pattern ${workpath}
 post-destroot {
     # fix rpath searches
+    set dylib_list {}
+    fs-traverse f ${destroot}${prefix}/lib/${name}-${version} {
+        if { [file isfile ${f}] && [string match "*.dylib" ${f}] } {
+            lappend dylib_list ${f}
+        }
+    }
     foreach f [concat \
         [glob -type f ${destroot}${prefix}/lib/${name}-${version}/bin/*] \
-        [glob -type f ${destroot}${prefix}/lib/${name}-${version}/*/*.dylib]] {
+        ${dylib_list}] {
         if {[file executable ${f}]
             || [string match *.dylib ${f}]} {
             fix_workpath_rpath ${f} \


### PR DESCRIPTION
* Fixes: https://trac.macports.org/ticket/64794
* Fixes: https://trac.macports.org/ticket/64824
* Fixes `libffi` conflict

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
