### PR TITLE
mozjs91: new port

### DIFF
--- a/lang/mozjs91/Portfile
+++ b/lang/mozjs91/Portfile
@@ -1,0 +1,117 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           muniversal 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime, TARGET_OS_SIMULATOR
+legacysupport.newest_darwin_requires_legacy 15
+
+name                mozjs91
+version             91.5.0
+set version_major   91
+categories          lang
+platforms           darwin
+license             {MPL-2 LGPL-2.1+}
+maintainers         nomaintainer
+description         JavaScript-C Engine
+long_description    SpiderMonkey is Mozilla's JavaScript engine written in C/C++. \
+                    It is used in various Mozilla products, including Firefox, \
+                    and is available under the MPL2.
+
+homepage            https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
+# build from GNOME releng tarball
+master_sites        https://ftp.gnome.org/pub/GNOME/teams/releng/tarballs-needing-help/mozjs/
+
+# For Rust
+supported_archs     x86_64 arm64
+
+distname            mozjs-${version}
+use_xz              yes
+
+checksums           rmd160  2576ab03d1293dde567bce6d5253974484653c4f \
+                    sha256  2f57cde35246a54a7abd25454ab5adfa076a8e6515509475eb6a37d048b7a156 \
+                    size    70715356
+
+depends_build       port:autoconf213 \
+                    port:cargo \
+                    port:pkgconfig \
+                    port:python310 \
+                    port:yasm
+
+depends_lib         port:nspr \
+                    port:xorg-libX11 \
+                    port:xorg-libXt
+
+# requires C++14 compiler to build
+compiler.cxx_standard 2014
+
+# Rust components require a MacPorts clang (i.e. one with llvm-config)
+compiler.blacklist  *gcc* clang macports-clang-3.*
+
+if {[regexp {macports-clang-(.*)} ${configure.compiler} -> llvm_ver]} {
+    configure.env-append \
+                    LLVM_CONFIG=${prefix}/bin/llvm-config-mp-${llvm_ver}
+}
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # Once Snow Leopard gets "real Rust", remove the next 3 lines
+    depends_build-replace port:cargo port:mrustc-rust
+    configure.env-append RUSTC=${prefix}/libexec/mrustc-rust/bin/rustc
+    configure.env-append CARGO=${prefix}/libexec/mrustc-rust/bin/cargo
+
+    depends_build-append port:cctools
+    configure.env-append AR=${prefix}/bin/ar
+}
+
+patchfiles          patch-skip-sdk-check.diff
+
+# Use absolute path for install_name
+post-patch {
+    reinplace "s|@executable_path|${prefix}/lib|g" ${worksrcpath}/config/rules.mk
+}
+
+configure.perl      /usr/bin/perl
+configure.python    ${prefix}/bin/python3.10
+
+# The combination of JS_STANDALONE=1 and --disable-jemalloc are needed
+# to ensure that mozglue is statically linked.
+configure.env-append \
+                    PYTHON3=${configure.python} \
+                    SHELL=/bin/bash \
+                    JS_STANDALONE=1
+
+configure.dir       ${worksrcpath}/js/src/obj
+configure.cmd       ../configure
+
+configure.args      --with-system-nspr \
+                    --disable-jemalloc \
+                    --disable-readline \
+                    --with-macos-sdk=${configure.sdkroot}
+
+configure.universal_args-delete --disable-dependency-tracking
+
+build.env-append    SHELL=/bin/bash
+build.dir           ${worksrcpath}/js/src/obj
+destroot.dir        ${worksrcpath}/js/src/obj
+
+post-destroot {
+    # make static lib name version specific to avoid conflict with other mozjs versions
+    move ${destroot}${prefix}/lib/libjs_static.ajs ${destroot}${prefix}/lib/libjs${version_major}_static.ajs
+}
+if {![info exists universal_possible]} {
+    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
+}
+
+if {${universal_possible} && [variant_isset universal]} {
+    set merger_host(x86_64) x86_64-apple-${os.platform}${os.major}
+    set merger_host(arm64) arm64-apple-${os.platform}${os.major}
+    set merger_configure_args(x86_64) "--host=x86_64-apple-${os.platform}${os.major} --target=x86_64-apple-${os.platform}${os.major}"
+    set merger_configure_args(arm64) "--host=arm64-apple-${os.platform}${os.major} --target=arm64-apple-${os.platform}${os.major}"
+} else {
+    configure.args-append \
+        --host=${build_arch}-apple-${os.platform}${os.major} \
+        --target=${build_arch}-apple-${os.platform}${os.major}
+}
+
+livecheck.type      none

--- a/lang/mozjs91/files/patch-skip-sdk-check.diff
+++ b/lang/mozjs91/files/patch-skip-sdk-check.diff
@@ -1,0 +1,11 @@
+--- build/moz.configure/toolchain.configure.orig
++++ build/moz.configure/toolchain.configure
+@@ -95,7 +95,7 @@
+         sdk_min_version = Version("10.12")
+ 
+         if sdk:
+-            sdk = sdk[0]
++            return sdk[0]
+         elif host.os == "OSX":
+             sdk = check_cmd_output(
+                 "xcrun", "--show-sdk-path", onerror=lambda: ""


### PR DESCRIPTION
#### Description

Skipping over mozjs78 since that version doesn't support arm64. The release officially only supports 10.12 and later but the build bots should tell us how far back this can go. This port was tested locally on Monterey. Due to the Rust requirement, only x86_64 and arm64 will be supported.

Once this is merged, we can start updating `gjs` to the latest version.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
