### PR TITLE
mozjs91: fall back to generic uptime logic pre-10.12

### DIFF
--- a/lang/mozjs91/Portfile
+++ b/lang/mozjs91/Portfile
@@ -64,7 +64,8 @@ if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
     configure.env-append AR=${prefix}/bin/ar
 }
 
-patchfiles          patch-skip-sdk-check.diff
+patchfiles          patch-skip-sdk-check.diff \
+                    patch-mozglue-clock_gettime.diff
 
 # Use absolute path for install_name
 post-patch {

--- a/lang/mozjs91/files/patch-mozglue-clock_gettime.diff
+++ b/lang/mozjs91/files/patch-mozglue-clock_gettime.diff
@@ -1,0 +1,26 @@
+error: use of undeclared identifier 'CLOCK_UPTIME_RAW'
+
+--- mozglue/misc/AwakeTimeStamp.cpp.orig
++++ mozglue/misc/AwakeTimeStamp.cpp
+@@ -58,6 +58,9 @@
+ #  include <sys/time.h>
+ #  include <sys/types.h>
+ #  include <mach/mach_time.h>
++#endif
++
++#if defined(__APPLE__) && defined(__MACH__) && defined(CLOCK_UPTIME_RAW)
+ 
+ AwakeTimeStamp AwakeTimeStamp::NowLoRes() {
+   return AwakeTimeStamp(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / kNSperUS);
+--- mozglue/misc/Uptime.cpp.orig
++++ mozglue/misc/Uptime.cpp
+@@ -32,7 +32,9 @@
+ #  include <sys/time.h>
+ #  include <sys/types.h>
+ #  include <mach/mach_time.h>
++#endif
+ 
++#if defined(__APPLE__) && defined(__MACH__) && defined(CLOCK_UPTIME_RAW) && defined(CLOCK_MONOTONIC_RAW)
+ const uint64_t kNSperMS = 1000000;
+ 
+ Maybe<uint64_t> NowExcludingSuspendMs() {


### PR DESCRIPTION
#### Description

Build bots are failing on  10.11 and earlier: https://build.macports.org/builders/ports-10.11_x86_64-builder/builds/176409

Check for `CLOCK_UPTIME_RAW` before using it. Possibly a future candidate for legacysupport, but mozglue has generic Unix fallback logic that we can use for now.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
