### PR TITLE
boost17[6-8]: don't modify PATH in post-extract

### DIFF
--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -58,8 +58,6 @@ post-extract {
     }
     # Enforce correct compiler and flags are used to build b2
     xinstall -m 755 -d ${workpath}/bin
-    configure.env-append  PATH=${workpath}/bin:$env(PATH)
-    build.env-append      PATH=${workpath}/bin:$env(PATH)
     ln -s ${configure.cxx} ${workpath}/bin/clang++
     ln -s ${configure.cc}  ${workpath}/bin/clang
     # Also link gcc/g++ for older systems
@@ -67,6 +65,8 @@ post-extract {
     ln -s ${configure.cxx} ${workpath}/bin/g++
     ln -s ${configure.cc}  ${workpath}/bin/gcc
 }
+configure.env-append  PATH=${workpath}/bin:$env(PATH)
+build.env-append      PATH=${workpath}/bin:$env(PATH)
 
 # Install prefix for this port
 set bprefix ${prefix}/libexec/boost/${branch}

--- a/devel/boost177/Portfile
+++ b/devel/boost177/Portfile
@@ -59,8 +59,6 @@ post-extract {
     }
     # Enforce correct compiler and flags are used to build b2
     xinstall -m 755 -d ${workpath}/bin
-    configure.env-append  PATH=${workpath}/bin:$env(PATH)
-    build.env-append      PATH=${workpath}/bin:$env(PATH)
     ln -s ${configure.cxx} ${workpath}/bin/clang++
     ln -s ${configure.cc}  ${workpath}/bin/clang
     # Also link gcc/g++ for older systems
@@ -68,6 +66,8 @@ post-extract {
     ln -s ${configure.cxx} ${workpath}/bin/g++
     ln -s ${configure.cc}  ${workpath}/bin/gcc
 }
+configure.env-append  PATH=${workpath}/bin:$env(PATH)
+build.env-append      PATH=${workpath}/bin:$env(PATH)
 
 # Install prefix for this port
 set bprefix ${prefix}/libexec/boost/${branch}

--- a/devel/boost178/Portfile
+++ b/devel/boost178/Portfile
@@ -59,8 +59,6 @@ post-extract {
     }
     # Enforce correct compiler and flags are used to build b2
     xinstall -m 755 -d ${workpath}/bin
-    configure.env-append  PATH=${workpath}/bin:$env(PATH)
-    build.env-append      PATH=${workpath}/bin:$env(PATH)
     ln -s ${configure.cxx} ${workpath}/bin/clang++
     ln -s ${configure.cc}  ${workpath}/bin/clang
     # Also link gcc/g++ for older systems
@@ -68,6 +66,8 @@ post-extract {
     ln -s ${configure.cxx} ${workpath}/bin/g++
     ln -s ${configure.cc}  ${workpath}/bin/gcc
 }
+configure.env-append  PATH=${workpath}/bin:$env(PATH)
+build.env-append      PATH=${workpath}/bin:$env(PATH)
 
 # Install prefix for this port
 set bprefix ${prefix}/libexec/boost/${branch}


### PR DESCRIPTION
#### Description

The current logic fails if `port build` is performed after a successful `port extract`.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
