### PR TITLE
esmf: Update to 8.2.0

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -12,10 +12,14 @@ compilers.allow_arguments_mismatch \
 mpi.setup
 mpi.enforce_variant netcdf-fortran
 
-github.setup        esmf-org esmf 8_0_1 ESMF_
-revision            2
+github.setup        esmf-org esmf 8_2_0 ESMF_
+revision            0
+checksums           rmd160  02dfccd24971fc5e89a5d0be874cf74abd8c2cec \
+                    sha256  3693987aba2c8ae8af67a0e222bea4099a48afe09b8d3d334106f9d7fc311485 \
+                    size    10814914
+
+version             [string map {_ .} ${github.version}]
 categories          science devel
-platforms           darwin
 license             NCSA
 maintainers         {takeshi @tenomoto}
 description         software for building and coupling weather, climate, and related models
@@ -25,24 +29,22 @@ long_description    The ESMF defines an architecture for composing complex, coup
 homepage            https://earthsystemmodeling.org
 github.tarball_from archive
 
-checksums           rmd160  59ded8c9e5db842fe7812c58ae19df98cb4bd9dd \
-                    sha256  9172fb73f3fe95c8188d889ee72fdadb4f978b1d969e1d8e401e8d106def1d84 \
-                    size    11571322
-
-depends_build       bin:ranlib:cctools \
-                    bin:install_name_tool:cctools
+depends_build       bin:ranlib:cctools
 
 depends_lib         port:netcdf \
                     port:netcdf-fortran \
-                    port:xercesc3
+                    port:xercesc3 \
+                    port:yaml-cpp
 
 if {${os.platform} eq "darwin" && ${os.major} < 12} {
     known_fail      yes
     pre-fetch {
-        ui_error "${name} is not supported on Lion or older."
-        error "unsupported platform"
+        ui_error "${name} @{version} requires OS X Mountain Lion or later."
+        return -code error "unsupported Mac OS X version"
     }
 }
+
+patchfiles          install_name.patch
 
 post-patch {
     if {[variant_isset openmpi]} {
@@ -82,8 +84,11 @@ pre-build {
                     ESMF_NETCDF_LIBPATH=${prefix}/lib \
                     ESMF_XERCES=standard \
                     ESMF_XERCES_INCLUDE=${prefix}/include \
-                    ESMF_XERCESF_LIBPATH=${prefix}/lib \
-                    ESMF_XERCES_LIBS=-lxerces-c
+                    ESMF_XERCES_LIBPATH=${prefix}/lib \
+                    ESMF_YAMLCPP=standard \
+                    ESMF_YAMLCPP_INCLUDE=${prefix}/include \
+                    ESMF_YAMLCPP_LIBPATH=${prefix}/lib \
+                    ESMF_INSTALL_LIBDIR=${prefix}/lib
     if {[variant_isset accelerate]} {
         build.env-append    ESMF_LAPACK=system \
                             ESMF_LAPACK_LIBS=-lvecLibFort
@@ -121,8 +126,10 @@ pre-destroot {
                     ESMF_NETCDF_LIBPATH=${prefix}/lib \
                     ESMF_XERCES=standard \
                     ESMF_XERCES_INCLUDE=${prefix}/include \
-                    ESMF_XERCESF_LIBPATH=${prefix}/lib \
-                    ESMF_XERCES_LIBS=-lxerces-c \
+                    ESMF_XERCES_LIBPATH=${prefix}/lib \
+                    ESMF_YAMLCPP=standard \
+                    ESMF_YAMLCPP_INCLUDE=${prefix}/include \
+                    ESMF_YAMLCPP_LIBPATH=${prefix}/lib \
                     ESMF_INSTALL_PREFIX=${destroot}${prefix} \
                     ESMF_INSTALL_HEADERDIR=${destroot}${prefix}/include/${name} \
                     ESMF_INSTALL_MODDIR=${destroot}${prefix}/include/${name} \
@@ -170,28 +177,5 @@ post-destroot {
     file copy ${worksrcpath}/src ${destroot}${prefix}/share/${name}
     system -W ${destroot}${prefix}/lib "ranlib libesmf.a"
     system -W ${destroot}${prefix}/lib "ranlib libesmftrace_static.a"
-    foreach l {libesmf.dylib libesmf_fullylinked.dylib} {
-        if {[file exists ${destroot}${prefix}/lib/${l}]} {
-            system -W ${destroot}${prefix}/lib "
-                install_name_tool -id ${prefix}/lib/${l} ${l}
-            "
-        }
-    }
-    set l "libesmftrace_preload.dylib"
-    if {[file exists ${destroot}${prefix}/lib/${l}]} {
-        system -W ${destroot}${prefix}/lib "
-            install_name_tool -id ${prefix}/lib/${l} ${l}
-            old=`otool -L ${l} | grep libesmf\.dylib | cut -d ' ' -f 1`
-            install_name_tool -change \${old} ${prefix}/lib/libesmf.dylib ${l}
-        "
-    }
-    foreach b {Info InfoC Regrid RegridWeightGen Scrip2Unstruct WebServController} {
-        if {[file exists ${destroot}${prefix}/bin/ESMF_${b}]} {
-            system -W ${destroot}${prefix}/bin "
-                old=`otool -L ESMF_${b} | grep libesmf | cut -d ' ' -f 1`
-                install_name_tool -change \${old} ${prefix}/lib/libesmf.dylib ESMF_${b}
-            "
-        }
-    }
     file delete ${destroot}${prefix}/lib/preload.sh
 }

--- a/science/esmf/files/install_name.patch
+++ b/science/esmf/files/install_name.patch
@@ -1,0 +1,64 @@
+Set library install names at build time. This may not be the best method
+but the build system is nonstandard and complicated and the best way may
+require more restructuring tham I'm prepared to do.
+
+Remove code that rewrites install names at install time which didn't
+work for several reasons:
+
+1. $(wildcard) was evaluated before the dylibs had been created so it
+   expanded to the empty string unless you ran it a second time
+2. The build system doesn't support DESTDIR so we include the dest dir
+   in the value of ESMF_INSTALL_LIBDIR so the rewritten install names
+   would contain the dest dir too
+3. The wrong install names were baked into the executables when they
+   were built and there was no makefile code to rewrite them
+--- build/common.mk.orig	2021-10-26 16:39:51.000000000 -0500
++++ build/common.mk	2022-04-25 18:07:23.000000000 -0500
+@@ -1030,6 +1030,7 @@
+ ESMF_SL_SUFFIX        = so
+ ifeq ($(ESMF_OS),Darwin)
+ ESMF_SL_SUFFIX        = dylib
++ESMF_SL_LIBOPTS       += -install_name $$INSTALLNAME
+ endif
+ ifeq ($(ESMF_OS),Cygwin)
+ ESMF_SL_SUFFIX        = dll.a
+@@ -3883,12 +3884,14 @@
+ 		do \
+ 		if [ -f $$NEXTLIB.$(ESMF_LIB_SUFFIX) ] ; then \
+ 		    $(ESMF_RM) $$NEXTLIB.$(ESMF_SL_SUFFIX) ; \
++		    INSTALLNAME=$(ESMF_INSTALL_LIBDIR_ABSPATH)/$$NEXTLIB.$(ESMF_SL_SUFFIX) ;\
+ 		    echo Converting $$NEXTLIB.a to $$NEXTLIB.$(ESMF_SL_SUFFIX) ;\
+ 		    mkdir tmp_$$NEXTLIB ;\
+ 		    cd tmp_$$NEXTLIB  ;\
+ 	                $(ESMF_AREXTRACT) ../$$NEXTLIB.$(ESMF_LIB_SUFFIX) ;\
+                     echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
+ 		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB.$(ESMF_SL_SUFFIX) *.o $(ESMF_SL_LIBLIBS) ;\
++		    INSTALLNAME=$(ESMF_INSTALL_LIBDIR_ABSPATH)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) ;\
+ 		    echo Converting $$NEXTLIB.$(ESMF_SL_SUFFIX) to $$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) ;\
+                     echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+ 		    $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/$$NEXTLIB\_fullylinked.$(ESMF_SL_SUFFIX) *.o $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) ;\
+--- makefile.orig	2021-10-26 16:39:51.000000000 -0500
++++ makefile	2022-04-25 00:38:29.000000000 -0500
+@@ -677,11 +677,6 @@
+ 	cp -f $(ESMF_MODDIR)/*.mod $(ESMF_INSTALL_MODDIR_ABSPATH)
+ 	mkdir -p $(ESMF_INSTALL_LIBDIR_ABSPATH)
+ 	cp -f $(ESMF_LIBDIR)/libesmf*.* $(ESMF_INSTALL_LIBDIR_ABSPATH)
+-	@for lib in $(wildcard $(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmf*.dylib) foo ; do \
+-	  if [ $$lib != "foo" ]; then \
+-	    install_name_tool -id "$$lib" $$lib ; \
+-	  fi ; \
+-	done
+ ifeq ($(ESMF_TRACE_LIB_BUILD),ON)
+ ifeq ($(ESMF_TRACE_BUILD_SHARED),ON)
+ 	$(MAKE) ESMF_PRELOADDIR=$(ESMF_INSTALL_LIBDIR_ABSPATH) build_preload_script
+--- src/Infrastructure/Trace/preload/makefile.orig	2021-10-26 16:39:51.000000000 -0500
++++ src/Infrastructure/Trace/preload/makefile	2022-04-25 19:25:09.000000000 -0500
+@@ -32,6 +32,8 @@
+ endif
+ 
+ tracelib_preload: preload.o preload_io.o preload_mpi.o wrappers.o wrappers_io.o wrappers_mpi.o
++	@INSTALLNAME=$(ESMF_INSTALL_LIBDIR_ABSPATH)/libesmftrace_preload.$(ESMF_SL_SUFFIX) ;\
++	echo $(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/libesmftrace_preload.$(ESMF_SL_SUFFIX) $^ $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) $(ESMF_TRACE_ESMFLIB) ;\
+ 	$(ESMF_SL_LIBLINKER) $(ESMF_SL_LIBOPTS) -o $(ESMF_LDIR)/libesmftrace_preload.$(ESMF_SL_SUFFIX) $^ $(ESMF_CXXLINKOPTS) $(ESMF_CXXLINKPATHS) $(ESMF_CXXLINKRPATHS) $(ESMF_CXXLINKLIBS) $(ESMF_TRACE_ESMFLIB)
+ 	$(MAKE) ESMF_PRELOADDIR=$(ESMF_LIBDIR) build_preload_script
+ 


### PR DESCRIPTION
#### Description

Update to 8.2.0 and fix port version number (dots instead of underscores between numbers).

Use MacPorts yaml-cpp rather than the possibly older bundled version. 

Remove the post-destroot code that fixed up the install names and instead patch the build system to use the correct install names to begin with.

Fix typo in ESMF_XERCES_LIBPATH environment variable name.

The binary of the previous version was broken due to the update of netcdf in 859375d since there was no subsequent revbump of esmf.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
