### PR TITLE
skaffold: update to 1.37.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.37.0 v
+github.setup        GoogleContainerTools skaffold 1.37.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  b62be1c496bbf254db1637a6a3d2a5a48a2b606b \
-                    sha256  a97a6f6cbf571f342183e5cf65c30932ade282b182fc92f108cb2a160a46779b \
-                    size    21624772
+checksums           rmd160  388eb0265f0d3bc0610b69ea2b723e3665e86f6e \
+                    sha256  8dfea015256761525d8c0e54713642bcd7ead3e3c96ff58e301d0b77b9ef3bd5 \
+                    size    21624610
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.37.1.

###### Tested on

macOS 12.3 21E230 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?