### PR TITLE
syncthing: update to 1.19.2

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.19.0 v
+go.setup            github.com/syncthing/syncthing 1.19.2 v
 revision            0
 categories          net
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
 homepage            https://syncthing.net
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  0d16df5427602d478c847f23d724625986ba467d \
-                        sha256  d44cf00cdcf472487cca5df88e254479ddeba5058aaa5c82fa7abc2f48adf196 \
-                        size    6197428
+                        rmd160  1616646488b0c6dd57b0652110f6827daad1831b \
+                        sha256  722fe8b9a3b881823cd0d329760652961e0144fe9c100efe1a9d87da051e5441 \
+                        size    6197758
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    496545a6307b \
@@ -100,10 +100,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  2122a2b193a2d096f3792e4f8d6a7bb2a504a0d5bba7b0d1bfe81707917831a3 \
                         size    78154 \
                     github.com/thejerf/suture \
-                        lock    v4.0.1 \
-                        rmd160  d5655c5791b8d08099693beb048e416826d0516d \
-                        sha256  aa987047e44c1d21d83cb35f125a9c19eb28a27c3def64bb3ff725536dc3a751 \
-                        size    38106 \
+                        lock    v4.0.2 \
+                        rmd160  40d89df2655c772b986c1324a8b7fccc0256787d \
+                        sha256  7bb9e81b6c0033939e93780b535551b4c9315f102fafc94ce4659fc983fcf78f \
+                        size    38431 \
                     github.com/syndtr/goleveldb \
                         lock    d9e9293bd0f7 \
                         rmd160  1c363aa498b3fae0918bf839dcaa673193080f50 \
@@ -180,10 +180,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
                     github.com/pierrec/lz4 \
-                        lock    v4.1.12 \
-                        rmd160  9860b2d228c09d636d832c31293a3befd220be45 \
-                        sha256  54ff5d346eb98d4a040c872328964ce47cf015221ff7ed97ff81aa1b17f04369 \
-                        size    40904518 \
+                        lock    v4.1.13 \
+                        rmd160  e87a1030785866dd2a450740c5ab27111001ac18 \
+                        sha256  1946f34c4c3aa6cecfbaef23785491a31a32d1160d7b909fccdcd232ea8a1463 \
+                        size    40904323 \
                     github.com/petermattis/goid \
                         lock    b0b1615b78e5 \
                         rmd160  67d260bb5f1a1a99879d0d009f7f0e9e2d872584 \


### PR DESCRIPTION
#### Description

Updates syncthing to 1.19.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
