### PR TITLE
google-cloud-sdk: update to 382.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             381.0.0
+version             382.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e97a4bc6af9267fd38d2fb1dc8b33853d0c30bdb \
-                    sha256  9686d92ff4c3a35d137f568e540ff4063dcc937df232f91fad46bd57c7b5dd51 \
-                    size    106499533
+    checksums       rmd160  87dc2b3b5712989ed7ebdd9d35277157b9705783 \
+                    sha256  4ea3850f3d204a105c960537eae2653ae9fa58c32db1c142c6955d749842950a \
+                    size    106559329
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  adf14808797885762568fa7d2b37606b37b60a97 \
-                    sha256  1d2893c4149f7aa45897886e7cc29ec736a36503bab7e268cb7e7141afa8ab6d \
-                    size    103094650
+    checksums       rmd160  1a2808d2153de818ffa59dbc81c3e374553da7d4 \
+                    sha256  f4d2f32068d83e2530b5e2f902423f695e54e396ac21a144274cb48e13db8c6e \
+                    size    103154437
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  8afa2ed292ca97aeaf5c2903d8e414ab91fcc992 \
-                    sha256  7402a8492b409fb052b3e67661b6817f7dde74373447c7523b35bcdaf2b14eb7 \
-                    size    101681730
+    checksums       rmd160  aab4cd065baec796a23bdbf15188281cdc69e67c \
+                    sha256  e12e7f334b29b810951c1358aa11e88734f90f1e216d2867ae2650dfabcd81f6 \
+                    size    101742015
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 382.0.0.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?