### PR TITLE
openjdk-distributions: move openjdk13-zulu to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -343,35 +343,6 @@ subport openjdk11-zulu {
     worksrcdir   ${distname}/zulu-11.jdk
 }
 
-subport openjdk13-zulu {
-    # https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
-    supported_archs  x86_64 arm64
-
-    version      13.46.15
-    revision     0
-
-    set openjdk_version 13.0.10
-
-    description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
-    long_description ${long_description_zulu}
-
-    master_sites https://cdn.azul.com/zulu/bin/
-
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  c37417003a010428e69a0b53e8800d9997e87577 \
-                     sha256  ed9142deef3d230928207ab64456ca0285213939afe78cd914c5b6689269e87d \
-                     size    200591500
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  6a0bcb3c4485dbdb768e54ea7a7165c0a2199431 \
-                     sha256  92eb552b109a1e68809c319df6dc29798fdd64a07098bd5821387e8b298657e5 \
-                     size    179912266
-    }
-
-    worksrcdir   ${distname}/zulu-13.jdk
-}
-
 # Remove after 2022-09-14
 subport openjdk16 {
     version      16.0.2

--- a/java/openjdk13-zulu/Portfile
+++ b/java/openjdk13-zulu/Portfile
@@ -1,0 +1,102 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk13-zulu
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
+supported_archs  x86_64 arm64
+
+version      13.46.15
+revision     0
+
+set openjdk_version 13.0.10
+
+description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
+long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
+                 specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
+                 verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
+                 respective Java SE version.
+
+master_sites https://cdn.azul.com/zulu/bin/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    checksums    rmd160  c37417003a010428e69a0b53e8800d9997e87577 \
+                 sha256  ed9142deef3d230928207ab64456ca0285213939afe78cd914c5b6689269e87d \
+                 size    200591500
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+    checksums    rmd160  6a0bcb3c4485dbdb768e54ea7a7165c0a2199431 \
+                 sha256  92eb552b109a1e68809c319df6dc29798fdd64a07098bd5821387e8b298657e5 \
+                 size    179912266
+}
+
+worksrcdir   ${distname}/zulu-13.jdk
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 18} {
+    # See https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.14 Mojave or later."
+        return -code error
+    }
+}
+
+homepage     https://www.azul.com/downloads/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk13-zulu` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?