### PR TITLE
vpype: update 1.10

### DIFF
--- a/graphics/vpype/Portfile
+++ b/graphics/vpype/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                vpype
-version             1.9.0
+version             1.10.0
 revision            0
 
-checksums           rmd160  b56bed854d574f69bf3c264d5c08c7061e238f6d \
-                    sha256  1b09fcd67ba911d8f558a09e3da6ae655ed921b7de599ebcacc7090550f77a71 \
-                    size    476328
+checksums           rmd160  61a169e1f8eb1b4467bc1bdd4ec802b73003eca3 \
+                    sha256  782aa5ceb87fd88c81caeb3382f380ef3854d50b27be8857feca611a7dfc60e5 \
+                    size    478984
 
 description         The Swiss-Army-knife command-line tool for plotter vector graphics.
 long_description    ${description}
@@ -21,7 +21,7 @@ license             MIT
 
 homepage            https://github.com/abey79/vpype
 
-python.default_version 39
+python.default_version 310
 
 depends_build-append \
                     port:py${python.version}-poetry-core
@@ -43,8 +43,4 @@ depends_lib-append  port:py${python.version}-asteval \
                     port:py${python.version}-svgwrite \
                     port:py${python.version}-tomli
 
-post-extract {
-    # vpype 1.9 pins shapely to 1.8.0 because of a compatibility issue with Pyinstaller
-    # this constraint must be relaxed for compatibility with py39-shapely
-    reinplace "s|\'Shapely\\\[vectorized\\\]==1\.8\.0\'|\'Shapely\\\[vectorized\\\]>=1\.8\.0\'|" ${worksrcpath}/setup.py
-}
+patchfiles          deps.patch

--- a/graphics/vpype/files/deps.patch
+++ b/graphics/vpype/files/deps.patch
@@ -1,0 +1,35 @@
+--- vpype/__init__.py.orig	2022-04-07 15:51:28.000000000 +0200
++++ vpype/__init__.py	2022-04-16 18:16:54.000000000 +0200
+@@ -14,9 +14,9 @@
+ 
+ 
+ def _get_version() -> str:
+-    import pkg_resources
++    from importlib.metadata import version
+ 
+-    return pkg_resources.get_distribution("vpype").version
++    return version(__name__)
+ 
+ 
+ __version__ = _get_version()
+
+
+--- setup.py.orig   2022-04-07 15:51:51.000000000 +0200
++++ setup.py    2022-04-16 18:30:10.000000000 +0200
+@@ -15,7 +15,7 @@
+  'vpype_viewer.qtviewer': ['resources/*']}
+ 
+ install_requires = \
+-['Shapely[vectorized]>=1.8.1.post1',
++['Shapely[vectorized]>=1.8.0',
+  'asteval>=0.9.26,<0.10.0',
+  'cachetools>=4.2.2',
+  'click>=8.0.1,<8.2.0',
+@@ -23,7 +23,6 @@
+  'numpy>=1.20',
+  'pnoise>=0.1.0,<0.2.0',
+  'scipy>=1.6,<2.0',
+- 'setuptools>=51.0.0,<52.0.0',
+  'svgelements>=1.6.10',
+  'svgwrite>=1.4,<1.5',
+  'tomli>=2.0.0,<3.0.0']

--- a/python/py-multiprocess/Portfile
+++ b/python/py-multiprocess/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-multiprocess
 version             0.70.12.2
+revision            1
 platforms           darwin
 license             BSD
 maintainers         nomaintainer
@@ -25,6 +26,9 @@ python.versions     37 38 39 310
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-dill
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description

Update vpype to 1.10

- Switched to Python 3.10
- Cleaned up shapely-related fix into a patch
- Back-ported fix to remove dependency on setuptools

In the process, I had to fix a missing dependency in py-multiprocess

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
