### PR TITLE
libcerf: update to 2.1

### DIFF
--- a/math/libcerf/Portfile
+++ b/math/libcerf/Portfile
@@ -5,11 +5,10 @@ PortGroup           gitlab 1.0
 PortGroup           cmake 1.1
 
 gitlab.instance     https://jugit.fz-juelich.de
-gitlab.setup        mlz libcerf 2.0 v
+gitlab.setup        mlz libcerf 2.1 v
 revision            0
 
 categories          math
-platforms           darwin
 license             MIT
 maintainers         {mojca @mojca} openmaintainer
 
@@ -18,9 +17,9 @@ long_description    The libcerf library is a self-contained numeric library that
                     an efficient and accurate implementation of complex error functions, \
                     along with Dawson, Faddeeva, and Voigt functions.
 
-checksums           rmd160  06b9a708863e719942d03f2b6e2e9a6cfbbfbf23 \
-                    sha256  2015156b0306d948da9ed509724e71564bf3aa742c8e9fa1e68fcd51f298e5a0 \
-                    size    65856
+checksums           rmd160  4fcfb848fad1a7d787b6a9d37cfc394c1ae31705 \
+                    sha256  4ab7b5669e2f519cb3c932d18a1cb1449b6131ab49fe5a96d6732a846dd1c389 \
+                    size    66385
 
 test.run            yes
 test.cmd            ctest


### PR DESCRIPTION
#### Description
- update to latest upstream version

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
