### PR TITLE
ncurses: fix build on Linux

### DIFF
--- a/devel/ncurses/Portfile
+++ b/devel/ncurses/Portfile
@@ -41,8 +41,12 @@ configure.args  --enable-widec \
                 --with-manpage-format=normal \
                 --without-pkg-config \
                 --enable-pc-files \
-                --with-pkg-config-libdir="${prefix}/lib/pkgconfig" \
+                --with-pkg-config-libdir="${prefix}/lib/pkgconfig"
+
+if {${os.platform} eq "darwin"} {
+    configure.args-append \
                 --disable-mixed-case
+}
 
 if {[string match *clang* ${configure.cxx}]} {
     configure.env-append    CXXLIBS=-stdlib=${configure.cxx_stdlib}


### PR DESCRIPTION
ncurses didn't build for me on Raspberry Pi OS. I found an [old patch](https://trac.macports.org/attachment/ticket/48957/ncurses.diff) by @RJVB on trac for this issue that still seems to work.

Closes: https://trac.macports.org/ticket/48957

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Linux raspberrypi 5.10.52-v7+ #1441 SMP Tue Aug 3 18:10:09 BST 2021 armv7l GNU/Linux

```
> port -v installed ncurses
The following ports are currently installed:
  ncurses @6.3_0 (active) requested_variants='' platform='linux 5' archs='arm64' date='2022-03-21T21:24:55+0000'
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? (trace mode isn't supported on Linux)
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
