### PR TITLE
openjdk17-zulu: update to 17.34.19

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.32.13
+version      17.34.19
 revision     0
 
-set openjdk_version 17.0.2
+set openjdk_version 17.0.3
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  3eced1f7701de4306f1fa24bc204cc56679afb03 \
-                 sha256  89d04b2d99b05dcb25114178e65f6a1c5ca742e125cab0a63d87e7e42f3fcb80 \
-                 size    193143505
+    checksums    rmd160  dbd49be4c782dd63f278dbcefd8727e40175f012 \
+                 sha256  a889b2c550b6cb6421c6e559c1a98a3f2a38ebe9feef2b48157a582347bac367 \
+                 size    193484877
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  ec8b93727a88ab77a692aac411a7cb63ce0ff709 \
-                 sha256  54247dde248ffbcd3c048675504b1c503b81daf2dc0d64a79e353c48d383c977 \
-                 size    190938303
+    checksums    rmd160  b77bb3eba4f53e6d4adad02ab0059787ffd1ec83 \
+                 sha256  79a457f106bf32aafd261a4748471fd10f5ce2a9aa2cc816a91864104c008dff \
+                 size    190867581
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 17.34.19.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?