### PR TITLE
openjdk8-correto: update to 8.332.08.1

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -115,13 +115,8 @@ subport openjdk8-corretto {
     # https://github.com/corretto/corretto-8/releases
     supported_archs  x86_64 arm64
 
-    if {${configure.build_arch} eq "x86_64"} {
-        version     8.322.06.1
-    } elseif {${configure.build_arch} eq "arm64"} {
-        version     8.322.06.4
-    }
-
-    revision     0
+    version     8.332.08.1
+    revision    0
 
     description  Amazon Corretto OpenJDK 8 (Long Term Support)
     long_description ${long_description_corretto}
@@ -130,14 +125,14 @@ subport openjdk8-corretto {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     amazon-corretto-${version}-macosx-x64
-        checksums    rmd160  98759066ee6e41884e3acbf7f9e7debd6a6d54d0 \
-                     sha256  b86a899aac567b86866fe3cff0b80ee7e7a53f93d9fbe1ec3a2c992376ff1cc6 \
-                     size    118882960
+        checksums    rmd160  4d61d171dccf47712455d3b4e3976a56de7ac665 \
+                     sha256  6a6e9a6d2592c3705ef736256486133e0c7f4adf8cbd90e8c95f2bda460c01ed \
+                     size    118754955
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     amazon-corretto-${version}-macosx-aarch64
-        checksums    rmd160  4ff32107a52db8c00caa3e73a4e12688694b3fc9 \
-                     sha256  2afab026da0b36b1de7a6dd67370cc1ace2fcb540717d40e9265847129cfb0f5 \
-                     size    103044275
+        checksums    rmd160  cb801bae9d5b436a6ffe014d4827e2a78aece294 \
+                     sha256  0801bcdf8bb85032a450ac78ffadcf9cfc0d1218c5cdf8a25e3ad1b31200a21e \
+                     size    102882291
     }
 
     worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto OpenJDK 8.332.08.1.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?