### PR TITLE
BLAKE3: new port (v1.3.1)

### DIFF
--- a/security/blake3/Portfile
+++ b/security/blake3/Portfile
@@ -1,0 +1,92 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        BLAKE3-team BLAKE3 1.3.1
+name                blake3
+github.tarball_from archive
+revision            0
+
+description         ${name} is a cryptographic hash function.
+long_description    ${name} is a cryptographic hash function that is \
+                    much faster than MD5, SHA-1, SHA-2, SHA-3, \
+                    and BLAKE2, secure, unlike MD5 and SHA-1, \
+                    secure against length extension, unlike SHA-2, \
+                    highly parallelizable, and capable of verified \
+                    streaming and incremental updates.
+
+categories          security
+installs_libs       no
+license             Apache-2
+maintainers         {@srirangav} openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  8f8a2571f4744d2fdd124bac90490ea70a2fd777 \
+                    sha256  112becf0983b5c83efff07f20b458f2dbcdbd768fd46502e7ddd831b83550109 \
+                    size    217773
+
+build.dir           ${worksrcpath}/b3sum
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/b3sum/target/[cargo.rust_platform]/release/b3sum \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    anyhow                          1.0.53  94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0 \
+    arrayref                         0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
+    arrayvec                         0.7.2  8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    block-buffer                    0.10.0  f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95 \
+    cc                              1.0.72  22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    clap                            3.0.12  2afefa54b5c7dd40918dc1e09f213a171ab5937aadccab45e804780b238f9f43 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    crossbeam-channel                0.5.2  e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa \
+    crossbeam-deque                  0.8.1  6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e \
+    crossbeam-epoch                  0.9.6  97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762 \
+    crossbeam-utils                  0.8.6  cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120 \
+    crypto-common                    0.1.1  683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0 \
+    digest                          0.10.1  b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b \
+    duct                            0.13.5  0fc6a0a59ed0888e0041cf708e66357b7ae1a82f1c67247e1f93b5e0818f7d8d \
+    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    fastrand                         1.7.0  c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf \
+    generic-array                   0.14.5  fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803 \
+    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    hashbrown                       0.11.2  ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
+    indexmap                         1.8.0  282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223 \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                           0.2.114  b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50 \
+    memchr                           2.4.1  308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a \
+    memmap                           0.7.0  6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b \
+    memoffset                        0.6.5  5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
+    num_cpus                        1.13.1  19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1 \
+    once_cell                        1.9.0  da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5 \
+    os_pipe                          0.9.2  fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213 \
+    os_str_bytes                     6.0.0  8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64 \
+    rayon                            1.5.1  c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90 \
+    rayon-core                       1.9.1  d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e \
+    redox_syscall                   0.2.10  8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    shared_child                     0.3.5  6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    subtle                           2.4.1  6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601 \
+    tempfile                         3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
+    termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
+    textwrap                        0.14.2  0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80 \
+    typenum                         1.15.0  dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987 \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    wild                             2.0.4  035793abb854745033f01a07647a79831eba29ec0be377205f2a25b0aa830020 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
#### Description

New port for b3sum from the BLAKE3 project

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

FYI, b3sum is written in rust and when I check the Portfile with port lint --nitpick, it gives me the same checksum warnings for rust / cargo dependencies that I see when linting other rust based ports (such as devel/gfold).  I am new to rust, so please let me know if there is a better way to implement this Portfile.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
