### PR TITLE
ghc-ppc-bootstrap: new port; latest release of GHC for PowerPC

### DIFF
--- a/lang/ghc-ppc-bootstrap/Portfile
+++ b/lang/ghc-ppc-bootstrap/Portfile
@@ -1,0 +1,76 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                ghc-ppc-bootstrap
+set canonicalname   ghc
+version             7.0.4
+revision            0
+categories          lang haskell
+maintainers         @barracuda156
+license             BSD
+platforms           darwin
+supported_archs     ppc
+universal_variant   no
+installs_libs       no
+
+description         The Glorious Glasgow Haskell Compilation System
+long_description    This is a package that installs a binary bootstrap ghc compiler.
+
+homepage            http://haskell.org/${canonicalname}
+master_sites        https://downloads.haskell.org/ghc/7.0.4/krabby/
+distname            GHC-${version}-powerpc
+distfiles			${distname}.pkg
+
+checksums           rmd160  38cc042793d2b4f4a6b901c6bb7f6a1f6959cce8 \
+                    sha256  81cc84e18d30d35d4103b21d146b264abd7f00879ae64ef492bc83d67231fb7c \
+                    size    171783399
+
+depends_extract     port:xar
+
+worksrcdir          ${canonicalname}-${version}
+
+extract {
+    system -W ${workpath} "mkdir -p ${worksrcpath}/pkg"
+    system -W ${workpath} "mkdir -p ${worksrcpath}/files"
+    system -W ${distpath} "cp ${distpath}/${distfiles} ${worksrcpath}/pkg"
+    system -W ${worksrcpath}/pkg "${prefix}/bin/xar -xf ${worksrcpath}/pkg/GHC-${version}-powerpc.pkg -C ${worksrcpath}/files"
+    system -W ${worksrcpath}/files/ghc.pkg "cat Payload | gunzip -dc | cpio -i"
+    
+if {![variant_isset framework]} {
+    system -W ${worksrcpath}/files/ghc.pkg "mv GHC.framework/Versions/7.0.4-powerpc/usr ${worksrcpath}/${name}"
+    system -W ${worksrcpath}/files/ghc.pkg "cp -R GHC.framework/Versions/7.0.4-powerpc/Tools ${worksrcpath}/${name}/share"
+    }
+}
+
+use_configure     no
+
+build {}
+
+if {![variant_isset framework]} {
+	destroot.destdir prefix=${destroot}/share
+	set path ${prefix}/share
+	destroot {
+		copy ${worksrcpath}/${name} ${destroot}${path}
+	}
+	
+	post-destroot {
+		# Delete dylibs; they arenʼt used by the bootstrap ghc and are incorrectly linked against /usr/local, causing rev-upgrade to complain.
+		fs-traverse f ${destroot}${path}/${name}/lib {
+			if {[file isfile ${f}]} {
+				if {[file extension ${f}] == ".dylib"} {
+					delete ${f}
+				}
+			}
+		}
+	}
+}
+
+variant framework description {Install as a Framework} {
+    destroot.destdir prefix=${destroot}${frameworks_dir}
+	destroot {
+		copy ${worksrcpath}/files/ghc.pkg/GHC.framework ${destroot}${frameworks_dir}
+	}
+}
+
+livecheck.type      none

--- a/lang/ghc-ppc-bootstrap/Portfile
+++ b/lang/ghc-ppc-bootstrap/Portfile
@@ -7,7 +7,7 @@ set canonicalname   ghc
 version             7.0.4
 revision            0
 categories          lang haskell
-maintainers         @barracuda156
+maintainers         Sergey Fedorov @barracuda156
 license             BSD
 platforms           darwin
 supported_archs     ppc
@@ -43,7 +43,7 @@ if {![variant_isset framework]} {
     }
 }
 
-use_configure     no
+use_configure no
 
 build {}
 
@@ -53,7 +53,7 @@ if {![variant_isset framework]} {
 	destroot {
 		copy ${worksrcpath}/${name} ${destroot}${path}
 	}
-	
+
 	post-destroot {
 		# Delete dylibs; they arenʼt used by the bootstrap ghc and are incorrectly linked against /usr/local, causing rev-upgrade to complain.
 		fs-traverse f ${destroot}${path}/${name}/lib {
@@ -63,6 +63,44 @@ if {![variant_isset framework]} {
 				}
 			}
 		}
+		# Fix directory refs
+		reinplace "s|/Library/Frameworks/GHC.framework/Versions/7.0.4-powerpc/usr|/opt/local/share/ghc-ppc-bootstrap|" \
+			${destroot}${path}/${name}/bin/hsc2hs \
+			${destroot}${path}/${name}/bin/runghc \
+			${destroot}${path}/${name}/bin/ghc-7.0.4 \
+			${destroot}${path}/${name}/bin/ghci-7.0.4 \
+			${destroot}${path}/${name}/bin/ghc-pkg-7.0.4 \
+			${destroot}${path}/${name}/bin/haddock-ghc-7.0.4 \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/array-0.3.0.2-f538acad67d0b6696484da310d5949cf.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/base-4.3.1.0-027b77b12e52d1549077882b70695ddf.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/bin-package-db-0.0.0.0-ebccf3a563d9cc82a12563267e3b3973.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/bytestring-0.9.1.10-518da2c2e8177a761e7c3f8131b096f3.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/Cabal-1.10.2.0-5e1f7ddd36b188ae16e45b3a77b9c766.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/containers-0.4.0.0-f1307d32d8f4b51a1487c01f0997b6d9.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/directory-1.1.0.0-c0b12e512fadecf7242b2ec3cd952b2e.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/extensible-exceptions-0.1.1.2-d8c5b906654260efd7249f497d17a831.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/filepath-1.2.0.0-956a4b0c127b8c317f6cac3946b0b803.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/ghc-7.0.4-75a79ada61f7974961ef6e048ae39af8.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/ghc-binary-0.5.0.2-a36b46d7bbe800f04bce8a86565c2e8f.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/ghc-prim-0.2.0.0-6bf7b03ebc9c668817e4379b6796c0c2.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/haskell98-1.1.0.1-6f6b89a32eb0b5c7df8a4aba3d9884d3.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/haskell2010-1.0.0.0-98ed3d653ac78fc3526ee288bfd554ae.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/hpc-0.5.0.6-86b8caed77dec5a6adf56b6a203114d8.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/integer-gmp-0.2.0.3-4c5ab8b517f0b5d4ecf2153d5dfb7f41.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/old-locale-1.0.0.2-25ff1e5e0486bb3cf2cb85cb7daf8f22.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/old-time-1.0.0.6-249d424df19da9487f0cb7da3ccb0868.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/pretty-1.0.1.2-f2c716197e95f5c78869e6b87f2330d9.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/process-1.0.1.5-7c01e525f8af6ff6ee54718777c83b45.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/random-1.0.0.3-186815de972cb506efde02a72b0d8f8b.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/template-haskell-2.5.0.0-5eb8b3886e957b3c9cb455b68e59f600.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/time-1.2.0.3-ad46a3ade48e0011608895f44cc02a52.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/unix-2.4.2.0-766adf3eeb77190cf0dabf1daf400c65.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/builtin_ffi.conf \
+			${destroot}${path}/${name}/lib/ghc-7.0.4/package.conf.d/builtin_rts.conf
+	}
+
+	post-activate {
+		catch {system "${prefix}/share/ghc-ppc-bootstrap/bin/ghc-pkg -v recache"}
 	}
 }
 
@@ -70,6 +108,53 @@ variant framework description {Install as a Framework} {
     destroot.destdir prefix=${destroot}${frameworks_dir}
 	destroot {
 		copy ${worksrcpath}/files/ghc.pkg/GHC.framework ${destroot}${frameworks_dir}
+	}
+
+	post-destroot {
+		fs-traverse f ${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib {
+			if {[file isfile ${f}]} {
+				if {[file extension ${f}] == ".dylib"} {
+					delete ${f}
+				}
+			}
+		}
+		reinplace "s|/Library|/opt/local/Library|" \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/bin/hsc2hs \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/bin/runghc \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/bin/ghc-7.0.4 \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/bin/ghci-7.0.4 \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/bin/ghc-pkg-7.0.4 \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/bin/haddock-ghc-7.0.4 \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/array-0.3.0.2-f538acad67d0b6696484da310d5949cf.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/base-4.3.1.0-027b77b12e52d1549077882b70695ddf.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/bin-package-db-0.0.0.0-ebccf3a563d9cc82a12563267e3b3973.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/bytestring-0.9.1.10-518da2c2e8177a761e7c3f8131b096f3.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/Cabal-1.10.2.0-5e1f7ddd36b188ae16e45b3a77b9c766.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/containers-0.4.0.0-f1307d32d8f4b51a1487c01f0997b6d9.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/directory-1.1.0.0-c0b12e512fadecf7242b2ec3cd952b2e.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/extensible-exceptions-0.1.1.2-d8c5b906654260efd7249f497d17a831.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/filepath-1.2.0.0-956a4b0c127b8c317f6cac3946b0b803.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/ghc-7.0.4-75a79ada61f7974961ef6e048ae39af8.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/ghc-binary-0.5.0.2-a36b46d7bbe800f04bce8a86565c2e8f.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/ghc-prim-0.2.0.0-6bf7b03ebc9c668817e4379b6796c0c2.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/haskell98-1.1.0.1-6f6b89a32eb0b5c7df8a4aba3d9884d3.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/haskell2010-1.0.0.0-98ed3d653ac78fc3526ee288bfd554ae.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/hpc-0.5.0.6-86b8caed77dec5a6adf56b6a203114d8.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/integer-gmp-0.2.0.3-4c5ab8b517f0b5d4ecf2153d5dfb7f41.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/old-locale-1.0.0.2-25ff1e5e0486bb3cf2cb85cb7daf8f22.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/old-time-1.0.0.6-249d424df19da9487f0cb7da3ccb0868.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/pretty-1.0.1.2-f2c716197e95f5c78869e6b87f2330d9.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/process-1.0.1.5-7c01e525f8af6ff6ee54718777c83b45.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/random-1.0.0.3-186815de972cb506efde02a72b0d8f8b.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/template-haskell-2.5.0.0-5eb8b3886e957b3c9cb455b68e59f600.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/time-1.2.0.3-ad46a3ade48e0011608895f44cc02a52.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/unix-2.4.2.0-766adf3eeb77190cf0dabf1daf400c65.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/builtin_ffi.conf \
+			${destroot}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/lib/ghc-7.0.4/package.conf.d/builtin_rts.conf
+	}
+
+	post-activate {
+		catch {system "${prefix}${frameworks_dir}/GHC.framework/Versions/7.0.4-powerpc/usr/bin/ghc-pkg -v recache"}
 	}
 }
 


### PR DESCRIPTION
#### Description

Macports currently has no `ghc` for PowerPC systems. This port addresses this problem. It is based on the latest available build for PowerPC on Haskell.org.
Once installed, it can be used to build `ghc` up to @7.6.3. Which means that we can build existing `ghc-bootstrap` for three archs (obviously, at the moment it cannot be built for PPC): https://ports.macports.org/port/ghc-bootstrap/details/

I can update `ghc-bootstrap` port to include PPC, however it would mean that while for i386 and x86_64 the port is downloaded and installed, for PPC it will need to be built using `ghc-ppc-bootstrap`. This sort of fails the name of -bootstrap, however it appears to be the only feasible solution for now.

@kencu @catap @evanmiller @mascguy @neverpanic What do you think?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC
Xcode 3.2

The compiler itself is reasonably tested, I used it to build `ghc` @7.6.2 and @7.6.3. (Optional framework variant is added just because the original pkg installs a framework. I did not test framework variant beyond verifying it destroots correctly.)

P. S. There is some bug in the base of `ghc` around 7.4.x–7.6.x versions which does not allow using them to build 7.7.x–7.10.x. So the pathway that I currently propose can lead to functional `ghc` @7.6.3 but not later. Long thread here: https://trac.macports.org/ticket/64698

Once/if I succeed in cross-building `ghc` 9.x for PowerPC, this port can be updated accordingly.