### PR TITLE
py-multiprocess: update to 0.70.12.2 and added py310

### DIFF
--- a/python/py-multiprocess/Portfile
+++ b/python/py-multiprocess/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-multiprocess
-version             0.70.11.1
+version             0.70.12.2
 platforms           darwin
 license             BSD
 maintainers         nomaintainer
@@ -16,11 +16,11 @@ long_description    ${description}
 homepage            https://pypi.org/project/multiprocess
 use_zip             yes
 
-checksums           rmd160  7556c9a4fb34e9d5d54742d3cda97f6bfe59e987 \
-                    sha256  9d5e417f3ebce4d027a3c900995840f167f316d9f73c0a7a1fbb4ac0116298d0 \
-                    size    2416439
+checksums           rmd160  6e3dd8fcbac45747e71126a1ea783ed1a2537078 \
+                    sha256  206bb9b97b73f87fec1ed15a19f8762950256aa84225450abc7150d02855a083 \
+                    size    3308461
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Updated py-multiprocess to 0.70.12.2 and added support for Python 3.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3 21E230 arm64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
