### PR TITLE
py-google-api: update to 2.41.0

### DIFF
--- a/python/py-google-api-core/Portfile
+++ b/python/py-google-api-core/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-google-api-core
+version             2.7.1
+revision            0
+
+categories-append   www devel
+supported_archs     noarch
+license             Apache-2.0
+maintainers         nomaintainer
+
+description         Google API client core library
+long_description    {*}${description}
+
+homepage            https://github.com/googleapis/python-api-core
+
+checksums           rmd160  ab449c2446ea350362fdb4d56bb8e50c3b62f4f6 \
+                    sha256  b0fa577e512f0c8e063386b974718b8614586a798c5894ed34bedf256d9dae24 \
+                    size    122056
+
+python.versions     37 38 39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-google-auth \
+                    port:py${python.version}-googleapis-common-protos \
+                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-requests
+}

--- a/python/py-google-api/Portfile
+++ b/python/py-google-api/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-google-api
 python.rootname     google-api-python-client
-version             1.7.11
+version             2.41.0
 revision            0
 
 categories-append   www devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/googleapis/google-api-python-client
 
-checksums           rmd160  5bc9b7adce5d4a0e6ad3864e3f6286f706cb6a8f \
-                    sha256  a8a88174f66d92aed7ebbd73744c2c319b4b1ce828e565f9ec721352d2e2fb8c \
-                    size    142837
+checksums           rmd160  9b5160018ac3a3482d86459d2bb51552e1b7fc60 \
+                    sha256  facbe8e25ea9d07241299bf7704f53dec154ad3dc52fec2ea23ca6d6e5f6b392 \
+                    size    7873449
 
 python.versions     37 38 39 310
 
@@ -33,22 +33,13 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-httplib2 \
                     port:py${python.version}-google-auth \
                     port:py${python.version}-google-auth-httplib2 \
-                    port:py${python.version}-six \
+                    port:py${python.version}-google-api-core \
                     port:py${python.version}-uritemplate
 
     post-destroot {
-        delete ${destroot}${python.pkgd}/uritemplate
-
-        set egg-info ${destroot}${python.pkgd}/google_api_python_client-${version}-py${python.branch}.egg-info
-        foreach d [glob -dir ${egg-info} *] {
-            file attributes ${d} -permissions 0644
-        }
-
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} README.md CHANGELOG \
+        xinstall -m 0644 -W ${worksrcpath} README.md \
             LICENSE ${destroot}${docdir}
-
-        xinstall -d -m 555 ${destroot}${prefix}/share/examples
     }
 }

--- a/python/py-googleapis-common-protos/Portfile
+++ b/python/py-googleapis-common-protos/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-googleapis-common-protos
+version             1.56.0
+revision            0
+
+categories-append   www devel
+supported_archs     noarch
+license             Apache-2.0
+maintainers         nomaintainer
+
+description         Common protobufs used in Google APIs
+long_description    {*}${description}
+
+homepage            https://github.com/googleapis/python-api-common-protos
+
+checksums           rmd160  85f98a686621cdaaec8f635b460a860492b750c7 \
+                    sha256  4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f \
+                    size    132706
+
+python.versions     37 38 39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-protobuf3
+}


### PR DESCRIPTION
#### Description
The update of `py-uritemplate` in 95668cdbdb5652143a474f6384536064d46d0b9e to v4 broke `py-google-api`... sorry about that. This PR updates `py-google-api` to the latest upstream version and adds ports for new requirements. 

From a quick look of ports that depend on `py-google-api` it appears that all of them support the v2 branch, but a bit more testing from maintainers would be beneficial before merging this PR... 

```
py37-google-api: py37-beancount, py37-tensor2tensor, py37-tensorflow-metadata, py37-tfx-bsl
py38-google-api: py38-beancount, py38-tensor2tensor, py38-tensorflow-metadata, py38-tfx-bsl
py39-google-api: gcalcli, py39-beancount, py39-tensor2tensor, py39-tensorflow-metadata, py39-tfx-bsl
py310-google-api: certbot, certbot-apache, certbot-dns-cloudflare, certbot-dns-cloudxns, certbot-dns-digitalocean, certbot-dns-dnsimple, certbot-dns-dnsmadeeasy, certbot-dns-gehirn, certbot-dns-google, certbot-dns-linode, certbot-dns-luadns, certbot-dns-nsone, certbot-dns-ovh, certbot-dns-rfc2136, certbot-dns-route53, certbot-dns-sakuracloud, certbot-nginx, py-google-api, py310-beancount
```

tagging the maintainers  of these ports here for their input: @mrdomino and @Schamschula

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
