### PR TITLE
pgbadger: bump perl versions

### DIFF
--- a/databases/pgbadger/Portfile
+++ b/databases/pgbadger/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  8297dac8875b0eac2091754464244f6c32abb6f8 \
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
-perl5.branches          5.26 5.28 5.30
+perl5.branches          5.28 5.30 5.32 5.34
 perl5.default_branch    5.28
 perl5.create_variants   ${perl5.branches}
 


### PR DESCRIPTION
#### Description

This fixes the buildbot as perl 5.26 packages are no longer available. I'm also adding the other new perl versions while I'm here.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
