### PR TITLE
gcc10-bootstrap: fixup builds

### DIFF
--- a/lang/gcc10-bootstrap/Portfile
+++ b/lang/gcc10-bootstrap/Portfile
@@ -106,6 +106,10 @@ patchfiles-append patch-darwin21.diff
 # https://trac.macports.org/ticket/63161
 patchfiles-append patch-build-i686.diff
 
+# Bootstrap fails with Clang 12.0.5 (XCode 12.5)
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
+patchfiles-append patch-xcode12-fix.diff
+
 # sterilize MacPorts build environment; we want nothing picked up from MP prefix
 compiler.cpath
 compiler.library_path
@@ -176,20 +180,25 @@ if {${os.major} >= 18 && ${configure.sdkroot} ne ""} {
     configure.args-append --with-sysroot="[regsub {MacOSX1[0-9]\.[0-9]+\.sdk} ${configure.sdkroot} {MacOSX.sdk}]"
 }
 
-# clang (as) from Xcode 12.5 has various problems with gcc build
-if { ${os.platform} eq "darwin" && \
-         ( [ vercmp ${xcodeversion} 12.5 ] >= 0 || [ vercmp ${cltversion} 12.5 ] >= 0 ) } {
-    pre-configure {
-        ui_warn "Applying '--without-build-config' workaround to Xcode ${xcodeversion} / CLT ${cltversion}"
-        ui_warn "If versions > 12.5 please check if it is still required"
-    }
-    # gcc has build issues on macOS 11.3 with the use of Xcode clang as 'as'
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
-    # https://trac.macports.org/ticket/62775
-    configure.args-append  --without-build-config
+if {${os.major} < 18 || ${os.major} > 19} {
+    default_variants    +universal
 }
 
-default_variants    +universal
+platform powerpc {
+    configure.universal_archs ppc ppc64
+}
+if { ${os.platform} eq "darwin" && ${os.major} >= 20 } {
+    platform i386 {
+        configure.universal_archs x86_64 arm64
+    }
+    platform arm {
+        configure.universal_archs x86_64 arm64
+    }
+} else {
+    platform i386 {
+        configure.universal_archs i386 x86_64
+    }
+}
 
 platform darwin 8 {
     configure.args-append \
@@ -199,10 +208,6 @@ platform darwin 8 {
 merger_arch_flag            yes
 merger_arch_compiler        yes
 merger_must_run_binaries    yes
-
-if {![info exists universal_possible]} {
-    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
-}
 
 set merger_host(arm64)  aarch64-apple-${os.platform}${os.major}
 set merger_host(i386)   i386-apple-${os.platform}${os.major}
@@ -216,14 +221,6 @@ foreach {arch target} [array get merger_host] {
 }
 
 if {${universal_possible} && [variant_isset universal]} {
-    configure.args-replace \
-                     --disable-multilib \
-                     --enable-multilib
-
-    configure.args-replace \
-                     --disable-multiarch \
-                     --enable-multiarch
-
     set universal_targets ""
     foreach arch ${configure.universal_archs} {
         set universal_targets "${universal_targets},$merger_host(${arch})"
@@ -261,21 +258,17 @@ you must use per target compiler. The easy way is using muniversal PG:
 
 PortGroup               muniversal 1.0
 
-if {![info exists universal_possible]} {
-    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
-}
-
-if {${universal_possible} && [variant_isset universal]} {
-    array set cpu_arch_map {arm64 aarch64 i386 x86 ppc powerpc ppc64  powerpc64 x86_64 x86_64}
+if \{\$\{universal_possible\} && \[variant_isset universal\]\} \{
+    array set cpu_arch_map \{arm64 aarch64 i386 x86 ppc powerpc ppc64  powerpc64 x86_64 x86_64\}
 
     configure.cc        {}
     configure.cxx       {}
 
-    foreach {arch target} [array get cpu_arch_map] {
-        lappend merger_configure_env(${arch}) \
-                        CC=${prefix}/libexec/gcc10-bootstrap/bin/${target}-apple-${os.platform}${os.major}-gcc
-        lappend merger_configure_env(${arch}) \
-                        CXX=${prefix}/libexec/gcc10-bootstrap/bin/${target}-apple-${os.platform}${os.major}-g++
+    foreach \{arch target\} \[array get cpu_arch_map\] \{
+        lappend merger_configure_env(\$\{arch\}) \
+                        CC=\$\{prefix\}/libexec/${name}/bin/\$\{target\}-apple-\$\{os.platform\}\$\{os.major\}-gcc
+        lappend merger_configure_env(\$\{arch\}) \
+                        CXX=\$\{prefix\}/libexec/${name}/bin/\$\{target\}-apple-\$\{os.platform\}\$\{os.major\}-g++
     }
 } else {
     configure.cc        \$\{prefix\}/libexec/${name}/bin/gcc

--- a/lang/gcc10-bootstrap/files/patch-xcode12-fix.diff
+++ b/lang/gcc10-bootstrap/files/patch-xcode12-fix.diff
@@ -1,0 +1,145 @@
+From 8b333df9484c1697f3a80530a47aa90b1859e970 Mon Sep 17 00:00:00 2001
+From: Iain Sandoe <iain@sandoe.co.uk>
+Date: Sat, 31 Jul 2021 16:29:03 +0100
+Subject: [PATCH] Darwin, X86, config: Adjust 'as' command lines [PR100340].
+
+Versions of the assembler using clang from XCode 12.5/12.5.1
+have a bug which produces different code layout between debug and
+non-debug input, leading to a compare fail for default configure
+parameters.
+
+This is a workaround fix to disable the optimisation that is
+responsible for the bug.
+
+Signed-off-by: Iain Sandoe <iain@sandoe.co.uk>
+
+PR target/100340 - Bootstrap fails with Clang 12.0.5 (XCode 12.5)
+
+	PR target/100340
+
+gcc/ChangeLog:
+
+	* config.in: Regenerate.
+	* config/i386/darwin.h (EXTRA_ASM_OPTS): New
+	(ASM_SPEC): Pass options to disable branch shortening where
+	needed.
+	* configure: Regenerate.
+	* configure.ac: Detect versions of 'as' that support the
+	optimisation which has the bug.
+
+(cherry picked from commit 743b8dd6fd757e997eb060d70fd4ae8e04fb56cd)
+---
+ gcc/config.in            |  7 +++++++
+ gcc/config/i386/darwin.h | 10 +++++++++-
+ gcc/configure            | 35 +++++++++++++++++++++++++++++++++++
+ gcc/configure.ac         |  9 +++++++++
+ 4 files changed, 60 insertions(+), 1 deletion(-)
+
+diff --git gcc/config.in gcc/config.in
+index 18db43ce4aeba..4d5da7dab3a81 100644
+--- gcc/config.in
++++ gcc/config.in
+@@ -604,6 +604,13 @@
+ #endif
+ 
+ 
++/* Define if your Mac OS X assembler supports -mllvm -x86-pad-for-align=false.
++   */
++#ifndef USED_FOR_TARGET
++#undef HAVE_AS_MLLVM_X86_PAD_FOR_ALIGN
++#endif
++
++
+ /* Define if your Mac OS X assembler supports the -mmacos-version-min option.
+    */
+ #ifndef USED_FOR_TARGET
+diff --git gcc/config/i386/darwin.h gcc/config/i386/darwin.h
+index c81db9bf09fcd..e4a5cbea65786 100644
+--- gcc/config/i386/darwin.h
++++ gcc/config/i386/darwin.h
+@@ -135,10 +135,18 @@ along with GCC; see the file COPYING3.  If not see
+   %{mfentry*:%eDarwin does not support -mfentry or associated options}" \
+   DARWIN_CC1_SPEC
+ 
++/* This is a workaround for a tool bug: see PR100340.  */
++
++#ifdef HAVE_AS_MLLVM_X86_PAD_FOR_ALIGN
++#define EXTRA_ASM_OPTS " -mllvm -x86-pad-for-align=false"
++#else
++#define EXTRA_ASM_OPTS ""
++#endif
++
+ #undef ASM_SPEC
+ #define ASM_SPEC "-arch %(darwin_arch) \
+   " ASM_OPTIONS " -force_cpusubtype_ALL \
+-  %{static}" ASM_MMACOSX_VERSION_MIN_SPEC
++  %{static}" ASM_MMACOSX_VERSION_MIN_SPEC EXTRA_ASM_OPTS
+ 
+ #undef ENDFILE_SPEC
+ #define ENDFILE_SPEC \
+diff --git gcc/configure gcc/configure
+index 0398dedd34ea8..e84ec2e4a6228 100755
+--- gcc/configure
++++ gcc/configure
+@@ -26919,6 +26919,41 @@ $as_echo "$as_me: WARNING: LTO for $target requires binutils >= 2.20.1, but vers
+ 	fi
+ 	;;
+     esac
++    case $target_os in
++       darwin2[0-9]* | darwin19*)
++        { $as_echo "$as_me:${as_lineno-$LINENO}: checking assembler for llvm assembler x86-pad-for-align option" >&5
++$as_echo_n "checking assembler for llvm assembler x86-pad-for-align option... " >&6; }
++if ${gcc_cv_as_mllvm_x86_pad_for_align+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  gcc_cv_as_mllvm_x86_pad_for_align=no
++  if test x$gcc_cv_as != x; then
++    $as_echo '.text' > conftest.s
++    if { ac_try='$gcc_cv_as $gcc_cv_as_flags -mllvm -x86-pad-for-align=false -o conftest.o conftest.s >&5'
++  { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_try\""; } >&5
++  (eval $ac_try) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; }
++    then
++	gcc_cv_as_mllvm_x86_pad_for_align=yes
++    else
++      echo "configure: failed program was" >&5
++      cat conftest.s >&5
++    fi
++    rm -f conftest.o conftest.s
++  fi
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $gcc_cv_as_mllvm_x86_pad_for_align" >&5
++$as_echo "$gcc_cv_as_mllvm_x86_pad_for_align" >&6; }
++if test $gcc_cv_as_mllvm_x86_pad_for_align = yes; then
++
++$as_echo "#define HAVE_AS_MLLVM_X86_PAD_FOR_ALIGN 1" >>confdefs.h
++
++fi
++
++       ;;
++    esac
+ 
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking assembler for -xbrace_comment" >&5
+ $as_echo_n "checking assembler for -xbrace_comment... " >&6; }
+diff --git gcc/configure.ac gcc/configure.ac
+index 1b31a246ae486..bd37d47f4a1d0 100644
+--- gcc/configure.ac
++++ gcc/configure.ac
+@@ -4729,6 +4729,15 @@ foo:	nop
+ 	fi
+ 	;;
+     esac
++    case $target_os in
++       darwin2[[0-9]]* | darwin19*)
++        gcc_GAS_CHECK_FEATURE([llvm assembler x86-pad-for-align option],
++          gcc_cv_as_mllvm_x86_pad_for_align,,
++          [-mllvm -x86-pad-for-align=false], [.text],,
++          [AC_DEFINE(HAVE_AS_MLLVM_X86_PAD_FOR_ALIGN, 1,
++	    [Define if your Mac OS X assembler supports -mllvm -x86-pad-for-align=false.])])
++       ;;
++    esac
+ 
+     gcc_GAS_CHECK_FEATURE([-xbrace_comment], gcc_cv_as_ix86_xbrace_comment,,
+       [-xbrace_comment=no], [.text],,


### PR DESCRIPTION
- remove compact code thats part of base
- add upstream xcode12 patch
- fix universal
- fix up usage notes

#### Description

All builds were +universal installing without issue, macOS Mojave was using `MacOSX10.13.sdk` with deployment target set to 10.13 to enable i386 architecture.

<br>

This PR does **not** make `gcc` and other binaries function more like a normal macports-gcc compiler, this still functions more like a cross-compiler. When using `gcc` or other normally named binaries it will only support a single arch so when launched as i386 `gcc` will compile for i386, if launched as x86_64 `gcc` will compile for x86_64 etc.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6 20G165 arm64
Xcode 13.2.1 13C100

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

command line tools install
macOS 10.9.5 13F1911 x86_64

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
