### PR TITLE
openjdk-distributions: move openjdk16-openj9 to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -386,30 +386,6 @@ subport openjdk16-graalvm {
     replaced_by  openjdk17-graalvm
 }
 
-subport openjdk16-openj9 {
-    # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
-    supported_archs  x86_64
-
-    version      16.0.2
-    revision     0
-
-    set build    7
-    set openj9_version 0.27.0
-
-    homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
-
-    description  Open Java Development Kit 16 (IBM Semeru) with Eclipse OpenJ9 VM
-    long_description ${long_description_ibm_semeru}
-
-    master_sites https://github.com/ibmruntimes/semeru16-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
-    distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  f1b5fec76825301cc3c8aee0d53b43a64dfd0590 \
-                 sha256  89e807261145243a358a2a626f64340944c03622f34eaa35429053e2085d7aef \
-                 size    205816803
-}
-
 # Remove after 2022-09-14
 subport openjdk16-temurin {
     version      16.0.2

--- a/java/openjdk16-openj9/Portfile
+++ b/java/openjdk16-openj9/Portfile
@@ -1,0 +1,85 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk16-openj9
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
+supported_archs  x86_64
+
+version      16.0.2
+revision     0
+
+set build    7
+set openj9_version 0.27.0
+
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 16
+long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
+                 built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
+
+master_sites https://github.com/ibmruntimes/semeru16-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+
+distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
+
+checksums    rmd160  f1b5fec76825301cc3c8aee0d53b43a64dfd0590 \
+             sha256  89e807261145243a358a2a626f64340944c03622f34eaa35429053e2085d7aef \
+             size    205816803
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk16-openj9` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?