### PR TITLE
openjdk-distributions: move openjdk17-zulu to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -22,9 +22,6 @@ set long_description_ibm_semeru \
     "The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications built with\
 the OpenJDK class libraries and the Eclipse OpenJ9 JVM."
 
-set long_description_oracle \
-    "Open-source Oracle builds of OpenJDK, the Java Development Kit, an implementation of the Java SE Platform."
-
 set long_description_sap \
     "Sap builds of openjdk for everyone who wish to use OpenJDK to run their applications."
 
@@ -515,35 +512,6 @@ subport openjdk17-sap {
                      size    177867623
     }
     worksrcdir   sapmachine-jdk-${version}.jdk
-}
-
-subport openjdk17-zulu {
-    # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
-    supported_archs  x86_64 arm64
-
-    version      17.32.13
-    revision     0
-
-    set openjdk_version 17.0.2
-
-    description  Azul Zulu Community OpenJDK 17 (Long Term Support)
-    long_description ${long_description_zulu}
-
-    master_sites https://cdn.azul.com/zulu/bin/
-
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  3eced1f7701de4306f1fa24bc204cc56679afb03 \
-                     sha256  89d04b2d99b05dcb25114178e65f6a1c5ca742e125cab0a63d87e7e42f3fcb80 \
-                     size    193143505
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  ec8b93727a88ab77a692aac411a7cb63ce0ff709 \
-                     sha256  54247dde248ffbcd3c048675504b1c503b81daf2dc0d64a79e353c48d383c977 \
-                     size    190938303
-    }
-
-    worksrcdir   ${distname}/zulu-17.jdk
 }
 
 if {${os.platform} eq "darwin"} {

--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -1,0 +1,102 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk17-zulu
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
+supported_archs  x86_64 arm64
+
+version      17.32.13
+revision     0
+
+set openjdk_version 17.0.2
+
+description  Azul Zulu Community OpenJDK 17 (Long Term Support)
+long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
+                 specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
+                 verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
+                 respective Java SE version.
+
+master_sites https://cdn.azul.com/zulu/bin/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    checksums    rmd160  3eced1f7701de4306f1fa24bc204cc56679afb03 \
+                 sha256  89d04b2d99b05dcb25114178e65f6a1c5ca742e125cab0a63d87e7e42f3fcb80 \
+                 size    193143505
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+    checksums    rmd160  ec8b93727a88ab77a692aac411a7cb63ce0ff709 \
+                 sha256  54247dde248ffbcd3c048675504b1c503b81daf2dc0d64a79e353c48d383c977 \
+                 size    190938303
+}
+
+worksrcdir   ${distname}/zulu-17.jdk
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 18} {
+    # See https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.14 Mojave or later."
+        return -code error
+    }
+}
+
+homepage     https://www.azul.com/downloads/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk17-zulu` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?