### PR TITLE
openjdk18-oracle: new submission

### DIFF
--- a/java/openjdk18-oracle/Portfile
+++ b/java/openjdk18-oracle/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk18-oracle
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://jdk.java.net/18/
+version      18
+set build    36
+revision     0
+
+description  Oracle OpenJDK 18
+long_description Open-source Oracle build of OpenJDK 18, the Java Development Kit, an implementation of the Java SE Platform.
+
+master_sites https://download.java.net/java/GA/jdk${version}/43f95e8614114aeaa8e8a5fcf20a682d/${build}/GPL/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     openjdk-${version}_macos-x64_bin
+    checksums    rmd160  7cfc98587bfc1d209cf58e973cf42b1af361d27b \
+                 sha256  527b61b4265caf45cdcbacfcf8fbcd0b4b280bede1eff32a5b252d855ff0534b \
+                 size    185375922
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     openjdk-${version}_macos-aarch64_bin
+    checksums    rmd160  8d36e7f1f202ac7e998ad837b41d98e2d4ed9a60 \
+                 sha256  6880a5b512d1c1df5013a04b2cef4e1261e881d7f246ea5483ffeb728b30b2f1 \
+                 size    183221810
+}
+
+worksrcdir   jdk-${version}.jdk
+
+homepage     https://jdk.java.net/18/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Oracle OpenJDK 18.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
