### PR TITLE
openjdk11-zulu: update to 11.56.19

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -320,10 +320,10 @@ subport openjdk11-zulu {
     # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
     supported_archs  x86_64 arm64
 
-    version      11.54.25
+    version      11.56.19
     revision     0
 
-    set openjdk_version 11.0.14.1
+    set openjdk_version 11.0.15
 
     description  Azul Zulu Community OpenJDK 11 (Long Term Support)
     long_description ${long_description_zulu}
@@ -332,14 +332,14 @@ subport openjdk11-zulu {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-        checksums    rmd160  1b144473c0ec1086ab295b3d7601a8e7611ce59e \
-                     sha256  fbfe3da2024a170b77efd94946aeb95ffe54377134403f92c682376e1f06e8f5 \
-                     size    193388486
+        checksums    rmd160  012f063dd25db637f7ed45d3919c1b3627e9f35d \
+                     sha256  2614e5c5de8e989d4d81759de4c333aa5b867b17ab9ee78754309ba65c7f6f55 \
+                     size    193550721
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-        checksums    rmd160  1b0182a86c1ae1a42741de3ae5e885b15186a924 \
-                     sha256  2076f8ce51c0e9ad7354e94b79513513b1697aa222f9503121d800c368b620a3 \
-                     size    176884357
+        checksums    rmd160  8a0f7adca8377f7ace5f5cf05e00fdc90d6d1349 \
+                     sha256  6bb0d2c6e8a29dcd9c577bbb2986352ba12481a9549ac2c0bcfd00ed60e538d2 \
+                     size    191059414
     }
 
     worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 11.56.19.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?