### PR TITLE
mtr: use github PortGroup

### DIFF
--- a/net/mtr/Portfile
+++ b/net/mtr/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                mtr
-version             0.95
+github.setup        traviscross mtr 0.95 v
 revision            0
 categories          net
 platforms           darwin
@@ -21,13 +21,13 @@ long_description    mtr combines the functionality of the 'traceroute' \
                     requests to each one to determine the quality of \
                     the link to each machine. As it does this, it \
                     prints running statistics about each machine.
-homepage            http://www.bitwizard.nl/mtr/
+homepage            https://www.bitwizard.nl/mtr/
 
 depends_build       port:pkgconfig
 depends_lib         port:ncurses \
                     port:jansson
 
-master_sites        ftp://ftp.bitwizard.nl/mtr/
+master_sites        macports_distfiles
 checksums           rmd160  71c29a1bd8546e724776bee281c661a9b0c11104 \
                     sha256  cead6802a1cd2a97d5fdf5e850bf6de4349a7a9d0f463ff715a1ed4555b64a41 \
                     size    291991
@@ -38,7 +38,3 @@ configure.args      --without-gtk \
 post-destroot {
     file attributes ${destroot}${prefix}/sbin/mtr-packet -permissions +s
 }
-
-livecheck.type      regex
-livecheck.url       [lindex ${master_sites} 0]
-livecheck.regex     "[quotemeta ${name}]-(\\d(\\.\\d+)*)[quotemeta ${extract.suffix}]"


### PR DESCRIPTION
#### Description

Upstream's FTP site is down and they're not putting tarballs on their HTTP site anymore. I've moved it to GitHub, which will also fix the livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
