### PR TITLE
mpich: Fix gcc builds; add gcc11

### DIFF
--- a/_resources/port1.0/group/mpi-1.0.tcl
+++ b/_resources/port1.0/group/mpi-1.0.tcl
@@ -327,9 +327,6 @@ proc mpi.setup {args} {
         # So only enable for 10.8+.
         if {${os.major} < 12} {
             lappend ::mpi.disabled_compilers -gcc9 -gcc10 -gcc11
-        } elseif {$is_mpich} {
-            # mpich: gcc11 subport currently disabled across-the-board
-            lappend ::mpi.disabled_compilers -gcc11
         }
 
         if {${os.arch} eq "arm"} {

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -101,13 +101,14 @@ if { ${os.arch} eq "arm" } {
 # However, gcc9+ builds fail on MacOS 10.7, so only enable for MacOS 10.8+.
 if { ${os.arch} eq "arm" } {
     lappend clist_unsupported \
-        gcc9 gcc10
+        gcc9
 } elseif { ${os.major} >= 12 } {
     dict set clist gcc9  {macports-gcc-9}
     dict set clist gcc10 {macports-gcc-10}
+    dict set clist gcc11 {macports-gcc-11}
 } else {
     lappend clist_unsupported \
-        gcc9 gcc10
+        gcc9 gcc10 gcc11
 }
 
 #-------------------------------------------------------------------------------
@@ -291,6 +292,7 @@ if {${subport_enabled}} {
             # see https://github.com/pmodels/mpich/issues/4300
             # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556
             configure.fflags-append -fallow-argument-mismatch
+            configure.fcflags-append -fallow-argument-mismatch
         }
 
         # GCC C++ always uses libstdc++
@@ -407,12 +409,13 @@ if {${subport_enabled}} {
         [variant_isset gcc6] ||
         [variant_isset gcc7] ||
         [variant_isset gcc8] ||
-        [variant_isset gcc9] } {
+        [variant_isset gcc9] ||
+        [variant_isset gcc10] } {
         set msg "
 ----------------------------------------
-NOTE: Default fortran changed to +gcc10; consider switching variants to enable\
+NOTE: Default fortran changed to +gcc11; consider switching variants to enable\
 pre-built packages for ${subport} by running:
-  sudo port clean ${subport} && sudo port upgrade ${subport} +gcc10 -[gcc_variant_name]
+  sudo port clean ${subport} && sudo port upgrade ${subport} +gcc11 -[gcc_variant_name]
 "
         notes-append    ${msg}
         unset msg


### PR DESCRIPTION
Maintainer update.

See also https://github.com/macports/macports-ports/pull/14348

@mascguy 