### PR TITLE
google-cloud-sdk: update to 381.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             380.0.0
+version             381.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d63e6b3ca9837fe3b7440122fcd426dc034bca06 \
-                    sha256  6fd0d47ed8c785638cd3b71b5674485a6e58cec81e2d84772c4afd794e34cd3e \
-                    size    105915868
+    checksums       rmd160  e97a4bc6af9267fd38d2fb1dc8b33853d0c30bdb \
+                    sha256  9686d92ff4c3a35d137f568e540ff4063dcc937df232f91fad46bd57c7b5dd51 \
+                    size    106499533
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  6c4245e24fbae08cf8b6febed9a9ca5e829cd264 \
-                    sha256  607e09724cf2bd0e928c6118e791efd453465b1950a9e7e88da34e1bb4e7dcfc \
-                    size    101164094
+    checksums       rmd160  adf14808797885762568fa7d2b37606b37b60a97 \
+                    sha256  1d2893c4149f7aa45897886e7cc29ec736a36503bab7e268cb7e7141afa8ab6d \
+                    size    103094650
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  07f3af0e588df2873b361ee5bc32b1c5dceaa0c6 \
-                    sha256  ad7909397c63988d8c639518ade3f168d7db5541965f99f791c90af75e61f315 \
-                    size    100643005
+    checksums       rmd160  8afa2ed292ca97aeaf5c2903d8e414ab91fcc992 \
+                    sha256  7402a8492b409fb052b3e67661b6817f7dde74373447c7523b35bcdaf2b14eb7 \
+                    size    101681730
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 381.0.0.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?