### PR TITLE
vlang: new port

### DIFF
--- a/lang/vlang/Portfile
+++ b/lang/vlang/Portfile
@@ -1,0 +1,103 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        vlang v 0.2.4
+name                vlang
+github.tarball_from archive
+revision            0
+
+description         Simple, fast, safe, compiled language for developing maintainable software
+long_description    {*}${description}. Compiles itself in <1s with zero library dependencies.
+
+license             MIT
+categories          lang
+maintainers         {harens @harens} openmaintainer
+
+set main_distfile   ${distfiles}
+
+# Install the compiler for vlang as a separate distfile.
+# Based on https://github.com/macports/macports-ports/blob/master/games/minetest/Portfile
+set vc_commit       fd5f57740ff6d7a8566b774318df54c2fa460f92
+set vc_distfile     ${vc_commit}${extract.suffix}
+set vc_mastersite   https://github.com/vlang/vc/archive
+
+distfiles           ${main_distfile}:main \
+                    ${vc_distfile}:vc
+
+master_sites        ${github.master_sites}:main \
+                    ${vc_mastersite}:vc
+
+checksums           ${main_distfile} \
+                    rmd160  36c9549425ebec8cd11fc22617e1453fd618053c \
+                    sha256  8cdbc32fb928051ce7959dd943af3efee26bddc4ed3700a1cb365be73a306bf9 \
+                    size    3502493 \
+                    ${vc_distfile} \
+                    rmd160  abb6cba7c973bae25328b3faefa77075967aec00 \
+                    sha256  f6896513cec7e065ae438fd098b8b13c08ee73eb3915578f703116ce98f72b3a \
+                    size    1284143
+
+compiler.c_standard 2011
+use_configure       no
+
+build {
+    # Disable vlang self update feature.
+    copy -force ${filespath}/vup.v ${worksrcpath}/cmd/tools
+
+    system -W ${worksrcpath} "${configure.cc} ${configure.cflags} -v -o v ../vc-${vc_commit}/v.c -lm ${configure.ldflags}"
+    system -W ${worksrcpath} "./v -cflags ${configure.cflags} -cc ${configure.cc} -prod self"
+}
+
+destroot {
+    set library_path ${destroot}${prefix}/lib/${name}
+    set examples_path ${destroot}${prefix}/share/examples
+
+    xinstall -d ${examples_path}
+    move ${worksrcpath}/examples ${examples_path}/${name}
+
+    xinstall -d ${library_path}
+    foreach f {cmd thirdparty v v.mod vlib} {
+        move ${worksrcpath}/${f} ${library_path}/${f}
+    }
+
+    ln -s ${prefix}/lib/${name}/v ${destroot}${prefix}/bin
+
+    # Vlang compiles the subcommands in the tools dir on first runtime usage (e.g. v doctor).
+    # Allow running Vlang to those in the _developer group, rather than running sudo each time.
+    # See https://github.com/vlang/v/issues/10324
+
+    system "
+        chgrp -R _developer ${library_path}/cmd/tools;
+        chmod -R g+w ${library_path}/cmd/tools;
+    "
+}
+
+# If /tmp/v exists, build fails if it isn't writable. Also fails at runtime if it isn't writable.
+# Assume MacPorts creates /tmp/v, and so make it writable to the _developer group
+# See https://github.com/vlang/v/issues/7713 and https://github.com/vlang/v/discussions/11796
+post-activate {
+    if {![file exists /tmp/v]} {
+        file mkdir /tmp/v
+    }
+    system "
+        chgrp -R _developer /tmp/v;
+        chmod -R g+w /tmp/v;
+    "
+}
+
+# Based on various Android ports - don't make files world-writable.
+# e.g. https://github.com/macports/macports-ports/blob/master/java/android/Portfile
+notes "
+The Vlang tools and cache directory are group _developer writable. You need to be a member of the
+_developer group to use Vlang. If you are not, run:
+
+sudo dscl . append /Groups/_developer GroupMembership <username>
+"
+
+# GitHub releases and tags are filled up with weekly releases
+# Stable release is many pages later, so MacPorts can't find it.
+# Fetch directly from version file.
+livecheck.url       https://raw.githubusercontent.com/vlang/v/master/v.mod
+# Ignore dots just by themselves - and remove apostraphes from version number
+livecheck.regex {([0-9]+.[0-9.]+)}

--- a/lang/vlang/files/vup.v
+++ b/lang/vlang/files/vup.v
@@ -1,0 +1,4 @@
+fn main(){
+   println('This v installation is provided by MacPorts. To update, please run:')
+   println('sudo port selfupdate && sudo port upgrade vlang')
+}


### PR DESCRIPTION
#### Description

A port for the [V Programming Language](https://vlang.io/).

The main complexities were the following:

- The compiler for V has to itself be built. This is fetched from [here](https://github.com/vlang/vc) as a separate distfile.
- Vlang won't run [unless its `tools` directory has write permission](https://github.com/vlang/v/issues/10324). This is since it compiles the subcommands locally during runtime. To get around this, rather than running everything with sudo, the user can add themselves to the `_developer` group.
- `/tmp/v` also needs to be writable during runtime. As well as this, if the directory already exists during buildtime (e.g. upgrading the port from source), [the build will fail](https://github.com/vlang/v/issues/7713) if Vlang can't write to it. The same process as above was carried out to fix this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.2.1 21D62 arm64
Command Line Tools 21D62

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
