### PR TITLE
py-flask: update to 2.1.1

### DIFF
--- a/python/py-flask/Portfile
+++ b/python/py-flask/Portfile
@@ -4,16 +4,16 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-flask
-version             2.0.2
+version             2.1.1
 revision            0
 
-checksums           rmd160  ca31637de5c5bbb1d514a62a2946ef27de9899eb \
-                    sha256  7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2 \
-                    size    628479
+checksums           rmd160  8f419a29ea56e60d989f8a36f557746df5534233 \
+                    sha256  a8c9bd3e558ec99646d177a9739c41df1ded0629480b4c8d2975412f3c9519c8 \
+                    size    630996
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 37 38 39 310
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 license             BSD
 supported_archs     noarch
 
@@ -26,6 +26,16 @@ master_sites        pypi:F/Flask/
 default distname    {Flask-${version}}
 
 if {${name} ne ${subport}} {
+    # The last supported version for 27
+    # See: https://github.com/pallets/flask/blob/main/CHANGES.rst#version-200
+    if {${python.version} <= 27} {
+        version             1.1.4
+        revision            0
+        checksums           rmd160  03b23def022b1cf6afdcae01cb840f4623288c43 \
+                            sha256  0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196 \
+                            size    635920
+    }
+
     depends_build-append    port:py${python.version}-setuptools
 
     depends_lib-append      port:py${python.version}-jinja2 \
@@ -33,9 +43,19 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-itsdangerous \
                             port:py${python.version}-click
 
+    if {${python.version} < 310} {
+        depends_lib-append  port:py${python.version}-importlib-metadata
+    }
+
+    depends_test-append     port:py${python.version}-pytest
+
+    # test before 2.x requires missed py-pathlib
+    if {${python.version} > 27} {
+        test.run            yes
+        test.cmd            py.test-${python.branch}
+        test.target         tests
+        test.env            PYTHONPATH=${build.dir}/build/lib
+    }
+
     livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/Flask/json
-    livecheck.regex     {Flask-(\d+(?:\.\d+)*)\.[tz]}
 }


### PR DESCRIPTION
#### Description

Also drop support of python 3.5 and 3.6 which can't be used because it hasn't got supported by py-werkzeug.

Fixes: https://trac.macports.org/ticket/64158

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->