### PR TITLE
wireguard-go: update to 0.0.20220316

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20220117
+version             0.0.20220316
 revision            0
-checksums           rmd160  1e2bf8a75c7dc302667006df0a1dab617ce354de \
-                    sha256  f4496b6db6c2f99ebbb744738dd6c93ebdbda0571b56cfb857916d20a696fe80 \
-                    size    109548
+checksums           rmd160  d5601921320010c1ec0cbd44a281feac53590b3a \
+                    sha256  fd6759c116e358d311309e049cc2dcc390bc326710f5fc175e0217b755330c2a \
+                    size    110444
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-go: update to 0.0.20220316

###### Tested on
macOS 12.2.1 21D62 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
