### PR TITLE
openjdk11-temurin: update to 11.0.15

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -295,13 +295,13 @@ subport openjdk11-sap {
 }
 
 subport openjdk11-temurin {
-    # https://adoptium.net/releases.html?variant=openjdk11&jvmVariant=hotspot
+    # https://adoptium.net/temurin/releases/
     supported_archs  x86_64
 
-    version      11.0.14.1
+    version      11.0.15
     revision     0
 
-    set build    1
+    set build    10
 
     description  Eclipse Temurin, based on OpenJDK 11
     long_description ${long_description_temurin}
@@ -311,9 +311,9 @@ subport openjdk11-temurin {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  256cf096156ca678da017e8768c7f12c841e9c10 \
-                 sha256  8c69808f5d9d209b195575e979de0e43cdf5d0f1acec1853a569601fe2c1f743 \
-                 size    191413871
+    checksums    rmd160  5d66fe3d953619e7a6ca326110654344f1883773 \
+                 sha256  ebd8b9553a7b4514599bc0566e108915ce7dc95d29d49a9b10b8afe4ab7cc9db \
+                 size    186328533
 }
 
 # Remove after 2022-09-14


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin OpenJDK 11.0.15.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?