### PR TITLE
ReadyMedia: add startup item

### DIFF
--- a/net/ReadyMedia/Portfile
+++ b/net/ReadyMedia/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                ReadyMedia
 version             1.3.0
-revision            1
+revision            2
 categories          net multimedia
-maintainers         nomaintainer
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 license             GPL-2
 
 description         a UPnP (TM) A/V & DLNA Media Server
@@ -31,8 +31,26 @@ depends_lib         path:lib/libavcodec.dylib:ffmpeg \
                     port:libexif \
                     port:sqlite3
 
-configure.args      --disable-silent-rules
+set db_path         ${prefix}/var/cache/minidlna
+
+configure.args      --disable-silent-rules \
+                    --with-db-path=${db_path} \
+                    --with-log-path=${prefix}/var/log
+
+add_users           minidlna group=minidlna home=${db_path} \
+                    realname=ReadyMedia shell=/usr/bin/false
+
+startupitem.create  yes
+startupitem.executable \
+                    ${prefix}/sbin/minidlnad -S -u minidlna -g minidlna \
+                    -P ${prefix}/var/run/minidlna/minidlna.pid \
+                    -f ${prefix}/etc/minidlna.conf
 
 post-destroot {
     xinstall -m 644 ${worksrcpath}/minidlna.conf ${destroot}${prefix}/etc/minidlna.conf.sample
 }
+
+notes "
+You may need to give daemondo Full Disk Access for ${name} to scan files when\
+using the startup item.
+"


### PR DESCRIPTION
###### Type(s)
- [x] enhancement

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?