### PR TITLE
qt56-qtconnectivity: fix for recent compilers

### DIFF
--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -1278,6 +1278,11 @@ foreach {module module_info} [array get modules] {
             ###############################################################################
 
             # special case
+            if { ${module} eq "qtconnectivity" } {
+                patchfiles-append patch-qtconnectivity_qtbug_76847.diff
+            }
+
+            # special case
             if { ${module} eq "qtdoc" } {
                 build.target    docs
                 destroot.target install_docs

--- a/aqua/qt56/files/patch-qtconnectivity_qtbug_76847.diff
+++ b/aqua/qt56/files/patch-qtconnectivity_qtbug_76847.diff
@@ -1,0 +1,281 @@
+diff --git src/bluetooth/osx/osxbtledeviceinquiry.mm src/bluetooth/osx/osxbtledeviceinquiry.mm
+index 4c000a2..d2ff1d4 100644
+--- src/bluetooth/osx/osxbtledeviceinquiry.mm
++++ src/bluetooth/osx/osxbtledeviceinquiry.mm
+@@ -117,7 +117,7 @@ QT_USE_NAMESPACE
+ 
+ - (void)dealloc
+ {
+-    if (manager) {
++    if (manager.data()) {
+         [manager setDelegate:nil];
+         if (internalState == InquiryActive)
+             [manager stopScan];
+diff --git src/bluetooth/qbluetoothdevicediscoveryagent_osx.mm src/bluetooth/qbluetoothdevicediscoveryagent_osx.mm
+index 18cda39..db982a5 100644
+--- src/bluetooth/qbluetoothdevicediscoveryagent_osx.mm
++++ src/bluetooth/qbluetoothdevicediscoveryagent_osx.mm
+@@ -197,7 +197,7 @@ QBluetoothDeviceDiscoveryAgentPrivate::QBluetoothDeviceDiscoveryAgentPrivate(con
+ 
+ QBluetoothDeviceDiscoveryAgentPrivate::~QBluetoothDeviceDiscoveryAgentPrivate()
+ {
+-    if (inquiryLE && agentState != NonActive) {
++    if (inquiryLE.data() && agentState != NonActive) {
+         // We want the LE scan to stop as soon as possible.
+         if (dispatch_queue_t leQueue = OSXBluetooth::qt_LE_queue()) {
+             // Local variable to be retained ...
+@@ -215,8 +215,8 @@ bool QBluetoothDeviceDiscoveryAgentPrivate::isValid() const
+     // can fail to initialize some important data-members
+     // (and the error is probably not even related to Bluetooth at all)
+     // - say, allocation error - this is what meant here by valid/invalid.
+-    return hostController && [hostController powerState] == kBluetoothHCIPowerStateON
+-           && inquiry;
++    return hostController.data() && [hostController powerState] == kBluetoothHCIPowerStateON
++           && inquiry.data();
+ }
+ 
+ bool QBluetoothDeviceDiscoveryAgentPrivate::isActive() const
+@@ -266,7 +266,7 @@ void QBluetoothDeviceDiscoveryAgentPrivate::startLE()
+     inquiryLE.reset([[LEDeviceInquiryObjC alloc] init]);
+ 
+     dispatch_queue_t leQueue(qt_LE_queue());
+-    if (!leQueue || !inquiryLE) {
++    if (!leQueue || !inquiryLE.data()) {
+         setError(QBluetoothDeviceDiscoveryAgent::UnknownError,
+                  QCoreApplication::translate(DEV_DISCOVERY, DD_NOT_STARTED_LE));
+         agentState = NonActive;
+@@ -442,7 +442,7 @@ void QBluetoothDeviceDiscoveryAgentPrivate::setError(QBluetoothDeviceDiscoveryAg
+ void QBluetoothDeviceDiscoveryAgentPrivate::checkLETimeout()
+ {
+     Q_ASSERT_X(agentState == LEScan, Q_FUNC_INFO, "invalid agent state");
+-    Q_ASSERT_X(inquiryLE, Q_FUNC_INFO, "LE device inquiry is nil");
++    Q_ASSERT_X(inquiryLE.data(), Q_FUNC_INFO, "LE device inquiry is nil");
+ 
+     using namespace OSXBluetooth;
+ 
+diff --git src/bluetooth/qbluetoothlocaldevice_osx.mm src/bluetooth/qbluetoothlocaldevice_osx.mm
+index 24cc2bb..f204774 100644
+--- src/bluetooth/qbluetoothlocaldevice_osx.mm
++++ src/bluetooth/qbluetoothlocaldevice_osx.mm
+@@ -147,7 +147,7 @@ QBluetoothLocalDevicePrivate::QBluetoothLocalDevicePrivate(QBluetoothLocalDevice
+ 
+ bool QBluetoothLocalDevicePrivate::isValid() const
+ {
+-    return hostController;
++    return hostController.data();
+ }
+ 
+ void QBluetoothLocalDevicePrivate::requestPairing(const QBluetoothAddress &address, Pairing pairing)
+diff --git src/bluetooth/qbluetoothserver_osx.mm src/bluetooth/qbluetoothserver_osx.mm
+index 99fcf58..352c793 100644
+--- src/bluetooth/qbluetoothserver_osx.mm
++++ src/bluetooth/qbluetoothserver_osx.mm
+@@ -114,7 +114,7 @@ bool QBluetoothServerPrivate::startListener(quint16 realPort)
+         return false;
+     }
+ 
+-    if (!listener)
++    if (!listener.data())
+         listener.reset([[ObjCListener alloc] initWithListener:this]);
+ 
+     bool result = false;
+@@ -136,7 +136,7 @@ void QBluetoothServerPrivate::stopListener()
+ 
+ void QBluetoothServerPrivate::openNotify(IOBluetoothRFCOMMChannel *channel)
+ {
+-    Q_ASSERT_X(listener, Q_FUNC_INFO, "invalid listener (nil)");
++    Q_ASSERT_X(listener.data(), Q_FUNC_INFO, "invalid listener (nil)");
+     Q_ASSERT_X(channel, Q_FUNC_INFO, "invalid channel (nil)");
+     Q_ASSERT_X(q_ptr, Q_FUNC_INFO, "invalid q_ptr (null)");
+ 
+@@ -148,7 +148,7 @@ void QBluetoothServerPrivate::openNotify(IOBluetoothRFCOMMChannel *channel)
+ 
+ void QBluetoothServerPrivate::openNotify(IOBluetoothL2CAPChannel *channel)
+ {
+-    Q_ASSERT_X(listener, Q_FUNC_INFO, "invalid listener (nil)");
++    Q_ASSERT_X(listener.data(), Q_FUNC_INFO, "invalid listener (nil)");
+     Q_ASSERT_X(channel, Q_FUNC_INFO, "invalid channel (nil)");
+     Q_ASSERT_X(q_ptr, Q_FUNC_INFO, "invalid q_ptr (null)");
+ 
+@@ -285,7 +285,7 @@ bool QBluetoothServer::listen(const QBluetoothAddress &address, quint16 port)
+ {
+     typedef QBluetoothServerPrivate::ObjCListener ObjCListener;
+ 
+-    if (d_ptr->listener) {
++    if (d_ptr->listener.data()) {
+         qCWarning(QT_BT_OSX) << Q_FUNC_INFO << "already in listen mode, "
+                                 "close server first";
+         return false;
+diff --git src/bluetooth/qbluetoothserviceinfo_osx.mm src/bluetooth/qbluetoothserviceinfo_osx.mm
+index ee19f1d..f540b1f 100644
+--- src/bluetooth/qbluetoothserviceinfo_osx.mm
++++ src/bluetooth/qbluetoothserviceinfo_osx.mm
+@@ -239,7 +239,7 @@ bool QBluetoothServiceInfoPrivate::unregisterService()
+     if (!registered)
+         return false;
+ 
+-    Q_ASSERT_X(serviceRecord, Q_FUNC_INFO, "service registered, but serviceRecord is nil");
++    Q_ASSERT_X(serviceRecord.data(), Q_FUNC_INFO, "service registered, but serviceRecord is nil");
+ 
+ #if QT_OSX_PLATFORM_SDK_EQUAL_OR_ABOVE(__MAC_10_9)
+     if (QSysInfo::MacintoshVersion >= QSysInfo::MV_10_9) {
+diff --git src/bluetooth/qbluetoothsocket_osx.mm src/bluetooth/qbluetoothsocket_osx.mm
+index aa99455..c6ccde8 100644
+--- src/bluetooth/qbluetoothsocket_osx.mm
++++ src/bluetooth/qbluetoothsocket_osx.mm
+@@ -97,13 +97,13 @@ void QBluetoothSocketPrivate::connectToService(const QBluetoothAddress &address,
+ 
+     if (socketType == QBluetoothServiceInfo::RfcommProtocol) {
+         rfcommChannel.reset([[ObjCRFCOMMChannel alloc] initWithDelegate:this]);
+-        if (rfcommChannel)
++        if (rfcommChannel.data())
+             status = [rfcommChannel connectAsyncToDevice:address withChannelID:port];
+         else
+             status = kIOReturnNoMemory;
+     } else if (socketType == QBluetoothServiceInfo::L2capProtocol) {
+         l2capChannel.reset([[ObjCL2CAPChannel alloc] initWithDelegate:this]);
+-        if (l2capChannel)
++        if (l2capChannel.data())
+             status = [l2capChannel connectAsyncToDevice:address withPSM:port];
+         else
+             status = kIOReturnNoMemory;
+@@ -177,10 +177,10 @@ QString QBluetoothSocketPrivate::peerName() const
+ 
+     NSString *nsName = nil;
+     if (socketType == QBluetoothServiceInfo::RfcommProtocol) {
+-        if (rfcommChannel)
++        if (rfcommChannel.data())
+             nsName = [rfcommChannel peerName];
+     } else if (socketType == QBluetoothServiceInfo::L2capProtocol) {
+-        if (l2capChannel)
++        if (l2capChannel.data())
+             nsName = [l2capChannel peerName];
+     }
+ 
+@@ -194,10 +194,10 @@ QBluetoothAddress QBluetoothSocketPrivate::peerAddress() const
+ {
+     BluetoothDeviceAddress addr = {};
+     if (socketType == QBluetoothServiceInfo::RfcommProtocol) {
+-        if (rfcommChannel)
++        if (rfcommChannel.data())
+             addr = [rfcommChannel peerAddress];
+     } else if (socketType == QBluetoothServiceInfo::L2capProtocol) {
+-        if (l2capChannel)
++        if (l2capChannel.data())
+             addr = [l2capChannel peerAddress];
+     }
+ 
+@@ -207,10 +207,10 @@ QBluetoothAddress QBluetoothSocketPrivate::peerAddress() const
+ quint16 QBluetoothSocketPrivate::peerPort() const
+ {
+     if (socketType == QBluetoothServiceInfo::RfcommProtocol) {
+-        if (rfcommChannel)
++        if (rfcommChannel.data())
+             return [rfcommChannel getChannelID];
+     } else if (socketType == QBluetoothServiceInfo::L2capProtocol) {
+-        if (l2capChannel)
++        if (l2capChannel.data())
+             return [l2capChannel getPSM];
+     }
+ 
+@@ -227,7 +227,7 @@ void QBluetoothSocketPrivate::_q_writeNotify()
+     Q_ASSERT_X(socketType == QBluetoothServiceInfo::L2capProtocol
+                || socketType == QBluetoothServiceInfo::RfcommProtocol,
+                Q_FUNC_INFO, "invalid socket type");
+-    Q_ASSERT_X(l2capChannel || rfcommChannel, Q_FUNC_INFO,
++    Q_ASSERT_X(l2capChannel.data() || rfcommChannel.data(), Q_FUNC_INFO,
+                "invalid socket (no open channel)");
+     Q_ASSERT_X(q_ptr, Q_FUNC_INFO, "invalid q_ptr (null)");
+ 
+@@ -271,13 +271,13 @@ bool QBluetoothSocketPrivate::setChannel(IOBluetoothRFCOMMChannel *channel)
+ 
+     openMode = QIODevice::ReadWrite;
+     rfcommChannel.reset([[ObjCRFCOMMChannel alloc] initWithDelegate:this channel:channel]);
+-    if (rfcommChannel) {// We do not handle errors, up to an external user.
++    if (rfcommChannel.data()) {// We do not handle errors, up to an external user.
+         q_ptr->setOpenMode(QIODevice::ReadWrite);
+         state = QBluetoothSocket::ConnectedState;
+         socketType = QBluetoothServiceInfo::RfcommProtocol;
+     }
+ 
+-    return rfcommChannel;
++    return rfcommChannel.data();
+ }
+ 
+ bool QBluetoothSocketPrivate::setChannel(IOBluetoothL2CAPChannel *channel)
+@@ -295,13 +295,13 @@ bool QBluetoothSocketPrivate::setChannel(IOBluetoothL2CAPChannel *channel)
+ 
+     openMode = QIODevice::ReadWrite;
+     l2capChannel.reset([[ObjCL2CAPChannel alloc] initWithDelegate:this channel:channel]);
+-    if (l2capChannel) {// We do not handle errors, up to an external user.
++    if (l2capChannel.data()) {// We do not handle errors, up to an external user.
+         q_ptr->setOpenMode(QIODevice::ReadWrite);
+         state = QBluetoothSocket::ConnectedState;
+         socketType = QBluetoothServiceInfo::L2capProtocol;
+     }
+ 
+-    return l2capChannel;
++    return l2capChannel.data();
+ }
+ 
+ 
+diff --git src/bluetooth/qbluetoothtransferreply_osx.mm src/bluetooth/qbluetoothtransferreply_osx.mm
+index 1b84626..fd55e50 100644
+--- src/bluetooth/qbluetoothtransferreply_osx.mm
++++ src/bluetooth/qbluetoothtransferreply_osx.mm
+@@ -130,13 +130,13 @@ QBluetoothTransferReplyOSXPrivate::~QBluetoothTransferReplyOSXPrivate()
+     // The OBEX session will be closed then. If
+     // somehow IOBluetooth/OBEX still has a reference to our
+     // session, it will not call any of delegate's callbacks.
+-    if (session)
++    if (session.data())
+         [session closeSession];
+ }
+ 
+ bool QBluetoothTransferReplyOSXPrivate::isActive() const
+ {
+-    return agent || (session && [session hasActiveRequest]);
++    return agent.data() || (session.data() && [session hasActiveRequest]);
+ }
+ 
+ bool QBluetoothTransferReplyOSXPrivate::startOPP(const QBluetoothAddress &device)
+@@ -212,7 +212,7 @@ void QBluetoothTransferReplyOSXPrivate::sendConnect(const QBluetoothAddress &dev
+ void QBluetoothTransferReplyOSXPrivate::sendPut()
+ {
+     Q_ASSERT_X(inputStream, Q_FUNC_INFO, "invalid input stream (null)");
+-    Q_ASSERT_X(session, Q_FUNC_INFO, "invalid OBEX session (nil)");
++    Q_ASSERT_X(session.data(), Q_FUNC_INFO, "invalid OBEX session (nil)");
+     Q_ASSERT_X([session isConnected], Q_FUNC_INFO, "not connected");
+     Q_ASSERT_X(![session hasActiveRequest], Q_FUNC_INFO,
+                "session already has an active request");
+@@ -262,7 +262,7 @@ void QBluetoothTransferReplyOSXPrivate::OBEXConnectError(OBEXError errorCode, OB
+     Q_UNUSED(errorCode)
+     Q_UNUSED(response)
+ 
+-    if (session) {
++    if (session.data()) {
+         setReplyError(QBluetoothTransferReply::SessionError,
+                       QCoreApplication::translate(TRANSFER_REPLY, TR_CONNECT_FAILED));
+     } else {
+@@ -277,7 +277,7 @@ void QBluetoothTransferReplyOSXPrivate::OBEXConnectError(OBEXError errorCode, OB
+ void QBluetoothTransferReplyOSXPrivate::OBEXConnectSuccess()
+ {
+     // Now that OBEX connect succeeded, we can send an OBEX put request.
+-    if (!session) {
++    if (!session.data()) {
+         // We're still in OBEXConnect(), it'll take care of next steps.
+         return;
+     }
+diff --git src/bluetooth/qlowenergycontroller_osx.mm src/bluetooth/qlowenergycontroller_osx.mm
+index a0b33a9..fa6e32a 100644
+--- src/bluetooth/qlowenergycontroller_osx.mm
++++ src/bluetooth/qlowenergycontroller_osx.mm
+@@ -202,7 +202,7 @@ QLowEnergyControllerPrivateOSX::~QLowEnergyControllerPrivateOSX()
+ 
+ bool QLowEnergyControllerPrivateOSX::isValid() const
+ {
+-    return centralManager;
++    return centralManager.data();
+ }
+ 
+ void QLowEnergyControllerPrivateOSX::_q_connected()


### PR DESCRIPTION
minor modification of patch used in qt59 and upstream
see: https://trac.macports.org/ticket/60889

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5 11G63 i386
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
