### PR TITLE
openjdk build fixes

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -103,7 +103,7 @@ if {${configure.build_arch} eq "arm64"} {
     configure.post_args --with-build-jdk=/Library/Java/JavaVirtualMachines/openjdk11-zulu/Contents/Home \
                         --openjdk-target=aarch64-apple-darwin
 } elseif {${configure.build_arch} eq "x86_64"} {
-    configure.post_args 
+    configure.post_args
 }
 build.type          gnu
 build.target        images

--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -77,7 +77,8 @@ variant optimized \
 
 variant debug \
     description {OpenJDK with debug information, all optimizations and all asserts} {
-    configure.args-append   --enable-debug
+    configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \

--- a/java/openjdk13/Portfile
+++ b/java/openjdk13/Portfile
@@ -35,7 +35,7 @@ set extraldflags "-Wl,-syslibroot,`xcrun --sdk macosx --show-sdk-path` -arch ${c
 set jchflags "-Wno-implicit-function-declaration -Wno-unused-parameter"
 set jcxxflags "-Wno-implicit-function-declaration -Wno-unused-parameter"
 set jldflags "-L`xcrun --sdk macosx --show-sdk-path`/usr/lib -L`xcrun --sdk macosx --show-sdk-path`/usr/lib/system"
-# default configure args 
+# default configure args
 configure.args      --with-debug-level=release \
                     --with-native-debug-symbols=none \
                     --with-version-pre=release \

--- a/java/openjdk13/Portfile
+++ b/java/openjdk13/Portfile
@@ -62,7 +62,8 @@ variant optimized \
 
 variant debug \
     description {OpenJDK with debug information, all optimizations and all asserts} {
-    configure.args-append   --enable-debug
+    configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \

--- a/java/openjdk15/Portfile
+++ b/java/openjdk15/Portfile
@@ -62,7 +62,8 @@ variant optimized \
 
 variant debug \
     description {OpenJDK with debug information, all optimizations and all asserts} {
-    configure.args-append   --enable-debug
+    configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \

--- a/java/openjdk15/Portfile
+++ b/java/openjdk15/Portfile
@@ -36,7 +36,7 @@ set extraldflags "-Wl,-syslibroot,`xcrun --sdk macosx --show-sdk-path` -arch ${c
 set jchflags "-Wno-implicit-function-declaration -Wno-unused-parameter"
 set jcxxflags "-Wno-implicit-function-declaration -Wno-unused-parameter"
 set jldflags "-L`xcrun --sdk macosx --show-sdk-path`/usr/lib -L`xcrun --sdk macosx --show-sdk-path`/usr/lib/system"
-# default configure args 
+# default configure args
 configure.args      --with-debug-level=release \
                     --with-native-debug-symbols=none \
                     --with-version-pre=release \

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -43,7 +43,7 @@ set extraldflags "-Wl,-syslibroot,`xcrun --sdk macosx --show-sdk-path` -arch ${c
 set jchflags "-Wno-implicit-function-declaration -Wno-unused-parameter"
 set jcxxflags "-Wno-implicit-function-declaration -Wno-unused-parameter"
 set jldflags "-L`xcrun --sdk macosx --show-sdk-path`/usr/lib -L`xcrun --sdk macosx --show-sdk-path`/usr/lib/system"
-# default configure args 
+# default configure args
 configure.args      --with-debug-level=release \
                     --with-native-debug-symbols=none \
                     --with-version-pre=release \

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -70,7 +70,8 @@ variant optimized \
 
 variant debug \
     description {OpenJDK with debug information, all optimizations and all asserts} {
-    configure.args-append   --enable-debug
+    configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -24,7 +24,8 @@ depends_build       port:autoconf \
                     port:openjdk17-bootstrap
 if {${configure.build_arch} eq "arm64"} {
     if {${os.major} == 21} {
-        patchfiles          patch-openjdk17-build1.diff
+        patchfiles          patch-openjdk17-build1.diff \
+                            0001-8280476-macOS-hotspot-arm64-bug-exposed-by-latest-cl.patch
     } else {
         patchfiles
     }

--- a/java/openjdk17/files/0001-8280476-macOS-hotspot-arm64-bug-exposed-by-latest-cl.patch
+++ b/java/openjdk17/files/0001-8280476-macOS-hotspot-arm64-bug-exposed-by-latest-cl.patch
@@ -1,0 +1,36 @@
+From f5d6fddc6df8c5c5456a2544b131833d5227292b Mon Sep 17 00:00:00 2001
+From: "Daniel D. Daugherty" <dcubed@openjdk.org>
+Date: Fri, 4 Feb 2022 17:37:01 +0000
+Subject: [PATCH] 8280476: [macOS] : hotspot arm64 bug exposed by latest clang
+
+Reviewed-by: kbarrett, adinn
+---
+ src/hotspot/cpu/aarch64/immediate_aarch64.cpp | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git src/hotspot/cpu/aarch64/immediate_aarch64.cpp src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+index 3e38b7cca04..916494605bc 100644
+--- src/hotspot/cpu/aarch64/immediate_aarch64.cpp
++++ src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+@@ -129,8 +129,17 @@ static inline uint32_t uimm(uint32_t val, int hi, int lo)
+ 
+ uint64_t replicate(uint64_t bits, int nbits, int count)
+ {
++  assert(count > 0, "must be");
++  assert(nbits > 0, "must be");
++  assert(count * nbits <= 64, "must be");
++
++  // Special case nbits == 64 since the shift below with that nbits value
++  // would result in undefined behavior.
++  if (nbits == 64) {
++    return bits;
++  }
++
+   uint64_t result = 0;
+-  // nbits may be 64 in which case we want mask to be -1
+   uint64_t mask = ones(nbits);
+   for (int i = 0; i < count ; i++) {
+     result <<= nbits;
+-- 
+2.35.1
+

--- a/java/openjdk18/Portfile
+++ b/java/openjdk18/Portfile
@@ -63,7 +63,8 @@ variant optimized \
 
 variant debug \
     description {OpenJDK with debug information, all optimizations and all asserts} {
-    configure.args-append   --enable-debug
+    configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -57,7 +57,8 @@ variant release \
 
 variant debug \
     description {OpenJDK with debug information, all optimizations and all asserts} {
-    configure.args-append   --enable-debug
+    configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant core \


### PR DESCRIPTION
#### Description

A couple of fixes for building the openjdk ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.4 21F5048e
Xcode 13.3 13E113 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
