### PR TITLE
mozjs91: fix configuration when `sdkroot` is empty

### DIFF
--- a/lang/mozjs91/Portfile
+++ b/lang/mozjs91/Portfile
@@ -86,8 +86,13 @@ configure.cmd       ../configure
 
 configure.args      --with-system-nspr \
                     --disable-jemalloc \
-                    --disable-readline \
-                    --with-macos-sdk=${configure.sdkroot}
+                    --disable-readline
+
+if {${configure.sdkroot} eq ""} {
+    configure.args-append --with-macos-sdk=/
+} else {
+    configure.args-append --with-macos-sdk=${configure.sdkroot}
+}
 
 configure.universal_args-delete --disable-dependency-tracking
 


### PR DESCRIPTION
#### Description

Attempt to fix failing build bots, e.g. https://build.macports.org/builders/ports-10.13_x86_64-builder/builds/145229

Tested locally through configure; the full build may uncover other issues.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
