### PR TITLE
gcc10+: recognize opportunistic use of zstd port

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -34,7 +34,7 @@ if {${os.arch} eq "arm"} {
 
     # Version must follow same scheme as with GCC snapshots below <version>-<commit-date>
     version         12-20220327
-    revision        0
+    revision        1
     subport         libgcc-devel { revision 0 }
 
     checksums       rmd160  76551e6d93d2a0a15afca6d66ed36f5f23b92b0a \
@@ -45,7 +45,7 @@ if {${os.arch} eq "arm"} {
     # Use regular GCC releases and snapshsots
 
     version         12-20220403
-    revision        0
+    revision        1
     subport         libgcc-devel { revision 0 }
 
     checksums       rmd160  7ab9d4c3ed8ada8ca619d21d22a524014b1aee01 \
@@ -85,7 +85,8 @@ depends_lib-append  port:cctools \
                     port:libiconv \
                     port:libmpc \
                     port:mpfr \
-                    port:zlib
+                    port:zlib \
+                    port:zstd
 depends_run-append  port:gcc_select \
                     port:libgcc-devel
 
@@ -130,6 +131,7 @@ configure.args      --enable-languages=[join ${gcc_configure_langs} ","] \
                     --with-mpfr=${prefix} \
                     --with-mpc=${prefix} \
                     --with-isl=${prefix} \
+                    --with-zstd=${prefix} \
                     --enable-stage1-checking \
                     --disable-multilib \
                     --enable-lto \

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -10,7 +10,7 @@ PortGroup           cltversion                   1.0
 epoch               6
 name                gcc10
 version             10.3.0
-revision            1
+revision            2
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -40,7 +40,7 @@ master_sites        https://ftpmirror.gnu.org/gcc/gcc-${version}/ \
 # Branch from the Darwin maintainer of GCC with Apple Silicon support
 if { ${os.arch} eq "arm" } {
     version         10.2.0
-    revision        2
+    revision        3
     master_sites    https://github.com/fxcoudert/gcc/archive
     distname        gcc-10-arm-20210220
     checksums       rmd160  7ad0ba740d46554b5a5ccdfdc75f4401a76108b4 \
@@ -88,7 +88,8 @@ depends_lib-append  port:cctools \
                     port:libiconv \
                     port:libmpc \
                     port:mpfr \
-                    port:zlib
+                    port:zlib \
+                    port:zstd
 depends_run-append  port:gcc_select \
                     port:libgcc10
 
@@ -127,6 +128,7 @@ configure.args      --enable-languages=[join ${gcc_configure_langs} ","] \
                     --with-mpfr=${prefix} \
                     --with-mpc=${prefix} \
                     --with-isl=${prefix} \
+                    --with-zstd=${prefix} \
                     --enable-stage1-checking \
                     --disable-multilib \
                     --enable-lto \

--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -13,7 +13,7 @@ name                gcc11
 
 # Note, ARM builds have their own version below...
 version             11.2.0
-revision            3
+revision            4
 
 platforms           darwin
 categories          lang
@@ -45,7 +45,7 @@ master_sites        https://ftpmirror.gnu.org/gcc/gcc-${version}/ \
 # Branch from the Darwin maintainer of GCC with Apple Silicon support
 if { ${os.arch} eq "arm" } {
     version         11.2.0
-    revision        1
+    revision        2
     master_sites    https://github.com/fxcoudert/gcc/archive
     distname        gcc-${version}-arm-20211126
     checksums       rmd160  ce5d0621028c8ff2bf3ab677b29f6c14e4c86dfe \
@@ -115,7 +115,8 @@ depends_lib-append  port:cctools \
                     port:libiconv \
                     port:libmpc \
                     port:mpfr \
-                    port:zlib
+                    port:zlib \
+                    port:zstd
 depends_run-append  port:gcc_select \
                     path:share/doc/libgcc/README:libgcc
 
@@ -157,6 +158,7 @@ configure.args      --enable-languages=[join ${gcc_configure_langs} ","] \
                     --with-mpfr=${prefix} \
                     --with-mpc=${prefix} \
                     --with-isl=${prefix} \
+                    --with-zstd=${prefix} \
                     --enable-stage1-checking \
                     --disable-multilib \
                     --enable-lto \


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/63750

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
