### PR TITLE
openjdk17-graalvm: update to 22.1.0

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -12,9 +12,9 @@ license          GPL-2 NoMirror
 universal_variant no
 
 # https://github.com/graalvm/graalvm-ce-builds/releases
-supported_archs  x86_64
+supported_archs  x86_64 arm64
 
-version      22.0.0.2
+version      22.1.0
 revision     0
 
 description  GraalVM Community Edition based on OpenJDK 17
@@ -22,11 +22,18 @@ long_description GraalVM is a universal virtual machine for running applications
                  JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
 
 master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-distname     graalvm-ce-java17-darwin-amd64-${version}
 
-checksums    rmd160  857dd0491c827e52aabe7891d1aaada29f802570 \
-             sha256  d54af9d1f4d0d351827395a714ed84d2489b023b74a9c13a431cc9d31d1e8f9a \
-             size    429797450
+if {${configure.build_arch} eq "x86_64"} {
+    distname     graalvm-ce-java17-darwin-amd64-${version}
+    checksums    rmd160  7e932f8907856537c4fd4a9915d14eb035ebd615 \
+                 sha256  b9327fa73531a822d9a27d25980396353869eefbd73fdcef89b4fceb9f529c75 \
+                 size    444981011
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     graalvm-ce-java17-darwin-aarch64-${version}
+    checksums    rmd160  f13dd6cbc5e41e0d28fd68b8c4091895147fe18b \
+                 sha256  06075cd390bd261721392cd6fd967b1d28c0500d1b5625272ea906038e5cd533 \
+                 size    418107972
+}
 
 worksrcdir   graalvm-ce-java17-${version}
 


### PR DESCRIPTION
#### Description

Update to GraalVM 22.1.0 for Java 17. This update also adds ARM64 support.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?