### PR TITLE
py-sip: update to 6.6.1

### DIFF
--- a/python/py-sip/Portfile
+++ b/python/py-sip/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-sip
-version             6.5.1
+version             6.6.1
 revision            0
 epoch               1
 
@@ -21,9 +21,9 @@ long_description    SIP is a tool that makes it very easy to create \
 
 homepage            https://www.riverbankcomputing.com/software/sip/
 
-checksums           rmd160  6dcf12ef1007812e9a2fff0483fbdaf423311282 \
-                    sha256  204f0240db8999a749d638a987b351861843e69239b811ec3d1881412c3706a6 \
-                    size    1197925
+checksums           rmd160  a3fb1ca47e41f04e018efbebd95d8a90041b71b1 \
+                    sha256  696c575c72144122701171f2cc767fe6cc87050ea755a04909152a8508ae10c3 \
+                    size    1134991
 
 python.versions     35 36 37 38 39 310
 
@@ -34,6 +34,12 @@ if {${name} ne ${subport}} {
         checksums   rmd160  fe56e4f7617fcc8aad3c63e10b19996f58ba44dc \
                     sha256  5d024c419b30fea8a6de8c71a560c7ab0bc3c221fbfb14d55a5b865bd58eaac5 \
                     size    1108126
+    } elseif {${python.version} == 36} {
+        version     6.5.1
+        revision    0
+        checksums   rmd160  6dcf12ef1007812e9a2fff0483fbdaf423311282 \
+                    sha256  204f0240db8999a749d638a987b351861843e69239b811ec3d1881412c3706a6 \
+                    size    1197925
     }
 
     depends_lib-append \


### PR DESCRIPTION
#### Description

py-sip: update to 6.6.1
lock py36-sip at 6.5.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.6 20G604
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
