### PR TITLE
7zip: new port (version 21.07)

### DIFF
--- a/archivers/7zip/Portfile
+++ b/archivers/7zip/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+PortGroup           clang_dependency 1.0
+
+name                7zip
+version             21.07
+revision            0
+
+categories          archivers
+license             LGPL-2.1
+maintainers         {@srirangav} openmaintainer
+
+description         ${name} is a file archiver with a high compression ratio.
+long_description    ${name} is a file archiver that has a high compression \
+                    ratio in 7z format with LZMA and LZMA2 compression, \
+                    supports packing and unpacking XZ, BZIP2, GZIP, TAR, \
+                    ZIP and WIM archives, and unpacking AR, ARJ, CAB, CHM, \
+                    CPIO, CramFS, DMG, EXT, FAT, GPT, HFS, IHEX, ISO, LZH, \
+                    LZMA, MBR, MSI, NSIS, NTFS, QCOW2, RAR, RPM, SquashFS, \
+                    UDF, UEFI, VDI, VHD, VHDX, VMDK, WIM, XAR and Z archives.
+
+homepage            https://www.7-zip.org/
+master_sites        ${homepage}/a/
+
+supported_archs     arm64 x86_64
+
+use_xz              yes
+distname            7z2107-src
+
+checksums           rmd160  f61c0fd91ecd9b9bad37d92bf2a871371886718b \
+                    sha256  213d594407cb8efcba36610b152ca4921eda14163310b43903d13e68313e1e39 \
+                    size    1230388
+
+use_configure       no
+build.cmd           make
+
+patch.dir           ${workpath}
+patchfiles          patch-7zip_gcc_mak.diff
+      
+if {${build_arch} eq "x86_64"} {
+    build {
+        system -W ${workpath}/CPP/7zip/Bundles/Alone2 \
+        "${build.cmd} -j -f ../../cmpl_mac_x64.mak"
+    }
+    destroot {
+        xinstall -m 755 -d ${destroot}${prefix}/bin
+        xinstall -m 755 \
+                 -s ${workpath}/CPP/7zip/Bundles/Alone2/b/m_x64/7zz \
+                 ${destroot}${prefix}/bin
+    }
+} elseif {${build_arch} eq "arm64"} {
+    build {
+        system -W ${workpath}/CPP/7zip/Bundles/Alone2 \
+        "${build.cmd} -j -f ../../cmpl_mac_arm64.mak"
+    }
+    destroot {
+        xinstall -m 755 -d ${destroot}${prefix}/bin
+        xinstall -m 755 \
+                 -s ${workpath}/CPP/7zip/Bundles/Alone2/b/m_arm64/7zz \
+                 ${destroot}${prefix}/bin
+    }
+}
+

--- a/archivers/7zip/files/patch-7zip_gcc_mak.diff
+++ b/archivers/7zip/files/patch-7zip_gcc_mak.diff
@@ -1,0 +1,11 @@
+--- CPP/7zip/7zip_gcc.mak.orig	2022-04-02 21:21:09.000000000 -0700
++++ CPP/7zip/7zip_gcc.mak	2022-04-02 21:21:39.000000000 -0700
+@@ -18,7 +18,7 @@
+ 
+ 
+ ifneq ($(CC), xlc)
+-CFLAGS_WARN_WALL = -Wall -Werror -Wextra
++CFLAGS_WARN_WALL = -Wall -Wextra
+ endif
+ 
+ # for object file


### PR DESCRIPTION
#### Description

New port for 7zip (version 21.07)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.4 20G417 arm64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
