### PR TITLE
qt5-qtcreator: say why full Xcode is needed

### DIFF
--- a/devel/qt5-qtcreator/Portfile
+++ b/devel/qt5-qtcreator/Portfile
@@ -49,7 +49,7 @@ license_noconflict  openssl
 
 if { ${subport} eq ${name}  } {
 
-    # Requires Xcode
+    # xcode-select: error: tool 'actool' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
     use_xcode yes
 
     qt5.depends_component  qtscript qtdeclarative qttools qtmacextras qtquickcontrols qtsvg


### PR DESCRIPTION
#### Description
Provide a reason good enough for me to not question the use of `use_xcode yes` here.
<!-- Note: it is best to make pull requests from a branch rather than from master -->
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
