### PR TITLE
wrk: update to 4.2.0

### DIFF
--- a/net/wrk/Portfile
+++ b/net/wrk/Portfile
@@ -6,8 +6,8 @@ PortGroup           compilers 1.0
 PortGroup           xcode_workaround 1.0
 PortGroup           openssl 1.0
 
-github.setup        wg wrk 4.1.0
-revision            2
+github.setup        wg wrk 4.2.0
+revision            0
 
 categories          net
 platforms           darwin
@@ -17,9 +17,9 @@ description         wrk HTTP benchmarking tool
 long_description    wrk is a modern HTTP benchmarking tool with optional LuaJIT HTTP request generation.
 homepage            https://github.com/wg/wrk
 
-checksums           rmd160  66508bc4bea66d7731510164037beaac5fe44de5 \
-                    sha256  49c309c834c484243d1f381505e7723326c5a9b6e328d88adef9ead804c8d83e \
-                    size    6478150
+checksums           rmd160  2ad5bca5cc3aa3486b67fae2bd99a4e31ed9fade \
+                    sha256  74e61fc31c8e4ddac7a20d3dc54b59dbf5401d659fdd03d5222566587812f988 \
+                    size    10973435
 
 depends_build-append \
                     port:perl5


### PR DESCRIPTION
#### Description

Update version of net/wrk to 4.2.0 (to fix an install issue on arm64 (M1 Macs).

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 arm64
Command Line Tools 13.3.1.0.1.1648687083

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
