### PR TITLE
mercurial: upgrade to @6.1.1

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -11,7 +11,7 @@ if {[variant_isset rust]} {
 name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-version             6.1
+version             6.1.1
 revision            0
 categories          devel python
 platforms           darwin
@@ -37,11 +37,13 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
 homepage            https://www.mercurial-scm.org
 
 checksums           ${distname}${extract.suffix}  \
-                    rmd160  71f464d948657dded24d3c8f4b9ad2de3bc9dbc8 \
-                    sha256  86f98645e4565a9256991dcde22b77b8e7d22ca6fbb60c1f4cdbd8469a38cc1f \
-                    size    8061104
+                    rmd160  91dfad36c73b3fd3fe468325f0922280c945dd12 \
+                    sha256  57b8a461d0ce13d9ae3817d8a8bdf9032e34edfaac3dbccb3b66b835dce93388 \
+                    size    8063346
 
 python.default_version 310
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
 depends_build-append \
                     port:py${python.version}-setuptools \


### PR DESCRIPTION
#### Description

Update to @6.1.1.
Add blacklist of gcc-4.x, since they may not understand `Wno-unused-result` flag and error out.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2