### PR TITLE
openjdk13-zulu: update to 13.48.19

### DIFF
--- a/java/openjdk13-zulu/Portfile
+++ b/java/openjdk13-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      13.46.15
+version      13.48.19
 revision     0
 
-set openjdk_version 13.0.10
+set openjdk_version 13.0.11
 
 description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  c37417003a010428e69a0b53e8800d9997e87577 \
-                 sha256  ed9142deef3d230928207ab64456ca0285213939afe78cd914c5b6689269e87d \
-                 size    200591500
+    checksums    rmd160  78d7bef0a42dd84b71118a7baf78f39b8ce20b82 \
+                 sha256  c47e0a44e19edcc2b1fdd451f7c6a86965ce8936e5df1123fdbfe2899eeb55e9 \
+                 size    200698199
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  6a0bcb3c4485dbdb768e54ea7a7165c0a2199431 \
-                 sha256  92eb552b109a1e68809c319df6dc29798fdd64a07098bd5821387e8b298657e5 \
-                 size    179912266
+    checksums    rmd160  a82d9f92075a99765848feff0405f7587c7526bd \
+                 sha256  77a1a462b4a797de8cda9032bf74924d6c0e095ca1de5a1890f08bf8545eb71a \
+                 size    180015317
 }
 
 worksrcdir   ${distname}/zulu-13.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 13.48.19.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?