### PR TITLE
libgit2-glib: disable vapigen for ppc

### DIFF
--- a/gnome/libgit2-glib/Portfile
+++ b/gnome/libgit2-glib/Portfile
@@ -46,6 +46,11 @@ configure.args      -Dgtk_doc=false \
                     -Dpython=false \
                     -Dtranslate_windows_paths=false
 
+platform darwin powerpc {
+    # vapigen is broken on PPC at the moment.
+    configure.args-append -Dvapi=false
+}
+
 # Work around lack of @rpath on Tiger, i.e. this error:
 # dyld: Library not loaded: @loader_path/libgit2-glib-1.0.0.dylib
 platform darwin 8 {


### PR DESCRIPTION
#### Description

Update `libgit2-glib` to disable `vapigen` on PPC, for the time-being. No other changes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 (10A190)
Xcode 3.2
