### PR TITLE
go: pin to version 1.17.8 for macOS 10.12 and older

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -28,7 +28,7 @@ revision            0
 
 # Subport for Go Unstable Version
 subport ${name}-devel {
-    version         1.18rc1
+    version         1.18
     revision        0
 }
 
@@ -61,17 +61,17 @@ livecheck.url       ${homepage}/dl/
 if {$subport eq "${name}-devel"} {
     # Go (DEVEL / UNSTABLE)
     checksums       ${go_src_dist} \
-                    rmd160  8d5eab5df73beb69e0d26c51cb89f8438ecd033f \
-                    sha256  5cec7a6653008fa85f8821b33665de37be289b7a02f17f36f705a88c43980bb8 \
-                    size    22800698 \
+                    rmd160  29299cd23b11bb8408b0abea5d2fb9aef1a5142c \
+                    sha256  38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6 \
+                    size    22827832 \
                     ${go_armbin_dist} \
-                    rmd160  99790ec9343bc5e7916a6bf5be1d7c12afd00038 \
-                    sha256  c82d02b5e80072756973f526e7b63403eb7632e254ab5ff2ae25935de8591a11 \
-                    size    137838311 \
+                    rmd160  326d409db30c233dbd9f1c909813792b00e99594 \
+                    sha256  9cab6123af9ffade905525d79fc9ee76651e716c85f1f215872b5f2976782480 \
+                    size    137870667 \
                     ${go_amdbin_dist} \
-                    rmd160  a102e48ad24e07f943e98d037a176c0a529f6c29 \
-                    sha256  67fd5b9b1859e532081242df780eaf0add33825097b1091247face8ad9b3ae8c \
-                    size    143644924
+                    rmd160  2dd3deb409b4dfbd0752ba9f63a6e3671d4a93f3 \
+                    sha256  70bb4a066997535e346c8bfa3e0dfe250d61100b17ccc5676274642447834969 \
+                    size    143698502
 
     livecheck.regex {go([0-9.A-z]+)\.src\.tar\.gz}
 } else {

--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -7,9 +7,23 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                go
-epoch               2
+epoch               3
 
-version             1.18
+# IMPORTANT:
+#
+# When updating major versions, please ensure that you have committed and
+# tested the candidate version using the `go-devel` port, to verify how it
+# builds against current and older versions of macOS.
+
+# Go 1.18 does not build on macOS 10.12 and older
+if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    version         1.17.8
+    set unsupported_macos true
+} else {
+    version         1.18
+    set unsupported_macos false
+}
+
 revision            0
 
 # Subport for Go Unstable Version
@@ -62,7 +76,28 @@ if {$subport eq "${name}-devel"} {
     livecheck.regex {go([0-9.A-z]+)\.src\.tar\.gz}
 } else {
     # Go (RELEASE)
-    checksums       ${go_src_dist} \
+
+    if {${unsupported_macos}} {
+        # 1.17
+        checksums   ${go_src_dist} \
+                    rmd160  2b01e8053b19d2104676ddcd85ea4aa5abcf2834 \
+                    sha256  2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a \
+                    size    22199282 \
+                    ${go_armbin_dist} \
+                    rmd160  74010929a3b67d3d2a4ef41fd1e612baba430648 \
+                    sha256  2827fb5d62453b30f0644382e22ab9d287c7bca868c374a15145b29e272443b1 \
+                    size    130325428 \
+                    ${go_amdbin_dist} \
+                    rmd160  ef81269da7ca70f5e2169aa19d353df17368e109 \
+                    sha256  345f530a6a4295a1bf0a25931c08bf31582ed83252580196bd643049dfef0563 \
+                    size    136872391
+
+        notes-append "
+            Please note: Go 1.18 does not build on macOS 10.12 and older, so Go ${version} has been installed.
+        "
+    } else {
+        # 1.18
+        checksums   ${go_src_dist} \
                     rmd160  29299cd23b11bb8408b0abea5d2fb9aef1a5142c \
                     sha256  38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6 \
                     size    22827832 \
@@ -74,6 +109,7 @@ if {$subport eq "${name}-devel"} {
                     rmd160  2dd3deb409b4dfbd0752ba9f63a6e3671d4a93f3 \
                     sha256  70bb4a066997535e346c8bfa3e0dfe250d61100b17ccc5676274642447834969 \
                     size    143698502
+    }
 
     livecheck.regex {go([0-9.]+)\.src\.tar\.gz}
 }


### PR DESCRIPTION
This change pins Go to 1.17.8 for macOS versions older than High Sierra, since 1.18 does not build on those versions of macOS.

This also bumps `go-devel` to 1.18.

CC: @mascguy @cjones051073 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d build`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
