### PR TITLE
openjdk-distributions: move openjdk17-sap to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -472,32 +472,6 @@ subport openjdk17-graalvm {
                  size    429797450
 }
 
-subport openjdk17-sap {
-    # https://sap.github.io/SapMachine/latest/17
-    supported_archs  x86_64 arm64
-
-    version      17.0.2
-    revision     0
-
-    description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
-    long_description ${long_description_sap}
-
-    master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
-
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     sapmachine-jdk-${version}_macos-x64_bin
-        checksums    rmd160  5c2458e509263d50ffdc5a647e2d4f3dd830c8e5 \
-                     sha256  228b9952002dd60e626c46b8ff051e8e25d577d358390cd52dd7e4ea50863cef \
-                     size    180149241
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     sapmachine-jdk-${version}_macos-aarch64_bin
-        checksums    rmd160  0aab18f0e415d024d0461ba5ba3f9e2b00f0f4e5 \
-                     sha256  06c28b5365527db346b5d2e121e5f70baaef0ddde07766c59c17bfc577a0e4c2 \
-                     size    177867623
-    }
-    worksrcdir   sapmachine-jdk-${version}.jdk
-}
-
 if {${os.platform} eq "darwin"} {
     # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
     if {[string match *-openj9 ${subport}] && ${os.major} < 14} {

--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -1,0 +1,90 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk17-sap
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://sap.github.io/SapMachine/latest/17
+supported_archs  x86_64 arm64
+
+version      17.0.2
+revision     0
+
+description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
+long_description Sap builds of OpenJDK for everyone who wish to use OpenJDK to run their applications.
+
+master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     sapmachine-jdk-${version}_macos-x64_bin
+    checksums    rmd160  5c2458e509263d50ffdc5a647e2d4f3dd830c8e5 \
+                 sha256  228b9952002dd60e626c46b8ff051e8e25d577d358390cd52dd7e4ea50863cef \
+                 size    180149241
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     sapmachine-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  0aab18f0e415d024d0461ba5ba3f9e2b00f0f4e5 \
+                 sha256  06c28b5365527db346b5d2e121e5f70baaef0ddde07766c59c17bfc577a0e4c2 \
+                 size    177867623
+}
+worksrcdir   sapmachine-jdk-${version}.jdk
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # See https://adoptium.net/supported_platforms.html
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://sapmachine.io
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk17-sap` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?