### PR TITLE
gcc-devel: improve header search locations

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -34,8 +34,8 @@ if {${os.arch} eq "arm"} {
 
     # Version must follow same scheme as with GCC snapshots below <version>-<commit-date>
     version         12-20220327
-    revision        0
-    subport         libgcc-devel { revision 0 }
+    revision        1
+    subport         libgcc-devel { revision 1 }
 
     checksums       rmd160  76551e6d93d2a0a15afca6d66ed36f5f23b92b0a \
                     sha256  a21729570ea54460986e0593bef3729356a06d8a9466a7ce5deca7d02948b57b \
@@ -45,8 +45,8 @@ if {${os.arch} eq "arm"} {
     # Use regular GCC releases and snapshsots
 
     version         12-20220403
-    revision        0
-    subport         libgcc-devel { revision 0 }
+    revision        1
+    subport         libgcc-devel { revision 1 }
 
     checksums       rmd160  7ab9d4c3ed8ada8ca619d21d22a524014b1aee01 \
                     sha256  f534aeab7a9809191130361c9f05e1b83bc8014c9fb833ca73549759221098e0 \
@@ -121,7 +121,7 @@ configure.args      --enable-languages=[join ${gcc_configure_langs} ","] \
                     --infodir=${prefix}/share/info \
                     --mandir=${prefix}/share/man \
                     --datarootdir=${prefix}/share/gcc-devel \
-                    --with-local-prefix=${prefix} \
+                    --with-local-prefix=no \
                     --with-system-zlib \
                     --disable-nls \
                     --program-suffix=-mp-devel \
@@ -198,23 +198,31 @@ pre-configure {
         configure.args-append --with-sysroot="[get_clean_sysroot]"
     }
 
-}
-
-variant enable_stdlib_flag description {Enable stdlib command line flag to select c++ runtime} {
-    # Enables support for specifying the c++ runtime via `-stdlib=` in a similar
-    # way to clang. For more details see the later comments in
-    #   https://www.mail-archive.com/gcc-patches@gcc.gnu.org/msg257385.html
-    # Note : This 'bakes' the libc++ include directory into gcc,
-    # which is then used as the default search location when `-stdlib=libc++`
-    # is given. Therefore to have consistency across various OS versions, and to enable
-    # modern c++ standards, use a recent macports clang port to provide this.
-    set mp_clang_ver       13
-    if {${subport} eq ${name}} {
-        depends_run-append port:clang-${mp_clang_ver}
+    # find the system C++ header files
+    # for more information on --with-gxx-libcxx-include-dir, see https://www.mail-archive.com/gcc-patches@gcc.gnu.org/msg257385.html
+    if { ${configure.sdkroot} ne "" && ${os.major} > 20 } {
+        set libcxx_include          [get_clean_sysroot]/usr/include/c++/v1
+    } else {
+        if { ${os.major} > 12 } {
+            if { ${use_xcode} } {
+                set libcxx_include  ${configure.developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1
+            } else {
+                set libcxx_include  /Library/Developer/CommandLineTools/usr/include/c++/v1
+            }
+        } elseif { ${os.major} > 10 } {
+            if { ${use_xcode} } {
+                set libcxx_include  ${configure.developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/lib/c++/v1
+            } else {
+                set libcxx_include  /usr/lib/c++/v1
+            }
+        } else {
+            # libc++ is provided by MacPorts port libcxx
+            # currently, the header files are not installed, but that could be fixed
+            set libcxx_include      /usr/include
+        }
     }
-    configure.args-append  --with-gxx-libcxx-include-dir="${prefix}/libexec/llvm-${mp_clang_ver}/include/c++/v1"
+    configure.args-append   --with-gxx-libcxx-include-dir=${libcxx_include}
 }
-default_variants-append +enable_stdlib_flag
 
 # https://trac.macports.org/ticket/29067
 # https://trac.macports.org/ticket/29104


### PR DESCRIPTION
Setting the local prefix to the MacPorts `${prefix}` does little good
since the sysroot is prepended.
The same reasoning applies to the default value of `/usr/local`.
Therefore, do not set the local prefix.

Since the `-stdlib=` uses the system libc++, it should also use the
corresponding system headers.
By including the sysroot in the path, the resulting compiler
respects the environment variable `SDKROOT`.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
