### PR TITLE
openjdk11: fix configure on arm64

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -109,6 +109,7 @@ variant core \
 if {${configure.build_arch} eq "arm64"} {
     configure.args-replace      --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk11-bootstrap/Contents/Home \
                                 --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk11-zulu/Contents/Home
+    configure.args-delete      --with-target-bits=64
     configure.post_args --with-build-jdk=/Library/Java/JavaVirtualMachines/openjdk11-zulu/Contents/Home \
                         --openjdk-target=aarch64-apple-darwin
 } elseif {${configure.build_arch} eq "x86_64"} {


### PR DESCRIPTION
#### Description
Set `--with-target-bits=64` to `configure.args-delete` on arm64 as `--with-target-bits=64` configure argument isn't supported on arm64 and it fails [macOS Big Sur (arm64) buildbot](https://build.macports.org/builders/ports-11_arm64-builder/builds/50585) and [macOS Monterey (arm64) buildbot](https://build.macports.org/builders/ports-12_arm64-builder/builds/47335)
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
