### PR TITLE
unshield: fix run-time issue on PowerPC

### DIFF
--- a/archivers/unshield/Portfile
+++ b/archivers/unshield/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           openssl 1.0
 
 github.setup        twogood unshield 1.5.1
-revision            0
+revision            1
 github.tarball_from archive
 
 categories          archivers compression sysutils
@@ -27,6 +27,11 @@ checksums           sha256  34cd97ff1e6f764436d71676e3d6842dc7bd8e2dd5014068da5c
                     size    67454
 
 configure.ldflags-append -liconv
+
+# https://github.com/twogood/unshield/issues/139
+platform powerpc {
+    configure.cflags-append -DWORDS_BIGENDIAN=1
+}
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

`unshield` is unusable on PowerPC due to a byte-swap issue. Fix tested locally on 10.4.11.

See: https://github.com/twogood/unshield/issues/139

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.4.11
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
