### PR TITLE
openssl3: Never use `__atomic_*` on macOS 10.7 and 10.8

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -63,6 +63,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 #   To be seen if needed with 3.0.0, and if it needs updating.
 #patchfiles-append   patch-pre-Sierra.diff
 
+# https://github.com/openssl/openssl/pull/18056
+# https://github.com/openssl/openssl/issues/18055
+patchfiles-append   patch-fix-clang-atomics.diff
+
 # https://github.com/openssl/openssl/pull/16584
 # https://github.com/openssl/openssl/issues/16551
 # Fixes "Undefined symbols for architecture i386: ___atomic_is_lock_free"

--- a/devel/openssl3/files/patch-fix-clang-atomics.diff
+++ b/devel/openssl3/files/patch-fix-clang-atomics.diff
@@ -1,0 +1,71 @@
+From 8ff922dbd89ff5b80b68f1d23200b3cdcdf2c0d7 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Thu, 7 Apr 2022 15:07:37 +0200
+Subject: [PATCH] Never use `__atomic_*` on macOS 10.7 and 10.8
+
+macOS 10.7 and 10.8 had a bit wired clang which is detected as
+`__GNUC__` which has `__ATOMIC_ACQ_REL` but it excepts one option at
+`__atomic_is_lock_free` instead of 2.
+
+This prevents OpenSSL to be compiled on such systems.
+
+Fixes: #18055
+
+Signed-off-by: Kirill A. Korinsky <kirill@korins.ky>
+---
+ crypto/threads_pthread.c | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+diff --git crypto/threads_pthread.c crypto/threads_pthread.c
+index 2b7280c09c..46b8459b5e 100644
+--- crypto/threads_pthread.c
++++ crypto/threads_pthread.c
+@@ -17,6 +17,18 @@
+ # include <atomic.h>
+ #endif
+ 
++#if defined(__apple_build_version__) && __apple_build_version__ < 6000000
++/*
++ * OS/X 10.7 and 10.8 had a weird version of clang which has __ATOMIC_ACQUIRE and
++ * __ATOMIC_ACQ_REL but which expects only one parameter for __atomic_is_lock_free()
++ * rather than two which has signature __atomic_is_lock_free(sizeof(_Atomic(T))).
++ * All of this makes impossible to use __atomic_is_lock_free here.
++ *
++ * See: https://github.com/llvm/llvm-project/commit/a4c2602b714e6c6edb98164550a5ae829b2de760
++ */
++#define BROKEN_CLANG_ATOMICS
++#endif
++
+ #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_SYS_WINDOWS)
+ 
+ # if defined(OPENSSL_SYS_UNIX)
+@@ -188,7 +200,7 @@ int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b)
+ 
+ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
+ {
+-# if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL)
++# if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL) && !defined(BROKEN_CLANG_ATOMICS)
+     if (__atomic_is_lock_free(sizeof(*val), val)) {
+         *ret = __atomic_add_fetch(val, amount, __ATOMIC_ACQ_REL);
+         return 1;
+@@ -215,7 +227,7 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
+ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
+                      CRYPTO_RWLOCK *lock)
+ {
+-# if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL)
++# if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL) && !defined(BROKEN_CLANG_ATOMICS)
+     if (__atomic_is_lock_free(sizeof(*val), val)) {
+         *ret = __atomic_or_fetch(val, op, __ATOMIC_ACQ_REL);
+         return 1;
+@@ -240,7 +252,7 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
+ 
+ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
+ {
+-# if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE)
++# if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE) && !defined(BROKEN_CLANG_ATOMICS)
+     if (__atomic_is_lock_free(sizeof(*val), val)) {
+         __atomic_load(val, ret, __ATOMIC_ACQUIRE);
+         return 1;
+-- 
+2.35.1
+

--- a/devel/openssl3/files/patch-fix-i386-atomics.diff
+++ b/devel/openssl3/files/patch-fix-i386-atomics.diff
@@ -1,48 +1,26 @@
-From 47574c32d31fc3c57baebf06a47b096191f9f2cd Mon Sep 17 00:00:00 2001
-From: xtkoba <69125751+xtkoba@users.noreply.github.com>
-Date: Sun, 12 Sep 2021 00:23:16 +0900
-Subject: [PATCH 1/8] Update crypto.h.in
+From b6c37e369f66a39eebd9e948f0a08e023bd7d304 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Sun, 10 Apr 2022 02:14:24 +0200
+Subject: [PATCH] Prevent clang from emitting atomic libcalls
 
+This commit is rebasing of https://github.com/openssl/openssl/pull/16584
+to the last master branch.
+
+This PR was used for MacPorts for near of 5 months, since
+https://github.com/macports/macports-ports/pull/12848
+
+Fixes: https://github.com/openssl/openssl/issues/16551
+
+Co-authored-by: Tee KOBAYASHI <xtkoba@gmail.com>
+Signed-off-by: Kirill A. Korinsky <kirill@korins.ky>
 ---
- include/openssl/crypto.h.in | 11 +++++++++--
- 1 file changed, 9 insertions(+), 2 deletions(-)
-
-diff --git include/openssl/crypto.h.in include/openssl/crypto.h.in
-index 724e2ca5da79..c5e668ef1e3a 100644
---- include/openssl/crypto.h.in
-+++ include/openssl/crypto.h.in
-@@ -85,10 +85,17 @@ __owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock);
- int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock);
- void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
- 
-+# ifdef __GNUC__
-+typedef __attribute__((__aligned__(8))) uint64_t CRYPTO_ATOMIC_U64;
-+# else
-+typedef uint64_t CRYPTO_ATOMIC_U64;
-+# endif
-+
- int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
--int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
-+int CRYPTO_atomic_or(CRYPTO_ATOMIC_U64 *val, uint64_t op, CRYPTO_ATOMIC_U64 *ret,
-                      CRYPTO_RWLOCK *lock);
--int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock);
-+int CRYPTO_atomic_load(CRYPTO_ATOMIC_U64 *val, CRYPTO_ATOMIC_U64 *ret,
-+                       CRYPTO_RWLOCK *lock);
- 
- /* No longer needed, so this is a no-op */
- #define OPENSSL_malloc_init() while(0) continue
-
-From e4ad3833d14a02aeed44aed5bc14a7a9fec1f241 Mon Sep 17 00:00:00 2001
-From: xtkoba <69125751+xtkoba@users.noreply.github.com>
-Date: Sun, 12 Sep 2021 00:24:17 +0900
-Subject: [PATCH 2/8] Update init.c
-
----
- crypto/init.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ crypto/init.c               |  4 ++--
+ crypto/threads_pthread.c    | 17 +++++++++++------
+ include/openssl/crypto.h.in |  8 ++++++++
+ 3 files changed, 21 insertions(+), 8 deletions(-)
 
 diff --git crypto/init.c crypto/init.c
-index 6a27d1a8e440..e254251b4c09 100644
+index b7d7ad0ea3..e8fc9e6d60 100644
 --- crypto/init.c
 +++ crypto/init.c
 @@ -34,7 +34,7 @@
@@ -63,191 +41,16 @@ index 6a27d1a8e440..e254251b4c09 100644
      int aloaddone = 0;
  
     /* Applications depend on 0 being returned when cleanup was already done */
-
-From c788331a415247c037ba5c74cce473552a03647e Mon Sep 17 00:00:00 2001
-From: xtkoba <69125751+xtkoba@users.noreply.github.com>
-Date: Sun, 12 Sep 2021 00:25:13 +0900
-Subject: [PATCH 3/8] Update threads_pthread.c
-
----
- crypto/threads_pthread.c | 5 +++--
- 1 file changed, 3 insertions(+), 2 deletions(-)
-
 diff --git crypto/threads_pthread.c crypto/threads_pthread.c
-index 9f00d8be5eae..fc617c9e5736 100644
+index 46b8459b5e..0071f6cbcf 100644
 --- crypto/threads_pthread.c
 +++ crypto/threads_pthread.c
-@@ -212,7 +212,7 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
-     return 1;
- }
- 
--int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
-+int CRYPTO_atomic_or(CRYPTO_ATOMIC_U64 *val, uint64_t op, CRYPTO_ATOMIC_U64 *ret,
+@@ -228,9 +228,11 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
                       CRYPTO_RWLOCK *lock)
  {
- # if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL)
-@@ -238,7 +238,8 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
-     return 1;
- }
- 
--int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
-+int CRYPTO_atomic_load(CRYPTO_ATOMIC_U64 *val, CRYPTO_ATOMIC_U64 *ret,
-+                       CRYPTO_RWLOCK *lock)
- {
- # if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE)
-     if (__atomic_is_lock_free(sizeof(*val), val)) {
-
-From f5d06dbffe2ecce2a32009411c99cf10e6da3251 Mon Sep 17 00:00:00 2001
-From: xtkoba <69125751+xtkoba@users.noreply.github.com>
-Date: Sun, 12 Sep 2021 02:18:54 +0900
-Subject: [PATCH 4/8] Update crypto.h.in
-
----
- include/openssl/crypto.h.in | 5 ++---
- 1 file changed, 2 insertions(+), 3 deletions(-)
-
-diff --git include/openssl/crypto.h.in include/openssl/crypto.h.in
-index c5e668ef1e3a..154a2039d1a8 100644
---- include/openssl/crypto.h.in
-+++ include/openssl/crypto.h.in
-@@ -92,10 +92,9 @@ typedef uint64_t CRYPTO_ATOMIC_U64;
- # endif
- 
- int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
--int CRYPTO_atomic_or(CRYPTO_ATOMIC_U64 *val, uint64_t op, CRYPTO_ATOMIC_U64 *ret,
-+int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
-                      CRYPTO_RWLOCK *lock);
--int CRYPTO_atomic_load(CRYPTO_ATOMIC_U64 *val, CRYPTO_ATOMIC_U64 *ret,
--                       CRYPTO_RWLOCK *lock);
-+int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock);
- 
- /* No longer needed, so this is a no-op */
- #define OPENSSL_malloc_init() while(0) continue
-
-From 3bcf939d0dbbcfb152bd96448807b80d4a103026 Mon Sep 17 00:00:00 2001
-From: xtkoba <69125751+xtkoba@users.noreply.github.com>
-Date: Sun, 12 Sep 2021 02:20:42 +0900
-Subject: [PATCH 5/8] Update threads_pthread.c
-
----
- crypto/threads_pthread.c | 10 +++++-----
- 1 file changed, 5 insertions(+), 5 deletions(-)
-
-diff --git crypto/threads_pthread.c crypto/threads_pthread.c
-index fc617c9e5736..2eafb6a766a2 100644
---- crypto/threads_pthread.c
-+++ crypto/threads_pthread.c
-@@ -212,12 +212,12 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
-     return 1;
- }
- 
--int CRYPTO_atomic_or(CRYPTO_ATOMIC_U64 *val, uint64_t op, CRYPTO_ATOMIC_U64 *ret,
-+int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
-                      CRYPTO_RWLOCK *lock)
- {
- # if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL)
-     if (__atomic_is_lock_free(sizeof(*val), val)) {
+ # if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL) && !defined(BROKEN_CLANG_ATOMICS)
+-    if (__atomic_is_lock_free(sizeof(*val), val)) {
 -        *ret = __atomic_or_fetch(val, op, __ATOMIC_ACQ_REL);
-+        *ret = __atomic_or_fetch((CRYPTO_ATOMIC_U64 *)val, op, __ATOMIC_ACQ_REL);
-         return 1;
-     }
- # elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
-@@ -238,12 +238,12 @@ int CRYPTO_atomic_or(CRYPTO_ATOMIC_U64 *val, uint64_t op, CRYPTO_ATOMIC_U64 *ret
-     return 1;
- }
- 
--int CRYPTO_atomic_load(CRYPTO_ATOMIC_U64 *val, CRYPTO_ATOMIC_U64 *ret,
--                       CRYPTO_RWLOCK *lock)
-+int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
- {
- # if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE)
-     if (__atomic_is_lock_free(sizeof(*val), val)) {
--        __atomic_load(val, ret, __ATOMIC_ACQUIRE);
-+        __atomic_load((CRYPTO_ATOMIC_U64 *)val, (CRYPTO_ATOMIC_U64 *)ret,
-+                      __ATOMIC_ACQUIRE);
-         return 1;
-     }
- # elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
-
-From d481145baf462bb45818062ba20bf4e9cbe280a1 Mon Sep 17 00:00:00 2001
-From: xtkoba <69125751+xtkoba@users.noreply.github.com>
-Date: Sun, 12 Sep 2021 02:37:23 +0900
-Subject: [PATCH 6/8] Update threads_pthread.c
-
----
- crypto/threads_pthread.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
-diff --git crypto/threads_pthread.c crypto/threads_pthread.c
-index 2eafb6a766a2..f85f0d7bdb01 100644
---- crypto/threads_pthread.c
-+++ crypto/threads_pthread.c
-@@ -216,7 +216,7 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
-                      CRYPTO_RWLOCK *lock)
- {
- # if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL)
--    if (__atomic_is_lock_free(sizeof(*val), val)) {
-+    if (__atomic_is_lock_free(sizeof(*val), (CRYPTO_ATOMIC_U64 *)val)) {
-         *ret = __atomic_or_fetch((CRYPTO_ATOMIC_U64 *)val, op, __ATOMIC_ACQ_REL);
-         return 1;
-     }
-@@ -241,7 +241,7 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
- int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
- {
- # if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE)
--    if (__atomic_is_lock_free(sizeof(*val), val)) {
-+    if (__atomic_is_lock_free(sizeof(*val), (CRYPTO_ATOMIC_U64 *)val)) {
-         __atomic_load((CRYPTO_ATOMIC_U64 *)val, (CRYPTO_ATOMIC_U64 *)ret,
-                       __ATOMIC_ACQUIRE);
-         return 1;
-
-From 7028811aba273f2457d1c3d2fa03a62c41ac932a Mon Sep 17 00:00:00 2001
-From: xtkoba <69125751+xtkoba@users.noreply.github.com>
-Date: Sun, 12 Sep 2021 07:13:01 +0900
-Subject: [PATCH 7/8] Update crypto.h.in
-
----
- include/openssl/crypto.h.in | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
-
-diff --git include/openssl/crypto.h.in include/openssl/crypto.h.in
-index 154a2039d1a8..076640066e4e 100644
---- include/openssl/crypto.h.in
-+++ include/openssl/crypto.h.in
-@@ -85,10 +85,12 @@ __owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock);
- int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock);
- void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
- 
--# ifdef __GNUC__
-+# if defined(__GNUC__) && !defined(OPENSSL_NO_STDINT_H)
- typedef __attribute__((__aligned__(8))) uint64_t CRYPTO_ATOMIC_U64;
-+#  define CRYPTO_ATOMIC_IS_ALIGNED_U64(val) (((uintptr_t)(val) & (8 - 1)) == 0)
- # else
- typedef uint64_t CRYPTO_ATOMIC_U64;
-+#  define CRYPTO_ATOMIC_IS_ALIGNED_U64(val) (1)
- # endif
- 
- int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
-
-From b5d7c5a0c443093790baae8d9061b140d5a65926 Mon Sep 17 00:00:00 2001
-From: xtkoba <69125751+xtkoba@users.noreply.github.com>
-Date: Sun, 12 Sep 2021 07:15:13 +0900
-Subject: [PATCH 8/8] Update threads_pthread.c
-
----
- crypto/threads_pthread.c | 18 +++++++++++-------
- 1 file changed, 11 insertions(+), 7 deletions(-)
-
-diff --git crypto/threads_pthread.c crypto/threads_pthread.c
-index f85f0d7bdb01..8425030a71e9 100644
---- crypto/threads_pthread.c
-+++ crypto/threads_pthread.c
-@@ -216,9 +216,11 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
-                      CRYPTO_RWLOCK *lock)
- {
- # if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL)
--    if (__atomic_is_lock_free(sizeof(*val), (CRYPTO_ATOMIC_U64 *)val)) {
--        *ret = __atomic_or_fetch((CRYPTO_ATOMIC_U64 *)val, op, __ATOMIC_ACQ_REL);
 -        return 1;
 +    if (CRYPTO_ATOMIC_IS_ALIGNED_U64(val) &&
 +        __atomic_is_lock_free(sizeof(*val), (CRYPTO_ATOMIC_U64 *)val)) {
@@ -257,13 +60,12 @@ index f85f0d7bdb01..8425030a71e9 100644
      }
  # elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
      /* This will work for all future Solaris versions. */
-@@ -241,10 +243,12 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
+@@ -253,9 +255,12 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
  int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
  {
- # if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE)
--    if (__atomic_is_lock_free(sizeof(*val), (CRYPTO_ATOMIC_U64 *)val)) {
--        __atomic_load((CRYPTO_ATOMIC_U64 *)val, (CRYPTO_ATOMIC_U64 *)ret,
--                      __ATOMIC_ACQUIRE);
+ # if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE) && !defined(BROKEN_CLANG_ATOMICS)
+-    if (__atomic_is_lock_free(sizeof(*val), val)) {
+-        __atomic_load(val, ret, __ATOMIC_ACQUIRE);
 -        return 1;
 +    if (CRYPTO_ATOMIC_IS_ALIGNED_U64(val) &&
 +        CRYPTO_ATOMIC_IS_ALIGNED_U64(ret) &&
@@ -274,3 +76,25 @@ index f85f0d7bdb01..8425030a71e9 100644
      }
  # elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
      /* This will work for all future Solaris versions. */
+diff --git include/openssl/crypto.h.in include/openssl/crypto.h.in
+index df7abb2a29..81b1d48c52 100644
+--- include/openssl/crypto.h.in
++++ include/openssl/crypto.h.in
+@@ -85,6 +85,14 @@ __owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock);
+ int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock);
+ void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
+ 
++# if defined(__GNUC__) && !defined(OPENSSL_NO_STDINT_H)
++typedef __attribute__((__aligned__(8))) uint64_t CRYPTO_ATOMIC_U64;
++#  define CRYPTO_ATOMIC_IS_ALIGNED_U64(val) (((uintptr_t)(val) & (8 - 1)) == 0)
++# else
++typedef uint64_t CRYPTO_ATOMIC_U64;
++#  define CRYPTO_ATOMIC_IS_ALIGNED_U64(val) (1)
++# endif
++
+ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
+ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
+                      CRYPTO_RWLOCK *lock);
+-- 
+2.35.1
+


### PR DESCRIPTION
#### Description

It also contains a rebase for existed patch for atomics.

Closes: https://trac.macports.org/ticket/64947


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->