### PR TITLE
fix building libusb for ppc: pragma errors

### DIFF
--- a/devel/libusb/Portfile
+++ b/devel/libusb/Portfile
@@ -43,6 +43,13 @@ if {${subport} eq ${name}} {
 
     # overload the github livecheck regex to look for versions that
     # are just numbers and '.', no letters (e.g., "1.0.19rc1").
+    
+    platform darwin {
+    	if {${build_arch} in "ppc ppc64"} {
+        # https://trac.macports.org/ticket/64408
+        patchfiles-append  patch-gcc-pragma-options-align-reset.diff
+    	}
+	}
 
     github.livecheck.regex  {([0-9.]+)}
 

--- a/devel/libusb/files/patch-gcc-pragma-options-align-reset.diff
+++ b/devel/libusb/files/patch-gcc-pragma-options-align-reset.diff
@@ -1,0 +1,12 @@
+--- libusb/os/darwin_usb.h.orig	2020-12-11 02:53:59.000000000 +0800
++++ libusb/os/darwin_usb.h	2021-11-21 10:31:42.000000000 +0800
+@@ -27,6 +27,9 @@
+ 
+ #include <IOKit/IOTypes.h>
+ #include <IOKit/IOCFBundle.h>
++#pragma options align=power
++#pragma options align=power
++#pragma options align=power
+ #include <IOKit/usb/IOUSBLib.h>
+ #include <IOKit/IOCFPlugIn.h>
+ 


### PR DESCRIPTION
#### Description

This is a fix for an error occurring on PowerPC systems, including 10.5.8 and 10.6 PPC. It has been around since at least @1.0.25, and I used this patch earlier, but it was not committed so far.
Example of the failure:

```
libtool: compile:  /opt/local/bin/gcc-mp-10 -DHAVE_CONFIG_H -I. -I.. -isystem/opt/local/include/LegacySupport -I/opt/local/include -std=gnu11 -Wall -Wextra -Wshadow -Wunused -Wwrite-strings -Werror=format-security -Werror=implicit-function-declaration -Werror=implicit-int -Werror=init-self -Werror=missing-prototypes -Werror=strict-prototypes -Werror=undef -Werror=uninitialized -fvisibility=hidden -pthread -pipe -Os -arch ppc -MT os/darwin_usb.lo -MD -MP -MF os/.deps/darwin_usb.Tpo -c os/darwin_usb.c  -fno-common -DPIC -o os/.libs/darwin_usb.o
In file included from /System/Library/Frameworks/IOKit.framework/Headers/usb/IOUSBLib.h:27,
                 from os/darwin_usb.h:30,
                 from os/darwin_usb.c:53:
/System/Library/Frameworks/IOKit.framework/Headers/usb/USB.h:584:9: error: too many '#pragma options align=reset'
  584 | #pragma options align=reset
      |         ^~~~~~~
/System/Library/Frameworks/IOKit.framework/Headers/usb/USB.h:602:9: error: too many '#pragma options align=reset'
  602 | #pragma options align=reset
      |         ^~~~~~~
/System/Library/Frameworks/IOKit.framework/Headers/usb/USB.h:622:9: error: too many '#pragma options align=reset'
  622 | #pragma options align=reset
      |         ^~~~~~~
In file included from os/darwin_usb.h:26,
                 from os/darwin_usb.c:53:
os/darwin_usb.c: In function 'darwin_get_cached_device':
os/darwin_usb.c:1024:21: warning: format '%x' expects argument of type 'unsigned int', but argument 6 has type 'UInt32' {aka 'long unsigned int'} [-Wformat=]
 1024 |       usbi_dbg(ctx, "matching sessionID/locationID 0x%" PRIx64 "/0x%x against cached device with sessionID/locationID 0x%" PRIx64 "/0x%x",
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1025 |                sessionID, locationID, new_device->session, new_device->location);
      |                           ~~~~~~~~~~
      |                           |
      |                           UInt32 {aka long unsigned int}
./libusbi.h:315:67: note: in definition of macro '_usbi_log'
  315 | #define _usbi_log(ctx, level, ...) usbi_log(ctx, level, __func__, __VA_ARGS__)
      |                                                                   ^~~~~~~~~~~
os/darwin_usb.c:1024:7: note: in expansion of macro 'usbi_dbg'
 1024 |       usbi_dbg(ctx, "matching sessionID/locationID 0x%" PRIx64 "/0x%x against cached device with sessionID/locationID 0x%" PRIx64 "/0x%x",
      |       ^~~~~~~~
os/darwin_usb.c:1024:21: warning: format '%x' expects argument of type 'unsigned int', but argument 8 has type 'UInt32' {aka 'long unsigned int'} [-Wformat=]
 1024 |       usbi_dbg(ctx, "matching sessionID/locationID 0x%" PRIx64 "/0x%x against cached device with sessionID/locationID 0x%" PRIx64 "/0x%x",
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1025 |                sessionID, locationID, new_device->session, new_device->location);
      |                                                            ~~~~~~~~~~~~~~~~~~~~
      |                                                                      |
      |                                                                      UInt32 {aka long unsigned int}
./libusbi.h:315:67: note: in definition of macro '_usbi_log'
  315 | #define _usbi_log(ctx, level, ...) usbi_log(ctx, level, __func__, __VA_ARGS__)
      |                                                                   ^~~~~~~~~~~
os/darwin_usb.c:1024:7: note: in expansion of macro 'usbi_dbg'
 1024 |       usbi_dbg(ctx, "matching sessionID/locationID 0x%" PRIx64 "/0x%x against cached device with sessionID/locationID 0x%" PRIx64 "/0x%x",
      |       ^~~~~~~~
os/darwin_usb.c: At top level:
os/darwin_usb.c:89:12: warning: 'darwin_detach_kernel_driver' declared 'static' but never defined [-Wunused-function]
   89 | static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [os/darwin_usb.lo] Error 1
make[2]: Leaving directory `/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_libusb/libusb/work/libusb-libusb-4239bc3/libusb'
make[1]: *** [all-recursive] Error 1
```

###### Type(s)

- [ x] bugfix

###### Tested on
macOS 10.5.8
Xcode 3.1.4

macOS 10.6 (10A190)
Xcode 3.2

macOS 10.6.8 (Rosetta)
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL: https://trac.macports.org/ticket/64408
