### PR TITLE
openjdk-distributions: move openjdk17-corretto to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -441,34 +441,6 @@ subport openjdk16-zulu {
     replaced_by  openjdk17-zulu
 }
 
-subport openjdk17-corretto {
-    # https://github.com/corretto/corretto-17/releases
-    supported_archs  x86_64 arm64
-
-    version      17.0.2.8.1
-    revision     0
-
-    description  Amazon Corretto OpenJDK 17 (Long Term Support)
-    long_description ${long_description_corretto}
-
-    master_sites https://corretto.aws/downloads/resources/${version}/
-
-    distname     amazon-corretto-${version}-macosx-x64
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     amazon-corretto-${version}-macosx-x64
-        checksums    rmd160  8a622fe2c8dd5eba07330804d7b98c3b67b5ee78 \
-                     sha256  eec3acc2d1d303ef23c79ed45a8374002e34c14e34ba0fa931e98cbf6b963345 \
-                     size    187776090
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     amazon-corretto-${version}-macosx-aarch64
-        checksums    rmd160  e5eb0341468193a223ec927abade6f151831da06 \
-                     sha256  b6d3c359bd31a3c1697fe386c927e139bd72572e72cdc12a08b5e1144fe35438 \
-                     size    185518346
-    }
-
-    worksrcdir   amazon-corretto-17.jdk
-}
-
 subport openjdk17-graalvm {
     # https://github.com/graalvm/graalvm-ce-builds/releases
     supported_archs  x86_64

--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -1,0 +1,97 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk18-corretto
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://github.com/corretto/corretto-17/releases
+supported_archs  x86_64 arm64
+
+version      17.0.2.8.1
+revision     0
+
+description  Amazon Corretto OpenJDK 17 (Long Term Support)
+long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
+
+master_sites https://corretto.aws/downloads/resources/${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     amazon-corretto-${version}-macosx-x64
+    checksums    rmd160  8a622fe2c8dd5eba07330804d7b98c3b67b5ee78 \
+                 sha256  eec3acc2d1d303ef23c79ed45a8374002e34c14e34ba0fa931e98cbf6b963345 \
+                 size    187776090
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     amazon-corretto-${version}-macosx-aarch64
+    checksums    rmd160  e5eb0341468193a223ec927abade6f151831da06 \
+                 sha256  b6d3c359bd31a3c1697fe386c927e139bd72572e72cdc12a08b5e1144fe35438 \
+                 size    185518346
+}
+
+worksrcdir   amazon-corretto-17.jdk
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    # See https://github.com/corretto/corretto-18/blob/release-18.0.0.37.1/CHANGELOG.md
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.13 High Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://aws.amazon.com/corretto/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk17-corretto` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?