### PR TITLE
rust: enable jemalloc

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -14,7 +14,7 @@ if {${subport} ne "${name}-bootstrap"} {
 }
 PortGroup           cargo   1.0
 
-revision            0
+revision            1
 categories          devel
 supported_archs     x86_64 arm64
 license             {MIT Apache-2}

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -17,7 +17,7 @@ version             1.60.0
 # src/stage0.json. Rust stable 1.x usually requires `set rustc_version 1.(x-1)`
 set rustc_version   1.59.0
 
-revision            0
+revision            1
 
 if { ${subport} eq ${name} } {
     PortGroup       openssl         1.0
@@ -113,6 +113,7 @@ if { ${subport} ne ${ccwrap} } {
                     port:ninja \
                     port:gmake
     depends_lib-append \
+                    port:jemalloc \
                     port:libffi \
                     port:libgit2 \
                     port:zlib
@@ -322,6 +323,7 @@ configure.args    --default-linker=${ld} \
                   --release-channel=stable \
                   --build=${rust_platform} \
                   --local-rust-root=${rust_root} \
+                  --set=rust.jemalloc \
                   --set=target.${rust_platform}.cc=${configure.cc} \
                   --set=target.${rust_platform}.cxx=${configure.cxx} \
                   --set=target.${rust_platform}.linker=${ld} \


### PR DESCRIPTION
Enable `jemalloc` in the Rust compiler, in an attempt to address https://github.com/macports/macports-ports/pull/14523#issuecomment-1093011889

CC: @l2dy 