### PR TITLE
Colima: Update to v0.3.4

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.3.2 v
+go.setup            github.com/abiosoft/colima 0.3.4 v
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  9f09adf2c4c6e1856d65b63ad3d77f00ac210e8b \
-                        sha256  fe7f46e6fc8bba003a7cb425f92c6a93c9744b46382eb4b08037725552915490 \
-                        size    537489
+                        rmd160  a645b75c552ea87711ab2a1665007f667916422b \
+                        sha256  4881ab13af183e83b49b6f4a58d404a7bb226d2c9d2ecf4cbfe3da4782c33e63 \
+                        size    538574
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    496545a6307b \


### PR DESCRIPTION
#### Description
Updated using `go2port`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3 21E230 arm64
Xcode 13.3 13E113


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
