### PR TITLE
lagrange: update to 1.12.0

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.11.2 v
+github.setup        skyjake lagrange 1.12.0 v
 revision            0
 github.tarball_from releases
 categories          net gemini
@@ -20,9 +20,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  a821833118349be255ca944f68bcce05c477374e \
-                    sha256  4e9a9ed38bcfc7b04856f0e2667d7afd535a8e06e367e2e4368ef5fb9105791f \
-                    size    8731314
+checksums           rmd160  db2fad5c488bfb434312fc511d5c86e8b40c71ef \
+                    sha256  3212e36ed0d7fd7a15c07236dd922c65bef71c4027187d853eec2ecffda05e75 \
+                    size    9237689
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
