### PR TITLE
emacs: ad-hoc patches to make 28.1 compile on old macOS boxes

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -61,6 +61,11 @@ depends_lib-append     port:gmp \
                        port:libxml2 \
                        port:ncurses
 
+if {$subport eq "emacs" || $subport eq "emacs-app"} {
+    patchfiles-append  patch-lib_verify.h.diff \
+                       patch-src_sysdep.c.diff
+}
+
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/emacs/${version}/leim
     delete ${destroot}${prefix}/bin/ctags
@@ -94,14 +99,14 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 }
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
-    set date        2022-04-13
+    set date        2022-04-16
     epoch           5
     version         [string map {- {}} ${date}]
     revision        0
 
     fetch.type      git
     git.url         --shallow-since=${date}T00:00:00 https://github.com/emacs-mirror/emacs.git
-    git.branch      8259e368001a6e30418efed40809e17f3f977622
+    git.branch      6815db492ff899e77b45be98414567ad96a8177c
 
     # --shallow-since needs a newer version of git than on some older systems
     # So use MacPorts version

--- a/editors/emacs/files/patch-lib_verify.h.diff
+++ b/editors/emacs/files/patch-lib_verify.h.diff
@@ -1,0 +1,11 @@
+--- lib/verify.h.orig
++++ lib/verify.h
+@@ -34,7 +34,7 @@ #define _GL_VERIFY_H
+ #ifndef __cplusplus
+ # if (201112L <= __STDC_VERSION__ \
+       || (!defined __STRICT_ANSI__ \
+-          && (4 < __GNUC__ + (6 <= __GNUC_MINOR__) || 4 <= __clang_major__)))
++          && (4 < __GNUC__ + (6 <= __GNUC_MINOR__) || 5 <= __clang_major__)))
+ #  define _GL_HAVE__STATIC_ASSERT 1
+ # endif
+ # if (202000L <= __STDC_VERSION__ \

--- a/editors/emacs/files/patch-src_sysdep.c.diff
+++ b/editors/emacs/files/patch-src_sysdep.c.diff
@@ -1,0 +1,61 @@
+--- src/sysdep.c.orig
++++ src/sysdep.c
+@@ -4027,6 +4027,9 @@ system_process_attributes (Lisp_Object pid)
+ 
+ #elif defined DARWIN_OS
+ 
++#define HAVE_RUSAGE_INFO_CURRENT (MAC_OS_X_VERSION_MIN_REQUIRED >= 101000)
++#define HAVE_PROC_PIDINFO (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
++
+ Lisp_Object
+ system_process_attributes (Lisp_Object pid)
+ {
+@@ -4130,6 +4133,7 @@ system_process_attributes (Lisp_Object pid)
+   attrs = Fcons (Fcons (Qtpgid, INT_TO_INTEGER (proc.kp_eproc.e_tpgid)),
+ 		 attrs);
+ 
++#if HAVE_RUSAGE_INFO_CURRENT
+   rusage_info_current ri;
+   if (proc_pid_rusage(proc_id, RUSAGE_INFO_CURRENT, (rusage_info_t *) &ri) == 0)
+     {
+@@ -4143,6 +4147,24 @@ system_process_attributes (Lisp_Object pid)
+ 
+       attrs = Fcons (Fcons (Qmajflt, INT_TO_INTEGER (ri.ri_pageins)), attrs);
+   }
++#else  /* !HAVE_RUSAGE_INFO_CURRENT */
++  struct rusage *rusage = proc.kp_proc.p_ru;
++  if (rusage)
++    {
++      attrs = Fcons (Fcons (Qminflt, INT_TO_INTEGER (rusage->ru_minflt)),
++		     attrs);
++      attrs = Fcons (Fcons (Qmajflt, INT_TO_INTEGER (rusage->ru_majflt)),
++		     attrs);
++
++      attrs = Fcons (Fcons (Qutime, make_lisp_timeval (rusage->ru_utime)),
++		     attrs);
++      attrs = Fcons (Fcons (Qstime, make_lisp_timeval (rusage->ru_stime)),
++		     attrs);
++      struct timespec t = timespec_add (timeval_to_timespec (rusage->ru_utime),
++					timeval_to_timespec (rusage->ru_stime));
++      attrs = Fcons (Fcons (Qtime, make_lisp_time (t)), attrs);
++    }
++#endif  /* !HAVE_RUSAGE_INFO_CURRENT */
+ 
+   starttime = proc.kp_proc.p_starttime;
+   attrs = Fcons (Fcons (Qnice,  make_fixnum (proc.kp_proc.p_nice)), attrs);
+@@ -4152,6 +4174,7 @@ system_process_attributes (Lisp_Object pid)
+   t = timespec_sub (now, timeval_to_timespec (starttime));
+   attrs = Fcons (Fcons (Qetime, make_lisp_time (t)), attrs);
+ 
++#if HAVE_PROC_PIDINFO
+   struct proc_taskinfo taskinfo;
+   if (proc_pidinfo (proc_id, PROC_PIDTASKINFO, 0, &taskinfo, sizeof (taskinfo)) > 0)
+     {
+@@ -4159,6 +4182,7 @@ system_process_attributes (Lisp_Object pid)
+       attrs = Fcons (Fcons (Qrss, make_fixnum (taskinfo.pti_resident_size / 1024)), attrs);
+       attrs = Fcons (Fcons (Qthcount, make_fixnum (taskinfo.pti_threadnum)), attrs);
+     }
++#endif	/* HAVE_PROC_PIDINFO */
+ 
+ #ifdef KERN_PROCARGS2
+   char args[ARG_MAX];


### PR DESCRIPTION
#### Description

See thread starting at

  https://lists.gnu.org/archive/html/emacs-devel/2022-04/msg00779.html

As mentioned there, it still doesn't work on my Lion box.  However, with these patches the old macOS computers in the build farm can proceed, I hope, and check whether it is a local problem or a generic one.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
