### PR TITLE
mozjs68: remove arm64 from `supported_archs`

### DIFF
--- a/lang/mozjs68/Portfile
+++ b/lang/mozjs68/Portfile
@@ -23,8 +23,9 @@ homepage            https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Sp
 # build from GNOME releng tarball
 master_sites        https://ftp.gnome.org/pub/GNOME/teams/releng/tarballs-needing-help/mozjs/
 
-# For Rust
-supported_archs     x86_64 arm64
+# Rust requires x86_64/arm64, and mozjs68 won't compile on arm64
+# See: https://trac.macports.org/ticket/64755
+supported_archs     x86_64
 
 distname            mozjs-${version}
 use_bzip2           yes


### PR DESCRIPTION
#### Description

Parts of the mozjs68 code assume x86-compatible assembler on Darwin. Hopefully we can re-add arm64 with mozjs78.

Closes: https://trac.macports.org/ticket/64755

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
