### PR TITLE
libzdb, libzdb-mysql5: remove obsolete subports

### DIFF
--- a/databases/libzdb-mysql55/Portfile
+++ b/databases/libzdb-mysql55/Portfile
@@ -154,18 +154,6 @@ subport libzdb-sqlite3 {
                         --datarootdir=${prefix}/share/${subport}
 }
 
-subport libzdb {
-
-    replaced_by         libzdb-mysql56
-    PortGroup           obsolete 1.0
-}
-
-subport libzdb-mysql5 {
-
-    replaced_by         libzdb-mysql56
-    PortGroup           obsolete 1.0
-}
-
 post-destroot {
 
     xinstall -d ${destroot}${prefix}/share/${subport}/doc


### PR DESCRIPTION
libzdb renamed to libzdb-mysql55 in ee4ca65d50 over 9 years ago
Replaced by libzdb-mysql56 in a2881ede6a nearly 8 years ago

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
