### PR TITLE
qt513-qtbase, qt5-qtbase, qt6-qtbase: ignore stderr for SDK version

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -222,7 +222,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtcharts {
@@ -1061,6 +1061,9 @@ foreach {module module_info} [array get modules] {
 
             # and also patch the mkspecs we are going to install as well
             patchfiles-append patch-qmake-dont-hard-code-x86_64-as-the-architecture-when-using-qmake-installed.diff
+
+            # see https://trac.macports.org/ticket/63805#comment:13
+            patchfiles-append patch-sdk-no-stderr.diff
 
             # find the Rez program
             patchfiles-append patch-find_rez.diff

--- a/aqua/qt5/files/patch-sdk-no-stderr.diff
+++ b/aqua/qt5/files/patch-sdk-no-stderr.diff
@@ -1,7 +1,7 @@
 Intentionally ignore stderr (including any benign errors from xcodebuild)
 so that it is not treated as part of the SDK version
 
-Upstream-Status: Pending (would be "Backport" for 5.13 if accepted upstream)
+Upstream-Status: Accepted (https://bugreports.qt.io/browse/QTBUG-102066)
 
 --- mkspecs/features/mac/sdk.mk.orig
 +++ mkspecs/features/mac/sdk.mk

--- a/aqua/qt5/files/patch-sdk-no-stderr.diff
+++ b/aqua/qt5/files/patch-sdk-no-stderr.diff
@@ -1,0 +1,15 @@
+Intentionally ignore stderr (including any benign errors from xcodebuild)
+so that it is not treated as part of the SDK version
+
+Upstream-Status: Pending (would be "Backport" for 5.13 if accepted upstream)
+
+--- mkspecs/features/mac/sdk.mk.orig
++++ mkspecs/features/mac/sdk.mk
+@@ -1,6 +1,6 @@
+ 
+ ifeq ($(QT_MAC_SDK_NO_VERSION_CHECK),)
+-    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>&1
++    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>/dev/null
+     CURRENT_MAC_SDK_VERSION := $(shell DEVELOPER_DIR=$(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) $(CHECK_SDK_COMMAND))
+     ifneq ($(CURRENT_MAC_SDK_VERSION),$(EXPORT_QMAKE_MAC_SDK_VERSION))
+         # We don't want to complain about out of date SDK unless the target needs to be remade.

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -164,7 +164,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 5"
+        "revision 6"
         "License: "
     }
     qtcharts {
@@ -889,6 +889,9 @@ foreach {module module_info} [array get modules] {
             # See e.g. octave
             # See the files mkspecs/features/qt_module.prf and qmake/generators/makefile.cpp
             patchfiles-append patch-pc_files.diff
+
+            # see https://trac.macports.org/ticket/63805#comment:13
+            patchfiles-append patch-sdk-no-stderr.diff
 
             # find the Rez program
             patchfiles-append patch-find_rez.diff

--- a/aqua/qt513/files/patch-sdk-no-stderr.diff
+++ b/aqua/qt513/files/patch-sdk-no-stderr.diff
@@ -1,0 +1,15 @@
+Intentionally ignore stderr (including any benign errors from xcodebuild)
+so that it is not treated as part of the SDK version
+
+Upstream-Status: Pending (would be "Backport" for 5.13 if accepted upstream)
+
+--- mkspecs/features/mac/sdk.mk.orig
++++ mkspecs/features/mac/sdk.mk
+@@ -1,6 +1,6 @@
+ 
+ ifeq ($(QT_MAC_SDK_NO_VERSION_CHECK),)
+-    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>&1
++    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>/dev/null
+     CURRENT_MAC_SDK_VERSION := $(shell DEVELOPER_DIR=$(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) $(CHECK_SDK_COMMAND))
+     ifneq ($(CURRENT_MAC_SDK_VERSION),$(EXPORT_QMAKE_MAC_SDK_VERSION))
+         # We don't want to complain about out of date SDK unless the target needs to be remade.

--- a/aqua/qt513/files/patch-sdk-no-stderr.diff
+++ b/aqua/qt513/files/patch-sdk-no-stderr.diff
@@ -1,7 +1,7 @@
 Intentionally ignore stderr (including any benign errors from xcodebuild)
 so that it is not treated as part of the SDK version
 
-Upstream-Status: Pending (would be "Backport" for 5.13 if accepted upstream)
+Upstream-Status: Backport (https://bugreports.qt.io/browse/QTBUG-102066)
 
 --- mkspecs/features/mac/sdk.mk.orig
 +++ mkspecs/features/mac/sdk.mk

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -152,7 +152,7 @@ array set modules {
          "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtconnectivity {
@@ -581,6 +581,9 @@ foreach {module module_info} [array get modules] {
             }
 
             minimum_developerversions 18 9
+
+            # see https://trac.macports.org/ticket/63805#comment:13
+            patchfiles-append patch-sdk-no-stderr.diff
 
             #-----------------------------------------------------------------------------
             # qtbase is used for:

--- a/aqua/qt6/files/patch-sdk-no-stderr.diff
+++ b/aqua/qt6/files/patch-sdk-no-stderr.diff
@@ -1,7 +1,7 @@
 Intentionally ignore stderr (including any benign errors from xcodebuild)
 so that it is not treated as part of the SDK version
 
-Upstream-Status: Pending (would be "Backport" for 5.13 if accepted upstream)
+Upstream-Status: Accepted (https://bugreports.qt.io/browse/QTBUG-102066)
 
 --- mkspecs/features/mac/sdk.mk.orig
 +++ mkspecs/features/mac/sdk.mk

--- a/aqua/qt6/files/patch-sdk-no-stderr.diff
+++ b/aqua/qt6/files/patch-sdk-no-stderr.diff
@@ -1,0 +1,15 @@
+Intentionally ignore stderr (including any benign errors from xcodebuild)
+so that it is not treated as part of the SDK version
+
+Upstream-Status: Pending (would be "Backport" for 5.13 if accepted upstream)
+
+--- mkspecs/features/mac/sdk.mk.orig
++++ mkspecs/features/mac/sdk.mk
+@@ -1,6 +1,6 @@
+ 
+ ifeq ($(QT_MAC_SDK_NO_VERSION_CHECK),)
+-    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>&1
++    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>/dev/null
+     CURRENT_MAC_SDK_VERSION := $(shell DEVELOPER_DIR=$(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) $(CHECK_SDK_COMMAND))
+     ifneq ($(CURRENT_MAC_SDK_VERSION),$(EXPORT_QMAKE_MAC_SDK_VERSION))
+         # We don't want to complain about out of date SDK unless the target needs to be remade.


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/63805

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3
Xcode 13.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
Full install tested only for qt5-qtbase; only patch phase is tested for qt513-qtbase and qt6-qtbase
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
