### PR TITLE
py-construct: add python310 variant

### DIFF
--- a/python/py-construct/Portfile
+++ b/python/py-construct/Portfile
@@ -15,7 +15,7 @@ categories-append   devel
 license             MIT
 supported_archs     noarch
 
-python.versions     27 37 38 39
+python.versions     27 37 38 39 310
 
 maintainers         {michaelld @michaelld} openmaintainer
 


### PR DESCRIPTION
#### Description

I ran my own tests on a project that uses construct, and saw no issues with python 3.10.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.6 20G165 x86_64
Command Line Tools 12.5.1.0.1.1623191612

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] (n/a) referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] (n/a) tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
