### PR TITLE
paho.mqtt.cpp: New port

### DIFF
--- a/net/paho.mqtt.cpp/Portfile
+++ b/net/paho.mqtt.cpp/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           openssl 1.0
+
+github.setup        eclipse paho.mqtt.cpp 1.2.0 v
+revision            0
+categories          net
+maintainers         nomaintainer
+license             EPL-2
+
+description         Library to enable C++ applications to connect to an MQTT broker to publish and receive messages.
+
+long_description    MQTT and MQTT-SN are lightweight publish/subscribe \
+                    messaging transports for TCP/IP and connectionless \
+                    protocols (such as UDP) respectively. The Eclipse \
+                    Paho project provides open source, mainly client side, \
+                    implementations of MQTT and MQTT-SN in a variety of \
+                    programming languages.
+
+depends_lib-append \
+                    port:paho.mqtt.c
+
+# We enable SSL so that the paho.mqtt.cpp library builds without issues
+configure.args-append \
+                    -DPAHO_WITH_SSL=ON
+
+checksums           rmd160  435b0a3366dd68811c372e76b02ddd868c55d43a \
+                    sha256  2640f780b1cab2baab0d85dd74a0298c4ff2976d8174cfe63a63d01233fee3ee \
+                    size    216127


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.3.1 20E241 x86_64
Xcode 12.5 12E262

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?

- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?

Tests are not enabled by default in the build (requires the additional CMake flag `-DPAHO_BUILD_TESTS=ON`), so I did not run the above two steps.

- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
