### PR TITLE
fontconfig: Add ~/Library/Fonts to default font directories

### DIFF
--- a/graphics/fontconfig/Portfile
+++ b/graphics/fontconfig/Portfile
@@ -5,7 +5,7 @@ PortGroup                   muniversal 1.0
 
 name                        fontconfig
 version                     2.13.1
-revision                    0
+revision                    1
 checksums                   rmd160  a971903874fb0395a7ab2d5705378af1ffce2b2c \
                             sha256  f655dd2a986d7aa97e052261b36aa67b0a64989496361eca8d604e6414006741 \
                             size    1723639
@@ -103,7 +103,8 @@ pre-pkg {
 platform macosx {
     lappend add_fonts       /Library/Fonts \
                             /Network/Library/Fonts \
-                            /System/Library/Fonts
+                            /System/Library/Fonts \
+                            ~/Library/Fonts
 }
 
 merger_arch_flag            no


### PR DESCRIPTION
#### Description

Add ~/Library/Fonts to default font directories

Closes: https://trac.macports.org/ticket/64879

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
   Warnings exist, but not due to my change:

   ```
   sudo port lint --nitpick fontconfig
   --->  Verifying Portfile for fontconfig
   Warning: Line 16 seems to hardcode the version number, consider using ${version} instead
   Warning: Line 72 using macosx_version; switch to macos_version or macos_version_major
   --->  0 errors and 2 warnings found.
   ```
- [x] tried existing tests with `sudo port test`?
   No existing tests.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
   I have font files installed in `~/Library/Fonts`. Now, `fc-cache && fc-list | sort | grep -q '^/Users/'; echo $?` prints `0`, showing that fontconfig is indexing these fonts.
