### PR TITLE
LaTeXML: update to upstream version 0.8.6

### DIFF
--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -4,11 +4,10 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                LaTeXML
-version             0.8.5
-checksums           rmd160  22a13fbd2a6bf65f2d65162f6c555bb9b7e2273e \
-                    sha256  1de821d0df8c88041ee10820188f33feac77d5618de4c0798a296a425f4e2637 \
-                    size    13083829
-
+version             0.8.6
+checksums           rmd160  3f71105b7da576ab73e714430626888080716602 \
+                    sha256  9529c651b67f5e8ddef1fd1852f974e756a17b711c46d4118f0677ad0e6e9bb1 \
+                    size    13776498
 license             public-domain
 maintainers         {nist.gov:bruce.miller @brucemiller}
 description         LaTeXML converts TeX to XML/HTML/MathML


### PR DESCRIPTION
#### Description

Updates LaTeXML to version 0.8.6

###### Type(s)

- [ X] bugfix
- [X ] enhancement
- [ ] security fix

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ X] checked your Portfile with `port lint --nitpick`?
- [ X] tried existing tests with `sudo port test`?
- [ X] tried a full install with `sudo port -vst install`?
- [ X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
