### PR TITLE
py-filelock: update to 3.6.0

### DIFF
--- a/python/py-filelock/Portfile
+++ b/python/py-filelock/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-filelock
-version             3.4.0
+version             3.6.0
 revision            0
 
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    This package contains a single module, which implements \
 
 homepage            https://py-filelock.readthedocs.io/
 
-checksums           rmd160  9d2213165c6dfc44a0652124fb8a74ee2bd3ac5b \
-                    sha256  93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4 \
-                    size    206359
+checksums           rmd160  2f8015dbd37109f9329987646bff50dc1ef6ae87 \
+                    sha256  9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85 \
+                    size    207185
 
 # keep version for PY27 and PY34, these are (indirect) dependencies of py-virtualenv
 python.versions     27 34 35 36 37 38 39 310
@@ -29,6 +29,15 @@ python.versions     27 34 35 36 37 38 39 310
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools_scm
+
+    if {${python.version} == 36} {
+        version     3.4.1
+        revision    0
+
+        checksums   rmd160  4df725914d2d3943b8ebabc699695ab1a6da700d \
+                    sha256  0f12f552b42b5bf60dba233710bf71337d35494fc8bdd4fd6d9f6d082ad45e06 \
+                    size    206768
+    }
 
     if {${python.version} <= 35} {
         version     3.2.1


### PR DESCRIPTION
#### Description

Note the epoch bump: this will downgrade any python 3.6 users from filelock 3.4 to 3.2.1. There's little change in filelock so I don't expect this to break any 3.6 users. But at any rate python 3.6 is no longer supported upstream and there's little point in giving it special support in MacPorts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
