### PR TITLE
gobject-introspection: update to 1.72.0

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -8,8 +8,8 @@ name                gobject-introspection
 conflicts           gobject-introspection-devel
 set my_name         gobject-introspection
 
-version             1.70.0
-revision            1
+version             1.72.0
+revision            0
 
 categories          gnome
 platforms           darwin
@@ -28,9 +28,9 @@ dist_subdir         ${my_name}
 distname            ${my_name}-${version}
 use_xz              yes
 
-checksums           rmd160  5d13fba531e1f1d1260722aacb524f1da650302e \
-                    sha256  902b4906e3102d17aa2fcb6dad1c19971c70f2a82a159ddc4a94df73a3cafc4a \
-                    size    1029372
+checksums           rmd160  9a340f9c422a0ee215f543e49553405276f3d760 \
+                    sha256  02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc \
+                    size    1040936
 
 set py_ver          3.10
 set py_ver_nodot    [string map {. {}} ${py_ver}]
@@ -65,6 +65,19 @@ configure.python    ${prefix}/bin/python${py_ver}
 
 configure.args      -Ddoctool=enabled \
                     -Dpython=${configure.python}
+
+# By default, gir will attempt to link programs using
+# the same compiler used to build Python itself. However,
+# the system clang on 10.6 does not appear to respect
+# LIBRARY_PATH, resulting in g-ir-scanner errors such as:
+#
+# ld: library not found for -lgio-2.0
+#
+# The following workaround selects a more up-to-date linker
+# when building this project. Identical logic already exists
+# in the gobject_introspection PortGroup, so dependent projects
+# should not require modification.
+build.env-append    CC=${configure.cc}
 
 platform darwin 8 {
     # Tiger does not support RPATHs at this time


### PR DESCRIPTION
#### Description

Update `gobject-introspection`, and fix a build issue that prevents a large number of ports from being installed on 10.6.

Closes: https://trac.macports.org/ticket/64791
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
