### PR TITLE
postgresql96-server: Bugfix startupitem

### DIFF
--- a/databases/postgresql96-server/Portfile
+++ b/databases/postgresql96-server/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 
 name                postgresql96-server
 version             9.6.24
+revision            1
 categories          databases
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
@@ -30,7 +31,8 @@ add_users           ${dbuser} group=${dbgrp} \
                     home=${prefix}/var/db/${rname} \
                     realname=PostgreSQL-96\ Server
 
-depends_run         port:${rname}
+depends_run         port:bash \
+                    port:${rname}
 
 use_configure       no
 
@@ -38,13 +40,14 @@ build               {}
 
 startupitem.create  yes
 startupitem.init    "PGCTL=${libdir}/bin/pg_ctl"
-startupitem.start   "su ${dbuser} -c \"\${PGCTL} -D \${POSTGRESQL96DATA:=${dbdir}} start -l ${logdir}/postgres.log\""
-startupitem.stop    "su ${dbuser} -c \"\${PGCTL} -D \${POSTGRESQL96DATA:=${dbdir}} stop -s -m fast\""
+startupitem.start   "sudo -u ${dbuser} ${prefix}/bin/bash -c \"\${PGCTL} -D \${POSTGRESQL96DATA:=${dbdir}} start -l ${logdir}/postgres.log\""
+startupitem.stop    "sudo -u ${dbuser} ${prefix}/bin/bash -c \"\${PGCTL} -D \${POSTGRESQL96DATA:=${dbdir}} stop -s -m fast\""
 
 destroot {
-    xinstall -m 755 -d ${destroot}${logdir}
-    system "touch ${destroot}${logdir}/postgres.log"
-    system "chown ${dbuser}:${dbgrp} ${destroot}${logdir}/postgres.log"
+    xinstall -d ${destroot}${logdir}
+    touch ${destroot}${logdir}/postgres.log
+    file attributes ${destroot}${logdir}/postgres.log \
+        -owner ${dbuser} -group ${dbgrp}
 }
 
 # https://trac.macports.org/ticket/64286
@@ -59,6 +62,6 @@ post-activate {
 notes "\nTo create a database instance, after install do\n\
         sudo mkdir -p ${dbdir}\n\
         sudo chown ${dbuser}:${dbgrp} ${dbdir}\n\
-        sudo su ${dbuser} -c \'cd ${dbhome} && ${libdir}/bin/initdb -D ${dbdir}\' "
+        sudo -u ${dbuser} bash -c \'cd ${dbhome} && ${libdir}/bin/initdb -D ${dbdir}\'"
 
 livecheck.type      none


### PR DESCRIPTION
* Bugfix startupitem with `sudo`, not `su`
* Use tcl commands in Portfile rather than `system` calls

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
