### PR TITLE
exact-image: build for BigSur/M1

### DIFF
--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.0
 
 name                exact-image
 version             1.0.2
-revision            0
+revision            1
 checksums           rmd160  2d33b4139e33f547ba3c7b7025f5045abdf5a17a \
                     sha256  0694c66be5dec41377acead475de69b3d7ffb42c702402f8b713f8b44cdc2791 \
                     size    322174
@@ -28,6 +28,7 @@ patchfiles-append   patch-no_fast.diff
 patchfiles-append   patch-cflags-cxxflags.diff
 patchfiles-append   patch-static-library-ar.diff
 patchfiles-append   patch-save-config.log.diff
+patchfiles-append   patch-codecs-jpeg2000.diff
 
 depends_build       port:pkgconfig
 depends_lib         port:antigraingeometry \

--- a/graphics/exact-image/files/patch-codecs-jpeg2000.diff
+++ b/graphics/exact-image/files/patch-codecs-jpeg2000.diff
@@ -1,0 +1,19 @@
+--- codecs/jpeg2000.cc.orig	2022-03-18 01:34:48.000000000 -0700
++++ codecs/jpeg2000.cc	2022-03-18 01:38:53.000000000 -0700
+@@ -67,14 +67,14 @@
+   return stream;
+ }
+ 
+-static int cpp_jas_read (jas_stream_obj_t* obj, char* buf, int cnt)
++static int cpp_jas_read (jas_stream_obj_t* obj, char* buf, unsigned int cnt)
+ {
+   std::istream* stream = (std::istream*) obj;
+   stream->read (buf, cnt);
+   return cnt;
+ }
+ 
+-static int cpp_jas_write (jas_stream_obj_t* obj, char* buf, int cnt)
++static int cpp_jas_write (jas_stream_obj_t* obj, const char* buf, unsigned int cnt)
+ {
+   std::ostream* stream = (std::ostream*) obj;
+   stream->write (buf, cnt);


### PR DESCRIPTION
#### Description

minor patch to allow exact-image to build on BigSur/M1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
