### PR TITLE
py-py7zr: update to 0.18.3

### DIFF
--- a/python/py-py7zr/Portfile
+++ b/python/py-py7zr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-py7zr
-version             0.17.4
+version             0.18.3
 revision            0
 
 platforms           darwin
@@ -16,9 +16,9 @@ long_description    ${description}
 
 homepage            https://github.com/miurahr/py7zr
 
-checksums           rmd160  99dd3488d47c9ab7d73acc9ac9ce174c3a432086 \
-                    sha256  1df67edaa8dd1613fc5a7de3354322e7bc75d989d6069924ce2d08bb7fabdd19 \
-                    size    3342099
+checksums           rmd160  cce45682465b4f016ba3ef8f4cea386937afbab6 \
+                    sha256  d5bdc81536316f209a3ca4e1ce6e2ef11d8a519d613be47bcdd084bf655f400f \
+                    size    4225238
 
 python.versions     38 39 310
 
@@ -33,6 +33,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-pycryptodomex \
                     port:py${python.version}-pyppmd \
                     port:py${python.version}-pyzstd \
+                    port:py${python.version}-zipfile-deflate64
 
     depends_test-append \
                     port:py${python.version}-coverage \

--- a/python/py-zipfile-deflate64/Portfile
+++ b/python/py-zipfile-deflate64/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-zipfile-deflate64
+version             0.2.0
+revision            0
+
+license             Apache-2.0
+maintainers         {@catap korins.ky:kirill} openmaintainer
+description         Extract Deflate64 ZIP archives with Python's zipfile API.
+long_description    ${description}
+
+homepage            https://github.com/brianhelba/zipfile-deflate64
+
+checksums           rmd160  7d693e28bc992f6ede619771990451fb23a96d7e \
+                    sha256  875a3299de102edf1c17f8cafcc528b1ca80b62dc4814b9cb56867ec59fbfd18 \
+                    size    62896
+
+python.versions     38 39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->