### PR TITLE
gdb-apple: fix build on 10.5/10.6

### DIFF
--- a/devel/gdb-apple/Portfile
+++ b/devel/gdb-apple/Portfile
@@ -37,19 +37,21 @@ distname        gdb-${version}
 master_sites    http://opensource.apple.com/tarballs/gdb
 
 checksums       rmd160  90290c3950dd06c1691a477b9ee302c00b681ed1 \
-                sha256  d25b056a826015e1e0ea338b9b8f03e40dce3ff4696faf95df259ae1a42698da
+                sha256  d25b056a826015e1e0ea338b9b8f03e40dce3ff4696faf95df259ae1a42698da \
+                size    18298209
 
 depends_build   port:gettext port:zlib port:flex port:texinfo
 
 depends_lib     port:libiconv port:ncurses port:sqlite3
 
-patchfiles      patch-macosx-nat.c.diff
+patchfiles      patch-gdb-headers.diff \
+                patch-macosx-nat.c.diff \
+                patch-macosx-tdep.c.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     patchfiles-append \
-                patch-macosx-tdep.c.diff \
-                patch-macosx-nat-threads.c.diff \
-                patch-gdb-availability.diff
+                patch-gdb-backtrace.diff \
+                patch-macosx-nat-threads.c.diff
 
     if {${os.major} == 8} {
         depends_build-append port:libmacho-headers

--- a/devel/gdb-apple/files/patch-gdb-backtrace.diff
+++ b/devel/gdb-apple/files/patch-gdb-backtrace.diff
@@ -1,0 +1,59 @@
+Check the deployment target before calling backtrace.
+
+This patch requires patch-gdb-headers.diff.
+
+--- gdb/remote.c
++++ gdb/remote.c
+@@ -64,7 +64,10 @@
+ #include "macosx-nat-dyld.h"
+ #include "macosx-nat-dyld-process.h"
+ #endif
++#ifdef HAVE_EXECINFO_H
+ #include <execinfo.h>
++#endif
++#include <AvailabilityMacros.h>
+ 
+ /* Prototypes for local functions.  */
+ static void cleanup_sigint_signal_handler (void *dummy);
+@@ -478,11 +481,13 @@ struct memory_packet_config
+ static void
+ remote_backtrace_self (const char *message)
+ {
++#if (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+   void *bt_buffer[100];
+   int count = backtrace (bt_buffer, 100);
+   if (message && message[0])
+     fprintf_filtered (gdb_stderr, "%s", message);
+   backtrace_symbols_fd (bt_buffer, count, STDERR_FILENO);
++#endif
+ }
+ 
+ static void
+--- gdb/utils.c
++++ gdb/utils.c
+@@ -28,7 +28,10 @@
+ #include "event-top.h"
+ #include "exceptions.h"
+ #include "bfd.h"
++#ifdef HAVE_EXECINFO_H
+ #include <execinfo.h>
++#endif
++#include <AvailabilityMacros.h>
+ #include <sys/resource.h>
+ #include <uuid/uuid.h>
+ #include <regex.h>
+@@ -882,12 +885,14 @@ internal_vproblem (struct internal_problem *problem,
+ 
+   /* APPLE LOCAL: Do a stack crawl of how we got here so we're more likely
+      to get useful bug reports.  */
++#if (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+   {
+     void *bt_buffer[15];
+     int count = backtrace (bt_buffer, 15);
+     fprintf (stderr, "gdb stack crawl at point of internal error:\n");
+     backtrace_symbols_fd (bt_buffer, count, STDERR_FILENO);
+   }
++#endif
+ 
+   /* Create a string containing the full error/warning message.  Need
+      to call query with this full string, as otherwize the reason

--- a/devel/gdb-apple/files/patch-gdb-headers.diff
+++ b/devel/gdb-apple/files/patch-gdb-headers.diff
@@ -63,13 +63,13 @@ on 10.4 and 10.5.
       else
         {
 -#if defined (NM_NEXTSTEP)
-+#if defined (NM_NEXTSTEP) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
++#if defined (NM_NEXTSTEP) && defined(TASK_DYLD_INFO)
            if (macosx_status->task == TASK_NULL)
              return 0;
  
 --- gdb/macosx/macosx-nat-inferior.c.orig
 +++ gdb/macosx/macosx-nat-inferior.c
-@@ -60,13 +60,18 @@
+@@ -60,13 +60,17 @@
  #include <sys/sysctl.h>
  #include <sys/proc.h>
  #include <mach/mach_error.h>
@@ -84,29 +84,28 @@ on 10.4 and 10.5.
  #include <libproc.h>
  #include <sys/proc_info.h>
 +#endif
-+#include <AvailabilityMacros.h>
  
  #include "macosx-nat-dyld.h"
  #include "macosx-nat-inferior.h"
-@@ -2701,6 +2706,7 @@ macosx_get_thread_name (ptid_t ptid)
+@@ -2701,6 +2705,7 @@ macosx_get_thread_name (ptid_t ptid)
    if (tp->private == NULL || tp->private->app_thread_port == 0)
      return NULL;
  
-+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
++#if defined(THREAD_IDENTIFIER_INFO)
    thread_identifier_info_data_t tident;
    unsigned int info_count;
    kern_return_t kret;
-@@ -2728,6 +2734,7 @@ macosx_get_thread_name (ptid_t ptid)
+@@ -2728,6 +2733,7 @@ macosx_get_thread_name (ptid_t ptid)
              }
          }
      }
-+#endif /* MAC_OS_X_VERSION_MIN_REQUIRED >= 1050 */
++#endif /* defined(THREAD_IDENTIFIER_INFO) */
    return buf;
  }
  
 --- gdb/macosx/macosx-nat-infthread.c
 +++ gdb/macosx/macosx-nat-infthread.c
-@@ -36,8 +36,11 @@
+@@ -36,8 +36,10 @@
  #include <sys/dir.h>
  #include <inttypes.h>
  
@@ -114,94 +113,38 @@ on 10.4 and 10.5.
  #include <libproc.h>
  #include <sys/proc_info.h>
 +#endif
-+#include <AvailabilityMacros.h>
  
  #include "macosx-nat-inferior.h"
  #include "macosx-nat-inferior-util.h"
-@@ -810,6 +813,7 @@ print_thread_info (thread_t tid, int *gdb_thread_id)
+@@ -810,6 +812,7 @@ print_thread_info (thread_t tid, int *gdb_thread_id)
      print_stack_frame (get_selected_frame (NULL), 0, LOCATION);
      switch_to_thread (current_ptid);
  
-+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
++#if defined(THREAD_IDENTIFIER_INFO)
    thread_identifier_info_data_t tident;
    info_count = THREAD_IDENTIFIER_INFO_COUNT;
    kret = thread_info (tid, THREAD_IDENTIFIER_INFO, (thread_info_t) &tident, 
-@@ -879,6 +883,7 @@ print_thread_info (thread_t tid, int *gdb_thread_id)
+@@ -879,6 +882,7 @@ print_thread_info (thread_t tid, int *gdb_thread_id)
        printf_filtered ("\tcurrent priority: %d\n", pth.pth_priority);
        printf_filtered ("\tmax priority: %d\n", pth.pth_maxpriority);
      }
-+#endif /* MAC_OS_X_VERSION_MIN_REQUIRED >= 1050 */
++#endif /* defined(THREAD_IDENTIFIER_INFO) */
  
    printf_filtered ("\tsuspend count: %d", info.suspend_count);
  
-@@ -1176,6 +1181,7 @@ macosx_print_thread_details (struct ui_out *uiout, ptid_t ptid)
+@@ -1176,6 +1180,7 @@ macosx_print_thread_details (struct ui_out *uiout, ptid_t ptid)
    ui_out_field_fmt (uiout, "mach-port-number", "0x%s", 
                      paddr_nz (app_thread_name));
  
-+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
++#if defined(THREAD_IDENTIFIER_INFO)
    thread_identifier_info_data_t tident;
    info_count = THREAD_IDENTIFIER_INFO_COUNT;
    kret = thread_info (tid, THREAD_IDENTIFIER_INFO, (thread_info_t) &tident, 
-@@ -1208,6 +1214,7 @@ macosx_print_thread_details (struct ui_out *uiout, ptid_t ptid)
+@@ -1208,6 +1213,7 @@ macosx_print_thread_details (struct ui_out *uiout, ptid_t ptid)
                                paddr_nz (struct_addr));
          }
      }
-+#endif /* MAC_OS_X_VERSION_MIN_REQUIRED >= 1050 */
++#endif /* defined(THREAD_IDENTIFIER_INFO) */
  }
  
  
---- gdb/remote.c
-+++ gdb/remote.c
-@@ -64,7 +64,10 @@
- #include "macosx-nat-dyld.h"
- #include "macosx-nat-dyld-process.h"
- #endif
-+#ifdef HAVE_EXECINFO_H
- #include <execinfo.h>
-+#endif
-+#include <AvailabilityMacros.h>
- 
- /* Prototypes for local functions.  */
- static void cleanup_sigint_signal_handler (void *dummy);
-@@ -478,11 +481,13 @@ struct memory_packet_config
- static void
- remote_backtrace_self (const char *message)
- {
-+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
-   void *bt_buffer[100];
-   int count = backtrace (bt_buffer, 100);
-   if (message && message[0])
-     fprintf_filtered (gdb_stderr, "%s", message);
-   backtrace_symbols_fd (bt_buffer, count, STDERR_FILENO);
-+#endif
- }
- 
- static void
---- gdb/utils.c
-+++ gdb/utils.c
-@@ -28,7 +28,10 @@
- #include "event-top.h"
- #include "exceptions.h"
- #include "bfd.h"
-+#ifdef HAVE_EXECINFO_H
- #include <execinfo.h>
-+#endif
-+#include <AvailabilityMacros.h>
- #include <sys/resource.h>
- #include <uuid/uuid.h>
- #include <regex.h>
-@@ -882,12 +885,14 @@ internal_vproblem (struct internal_problem *problem,
- 
-   /* APPLE LOCAL: Do a stack crawl of how we got here so we're more likely
-      to get useful bug reports.  */
-+#if (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
-   {
-     void *bt_buffer[15];
-     int count = backtrace (bt_buffer, 15);
-     fprintf (stderr, "gdb stack crawl at point of internal error:\n");
-     backtrace_symbols_fd (bt_buffer, count, STDERR_FILENO);
-   }
-+#endif
- 
-   /* Create a string containing the full error/warning message.  Need
-      to call query with this full string, as otherwize the reason

--- a/devel/gdb-apple/files/patch-macosx-tdep.c.diff
+++ b/devel/gdb-apple/files/patch-macosx-tdep.c.diff
@@ -1,7 +1,18 @@
+Fixes duplicate symbol error linking on 10.6
+
 Fixes compilation targeting 10.4 and 10.5
 
 --- gdb/macosx/macosx-tdep.c.orig
 +++ gdb/macosx/macosx-tdep.c
+@@ -160,7 +160,7 @@
+ #define BFD_GETL32(addr) ((((((uint32_t) addr[3] << 8) | addr[2]) << 8) | addr[1]) << 8 | addr[0])
+ #define BFD_GETL64(addr) ((((((((((uint64_t) addr[7] << 8) | addr[6]) << 8) | addr[5]) << 8 | addr[4]) << 8 | addr[3]) << 8 | addr[2]) << 8 | addr[1]) << 8 | addr[0])
+ 
+-unsigned char macosx_symbol_types[256];
++static unsigned char macosx_symbol_types[256];
+ 
+ static unsigned char
+ macosx_symbol_type_base (macho_type)
 @@ -1558,7 +1558,11 @@
    if (plist_data == NULL)
      return NULL;


### PR DESCRIPTION
#### Description

* Split `patch-gdb-availability.diff` into 2 pieces to be more manageable
* Promote the larger piece to be applied unconditionally, testing function-relevant macros instead of MAC_OS_X_VERSION_MIN_REQUIRED (this fixes a build problem on 10.5)
* Fix a duplicate symbol linking error witnessed on 10.6 with clang-11
* Promote `patch-macosx-tdep.c.diff` to be applied unconditionally
* Add `size` to the checksums

CC @kencu and @barracuda156
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.6.8
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
