### PR TITLE
google-cloud-sdk: update to 380.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             379.0.0
+version             380.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  68673b87817cb8e5a518bab2aa94f08dcc4c22a0 \
-                    sha256  a74d0e1eee0a9dfae03b692c775a415078a1a1b05bda18a740f23494b61c83f6 \
-                    size    105872255
+    checksums       rmd160  d63e6b3ca9837fe3b7440122fcd426dc034bca06 \
+                    sha256  6fd0d47ed8c785638cd3b71b5674485a6e58cec81e2d84772c4afd794e34cd3e \
+                    size    105915868
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d94868e9cdd341cee81b2309e84a2b35b5c7f035 \
-                    sha256  ca39f8cd97ba1c5410787dd29e3774f53fc6192296b67ea40d5b668e491c5368 \
-                    size    101108499
+    checksums       rmd160  6c4245e24fbae08cf8b6febed9a9ca5e829cd264 \
+                    sha256  607e09724cf2bd0e928c6118e791efd453465b1950a9e7e88da34e1bb4e7dcfc \
+                    size    101164094
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  8ec46bd539ebc16b8627ddd98c49e88b595ad9e0 \
-                    sha256  0b68fa93df82558315bb258de9582d8d506139cacf5cb2fdc1449de1b9fea9ef \
-                    size    100582033
+    checksums       rmd160  07f3af0e588df2873b361ee5bc32b1c5dceaa0c6 \
+                    sha256  ad7909397c63988d8c639518ade3f168d7db5541965f99f791c90af75e61f315 \
+                    size    100643005
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 380.0.0.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?