### PR TITLE
varnish: fix build on macOS before 10.15

### DIFF
--- a/www/varnish/Portfile
+++ b/www/varnish/Portfile
@@ -33,6 +33,9 @@ depends_build         port:pkgconfig \
 
 depends_lib           port:pcre2
 
+patch.pre_args        -p1
+patchfiles            python310.diff
+
 use_autoreconf        yes
 autoreconf.args       -fi
 

--- a/www/varnish/files/python310.diff
+++ b/www/varnish/files/python310.diff
@@ -1,0 +1,32 @@
+https://github.com/varnishcache/varnish-cache/pull/3796
+
+diff --git a/varnish-legacy.m4 b/varnish-legacy.m4
+index e4ba1b9cea..54ef004829 100644
+--- a/varnish-legacy.m4
++++ b/varnish-legacy.m4
+@@ -100,8 +100,8 @@ AC_SUBST([VMOD_DIR])
+ 
+ AC_DEFUN([VARNISH_VMODTOOL],
+ [
+-AC_CHECK_PROGS(PYTHON, [python3.9 python3.8 python3.7 python3.6 python3.5 dnl
+-  python3.4 python3 python, "no"])
++AC_CHECK_PROGS(PYTHON, [python3.10 python3.9 python3.8 python3.7 python3.6 dnl
++ python3.5 python3.4 python3 python, "no"])
+ if test "x$PYTHON" = "xno"; then
+   AC_MSG_ERROR([Python >= 3.4 is needed to build, please install python.])
+ fi
+diff --git a/varnish.m4 b/varnish.m4
+index abd8dfc784..cdf0392bf0 100644
+--- a/varnish.m4
++++ b/varnish.m4
+@@ -125,8 +125,8 @@ AC_DEFUN([_VARNISH_CHECK_DEVEL], [
+ # ---------------------
+ AC_DEFUN([_VARNISH_CHECK_PYTHON], [
+ 	m4_define_default([_AM_PYTHON_INTERPRETER_LIST],
+-		[python3.9 python3.8 python3.7 python3.6 python3.5 dnl
+-		python3.4 python3 python])
++		[python3.10 python3.9 python3.8 python3.7 python3.6 dnl
++		python3.5 python3.4 python3 python])
+ 	AM_PATH_PYTHON([3.4], [], [
+ 		AC_MSG_ERROR([Python >= 3.4 is required.])
+ 	])


### PR DESCRIPTION
-------

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->