### PR TITLE
cargo: remove libssh2 header copy on post-extract

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -8,13 +8,15 @@ if {${subport} ne "${name}-bootstrap"} {
     PortGroup       github 1.0
 
     github.setup    rust-lang ${name} 0.61.1
+    revision        2
 } else {
     # Should match current Rust version
     version         1.60.0
+    revision        1
 }
+
 PortGroup           cargo   1.0
 
-revision            1
 categories          devel
 supported_archs     x86_64 arm64
 license             {MIT Apache-2}
@@ -56,20 +58,6 @@ if {${subport} ne "${name}-bootstrap"} {
     pre-configure {
         # create Cargo.lock
         system -W ${worksrcpath} "${cargo.bin} update"
-    }
-
-    post-extract {
-        foreach {cname cversion chksum} ${cargo.crates} {
-            # the libssh2-sys crate requires the header files from
-            #    a version of libssh2 that has not been released
-            #    (e.g. channel.c uses the error code LIBSSH2_ERROR_CHANNEL_WINDOW_FULL)
-            # make sure these header files are found properly
-            if {${cname} eq "libssh2-sys"} {
-                foreach f [glob -tail -directory ${cargo.home}/macports/libssh2-sys-${cversion}/libssh2/include/ *.h] {
-                    ln -s ../include/${f} ${cargo.home}/macports/libssh2-sys-${cversion}/libssh2/src/
-                }
-            }
-        }
     }
 
     build.env-append OPENSSL_DIR=[openssl::install_area]


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
