### PR TITLE
pcre2: update to 10.40

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -10,7 +10,7 @@ if {${subport} eq ${name}} {
 subport pcre2 {
     PortGroup       github 1.0
 
-    github.setup    PhilipHazel pcre2 10.39 pcre2-
+    github.setup    PCRE2Project pcre2 10.40 pcre2-
     github.tarball_from releases
     revision        0
 }
@@ -42,9 +42,9 @@ use_bzip2           yes
 set rmd160(pcre)    9792fbed380a39be36674e74839b9a2a6a4ce65a
 set sha256(pcre)    4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8
 set size(pcre)      1578809
-set rmd160(pcre2)   ad093c4cffd04323022a1753cd650cb100f9ddb8
-set sha256(pcre2)   0f03caf57f81d9ff362ac28cd389c055ec2bf0678d277349a1a4bee00ad6d440
-set size(pcre2)     1730729
+set rmd160(pcre2)   9728e170b4da3ed594e18934b403e97fe4b72291
+set sha256(pcre2)   14e4b83c4783933dc17e964318e6324f7cae1bc75d8f3c79bc6969f00c159d68
+set size(pcre2)     1765440
 checksums           rmd160  $rmd160(${subport}) \
                     sha256  $sha256(${subport}) \
                     size    $size(${subport})
@@ -59,16 +59,8 @@ configure.args      --disable-silent-rules \
                     --enable-${subport}grep-libz \
                     --enable-${subport}test-libedit
 
-# PCRE's JIT is not Apple Silicon compatible yet.
-# https://bugs.exim.org/show_bug.cgi?id=2618
-# The pkg-config files vary depending on whether or not JIT is enabled
-# so we have to disable it for all archs if arm64 is among the archs.
 variant universal {}
-if {"arm64" in [get_canonical_archs]} {
-    configure.args-append --disable-jit
-} else {
-    configure.args-append --enable-jit
-}
+configure.args-append --enable-jit
 
 subport pcre {
     PortGroup clang_dependency 1.0


### PR DESCRIPTION
While at it make sure to use the correct GitHub name and to enable jit for arm64 which has been supported for several releases already

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
Not tested with macports, I use brew

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?