### PR TITLE
libtommath: fix build error with MoarVM

### DIFF
--- a/math/libtommath/Portfile
+++ b/math/libtommath/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libtom libtommath 1.2.0 v
+revision            1
 categories          math
 platforms           darwin
 maintainers         nomaintainer
@@ -27,7 +28,8 @@ checksums           rmd160  fe6b5cbc12191a492efb2999cb88b765bc984b5d \
                     sha256  b7c75eecf680219484055fcedd686064409254ae44bc31a96c5032843c0e18b1 \
                     size    622120
 
-patchfiles          patch-makefile.diff
+patchfiles          patch-makefile.diff \
+                    patch-pr-476.diff
 
 worksrcdir          ${name}-${version}
 

--- a/math/libtommath/files/patch-pr-476.diff
+++ b/math/libtommath/files/patch-pr-476.diff
@@ -1,0 +1,31 @@
+This patch lets MoarVM build against libtommath
+
+https://github.com/libtom/libtommath/pull/476
+
+--- bn_mp_set_double.c.orig
++++ bn_mp_set_double.c
+@@ -3,7 +3,7 @@
+ /* LibTomMath, multiple-precision integer library -- Tom St Denis */
+ /* SPDX-License-Identifier: Unlicense */
+ 
+-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
++#if defined(MP_HAS_SET_DOUBLE)
+ mp_err mp_set_double(mp_int *a, double b)
+ {
+    uint64_t frac;
+--- tommath_private.h.orig
++++ tommath_private.h
+@@ -164,6 +164,13 @@
+ 
+ MP_STATIC_ASSERT(prec_geq_min_prec, MP_PREC >= MP_MIN_PREC)
+ 
++#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) \
++   || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) \
++   || defined(__i386__) || defined(_M_X86) \
++   || defined(__aarch64__) || defined(__arm__)
++#define MP_HAS_SET_DOUBLE
++#endif
++
+ /* random number source */
+ extern MP_PRIVATE mp_err(*s_mp_rand_source)(void *out, size_t size);
+ 


### PR DESCRIPTION
#### Description

This is a first step toward removing the install conflict between the `MoarVM` and `libtommath` ports. The patch derives from a merged pull request. (libtommath has not had a formal release since 2019.)

See: https://github.com/libtom/libtommath/issues/159
See: https://github.com/libtom/libtommath/pull/476

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
