### PR TITLE
py-zopfli: update to 0.2.1

### DIFF
--- a/python/py-zopfli/Portfile
+++ b/python/py-zopfli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-zopfli
-version             0.1.9
+version             0.2.1
 revision            0
 
 license             Apache-2
@@ -16,9 +16,9 @@ long_description    ${description}
 homepage            https://github.com/obp/py-zopfli
 use_zip             yes
 
-checksums           rmd160  515dcab9846387ccf4725a8c0fdaf6938816c7b2 \
-                    sha256  78de3cc08a8efaa8013d61528907d91ac4d6cc014ffd8a41cc10ee75e9e60d7b \
-                    size    79873
+checksums           rmd160  1d7bf5bdac340162c16e661716dcd8672df8502d \
+                    sha256  e5263d2806e2c1ccb23f52b2972a235d31d42f22f3fa3032cc9aded51e9bf2c6 \
+                    size    205086
 
 python.versions     37 38 39 310
 
@@ -34,10 +34,12 @@ if {${name} ne ${subport}} {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
     }
 
+    depends_test-append \
+                    port:py${python.version}-pytest
+
     test.run        yes
-    test.dir        ${build.dir}/tests
-    test.cmd        ${python.bin} tests.py
-    test.target
+    test.cmd        py.test-${python.branch}
+    test.target     tests
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->