### PR TITLE
weechat: update to 3.5

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             3.4.1
+version             3.5
 revision            0
-checksums           rmd160  e4eed9dd4ee8e0d61c7ab59a6dbd1d397c279402 \
-                    sha256  7e088109ad5dfbcb08a9a6b1dd70ea8236093fed8a13ee9d9c98881d7b1aeae7 \
-                    size    2617856
+checksums           rmd160  726a83435e4678a8ee9059c24ad5b598227146ea \
+                    sha256  ea904e4cec8edd0bd24f3ea17f6d6dff97ca00ee0571ee972e79e54c8c08170c \
+                    size    2693072
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 3.5

###### Tested on
macOS 12.2.1 21D62 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?