### PR TITLE
hdf4: Fix test and runtime failures on arm64

### DIFF
--- a/science/hdf4/Portfile
+++ b/science/hdf4/Portfile
@@ -5,8 +5,7 @@ PortGroup compilers 1.0
 
 name                hdf4
 version             4.2.15
-revision            1
-platforms           darwin
+revision            2
 categories          science
 license             NCSA
 maintainers         {takeshi @tenomoto}
@@ -40,7 +39,8 @@ patchfiles          patch-configure.diff \
                     patch-mfhdf-test-tncvargetfill.c.diff \
                     patch-mfhdf-test-tsd.c.diff \
                     patch-mfhdf-test-tszip.c.diff \
-                    patch-hdf-test-mgr.c.diff
+                    patch-hdf-test-mgr.c.diff \
+                    arm64.patch
 
 configure.args      --disable-netcdf --disable-fortran \
                     --with-jpeg=${prefix} --enable-shared \

--- a/science/hdf4/files/arm64.patch
+++ b/science/hdf4/files/arm64.patch
@@ -1,0 +1,225 @@
+Fix test failures and runtime errors on arm64 systems.
+--- hdf/src/hconv.h.orig	2020-03-03 11:40:50.000000000 -0600
++++ hdf/src/hconv.h	2022-04-16 00:31:04.000000000 -0500
+@@ -59,7 +59,7 @@
+ /* CONSTANT DEFINITIONS                                                      */
+ /*****************************************************************************/
+ /* Generally Big-Endian machines */
+-#if !defined(INTEL86) && !defined(MIPSEL) && !defined(DEC_ALPHA) && !defined(I860) && !defined(SUN386) && !(defined(__ia64) && !(defined(hpux) || defined(__hpux))) && !defined(__x86_64__)
++#if !defined(INTEL86) && !defined(MIPSEL) && !defined(DEC_ALPHA) && !defined(I860) && !defined(SUN386) && !(defined(__ia64) && !(defined(hpux) || defined(__hpux))) && !defined(__x86_64__) && !defined(__aarch64__)
+ #       define UI8_IN     DFKnb1b   /* Unsigned Integer, 8 bits */
+ #       define UI8_OUT    DFKnb1b
+ #       define SI16_IN    DFKnb2b   /* S = Signed */
+--- mfhdf/fortran/jackets.c.in.orig	2020-03-03 11:40:50.000000000 -0600
++++ mfhdf/fortran/jackets.c.in	2022-04-16 00:19:22.000000000 -0500
+@@ -34,7 +34,7 @@
+ 
+ struct ncfils {            /* This will be a common block from Fortran */
+     double dd;
+-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+     int ll;
+ #else
+     long ll;
+@@ -65,7 +65,7 @@
+ 
+ struct ncfils {            /* This will be a common block from Fortran */
+     double dd;
+-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+     int ll;
+ #else
+     long ll;
+@@ -420,7 +420,7 @@
+ }
+ #endif /* FORTRAN_HAS_NO_SHORT */
+ 
+-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ /*
+  * Convert multi-dimensional array of NCLONGs stored in ints to packed
+  * array of longs, in malloc'ed space.  Returns pointer to longs or NULL
+@@ -908,7 +908,7 @@
+     return;
+     }                /* else */
+ #endif                /* FORTRAN_HAS_NO_SHORT */
+-#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ #ifdef HDF
+     if ((nc_type) datatype == NC_LONG && handle->file_type!=HDF_FILE) {
+     long          longs = *(int *)value;
+@@ -1022,7 +1022,7 @@
+     return;
+     }                /* else */
+ #endif                /* FORTRAN_HAS_NO_SHORT */
+-#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ #ifdef HDF
+     if ((nc_type) datatype == NC_LONG && handle->file_type!=HDF_FILE) {
+     long *longs = itol (value, ncount, ndims);
+@@ -1133,7 +1133,7 @@
+     tmpbasis    = nctypelen(NC_LONG);
+     else
+ #endif
+-#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+     if (datatype == NC_LONG)
+     tmpbasis    = sizeof(int);
+     else
+@@ -1190,7 +1190,7 @@
+     return;
+     }                /* else */
+ #endif                /* FORTRAN_HAS_NO_SHORT */
+-#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ #ifdef HDF
+     if ((nc_type) datatype == NC_LONG && handle->file_type!=HDF_FILE) {
+     long *longs = itolg (value, ncount, nbasis, ndims);
+@@ -1326,7 +1326,7 @@
+     return;
+     }                /* else */
+ #endif                /* FORTRAN_HAS_NO_SHORT */
+-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ #ifdef HDF
+     if ((nc_type) datatype == NC_LONG && handle->file_type!=HDF_FILE) {
+     long          longs;
+@@ -1468,7 +1468,7 @@
+     return;
+     }                /* else */
+ #endif                /* FORTRAN_HAS_NO_SHORT */
+-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ #ifdef HDF
+     if ((nc_type) datatype == NC_LONG && handle->file_type!=HDF_FILE) {
+     long iocount = dimprod (ncount, ndims);    /* product of dimensions */
+@@ -1606,7 +1606,7 @@
+     tmpbasis    = nctypelen(NC_LONG);
+     else
+ #endif
+-#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+     if (datatype == NC_LONG)
+     tmpbasis    = sizeof(int);
+     else
+@@ -1677,7 +1677,7 @@
+     return;
+     }                /* else */
+ #endif                /* FORTRAN_HAS_NO_SHORT */
+-#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ #ifdef HDF
+     if ((nc_type) datatype == NC_LONG && handle->file_type!=HDF_FILE) {
+     long iocount = dimprod (ncount, ndims);    /* product of dimensions */
+@@ -1843,7 +1843,7 @@
+     return;
+     }                /* else */
+ #endif                /* FORTRAN_HAS_NO_SHORT */
+-#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ #ifdef HDF
+     if ((nc_type) *datatype == NC_LONG && handle->file_type!=HDF_FILE) {
+     long *longs = itol (value, attlen, 1);
+@@ -2008,7 +2008,7 @@
+     return;
+     }                /* else */
+ #endif                /* FORTRAN_HAS_NO_SHORT */
+-#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__
++#if  defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __aarch64__
+ #ifdef HDF
+     if ((nc_type) datatype == NC_LONG && handle->file_type!=HDF_FILE) {
+ /* EIP  We need to use int buffer to read data in on the platforms where long is 8 bytes
+--- mfhdf/libsrc/netcdf.h.in.orig	2020-03-03 11:40:50.000000000 -0600
++++ mfhdf/libsrc/netcdf.h.in	2022-04-16 00:17:55.000000000 -0500
+@@ -293,7 +293,7 @@
+ /*
+  * Variables/attributes of type NC_LONG should use the C type 'nclong'
+  */
+-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__
++#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__ || defined __aarch64__
+ /*
+  * LP64 (also known as 4/8/8) denotes long and pointer as 64 bit types.
+  * http://www.unix.org/version2/whatsnew/lp64_wp.html
+--- mfhdf/libsrc/putget.c.orig	2020-03-03 11:40:50.000000000 -0600
++++ mfhdf/libsrc/putget.c	2022-04-16 00:27:24.000000000 -0500
+@@ -665,7 +665,7 @@
+     case NC_SHORT :
+         return( xdr_NCvshort(xdrs, (unsigned)rem/2, (short *)values) ) ;
+     case NC_LONG :
+-#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__ 
++#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__ || defined __aarch64__
+         return( xdr_int(xdrs, (nclong *)values) ) ;
+ #else
+         return( xdr_long(xdrs, (nclong *)values) ) ;
+--- mfhdf/libsrc/xdrposix.c.orig	2020-03-03 11:40:50.000000000 -0600
++++ mfhdf/libsrc/xdrposix.c	2022-04-16 00:26:30.000000000 -0500
+@@ -262,7 +262,7 @@
+ 
+ static bool_t   xdrposix_getlong();
+ static bool_t   xdrposix_putlong();
+-#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__
++#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__ || defined __aarch64__
+ static bool_t   xdrposix_getint();
+ static bool_t   xdrposix_putint();
+ #endif
+@@ -276,7 +276,7 @@
+ #if (defined __sun && defined _LP64)
+ static rpc_inline_t *    xdrposix_inline();
+ #else
+-#if ((defined __x86_64__ ) && !(defined __sun && defined _LP64)) || defined __powerpc64__
++#if ((defined __x86_64__ ) && !(defined __sun && defined _LP64)) || defined __powerpc64__ || defined __aarch64__
+ static int32_t *    xdrposix_inline();
+ #else
+ static netlong *    xdrposix_inline();
+@@ -302,9 +302,9 @@
+     xdrposix_getpos,    /* get offset in the stream */
+     xdrposix_setpos,    /* set offset in the stream */
+     xdrposix_inline,    /* prime stream for inline macros */
+-#if (defined __sun && defined _LP64) || defined __x86_64__ || defined __powerpc64__
++#if (defined __sun && defined _LP64) || defined __x86_64__ || defined __powerpc64__ || defined __aarch64__
+     xdrposix_destroy,   /* destroy stream */
+-#if !(defined __x86_64__) && !(defined __powerpc64__) || (defined  __sun && defined _LP64) /* i.e. we are on SUN/Intel in 64-bit mode */
++#if !(defined __x86_64__) && !(defined __powerpc64__) && !(defined __aarch64__) || (defined  __sun && defined _LP64) /* i.e. we are on SUN/Intel in 64-bit mode */
+     NULL,               /* no xdr_control function defined */
+ #endif
+     /* Solaris 64-bit (arch=v9 and arch=amd64) has 64 bits long and 32 bits int. */
+@@ -560,7 +560,7 @@
+ #if (defined __sun && defined _LP64)
+ static rpc_inline_t *
+ #else
+-#if ((defined  __x86_64__) && !(defined __sun && defined _LP64)) || defined __powerpc64__
++#if ((defined  __x86_64__) && !(defined __sun && defined _LP64)) || defined __powerpc64__ || defined __aarch64__
+ static int32_t *
+ #else
+ static netlong *
+@@ -581,7 +581,7 @@
+     return (NULL);
+ }
+ 
+-#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64  || defined __x86_64__ || defined __powerpc64__
++#if (_MIPS_SZLONG == 64) || (defined __sun && defined _LP64) || defined AIX5L64  || defined __x86_64__ || defined __powerpc64__ || defined __aarch64__
+ 
+ static bool_t
+ xdrposix_getint(xdrs, lp)
+--- mfhdf/ncgen/ncgen.l.orig	2020-03-03 11:40:50.000000000 -0600
++++ mfhdf/ncgen/ncgen.l	2022-04-16 00:21:32.000000000 -0500
+@@ -113,7 +113,7 @@
+             yyerror(errstr);
+         }
+ 
+-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || __powerpc64__
++#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__ || defined __aarch64__
+         if (dd < INT_MIN  ||  dd > INT_MAX)
+ #else
+         if (dd < LONG_MIN  ||  dd > LONG_MAX)
+--- mfhdf/ncgen/ncgenyy.c.orig	2020-03-03 11:40:50.000000000 -0600
++++ mfhdf/ncgen/ncgenyy.c	2022-04-16 00:21:42.000000000 -0500
+@@ -991,7 +991,7 @@
+             yyerror(errstr);
+         }
+ 
+-#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || __powerpc64__
++#if defined __alpha || (_MIPS_SZLONG == 64) || defined __ia64 || (defined __sun && defined _LP64) || defined AIX5L64 || defined __x86_64__ || defined __powerpc64__ || defined __aarch64__
+         if (dd < INT_MIN  ||  dd > INT_MAX)
+ #else
+         if (dd < LONG_MIN  ||  dd > LONG_MAX)


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/62341

Although the test suite still does not pass on either x86_64 or arm64, these changes do drastically reduce the test failures on arm64 and make the sample program provided by the user in the ticket work correctly on arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.5 20G527 arm64
Xcode 13.0 13A233

macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
