### PR TITLE
multiple ports: use HTTPS for invisible-island.net distfiles

### DIFF
--- a/devel/bcpp/Portfile
+++ b/devel/bcpp/Portfile
@@ -12,8 +12,8 @@ long_description \
 	(by design) not attempt to wrap long statements.
 homepage         https://invisible-island.net/bcpp/
 platforms        darwin
-master_sites     ftp://ftp.invisible-island.net/pub/bcpp/ \
-                 https://invisible-mirror.net/archives/bcpp/
+master_sites     https://invisible-island.net/archives/${name}/ \
+                 https://invisible-mirror.net/archives/${name}/
 extract.suffix   .tgz
 checksums        rmd160  0f52c8a88f9f032e9996766dd07e8e81a9f4ef10 \
                  sha256  567ca0e803bfd57c41686f3b1a7df4ee4cec3c2d57ad4f8e5cda247fc5735269 \

--- a/devel/byacc/Portfile
+++ b/devel/byacc/Portfile
@@ -9,15 +9,15 @@ maintainers      {toby @tobypeterson}
 license          public-domain
 description      Berkeley Yacc
 long_description \
-	Berkeley Yacc (byacc) is generally conceded to \
-	be the best yacc variant available. In contrast \
-	to bison, it is written to avoid dependencies \
-	upon a particular compiler.
+        Berkeley Yacc (byacc) is generally conceded to \
+        be the best yacc variant available. In contrast \
+        to bison, it is written to avoid dependencies \
+        upon a particular compiler.
 homepage         https://invisible-island.net/byacc/
 platforms        darwin
 
-master_sites     ftp://ftp.invisible-island.net/pub/byacc/ \
-                 https://invisible-mirror.net/archives/byacc/
+master_sites     https://invisible-island.net/archives/${name}/ \
+                 https://invisible-mirror.net/archives/${name}/
 extract.suffix   .tgz
 
 checksums        rmd160 ebf3323cdcbadc06ea8001771765a0b5370702c8 \

--- a/devel/cproto/Portfile
+++ b/devel/cproto/Portfile
@@ -18,8 +18,8 @@ long_description    ${name} is a program that generates function prototypes \
                     and the ANSI C style.
 
 homepage            https://invisible-island.net/cproto/cproto.html
-master_sites        https://invisible-mirror.net/archives/${name}/ \
-                    ftp://ftp.invisible-island.net/cproto/
+master_sites        https://invisible-island.net/archives/${name}/ \
+                    https://invisible-mirror.net/archives/${name}/
 
 extract.suffix      .tgz
 

--- a/devel/dialog/Portfile
+++ b/devel/dialog/Portfile
@@ -16,8 +16,8 @@ long_description    ${name} is {*}${description}. It is non-graphical (it uses \
                     curses) so it can be run in the console or an xterm.
 
 homepage            https://invisible-island.net/dialog/
-master_sites        ftp://ftp.invisible-island.net/pub/dialog/ \
-                    https://invisible-mirror.net/archives/dialog/
+master_sites        https://invisible-island.net/archives/${name}/ \
+                    https://invisible-mirror.net/archives/${name}/
 
 extract.suffix      .tgz
 

--- a/devel/diffstat/Portfile
+++ b/devel/diffstat/Portfile
@@ -3,6 +3,7 @@ PortSystem 1.0
 name                    diffstat
 version                 1.64
 categories              devel
+license                 MIT
 maintainers             {toby @tobypeterson}
 description             Make histogram from diff-output
 long_description        diffstat reads the output of diff and displays a histogram\
@@ -10,8 +11,8 @@ long_description        diffstat reads the output of diff and displays a histogr
                         It is useful for reviewing large, complex patch files.
 homepage                https://invisible-island.net/diffstat/
 platforms               darwin
-master_sites            ftp://ftp.invisible-island.net/pub/diffstat/ \
-                        https://invisible-mirror.net/archives/diffstat/
+master_sites            https://invisible-island.net/archives/${name}/ \
+                        https://invisible-mirror.net/archives/${name}/
 extract.suffix          .tgz
 checksums               rmd160 2e212599a50aa0dce86ac9022d41acc6e85f71b2 \
                         sha256 b8aee38d9d2e1d05926e6b55810a9d2c2dd407f24d6a267387563a4436e3f7fc \

--- a/devel/reflex/Portfile
+++ b/devel/reflex/Portfile
@@ -24,8 +24,8 @@ long_description    Reflex is a new implementation of flex, which is a tool \
                     text.
 
 homepage            https://invisible-island.net/reflex/
-master_sites        ftp://ftp.invisible-island.net/pub/reflex/ \
-                    https://invisible-mirror.net/archives/reflex/
+master_sites        https://invisible-island.net/archives/${name}/ \
+                    https://invisible-mirror.net/archives/${name}/
 distname            ${name}-${version_date}
 extract.suffix      .tgz
 

--- a/devel/vttest/Portfile
+++ b/devel/vttest/Portfile
@@ -18,8 +18,8 @@ long_description    Test the compatibility of VT100/VT220/XTerm terminal \
 
 homepage            https://invisible-island.net/vttest/
 
-master_sites        ftp://ftp.invisible-island.net/pub/vttest/ \
-                    https://invisible-mirror.net/archives/vttest/
+master_sites        https://invisible-island.net/archives/${name}/ \
+                    https://invisible-mirror.net/archives/${name}/
 
 extract.suffix      .tgz
 

--- a/editors/vile/Portfile
+++ b/editors/vile/Portfile
@@ -24,7 +24,7 @@ long_description    vile is a text editor which is extremely compatible \
                     interpreter, and robust support for non-Unix hosts.
 
 homepage            https://invisible-island.net/vile/
-master_sites        ftp://ftp.invisible-island.net/pub/${name}/current/ \
+master_sites        https://invisible-island.net/archives/${name}/current/ \
                     https://invisible-mirror.net/archives/${name}/current/
 extract.suffix      .tgz
 

--- a/lang/mawk/Portfile
+++ b/lang/mawk/Portfile
@@ -16,7 +16,7 @@ platforms       darwin
 license         GPL-2
 maintainers     {toby @tobypeterson}
 
-master_sites    ftp://ftp.invisible-island.net/pub/${name}/ \
+master_sites    https://invisible-island.net/archives/${name}/ \
                 https://invisible-mirror.net/archives/${name}/
 extract.suffix  .tgz
 checksums       rmd160 4b845606dae6ae259f507f9ad3f08d02c4f48586 \

--- a/math/add/Portfile
+++ b/math/add/Portfile
@@ -15,7 +15,8 @@ long_description    add is a fixed-point calculator that operates as a full-scre
                     It is designed for use as a checkbook or expense-account balancing tool.
 
 homepage            https://invisible-island.net/add/
-master_sites        ftp://ftp.invisible-island.net/pub/add/
+master_sites        https://invisible-island.net/archives/${name}/ \
+                    https://invisible-mirror.net/archives/${name}/
 extract.suffix      .tgz
 
 checksums           rmd160  b401b0f2866efe87844e0ba2a24853ba067fd1ed \

--- a/x11/luit/Portfile
+++ b/x11/luit/Portfile
@@ -1,18 +1,18 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-
 PortSystem          1.0
 
 name                luit
 version             2.0.20220111
 categories          x11
 license             X11
+platforms           darwin
 maintainers         {invisible-island.net:dickey @ThomasDickey} openmaintainer
 description         filter that converts legacy encodings to/from UTF-8
 long_description    ${name} is a filter that converts terminal I/O \
                     between legacy encodings and UTF-8.
 
 homepage            https://invisible-island.net/${name}/
-master_sites        https://invisible-mirror.net/archives/${name}/current/
+master_sites        https://invisible-island.net/archives/${name}/current/ \
+                    https://invisible-mirror.net/archives/${name}/current/
 
 extract.suffix      .tgz
 
@@ -21,11 +21,12 @@ checksums           rmd160  82bd24c29a30d48a12ec3d91d58027f68813ffdc \
                     size    204924
 
 installs_libs       no
-
-depends_build       port:pkgconfig
-
 use_parallel_build  yes
+
+depends_build \
+	port:pkgconfig
 
 livecheck.type    regex
 livecheck.regex   ${name}-(\\d+(?:\\.\\d+)*)
 livecheck.url     https://invisible-mirror.net/archives/luit/current/?C=M&O=D
+livecheck.version ${name}-${version}${extract.suffix}

--- a/x11/xterm/Portfile
+++ b/x11/xterm/Portfile
@@ -18,8 +18,8 @@ long_description    The xterm program is a terminal emulator for the X \
                     including colors, Unicode, etc.
 
 homepage            https://invisible-island.net/xterm/
-master_sites        ftp://ftp.invisible-island.net/pub/xterm/ \
-                    https://invisible-mirror.net/archives/xterm/
+master_sites        https://invisible-island.net/archives/${name}/ \
+                    https://invisible-mirror.net/archives/${name}/
 extract.suffix      .tgz
 
 depends_build       port:xorg-xorgproto


### PR DESCRIPTION
#### Description

Update URLs for invisible-island.net to replace FTP with HTTPS, matching invisible-mirror.net

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
macOS 11.6.5 20G527 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
