### PR TITLE
openjdk15-zulu: update to 15.40.19

### DIFF
--- a/java/openjdk15-zulu/Portfile
+++ b/java/openjdk15-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-15-mts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      15.38.17
+version      15.40.19
 revision     0
 
-set openjdk_version 15.0.6
+set openjdk_version 15.0.7
 
 description  Azul Zulu Community OpenJDK 15 (Medium Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  3a46d9f2b822667113a3fe400300dcd56466f218 \
-                 sha256  59a2e0fac951fb48ccd11a39d16752bf7e375871d5fe92d3a63f032ddfbe8b44 \
-                 size    202445259
+    checksums    rmd160  53fb2586e539eb30bc7758d4ed17d3063eb04bbf \
+                 sha256  37c679f4c637306dcda7b2bcc26d99d6c2aec41578b812644f2502bb996ffdc1 \
+                 size    202520858
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  5f413443e65273dc53b059cea7965b2e6f8ed95b \
-                 sha256  3a0b2e6b36af26d996b5ec73418203e462be233da021f41c1834196e3bc2e60d \
-                 size    176748838
+    checksums    rmd160  c478b8c8b73fda666b75909fb4106ea03d794415 \
+                 sha256  84f5a9d1705621cf7502e070872e154b0dab7e36f02146031cbf9435e3af7199 \
+                 size    176817125
 }
 
 worksrcdir   ${distname}/zulu-15.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 15.40.19.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?