### PR TITLE
openjdk-distributions: move openjdk17-graalvm to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -453,25 +453,6 @@ subport openjdk16-zulu {
     replaced_by  openjdk17-zulu
 }
 
-subport openjdk17-graalvm {
-    # https://github.com/graalvm/graalvm-ce-builds/releases
-    supported_archs  x86_64
-
-    version      22.0.0.2
-    revision     0
-
-    description  GraalVM Community Edition based on OpenJDK 17
-    long_description ${long_description_graalvm}
-
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-    distname     graalvm-ce-java17-darwin-amd64-${version}
-    worksrcdir   graalvm-ce-java17-${version}
-
-    checksums    rmd160  857dd0491c827e52aabe7891d1aaada29f802570 \
-                 sha256  d54af9d1f4d0d351827395a714ed84d2489b023b74a9c13a431cc9d31d1e8f9a \
-                 size    429797450
-}
-
 if {${os.platform} eq "darwin"} {
     # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
     if {[string match *-openj9 ${subport}] && ${os.major} < 14} {

--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -1,0 +1,81 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk17-graalvm
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://github.com/graalvm/graalvm-ce-builds/releases
+supported_archs  x86_64 arm64
+
+version      22.0.0.2
+revision     0
+
+description  GraalVM Community Edition based on OpenJDK 17
+long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
+                 JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
+
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+distname     graalvm-ce-java17-darwin-amd64-${version}
+
+checksums    rmd160  857dd0491c827e52aabe7891d1aaada29f802570 \
+             sha256  d54af9d1f4d0d351827395a714ed84d2489b023b74a9c13a431cc9d31d1e8f9a \
+             size    429797450
+
+worksrcdir   graalvm-ce-java17-${version}
+
+homepage     https://www.graalvm.org
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk17-graalvm` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?