### PR TITLE
jdk17: new submission

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -1,0 +1,90 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             jdk17
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          NFTC NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://www.oracle.com/java/technologies/downloads/#jdk17-mac
+version      17.0.3
+set build    8
+revision     0
+
+description  Oracle Java SE Development Kit 17
+long_description Java Platform, Standard Edition Development Kit (JDK). \
+    The JDK is a development environment for building applications and components using the Java programming language. \
+    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
+
+master_sites https://download.oracle.com/java/17/archive/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     jdk-${version}_macos-x64_bin
+    checksums    rmd160  faabac02ab11cebfcc41b0c6af9202d12344f503 \
+                 sha256  dc12044350a5c06d38c1d1d4c33b9855cd954d7cdb10a040f91c332d34213cb4 \
+                 size    178217542
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  4824d0cc63ad70569deccce7fc7992b52950cb78 \
+                 sha256  939b32a0e71d54bc9fa48eaf2b551b6c7c7fddbe2d63ec5d2cb618a7a92154d9 \
+                 size    175548784
+}
+
+worksrcdir   jdk-${version}.jdk
+
+homepage     https://www.oracle.com/java/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for the Oracle Java SE 17 Development Kit.

Note that this is not the same as what's provided by the existing `openjdk17-oracle` port. This port is not for the GPL-licensed Oracle OpenJDK, but for the [NFTC](https://java.com/freeuselicense)-licensed Oracle Java SE JDK. The benefit of this new port is that it still receives updates for Java 17, while updates for Oracle OpenJDK 17 have already ended.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?