### PR TITLE
openjdk18-temurin: new submission

### DIFF
--- a/java/openjdk18-temurin/Portfile
+++ b/java/openjdk18-temurin/Portfile
@@ -1,0 +1,92 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk18-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/
+supported_archs  x86_64 arm64
+
+version      18
+set build    36
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK 18
+long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin18-binaries/releases/download/jdk-${version}%2B${build}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     OpenJDK18U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  78ae0d160e4d8881faa149092716195e95d0c36a \
+                 sha256  cdef36a561d7550fb505a9c36fedf363af16a5984c92e74f5abaa25172c12537 \
+                 size    187839669
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     OpenJDK18U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  50ba39557a02d6fd105e70e1bc5d19023c3ffe02 \
+                 sha256  ac0beb8843f4bc360656ad828fdc9b06937a2ea67cb4d5ef6e3c37c09f5501d4 \
+                 size    178744694
+}
+
+worksrcdir   jdk-${version}+${build}
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # See https://adoptium.net/supported-platforms/
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://adoptium.net
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Eclipse Temurin OpenJDK 18.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?