### PR TITLE
slum: Switch to fork, update, fix arm64 build

### DIFF
--- a/net/slurm/Portfile
+++ b/net/slurm/Portfile
@@ -2,20 +2,21 @@
 
 PortSystem      1.0
 
-name            slurm
-version         0.3.3
+PortGroup       github 1.0
+PortGroup       cmake 1.1
 
-checksums       rmd160  6f154e5e6be0ac746dc67e152cf9caf1580c14fe \
-                sha256  b25889aa1910b1bb48e4eafdac0c810bc02e8b98ddb2ade0aed2ec64672d6834
+github.setup    mattthias slurm d0cc378c8fd250a59b2c43d5322df23f6d487308
+version         20211014
+checksums       rmd160  4e536861430578fce4bb6a1aa38a13183cfedf68 \
+                sha256  a5a0ce11cbe7dc7eb355d7775e3e614e3bfaff09d0f7737ba4179ed7baedc171 \
+                size    36541
 
 categories      net
 license         GPL-2+
 maintainers     wormulon.net:hscholz
 platforms       darwin freebsd netbsd openbsd
 
-homepage        http://www.wormulon.net/slurm/
-master_sites    http://www.wormulon.net/files/slurm/
-description     generic network load monitor
+description     yet another network load monitor
 long_description \
     slurm started as a port of pppstatus to FreeBSD and now is a generic \
     curses based network load monitor. \
@@ -23,4 +24,5 @@ long_description \
     interface statistics for all kinds of network interfaces on most \
     Unix systems.
 
-configure.args   --mandir=${prefix}/share/man
+depends_lib-append \
+                port:ncurses


### PR DESCRIPTION
#### Description

Upstream for slurm is dead. Switch to a fork that seems to be maintained by some debian people and update to the current state (note that the published releases are very old).

This fixes the build on arm64, which would otherwise require a autoreconf because config.sub does not understand the arm64 machine.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 arm64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
