### PR TITLE
gcc10-bootstrap: skip bootstrap comparison

### DIFF
--- a/lang/gcc10-bootstrap/Portfile
+++ b/lang/gcc10-bootstrap/Portfile
@@ -110,6 +110,15 @@ patchfiles-append patch-build-i686.diff
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
 patchfiles-append patch-xcode12-fix.diff
 
+# Skip bootstrap comparison entirely
+post-patch {
+    reinplace {s|^do-compare =|do-compare = /usr/bin/true|g} \
+        ${worksrcpath}/Makefile.in \
+        ${worksrcpath}/config/bootstrap-debug.mk \
+        ${worksrcpath}/config/bootstrap-debug-lean.mk \
+        ${worksrcpath}/config/bootstrap-debug-lib.mk
+}
+
 # sterilize MacPorts build environment; we want nothing picked up from MP prefix
 compiler.cpath
 compiler.library_path


### PR DESCRIPTION
#### Description

As suggested let skip it to make build stable.

Closes: https://trac.macports.org/ticket/65033

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS 10.10.5 14F2511 x86_64
Xcode 7.2.1 7C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->