### PR TITLE
py-kitchen: update to version 1.2.6_1

### DIFF
--- a/python/py-kitchen/Portfile
+++ b/python/py-kitchen/Portfile
@@ -5,8 +5,9 @@ PortGroup           python 1.0
 
 name                py-kitchen
 version             1.2.6
+revision            1
 supported_archs     noarch
-license             LGPL-21
+license             LGPL-2.1
 
 python.versions     37 38 39 310
 
@@ -28,9 +29,11 @@ checksums           rmd160  67fd6269f9eabb6f299022770ee8d1e6395067e7 \
 
 if {${name} ne ${subport}} {
 
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
     depends_lib-append \
                         port:py${python.version}-chardet
 
-    livecheck.type      none
 }
 


### PR DESCRIPTION
#### Description

Update py-kitchen Portfile to fix issues identified in initial version by @herbygillot and @reneeotten.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
