### PR TITLE
kustomize: update to 4.5.4

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.5.3 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.5.4 kustomize/v
 revision            0
 
 categories          devel
@@ -23,9 +23,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  eaedd6f48d4d178493f68b525ec02d923248361d \
-                    sha256  4be155c98ac220a6a0f7964ba42002e7a7884be494d723d4670238e28e49d461 \
-                    size    4710696
+checksums           rmd160  a6dcc22c9941ede08d3fe42b4a05e0316ac3c1d6 \
+                    sha256  7fbf59db6880a1c088cd394668078c48c3949d31331b0821001833170d8eae1f \
+                    size    4711002
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 4.5.4.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?