### PR TITLE
qemu: fix linux guests on arm hvf

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                    qemu
 version                 6.2.0
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 platforms               darwin
@@ -63,6 +63,11 @@ patchfiles-append       patch-qemu-include-qemu-osdep.diff
 
 # MAP_JIT workaround
 patchfiles-append       patch-qemu-tcg-region.diff
+
+# Backports from QEMU 7 which are necessary for newer Linux guests on ARM
+# See https://gitlab.com/qemu-project/qemu/-/issues/899
+patchfiles-append       patch-qemu-ad99f64.diff
+patchfiles-append       patch-qemu-7f6c295.diff
 
 # "ERROR: You need at least GCC v7.5 or Clang v6.0 (or XCode Clang v10.0)"
 compiler.blacklist      {clang < 1000} {macports-clang-[3-5].*} {macports-gcc-[56]} {*gcc-[34].*}

--- a/emulators/qemu/files/patch-qemu-7f6c295.diff
+++ b/emulators/qemu/files/patch-qemu-7f6c295.diff
@@ -1,0 +1,32 @@
+diff --git target/arm/hvf/hvf.c target/arm/hvf/hvf.c
+index 808c96da8ccbd8d191f5b78ed397d39463aa3809..4d4ddab348a7d73c4c99ca18705dc3257aebfa8a 100644
+--- target/arm/hvf/hvf.c
++++ target/arm/hvf/hvf.c
+@@ -754,6 +754,15 @@ static bool hvf_handle_psci_call(CPUState *cpu)
+     return true;
+ }
+ 
++static bool is_id_sysreg(uint32_t reg)
++{
++    return SYSREG_OP0(reg) == 3 &&
++           SYSREG_OP1(reg) == 0 &&
++           SYSREG_CRN(reg) == 0 &&
++           SYSREG_CRM(reg) >= 1 &&
++           SYSREG_CRM(reg) < 8;
++}
++
+ static int hvf_sysreg_read(CPUState *cpu, uint32_t reg, uint32_t rt)
+ {
+     ARMCPU *arm_cpu = ARM_CPU(cpu);
+@@ -806,6 +815,11 @@ static int hvf_sysreg_read(CPUState *cpu, uint32_t reg, uint32_t rt)
+         /* Dummy register */
+         break;
+     default:
++        if (is_id_sysreg(reg)) {
++            /* ID system registers read as RES0 */
++            val = 0;
++            break;
++        }
+         cpu_synchronize_state(cpu);
+         trace_hvf_unhandled_sysreg_read(env->pc, reg,
+                                         SYSREG_OP0(reg),

--- a/emulators/qemu/files/patch-qemu-ad99f64.diff
+++ b/emulators/qemu/files/patch-qemu-ad99f64.diff
@@ -1,0 +1,107 @@
+diff --git target/arm/hvf/hvf.c target/arm/hvf/hvf.c
+index 0dc96560d3469316907f70efcc971b540687a570..808c96da8ccbd8d191f5b78ed397d39463aa3809 100644
+--- target/arm/hvf/hvf.c
++++ target/arm/hvf/hvf.c
+@@ -35,9 +35,34 @@
+         ENCODE_AA64_CP_REG(CP_REG_ARM64_SYSREG_CP, crn, crm, op0, op1, op2)
+ #define PL1_WRITE_MASK 0x4
+ 
++#define SYSREG_OP0_SHIFT      20
++#define SYSREG_OP0_MASK       0x3
++#define SYSREG_OP0(sysreg)    ((sysreg >> SYSREG_OP0_SHIFT) & SYSREG_OP0_MASK)
++#define SYSREG_OP1_SHIFT      14
++#define SYSREG_OP1_MASK       0x7
++#define SYSREG_OP1(sysreg)    ((sysreg >> SYSREG_OP1_SHIFT) & SYSREG_OP1_MASK)
++#define SYSREG_CRN_SHIFT      10
++#define SYSREG_CRN_MASK       0xf
++#define SYSREG_CRN(sysreg)    ((sysreg >> SYSREG_CRN_SHIFT) & SYSREG_CRN_MASK)
++#define SYSREG_CRM_SHIFT      1
++#define SYSREG_CRM_MASK       0xf
++#define SYSREG_CRM(sysreg)    ((sysreg >> SYSREG_CRM_SHIFT) & SYSREG_CRM_MASK)
++#define SYSREG_OP2_SHIFT      17
++#define SYSREG_OP2_MASK       0x7
++#define SYSREG_OP2(sysreg)    ((sysreg >> SYSREG_OP2_SHIFT) & SYSREG_OP2_MASK)
++
+ #define SYSREG(op0, op1, crn, crm, op2) \
+-    ((op0 << 20) | (op2 << 17) | (op1 << 14) | (crn << 10) | (crm << 1))
+-#define SYSREG_MASK           SYSREG(0x3, 0x7, 0xf, 0xf, 0x7)
++    ((op0 << SYSREG_OP0_SHIFT) | \
++     (op1 << SYSREG_OP1_SHIFT) | \
++     (crn << SYSREG_CRN_SHIFT) | \
++     (crm << SYSREG_CRM_SHIFT) | \
++     (op2 << SYSREG_OP2_SHIFT))
++#define SYSREG_MASK \
++    SYSREG(SYSREG_OP0_MASK, \
++           SYSREG_OP1_MASK, \
++           SYSREG_CRN_MASK, \
++           SYSREG_CRM_MASK, \
++           SYSREG_OP2_MASK)
+ #define SYSREG_OSLAR_EL1      SYSREG(2, 0, 1, 0, 4)
+ #define SYSREG_OSLSR_EL1      SYSREG(2, 0, 1, 1, 4)
+ #define SYSREG_OSDLR_EL1      SYSREG(2, 0, 1, 3, 4)
+@@ -783,21 +808,21 @@ static int hvf_sysreg_read(CPUState *cpu, uint32_t reg, uint32_t rt)
+     default:
+         cpu_synchronize_state(cpu);
+         trace_hvf_unhandled_sysreg_read(env->pc, reg,
+-                                        (reg >> 20) & 0x3,
+-                                        (reg >> 14) & 0x7,
+-                                        (reg >> 10) & 0xf,
+-                                        (reg >> 1) & 0xf,
+-                                        (reg >> 17) & 0x7);
++                                        SYSREG_OP0(reg),
++                                        SYSREG_OP1(reg),
++                                        SYSREG_CRN(reg),
++                                        SYSREG_CRM(reg),
++                                        SYSREG_OP2(reg));
+         hvf_raise_exception(cpu, EXCP_UDEF, syn_uncategorized());
+         return 1;
+     }
+ 
+     trace_hvf_sysreg_read(reg,
+-                          (reg >> 20) & 0x3,
+-                          (reg >> 14) & 0x7,
+-                          (reg >> 10) & 0xf,
+-                          (reg >> 1) & 0xf,
+-                          (reg >> 17) & 0x7,
++                          SYSREG_OP0(reg),
++                          SYSREG_OP1(reg),
++                          SYSREG_CRN(reg),
++                          SYSREG_CRM(reg),
++                          SYSREG_OP2(reg),
+                           val);
+     hvf_set_reg(cpu, rt, val);
+ 
+@@ -886,11 +911,11 @@ static int hvf_sysreg_write(CPUState *cpu, uint32_t reg, uint64_t val)
+     CPUARMState *env = &arm_cpu->env;
+ 
+     trace_hvf_sysreg_write(reg,
+-                           (reg >> 20) & 0x3,
+-                           (reg >> 14) & 0x7,
+-                           (reg >> 10) & 0xf,
+-                           (reg >> 1) & 0xf,
+-                           (reg >> 17) & 0x7,
++                           SYSREG_OP0(reg),
++                           SYSREG_OP1(reg),
++                           SYSREG_CRN(reg),
++                           SYSREG_CRM(reg),
++                           SYSREG_OP2(reg),
+                            val);
+ 
+     switch (reg) {
+@@ -960,11 +985,11 @@ static int hvf_sysreg_write(CPUState *cpu, uint32_t reg, uint64_t val)
+     default:
+         cpu_synchronize_state(cpu);
+         trace_hvf_unhandled_sysreg_write(env->pc, reg,
+-                                         (reg >> 20) & 0x3,
+-                                         (reg >> 14) & 0x7,
+-                                         (reg >> 10) & 0xf,
+-                                         (reg >> 1) & 0xf,
+-                                         (reg >> 17) & 0x7);
++                                         SYSREG_OP0(reg),
++                                         SYSREG_OP1(reg),
++                                         SYSREG_CRN(reg),
++                                         SYSREG_CRM(reg),
++                                         SYSREG_OP2(reg));
+         hvf_raise_exception(cpu, EXCP_UDEF, syn_uncategorized());
+         return 1;
+     }


### PR DESCRIPTION
#### Description

This fixes an issue with recent Linux kernels not wanting to run on QEMU on M1 systems.

See upstream ticket: https://gitlab.com/qemu-project/qemu/-/issues/899

This applies the same patches as applied in Homebrew's 6.2.0_1 revision of qemu. These are backports of commits made to QEMU master.

See Homebrew PR: https://github.com/Homebrew/homebrew-core/pull/96743
See Homebrew commit: https://github.com/Homebrew/homebrew-core/commit/0301a2b3a8781d2fa4d3d46bec29644d69cf13db

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
