### PR TITLE
openjdk-distributions: move openjdk17-temurin to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -619,37 +619,6 @@ subport openjdk17-sap {
     worksrcdir   sapmachine-jdk-${version}.jdk
 }
 
-subport openjdk17-temurin {
-    # https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
-    supported_archs  x86_64 arm64
-
-    # Java 17 is the first Temurin release with arm64 support
-    supported_archs  x86_64 arm64
-
-    version 17.0.2
-    set build    8
-    revision     0
-
-    description  Eclipse Temurin, based on OpenJDK 17
-    long_description ${long_description_temurin}
-
-    master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${version}%2B${build}/
-
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-        checksums    rmd160  90939e1b687b025674faf1f45b1274fe2e420109 \
-                     sha256  3630e21a571b7180876bf08f85d0aac0bdbb3267b2ae9bd242f4933b21f9be32 \
-                     size    192611208
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-        checksums    rmd160  e4063da6a1139c137af930c8cf5c5988bb75354d \
-                     sha256  157518e999d712b541b883c6c167f8faabbef1d590da9fe7233541b4adb21ea4 \
-                     size    182550014
-    }
-
-    worksrcdir   jdk-${version}+${build}
-}
-
 subport openjdk17-zulu {
     # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
     supported_archs  x86_64 arm64

--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -1,0 +1,92 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk17-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
+supported_archs  x86_64 arm64
+
+version      17.0.2
+set build    8
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK 17
+long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${version}%2B${build}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  90939e1b687b025674faf1f45b1274fe2e420109 \
+                 sha256  3630e21a571b7180876bf08f85d0aac0bdbb3267b2ae9bd242f4933b21f9be32 \
+                 size    192611208
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  e4063da6a1139c137af930c8cf5c5988bb75354d \
+                 sha256  157518e999d712b541b883c6c167f8faabbef1d590da9fe7233541b4adb21ea4 \
+                 size    182550014
+}
+
+worksrcdir   jdk-${version}+${build}
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # See https://adoptium.net/supported_platforms.html
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://adoptium.net
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk17-temurin` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?