### PR TITLE
cltversion: fix spurious warnings with no CLT installation on macOS ≥ 11

### DIFF
--- a/_resources/port1.0/group/cltversion-1.0.tcl
+++ b/_resources/port1.0/group/cltversion-1.0.tcl
@@ -19,7 +19,7 @@ default cltversion       {[cltversion::get_default_cltversion]}
 default developerversion {[cltversion::get_default_developerversion]}
 
 proc cltversion::get_default_cltversion {} {
-    global cltversion._cltversion_version_cache
+    global cltversion._cltversion_version_cache os.major
 
     if {[info exists cltversion._cltversion_version_cache]} {
         return [set cltversion._cltversion_version_cache]
@@ -49,8 +49,14 @@ proc cltversion::get_default_cltversion {} {
 
         # On OS X 10.9, running `xcode-select --install` seems to reinstall the command line tools.
         # For later OS versions, however, if `/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib` exists, then `xcode-select --install` refuses to reinstall.
+        #
+        # /usr/lib/libxcselect.dylib will not exist as a file on disk on macOS
+        # 11 or later (Darwin 20 or later) because individual system dylibs are
+        # only shipped in the dyld shared cache. Rest assured that if the OS is
+        # that new, it's always appropriate to look for a Command Line Tools
+        # installation at the path given here.
 
-        if {[file exists /usr/lib/libxcselect.dylib]} {
+        if {[file exists /usr/lib/libxcselect.dylib] || ${os.major} >= 20} {
             set test_file /Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib
         } else {
             set test_file /usr/bin/make


### PR DESCRIPTION
#### Description

On macOS 11 and 12, when Command Line Tools (CLT) are not installed, cltversion produced these warnings:

```
Warning: cltversion: The Command Line Tools are installed, but MacPorts cannot determine the version.
Warning: cltversion: For a possible fix, please see: https://trac.macports.org/wiki/ProblemHotlist#reinstall-clt
```

This was confusing, because CLT were not installed. The linked document discusses reinstalling CLT, but this is nonsense when CLT is not present and there’s no need or desire to install CLT. CLT may intentionally be absent if a fully-functioning Xcode installation is available. This warning may have caused quite a bit of busywork by macOS 11 and 12 users, dutifully silencing the warning by installing CLT unnecessarily.

The warning appeared because cltversion looked for `/usr/lib/libxcselect.dylib` on disk to determine if it should look for a new-style CLT installation, but `/usr/lib/libxcselect.dylib` does not exist as a file on disk on macOS 11 or later (Darwin 20 or later), since individual system dylibs are only shipped in the dyld shared cache on these newer OS versions. The file’s absence caused cltversion to search for an old-style CLT installation, checking for the existence of `/usr/bin/make`. On modern OS versions, `/usr/bin/make` is always present as a stub that delegates to make in the active developer tools installation—it’s bundled with the OS and will never be missing.

This fix makes cltversion look for a new-style CLT installation if the OS is so new that it doesn’t ship system dylibs outside of the dyld cache. Rest assured that on OS versions this new, no old-style CLT installations are even possible.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3 13E113

Note: tested with `port uninstall gcc11`, `port install gcc11`.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
