### PR TITLE
py-awscli2: update to 2.5.4

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.4.29
+github.setup        aws aws-cli 2.5.4
 revision            0
 
 categories          python devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  7f8a5fb55335fd499bd331fc31d541da5bd99059 \
-                    sha256  0acf2534d414752046e9c152672ef5845bffad8d3c80fd28e9d016b00948aaf3 \
-                    size    10342790
+checksums           rmd160  860964286ea6666b152298a44069d3da5138841d \
+                    sha256  158b17e37e45cc12c352decf121dc91b00f97a7accbfd3412fdba748685f84a1 \
+                    size    10390460
 
 # This is what Amazon currently supports and there
 # are hard errors with later Pythons right now.

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,9 +1,9 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-diff -ru aws-cli-2.4.29-orig/setup.cfg aws-cli-2.4.29/setup.cfg
---- aws-cli-2.4.29-orig/setup.cfg	2022-03-25 18:15:06.000000000 -0400
-+++ aws-cli-2.4.29/setup.cfg	2022-03-27 15:54:42.273186766 -0400
+diff -ru aws-cli-2.5.4-orig/setup.cfg aws-cli-2.5.4/setup.cfg
+--- aws-cli-2.5.4-orig/setup.cfg	2022-04-08 15:50:52.000000000 -0400
++++ aws-cli-2.5.4/setup.cfg	2022-04-13 09:29:18.850015360 -0400
 @@ -28,17 +28,17 @@
  python_requires = >=3.8
  include_package_data = True
@@ -13,7 +13,7 @@ diff -ru aws-cli-2.4.29-orig/setup.cfg aws-cli-2.4.29/setup.cfg
 -    cryptography>=3.3.2,<37.0.0
 -    ruamel.yaml>=0.15.0,<0.16.0
 -    wcwidth<0.2.0
--    prompt-toolkit>=3.0.24,<3.1.0
+-    prompt-toolkit>=3.0.24,<3.0.29
 -    distro>=1.5.0,<1.6.0
 -    awscrt>=0.12.4,<=0.13.5
 -    python-dateutil>=2.1,<3.0.0


### PR DESCRIPTION
#### Description

Note that awscli2 upstream is now pinning a harder dependency on prompt_toolkit. The propmt_toolkit upstream introduced a breaking change in a minor revision. However, grepping the awscli2 codebase the broken function is only used in unit test fixtures so awscli2 is OK with the update.

The MacPorts prompt_toolkit hasn't been updated in a few months anyway. Because the API breakage in prompt_toolkit could easily impact the other packages with that dependency I think the eventual upgrade of prompt_toolkit should get some careful review to make sure nobody else is impacted by the break. However, when that update does happen, awscli2 is ok with the newer version and they may even bump the version requirements at some point before then.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
