### PR TITLE
mysql8: update libprotobuf workaround for new protobuf version

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -15,8 +15,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     4
-set revision_server     0
+set revision_client     5
+set revision_server     1
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -194,12 +194,12 @@ if {$subport eq $name} {
             system "$gzip -9vf ${manpage}"
         }
 
-        xinstall -m 755 -o root -d ${destroot}${prefix}/etc/${name_mysql}
+        xinstall -m 0755 -o root -d ${destroot}${prefix}/etc/${name_mysql}
 
         copy ${cmake.build_dir}/macports/macports-default.cnf \
             ${destroot}${prefix}/etc/${name_mysql}/
 
-        xinstall -m 755 -o root -d \
+        xinstall -m 0755 -o root -d \
             ${destroot}${prefix}/share/${name_mysql}/support-files/macports
 
         copy ${cmake.build_dir}/macports/my.cnf \
@@ -212,8 +212,8 @@ if {$subport eq $name} {
 #           ${destroot}${prefix}/doc/${name_mysql}/
 
         # workaround for https://trac.macports.org/ticket/63456
-        ln -s -f ../mysql/libprotobuf-lite.3.11.4.dylib \
-            ${destroot}${prefix}/lib/${name_mysql}/plugin/libprotobuf-lite.3.11.4.dylib
+        ln -s -f ../mysql/libprotobuf-lite.3.19.4.dylib \
+            ${destroot}${prefix}/lib/${name_mysql}/plugin/libprotobuf-lite.3.19.4.dylib
 
     }
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65077

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
