### PR TITLE
aubio: fix build on macOS 10.8 Mountain Lion and older

### DIFF
--- a/audio/aubio/Portfile
+++ b/audio/aubio/Portfile
@@ -5,6 +5,7 @@ PortGroup               waf 1.0
 
 # strnlen
 PortGroup               legacysupport 1.0
+
 legacysupport.newest_darwin_requires_legacy 10
 
 name                    aubio
@@ -47,6 +48,11 @@ configure.ldflags-delete \
 configure.args-append   --enable-fftw3f \
                         --disable-jack \
                         --notests
+
+# Mountain Lion and older lacks vDSP_DCT_CreateSetup function in Accelerate framework.
+if {${os.platform} eq "darwin" && ${os.major} < 13} {
+    configure.args-append   --disable-accelerate
+}
 
 configure.post_args-delete  --nocache
 variant jack description {Enable jack support} {


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/64849

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008
GitHub Actions CI build

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
