### PR TITLE
openjdk11-corretto: update to 11.0.15.9.1

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -199,9 +199,9 @@ subport openjdk8-openj9-large-heap {
 
 subport openjdk11-corretto {
     # https://github.com/corretto/corretto-11/releases
-    supported_archs  x86_64
+    supported_archs  x86_64 arm64
 
-    version      11.0.14.10.1
+    version      11.0.15.9.1
     revision     0
 
     description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -209,10 +209,17 @@ subport openjdk11-corretto {
 
     master_sites https://corretto.aws/downloads/resources/${version}/
 
-    distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  39004f9cabd34ba08af06c37be3c8896bde2176d \
-                 sha256  d4b8e365091ebcadd3c70709c26ab01d7a58aeb57978e0d68a7805f4cee6be71 \
-                 size    187369666
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     amazon-corretto-${version}-macosx-x64
+        checksums    rmd160  752d92e2e87d3feda836e7c7afa39982ea6b24f3 \
+                     sha256  36afb7f091cd9b986a50c3f878f167c59eae615f004b2cb1c5c394f9f2fc215a \
+                     size    187526579
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     amazon-corretto-${version}-macosx-aarch64
+        checksums    rmd160  d1980a49d5539b892a6ed09f7d100501da1c7d80 \
+                     sha256  939f0cc40f4dd749647e352ea2759fbf73c8c59662476ca237113abf9eed0710 \
+                     size    185394420
+    }
 
     worksrcdir   amazon-corretto-11.jdk
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto OpenJDK 11.0.15.9.1. Add arm64 support.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?