### PR TITLE
Cryfs: Update to 0.11.2 and dependency

### DIFF
--- a/devel/range-v3/Portfile
+++ b/devel/range-v3/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake  1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        ericniebler range-v3 0.10.0
+github.setup        ericniebler range-v3 0.11.0
 homepage            https://ericniebler.github.io/range-v3
 categories          devel
 platforms           darwin
@@ -37,9 +37,15 @@ long_description    \
     about support or long-term stability. This code will evolve without regard \
     to backwards compatibility.
 
-checksums           rmd160  a9d538fee06f5998833c4715897cdad6c9c98861 \
-                    sha256  9d33f7bdbbd1288f69915d84b5d836e501fa349aaaa4c7e9ea70a357213afb30 \
-                    size    525776
+checksums           rmd160  f83c1dc09e53bc379cf1e7f0a5d0a0dcad437925 \
+                    sha256  5a4d401d1ece3e8ec43a3c36ae6254704436ac308adc23164cbce259d36ec749 \
+                    size    533176
+
+patchfiles fix_include_dir.diff
 
 compiler.blacklist-append {clang < 900}
 depends_build-append port:doxygen
+
+# warnings have to be ignored until this issue is relolved :
+# https://github.com/ericniebler/range-v3/issues/1685
+configure.args-append -DRANGES_HAS_WERROR=0

--- a/devel/range-v3/files/fix_include_dir.diff
+++ b/devel/range-v3/files/fix_include_dir.diff
@@ -1,0 +1,34 @@
+--- CMakeLists.txt.orig	2020-08-07 01:05:10.000000000 +0200
++++ CMakeLists.txt	2022-05-07 15:19:48.000000000 +0200
+@@ -23,20 +23,20 @@
+ add_library(range-v3-meta INTERFACE)
+ add_library(range-v3::meta ALIAS range-v3-meta)
+ target_include_directories(range-v3-meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
+-target_include_directories(range-v3-meta SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
++target_include_directories(range-v3-meta SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/range-v3>)
+ target_compile_options(range-v3-meta INTERFACE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
+ 
+ add_library(range-v3-concepts INTERFACE)
+ add_library(range-v3::concepts ALIAS range-v3-concepts)
+ target_include_directories(range-v3-concepts INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
+-target_include_directories(range-v3-concepts SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
++target_include_directories(range-v3-concepts SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/range-v3>)
+ target_compile_options(range-v3-concepts INTERFACE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
+ target_link_libraries(range-v3-concepts INTERFACE range-v3::meta)
+ 
+ add_library(range-v3 INTERFACE)
+ add_library(range-v3::range-v3 ALIAS range-v3)
+ target_include_directories(range-v3 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
+-target_include_directories(range-v3 SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
++target_include_directories(range-v3 SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/range-v3>)
+ target_compile_options(range-v3 INTERFACE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
+ target_link_libraries(range-v3 INTERFACE range-v3::concepts range-v3::meta)
+ 
+@@ -173,6 +173,6 @@
+   ${CMAKE_CURRENT_BINARY_DIR}/range-v3-config-version.cmake
+   cmake/range-v3-config.cmake
+   DESTINATION lib/cmake/range-v3)
+-install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*")
++install(DIRECTORY include/ DESTINATION include/range-v3 FILES_MATCHING PATTERN "*")
+ 
+ export(EXPORT range-v3-targets FILE range-v3-config.cmake)

--- a/fuse/macfuse/Portfile
+++ b/fuse/macfuse/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        osxfuse osxfuse 4.3.1 macfuse-
-revision            0
+revision            1
 name                macfuse
 conflicts           osxfuse
 categories          fuse
@@ -69,6 +69,7 @@ destroot {
     copy {*}[glob ${pkg}/Library/Frameworks/*] ${destroot}${prefix}/Library/Frameworks
     copy {*}[glob ${pkg}/usr/local/include/*] ${destroot}${prefix}/include
     copy {*}[glob ${pkg}/usr/local/lib/pkgconfig/*] ${destroot}${prefix}/lib/pkgconfig
+    reinplace "s|/usr/local|${prefix}|g" [glob ${destroot}${prefix}/lib/pkgconfig/*]
     copy {*}[glob -type f ${pkg}/usr/local/lib/*] ${destroot}${prefix}/lib
     # remove unwanted files like ._uninstall_macfuse.app
     system "find  ${destroot}${prefix} -type f -iname '._*' -delete"

--- a/net/cryfs/Portfile
+++ b/net/cryfs/Portfile
@@ -1,12 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                1.0
+PortGroup                 fuse 1.0
 PortGroup                 github 1.0
 PortGroup                 cmake 1.1
 PortGroup                 boost 1.0
 
-github.setup              cryfs cryfs 0.10.3
-revision                  2
+github.setup              cryfs cryfs 0.11.2
+revision                  0
 github.tarball_from       releases
 
 license                   LGPL-3
@@ -23,17 +24,24 @@ long_description          CryFS encrypts your files, so you can safely store the
 
 homepage                  https://www.cryfs.org/
 
-checksums                 rmd160  ba20af5cc2d77954b3a6f248b230860242cb690f \
-                          sha256  20348e6e2ff670505a14d4f8b2a9aa6104ce301d31ef50100cd03d17c1d7322b \
-                          size    10184695
+checksums                 rmd160  798106ac28621532695bf29ec39c47e64f5bf674 \
+                          sha256  a89ab8fea2d494b496867107ec0a3772fe606ebd71ef12152fcd233f463a2c00 \
+                          size    10419264
 
 extract.mkdir             yes
 
-depends_build-append      path:lib/libssl.dylib:openssl
+patchfiles                gitversion_python3_fix.diff
+post-patch {
+    reinplace "s|@@PYTHONBIN@@|${prefix}/bin/python3.10|g" ${worksrcpath}/src/gitversion/gitversion.cmake
+}
+
+depends_build-append      path:lib/libssl.dylib:openssl \
+                          port:range-v3 \
+                          port:spdlog \
+                          port:python310
 
 depends_lib-append        port:curl \
-                          port:libomp \
-                          port:osxfuse
+                          port:libomp
 
 cmake.build_type          Release
 universal_variant         no
@@ -42,4 +50,5 @@ compiler.cxx_standard     2014
 
 configure.args-append    -DBoost_USE_MULTITHREADED=on \
                          -DBoost_USE_STATIC_LIBS=off \
-                         -DCRYFS_UPDATE_CHECKS=off
+                         -DCRYFS_UPDATE_CHECKS=off \
+                         -DDEPENDENCY_CONFIG=${worksrcpath}/cmake-utils/DependenciesFromLocalSystem.cmake

--- a/net/cryfs/files/gitversion_python3_fix.diff
+++ b/net/cryfs/files/gitversion_python3_fix.diff
@@ -1,0 +1,11 @@
+--- src/gitversion/gitversion.cmake.orig	2022-02-22 06:22:55.000000000 +0100
++++ src/gitversion/gitversion.cmake	2022-05-07 15:40:30.000000000 +0200
+@@ -1,7 +1,7 @@
+ set(DIR_OF_GITVERSION_TOOL "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "DIR_OF_GITVERSION_TOOL")
+ 
+ function (get_git_version OUTPUT_VARIABLE)
+-    EXECUTE_PROCESS(COMMAND python ${DIR_OF_GITVERSION_TOOL}/getversion.py
++    EXECUTE_PROCESS(COMMAND @@PYTHONBIN@@ ${DIR_OF_GITVERSION_TOOL}/getversion.py
+         WORKING_DIRECTORY ${DIR_OF_GITVERSION_TOOL}
+         OUTPUT_VARIABLE VERSION
+         ERROR_VARIABLE error


### PR DESCRIPTION
#### Description

Update Cryfs to 0.11.2 and the required range-v3 to 0.11.0

range-v3 has to be compiled without WERROR due to https://github.com/ericniebler/range-v3/issues/1685
is it OK to add a comment in the portfile describing this ?

I added python310 as a build dependency (used by the gitversion tool). python37 was previously used but has been deleted by @cjones051073 here: https://github.com/macports/macports-ports/commit/5c327283f4bb55253aab71f33f21e2418c236676#diff-5f109b2ba1617f8f933af9a477e0cec88b3fab6742a424a2d34a972801b25ec3L31. please comment if it is a mistake to add it back. I also patched the tool to explicitely use python3 instead of python, which the cryfs project did in https://github.com/cryfs/cryfs/commit/5f908c641cd5854b8a347f842b996bfe76a64577

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 12.3.1 21E258 arm64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
