### PR TITLE
MoarVM: fix build on 10.8 and earlier

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -39,6 +39,8 @@ depends_lib         port:dyncall \
                     port:libuv
 #                   port:libtommath
 
+patchfiles          patch-Configure.diff
+
 # https://trac.macports.org/ticket/53950
 compiler.blacklist  cc gcc-* apple-gcc-* llvm-gcc-*
 if {${os.platform} eq "darwin" && ${os.arch} eq "powerpc"} {

--- a/lang/MoarVM/files/patch-Configure.diff
+++ b/lang/MoarVM/files/patch-Configure.diff
@@ -1,0 +1,23 @@
+Configuring with a mix of GNU and non-GNU tools seems to work just fine.
+
+See: https://github.com/MoarVM/MoarVM/issues/1149
+
+--- Configure.pl.orig
++++ Configure.pl
+@@ -192,14 +192,14 @@
+     if ($gnu_toolchain && $gnu_count != scalar @check_tools) {
+         print "\nNot all tools in the toolchain are GNU. Please correct this and retry.\n"
+             . "See README.markdown for more details.\n\n";
+-        exit -1;
++#       exit -1;
+     }
+ 
+     ## Otherwise, make sure that none of them are GNU
+     elsif (!$gnu_toolchain && $gnu_count != 0) {
+         print "\nGNU tools detected, despite this not being a GNU-oriented build.\n"
+             ." Please correct this and retry. See README.markdown for more details.\n\n";
+-        exit -1;
++#       exit -1;
+     }
+ }
+ 


### PR DESCRIPTION
#### Description

Attempt to fix failing build bots, e.g. https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/83899

Tested locally through configure on an unaffected system.

See: https://github.com/MoarVM/MoarVM/issues/1149
Closes: https://trac.macports.org/ticket/64587

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
