### PR TITLE
openjdk7-zulu: update to 7.54.0.13

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -91,10 +91,10 @@ subport openjdk7-zulu {
     # https://www.azul.com/downloads/?version=java-7-lts&os=macos&package=jdk
     supported_archs  x86_64
 
-    version      7.52.0.11
+    version      7.54.0.13
     revision     0
 
-    set openjdk_version 7.0.332
+    set openjdk_version 7.0.342
 
     description  Azul Zulu Community OpenJDK 7 (Long Term Support)
     long_description ${long_description_zulu}
@@ -102,9 +102,9 @@ subport openjdk7-zulu {
     master_sites https://cdn.azul.com/zulu/bin/
 
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  ad2a8a147e47327854ce5adfd7c9ae9da3f363e6 \
-                 sha256  c677a720a1e06fbf6fe20a8d15ea54a184fb783ece7a6707efe67ab6376846ae \
-                 size    68509988
+    checksums    rmd160  5b7a9a2a6c08501a6585df46389d8438b1df23d7 \
+                 sha256  dcc720d6fe21f4c73d41e3276c032396f4e0a91f51b0fcf2b6530a3daa93c61d \
+                 size    68525632
 
     worksrcdir   ${distname}/zulu-7.jdk
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 7.54.0.13.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?