### PR TITLE
openjdk8: replace 'subport' with 'name'

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -94,9 +94,9 @@ post-destroot {
 }
 
 notes "
-If you want to make ${subport} the default JDK, add this to shell profile:
+If you want to make ${name} the default JDK, add this to shell profile:
 export JAVA_HOME=${jdk_path}/Contents/Home
-If you want to make the JRE installed by the ${subport} the default JRE, add this to shell profile:
+If you want to make the JRE installed by the ${name} the default JRE, add this to shell profile:
 export JAVA_HOME=${jre_path}/Contents/Home
 "
     


### PR DESCRIPTION
#### Description

Replace `${subport}` with `${name}` because this port is no longer a subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?