### PR TITLE
mpich: remove obsolete +tuned variant

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -381,9 +381,6 @@ if {${subport_enabled}} {
                                 --with-pm=gforker
     }
 
-    # Renamed to standardaized 'native' name; remove 2022/02
-    variant tuned requires native description {Build with more optimizations} {}
-
     variant native description {Build for local machine} {
         configure.args-replace      --enable-fast=O2 \
                                     --enable-fast=all


### PR DESCRIPTION
Renamed to +native in f1b9be899ccb a year ago

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
