### PR TITLE
dbeaver-community: add support for openjdk18

### DIFF
--- a/databases/dbeaver-community/Portfile
+++ b/databases/dbeaver-community/Portfile
@@ -49,7 +49,7 @@ checksums           dbeaver-ce-${version}-macosx.cocoa.x86_64${extract.suffix} \
 extract.mkdir       yes
 use_configure       no
 
-depends_run         port:openjdk17
+depends_run         port:openjdk18
 
 # Since the user in any case needs to have OpenJDK to run this port, it is
 # better to install OpenJDK from MacPorts, with which there is no issue like
@@ -57,7 +57,7 @@ depends_run         port:openjdk17
 patchfiles          patch-java-path.diff
 
 post-patch {
-    reinplace "s|@@JAVA_VERSION@@|openjdk17|g" \
+    reinplace "s|@@JAVA_VERSION@@|openjdk18|g" \
         ${worksrcpath}/DBeaver.app/Contents/Info.plist
 }
 

--- a/databases/dbeaver-community/Portfile
+++ b/databases/dbeaver-community/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        dbeaver dbeaver 22.0.1
 github.tarball_from releases
-revision            0
+revision            1
 name                dbeaver-community
 
 categories          databases
@@ -57,7 +57,7 @@ depends_run         port:openjdk17
 patchfiles          patch-java-path.diff
 
 post-patch {
-    reinplace "s|@@JAVA_VERSION@@|openjdk17-temurin|g" \
+    reinplace "s|@@JAVA_VERSION@@|openjdk17|g" \
         ${worksrcpath}/DBeaver.app/Contents/Info.plist
 }
 


### PR DESCRIPTION
#### Description
Added support for `openjdk17` port
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
