### PR TITLE
transmission-x11: move to Cmake build system, fixes build on PPC

### DIFF
--- a/net/transmission-x11/Portfile
+++ b/net/transmission-x11/Portfile
@@ -68,7 +68,8 @@ post-extract {
 default_variants    +gtk
 
 variant aqua description {Build Aqua front-end} {
-    configure.args-replace  -DENABLE_QT=OFF -DENABLE_QT=ON
+    configure.args-replace  -DENABLE_QT=OFF -DENABLE_QT=ON \
+    						-DENABLE_MAC=OFF -DENABLE_MAC=ON
 }
 
 variant gtk description {Build Gtk3 front-end} {
@@ -86,7 +87,7 @@ variant gtk description {Build Gtk3 front-end} {
     }
 }
 
-platform darwin 8 {
+if {${os.platform} eq "darwin" && ${os.major} < 9} {
     pre-fetch {
         ui_error "${name} requires Mac OS X 10.5 or greater."
         return -code error "incompatible Mac OS X version"

--- a/net/transmission-x11/Portfile
+++ b/net/transmission-x11/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup			cmake 1.1
+PortGroup           cmake 1.1
 
 github.setup        transmission transmission 3.00
 revision            2
@@ -23,9 +23,9 @@ homepage            https://transmissionbt.com
 github.tarball_from releases
 use_xz              yes
 
-checksums           rmd160  5286c3e183474cba6ed1c6cfc022f4f5afab4fda \
-                    sha256  9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2 \
-                    size    3329220
+checksums           rmd160 5286c3e183474cba6ed1c6cfc022f4f5afab4fda \
+                    sha256 9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2 \
+                    size   3329220
 
 # Do not remove this as it allows transmission and this port to share files
 dist_subdir         transmission
@@ -43,33 +43,32 @@ depends_lib         port:miniupnpc \
                     port:zlib \
                     port:libb64
 
-configure.args-append	-DENABLE_CLI=ON \
-						-DENABLE_DAEMON=ON \
-						-DENABLE_GTK=OFF \
-						-DINSTALL_DOC=OFF \
-						-DENABLE_MAC=OFF \
-						-DENABLE_QT=OFF \
-						-DUSE_SYSTEM_B64=ON \
-						-DENABLE_TESTS=OFF \
-						-DENABLE_NLS=OFF
-						
-configure.ldflags-append \
-						-lstdc++
+configure.args-append -DENABLE_CLI=ON \
+                      -DENABLE_DAEMON=ON \
+                      -DENABLE_GTK=OFF \
+                      -DINSTALL_DOC=OFF \
+                      -DENABLE_MAC=OFF \
+                      -DENABLE_QT=OFF \
+                      -DUSE_SYSTEM_B64=ON \
+                      -DENABLE_TESTS=OFF \
+                      -DENABLE_NLS=OFF
 
-compiler.c_standard	2011
+configure.ldflags-append -lstdc++
+
+compiler.c_standard 2011
 
 post-extract {
     # https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=c13b5e88c6e9c7bd2698d844cb5ed127ed809f7e
     # Prevent m4_copy error when running aclocal
-    #  m4_copy: won't overwrite defined macro: glib_DEFUN
+    # m4_copy: won't overwrite defined macro: glib_DEFUN
     delete ${worksrcpath}/m4/glib-gettext.m4
 }
 
-default_variants    +gtk
+default_variants +gtk
 
 variant aqua description {Build Aqua front-end} {
-    configure.args-replace  -DENABLE_QT=OFF -DENABLE_QT=ON \
-    						-DENABLE_MAC=OFF -DENABLE_MAC=ON
+    configure.args-replace -DENABLE_QT=OFF -DENABLE_QT=ON \
+                           -DENABLE_MAC=OFF -DENABLE_MAC=ON
 }
 
 variant gtk description {Build Gtk3 front-end} {

--- a/net/transmission-x11/Portfile
+++ b/net/transmission-x11/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup			cmake 1.1
 
 github.setup        transmission transmission 3.00
-revision            1
+revision            2
 name                transmission-x11
 categories          net x11
 license             {GPL-2 OpenSSLException}
@@ -26,44 +27,48 @@ checksums           rmd160  5286c3e183474cba6ed1c6cfc022f4f5afab4fda \
                     sha256  9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2 \
                     size    3329220
 
-platforms           darwin freebsd
-
 # Do not remove this as it allows transmission and this port to share files
 dist_subdir         transmission
 
 depends_build       port:intltool \
                     port:pkgconfig \
-                    port:autoconf \
-                    port:automake \
+                    port:cmake \
                     port:libtool
 
 depends_lib         port:miniupnpc \
                     path:lib/libssl.dylib:openssl \
                     port:curl \
                     port:gettext \
-                    port:libevent
+                    port:libevent \
+                    port:zlib \
+                    port:libb64
 
-# reconfigure using upstream autogen.sh for intltool 0.51 compatibility
+configure.args-append	-DENABLE_CLI=ON \
+						-DENABLE_DAEMON=ON \
+						-DENABLE_GTK=OFF \
+						-DINSTALL_DOC=OFF \
+						-DENABLE_MAC=OFF \
+						-DENABLE_QT=OFF \
+						-DUSE_SYSTEM_B64=ON \
+						-DENABLE_TESTS=OFF \
+						-DENABLE_NLS=OFF
+						
+configure.ldflags-append \
+						-lstdc++
 
-configure.cmd       ./autogen.sh
-
-configure.args      --enable-daemon \
-                    --enable-cli \
-                    --without-gtk \
-                    --disable-mac
+compiler.c_standard	2011
 
 post-extract {
     # https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=c13b5e88c6e9c7bd2698d844cb5ed127ed809f7e
     # Prevent m4_copy error when running aclocal
     #  m4_copy: won't overwrite defined macro: glib_DEFUN
     delete ${worksrcpath}/m4/glib-gettext.m4
-
 }
 
 default_variants    +gtk
 
 variant aqua description {Build Aqua front-end} {
-    configure.args-replace  --disable-mac --enable-mac
+    configure.args-replace  -DENABLE_QT=OFF -DENABLE_QT=ON
 }
 
 variant gtk description {Build Gtk3 front-end} {
@@ -71,9 +76,9 @@ variant gtk description {Build Gtk3 front-end} {
                             port:libnotify \
                             port:desktop-file-utils
 
-    depends_run             port:adwaita-icon-theme
+    configure.args-replace  -DENABLE_GTK=OFF -DENABLE_GTK=ON
 
-    configure.args-replace  --without-gtk --with-gtk
+    depends_run             port:adwaita-icon-theme
 
     post-activate {
         system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"


### PR DESCRIPTION
#### Description

Move to `cmake` build system. Only revision changes, `transmission` version remains @3.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2
