### PR TITLE
py-ipympl: add py38, py39, py310 subports and update to 0.7.0

### DIFF
--- a/python/py-ipympl/Portfile
+++ b/python/py-ipympl/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-ipympl
-version             0.3.3
+version             0.7.0
 revision            0
 platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 35 36 37
+python.versions     36 37 38 39 310
 
 maintainers         {aronnax @lpsinger} openmaintainer
 
@@ -24,17 +24,16 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  1119e3e56d190518ea0ca1f4b2ecc79f8a6964fc \
-                    sha256  edf4374806d704f35334260678d2e94db5079a3d5ef75ed88b8fc2a4a080ba54 \
-                    size    467977
+checksums           rmd160  edabf6803acf97df26b7fe0b24483da64bee70c5 \
+                    sha256  f0f1f356d8cb9d4fb51bb86dbbf837c190145316cb72f66081872ebc4d6db0a1 \
+                    size    56729
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-jupyter_packaging
 
     depends_lib-append  port:py${python.version}-ipykernel \
                         port:py${python.version}-ipywidgets \
                         port:py${python.version}-matplotlib
-
-    livecheck.type      none
 }


### PR DESCRIPTION
#### Description

Add py38, py39 and py310 subports.
Update to 0.7.0, which is the last version which works for me (as of 0.8.0, a simple plot in a .ipynb notebook doesn't show anymore).
Add dependency to py-jupyter_packaging and remove unsupported py27 and py35 subports.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
