### PR TITLE
openjdk18-corretto: update to 18.0.1.10.1

### DIFF
--- a/java/openjdk18-corretto/Portfile
+++ b/java/openjdk18-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-18/releases
-version      18.0.0.37.1
+version      18.0.1.10.1
 revision     0
 
 description  Amazon Corretto OpenJDK 18 (Short Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  2ac6dfa769e5545904a641e61553333ed8aeeb48 \
-                 sha256  0e06a86c3bbbd5ad7b908b5a75d3a2ab6fe30f62703ed6c8dcf9875f796fe9c9 \
-                 size    188570375
+    checksums    rmd160  83f208e0801e0c266dd6e2bb18caec8c5b709c94 \
+                 sha256  fcefcb33a9d5b5b1be666a6eb8316243c6d960bd2dc8eb3cc84f0fed6509c1d3 \
+                 size    188679093
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  d23ccd710766354c36bec80e522816ce85721e62 \
-                 sha256  7d196b604b7518af9af6f5529e91978c1d06920e5ecd0d5d7c3a6aaaa42149f8 \
-                 size    186440646
+    checksums    rmd160  7fd5f55feccf55c40e9799f794dc67217547f03b \
+                 sha256  16efc9b728af72a3375e47dd73e4fb4ed0c0e6d8006e3aeaa98bdcd87dcac1d7 \
+                 size    186534095
 }
 
 worksrcdir   amazon-corretto-18.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 17} {
-    # See https://github.com/corretto/corretto-18/blob/release-18.0.0.37.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-18/blob/release-18.0.1.10.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.13 High Sierra or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto OpenJDK 18.0.1.10.1.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?