### PR TITLE
git: fix build on <10.10

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,6 +4,8 @@ PortSystem          1.0
 PortGroup           legacysupport   1.1
 PortGroup           perl5           1.0
 
+legacysupport.newest_darwin_requires_legacy 9
+
 name                git
 version             2.36.0
 revision            0
@@ -56,6 +58,12 @@ patchfiles          patch-Makefile.diff \
                     patch-sha1dc-older-apple-gcc-versions.diff \
                     patch-gitk-git-gitk.diff
 patch.pre_args      -p1
+
+# Git 2.36.0 implements a new FSEvent listener that uses
+# the API available in Yosemite and newer.
+if {${os.platform} eq "darwin" && ${os.major} < 14} {
+    patchfiles-append   patch-ignore-fsmonitor-daemon-backend.diff
+}
 
 extract.only        git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}

--- a/devel/git/files/patch-Makefile.diff
+++ b/devel/git/files/patch-Makefile.diff
@@ -1,6 +1,6 @@
 --- a/Makefile.orig
 +++ b/Makefile
-@@ -1257,7 +1257,7 @@
+@@ -1336,7 +1336,7 @@
  ifeq ($(COMPUTE_HEADER_DEPENDENCIES),auto)
  dep_check = $(shell $(CC) $(ALL_CFLAGS) \
  	-c -MF /dev/null -MQ /dev/null -MMD -MP \

--- a/devel/git/files/patch-ignore-fsmonitor-daemon-backend.diff
+++ b/devel/git/files/patch-ignore-fsmonitor-daemon-backend.diff
@@ -1,0 +1,17 @@
+--- a/Makefile.orig
++++ b/Makefile
+@@ -2002,10 +2002,10 @@ ifdef NEED_ACCESS_ROOT_HANDLER
+ 	COMPAT_OBJS += compat/access.o
+ endif
+ 
+-ifdef FSMONITOR_DAEMON_BACKEND
+-	COMPAT_CFLAGS += -DHAVE_FSMONITOR_DAEMON_BACKEND
+-	COMPAT_OBJS += compat/fsmonitor/fsm-listen-$(FSMONITOR_DAEMON_BACKEND).o
+-endif
++# ifdef FSMONITOR_DAEMON_BACKEND
++#	 COMPAT_CFLAGS += -DHAVE_FSMONITOR_DAEMON_BACKEND
++#	 COMPAT_OBJS += compat/fsmonitor/fsm-listen-$(FSMONITOR_DAEMON_BACKEND).o
++# endif
+ 
+ ifeq ($(TCLTK_PATH),)
+ NO_TCLTK = NoThanks


### PR DESCRIPTION
* simply do not compile a new file system event listener on systems older than OS X Yosmeite
* fix hunks in Makefile patch
* legacysupport portgroup should be used exactly on 10.5 (it breaks compilation, I don't have ability to test it on older systems)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008
GitHub Actions CI build

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
