### PR TITLE
openjdk8-corretto: add arm64 support

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -113,9 +113,14 @@ subport openjdk7-zulu {
 
 subport openjdk8-corretto {
     # https://github.com/corretto/corretto-8/releases
-    supported_archs  x86_64
+    supported_archs  x86_64 arm64
 
-    version      8.322.06.1
+    if {${configure.build_arch} eq "x86_64"} {
+        version     8.322.06.1
+    } elseif {${configure.build_arch} eq "arm64"} {
+        version     8.322.06.4
+    }
+
     revision     0
 
     description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -123,10 +128,17 @@ subport openjdk8-corretto {
 
     master_sites https://corretto.aws/downloads/resources/${version}/
 
-    distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  98759066ee6e41884e3acbf7f9e7debd6a6d54d0 \
-                 sha256  b86a899aac567b86866fe3cff0b80ee7e7a53f93d9fbe1ec3a2c992376ff1cc6 \
-                 size    118882960
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     amazon-corretto-${version}-macosx-x64
+        checksums    rmd160  98759066ee6e41884e3acbf7f9e7debd6a6d54d0 \
+                     sha256  b86a899aac567b86866fe3cff0b80ee7e7a53f93d9fbe1ec3a2c992376ff1cc6 \
+                     size    118882960
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     amazon-corretto-${version}-macosx-aarch64
+        checksums    rmd160  4ff32107a52db8c00caa3e73a4e12688694b3fc9 \
+                     sha256  2afab026da0b36b1de7a6dd67370cc1ace2fcb540717d40e9265847129cfb0f5 \
+                     size    103044275
+    }
 
     worksrcdir   amazon-corretto-8.jdk
 }


### PR DESCRIPTION
#### Description

Add Amazon Carretto OpenJDK 8 for arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?