### PR TITLE
dbus: update to @1.14.0

### DIFF
--- a/devel/dbus/Portfile
+++ b/devel/dbus/Portfile
@@ -25,9 +25,10 @@ use_xz          yes
 
 # See r68276
 # For configure
-#    see https://trac.macports.org/ticket/47741#comment:12 for EXTERNAL authentication
+# see https://trac.macports.org/ticket/47741#comment:12 for EXTERNAL authentication
 patchfiles      patch-bus-system.conf.in.diff \
-                patch-configure.diff
+                patch-configure.diff \
+                patch-dbus-server-launchd.diff
 
 # see https://bugs.freedesktop.org/show_bug.cgi?id=9449
 if {$macosx_deployment_target eq "10.4"} {

--- a/devel/dbus/Portfile
+++ b/devel/dbus/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       muniversal 1.0
 
 name            dbus
-version         1.12.20
+version         1.14.0
 maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 categories      devel
 platforms       darwin
@@ -17,9 +17,11 @@ long_description \
 homepage        https://www.freedesktop.org/wiki/Software/dbus/
 master_sites    https://dbus.freedesktop.org/releases/dbus/
 
-checksums       rmd160  a41d7941c58da66dc5ca13927a14d0561ddb4a12 \
-                sha256  f77620140ecb4cdc67f37fb444f8a6bea70b5b6461f12f1cbe2cec60fa7de5fe \
-                size    2095511
+checksums       rmd160 33635da491082e358e541fd8c9891bf688d01648 \
+                sha256 ccd7cce37596e0a19558fd6648d1272ab43f011d80c8635aea8fd0bad58aebd4 \
+                size   1360228
+
+use_xz          yes
 
 # See r68276
 # For configure

--- a/devel/dbus/files/patch-configure.diff
+++ b/devel/dbus/files/patch-configure.diff
@@ -1,6 +1,6 @@
---- configure.orig	2017-04-05 15:25:13.000000000 +0000
-+++ configure	2017-05-31 14:40:27.000000000 +0000
-@@ -17722,6 +17722,7 @@
+--- configure.orig	2022-02-28 20:24:19.000000000 +0800
++++ configure	2022-04-04 12:07:15.000000000 +0800
+@@ -18664,6 +18664,7 @@
  dbus_win=no
  dbus_cygwin=no
  dbus_unix=no
@@ -8,7 +8,7 @@
  case "${host}" in
      *-mingw32ce*)
          dbus_win=yes
-@@ -17734,6 +17735,10 @@
+@@ -18676,6 +18677,10 @@
          dbus_cygwin=yes
          dbus_unix=yes
          ;;
@@ -19,12 +19,12 @@
      *)
          dbus_unix=yes
         ;;
-@@ -17778,7 +17783,7 @@
+@@ -18735,7 +18740,7 @@
  
  # For best security, assume that all non-Windows platforms can do
  # credentials-passing.
--if test "$dbus_win" = yes; then :
-+if test "$dbus_win" = yes || test "$dbus_darwin" = yes ; then :
+-if test "$dbus_win" = yes
++if test "$dbus_win" = yes || test "$dbus_darwin" = yes ;
+ then :
    DBUS_SESSION_CONF_MAYBE_AUTH_EXTERNAL="<!--<auth>EXTERNAL</auth>-->"
- else
-   DBUS_SESSION_CONF_MAYBE_AUTH_EXTERNAL="<auth>EXTERNAL</auth>"
+ else $as_nop

--- a/devel/dbus/files/patch-dbus-server-launchd.diff
+++ b/devel/dbus/files/patch-dbus-server-launchd.diff
@@ -1,0 +1,10 @@
+--- dbus/dbus-server-launchd.c.orig	2022-02-23 22:39:11.000000000 +0800
++++ dbus/dbus-server-launchd.c	2022-04-22 12:08:53.000000000 +0800
+@@ -26,6 +26,7 @@
+  */
+ 
+ #include <config.h>
++#include <unistd.h>
+ #include "dbus-server-launchd.h"
+ 
+ /**


### PR DESCRIPTION
#### Description

Update to @1.14.0, one patch updated accordingly, no other changes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10.6 (10A190)
Xcode 3.2
