### PR TITLE
py-nbconvert: update to 6.4.5

### DIFF
--- a/python/py-nbconvert/Portfile
+++ b/python/py-nbconvert/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-nbconvert
-version             6.1.0
+version             6.4.5
 revision            0
 categories-append   textproc
 platforms           darwin
@@ -20,9 +20,9 @@ long_description    ${description}
 
 homepage            https://jupyter.org/
 
-checksums           rmd160  ca9ecf38764b340e42085b9cd8c0853b64af71d3 \
-                    sha256  d22a8ff202644d31db254d24d52c3a96c82156623fcd7c7f987bba2612303ec9 \
-                    size    894596
+checksums           rmd160  bd733a46ffb2f0558913f158e51d3f9853bc0c8d \
+                    sha256  21163a8e2073c07109ca8f398836e45efdba2aacea68d6f75a8a545fef070d4e \
+                    size    906309
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \
@@ -38,7 +38,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-pandocfilters \
                         port:py${python.version}-testpath \
                         port:py${python.version}-defusedxml \
-                        port:py${python.version}-nbclient
+                        port:py${python.version}-nbclient \
+                        port:py${python.version}-beautifulsoup4
 
     if {${python.version} eq 27} {
         version             5.5.0


### PR DESCRIPTION
#### Description
Update py-nbconvert to 6.4.5 (solves https://trac.macports.org/ticket/64901).

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
