### PR TITLE
mingw-w64: update to v10.0.0

### DIFF
--- a/cross/mingw-w64/Portfile
+++ b/cross/mingw-w64/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        mirror mingw-w64 9.0.0 v
+github.setup        mirror mingw-w64 10.0.0 v
 set mingw_name      w64-mingw32
 
 platforms           darwin
@@ -18,9 +18,9 @@ long_description    Mingw-w64 is an advancement of the original mingw.org projec
 
 homepage            http://mingw-w64.sourceforge.net/
 
-checksums           rmd160  00283408fb97100817d2f4aca149526443e428c2 \
-                    sha256  4a7d40a4e1125142e417b9161191e8efda5633f5062a2560eaf636a79230b4e6 \
-                    size    13107021
+checksums           rmd160  cda1704d75239f6b6f51b7a548b0c2ac27c0f895 \
+                    sha256  9dd3d3d5e02c194963f630089731eeea907c47664aee30924a79f42cd24a4548 \
+                    size    13263930
 
 # needs an out-of-source build
 configure.dir       ${workpath}/build


### PR DESCRIPTION
#### Description

Update to the latest mingw-w64 version.

Tested by compiling
- DXVK-macOS-1.9 > 1.10.1-async
- wine-7.5 (i386 & x86_64)

Still this was while using #13964 so might want to get that merged first, we want that if there's ever an intention to _try_ to support any arm targets

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
