### PR TITLE
openjdk11-sap: update to 11.0.15

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -278,7 +278,7 @@ subport openjdk11-sap {
     # https://sap.github.io/SapMachine/latest/11
     supported_archs  x86_64
 
-    version      11.0.14.1
+    version      11.0.15
     revision     0
     
     description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -288,9 +288,9 @@ subport openjdk11-sap {
     distname     sapmachine-jdk-${version}_osx-x64_bin
     worksrcdir   sapmachine-jdk-${version}.jdk
     
-    checksums    rmd160  22e2f87e45bb3bec3df2d862398e03a6d0a84f98 \
-                 sha256  497c5d0e697867f44f62a6cf5a8caabe2ceb623dd6c229278a3d5c1d3d11d9fb \
-                 size    186755870
+    checksums    rmd160  a96ee4be77f52adaff3e89faa39a0f669dce07b7 \
+                 sha256  6edc3e6d4a5fcc2782b24d5957fbdfa16f20e5e349d9b28fd536be0d32deb041 \
+                 size    186905185
 
 }
 


### PR DESCRIPTION
#### Description

Update to SapMachine OpenJDK 11.0.15.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?