### PR TITLE
compiler_wrapper PG: create wrappers in post-extract

### DIFF
--- a/_resources/port1.0/group/compiler_wrapper-1.0.tcl
+++ b/_resources/port1.0/group/compiler_wrapper-1.0.tcl
@@ -88,7 +88,7 @@ proc compwrap::wrapped_compiler_path {tag} {
     # Get the underlying compiler
     set comp [option configure.${tag}]
     # If not defined, or tag not in list of known compilers to wrap, just return
-    if {${comp} eq "" || [lsearch -exact [option compwrap.compilers_to_wrap] ${tag}] < 0} {
+    if {${comp} eq "" || ${tag} ni [option compwrap.compilers_to_wrap]} {
         return ${comp}
     }
     return [compwrap::wrapped_command_path ${tag} ${comp}]

--- a/_resources/port1.0/group/compiler_wrapper-1.0.tcl
+++ b/_resources/port1.0/group/compiler_wrapper-1.0.tcl
@@ -106,6 +106,21 @@ proc compwrap::wrap_compiler {tag} {
         return ${comp}
     }
 
+    return ${wrapcomp}
+}
+
+post-extract {
+    foreach tag [option compwrap.compilers_to_wrap] {
+
+        # Get the underlying compiler
+        set comp [option configure.${tag}]
+
+        # Get the wrapper path
+        set wrapcomp [compwrap::wrapped_compiler_path ${tag}]
+        if { ${wrapcomp} eq ${comp} } {
+            continue
+        }
+
         # Create the directory for the wrapper.
         set wrapdir [file dirname ${wrapcomp}]
         if {![file exists ${wrapdir}]} {
@@ -176,8 +191,7 @@ proc compwrap::wrap_compiler {tag} {
         }
         puts ${f} "exec ${comp} ${comp_opts}"
         close ${f}
-
-    return ${wrapcomp}
+    }
 }
 
 # Set various env vars


### PR DESCRIPTION
This allows `compwrap::wrap_compiler` to be called
anywhere in the Portfile.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
