### PR TITLE
py-awscli2: update to 2.4.29

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.4.25
+github.setup        aws aws-cli 2.4.29
 revision            0
 
 categories          python devel
@@ -19,13 +19,13 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  b8cc7c3523516a4a0bf0691f925d0ca00863e2b7 \
-                    sha256  9cbfb1f68358fe3107e7d34f4dc2585658d112ffb455ec43d37f8f6271684107 \
-                    size    10284833
+checksums           rmd160  7f8a5fb55335fd499bd331fc31d541da5bd99059 \
+                    sha256  0acf2534d414752046e9c152672ef5845bffad8d3c80fd28e9d016b00948aaf3 \
+                    size    10342790
 
 # This is what Amazon currently supports and there
 # are hard errors with later Pythons right now.
-python.versions     37 38
+python.versions     38 39
 
 if {${name} ne ${subport}} {
     if {${os.platform} eq "darwin" && ${os.major} <= 15} {

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,11 +1,11 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-diff -ru aws-cli-2.4.21-orig/setup.cfg aws-cli-2.4.21/setup.cfg
---- aws-cli-2.4.21-orig/setup.cfg	2022-02-24 16:06:48.000000000 -0500
-+++ aws-cli-2.4.21/setup.cfg	2022-02-24 18:15:19.211941180 -0500
+diff -ru aws-cli-2.4.29-orig/setup.cfg aws-cli-2.4.29/setup.cfg
+--- aws-cli-2.4.29-orig/setup.cfg	2022-03-25 18:15:06.000000000 -0400
++++ aws-cli-2.4.29/setup.cfg	2022-03-27 15:54:42.273186766 -0400
 @@ -28,17 +28,17 @@
- python_requires = >=3.7
+ python_requires = >=3.8
  include_package_data = True
  install_requires =
 -    colorama>=0.2.5,<0.4.4
@@ -15,6 +15,10 @@ diff -ru aws-cli-2.4.21-orig/setup.cfg aws-cli-2.4.21/setup.cfg
 -    wcwidth<0.2.0
 -    prompt-toolkit>=3.0.24,<3.1.0
 -    distro>=1.5.0,<1.6.0
+-    awscrt>=0.12.4,<=0.13.5
+-    python-dateutil>=2.1,<3.0.0
+-    jmespath>=0.7.1,<1.0.0
+-    urllib3>=1.25.4,<1.27
 +    colorama
 +    docutils
 +    cryptography
@@ -22,10 +26,7 @@ diff -ru aws-cli-2.4.21-orig/setup.cfg aws-cli-2.4.21/setup.cfg
 +    wcwidth
 +    prompt-toolkit
 +    distro
-     awscrt==0.12.4
--    python-dateutil>=2.1,<3.0.0
--    jmespath>=0.7.1,<1.0.0
--    urllib3>=1.25.4,<1.27
++    awscrt==0.13.5
 +    python-dateutil
 +    jmespath
 +    urllib3

--- a/python/py-awscrt/Portfile
+++ b/python/py-awscrt/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-awscrt
 # This is only used by awscli2. Bump when Amazon bumps
 # their pinned version in awscli2's setup.cfg.
-version             0.12.4
+version             0.13.5
 revision            0
 
 categories-append   devel
@@ -18,14 +18,10 @@ description         A common runtime for AWS Python projects
 long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
-# The /packages/source/ redirect is not working for older tarballs of awscrt,
-# so when updating this package, you're either removing this line entirely
-# or changing the master_sites
-master_sites        https://files.pythonhosted.org/packages/e3/62/aaf36ad07eb01e36d6a0b5bfe2782ab1b2577e59421b351063e5b2c0a77f
 
-checksums           rmd160  011654ef4d2bc5896ef36d8fb0a0517cd82b9dc2 \
-                    sha256  6ad69336bc5277f501bd7e33f82e11db2665370c7d279496ee39fe2f369baeb2 \
-                    size    18445291
+checksums           rmd160  7623ca588fb06dceb457f9b28cc96889e37ccb86 \
+                    sha256  7543658cc2ac6e5e9e072844622bd681125ccd3070dcdd51565f2bddef3df268 \
+                    size    19890641
 
 python.versions     37 38 39 310
 


### PR DESCRIPTION
#### Description

Amazon bumped their dependency on py-awscrt so that is bumped as well. They also ditched Python 3.7 support and declared Python 3.9 support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1715 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
