### PR TITLE
java-1.0.tcl: remove openjdkXX-zulu for arm64

### DIFF
--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -55,17 +55,6 @@ namespace eval java {
         if { ${java.version} ne "" } {
             ui_debug "java-portgroup: Trying to find JVM version: ${java.version}"
 
-            # If on arm automatically adjust to the *-zulu fallback versions
-            # as required, as currently these are the only ones supporting arm.
-            # To be reviewed as support for arm comes for the other versions.
-            # Following regex matches openjdk<version> only.
-            if { [option configure.build_arch] eq "arm64" &&
-                 [regexp {openjdk(\d{1,2}$)} ${java.fallback}] } {
-                set newjdk ${java.fallback}-zulu
-                ui_debug "Redefining java fallback ${java.fallback} to ${newjdk} for arm compatibility"
-                java.fallback ${newjdk}
-            }
-
             # For macOS >= Big Sur, the JDK discovery was re-implemented because
             # the previous approach relied on '/usr/libexec/java_home -v' whose
             # behaviour changed with Big Sur. The new implementation can

--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -55,6 +55,17 @@ namespace eval java {
         if { ${java.version} ne "" } {
             ui_debug "java-portgroup: Trying to find JVM version: ${java.version}"
 
+            # If on arm automatically adjust to the *-zulu fallback versions
+            # as required, as currently these are the only ones supporting arm.
+            # To be reviewed as support for arm comes for the other versions.
+            # Following regex matches openjdk<version> only.
+            if { [option configure.build_arch] eq "arm64" &&
+                 [regexp {openjdk(\d{1}$)} ${java.fallback}] } {
+                set newjdk ${java.fallback}-zulu
+                ui_debug "Redefining java fallback ${java.fallback} to ${newjdk} for arm compatibility"
+                java.fallback ${newjdk}
+            }
+
             # For macOS >= Big Sur, the JDK discovery was re-implemented because
             # the previous approach relied on '/usr/libexec/java_home -v' whose
             # behaviour changed with Big Sur. The new implementation can


### PR DESCRIPTION
Remove Azul Zulu for arm64 as every OpenJDK implementation, starting from OpenJDK 17 supports arm64 builds. Moreover, Amazon Corretto supports arm64 since its last OpenJDK 8 release.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
