### PR TITLE
py-last: update to 5.0.0

### DIFF
--- a/python/py-httpcore/Portfile
+++ b/python/py-httpcore/Portfile
@@ -4,19 +4,19 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-httpcore
-version             0.12.2
+version             0.14.7
 platforms           darwin
 license             BSD
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         A minimal low level HTTP client.
 long_description    {*}${description}
 supported_archs     noarch
 homepage            https://github.com/encode/httpcore
 
-checksums           rmd160  108fe8d58175a52fc9767e8b7034dff33db79389 \
-                    sha256  dd1d762d4f7c2702149d06be2597c35fb154c5eff9789a8c5823fbcf4d2978d6 \
-                    size    42392
+checksums           rmd160  e43b5d5b443d3bdb1d15c03b8e50373c7fd16620 \
+                    sha256  7503ec1c0f559066e7e39bc4003fd2ce023d01cf51793e3c173b864eb456ead1 \
+                    size    53400
 
 python.versions     37 38 39 310
 
@@ -25,8 +25,10 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools
 
     depends_lib-append \
-                    port:py${python.version}-h11      \
+                    port:py${python.version}-anyio \
+                    port:py${python.version}-certifi \
+                    port:py${python.version}-h11 \
                     port:py${python.version}-sniffio
-                    
+
     livecheck.type  none
 }

--- a/python/py-httpx/Portfile
+++ b/python/py-httpx/Portfile
@@ -8,7 +8,8 @@ version             0.22.0
 revision            0
 platforms           darwin
 license             BSD
-maintainers         nomaintainer
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         The next generation HTTP client.
 long_description    {*}${description}
@@ -26,10 +27,11 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools
 
     depends_lib-append \
-                    port:py${python.version}-certifi  \
-                    port:py${python.version}-sniffio  \
-                    port:py${python.version}-rfc3986  \
-                    port:py${python.version}-httpcore
+                    port:py${python.version}-certifi \
+                    port:py${python.version}-charset-normalizer  \
+                    port:py${python.version}-httpcore \
+                    port:py${python.version}-rfc3986 \
+                    port:py${python.version}-sniffio
 
     livecheck.type  none
 }

--- a/python/py-last/Portfile
+++ b/python/py-last/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-last
 python.rootname     pylast
-version             4.5.0
+version             5.0.0
 revision            0
 
 categories-append   devel audio
@@ -20,9 +20,9 @@ homepage            https://github.com/pylast/pylast
 
 maintainers         {@catap korins.ky:kirill} openmaintainer
 
-checksums           rmd160  1052d79e022a8513af3d64622039b43a2a30b4f1 \
-                    sha256  62800b72e971dadac40c3d6f538c6188219d6f53853ddc48d69d9fc25659018f \
-                    size    44070
+checksums           rmd160  9ee82f7ae02ddc590b586130ea017d8e4dc70207 \
+                    sha256  5018b66c2b4632d71abd8103b73e66e4dd14c6609a8f7ba7e5aa26c736df2df8 \
+                    size    43871
 
 python.versions     37 38 39 310
 
@@ -32,11 +32,21 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools_scm \
                     port:py${python.version}-setuptools_scm_git_archive
 
+    depends_lib-append \
+                    port:py${python.version}-httpx
+
     depends_test-append \
                     port:py${python.version}-flaky \
-                    port:py${python.version}-pytest
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-pytest-cov \
+                    port:py${python.version}-pytest-random-order \
+                    port:py${python.version}-yaml
 
+    # See https://github.com/pylast/pylast/issues/397
     test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+    test.target     tests
 
     livecheck.type  none
 }

--- a/python/py-pytest-random-order/Portfile
+++ b/python/py-pytest-random-order/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pytest-random-order
+version             1.0.4
+revision            0
+
+supported_archs     noarch
+license             MIT
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+description         Randomise the order in which pytest tests are run with some control over the randomness
+long_description    ${description}
+
+homepage            https://github.com/jbasko/pytest-random-order
+
+checksums           rmd160  02e9bbad6a7bbb31adf090dc26b607ddcf3f18f5 \
+                    sha256  6b2159342a4c8c10855bc4fc6d65ee890fc614cb2b4ff688979b008a82a0ff52 \
+                    size    18045
+
+python.versions     37 38 39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-pytest
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->