### PR TITLE
openjdk18-sap: update to 18.0.1

### DIFF
--- a/java/openjdk18-sap/Portfile
+++ b/java/openjdk18-sap/Portfile
@@ -13,7 +13,7 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-version      18
+version      18.0.1
 revision     0
 
 description  SapMachine 18
@@ -23,14 +23,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  feddc96bb771a7a9fdc870517f7135decd68529b \
-                 sha256  930e6ab1d4452a16ef73aa519f4a47c1c06a5d21a1233a1e68e2459fb0a5d8cd \
-                 size    181223016
+    checksums    rmd160  d8af6cf30a6f3c79217b502b46dafd97879901e4 \
+                 sha256  f876e444c7761303c180de6f43c092c6531581576b0342e4f2d41716fb6ce16a \
+                 size    181391732
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  cc3cd90bbd8fd46775ad300302248bb7d2e19fbe \
-                 sha256  47c5fb2b20dc18080426106703d616e3db8f76e0b791bc1ef32c3b4bec6867d9 \
-                 size    179060893
+    checksums    rmd160  3f549834151793e9ca7d7c56e208ca641381d755 \
+                 sha256  340846512d086051e61b36be3eb4a2a30845ea759505084779ca1b9658d1c491 \
+                 size    179287803
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine OpenJDK 18.0.1.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?