### PR TITLE
google-cloud-sdk: update to 378.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             377.0.0
+version             378.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f14e35aac6fc2bced5ab4b86cbfa957d13cf169f \
-                    sha256  b9ac993dbb3685e1d3022638a3585af1ab596a0b5ffd29026a8c854e1395d1aa \
-                    size    106744505
+    checksums       rmd160  1c0a1c86852ad1efc3a099b223ba9980fb9e949b \
+                    sha256  5e804acfb02026226a0e5cc2483f5eb733bb710de16bdadd8acfc464d5814d03 \
+                    size    105809605
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  0c55e5398f8b7227f8863cfb82560ffde2b51939 \
-                    sha256  1175bfb9040dbc90e9f9efbb87064b3f8e7894b273a7c7eae7fa59fcb1b668c4 \
-                    size    101962102
+    checksums       rmd160  18babe08fe4b48e65e4e0418297215569659d8ed \
+                    sha256  5949aa0b842b5abe39b6bfed9f532cd261fa6a9b4ad7cd7ebece936250ae34a7 \
+                    size    101029320
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  fe61af23eba0480aae2989ecbcf575126dee4f6f \
-                    sha256  7cf3421fb88d66b263964de6eb76aebfb39c93ab674109dbad3c8fa5f189d4c1 \
-                    size    101448005
+    checksums       rmd160  b6dafb668be4294422dd9efcc7b75f53350951ab \
+                    sha256  09fab992c586dbac778a8031fa6f8983b453e979d168df92bca6ecb0d2d75034 \
+                    size    100510098
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 378.0.0.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?