### PR TITLE
openjdk-distributions: remove previously obsoleted openjdk15-openj9* ports

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -50,8 +50,6 @@ set obsoleted_ports {
     openjdk8-graalvm
     openjdk8-openj9-large-heap
     openjdk11-openj9-large-heap
-    openjdk15-openj9
-    openjdk15-openj9-large-heap
     openjdk16
     openjdk16-graalvm
     openjdk16-temurin
@@ -447,20 +445,6 @@ subport openjdk15 {
     }
 
     depends_run-append port:openjdk15-zulu
-}
-
-# Remove after 2022-03-22
-subport openjdk15-openj9 {
-    version      15.0.2
-    revision     1
-    replaced_by  openjdk16-openj9
-}
-
-# Remove after 2022-03-22
-subport openjdk15-openj9-large-heap {
-    version      15.0.2
-    revision     1
-    replaced_by  openjdk16-openj9
 }
 
 subport openjdk15-zulu {


### PR DESCRIPTION
#### Description

Remove previously obsoleted `openjdk15-openj9*` ports.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?