### PR TITLE
qt6-qtbase: allow building with macOS 10.14 SDK

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -492,13 +492,6 @@ if { ${os.major} < 18 } {
         ui_error "${subport} requires macOS 10.14 or later"
         return -code error "incompatible OS version"
     }
-} elseif { ${os.major} == 18 } {
-    # https://trac.macports.org/ticket/64345
-    known_fail  yes
-    pre-fetch {
-        ui_error "${subport} is currently broken on macOS 10.14, see https://trac.macports.org/ticket/64345"
-        return -code error "incompatible OS version"
-    }
 }
 
 foreach {module module_info} [array get modules] {
@@ -584,6 +577,10 @@ foreach {module module_info} [array get modules] {
 
             # see https://trac.macports.org/ticket/63805#comment:13
             patchfiles-append patch-sdk-no-stderr.diff
+
+            # Allow building with macOS 10.14 SDK
+            # see https://trac.macports.org/ticket/64345
+            patchfiles-append patch-macos-10.14-sdk.diff
 
             #-----------------------------------------------------------------------------
             # qtbase is used for:

--- a/aqua/qt6/files/patch-macos-10.14-sdk.diff
+++ b/aqua/qt6/files/patch-macos-10.14-sdk.diff
@@ -1,0 +1,16 @@
+Allow building with macOS 10.14 SDK (will still warn about
+"Instance method '-charactersByApplyingModifiers' unknown")
+
+Upstream-Status: Inappropriate [violates DRY]
+
+--- src/gui/platform/darwin/qapplekeymapper.mm.orig
++++ src/gui/platform/darwin/qapplekeymapper.mm
+@@ -528,7 +528,7 @@
+                 // we first run the event through the Carbon APIs and then
+                 // compare the results to Cocoa.
+                 auto cocoaModifiers = toCocoaModifiers(qtModifiers);
+-                auto *charactersWithModifiers = [NSApp.currentEvent charactersByApplyingModifiers:cocoaModifiers];
++                NSString *charactersWithModifiers = [NSApp.currentEvent charactersByApplyingModifiers:cocoaModifiers];
+ 
+                 QChar cocoaUnicodeKey;
+                 if (charactersWithModifiers.length > 0)


### PR DESCRIPTION
[skip ci]

Fixes: https://trac.macports.org/ticket/64345

#### Description
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
**Only patch phase is tested**; could someone with access to 10.14 please check if the port now builds, or if it now encounters other errors?

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
