### PR TITLE
glib2-upstream: new port for latest upstream release, to proactively support testing

### DIFF
--- a/devel/glib2-devel/Portfile
+++ b/devel/glib2-devel/Portfile
@@ -9,7 +9,7 @@ PortGroup                   muniversal 1.0
 # Please keep the glib2 and glib2-devel ports as similar as possible.
 
 name                        glib2-devel
-conflicts                   glib2
+conflicts                   glib2 glib2-upstream
 set my_name                 glib
 version                     2.66.8
 revision                    0

--- a/devel/glib2-upstream/Portfile
+++ b/devel/glib2-upstream/Portfile
@@ -1,0 +1,193 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   compiler_blacklist_versions 1.0
+PortGroup                   clang_dependency 1.0
+PortGroup                   meson 1.0
+PortGroup                   muniversal 1.0
+
+# to get past the aligned memory access error
+PortGroup                   legacysupport 1.1
+
+# Please keep the glib2 and glib2-devel ports as similar as possible.
+
+name                        glib2-upstream
+conflicts                   glib2 glib2-devel
+set my_name                 glib
+version                     2.72.1
+revision                    0
+checksums           rmd160  48c867d89c423e6fd3c525e42a9e3ee41ea447a0 \
+                    sha256  c07e57147b254cef92ce80a0378dc0c02a4358e7de4702e9f403069781095fe2 \
+                    size    4890672
+
+set branch                  [join [lrange [split ${version} .] 0 1] .]
+categories                  devel
+maintainers                 {mascguy @mascguy} {ryandesign @ryandesign} openmaintainer
+license                     LGPL-2+
+homepage                    https://wiki.gnome.org/Projects/GLib
+platforms                   darwin
+dist_subdir                 glib2
+distname                    ${my_name}-${version}
+use_xz                      yes
+use_parallel_build          yes
+
+description                 Library with data structure functions and other constructs
+
+long_description            Glib is a library which includes support routines \
+                            for C, such as lists, trees, hashes, memory \
+                            allocation, and many other things.
+
+master_sites                gnome:sources/${my_name}/${branch}/
+
+patchfiles                  libintl.patch \
+                            patch-gio-tests-meson.build.diff \
+                            patch-glib_gunicollate.c.diff \
+                            patch-gio_xdgmime_xdgmime.c.diff \
+                            patch-get-launchd-dbus-session-address.diff \
+                            patch-gmodule-gmodule-dl.c.diff \
+                            patch-meson_build-meson_options-appinfo.diff \
+                            patch-meson-build-python-path.diff \
+                            patch-meson_build-atomic-test-older-clang-versions.diff \
+                            universal.patch \
+                            patch-glib2-findfolders-before-SL.diff \
+                            patch-declarations.diff
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    patchfiles-append       patch-gio_gcredentialsprivate.h \
+                            patch-gio_gsocket.h
+}
+
+if {${os.platform} eq "darwin" && ${os.major} == 10 && ${build_arch} eq "ppc"} {
+    patchfiles-replace      patch-glib2-findfolders-before-SL.diff patch-glib2-findfolders-before-Lion.diff
+}
+
+depends_build-append        port:gettext \
+                            bin:xmllint:libxml2 \
+                            port:pkgconfig
+
+set py_ver                  3.10
+set py_ver_nodot            [string map {. {}} ${py_ver}]
+
+depends_lib                 port:gettext-runtime \
+                            port:libffi \
+                            port:libiconv \
+                            port:pcre \
+                            port:python${py_ver_nodot} \
+                            port:zlib
+
+if {[vercmp ${macosx_deployment_target} 10.9] < 0} {
+    # fatal error: error in backend: Cannot select: 0x103357f10: i8,ch = AtomicLoad 0x10334b410, 0x103354b10<Volatile LD1[@is_running.b]> [ID=18]
+    compiler.blacklist-append   {clang < 500}
+} else {
+    # gcocoanotificationbackend.c:115:52: error: array subscript is not an integer
+    compiler.blacklist-append   {clang < 600}
+}
+
+# https://bugzilla.gnome.org/show_bug.cgi?id=697017
+compiler.blacklist-append   gcc-3.3 *gcc-4.0 *gcc-4.2
+
+# -lresolv is needed at least on Tiger PPC.
+configure.ldflags-append    -lresolv \
+                            -bind_at_load
+
+configure.cflags-append     -fstrict-aliasing
+
+# stop excessive warnings
+configure.cflags-append     -Wno-deprecated-declarations
+configure.objcflags-append  -Wno-deprecated-declarations
+
+configure.args              -Ddefault_library=both \
+                            -Dwarning_level=0
+
+configure.perl              /usr/bin/perl
+configure.python            ${prefix}/bin/python${py_ver}
+configure.env-append        PERL_PATH=${configure.perl}
+
+
+if {![info exists universal_possible]} {
+    set universal_possible [expr {${os.universal_supported} && [llength ${configure.universal_archs}] >= 2}]
+}
+if {${universal_possible} && [variant_isset universal]} {
+    foreach my_arch {ppc ppc64 i386 x86_64 arm64} {
+        # strip the automatic setting of host, meson does not accept
+        set merger_host(${my_arch}) ""
+    }
+}
+
+post-patch {
+    reinplace -W ${worksrcpath} "s|@PYTHON@|${configure.python}|" meson.build
+    reinplace -W ${worksrcpath} "s|@PREFIX@|${prefix}|g" gio/xdgmime/xdgmime.c glib/gi18n-lib.h glib/gi18n.h gio/gdbusaddress.c
+    reinplace "s|data_dirs = \"/usr|data_dirs = \"${prefix}/share:/usr|g" ${worksrcpath}/glib/gutils.c
+    reinplace "s|path = \"/bin|path = \"${prefix}/bin:/bin|g" ${worksrcpath}/glib/gutils.c ${worksrcpath}/glib/gspawn.c
+}
+
+# this edit does not, for some reason, apply against the build-arm64 config.h
+# and should not be needed if we're using the muniversal PortGroup
+# needs testing on 32 bit systems to be certain of this
+#post-configure {
+#    system "ed - ${build.dir}/config.h < ${filespath}/config.h.ed"
+#}
+
+build.args-append           --verbose
+
+post-build {
+    if {[variant_exists universal] && [variant_isset universal]} {
+        set dirs {}
+        foreach arch ${universal_archs_to_use} {
+            lappend dirs ${workpath}/build-${arch}
+        }
+    } else {
+        set dirs ${workpath}/build
+    }
+    foreach dir ${dirs} {
+        # -lm is spuriously added by meson NYD to some builds (arm64)
+        reinplace -q {s| -lm||g}              ${dir}/meson-private/glib-2.0.pc
+    }
+}
+
+test.args-append            --verbose
+test.run                    yes
+test.target                 test
+
+post-destroot {
+    delete ${destroot}${prefix}/lib/charset.alias
+
+    set docdir ${prefix}/share/doc/${my_name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} AUTHORS COPYING HACKING NEWS README.md \
+        ${destroot}${docdir}
+}
+
+platform darwin {
+    configure.args-append   -Ddtrace=false
+}
+
+platform darwin 8 {
+    # meson on Tiger cannot use rpaths, so we workaround with this to find dylibs
+    foreach my_phase {build test destroot} {
+        ${my_phase}.env-append  "DYLD_LIBRARY_PATH=${build_dir}/glib:${build_dir}/gobject:${build_dir}/gio:${build_dir}/gthread:${build_dir}/gmodule"
+    }
+}
+
+variant quartz conflicts x11 {
+    configure.args-append   -Dappinfo_backend=native
+}
+
+variant x11 conflicts quartz {
+    configure.args-append   -Dappinfo_backend=generic
+}
+
+if {![variant_isset quartz]} {
+    default_variants +x11
+}
+if {![variant_isset x11]} {
+    default_variants +quartz
+}
+if {![variant_isset quartz] && ![variant_isset x11]} {
+    pre-configure {
+        return -code error "Either +x11 or +quartz is required"
+    }
+}
+
+livecheck.type              gnome-with-unstable
+livecheck.name              ${my_name}

--- a/devel/glib2-upstream/files/config.h.ed
+++ b/devel/glib2-upstream/files/config.h.ed
@@ -1,0 +1,36 @@
+/ G_VA_COPY_AS_ARRAY /c
+#ifdef __LP64__
+#define G_VA_COPY_AS_ARRAY 1
+#else
+/* #undef G_VA_COPY_AS_ARRAY */
+#endif
+.
+/ SIZEOF_LONG /c
+#ifdef __LP64__
+#define SIZEOF_LONG 8
+#else
+#define SIZEOF_LONG 4
+#endif
+.
+/ SIZEOF_SIZE_T /c
+#ifdef __LP64__
+#define SIZEOF_SIZE_T 8
+#else
+#define SIZEOF_SIZE_T 4
+#endif
+.
+/ SIZEOF_SSIZE_T /c
+#ifdef __LP64__
+#define SIZEOF_SSIZE_T 8
+#else
+#define SIZEOF_SSIZE_T 4
+#endif
+.
+/ SIZEOF_VOID_P /c
+#ifdef __LP64__
+#define SIZEOF_VOID_P 8
+#else
+#define SIZEOF_VOID_P 4
+#endif
+.
+w

--- a/devel/glib2-upstream/files/libintl.patch
+++ b/devel/glib2-upstream/files/libintl.patch
@@ -1,0 +1,23 @@
+Ensure libintl.h can be found even if -I/opt/local/include is not in CPPFLAGS.
+--- glib/gi18n-lib.h.orig	2017-07-13 18:03:39.000000000 -0500
++++ glib/gi18n-lib.h	2018-01-31 18:18:52.000000000 -0600
+@@ -20,7 +20,7 @@
+ 
+ #include <glib.h>
+ 
+-#include <libintl.h>
++#include <@PREFIX@/include/libintl.h>
+ #include <string.h>
+ 
+ #ifndef GETTEXT_PACKAGE
+--- glib/gi18n.h.orig	2017-07-13 18:03:39.000000000 -0500
++++ glib/gi18n.h	2018-01-31 18:18:56.000000000 -0600
+@@ -20,7 +20,7 @@
+ 
+ #include <glib.h>
+ 
+-#include <libintl.h>
++#include <@PREFIX@/include/libintl.h>
+ #include <string.h>
+ 
+ #define  _(String) gettext (String)

--- a/devel/glib2-upstream/files/patch-declarations.diff
+++ b/devel/glib2-upstream/files/patch-declarations.diff
@@ -1,0 +1,11 @@
+--- meson.build.orig	2022-03-17 23:01:31.000000000 +0800
++++ meson.build	2022-04-04 05:56:47.000000000 +0800
+@@ -475,7 +475,7 @@
+     # Due to pervasive use of things like GPOINTER_TO_UINT(), we do not support
+     # building with -Wbad-function-cast.
+     '-Wno-bad-function-cast',
+-    '-Werror=declaration-after-statement',
++    '-Wno-declaration-after-statement',
+     '-Werror=implicit-function-declaration',
+     '-Werror=missing-prototypes',
+   ]

--- a/devel/glib2-upstream/files/patch-get-launchd-dbus-session-address.diff
+++ b/devel/glib2-upstream/files/patch-get-launchd-dbus-session-address.diff
@@ -1,0 +1,128 @@
+--- gio/gdbusaddress.c.orig	2020-10-01 07:43:53.000000000 -0500
++++ gio/gdbusaddress.c	2021-12-15 18:20:06.000000000 -0600
+@@ -1223,6 +1223,103 @@
+ 
+ /* ---------------------------------------------------------------------------------------------------- */
+ 
++/*
++ * MacPorts specific D-Bus implementation
++ *
++ * When building under MacPorts on darwin
++ * plaforms (including Mac OS X), the
++ * symbols G_OS_UNIX and __APPLE__ are
++ * asserted.
++ *
++ * The D-Bus session daemon is controlled
++ * using the Apple launchd facility.
++ *
++ * For launchd command details see
++ *   http://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages
++ *
++ *   launchd(8)
++ *   launchctl(1)
++ *   launchd.plist(5)
++ */
++
++#if defined (G_OS_UNIX) && defined (__APPLE__)
++static gchar *
++get_session_address_macports_specific (GError **error)
++{
++  gchar *ret;
++  gchar *command_line;
++  gchar *launchctl_stdout;
++  gchar *launchctl_stderr;
++  gint exit_status;
++
++  ret = NULL;
++  command_line = NULL;
++  launchctl_stdout = NULL;
++  launchctl_stderr = NULL;
++
++  command_line = g_strdup ("launchctl getenv DBUS_LAUNCHD_SESSION_BUS_SOCKET");
++
++  if (G_UNLIKELY (_g_dbus_debug_address ()))
++    {
++      _g_dbus_debug_print_lock ();
++      g_print ("GDBus-debug:Address: launchctl command line: `%s'\n", command_line);
++      _g_dbus_debug_print_unlock ();
++    }
++
++  if (g_spawn_command_line_sync (command_line,
++                                 &launchctl_stdout,
++                                 &launchctl_stderr,
++                                 &exit_status,
++                                 error))
++    {
++      if (g_spawn_check_exit_status (exit_status, error))
++        {
++            if (launchctl_stdout != NULL)
++              {
++                if (G_UNLIKELY (_g_dbus_debug_address ()))
++                  {
++                    gchar *s;
++                    _g_dbus_debug_print_lock ();
++                    g_print ("GDBus-debug:Address: launchctl stdout:");
++                    s = _g_dbus_hexdump (launchctl_stdout, strlen (launchctl_stdout) + 1, 2);
++                    g_print ("\n%s", s);
++                    g_free (s);
++                    _g_dbus_debug_print_unlock ();
++                  }
++
++                if (*launchctl_stdout != '\0')
++                  {
++                    gchar *lastchar;
++
++                    lastchar = launchctl_stdout + strlen(launchctl_stdout) - 1;
++                    if (*lastchar == '\n') *lastchar = '\0';
++                    ret = g_strdup_printf ("unix:path=%s", launchctl_stdout);
++                  }
++                else
++                  {
++                    g_set_error (error,
++                                 G_IO_ERROR,
++                                 G_IO_ERROR_FAILED,
++                                 _("Session D-Bus not running. Try running `launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist'."));
++                  }
++              }
++        }
++      else
++        {
++          g_prefix_error (error, _("Error spawning command line `%s': "), command_line);
++        }
++    }
++
++  g_free (command_line);
++  g_free (launchctl_stdout);
++  g_free (launchctl_stderr);
++
++  return ret;
++}
++#endif
++
++/* ---------------------------------------------------------------------------------------------------- */
++
+ static gchar *
+ get_session_address_platform_specific (GError **error)
+ {
+@@ -1251,7 +1348,12 @@
+    * X11 autolaunching; on Windows this means a different autolaunching
+    * mechanism based on shared memory.
+    */
++
++#ifdef __APPLE__
++  return get_session_address_macports_specific (error);
++#else
+   return get_session_address_dbus_launch (error);
++#endif
+ }
+ 
+ /* ---------------------------------------------------------------------------------------------------- */
+@@ -1323,7 +1425,7 @@
+       ret = g_strdup (g_getenv ("DBUS_SYSTEM_BUS_ADDRESS"));
+       if (ret == NULL)
+         {
+-          ret = g_strdup ("unix:path=/var/run/dbus/system_bus_socket");
++          ret = g_strdup ("unix:path=@PREFIX@/var/run/dbus/system_bus_socket");
+         }
+       break;
+ 

--- a/devel/glib2-upstream/files/patch-gio-tests-meson.build.diff
+++ b/devel/glib2-upstream/files/patch-gio-tests-meson.build.diff
@@ -1,0 +1,16 @@
+Disable tests that use dbus because we do not want to declare a
+dependency on something only used to run optional tests and we do not
+want the test suite to find and use dbus opportunistically which could
+fail if glib2 is being built universal and dbus is not installed
+universal.
+--- gio/tests/meson.build.orig	2022-04-21 01:45:28.000000000 +0800
++++ gio/tests/meson.build	2022-04-21 01:52:42.000000000 +0800
+@@ -170,7 +170,7 @@
+   }
+ endif
+ 
+-have_dbus_daemon = find_program('dbus-daemon', required : false).found()
++have_dbus_daemon = false
+ if have_dbus_daemon
+   gio_tests += {
+     'debugcontroller' : {},

--- a/devel/glib2-upstream/files/patch-gio_gcredentialsprivate.h
+++ b/devel/glib2-upstream/files/patch-gio_gcredentialsprivate.h
@@ -1,0 +1,27 @@
+--- gio/gcredentialsprivate.h.orig	2022-03-17 23:01:31.000000000 +0800
++++ gio/gcredentialsprivate.h	2022-04-04 06:56:04.000000000 +0800
+@@ -135,7 +135,7 @@
+ #define G_CREDENTIALS_USE_NETBSD_UNPCBID 1
+ #define G_CREDENTIALS_NATIVE_TYPE G_CREDENTIALS_TYPE_NETBSD_UNPCBID
+ #define G_CREDENTIALS_NATIVE_SIZE (sizeof (struct unpcbid))
+-/* #undef G_CREDENTIALS_UNIX_CREDENTIALS_MESSAGE_SUPPORTED */
++#define G_CREDENTIALS_SOCKET_GET_CREDENTIALS_SUPPORTED 1
+ #define G_CREDENTIALS_SPOOFING_SUPPORTED 1
+ #define G_CREDENTIALS_HAS_PID 1
+ 
+@@ -160,6 +160,15 @@
+ 
+ #elif defined(__APPLE__)
+ #include <sys/ucred.h>
++#ifndef SOL_LOCAL
++#define SOL_LOCAL 0
++#endif
++#ifndef LOCAL_PEERCRED
++#define LOCAL_PEERCRED          0x001           /* retrieve peer credentails */
++#endif
++#ifndef LOCAL_PEERPID
++#define LOCAL_PEERPID           0x002           /* retrieve peer pid */
++#endif
+ #define G_CREDENTIALS_SUPPORTED 1
+ #define G_CREDENTIALS_USE_APPLE_XUCRED 1
+ #define G_CREDENTIALS_NATIVE_TYPE G_CREDENTIALS_TYPE_APPLE_XUCRED

--- a/devel/glib2-upstream/files/patch-gio_gsocket.h
+++ b/devel/glib2-upstream/files/patch-gio_gsocket.h
@@ -1,0 +1,18 @@
+--- gio/gsocket.h.orig	2022-03-17 23:01:31.000000000 +0800
++++ gio/gsocket.h	2022-04-04 06:55:30.000000000 +0800
+@@ -43,6 +43,15 @@
+ #define G_SOCKET_GET_CLASS(inst)                            (G_TYPE_INSTANCE_GET_CLASS ((inst),                      \
+                                                              G_TYPE_SOCKET, GSocketClass))
+ 
++#if defined(__APPLE__)
++#ifndef LOCAL_PEERCRED
++#define LOCAL_PEERCRED          0x001           /* retrieve peer credentails */
++#endif
++#ifndef LOCAL_PEERPID
++#define LOCAL_PEERPID           0x002           /* retrieve peer pid */
++#endif
++#endif
++
+ typedef struct _GSocketPrivate                              GSocketPrivate;
+ typedef struct _GSocketClass                                GSocketClass;
+ 

--- a/devel/glib2-upstream/files/patch-gio_xdgmime_xdgmime.c.diff
+++ b/devel/glib2-upstream/files/patch-gio_xdgmime_xdgmime.c.diff
@@ -1,0 +1,11 @@
+--- gio/xdgmime/xdgmime.c.orig	2019-01-21 07:38:50.000000000 -0600
++++ gio/xdgmime/xdgmime.c	2019-01-30 10:33:48.000000000 -0600
+@@ -235,7 +235,7 @@
+   xdg_data_dirs = getenv ("XDG_DATA_DIRS");
+ 
+   if (xdg_data_dirs == NULL)
+-    xdg_data_dirs = "/usr/local/share/:/usr/share/";
++    xdg_data_dirs = "@PREFIX@/share/:/usr/share/";
+ 
+   /* Work out how many dirs we’re dealing with. */
+   if (xdg_data_home != NULL || home != NULL)

--- a/devel/glib2-upstream/files/patch-glib2-findfolders-before-Lion.diff
+++ b/devel/glib2-upstream/files/patch-glib2-findfolders-before-Lion.diff
@@ -1,0 +1,83 @@
+--- glib/gosxutils.m.orig	2022-03-17 23:01:31.000000000 +0800
++++ glib/gosxutils.m	2022-04-04 05:41:18.000000000 +0800
+@@ -21,17 +21,31 @@
+ #include "gutils.h"
+ #include "gstrfuncs.h"
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
++#define POOLSTART NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#define POOLEND   [pool release];
++#else
++#define POOLSTART
++#define POOLEND
++#endif
++
+ void load_user_special_dirs_macos (gchar **table);
+ 
+ static gchar *
+ find_folder (NSSearchPathDirectory type)
+ {
++POOLSTART
++
+   gchar *filename;
+   NSString *path;
+   NSArray *paths;
+ 
+   paths = NSSearchPathForDirectoriesInDomains (type, NSUserDomainMask, YES);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+   path = [paths firstObject];
++#else
++  path = [paths count] ? [paths objectAtIndex:0] : NULL;
++#endif
+   if (path == nil)
+     {
+       return NULL;
+@@ -39,6 +53,8 @@
+ 
+   filename = g_strdup ([path UTF8String]);
+ 
++POOLEND
++
+   return filename;
+ }
+ 
+@@ -47,10 +63,37 @@
+ {
+   table[G_USER_DIRECTORY_DESKTOP] = find_folder (NSDesktopDirectory);
+   table[G_USER_DIRECTORY_DOCUMENTS] = find_folder (NSDocumentDirectory);
++  
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
++  
+   table[G_USER_DIRECTORY_DOWNLOAD] = find_folder (NSDownloadsDirectory);
+   table[G_USER_DIRECTORY_MUSIC] = find_folder (NSMusicDirectory);
+   table[G_USER_DIRECTORY_PICTURES] = find_folder (NSPicturesDirectory);
+   table[G_USER_DIRECTORY_PUBLIC_SHARE] = find_folder (NSSharedPublicDirectory);
+   table[G_USER_DIRECTORY_TEMPLATES] = NULL;
+   table[G_USER_DIRECTORY_VIDEOS] = find_folder (NSMoviesDirectory);
+-}
++
++#else
++POOLSTART
++
++  /* for Tiger and Leopard we have to emulate some by finding the home folder and appending the needed SubFolder name
++     even with different languages, these still have the same names to the system; they are just displayed differently
++  */
++
++# if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
++    table[G_USER_DIRECTORY_DOWNLOAD] = find_folder (NSDownloadsDirectory);
++# else
++    /* for Tiger there is no DownloadsDir, so we use Desktop as glib did previously */
++    table[G_USER_DIRECTORY_DOWNLOAD] = find_folder (NSDesktopDirectory);
++# endif
++
++  table[G_USER_DIRECTORY_MUSIC] = g_strdup ([[NSHomeDirectory() stringByAppendingPathComponent:@"Music"] UTF8String]);
++  table[G_USER_DIRECTORY_PICTURES] = g_strdup ([[NSHomeDirectory() stringByAppendingPathComponent:@"Pictures"] UTF8String]);
++  table[G_USER_DIRECTORY_PUBLIC_SHARE] = g_strdup ([[NSHomeDirectory() stringByAppendingPathComponent:@"Public"] UTF8String]);
++  table[G_USER_DIRECTORY_TEMPLATES] = NULL;
++  table[G_USER_DIRECTORY_VIDEOS] = g_strdup ([[NSHomeDirectory() stringByAppendingPathComponent:@"Movies"] UTF8String]);
++
++POOLEND
++
++#endif
++}
+\ No newline at end of file

--- a/devel/glib2-upstream/files/patch-glib2-findfolders-before-SL.diff
+++ b/devel/glib2-upstream/files/patch-glib2-findfolders-before-SL.diff
@@ -1,0 +1,83 @@
+--- glib/gosxutils.m.orig	2022-03-17 23:01:31.000000000 +0800
++++ glib/gosxutils.m	2022-04-04 05:41:18.000000000 +0800
+@@ -21,17 +21,31 @@
+ #include "gutils.h"
+ #include "gstrfuncs.h"
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
++#define POOLSTART NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#define POOLEND   [pool release];
++#else
++#define POOLSTART
++#define POOLEND
++#endif
++
+ void load_user_special_dirs_macos (gchar **table);
+ 
+ static gchar *
+ find_folder (NSSearchPathDirectory type)
+ {
++POOLSTART
++
+   gchar *filename;
+   NSString *path;
+   NSArray *paths;
+ 
+   paths = NSSearchPathForDirectoriesInDomains (type, NSUserDomainMask, YES);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+   path = [paths firstObject];
++#else
++  path = [paths count] ? [paths objectAtIndex:0] : NULL;
++#endif
+   if (path == nil)
+     {
+       return NULL;
+@@ -39,6 +53,8 @@
+ 
+   filename = g_strdup ([path UTF8String]);
+ 
++POOLEND
++
+   return filename;
+ }
+ 
+@@ -47,10 +63,37 @@
+ {
+   table[G_USER_DIRECTORY_DESKTOP] = find_folder (NSDesktopDirectory);
+   table[G_USER_DIRECTORY_DOCUMENTS] = find_folder (NSDocumentDirectory);
++  
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++  
+   table[G_USER_DIRECTORY_DOWNLOAD] = find_folder (NSDownloadsDirectory);
+   table[G_USER_DIRECTORY_MUSIC] = find_folder (NSMusicDirectory);
+   table[G_USER_DIRECTORY_PICTURES] = find_folder (NSPicturesDirectory);
+   table[G_USER_DIRECTORY_PUBLIC_SHARE] = find_folder (NSSharedPublicDirectory);
+   table[G_USER_DIRECTORY_TEMPLATES] = NULL;
+   table[G_USER_DIRECTORY_VIDEOS] = find_folder (NSMoviesDirectory);
+-}
++
++#else
++POOLSTART
++
++  /* for Tiger and Leopard we have to emulate some by finding the home folder and appending the needed SubFolder name
++     even with different languages, these still have the same names to the system; they are just displayed differently
++  */
++
++# if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
++    table[G_USER_DIRECTORY_DOWNLOAD] = find_folder (NSDownloadsDirectory);
++# else
++    /* for Tiger there is no DownloadsDir, so we use Desktop as glib did previously */
++    table[G_USER_DIRECTORY_DOWNLOAD] = find_folder (NSDesktopDirectory);
++# endif
++
++  table[G_USER_DIRECTORY_MUSIC] = g_strdup ([[NSHomeDirectory() stringByAppendingPathComponent:@"Music"] UTF8String]);
++  table[G_USER_DIRECTORY_PICTURES] = g_strdup ([[NSHomeDirectory() stringByAppendingPathComponent:@"Pictures"] UTF8String]);
++  table[G_USER_DIRECTORY_PUBLIC_SHARE] = g_strdup ([[NSHomeDirectory() stringByAppendingPathComponent:@"Public"] UTF8String]);
++  table[G_USER_DIRECTORY_TEMPLATES] = NULL;
++  table[G_USER_DIRECTORY_VIDEOS] = g_strdup ([[NSHomeDirectory() stringByAppendingPathComponent:@"Movies"] UTF8String]);
++
++POOLEND
++
++#endif
++}
+\ No newline at end of file

--- a/devel/glib2-upstream/files/patch-glib_gunicollate.c.diff
+++ b/devel/glib2-upstream/files/patch-glib_gunicollate.c.diff
@@ -1,0 +1,12 @@
+--- glib/gunicollate.c.orig	2017-03-08 21:37:21.000000000 -0600
++++ glib/gunicollate.c	2017-03-29 21:05:12.000000000 -0500
+@@ -24,6 +24,9 @@
+ #include <wchar.h>
+ #endif
+ 
++/* Carbon is not available on 64-bit */
++#undef HAVE_CARBON
++
+ #ifdef HAVE_CARBON
+ #include <CoreServices/CoreServices.h>
+ #endif

--- a/devel/glib2-upstream/files/patch-gmodule-gmodule-dl.c.diff
+++ b/devel/glib2-upstream/files/patch-gmodule-gmodule-dl.c.diff
@@ -1,0 +1,30 @@
+--- gmodule/gmodule-dl.c.orig	2022-04-14 19:15:25.000000000 +0800
++++ gmodule/gmodule-dl.c	2022-04-21 03:56:41.000000000 +0800
+@@ -180,15 +180,18 @@
+ static void
+ _g_module_close (gpointer handle)
+ {
+-#if defined(__BIONIC__)
+-  if (handle != RTLD_DEFAULT)
+-#endif
+-    {
+-      lock_dlerror ();
+-      if (dlclose (handle) != 0)
+-        g_module_set_error (fetch_dlerror (TRUE));
+-      unlock_dlerror ();
+-    }
++   /* Intentionally not dlclose()ing because it is safer to leave the library
++    * loaded in memory than to close it and possibly leave dangling pointers
++    * to things like atexit handlers, atfork handlers, blocks, etc.
++    *
++    * See https://trac.macports.org/ticket/45309 for an example from when
++    * a library used by a module added a new dependency which had an
++    * initializer which added a child atfork handler.  The result is that
++    * after closing the module, the system had a dangling pointer for the
++    * atfork handler which would at best crash on the child side of fork()
++    * and at worst lead to arbitrary code execution of whatever happened to be
++    * at that location in memory at a later time in the process.
++    */
+ }
+ 
+ static gpointer

--- a/devel/glib2-upstream/files/patch-meson-build-python-path.diff
+++ b/devel/glib2-upstream/files/patch-meson-build-python-path.diff
@@ -1,0 +1,17 @@
+GLib2 tries to find "python3" and if it can't find it, it will go for "python"; if port select wasn't explicitly run, this will likely end-up with Python 2.7. As a fallback, meson can use whatever python it's running on if the argument to find_installation is empty.
+
+
+--- meson.build.orig	2019-11-21 00:41:53.000000000 -0300
++++ meson.build	2019-11-21 00:44:00.000000000 -0300
+@@ -1992,9 +1992,9 @@
+ 
+ glib_conf.set('HAVE_PROC_SELF_CMDLINE', have_proc_self_cmdline)
+ 
+-python = import('python').find_installation('python3')
++python = import('python').find_installation('')
+ # used for '#!/usr/bin/env <name>'
+-python_name = 'python3'
++python_name = '@PYTHON@'
+ 
+ python_version = python.language_version()
+ python_version_req = '>=3.4'

--- a/devel/glib2-upstream/files/patch-meson_build-atomic-test-older-clang-versions.diff
+++ b/devel/glib2-upstream/files/patch-meson_build-atomic-test-older-clang-versions.diff
@@ -1,0 +1,13 @@
+--- meson.build.ken	2021-02-15 15:00:56.000000000 -0800
++++ meson.build	2021-02-15 15:04:16.000000000 -0800
+@@ -1624,8 +1624,8 @@
+ # We know that we can always use real ("lock free") atomic operations with MSVC
+ if cc.get_id() == 'msvc' or cc.get_id() == 'clang-cl' or cc.links(atomictest, name : 'atomic ops')
+   have_atomic_lock_free = true
+-  if cc.get_id() == 'gcc' and not cc.compiles(atomicdefine, name : 'atomic ops define')
+-    # Old gcc release may provide
++  if cc.get_id() == 'gcc' or cc.get_id() == 'clang' and not cc.compiles(atomicdefine, name : 'atomic ops define')
++    # Old gcc and clang releases may provide
+     # __sync_bool_compare_and_swap but doesn't define
+     # __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4
+     glib_conf.set('__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4', true)

--- a/devel/glib2-upstream/files/patch-meson_build-meson_options-appinfo.diff
+++ b/devel/glib2-upstream/files/patch-meson_build-meson_options-appinfo.diff
@@ -1,0 +1,94 @@
+--- gio/giomodule.c.orig	2020-03-18 08:16:11.000000000 -0500
++++ gio/giomodule.c	2021-08-14 00:05:07.000000000 -0500
+@@ -47,12 +47,13 @@
+ #endif
+ #include <glib/gstdio.h>
+ 
+-#if defined(G_OS_UNIX) && !defined(HAVE_COCOA)
++#if defined(G_OS_UNIX)
++#if !defined(HAVE_COCOA) || defined(USE_APPINFO_GENERIC)
+ #include "gdesktopappinfo.h"
+-#endif
+-#ifdef HAVE_COCOA
++#elif defined(HAVE_COCOA)
+ #include "gosxappinfo.h"
+ #endif
++#endif
+ 
+ #ifdef HAVE_COCOA
+ #include <AvailabilityMacros.h>
+@@ -1088,7 +1089,7 @@
+     {
+       registered_extensions = TRUE;
+       
+-#if defined(G_OS_UNIX) && !defined(HAVE_COCOA)
++#if defined(G_OS_UNIX) && (!defined(HAVE_COCOA) || defined(USE_APPINFO_GENERIC))
+ #if !GLIB_CHECK_VERSION (3, 0, 0)
+       ep = g_io_extension_point_register (G_DESKTOP_APP_INFO_LOOKUP_EXTENSION_POINT_NAME);
+       g_io_extension_point_set_required_type (ep, G_TYPE_DESKTOP_APP_INFO_LOOKUP);
+@@ -1219,8 +1220,10 @@
+ #endif
+ #ifdef HAVE_COCOA
+       g_type_ensure (g_nextstep_settings_backend_get_type ());
++#ifndef USE_APPINFO_GENERIC
+       g_type_ensure (g_osx_app_info_get_type ());
+ #endif
++#endif
+ #ifdef G_OS_UNIX
+       g_type_ensure (_g_unix_volume_monitor_get_type ());
+       g_type_ensure (g_fdo_notification_backend_get_type ());
+--- meson_options.txt.orig	2019-11-13 18:24:37.000000000 -0300
++++ meson_options.txt	2019-11-13 18:27:07.000000000 -0300
+@@ -1,3 +1,9 @@
++option('appinfo_backend',
++       type : 'combo',
++       choices : ['generic', 'native'],
++       value : 'generic',
++       description : 'appinfo backend to use; either freedesktop (for x11 based builds) or native (for quartz based builds)')
++       
+ option('runtime_libdir',
+        type : 'string',
+        value : '',
+--- gio/meson.build.orig	2022-03-17 23:01:31.000000000 +0800
++++ gio/meson.build	2022-04-04 05:29:36.000000000 +0800
+@@ -380,16 +380,23 @@
+     'gunixoutputstream.h',
+   )
+ 
++	appinfo_backend = get_option('appinfo_backend')
+   if glib_have_cocoa
+     settings_sources += files('gnextstepsettingsbackend.m')
+-    contenttype_sources += files('gosxcontenttype.m')
+-    appinfo_sources += files('gosxappinfo.m')
++    if appinfo_backend == 'native'
++      contenttype_sources += files('gosxcontenttype.m')
++      appinfo_sources += files('gosxappinfo.m')
++      application_headers += files('gosxappinfo.h')
++    else
++      contenttype_sources += files('gcontenttype.c')
++      appinfo_sources += files('gdesktopappinfo.c')
++      gio_unix_include_headers += files('gdesktopappinfo.h')
++    endif
+     framework_dep = dependency('appleframeworks', modules : ['Foundation', 'CoreFoundation', 'AppKit'])
+     platform_deps += [framework_dep]
+     if glib_have_os_x_9_or_later
+       unix_sources += files('gcocoanotificationbackend.m')
+     endif
+-    application_headers += files('gosxappinfo.h')
+   else
+     contenttype_sources += files('gcontenttype.c')
+     appinfo_sources += files('gdesktopappinfo.c')
+@@ -784,6 +791,13 @@
+   install_dir: bash_comp_inst_dir)
+ endif
+ 
++appinfo_backend = get_option('appinfo_backend') 
++if appinfo_backend == 'native'
++  glib_conf.set('USE_APPINFO_NATIVE', 1)
++else
++  glib_conf.set('USE_APPINFO_GENERIC', 1)
++endif
++
+ if enable_dtrace
+   gio_dtrace_obj = dtrace_obj_gen.process('gio_probes.d')
+   gio_dtrace_hdr = dtrace_hdr_gen.process('gio_probes.d')

--- a/devel/glib2-upstream/files/universal.patch
+++ b/devel/glib2-upstream/files/universal.patch
@@ -1,0 +1,234 @@
+Allow universal builds. This is only part of the solution; the config.h.ed
+script is the other part. If new variables appear in the configure script
+that are affected by endianness or bitness, remember to handle them both
+here and in config.h.ed.
+--- glib/glibconfig.h.in.orig	2019-11-17 14:17:08.000000000 -0300
++++ glib/glibconfig.h.in	2019-11-17 14:15:42.000000000 -0300
+@@ -58,21 +58,43 @@
+ 
+ #define G_HAVE_GINT64 1          /* deprecated, always true */
+ 
+-@glib_extension@typedef signed @gint64@ gint64;
+-@glib_extension@typedef unsigned @gint64@ guint64;
+-
+-#define G_GINT64_CONSTANT(val)	@gint64_constant@
+-#define G_GUINT64_CONSTANT(val)	@guint64_constant@
++#ifdef __LP64__
++typedef signed long gint64;
++typedef unsigned long guint64;
++#else
++G_GNUC_EXTENSION typedef signed long long gint64;
++G_GNUC_EXTENSION typedef unsigned long long guint64;
++#endif
+ 
+-#define G_GINT64_MODIFIER @gint64_modifier@
+-#define G_GINT64_FORMAT @gint64_format@
+-#define G_GUINT64_FORMAT @guint64_format@
++#ifdef __LP64__
++#define G_GINT64_CONSTANT(val)	(val##L)
++#define G_GUINT64_CONSTANT(val)	(val##UL)
++#else
++#define G_GINT64_CONSTANT(val)	(G_GNUC_EXTENSION (val##LL))
++#define G_GUINT64_CONSTANT(val)	(G_GNUC_EXTENSION (val##ULL))
++#endif
+ 
++#ifdef __LP64__
++#define G_GINT64_MODIFIER "l"
++#define G_GINT64_FORMAT "li"
++#define G_GUINT64_FORMAT "lu"
++#else
++#define G_GINT64_MODIFIER "ll"
++#define G_GINT64_FORMAT "lli"
++#define G_GUINT64_FORMAT "llu"
++#endif
+ 
+-#define GLIB_SIZEOF_VOID_P @glib_void_p@
+-#define GLIB_SIZEOF_LONG   @glib_long@
+-#define GLIB_SIZEOF_SIZE_T @glib_size_t@
+-#define GLIB_SIZEOF_SSIZE_T @glib_ssize_t@
++#ifdef __LP64__
++#define GLIB_SIZEOF_VOID_P 8
++#define GLIB_SIZEOF_LONG   8
++#define GLIB_SIZEOF_SIZE_T 8
++#define GLIB_SIZEOF_SSIZE_T 8
++#else
++#define GLIB_SIZEOF_VOID_P 4
++#define GLIB_SIZEOF_LONG   4
++#define GLIB_SIZEOF_SIZE_T 4
++#define GLIB_SIZEOF_SSIZE_T 4
++#endif
+ 
+ typedef signed @glib_size_type_define@ gssize;
+ typedef unsigned @glib_size_type_define@ gsize;
+@@ -95,18 +117,39 @@
+ 
+ #define G_POLLFD_FORMAT @g_pollfd_format@
+ 
+-#define GPOINTER_TO_INT(p)	((gint)  @glib_gpi_cast@ (p))
+-#define GPOINTER_TO_UINT(p)	((guint) @glib_gpui_cast@ (p))
++#ifdef __LP64__
++#define GPOINTER_TO_INT(p)	((gint)  (glong) (p))
++#define GPOINTER_TO_UINT(p)	((guint) (gulong) (p))
++#else
++#define GPOINTER_TO_INT(p)	((gint)  (gint) (p))
++#define GPOINTER_TO_UINT(p)	((guint) (guint) (p))
++#endif
+ 
+-#define GINT_TO_POINTER(i)	((gpointer) @glib_gpi_cast@ (i))
+-#define GUINT_TO_POINTER(u)	((gpointer) @glib_gpui_cast@ (u))
++#ifdef __LP64__
++#define GINT_TO_POINTER(i)	((gpointer) (glong) (i))
++#define GUINT_TO_POINTER(u)	((gpointer) (gulong) (u))
++#else
++#define GINT_TO_POINTER(i)	((gpointer) (gint) (i))
++#define GUINT_TO_POINTER(u)	((gpointer) (guint) (u))
++#endif
+ 
+-typedef signed @glib_intptr_type_define@ gintptr;
+-typedef unsigned @glib_intptr_type_define@ guintptr;
++#ifdef __LP64__
++typedef signed long gintptr;
++typedef unsigned long guintptr;
++#else
++typedef signed int gintptr;
++typedef unsigned int guintptr;
++#endif
+ 
+-#define G_GINTPTR_MODIFIER      @gintptr_modifier@
+-#define G_GINTPTR_FORMAT        @gintptr_format@
+-#define G_GUINTPTR_FORMAT       @guintptr_format@
++#ifdef __LP64__
++#define G_GINTPTR_MODIFIER      "l"
++#define G_GINTPTR_FORMAT        "li"
++#define G_GUINTPTR_FORMAT       "lu"
++#else
++#define G_GINTPTR_MODIFIER      ""
++#define G_GINTPTR_FORMAT        "i"
++#define G_GUINTPTR_FORMAT       "u"
++#endif
+ 
+ #define GLIB_MAJOR_VERSION @GLIB_MAJOR_VERSION@
+ #define GLIB_MINOR_VERSION @GLIB_MINOR_VERSION@
+@@ -114,7 +157,10 @@
+ 
+ @glib_os@
+ 
+-@glib_vacopy@
++#if defined(__ppc64__) || defined(__x86_64__)
++#define G_VA_COPY_AS_ARRAY 1
++#endif
++
+ 
+ @g_have_iso_c_varargs@
+ @g_have_iso_cxx_varargs@
+@@ -150,34 +196,75 @@
+ #mesondefine G_ATOMIC_OP_MEMORY_BARRIER_NEEDED
+ #mesondefine G_ATOMIC_LOCK_FREE
+ 
+-#define GINT16_TO_@g_bs_native@(val)	((gint16) (val))
+-#define GUINT16_TO_@g_bs_native@(val)	((guint16) (val))
+-#define GINT16_TO_@g_bs_alien@(val)	((gint16) GUINT16_SWAP_LE_BE (val))
+-#define GUINT16_TO_@g_bs_alien@(val)	(GUINT16_SWAP_LE_BE (val))
+-
+-#define GINT32_TO_@g_bs_native@(val)	((gint32) (val))
+-#define GUINT32_TO_@g_bs_native@(val)	((guint32) (val))
+-#define GINT32_TO_@g_bs_alien@(val)	((gint32) GUINT32_SWAP_LE_BE (val))
+-#define GUINT32_TO_@g_bs_alien@(val)	(GUINT32_SWAP_LE_BE (val))
+-
+-#define GINT64_TO_@g_bs_native@(val)	((gint64) (val))
+-#define GUINT64_TO_@g_bs_native@(val)	((guint64) (val))
+-#define GINT64_TO_@g_bs_alien@(val)	((gint64) GUINT64_SWAP_LE_BE (val))
+-#define GUINT64_TO_@g_bs_alien@(val)	(GUINT64_SWAP_LE_BE (val))
+-
+-#define GLONG_TO_LE(val)	((glong) GINT@glongbits@_TO_LE (val))
+-#define GULONG_TO_LE(val)	((gulong) GUINT@glongbits@_TO_LE (val))
+-#define GLONG_TO_BE(val)	((glong) GINT@glongbits@_TO_BE (val))
+-#define GULONG_TO_BE(val)	((gulong) GUINT@glongbits@_TO_BE (val))
++#ifdef __BIG_ENDIAN__
++#define GINT16_TO_BE(val)	((gint16) (val))
++#define GUINT16_TO_BE(val)	((guint16) (val))
++#define GINT16_TO_LE(val)	((gint16) GUINT16_SWAP_LE_BE (val))
++#define GUINT16_TO_LE(val)	(GUINT16_SWAP_LE_BE (val))
++#else
++#define GINT16_TO_LE(val)	((gint16) (val))
++#define GUINT16_TO_LE(val)	((guint16) (val))
++#define GINT16_TO_BE(val)	((gint16) GUINT16_SWAP_LE_BE (val))
++#define GUINT16_TO_BE(val)	(GUINT16_SWAP_LE_BE (val))
++#endif
++
++#ifdef __BIG_ENDIAN__
++#define GINT32_TO_BE(val)	((gint32) (val))
++#define GUINT32_TO_BE(val)	((guint32) (val))
++#define GINT32_TO_LE(val)	((gint32) GUINT32_SWAP_LE_BE (val))
++#define GUINT32_TO_LE(val)	(GUINT32_SWAP_LE_BE (val))
++#else
++#define GINT32_TO_LE(val)	((gint32) (val))
++#define GUINT32_TO_LE(val)	((guint32) (val))
++#define GINT32_TO_BE(val)	((gint32) GUINT32_SWAP_LE_BE (val))
++#define GUINT32_TO_BE(val)	(GUINT32_SWAP_LE_BE (val))
++#endif
++
++#ifdef __BIG_ENDIAN__
++#define GINT64_TO_BE(val)	((gint64) (val))
++#define GUINT64_TO_BE(val)	((guint64) (val))
++#define GINT64_TO_LE(val)	((gint64) GUINT64_SWAP_LE_BE (val))
++#define GUINT64_TO_LE(val)	(GUINT64_SWAP_LE_BE (val))
++#else
++#define GINT64_TO_LE(val)	((gint64) (val))
++#define GUINT64_TO_LE(val)	((guint64) (val))
++#define GINT64_TO_BE(val)	((gint64) GUINT64_SWAP_LE_BE (val))
++#define GUINT64_TO_BE(val)	(GUINT64_SWAP_LE_BE (val))
++#endif
++
++#ifdef __LP64__
++#define GLONG_TO_LE(val)	((glong) GINT64_TO_LE (val))
++#define GULONG_TO_LE(val)	((gulong) GUINT64_TO_LE (val))
++#define GLONG_TO_BE(val)	((glong) GINT64_TO_BE (val))
++#define GULONG_TO_BE(val)	((gulong) GUINT64_TO_BE (val))
++#else
++#define GLONG_TO_LE(val)	((glong) GINT32_TO_LE (val))
++#define GULONG_TO_LE(val)	((gulong) GUINT32_TO_LE (val))
++#define GLONG_TO_BE(val)	((glong) GINT32_TO_BE (val))
++#define GULONG_TO_BE(val)	((gulong) GUINT32_TO_BE (val))
++#endif
+ #define GINT_TO_LE(val)		((gint) GINT@gintbits@_TO_LE (val))
+ #define GUINT_TO_LE(val)	((guint) GUINT@gintbits@_TO_LE (val))
+ #define GINT_TO_BE(val)		((gint) GINT@gintbits@_TO_BE (val))
+ #define GUINT_TO_BE(val)	((guint) GUINT@gintbits@_TO_BE (val))
+-#define GSIZE_TO_LE(val)	((gsize) GUINT@gsizebits@_TO_LE (val))
+-#define GSSIZE_TO_LE(val)	((gssize) GINT@gsizebits@_TO_LE (val))
+-#define GSIZE_TO_BE(val)	((gsize) GUINT@gsizebits@_TO_BE (val))
+-#define GSSIZE_TO_BE(val)	((gssize) GINT@gsizebits@_TO_BE (val))
+-#define G_BYTE_ORDER @g_byte_order@
++#ifdef __LP64__
++#define GSIZE_TO_LE(val)	((gsize) GUINT64_TO_LE (val))
++#define GSSIZE_TO_LE(val)	((gssize) GINT64_TO_LE (val))
++#define GSIZE_TO_BE(val)	((gsize) GUINT64_TO_BE (val))
++#define GSSIZE_TO_BE(val)	((gssize) GINT64_TO_BE (val))
++#else
++#define GSIZE_TO_LE(val)	((gsize) GUINT32_TO_LE (val))
++#define GSSIZE_TO_LE(val)	((gssize) GINT32_TO_LE (val))
++#define GSIZE_TO_BE(val)	((gsize) GUINT32_TO_BE (val))
++#define GSSIZE_TO_BE(val)	((gssize) GINT32_TO_BE (val))
++#endif
++#ifdef __BIG_ENDIAN__
++#define G_BYTE_ORDER G_BIG_ENDIAN
++#else
++#define G_BYTE_ORDER G_LITTLE_ENDIAN
++#endif
++
++@glib_is_powerpc@
+ 
+ #define GLIB_SYSDEF_POLLIN =@g_pollin@
+ #define GLIB_SYSDEF_POLLOUT =@g_pollout@
+--- meson.build.orig	2019-11-17 14:26:49.000000000 -0300
++++ meson.build	2019-11-17 14:27:32.000000000 -0300
+@@ -1584,6 +1584,8 @@
+   glibconfig_conf.set(d[1], val)
+ endforeach
+ 
++glib_is_powerpc = '#if (defined(__PPC__) || defined(__PPC64__) || defined(__powerpc__) || defined(__powerpc64__) || defined(_ARCH_PPC)  || defined(_ARCH_PPC64))\n#ifdef G_ATOMIC_OP_MEMORY_BARRIER_NEEDED\n#undef G_ATOMIC_OP_MEMORY_BARRIER_NEEDED\n#endif\n#define G_ATOMIC_OP_MEMORY_BARRIER_NEEDED 1\n#else\n#ifdef G_ATOMIC_OP_MEMORY_BARRIER_NEEDED\n#undef G_ATOMIC_OP_MEMORY_BARRIER_NEEDED\n#endif\n#endif'
++glibconfig_conf.set('glib_is_powerpc', glib_is_powerpc)
+ 
+ # We need to decide at configure time if GLib will use real atomic
+ # operations ("lock free") or emulated ones with a mutex.  This is

--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -9,7 +9,7 @@ PortGroup                   muniversal 1.0
 # Please keep the glib2 and glib2-devel ports as similar as possible.
 
 name                        glib2
-conflicts                   glib2-devel
+conflicts                   glib2-devel glib2-upstream
 set my_name                 glib
 version                     2.64.6
 revision                    2


### PR DESCRIPTION
#### Description

New port `glib2-upstream`, covering the latest-and-greatest release of `glib2`. 

Includes updated patches, along with a fix for building 10.6 PPC. (Only applied in that specific case.)

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7
Xcode 12.4

macOS 10.6 PPC (10A190)
Xcode 3.2

macOS 10.5.8
Xcode 3.1.4

macOS 10.4.11
Xcode 2.5