### PR TITLE
kotlin: update to 1.6.21

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.6.20 v
+github.setup        JetBrains kotlin 1.6.21 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  aa36b44de3db8a3caa81fa6dbc6a420d13e9410b \
-                    sha256  daf17db1c194f4205f3af67129367a69b388f819177963dc53a7b4b2c4d8ce22 \
-                    size    72466724
+checksums           rmd160  24a387236d66950984da1c3904fcd234183fcdb6 \
+                    sha256  632166fed89f3f430482f5aa07f2e20b923b72ef688c8f5a7df3aa1502c6d8ba \
+                    size    72467060
 
 java.version        1.8+
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

Update to Kotlin 1.6.21.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?