### PR TITLE
prawcore: new port (v.2.3.0)

### DIFF
--- a/python/py-prawcore/Portfile
+++ b/python/py-prawcore/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-prawcore
+version             2.3.0
+supported_archs     noarch
+license             BSD
+
+python.versions     37 38 39 310
+
+maintainers         nomaintainer
+
+description         ${name} is a low-level communication layer used by PRAW 4+.
+long_description    {*}${description}
+
+homepage            https://github.com/praw-dev/prawcore
+
+checksums           rmd160  2a6f72e206ca57f64b99d03b5d9b1a7b69265cae \
+                    sha256  daf1ccd4b7a80dc4e6567d48336d782e94a9a6dad83770fc2edf76dc9a84f56d \
+                    size    1163513
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-requests \
+                        port:py${python.version}-certifi \
+                        port:py${python.version}-charset-normalizer \
+                        port:py${python.version}-idna \
+                        port:py${python.version}-urllib3
+
+    livecheck.type      none
+}
+


### PR DESCRIPTION
#### Description

New port for prawcore

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
