### PR TITLE
retdec-devel: update to 20220323

### DIFF
--- a/devel/retdec/Portfile
+++ b/devel/retdec/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        avast retdec 4.0 v
-revision            5
+revision            0
 conflicts           ${name}-devel
 
 categories          devel
@@ -90,14 +90,14 @@ build.env-append    MAKE=${prefix}/bin/gmake
 subport retdec-devel {
     conflicts       $name
 
-    github.setup    avast retdec 2b375003a6c433590430817c94aa4e0e719e9090
-    version         20220218
+    github.setup    avast retdec 05c9b11351d3e82012d823fa3709f940033768cf
+    version         20220323
     revision        0
     epoch           1
 
-    checksums       rmd160  7f0044589f1e37a5a35028b2b0dbbfd838154aeb \
-                    sha256  8b83c113637d3bc82fc3ff9c282684f05d3ab295adf4f2d5a54382f266586106 \
-                    size    12141137
+    checksums       rmd160  a0aa843afee6de21ca6e6c4f2995034bda3d3a8b \
+                    sha256  35100ba844cece406f68046569681ededca608b9f6210769a6563dda551db86a \
+                    size    27120697
 
     patch.pre_args  -p1
     patchfiles      patch-hardcoded-make-devel.diff


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->