### PR TITLE
Fix libtapi for PowerPC and bump MoarVM/nqp/rakudo versions

### DIFF
--- a/devel/libtapi/Portfile
+++ b/devel/libtapi/Portfile
@@ -102,6 +102,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 # add support for PPC architectures
 patchfiles-append       patch-0004-tapi-add-PPC-support.diff
 
+platform darwin powerpc {
+	# fix a bug in Lexer.cpp, see https://systems.nic.uoregon.edu/internal-wiki/index.php?title=Tau_clang_plugin
+	patchfiles-append	patch-lexer.diff
+}
+
 # add a missing strnlen definition if needed
 patchfiles-append       patch-0006-strnlen.diff
 

--- a/devel/libtapi/files/patch-lexer.diff
+++ b/devel/libtapi/files/patch-lexer.diff
@@ -1,0 +1,11 @@
+--- src/llvm/projects/clang/lib/Lex/Lexer.cpp.orig	2020-12-19 14:12:05.000000000 +0800
++++ src/llvm/projects/clang/lib/Lex/Lexer.cpp	2022-03-21 21:05:18.000000000 +0800
+@@ -2573,7 +2573,7 @@
+         '/', '/', '/', '/',  '/', '/', '/', '/'
+       };
+       while (CurPtr+16 <= BufferEnd &&
+-             !vec_any_eq(*(const vector unsigned char*)CurPtr, Slashes))
++             !vec_any_eq(*(const __vector unsigned char*)CurPtr, Slashes))
+         CurPtr += 16;
+ #else
+       // Scan for '/' quickly.  Many block comments are very large.

--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -53,6 +53,11 @@ platform darwin 8 {
     patchfiles-append patch-build-setup-tiger.diff
 }
 
+if {${os.platform} eq "darwin" && ${os.major} >= 10} {
+    configure.args-append \
+                    --no-mimalloc
+}
+
 # https://github.com/MoarVM/MoarVM/issues/414
 universal_variant   no
 # Unsupported by Configure.pl

--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -9,8 +9,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                MoarVM
-version             2021.07
-revision            1
+version             2022.02
+revision            0
 categories          lang devel
 platforms           darwin
 license             Artistic-2 MIT BSD ISC public-domain
@@ -21,9 +21,9 @@ long_description    MoarVM is a virtual machine built especially for \
 homepage            https://moarvm.org/
 master_sites        https://moarvm.org/releases/
 
-checksums           rmd160  fab74335e4c4ab7c35d687030ed167a3f3817834 \
-                    sha256  8437ceefa5c132d0cf8328b22604e26f0a2a54c0377538aa9ae4bdfcf66d63fe \
-                    size    5451296
+checksums           rmd160  e0cb196e59ceb09bae3a9d68b4b6d463173d93ce \
+                    sha256  4f93cdce6b8a565a32282bb38cc971cefeb71f5d022c850c338ee8145574ee96 \
+                    size    14640429
 
 depends_build       port:perl5 \
                     port:pkgconfig

--- a/lang/nqp/Portfile
+++ b/lang/nqp/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Raku nqp 2021.07
+github.setup        Raku nqp 2022.02
+revision            0
 description         A lightweight Perl-6 like language for virtual machines
 long_description    This is "Not Quite Perl" -- a lightweight Perl 6-like \
                     environment for virtual machines.  The key feature of \
@@ -21,9 +22,9 @@ platforms           darwin
 github.tarball_from \
                     releases
 
-checksums           rmd160  ed6a00f94b484cefb98a810c5bbdb3f5f0115ad8 \
-                    sha256  dcaaf2a43ab3b752be6f4147a88abdc5b897e5ba85e536a0282bde8e4d363ea4 \
-                    size    5207096
+checksums           rmd160  ca8fb8c19fc22fa2a182f526f7e63b12515a569e \
+                    sha256  25d3c99745cd84f4049a9bd9cf26bb5dc817925abaafe71c9bdb68841cdb18b1 \
+                    size    5220819
 
 depends_build       port:perl5
 

--- a/lang/rakudo/Portfile
+++ b/lang/rakudo/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rakudo rakudo 2021.07
+github.setup        rakudo rakudo 2022.02
+revision            0
 description         Perl6 compiler
 long_description    Rakudo is a compiler for the Perl 6 language (version 6.d) \
                     Rakudo is built using NQP (Not Quite Perl 6), which in \
@@ -19,9 +20,9 @@ homepage            https://rakudo.org/
 github.tarball_from \
                     releases
 
-checksums           rmd160  a36c9b7867be8c4d35d9eabcd1fca535695fb4a5 \
-                    sha256  178afe4dc8b2f32e155eb2f8482e1125409edfd8451c39d33a472047047fab52 \
-                    size    7728968
+checksums           rmd160  a6de8c82f087403fa56886016f87d4228093e8f5 \
+                    sha256  6a6e9dbcc6d9a1610a34c6ec67e2d3f694d7b33e9e0a0f224543089fa7f71332 \
+                    size    6140289
 
 depends_build       port:perl5
 


### PR DESCRIPTION
#### Description

A fix for Darwin PowerPC.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->

- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL (https://trac.macports.org/ticket/64187)
