### PR TITLE
dosbox-x: update to 0.83.24

### DIFF
--- a/emulators/dosbox-x/Portfile
+++ b/emulators/dosbox-x/Portfile
@@ -7,12 +7,12 @@ PortGroup           app 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 
-github.setup        joncampbell123 dosbox-x 0.83.23 dosbox-x-v
+github.setup        joncampbell123 dosbox-x 0.83.24 dosbox-x-v
 revision            0
 
-checksums           rmd160  6ee7cab4cb0f1d95cdd48e018c073f6142d9011d \
-                    sha256  026f3986aae61d5f5cc7a95c7ad8ee9646f3249b282c8136a00b239bf6fed711 \
-                    size    64494344
+checksums           rmd160  213d81414b8eab1c0336e31837a0a4b5e330761b \
+                    sha256  f4746f1524cac58756123c7acbbc565e215d7f298a19667fd845dbba040c6021 \
+                    size    64650623
 
 categories          emulators
 platforms           darwin


### PR DESCRIPTION
#### Description

Update dosbox-x to v.0.83.24

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.5 20G527 arm64
Xcode 12.5.1 12E507


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
