### PR TITLE
spring-boot-cli: update to 2.6.7

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.6.6
+version         2.6.7
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  d7b570b6aa0b917a787999ea7c1f7652500551a9 \
-                sha256  dca486788c937cbfc26c76ccf71cce9bf765c957dbd68f4e1b4ffe88f0579a36 \
-                size    14305757
+checksums       rmd160  13205650874660104ebd60deb70460df8189ba1a \
+                sha256  bfb191c171b839892f512ef3988d94ec7c2a6d344a148edb57d0eed413ecafd5 \
+                size    14306006
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot 2.6.7.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?