### PR TITLE
py-prompt_toolkit: update to latest version 3.0.29

### DIFF
--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-prompt_toolkit
-version             3.0.20
+version             3.0.29
 revision            0
 
 license             BSD
@@ -18,9 +18,9 @@ python.versions     27 35 36 37 38 39 310
 
 homepage            https://github.com/prompt-toolkit/python-prompt-toolkit
 
-checksums           rmd160  69b0ee0261552ddb50a7271b38a523689c01ff26 \
-                    sha256  eb71d5a6b72ce6db177af4a7d4d7085b99756bf656d98ffcc4fecd36850eea6c \
-                    size    3037349
+checksums           rmd160  75652e92e507444e9bb171bfa6287969d01cc15b \
+                    sha256  bd640f60e8cecd74f0dc249713d433ace2ddc62b65ee07f96d358e0b152b6ea7 \
+                    size    417831
 
 if {${name} ne ${subport}} {
     if {${python.version} eq 27} {


### PR DESCRIPTION
#### Description
Makes xonsh stop spewing DeprecationWarnings

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
