### PR TITLE
tuir: new port (v.1.29.0)

### DIFF
--- a/net/tuir/Portfile
+++ b/net/tuir/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                tuir
+version             1.29.0
+supported_archs     noarch
+license             MIT
+categories          net
+
+python.default_version \
+                    310
+
+maintainers         nomaintainer
+
+description         Browse Reddit from your terminal
+long_description    A text-based interface (TUI) to view and interact with \
+                    Reddit from your terminal.
+
+homepage            https://gitlab.com/ajak/tuir
+
+checksums           rmd160  55d833ad20a50b9675f8be750b56ee81cb93b4a9 \
+                    sha256  311d4874d194cc10b791834d735d478d02f306aca8766dc9cf0bde15c100ab1b \
+                    size    17729141
+
+depends_build-append \
+                    port:py${python.version}-setuptools
+
+depends_lib-append  port:py${python.version}-six \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-beautifulsoup4 \
+                    port:py${python.version}-decorator \
+                    port:py${python.version}-kitchen


### PR DESCRIPTION
#### Description

New port - tuir v.1.29.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
