### PR TITLE
openjdk11-graalvm: update to 22.1.0

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -226,21 +226,29 @@ subport openjdk11-corretto {
 
 subport openjdk11-graalvm {
     # https://github.com/graalvm/graalvm-ce-builds/releases
-    supported_archs  x86_64
+    supported_archs  x86_64 arm64
 
-    version      22.0.0.2
+    version      22.1.0
     revision     0
 
     description  GraalVM Community Edition based on OpenJDK 11
     long_description ${long_description_graalvm}
 
     master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-    distname     graalvm-ce-java11-darwin-amd64-${version}
-    worksrcdir   graalvm-ce-java11-${version}
 
-    checksums    rmd160  d45ec5d0f9dae092471fe1c9381769f23efb08da \
-                 sha256  8280159b8a66c51a839c8079d885928a7f759d5da0632f3af7300df2b63a6323 \
-                 size    418371142
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     graalvm-ce-java11-darwin-amd64-${version}
+        checksums    rmd160  6c4afee0143d6cf4373fa8faf36a6e3eeb4bce22 \
+                     sha256  c4c9df94ca47b83b582758b87d39042732ba0193fc63f1ab93f6818005a1fe6b \
+                     size    435795441
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     graalvm-ce-java11-darwin-aarch64-${version}
+        checksums    rmd160  5e834b8bc8ea1150e1f8f95bdc623a81d904fddc \
+                     sha256  06bc19a0b1e93aa3df5e15c08e97f8cef624cb6070eeae40a69a51ec7fd41152 \
+                     size    404445467
+    }
+
+    worksrcdir   graalvm-ce-java11-${version}
 }
 
 subport openjdk11-openj9 {


### PR DESCRIPTION
#### Description

Update to GraalVM 22.1.0 for Java 11. This update also adds ARM64 support.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?