### PR TITLE
gnutar: fix man/info pages

### DIFF
--- a/archivers/gnutar/Portfile
+++ b/archivers/gnutar/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                gnutar
 version             1.34
-revision            1
+revision            2
 
 categories          archivers
 maintainers         nomaintainer
@@ -45,6 +45,8 @@ post-destroot {
         ChangeLog.1 INSTALL NEWS README THANKS TODO \
         ${destroot}${prefix}/share/doc/${name}
     foreach f [glob ${destroot}${prefix}/share/info/tar.info*] {
+        reinplace "s|(tar)|(gnutar)|g" $f
+        reinplace -E "s/\[\[:<:\]\]tar\\.info\[\[:>:\]\]/gnutar.info/g" $f
         move ${f} [string map {tar.info gnutar.info} ${f}]
     }
 
@@ -53,7 +55,7 @@ post-destroot {
     ln -sf ${prefix}/bin/gnutar ${destroot}${prefix}/bin/gtar
 
     xinstall -m 0755 -d ${destroot}${prefix}/libexec/gnubin/man/man1
-    system "help2man ${worksrcpath}/src/tar | gzip -9 > ${destroot}${prefix}/libexec/gnubin/man/man1/tar.1.gz"
+    ln -sf ${prefix}/share/man/man1/gnutar.1.gz ${destroot}${prefix}/libexec/gnubin/man/man1/tar.1.gz
 }
 
 livecheck.type      regex


### PR DESCRIPTION
* Man: Put into libexec/gnubin a symlink to normal man page, instead
of generating another one with help2man.
* Info: Fix file name in *.info files.

Closes: https://trac.macports.org/ticket/64872

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.1 20G224 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
