### PR TITLE
gtk-doc: add python310 variant, remove python36

### DIFF
--- a/gnome/gtk-doc/Portfile
+++ b/gnome/gtk-doc/Portfile
@@ -49,19 +49,7 @@ configure.env-append XSLTPROC=${prefix}/bin/xsltproc
 configure.args      --with-xml-catalog=${prefix}/etc/xml/catalog \
                     --disable-silent-rules
 
-variant python36 conflicts python37 python38 python39 description {Build using Python 3.6} {
-    depends_lib-append \
-        port:python36 \
-        port:py36-anytree \
-        port:py36-lxml \
-        port:py36-pygments
-
-    depends_test        port:py36-mock
-
-    configure.python    ${prefix}/bin/python3.6
-}
-
-variant python37 conflicts python36 python38 python39 description {Build using Python 3.7} {
+variant python37 conflicts python38 python39 python310 description {Build using Python 3.7} {
     depends_lib-append \
         port:python37 \
         port:py37-anytree \
@@ -73,7 +61,7 @@ variant python37 conflicts python36 python38 python39 description {Build using P
     configure.python    ${prefix}/bin/python3.7
 }
 
-variant python38 conflicts python36 python37 python39 description {Build using Python 3.8} {
+variant python38 conflicts python37 python39 python310 description {Build using Python 3.8} {
     depends_lib-append \
         port:python38 \
         port:py38-anytree \
@@ -85,7 +73,7 @@ variant python38 conflicts python36 python37 python39 description {Build using P
     configure.python    ${prefix}/bin/python3.8
 }
 
-variant python39 conflicts python36 python37 python38 description {Build using Python 3.9} {
+variant python39 conflicts python37 python38 python310 description {Build using Python 3.9} {
     depends_lib-append \
         port:python39 \
         port:py39-anytree \
@@ -97,11 +85,23 @@ variant python39 conflicts python36 python37 python38 description {Build using P
     configure.python    ${prefix}/bin/python3.9
 }
 
-if {![variant_isset python36] &&
-    ![variant_isset python37] &&
+variant python310 conflicts python37 python38 python39 description {Build using Python 3.10} {
+    depends_lib-append \
+        port:python310 \
+        port:py310-anytree \
+        port:py310-lxml \
+        port:py310-pygments
+
+    depends_test        port:py310-mock
+
+    configure.python    ${prefix}/bin/python3.10
+}
+
+if {![variant_isset python37] &&
     ![variant_isset python38] &&
-    ![variant_isset python39] } {
-    default_variants +python39
+    ![variant_isset python39] &&
+    ![variant_isset python310] } {
+    default_variants +python310
 }
 
 # some tests are known to fail in gtk-doc 1.29+

--- a/python/py-anytree/Portfile
+++ b/python/py-anytree/Portfile
@@ -8,7 +8,6 @@ version             2.8.0
 revision            1
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             Apache-2
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -22,7 +21,7 @@ checksums           rmd160  2f48920927d32f56c584bcfce9dc40fabe604faa \
                     sha256  3f0f93f355a91bc3e6245319bf4c1d50e3416cc7a35cc1133c1ff38306bbccab \
                     size    189484
 
-python.versions     27 35 36 37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -43,12 +42,5 @@ if {${name} ne ${subport}} {
     depends_test-append \
                     port:py${python.version}-nose
 
-    if {${python.version} eq 27} {
-        depends_test-append \
-                    port:py${python.version}-enum34
-    }
-
     test.run        yes
-
-    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- gtk-doc: add new `python310` variant and use as default, remove `python36` variant for EOL Python version
- py-anytree: add py310 subport, remove subports for EOL Python versions (no dependents)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
