### PR TITLE
google-cloud-sdk: update to 379.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             378.0.0
+version             379.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1c0a1c86852ad1efc3a099b223ba9980fb9e949b \
-                    sha256  5e804acfb02026226a0e5cc2483f5eb733bb710de16bdadd8acfc464d5814d03 \
-                    size    105809605
+    checksums       rmd160  68673b87817cb8e5a518bab2aa94f08dcc4c22a0 \
+                    sha256  a74d0e1eee0a9dfae03b692c775a415078a1a1b05bda18a740f23494b61c83f6 \
+                    size    105872255
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  18babe08fe4b48e65e4e0418297215569659d8ed \
-                    sha256  5949aa0b842b5abe39b6bfed9f532cd261fa6a9b4ad7cd7ebece936250ae34a7 \
-                    size    101029320
+    checksums       rmd160  d94868e9cdd341cee81b2309e84a2b35b5c7f035 \
+                    sha256  ca39f8cd97ba1c5410787dd29e3774f53fc6192296b67ea40d5b668e491c5368 \
+                    size    101108499
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  b6dafb668be4294422dd9efcc7b75f53350951ab \
-                    sha256  09fab992c586dbac778a8031fa6f8983b453e979d168df92bca6ecb0d2d75034 \
-                    size    100510098
+    checksums       rmd160  8ec46bd539ebc16b8627ddd98c49e88b595ad9e0 \
+                    sha256  0b68fa93df82558315bb258de9582d8d506139cacf5cb2fdc1449de1b9fea9ef \
+                    size    100582033
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 379.0.0.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?