### PR TITLE
py-igraph: fix building with external igraph

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -45,11 +45,7 @@ if {${name} ne ${subport}} {
 
         depends_build-append    path:bin/pkg-config:pkgconfig
 
-        # To avoid building the vendored igraph, --use-pkg-config must be passed not only
-        # to setup.py build, but also to setup.py install. When updating post-0.9.5,
-        # check if this is still necessary.
-        build.args-append       --use-pkg-config
-        destroot.args-append    --use-pkg-config
+        build.args-append       -C--global-option=--use-pkg-config
     } else {
         # Build with vendored igraph library
 


### PR DESCRIPTION

#### Description

 - Fixes building with an external igraph library, which was broken when PEP 517 support was added

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
