### PR TITLE
lilypond: make devel version use Guile 2; remove dependency on netpbm

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -43,7 +43,7 @@ compiler.cxx_standard 2011
 
 if {${subport} eq ${name}} {
     version         2.22.2
-    revision        0
+    revision        1
     conflicts       lilypond-devel
     checksums       rmd160  571de8313f90be3a41b0f7f0bd82a48f67e4f245 \
                     sha256  dde90854fa7de1012f4e1304a68617aea9ab322932ec0ce76984f60d26aa23be \
@@ -58,7 +58,7 @@ if {${subport} eq ${name}} {
     }
 } else {
     version         2.23.7
-    revision        0
+    revision        1
     conflicts       lilypond
     checksums       rmd160  41a82e8b411581b0dd4c9476edf60ce6be41f726 \
                     sha256  b5674df4c2371cb6d59a06ea54eaba6c87f2e7c503c9f17ec3db3facd61807c0 \
@@ -78,7 +78,6 @@ livecheck.url       ${homepage}/${livecheck_url}
 platforms           darwin
 universal_variant   no
 
-
 depends_build-append \
                     port:autoconf \
                     port:bison \
@@ -95,11 +94,6 @@ depends_build-append \
                     port:texinfo \
                     port:urw-core35-fonts
 
-if {${subport} eq ${name}} {
-    # Will be gone in next stable release.
-    depends_build-append \
-                    port:netpbm
-}
 if {![variant_isset mactex]} {
     depends_build-append \
                     port:texlive-fonts-recommended \
@@ -119,13 +113,25 @@ set py_ver_nodot    [string map {. {}} ${py_ver}]
 depends_lib-append  path:lib/pkgconfig/pango.pc:pango \
                     port:extractpdfmark \
                     port:ghostscript \
-                    port:guile18 \
                     port:python${py_ver_nodot}
+
+if {${subport} eq ${name}} {
+    depends_lib-append  port:guile18
+} else {
+    depends_lib-append  port:guile
+}
 
 build.type          gnu
 configure.cmd       autoconf -f && ./configure
 configure.python    ${prefix}/bin/python${py_ver}
 
+if {${subport} ne ${name}} {
+    # These targets also build and install compiled Scheme files (with
+    # extension '.go').  This is essential to make LilyPond run with
+    # an acceptable speed while using Guile 2.2.
+    build.target        bytecode
+    destroot.target     install-bytecode
+}
 
 set lilypond.texgyredir \
     "${prefix}/share/texmf-texlive/fonts/opentype/public/tex-gyre"
@@ -176,7 +182,6 @@ if {[variant_isset mactex]} {
     }
 }
 
-
 if {[variant_isset docs]} {
     if {${subport} ne ${name}} {
         # Currently, +docs only builds the info files.  For a complete
@@ -190,8 +195,10 @@ if {[variant_isset docs]} {
 configure.args-append   --with-urwotf-dir=${prefix}/share/fonts/urw-core35-fonts
 configure.args-append   --with-texgyre-dir=${lilypond.texgyredir}
 
-configure.env-append    GUILE=${prefix}/bin/guile18
-configure.env-append    GUILE_FLAVOR=guile-1.8
+if {${subport} eq ${name}} {
+    configure.env-append    GUILE=${prefix}/bin/guile18
+    configure.env-append    GUILE_FLAVOR=guile-1.8
+}
 
 configure.env-append    PYTHON=${configure.python}
 build.env-append        PYTHON=${configure.python}
@@ -217,11 +224,13 @@ if {${subport} eq ${name}} {
 }
 
 post-patch {
-    # Use guile18 header files.
-    reinplace -W ${worksrcpath} \
-        s|libguile\.h|libguile18.h|g \
-        configure.ac \
-        lily/include/lily-guile.hh
+    if {${subport} eq ${name}} {
+        # Use guile18 header files.
+        reinplace -W ${worksrcpath} \
+            s|libguile\.h|libguile18.h|g \
+            configure.ac \
+            lily/include/lily-guile.hh
+    }
 
     # Correct mf2pt1 binary location.
     reinplace -W ${worksrcpath} \


### PR DESCRIPTION
###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
