### PR TITLE
libsoup-devel: update to @3.0.6

### DIFF
--- a/gnome/libsoup-devel/Portfile
+++ b/gnome/libsoup-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson 1.0
 name                libsoup-devel
 conflicts           libsoup
 set my_name         libsoup
-version             2.74.2
+version             3.0.6
 revision            0
 
 categories          gnome net
@@ -29,9 +29,9 @@ use_xz              yes
 distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 
-checksums           rmd160  b9d6df15524618f8376ed9735902952b49b0ddc6 \
-                    sha256  f0a427656e5fe19e1df71c107e88dfa1b2e673c25c547b7823b6018b40d01159 \
-                    size    1497356
+checksums           rmd160  57ba023d43546ab0224f3f8afea80a83122a250e \
+                    sha256  b45d59f840b9acf9bb45fd45854e3ef672f57e3ab957401c3ad8d7502ac23da6 \
+                    size    1527232
 
 depends_build-append \
                     port:pkgconfig \
@@ -40,24 +40,38 @@ depends_build-append \
                     path:bin/vala:vala
 
 depends_lib         port:brotli \
-                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    port:glib2-upstream \
                     port:glib-networking \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     port:kerberos5 \
                     port:libpsl \
                     port:libxml2 \
                     port:sqlite3 \
-                    port:zlib
+                    port:zlib \
+                    port:nghttp2 \
+                    port:apache2
 
 configure.args      -Dbrotli=enabled \
-                    -Dgnome=false \
                     -Dgssapi=enabled \
                     -Dgtk_doc=true \
                     -Dintrospection=enabled \
                     -Dntlm=disabled \
                     -Dsysprof=disabled \
-                    -Dvapi=enabled \
                     -Dtests=false
+
+# help it to find python
+patchfiles-append   patch-find-python.diff
+configure.python    ${prefix}/bin/python3.9
+
+post-patch {
+    reinplace "s|@@PYTHON3_BIN@@|${configure.python}|" \
+        ${worksrcpath}/meson.build
+    reinplace "s|/usr/bin/env python3|${configure.python}|" \
+        ${worksrcpath}/get_apache_modules_dirs.py \
+        ${worksrcpath}/libsoup/generate-header-names.py \
+        ${worksrcpath}/libsoup/generate-version-header.py \
+        ${worksrcpath}/tests/http2-server.py
+}
 
 if {![info exists universal_possible]} {
     set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
@@ -73,6 +87,11 @@ if {${universal_possible} && [variant_isset universal]} {
     destroot.env-append    "CC=${configure.cc} ${configure.cc_archflags}"
 }
 
+platform darwin powerpc {
+    # vapigen is broken on PPC at the moment
+    configure.args-append -Dvapi=disabled
+}
+
 platform darwin 8 {
     # meson on Tiger cannot use rpaths, so we workaround with this to find dylib
     destroot.env-append    "DYLD_LIBRARY_PATH=${build_dir}/${my_name}"
@@ -82,10 +101,5 @@ variant gnome description {Enable GNOME support} {
     configure.args-replace -Dgnome=false -Dgnome=true
 }
 
-default_variants    +gnome
-
 livecheck.type      gnome
 livecheck.name      ${my_name}
-# restrict livecheck to 2.* release branch
-# new 3.* branch breaks API/ABI
-livecheck.regex     LATEST-IS-(2\\.\\d*\[02468\](?:\\.\\d+)*)

--- a/gnome/libsoup-devel/files/patch-find-python.diff
+++ b/gnome/libsoup-devel/files/patch-find-python.diff
@@ -1,0 +1,25 @@
+--- meson.build.orig	2022-05-17 12:15:10.480385710 -0400
++++ meson.build	2022-05-17 12:17:51.654329294 -0400
+@@ -282,21 +282,21 @@
+   have_autobahn = false
+ else
+   have_autobahn = find_program('wstest', required: get_option('autobahn')).found()
+ endif
+ 
+ # Quart server used for HTTP/2 tests
+ quart_found = false
+ 
+ if not get_option('http2_tests').disabled()
+   pymod = import('python')
+-  python = pymod.find_installation('python3')
++  python = pymod.find_installation('@@PYTHON3_BIN@@')
+   if python.found()
+     ret = run_command(python, '-c', 'import importlib\nassert(importlib.find_loader("quart"))', check: false)
+     if ret.returncode() == 0
+       quart_found = true
+     endif
+   endif
+   message('Python module quart found: @0@'.format(quart_found.to_string('YES', 'NO')))
+   if get_option('http2_tests').enabled() and not quart_found
+     error('quart is required for http2 tests')
+   endif


### PR DESCRIPTION
#### Description

Update `libsoup-devel` to @3.0.6, disable `vapigen` for PowerPC until fixed, remove obsolete `gnome` option.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.6
Xcode 3.2
