### PR TITLE
ruby*: enable tests

### DIFF
--- a/lang/ruby26/Portfile
+++ b/lang/ruby26/Portfile
@@ -207,6 +207,8 @@ platform darwin {
     }
 }
 
+test.run        yes
+test.target     check
 
 livecheck.type  regex
 livecheck.url   https://cache.ruby-lang.org/pub/ruby/2.6/

--- a/lang/ruby27/Portfile
+++ b/lang/ruby27/Portfile
@@ -171,6 +171,8 @@ platform darwin {
     }
 }
 
+test.run        yes
+test.target     check
 
 livecheck.type  regex
 livecheck.url   https://cache.ruby-lang.org/pub/ruby/2.7/

--- a/lang/ruby30/Portfile
+++ b/lang/ruby30/Portfile
@@ -167,6 +167,8 @@ platform darwin {
     }
 }
 
+test.run        yes
+test.target     check
 
 livecheck.type  regex
 livecheck.url   https://cache.ruby-lang.org/pub/ruby/3.0/

--- a/lang/ruby31/Portfile
+++ b/lang/ruby31/Portfile
@@ -154,6 +154,8 @@ platform darwin {
     }
 }
 
+test.run        yes
+test.target     check
 
 livecheck.type  regex
 livecheck.url   https://cache.ruby-lang.org/pub/ruby/${ruby_ver}/


### PR DESCRIPTION
#### Description

Enable the test suite in non-obsolete Ruby ports.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
