### PR TITLE
py-kitchen: new port (v.1.2.6)

### DIFF
--- a/python/py-kitchen/Portfile
+++ b/python/py-kitchen/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-kitchen
+version             1.2.6
+supported_archs     noarch
+license             LGPL-21
+
+python.versions     37 38 39 310
+
+maintainers         nomaintainer
+
+description         ${name} is a python API for commonly used snippets of \
+                    code
+long_description    The ${name} module provides a python API for all sorts \
+                    of little useful snippets of code that everybody ends \
+                    up writing for their projects but never seem big enough \
+                    to build an independent release. Use kitchen and stop \
+                    cutting and pasting that code over and over.
+
+homepage            https://github.com/fedora-infra/kitchen
+
+checksums           rmd160  67fd6269f9eabb6f299022770ee8d1e6395067e7 \
+                    sha256  b84cf582f1bd1556b60ebc7370b9d331eb9247b6b070ce89dfe959cba2c0b03c \
+                    size    255369
+
+if {${name} ne ${subport}} {
+
+    depends_lib-append \
+                        port:py${python.version}-chardet
+
+    livecheck.type      none
+}
+


### PR DESCRIPTION
#### Description

new port for Python Kitchen

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
