### PR TITLE
qt5-qtwebengine-gn: add livecheck

### DIFF
--- a/devel/gn-devel/Portfile
+++ b/devel/gn-devel/Portfile
@@ -14,7 +14,8 @@ long_description    GN is a meta-build system that generates build files for Nin
 homepage            https://gn.googlesource.com/gn
 
 subport qt5-qtwebengine-gn {
-    version         20201210
+    set hyphen_version 2020-12-10
+    version         [string map {"-" ""} ${hyphen_version}]
     revision        0
     description     {*}${description} (for building qtwebengine)
     long_description {*}${long_description} This port is for building qt5-qtwebengine \
@@ -104,6 +105,11 @@ if {${subport} eq ${name}} {
     # (reported: https://bugreports.qt.io/browse/QTBUG-99682), as well as dependency on googletest
     # Does not affect building qt5-qtwebengine
     test.run        no
+
+    livecheck.type  regex
+    livecheck.url   https://github.com/qt/qtwebengine-chromium/commits/87-based/gn
+    livecheck.version ${hyphen_version}
+    livecheck.regex {<relative-time\s+datetime="(\d{4}-\d{2}-\d{2})T\d{2}:\d{2}:\d{2}Z"}
 }
 
 set python_branch   3.10


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.15.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
