### PR TITLE
openjdk17-microsoft: new submission

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -1,0 +1,90 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk17-microsoft
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
+supported_archs  x86_64 arm64
+
+set build 7
+
+version      17.0.3
+revision     0
+
+description  Microsoft Build of OpenJDK 17 (Long Term Support)
+long_description The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source \
+    and available for free for anyone to deploy anywhere.
+
+master_sites https://aka.ms/download-jdk/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     microsoft-jdk-${version}-macOS-x64
+    checksums    rmd160  7d8b26bbd28d14f0ff65c8178b0246a679380858 \
+                 sha256  17e2e0fe8ac0745850a1537b7c111178ad57a912bddeafaf6f82548c8c7cc1be \
+                 size    187304425
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     microsoft-jdk-${version}-macOS-aarch64
+    checksums    rmd160  c88e507c3b79167fe30639ae51fc87edf6f61888 \
+                 sha256  3695ee9c60925fc370b34e5f9954bc1834ad55e321e8b0b622ac51c12f8fdb38 \
+                 size    177743370
+}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://www.microsoft.com/openjdk
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for the Microsoft build of OpenJDK 17.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?