### PR TITLE
libunistring: fixed build on macOS 10.7 and 10.8

### DIFF
--- a/textproc/libunistring/Portfile
+++ b/textproc/libunistring/Portfile
@@ -44,7 +44,8 @@ platform darwin 8 {
 depends_lib         port:libiconv
 
 patchfiles          0100-float-endian-detection.patch \
-                    0700-multiarch-libc.patch
+                    0700-multiarch-libc.patch \
+                    patch-clang-before-34.diff
 
 use_autoreconf      yes
 autoreconf.args     -fvi

--- a/textproc/libunistring/files/patch-clang-before-34.diff
+++ b/textproc/libunistring/files/patch-clang-before-34.diff
@@ -1,0 +1,48 @@
+https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=605e20a698d3f7296cda18ac7dd84b1a8f388b50
+https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=d125d4f6d1a5d9845824aaf1d1c9dc69699bf2f1
+
+diff --git config.h.in config.h.in
+index 6fcbc98..fb668a2 100644
+--- config.h.in
++++ config.h.in
+@@ -1635,7 +1635,9 @@
+ /* Attributes.  */
+ #if (defined __has_attribute \
+      && (!defined __clang_minor__ \
+-         || 3 < __clang_major__ + (5 <= __clang_minor__)))
++         || (defined __apple_build_version__ \
++             ? 6000000 <= __apple_build_version__ \
++             : 3 < __clang_major__ + (5 <= __clang_minor__))))
+ # define _GL_HAS_ATTRIBUTE(attr) __has_attribute (__##attr##__)
+ #else
+ # define _GL_HAS_ATTRIBUTE(attr) _GL_ATTR_##attr
+diff --git gnulib-m4/gnulib-common.m4 gnulib-m4/gnulib-common.m4
+index 87a9a75..789eefe 100644
+--- gnulib-m4/gnulib-common.m4
++++ gnulib-m4/gnulib-common.m4
+@@ -69,7 +69,9 @@ AC_DEFUN([gl_COMMON_BODY], [
+ [/* Attributes.  */
+ #if (defined __has_attribute \
+      && (!defined __clang_minor__ \
+-         || 3 < __clang_major__ + (5 <= __clang_minor__)))
++         || (defined __apple_build_version__ \
++             ? 6000000 <= __apple_build_version__ \
++             : 3 < __clang_major__ + (5 <= __clang_minor__))))
+ # define _GL_HAS_ATTRIBUTE(attr) __has_attribute (__##attr##__)
+ #else
+ # define _GL_HAS_ATTRIBUTE(attr) _GL_ATTR_##attr
+diff --git lib/unistring/cdefs.h lib/unistring/cdefs.h
+index 3faf5ba..af178d1 100644
+--- lib/unistring/cdefs.h
++++ lib/unistring/cdefs.h
+@@ -74,7 +74,9 @@
+ 
+ #if (defined __has_attribute \
+      && (!defined __clang_minor__ \
+-         || 3 < __clang_major__ + (5 <= __clang_minor__)))
++         || (defined __apple_build_version__ \
++             ? 6000000 <= __apple_build_version__ \
++             : 3 < __clang_major__ + (5 <= __clang_minor__))))
+ # define _UC_HAS_ATTRIBUTE(attr) __has_attribute (__##attr##__)
+ #else
+ # define _UC_HAS_ATTRIBUTE(attr) _UC_ATTR_##attr


### PR DESCRIPTION
###### Description

Similar issue with https://github.com/macports/macports-ports/pull/14131

See: https://trac.macports.org/ticket/64727

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->