### PR TITLE
mpich: Disable test requiring python

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -171,6 +171,7 @@ if {${subport_enabled}} {
                     --with-pm=hydra                  \
                     --with-thread-package=posix      \
                     --with-hwloc-prefix=${prefix}    \
+                    --disable-collalgo-tests         \
                     "F90FLAGS='' F90=''"
 
     if {${os.major} < 12} {


### PR DESCRIPTION
Maintainer update.

Fix broken buildbot builds. (Disable test that required python3 rather than pulling in python3 for a test we're not running anyway.)