### PR TITLE
gnutls: update to @3.7.4

### DIFF
--- a/devel/gnutls/Portfile
+++ b/devel/gnutls/Portfile
@@ -9,8 +9,8 @@ PortGroup       legacysupport 1.0
 PortGroup       muniversal 1.0
 
 name            gnutls
-version         3.6.16
-revision        3
+version         3.7.4
+revision        0
 set branch      [join [lrange [split ${version} .] 0 1] .]
 set major       [join [lrange [split ${version} .] 0 2] .]
 categories      devel security
@@ -27,9 +27,9 @@ homepage        http://www.gnutls.org/
 master_sites    https://www.gnupg.org/ftp/gcrypt/gnutls/v${branch}/ \
                 https://mirrors.dotsrc.org/gcrypt/gnutls/v${branch}/
 
-checksums       rmd160  d6bc8751c569db6033234c810b45eb661f77b4b4 \
-                sha256  1b79b381ac283d8b054368b335c408fedcb9b7144e0c07f531e3537d4328f3b3 \
-                size    5639992
+checksums		rmd160  8aeae9fa379ee637082832e619f4d078d5147eb8 \
+				sha256  e6adbebcfbc95867de01060d93c789938cf89cc1d1f6ef9ef661890f6217451f \
+            	size    6131772
 
 use_xz          yes
 
@@ -53,10 +53,11 @@ depends_lib-append \
                 port:libunistring \
                 port:p11-kit \
                 port:nettle \
-                port:zlib
+                port:zlib \
+                port:zstd
 
-patchfiles      patch-lib-system-certs.c.diff
-patchfiles-append implicit.patch
+patchfiles      patch-lib-system-certs.c.diff \
+				implicit.patch
 
 post-patch {
     # Remove comments which confuse at least Leopard's assembler.


### PR DESCRIPTION
#### Description

Update of `gnutls` to @3.7.4 (the latest version).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10.6 PPC (10A190)
Xcode 3.2

macOS 10.4.11
Xcode 2.5
