### PR TITLE
neovim: update to version 0.7.0

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -6,7 +6,7 @@ PortGroup github 1.0
 # use cmake 1.0 for CMAKE_BUILD_TYPE=Release
 PortGroup cmake 1.0
 
-github.setup            neovim neovim 0.6.1 v
+github.setup            neovim neovim 0.7.0 v
 revision                0
 categories              editors
 platforms               darwin
@@ -23,9 +23,9 @@ long_description \
 
 homepage                https://neovim.io
 
-checksums               rmd160  a555d6a1283794b64bb12507a17cdbf120b1344e \
-                        sha256  5fe6b63e259753ebb4aa743fc8d90bd3ea489f7db5a205c06eca3d62545937f4 \
-                        size    10597444
+checksums               rmd160  81821a8867549125ca3a658957f7e509ce94b8e9 \
+                        sha256  b177eff79f671ed71d340ed43cfec1c81f3671ea17624142bf3855b2019c7f4e \
+                        size    10923550
 
 depends_build-append    port:pkgconfig
 


### PR DESCRIPTION
#### Description

update to neovim 0.7.0

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 arm64
Xcode 13.3.1 13E500a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?