### PR TITLE
npm[6-8]: depend on nodejs14 on 10.8 and earlier

### DIFF
--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -38,7 +38,7 @@ depends_lib         path:bin/node:nodejs16
 
 platform darwin {
     if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs16 path:bin/node:nodejs8
+        depends_lib-replace path:bin/node:nodejs16 path:bin/node:nodejs14
     }
 }
 

--- a/devel/npm7/Portfile
+++ b/devel/npm7/Portfile
@@ -38,7 +38,7 @@ depends_lib         path:bin/node:nodejs16
 
 platform darwin {
     if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs16 path:bin/node:nodejs8
+        depends_lib-replace path:bin/node:nodejs16 path:bin/node:nodejs14
     }
 }
 

--- a/devel/npm8/Portfile
+++ b/devel/npm8/Portfile
@@ -38,7 +38,7 @@ depends_lib         path:bin/node:nodejs16
 
 platform darwin {
     if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs16 path:bin/node:nodejs8
+        depends_lib-replace path:bin/node:nodejs16 path:bin/node:nodejs14
     }
 }
 


### PR DESCRIPTION
#### Description

`nodejs14` installs just fine on legacy systems.

Closes: https://trac.macports.org/ticket/61214
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
