### PR TITLE
openjdk18-corretto: new submission

### DIFF
--- a/java/openjdk18-corretto/Portfile
+++ b/java/openjdk18-corretto/Portfile
@@ -1,0 +1,97 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk18-corretto
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://github.com/corretto/corretto-18/releases
+version      18.0.0.37.1
+revision     0
+
+description  Amazon Corretto OpenJDK 18 (Short Term Support)
+long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
+
+master_sites https://corretto.aws/downloads/resources/${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     amazon-corretto-${version}-macosx-x64
+    checksums    rmd160  2ac6dfa769e5545904a641e61553333ed8aeeb48 \
+                 sha256  0e06a86c3bbbd5ad7b908b5a75d3a2ab6fe30f62703ed6c8dcf9875f796fe9c9 \
+                 size    188570375
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     amazon-corretto-${version}-macosx-aarch64
+    checksums    rmd160  d23ccd710766354c36bec80e522816ce85721e62 \
+                 sha256  7d196b604b7518af9af6f5529e91978c1d06920e5ecd0d5d7c3a6aaaa42149f8 \
+                 size    186440646
+}
+
+worksrcdir   amazon-corretto-18.jdk
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    # See https://github.com/corretto/corretto-18/blob/release-18.0.0.37.1/CHANGELOG.md
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.13 High Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://aws.amazon.com/corretto/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Amazon Corretto OpenJDK 18.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?