### PR TITLE
poppler: update to 22.04.0

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.1
 
 name                poppler
-version             22.03.0
+version             22.04.0
 revision            0
 
 conflicts           xpdf-tools
@@ -24,9 +24,9 @@ master_sites        ${homepage} \
 
 use_xz              yes
 
-checksums           rmd160  c9b99e92fbdfc4d720c43493808f4082258e3036 \
-                    sha256  728c78ba94d75a55f6b6355d4fbdaa6f49934d9616be58e5e679a9cfd0980e1e \
-                    size    1809940
+checksums           rmd160  e1af1049b6bc221f21260b86b551abccf3efd375 \
+                    sha256  813fb4b90e7bda63df53205c548602bae728887a60f4048aae4dbd9b1927deff \
+                    size    1817800
 
 depends_build-append \
                     port:pkgconfig \

--- a/graphics/poppler/files/patch-check-boost.diff
+++ b/graphics/poppler/files/patch-check-boost.diff
@@ -1,6 +1,6 @@
 --- CMakeLists.txt.orig
 +++ CMakeLists.txt
-@@ -201,11 +201,13 @@
+@@ -195,11 +195,13 @@
  # Check for Cairo rendering backend
  macro_optional_find_package(Cairo ${CAIRO_VERSION})
  

--- a/graphics/poppler/files/patch-glib_CMakeFiles.txt-fix-include-ordering.diff
+++ b/graphics/poppler/files/patch-glib_CMakeFiles.txt-fix-include-ordering.diff
@@ -1,6 +1,6 @@
 --- glib/CMakeLists.txt.orig
 +++ glib/CMakeLists.txt
-@@ -119,6 +119,7 @@
+@@ -116,6 +116,7 @@
    # General gir: Reset object-list for introspection & load tool args
    set(INTROSPECTION_GIRS)
    set(INTROSPECTION_SCANNER_ARGS "--add-include-path=${CMAKE_CURRENT_SOURCE_DIR}" "--warn-all")
@@ -8,7 +8,7 @@
    set(INTROSPECTION_COMPILER_ARGS ${INTROSPECTION_COMPILER_ARGS} "--includedir=${CMAKE_CURRENT_SOURCE_DIR}")
  
    # Poppler: Assign package to gir & export keys
-@@ -130,9 +131,27 @@
+@@ -127,9 +128,27 @@
  
    # Format list of include directories as compiler flags
    get_directory_property(_tmp_includes INCLUDE_DIRECTORIES)


### PR DESCRIPTION
#### Description

Courtesy PR for the primary port owner.

poppler: update to 22.04.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.5 20G526
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
