### PR TITLE
lapack: update to 3.10.1

### DIFF
--- a/math/lapack/Portfile
+++ b/math/lapack/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Reference-LAPACK lapack 3.10.0 v
+github.setup        Reference-LAPACK lapack 3.10.1 v
 if {${subport} eq ${name}} {
     PortGroup           compilers 1.0
     compilers.choose    cc fc f77 f90
@@ -25,9 +25,9 @@ long_description \
     eigenvalue problems, and singular value problems.
 homepage            http://www.netlib.org/${name}/
 
-checksums           rmd160  9b72149acdfd72e9d4731cd8b37c2ed8b24063f5 \
-                    sha256  5dda370a83a17f2ceb6a6661ab8f3aa1523eff5d70a8b436846c75257c836b74 \
-                    size    7632043
+checksums           rmd160  bfae414d56c156ef9399dce073fd14e1c674e9af \
+                    sha256  62ca09e81aefc1cae06861773aca26e143cb5226aefc4d2470c6c42b3598981e \
+                    size    7633700
 
 configure.cppflags-append \
                     -DADD_


### PR DESCRIPTION
#### Description

lapack: update to 3.10.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 11.6.6 20G604
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
