### PR TITLE
grafana: update to v8.5.0

### DIFF
--- a/net/grafana/Portfile
+++ b/net/grafana/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 PortGroup           legacysupport 1.1
 
-go.setup            github.com/grafana/grafana 7.5.7 v
+go.setup            github.com/grafana/grafana 8.5.0 v
 revision            0
 
 homepage            https://grafana.com
@@ -24,14 +24,14 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  af50ff58a17d78f8d1986c8c45fb16ee20581206 \
-                    sha256  ec1271b5a7202a12cb8046141025ad61aaa42e54425ab40acb7de46461896838 \
-                    size    10926986
+checksums           rmd160  25aad04c14f619c2d0647fe0876726f7b45a1229 \
+                    sha256  f5e21977a0d8c473cd76f7f769f6a27434e5f3b3099c6fa3586108749819e56e \
+                    size    18701558
 
 github.tarball_from archive
 
 depends_build-append \
-                    path:bin/node:nodejs15 \
+                    path:bin/node:nodejs16 \
                     port:yarn
 
 # Allow fetching deps at build time for now
@@ -66,12 +66,6 @@ post-patch {
     reinplace "s|@PREFIX@|${prefix}|g"              ${workpath}/${grafana_plist}
     reinplace "s|@CONFFILE@|${grafana_conf_file}|g" ${workpath}/${grafana_plist}
     reinplace "s|@SHAREDIR@|${grafana_share_dir}|g" ${workpath}/${grafana_plist}
-
-    # Disable nodejs version limitation
-    reinplace {s|"node": ">=12 <13"|"node": ">=12"|} ${worksrcpath}/package.json
-
-    # Run yarn in verbose mode
-    reinplace {s|yarn install|yarn install --verbose|g} ${worksrcpath}/Makefile
 }
 
 


### PR DESCRIPTION
In addition to the version bump, therea are two other changes needed for
this to build:

- Remove the tweak that added --verbose from yarn install, which no
  longer works as of yarn v3.2 (bundled with Grafana)
- Remove the package.json nodejs version tweaking; Grafana asserts
  >= 16, with no upper limit.

#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
