### PR TITLE
KeePassXC: fix compilation on macos < 10.11

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -33,7 +33,7 @@ license_noconflict      openssl
 if {${subport} eq ${name}} {
     # stable
     github.setup        keepassxreboot keepassxc 2.7.0
-    revision            0
+    revision            1
     github.tarball_from releases
     distname            keepassxc-${version}-src
     use_xz              yes
@@ -103,6 +103,7 @@ depends_lib-append      port:argon2 \
 
 patchfiles              patch-no-deployqt.diff \
                         patch-no-findpackage-path.diff \
+                        patch-qt56-qoverload.diff \
                         patch-touch-id.diff
 
 # KeePassXC uses -fstack-protector-strong on Clang [1]. That flag is not
@@ -129,6 +130,12 @@ configure.pre_args-append \
     -DWITH_XC_UPDATECHECK=OFF \
     -DWITH_XC_DOCS=OFF
 
+# In the future the Touch ID feature may require Darwin 17 (10.13)
+# https://github.com/keepassxreboot/keepassxc/issues/2484
+if {${os.major} < 16} {
+    configure.pre_args-append   -DWITH_XC_TOUCHID=OFF
+}
+
 # QTest::addRow was introduced in Qt 5.9
 # Don't build tests in that case
 if {[vercmp ${qt5.version} 5.9] < 0} {
@@ -136,16 +143,21 @@ if {[vercmp ${qt5.version} 5.9] < 0} {
 }
 
 post-destroot {
-    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    set kp_doc_path ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d ${kp_doc_path}
     xinstall -W ${worksrcpath} COPYING LICENSE.BSD LICENSE.CC0 \
              LICENSE.GPL-2 LICENSE.GPL-3 LICENSE.LGPL-2.1 LICENSE.LGPL-3 \
              LICENSE.MIT LICENSE.NOKIA-LGPL-EXCEPTION LICENSE.OFL \
-             ${destroot}${prefix}/share/doc/${name}
+             ${kp_doc_path}
 
-    ln -s ${applications_dir}/KeePassXC.app/Contents/MacOS/keepassxc-cli \
-        ${destroot}${prefix}/bin/keepassxc-cli
-    ln -s ${applications_dir}/KeePassXC.app/Contents/MacOS/keepassxc-proxy \
-        ${destroot}${prefix}/bin/keepassxc-proxy
+    set kp_app_path ${applications_dir}/KeePassXC.app/Contents/MacOS
+    set kp_bin_path ${destroot}${prefix}/bin
+
+    ln -s ${kp_app_path}/keepassxc-cli \
+        ${kp_bin_path}/keepassxc-cli
+    ln -s ${kp_app_path}/keepassxc-proxy \
+        ${kp_bin_path}/keepassxc-proxy
 }
 
 test.run        yes

--- a/security/KeePassXC/files/patch-qt56-qoverload.diff
+++ b/security/KeePassXC/files/patch-qt56-qoverload.diff
@@ -1,0 +1,26 @@
+commit f7391d904999138158d9bca9e7c34ef18550e2fe
+Author: tenzap <fabstz-it@yahoo.fr>
+Date:   Sat Mar 26 11:23:32 2022 +0100
+
+    fix compilation of TagsEdit.cpp
+    
+    qOverload appeared with qt5.7
+    
+    Reported error:
+    keepassxc-2.7.0-src/src/gui/tag/TagsEdit.cpp:414:34: error: use of undeclared identifier 'qOverload'
+            connect(completer.get(), qOverload<QString const&>(&QCompleter::activated), [this](QString const& text) {
+                                     ^
+
+diff --git a/src/gui/tag/TagsEdit.cpp b/src/gui/tag/TagsEdit.cpp
+index b4bfb7f..a347940 100644
+--- src/gui/tag/TagsEdit.cpp
++++ src/gui/tag/TagsEdit.cpp
+@@ -411,7 +411,7 @@ struct TagsEdit::Impl
+     void setupCompleter()
+     {
+         completer->setWidget(ifce);
+-        connect(completer.get(), qOverload<QString const&>(&QCompleter::activated), [this](QString const& text) {
++        connect(completer.get(), static_cast<void (QCompleter::*)(QString const&)>(&QCompleter::activated), [this](QString const& text) {
+             currentText(text);
+         });
+     }

--- a/security/KeePassXC/files/patch-touch-id.diff
+++ b/security/KeePassXC/files/patch-touch-id.diff
@@ -1,43 +1,189 @@
+commit 1e927a3ae50211f9bcff54858d04fc4474bfe13d
+Author: tenzap <fabstz-it@yahoo.fr>
+Date:   Sat Mar 26 10:44:33 2022 +0100
+
+    restore WITH_XC_TOUCHID configure option
+    
+    To be able to compile on macOS versions that don't support TouchID and related APIs
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index baa399d..a685ff0 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -59,6 +59,9 @@ option(WITH_XC_UPDATECHECK "Include automatic update checks; disable for control
+ if(UNIX AND NOT APPLE)
+     option(WITH_XC_FDOSECRETS "Implement freedesktop.org Secret Storage Spec server side API." OFF)
+ endif()
++if(APPLE)
++    option(WITH_XC_TOUCHID "Include TouchID support for macOS." ON)
++endif()
+ option(WITH_XC_DOCS "Enable building of documentation" ON)
+ 
+ if(WITH_CCACHE)
+@@ -82,6 +85,9 @@ if(WITH_XC_ALL)
+     if(UNIX AND NOT APPLE)
+         set(WITH_XC_FDOSECRETS ON)
+     endif()
++    if(APPLE)
++        set(WITH_XC_TOUCHID ON)
++    endif()
+ endif()
+ 
+ # Prefer WITH_XC_NETWORKING setting over WITH_XC_UPDATECHECK
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 38d162e..d46a163 100644
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -240,6 +240,9 @@ add_feature_info(UpdateCheck WITH_XC_UPDATECHECK "Automatic update checking")
+ if(UNIX AND NOT APPLE)
+     add_feature_info(FdoSecrets WITH_XC_FDOSECRETS "Implement freedesktop.org Secret Storage Spec server side API.")
+ endif()
++if(APPLE)
++    add_feature_info(TouchID WITH_XC_TOUCHID "TouchID integration")
++endif()
+ 
+ add_subdirectory(browser)
+ add_subdirectory(proxy)
+@@ -351,10 +354,13 @@ if(WITH_XC_KEESHARE)
+ endif()
+ 
+ if(APPLE)
+-    target_link_libraries(keepassx_core "-framework Foundation -framework AppKit -framework Carbon -framework Security -framework LocalAuthentication")
++    target_link_libraries(keepassx_core "-framework Foundation -framework AppKit -framework Carbon")
+     if(Qt5MacExtras_FOUND)
+         target_link_libraries(keepassx_core Qt5::MacExtras)
+     endif()
++    if(WITH_XC_TOUCHID)
++        target_link_libraries(keepassx_core "-framework Security -framework LocalAuthentication")
++    endif()
+ endif()
+ if(HAIKU)
+     target_link_libraries(keepassx_core network)
+diff --git a/src/config-keepassx.h.cmake b/src/config-keepassx.h.cmake
+index 6b855c6..da94bba 100644
+--- src/config-keepassx.h.cmake
++++ src/config-keepassx.h.cmake
+@@ -19,6 +19,7 @@
+ #cmakedefine WITH_XC_SSHAGENT
+ #cmakedefine WITH_XC_KEESHARE
+ #cmakedefine WITH_XC_UPDATECHECK
++#cmakedefine WITH_XC_TOUCHID
+ #cmakedefine WITH_XC_FDOSECRETS
+ #cmakedefine WITH_XC_DOCS
+ 
+diff --git a/src/gui/DatabaseOpenWidget.cpp b/src/gui/DatabaseOpenWidget.cpp
+index bfa4af1..2e7ebf4 100644
+--- src/gui/DatabaseOpenWidget.cpp
++++ src/gui/DatabaseOpenWidget.cpp
+@@ -59,7 +59,7 @@ namespace
+         if (isQuickUnlockAvailable()) {
+ #if defined(Q_CC_MSVC)
+             return getWindowsHello()->hasKey(filename);
+-#elif defined(Q_OS_MACOS)
++#elif defined(Q_OS_MACOS) && defined (WITH_XC_TOUCHID)
+             return TouchID::getInstance().containsKey(filename);
+ #endif
+         }
+@@ -279,7 +279,7 @@ void DatabaseOpenWidget::openDatabase()
+ #if defined(Q_CC_MSVC)
+             // Store the password using Windows Hello
+             getWindowsHello()->storeKey(m_filename, keyData);
+-#elif defined(Q_OS_MACOS)
++#elif defined(Q_OS_MACOS) && defined(WITH_XC_TOUCHID)
+             // Store the password using TouchID
+             TouchID::getInstance().storeKey(m_filename, keyData);
+ #endif
+@@ -336,7 +336,7 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::buildDatabaseKey()
+             m_ui->messageWidget->showMessage(tr("Failed to authenticate with Windows Hello"), MessageWidget::Error);
+             return {};
+         }
+-#elif defined(Q_OS_MACOS)
++#elif defined(Q_OS_MACOS) && defined(WITH_XC_TOUCHID)
+         if (!TouchID::getInstance().getKey(m_filename, keyData)) {
+             // Failed to retrieve Quick Unlock data
+             m_ui->messageWidget->showMessage(tr("Failed to authenticate with Touch ID"), MessageWidget::Error);
+@@ -532,7 +532,7 @@ void DatabaseOpenWidget::resetQuickUnlock()
+ {
+ #if defined(Q_CC_MSVC)
+     getWindowsHello()->reset(m_filename);
+-#elif defined(Q_OS_MACOS)
++#elif defined(Q_OS_MACOS) && defined(WITH_XC_TOUCHID)
+     TouchID::getInstance().reset(m_filename);
+ #endif
+     load(m_filename);
+diff --git a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+index 2dae5cb..e5c5cff 100644
+--- src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
++++ src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+@@ -200,7 +200,7 @@ bool DatabaseSettingsWidgetDatabaseKey::save()
+ 
+     m_db->setKey(newKey, true, false, false);
+ 
+-#if defined(Q_OS_MACOS)
++#if defined(Q_OS_MACOS) && defined(WITH_XC_TOUCHID)
+     TouchID::getInstance().reset(m_db->filePath());
+ #elif defined(Q_CC_MSVC)
+     getWindowsHello()->reset(m_db->filePath());
+diff --git a/src/touchid/TouchID.mm b/src/touchid/TouchID.mm
+index 236711e..668a41b 100644
 --- src/touchid/TouchID.mm
 +++ src/touchid/TouchID.mm
-@@ -105,10 +105,12 @@
-                                                     &error);
-     } else {
- #endif
-+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101201
-         sacObject = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
-                                                     kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-                                                     kSecAccessControlTouchIDCurrentSet, // depr: kSecAccessControlBiometryCurrentSet,
-                                                     &error);
-+#endif
- #if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
-     }
- #endif
-@@ -236,6 +238,9 @@
+@@ -1,7 +1,9 @@
+ #define SECURITY_ACCOUNT_PREFIX QString("KeepassXC_TouchID_Keys_")
+ 
+ #include "touchid/TouchID.h"
++#include "config-keepassx.h"
+ 
++#ifdef WITH_XC_TOUCHID
+ #include "crypto/Random.h"
+ #include "crypto/SymmetricCipher.h"
+ #include "crypto/CryptoHash.h"
+@@ -24,6 +26,7 @@ inline QString hash(const QString& value)
+     QByteArray result = CryptoHash::hash(value.toUtf8(), CryptoHash::Sha256).toHex();
+     return QString(result);
+ }
++#endif //defined(WITH_XC_TOUCHID)
+ 
+ /**
+  * Singleton
+@@ -35,6 +38,7 @@ inline QString hash(const QString& value)
+     return instance;
+ }
+ 
++#ifdef WITH_XC_TOUCHID
+ /**
+  * Generates a random AES 256bit key and uses it to encrypt the PasswordKey that
+  * protects the database. The encrypted PasswordKey is kept in memory while the
+@@ -230,12 +234,16 @@ inline QString hash(const QString& value)
+ {
+     return m_encryptedMasterKeys.contains(dbPath);
+ }
++#endif //defined(WITH_XC_TOUCHID)
+ 
+ /**
+  * Dynamic check if TouchID is available on the current machine.
   */
  bool TouchID::isAvailable()
  {
-+#if MAC_OS_X_VERSION_MIN_REQUIRED < 101201
++#ifndef WITH_XC_TOUCHID
 +	return false;
 +#else
      // cache result
      if (this->m_available != TOUCHID_UNDEFINED) {
          return (this->m_available == TOUCHID_AVAILABLE);
-@@ -264,6 +269,7 @@
+@@ -264,8 +272,10 @@ inline QString hash(const QString& value)
          this->m_available = TOUCHID_NOT_AVAILABLE;
          return false;
      }
-+#endif
++#endif //defined(WITH_XC_TOUCHID)
  }
  
++#ifdef WITH_XC_TOUCHID
  typedef enum
-@@ -294,7 +300,9 @@
-             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometricsOrWatch;
-         } else {
- #endif
-+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101201
-             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
-+#endif
- #if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
-         }
- #endif
+ {
+     kTouchIDResultNone,
+@@ -329,3 +339,4 @@ inline QString hash(const QString& value)
+ 
+     this->m_encryptedMasterKeys.remove(databasePath);
+ }
++#endif //defined(WITH_XC_TOUCHID)


### PR DESCRIPTION
Add patch to fix compilation with qt < 5.7 (for macos 10.7)
Update touchid patch to fix compilation on macos < 10.11

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
