### PR TITLE
openjdk17-sap: update to 17.0.3

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.2
+version      17.0.3
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  5c2458e509263d50ffdc5a647e2d4f3dd830c8e5 \
-                 sha256  228b9952002dd60e626c46b8ff051e8e25d577d358390cd52dd7e4ea50863cef \
-                 size    180149241
+    checksums    rmd160  14df5f12eecd43df3bcf781b4b702a497d463507 \
+                 sha256  eb3dc4f099b3038368e7cd0762d7820f07d64fc6bc880ae5e8606ece1b32b1c0 \
+                 size    180138613
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  0aab18f0e415d024d0461ba5ba3f9e2b00f0f4e5 \
-                 sha256  06c28b5365527db346b5d2e121e5f70baaef0ddde07766c59c17bfc577a0e4c2 \
-                 size    177867623
+    checksums    rmd160  0425307ac13bf1506ce6e170b977c7fe6af404ba \
+                 sha256  5b1718288aea89aa22db1dc71388a9ffeae9befe2c8a057af4d8103daef5fcdb \
+                 size    177915159
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine OpenJDK 17.0.3.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?