### PR TITLE
crossgcc: add depends zstd for gcc10 and later

### DIFF
--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -272,6 +272,11 @@ proc crossgcc.setup {target version} {
         # fatal error: error in backend: ran out of registers during register allocation
         compiler.blacklist  {clang >= 421 < 422}
 
+        # Opportunistic links zstd for LTO byte code compression
+        if { ${version} >= 10.0 } {
+            depends_lib-append  port:zstd
+        }
+
         # Section taken from gcc11 Portfile
         if { ${version} >= 11.0 } {
             # https://trac.macports.org/ticket/29067

--- a/cross/arm-none-eabi-gcc/Portfile
+++ b/cross/arm-none-eabi-gcc/Portfile
@@ -7,7 +7,7 @@ set gccversion      11.2.0
 set newlibversion   4.1.0
 crossgcc.setup      arm-none-eabi ${gccversion}
 crossgcc.setup_libc newlib ${newlibversion}
-revision            1
+revision            2
 
 maintainers         nomaintainer
 

--- a/cross/avr-gcc/Portfile
+++ b/cross/avr-gcc/Portfile
@@ -5,7 +5,7 @@ PortGroup               crossgcc 1.0
 
 name                    avr-gcc
 crossgcc.setup          avr 11.2.0
-revision                1
+revision                2
 
 maintainers             nomaintainer
 license                 {GPL-3+ Permissive}

--- a/cross/i686-w64-mingw32-gcc/Portfile
+++ b/cross/i686-w64-mingw32-gcc/Portfile
@@ -73,8 +73,7 @@ subport ${mingw_target}-gcc-nothreads {
 # Final phase
 if {${subport} eq ${name}} {
     depends_lib-append      port:${mingw_target}-crt \
-                            port:${mingw_target}-winpthreads  \
-                            port:zstd
+                            port:${mingw_target}-winpthreads
 
     depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads
 

--- a/cross/x86_64-w64-mingw32-gcc/Portfile
+++ b/cross/x86_64-w64-mingw32-gcc/Portfile
@@ -70,8 +70,7 @@ subport ${mingw_target}-gcc-nothreads {
 # Final phase
 if {${subport} eq ${name}} {
     depends_lib-append      port:${mingw_target}-crt \
-                            port:${mingw_target}-winpthreads \
-                            port:zstd
+                            port:${mingw_target}-winpthreads
 
     depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads
 


### PR DESCRIPTION
Moved depends_lib zstd into the portgroup as discussed in https://github.com/macports/macports-ports/pull/13671

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
