### PR TITLE
openjdk8-zulu: update to 8.62.0.19

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
-version      8.60.0.21
+version      8.62.0.19
 revision     0
 
-set openjdk_version 8.0.322
+set openjdk_version 8.0.332
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  01ca97a28d979f5468542fc4ff53a1185d54d119 \
-                 sha256  dece2b4105501353adf58fdd04a8ae959e2112e6ff9a743cbf222598f8ebc2ca \
-                 size    108226544
+    checksums    rmd160  660b8025b0e7c7b548712dba2750ec52533d681e \
+                 sha256  9b2a14112de141bdcef0ee34a57072b3310568b365ca5ecf54724a8100039339 \
+                 size    108062182
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  063f83e35c5c8057c95333f65647461f636cf626 \
-                 sha256  87410301c7e0e33ece61b4404c3c8ebfc3e75dd9f74d3ebae30833631e2dff60 \
-                 size    105912737
+    checksums    rmd160  76bec864caf7c23762a241c51f77cb459a3aad67 \
+                 sha256  e5c84a46bbd985c3a53358db9c97a6fd4930f92b833c3163a0d1e47dab59768c \
+                 size    105742233
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 8.62.0.19.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?