### PR TITLE
KeePassXC: fix compilation with minizip

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -33,7 +33,7 @@ license_noconflict      openssl
 if {${subport} eq ${name}} {
     # stable
     github.setup        keepassxreboot keepassxc 2.7.0
-    revision            1
+    revision            2
     github.tarball_from releases
     distname            keepassxc-${version}-src
     use_xz              yes
@@ -104,6 +104,7 @@ depends_lib-append      port:argon2 \
 patchfiles              patch-no-deployqt.diff \
                         patch-no-findpackage-path.diff \
                         patch-qt56-qoverload.diff \
+                        patch-minizip-include.diff \
                         patch-touch-id.diff
 
 # KeePassXC uses -fstack-protector-strong on Clang [1]. That flag is not

--- a/security/KeePassXC/files/patch-minizip-include.diff
+++ b/security/KeePassXC/files/patch-minizip-include.diff
@@ -1,0 +1,56 @@
+From 31db3c325d2ffc9dedc240d8ac5036fe6f1cf5c3 Mon Sep 17 00:00:00 2001
+From: Jonathan White <support@dmapps.us>
+Date: Thu, 24 Mar 2022 22:53:02 -0400
+Subject: [PATCH] Fix compiling with minizip-ng
+
+* minizip-ng has slightly different defines and function names than the original minizip. These changes adapt the existing code to use the minizip-ng versions if necessary.
+---
+ src/keeshare/CMakeLists.txt  | 1 -
+ src/keeshare/ShareExport.cpp | 9 ++++++++-
+ src/keeshare/ShareImport.cpp | 2 +-
+ 3 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/keeshare/CMakeLists.txt b/src/keeshare/CMakeLists.txt
+index 9fcc55dc28..a108b784b8 100644
+--- src/keeshare/CMakeLists.txt
++++ src/keeshare/CMakeLists.txt
+@@ -17,6 +17,5 @@ if(WITH_XC_KEESHARE)
+ 
+     add_library(keeshare STATIC ${keeshare_SOURCES})
+     target_link_libraries(keeshare PUBLIC Qt5::Core Qt5::Widgets ${BOTAN2_LIBRARIES} ${ZLIB_LIBRARIES} PRIVATE ${MINIZIP_LIBRARIES})
+-    target_include_directories(keeshare SYSTEM PRIVATE ${MINIZIP_INCLUDE_DIR})
+     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+ endif(WITH_XC_KEESHARE)
+diff --git a/src/keeshare/ShareExport.cpp b/src/keeshare/ShareExport.cpp
+index a457033af7..d43ef73cb3 100644
+--- src/keeshare/ShareExport.cpp
++++ src/keeshare/ShareExport.cpp
+@@ -27,7 +27,14 @@
+ 
+ #include <QBuffer>
+ #include <botan/pubkey.h>
+-#include <zip.h>
++#include <minizip/zip.h>
++
++// Compatibility with minizip-ng
++#ifdef MZ_VERSION_BUILD
++#undef Z_BEST_COMPRESSION
++#define Z_BEST_COMPRESSION MZ_COMPRESS_LEVEL_BEST
++#define zipOpenNewFileInZip64 zipOpenNewFileInZip_64
++#endif
+ 
+ namespace
+ {
+diff --git a/src/keeshare/ShareImport.cpp b/src/keeshare/ShareImport.cpp
+index 123486456e..eb93912e76 100644
+--- src/keeshare/ShareImport.cpp
++++ src/keeshare/ShareImport.cpp
+@@ -21,7 +21,7 @@
+ #include "keys/PasswordKey.h"
+ 
+ #include <QBuffer>
+-#include <unzip.h>
++#include <minizip/unzip.h>
+ 
+ namespace
+ {


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/64921

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
Can't test on the systems where it bugs.
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
