### PR TITLE
fava: update to 1.21, use Python 3.10

### DIFF
--- a/python/fava/Portfile
+++ b/python/fava/Portfile
@@ -5,14 +5,13 @@ PortGroup               python 1.0
 
 name                    fava
 categories-append       finance
-version                 1.20.1
+version                 1.21
 revision                0
-checksums               rmd160  0e15595ecf661d42600e39c2acda4376a0dd3cb7 \
-                        sha256  e2d13041acfeab9a63addb2a56678b126476a277badac6a9fec0b2944f61a037 \
-                        size    1725161
+checksums               rmd160  f9045f4b5037116f2293b0a61e19b62a75df1592 \
+                        sha256  d1a1422848e65e7eb275d80d322f6de2bcea1dc37b5412e8cf72c483d6a998d6 \
+                        size    1250384
 
 license                 MIT
-platforms               darwin
 supported_archs         noarch
 maintainers             {wholezero.org:macports @mrdomino} openmaintainer
 
@@ -20,9 +19,11 @@ description             Beancount web server
 long_description        Fava is a web frontend for the Beancount plain-text accounting system.
 homepage                https://beancount.github.io/fava/
 
-python.versions         37 38 39 310
+python.default_version  310
+python.pep517           yes
 
-depends_build-append    port:py${python.version}-setuptools_scm
+depends_build-append    port:py${python.version}-setuptools_scm \
+                        port:py${python.version}-colorama
 
 depends_lib-append      port:py${python.version}-babel \
                         port:py${python.version}-beancount \
@@ -33,6 +34,5 @@ depends_lib-append      port:py${python.version}-babel \
                         port:py${python.version}-jinja2 \
                         port:py${python.version}-markdown2 \
                         port:py${python.version}-ply \
-                        port:py${python.version}-rsa \
-                        port:py${python.version}-setuptools \
-                        port:py${python.version}-simplejson
+                        port:py${python.version}-simplejson \
+                        port:py${python.version}-werkzeug


### PR DESCRIPTION
#### Description
- update to latest version (1.21), use Python 3.10 ; no point in setting `python.versions` if the portname does not start with `py-`
- 
Closes: https://trac.macports.org/ticket/61283

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
