### PR TITLE
skaffold: update to 1.38.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.37.1 v
+github.setup        GoogleContainerTools skaffold 1.38.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  388eb0265f0d3bc0610b69ea2b723e3665e86f6e \
-                    sha256  8dfea015256761525d8c0e54713642bcd7ead3e3c96ff58e301d0b77b9ef3bd5 \
-                    size    21624610
+checksums           rmd160  3d8c15e5d8d81926799fcf1cb2e65f68dd5ef977 \
+                    sha256  42f8f8a6f8f55f8031c87de3c3d35334f2e1f71c2a2120d3cc1a15f8ed71ba31 \
+                    size    21311034
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.38.0.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?