### PR TITLE
openjdk18-oracle: update to 18.0.1.1

### DIFF
--- a/java/openjdk18-oracle/Portfile
+++ b/java/openjdk18-oracle/Portfile
@@ -14,25 +14,25 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/18/
-version      18
-set build    36
+version      18.0.1.1
+set build    2
 revision     0
 
 description  Oracle OpenJDK 18
 long_description Open-source Oracle build of OpenJDK 18, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/43f95e8614114aeaa8e8a5fcf20a682d/${build}/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/65ae32619e2f40f3a9af3af1851d6e19/${build}/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  7cfc98587bfc1d209cf58e973cf42b1af361d27b \
-                 sha256  527b61b4265caf45cdcbacfcf8fbcd0b4b280bede1eff32a5b252d855ff0534b \
-                 size    185375922
+    checksums    rmd160  1e796dbda1ddcb4680760e51410e59d923c858ff \
+                 sha256  f02d17ec5a387555f8489abc352d973b6c10364409b597046025938e2266d72a \
+                 size    185423668
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  8d36e7f1f202ac7e998ad837b41d98e2d4ed9a60 \
-                 sha256  6880a5b512d1c1df5013a04b2cef4e1261e881d7f246ea5483ffeb728b30b2f1 \
-                 size    183221810
+    checksums    rmd160  cb5a455f5094adbca4ff97c12589dbb05ccf6764 \
+                 sha256  29773ad68063bdad7fbaeb762cd873d3f243e86de380d3ac5335cdb929371fb5 \
+                 size    183267676
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 18.0.1.1.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?