### PR TITLE
openjdk17-corretto: update to 17.0.3.6.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.2.8.1
+version      17.0.3.6.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  8a622fe2c8dd5eba07330804d7b98c3b67b5ee78 \
-                 sha256  eec3acc2d1d303ef23c79ed45a8374002e34c14e34ba0fa931e98cbf6b963345 \
-                 size    187776090
+    checksums    rmd160  f044c2766aaba6a5c8422b434755322c7f550dff \
+                 sha256  8d5390c8af8063d0f584eb0dcd9d0a85e685ee76de3ffaacc19fab1b5c658669 \
+                 size    188083065
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  e5eb0341468193a223ec927abade6f151831da06 \
-                 sha256  b6d3c359bd31a3c1697fe386c927e139bd72572e72cdc12a08b5e1144fe35438 \
-                 size    185518346
+    checksums    rmd160  927b93f0350596c6af87271248e91febdb2bfe18 \
+                 sha256  27e5a2969a6abf3b7f390e0e63d8e622a353d31a289898fcfd808dd605f9a6ba \
+                 size    185932597
 }
 
 worksrcdir   amazon-corretto-17.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 17} {
-    # See https://github.com/corretto/corretto-18/blob/release-18.0.0.37.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-17/blob/release-17.0.3.6.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.13 High Sierra or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto OpenJDK 17.0.3.6.1.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?