### PR TITLE
google-cloud-sdk: update to 383.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             382.0.0
+version             383.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  87dc2b3b5712989ed7ebdd9d35277157b9705783 \
-                    sha256  4ea3850f3d204a105c960537eae2653ae9fa58c32db1c142c6955d749842950a \
-                    size    106559329
+    checksums       rmd160  f438ef0b5c28c3235a8ed38f9c3a6380927e098c \
+                    sha256  b2af07e82c6ae5adaa0ad22b303d15ea6f2146ad47f26cdb0cd6d753ccee441b \
+                    size    106682635
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1a2808d2153de818ffa59dbc81c3e374553da7d4 \
-                    sha256  f4d2f32068d83e2530b5e2f902423f695e54e396ac21a144274cb48e13db8c6e \
-                    size    103154437
+    checksums       rmd160  472272a12aeb655aa4c825c197c828f0dd6d834f \
+                    sha256  88ec9e58b88b4ee8161a9b7e2923495c9302ebd741dd2e77557a2ce895e96ab3 \
+                    size    103276851
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  aab4cd065baec796a23bdbf15188281cdc69e67c \
-                    sha256  e12e7f334b29b810951c1358aa11e88734f90f1e216d2867ae2650dfabcd81f6 \
-                    size    101742015
+    checksums       rmd160  1df08e88ada6ab91ab1883fb9bc66bce22d89f83 \
+                    sha256  f04ebc3e932c7d5c57af3d82d080af1e13de910059b6516779e790d5e3e1f6a8 \
+                    size    101863708
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 383.0.1.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?