### PR TITLE
qt6-qtimageformats: unset known_fail

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -992,18 +992,6 @@ foreach {module module_info} [array get modules] {
             ###############################################################################
             # Special Cases
             ###############################################################################
-
-            if {${module} eq "qtimageformats"} {
-                # https://trac.macports.org/ticket/64346
-                known_fail  yes
-                depends_lib
-                depends_build
-                depends_extract
-                pre-fetch {
-                    ui_error "${subport} is currently broken, see https://trac.macports.org/ticket/64346"
-                    return -code error "broken port"
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
This should’ve been part of #14426.

See: https://trac.macports.org/ticket/64346

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
