### PR TITLE
hdf5: 1.12.2 and related bumps.

### DIFF
--- a/gis/kealib/Portfile
+++ b/gis/kealib/Portfile
@@ -3,7 +3,7 @@ PortGroup           cmake 1.0
 PortGroup           bitbucket 1.0
 
 bitbucket.setup     chchrsc kealib 1.4.10
-revision            6
+revision            7
 categories          gis
 license             MIT
 maintainers         {vince @Veence}

--- a/graphics/InsightToolkit-devel/Portfile
+++ b/graphics/InsightToolkit-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                InsightToolkit-devel
 version             4.8.2
-revision            10
+revision            11
 categories          graphics devel
 platforms           darwin
 license             Apache

--- a/graphics/field3d/Portfile
+++ b/graphics/field3d/Portfile
@@ -7,7 +7,7 @@ PortGroup               compiler_wrapper 1.0
 
 github.setup            imageworks Field3D 1.7.3 v
 name                    field3d
-revision                3
+revision                4
 
 checksums               rmd160  b540eed98c0c4abf529289e87032d3bdac47be5f \
                         sha256  b4f6e5c6aeb8d014be7d1d9cabc1f9464094f7f287fbfe33a37def2a73549d52 \

--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -10,7 +10,7 @@ PortGroup           boost 1.0
 
 github.setup        ukoethe vigra 1-11-1 Version-
 version             [strsed ${github.version} {g/-/./}]
-revision            14
+revision            15
 categories          graphics
 platforms           darwin
 license             MIT

--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
 github.setup        libvips libvips 8.11.4 v
-revision            0
+revision            1
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.

--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -15,7 +15,7 @@ compiler.blacklist-append {clang < 900}
 
 name                vtk
 version             8.2.0
-revision            10
+revision            11
 categories          graphics devel
 platforms           darwin
 license             BSD

--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 github.setup        BVLC caffe 1de4cebfb81d50267d0d8c2595372b14e1408248
 version             20170817
-revision            17
+revision            18
 
 categories          math science
 maintainers         nomaintainer

--- a/math/deal.ii/Portfile
+++ b/math/deal.ii/Portfile
@@ -9,7 +9,7 @@ PortGroup               boost          1.0
 
 github.setup            dealii dealii 9.3.1 v
 name                    deal.ii
-revision                1
+revision                2
 categories              math science
 license                 LGPL-2.1+
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/math/gnudatalanguage/Portfile
+++ b/math/gnudatalanguage/Portfile
@@ -7,7 +7,7 @@ PortGroup                   mpi 1.0
 PortGroup                   github 1.0
 
 github.setup                gnudatalanguage gdl 1.0.0-rc.3 v
-revision                    10
+revision                    11
 name                        ${github.author}
 epoch                       2
 

--- a/math/mathgl/Portfile
+++ b/math/mathgl/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                mathgl
 version             8.0.1
-revision            0
+revision            1
 categories          math
 license             GPL-3
 maintainers         {mps @Schamschula} openmaintainer

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -9,7 +9,7 @@ PortGroup           linear_algebra 1.0
 name                octave
 version             6.4.0
 set package_version 6.x.x
-revision            2
+revision            3
 
 categories          math science
 platforms           darwin

--- a/math/shogun-devel/Portfile
+++ b/math/shogun-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.0
 name                shogun-devel
 version             4.0.0
 set branch          [join [lrange [split ${version} .] 0 1] .]
-revision            18
+revision            19
 categories          math science
 platforms           darwin
 license             GPL-3

--- a/math/shogun/Portfile
+++ b/math/shogun/Portfile
@@ -6,7 +6,7 @@ PortGroup           compilers 1.0
 name                shogun
 version             2.1.0
 set branch          [join [lrange [split ${version} .] 0 1] .]
-revision            21
+revision            22
 categories          math science
 platforms           darwin
 license             GPL-3

--- a/perl/p5-pdl-io-hdf5/Portfile
+++ b/perl/p5-pdl-io-hdf5/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         PDL-IO-HDF5 0.73
-revision            10
+revision            11
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         PDL::IO::HDF5 - PDL Interface to the HDF5 Data Format.

--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -9,7 +9,7 @@ github.setup            h5py h5py 3.6.0
 name                    py-h5py
 
 # h5py needs to be re-built after hdf5 upgrades
-revision                0
+revision                1
 
 checksums \
     rmd160  d82b683285f063e32fc868e9bc0deb53017e340f \

--- a/python/py-isce2/Portfile
+++ b/python/py-isce2/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           compilers 1.0
 
 github.setup        isce-framework isce2 2.3.2 v
-revision            5
+revision            6
 name                py-isce2
 license             Apache-2
 

--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -7,7 +7,7 @@ PortGroup           mpi 1.0
 name                py-netcdf4
 python.rootname     netCDF4
 version             1.5.8
-revision            0
+revision            1
 
 categories-append   science
 platforms           darwin
@@ -39,7 +39,7 @@ python.versions     27 35 36 37 38 39 310
 if {${name} ne ${subport}} {
     if {${python.version} in "27 35"} {
         version         1.5.3
-        revision        5
+        revision        6
         checksums       rmd160  b855fcb0cc51bf349824ada5129feab9f3911728 \
                         sha256  2a3ca855848f4bbf07fac366da77a681fcead18c0a8813d91d46302f562dc3be \
                         size    790343

--- a/python/py-nio/Portfile
+++ b/python/py-nio/Portfile
@@ -6,7 +6,7 @@ PortGroup compilers 1.0
 
 name                py-nio
 version             1.3.0b1
-revision            21
+revision            22
 categories-append   science
 platforms           darwin
 license             PyNIO

--- a/python/py-pyne/Portfile
+++ b/python/py-pyne/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        pyne pyne 0.4.1
 
-revision            12
+revision            13
 name                py-pyne
 categories-append   science
 platforms           darwin

--- a/python/py-stfio/Portfile
+++ b/python/py-stfio/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-stfio
 version             0.15.8
-revision            6
+revision            7
 categories          python science
 license             GPL-2
 maintainers         {gmx.de:christsc @neurodroid}

--- a/python/py-tables/Portfile
+++ b/python/py-tables/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 
 name                py-tables
 version             3.6.1
-revision            2
+revision            3
 categories-append   science
 platforms           darwin
 license             BSD
@@ -32,7 +32,7 @@ if {${name} ne ${subport}} {
     # Last version that supports python 2.7
     if {${python.version} eq 27} {
         version        3.5.2
-        revision       4
+        revision       5
         distname       ${python.rootname}-${version}
         checksums      rmd160  9e5aa9f3b270888c853eb5f30cd6461a362bb1c1 \
                        sha256  b220e32262bab320aa41d33125a7851ff898be97c0de30b456247508e2cc33c2 \

--- a/science/ALPSCore/Portfile
+++ b/science/ALPSCore/Portfile
@@ -7,7 +7,7 @@ PortGroup           mpi 1.0
 PortGroup           boost 1.0
 
 github.setup        ALPSCore ALPSCore 2.2.0 v
-revision            8
+revision            9
 
 categories          science
 platforms           darwin

--- a/science/ALPSMaxent/Portfile
+++ b/science/ALPSMaxent/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 name                ALPSMaxent
 
 github.setup        CQMP Maxent 1.0 v
-revision            13
+revision            14
 categories          science
 platforms           darwin
 license             GPL-2

--- a/science/AppCSXCAD/Portfile
+++ b/science/AppCSXCAD/Portfile
@@ -12,7 +12,7 @@ version             20210214-[string range ${github.version} 0 7]
 checksums           rmd160  5dae0219f1ec515d03dd20e2a59460871b403a8a \
                     sha256  1a41f9208e716e4b3203cd20b1612a83682533785f3f4da17115bec78ae22f22 \
                     size    18779
-revision            0
+revision            1
 
 platforms           darwin macosx
 categories          science

--- a/science/H5Part/Portfile
+++ b/science/H5Part/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                H5Part
 version             1.6.6
-revision            17
+revision            18
 categories          science
 maintainers         lbl.gov:ghweber
 license             BSD

--- a/science/HDF5-External-Filter-Plugins/Portfile
+++ b/science/HDF5-External-Filter-Plugins/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.0
 
 github.setup        nexusformat HDF5-External-Filter-Plugins 0.1.0 v
-revision            6
+revision            7
 categories          science
 platforms           darwin
 license             BSD MIT

--- a/science/abinit/Portfile
+++ b/science/abinit/Portfile
@@ -6,7 +6,7 @@ PortGroup           linear_algebra 1.0
 
 name                abinit
 version             9.2.2
-revision            1
+revision            2
 categories          science
 platforms           darwin
 license             GPL-3

--- a/science/alps/Portfile
+++ b/science/alps/Portfile
@@ -6,7 +6,7 @@ PortGroup               compilers 1.0
 
 name                    alps
 version                 2.3.0
-revision                11
+revision                12
 checksums               rmd160  40a04447f7c6d26aff0124a3b0f879aedc981ed9 \
                         sha256  a40963811a05ad874e9f02747c532a4873095b94e183ecd31869199f58be1f65 \
                         size    127625225

--- a/science/armadillo/Portfile
+++ b/science/armadillo/Portfile
@@ -6,7 +6,7 @@ PortGroup                       mpi 1.0
 
 name                            armadillo
 version                         11.0.1
-revision                        0
+revision                        1
 categories                      science
 maintainers                     {mps @Schamschula} openmaintainer
 license                         Apache-2

--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,7 +5,7 @@ PortGroup                   mpi 1.0
 
 name                        cdo
 version                     2.0.5
-revision                    0
+revision                    1
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
 license                     GPL-2

--- a/science/cgnslib/Portfile
+++ b/science/cgnslib/Portfile
@@ -7,7 +7,7 @@ PortGroup                   mpi        1.0
 PortGroup                   muniversal 1.0
 
 github.setup                CGNS CGNS 4.1.1 v
-revision                    3
+revision                    4
 name                        cgnslib
 categories                  science
 platforms                   darwin

--- a/science/crystfel/Portfile
+++ b/science/crystfel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                crystfel
 version             0.6.1
-revision            13
+revision            14
 categories          science
 platforms           darwin
 license             GPL-3

--- a/science/digital_rf/Portfile
+++ b/science/digital_rf/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           boost 1.0
 
 github.setup        MITHaystack digital_rf 2.6.1
-revision            12
+revision            13
 
 categories          science
 license             BSD

--- a/science/flann/Portfile
+++ b/science/flann/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           github 1.0
 
 github.setup        mariusmuja flann 1.9.1
-revision            9
+revision            10
 categories          science devel
 maintainers         nomaintainer
 description         Fast Library for Approximate Nearest Neighbors

--- a/science/gds/Portfile
+++ b/science/gds/Portfile
@@ -7,7 +7,7 @@ PortGroup     python 1.0
 
 name          gds
 version       2.18.7
-revision      8
+revision      9
 categories    science
 platforms     darwin
 maintainers   {ligo.org:ed.maros @emaros} openmaintainer

--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -8,7 +8,7 @@ PortGroup               muniversal     1.0
 
 name                    gmsh
 version                 4.9.3
-revision                0
+revision                1
 categories              science
 platforms               darwin
 license                 GPL-2+

--- a/science/gmtk/Portfile
+++ b/science/gmtk/Portfile
@@ -7,7 +7,7 @@ wxWidgets.use       wxWidgets-3.0
 
 name                gmtk
 version             1.4.3
-revision            11
+revision            12
 categories          science
 platforms           darwin
 license             OSL-3

--- a/science/gmtsar/Portfile
+++ b/science/gmtsar/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                gmtsar
 version             5.7
-revision            5
+revision            6
 categories          science
 platforms           darwin
 license             GPL-3

--- a/science/grads/Portfile
+++ b/science/grads/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                grads
 version             2.2.1
-revision            11
+revision            12
 set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 maintainers         {takeshi @tenomoto}

--- a/science/h4h5tools/Portfile
+++ b/science/h4h5tools/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            h4h5tools
 version         2.2.3
-revision        11
+revision        12
 categories      science
 # Equivalent to BSD + explicitly requiring modifications to be documented
 license         Permissive

--- a/science/h5utils/Portfile
+++ b/science/h5utils/Portfile
@@ -5,7 +5,7 @@ PortGroup           mpi 1.0
 
 name                h5utils
 version             1.12.1
-revision            20
+revision            21
 categories          science
 platforms           darwin
 maintainers         ece.pdx.edu:higginja openmaintainer

--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           legacysupport 1.1
 
 name                hdf5
-version             1.12.1
+version             1.12.2
 revision            0
 set shortversion    [join [lrange [split ${version} .] 0 1] .]
 categories          science
@@ -27,9 +27,9 @@ platforms           darwin
 master_sites \
     https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${shortversion}/hdf5-${version}/src
 checksums \
-    rmd160  3b37d7cd6ce728036119311d9bf61956332d44b1 \
-    sha256  aaf9f532b3eda83d3d3adc9f8b40a9b763152218fa45349c3bc77502ca1f8f1c \
-    size    9724309
+    rmd160  87b741689bf74e95617437ec89be3133e63d4f87 \
+    sha256  1a88bbe36213a2cea0c8397201a459643e7155c9dc91e062675b3fb07ee38afe \
+    size    10494264
 mpi.setup           -gcc44 -gcc45
 
 use_bzip2           yes

--- a/science/hdfeos5/Portfile
+++ b/science/hdfeos5/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 
 name                hdfeos5
 version             1.16
-revision            6
+revision            7
 categories          science
 platforms           darwin
 license             public-domain

--- a/science/ismrmrd/Portfile
+++ b/science/ismrmrd/Portfile
@@ -7,7 +7,7 @@ PortGroup               conflicts_build 1.0
 PortGroup               boost 1.0
 
 github.setup            ismrmrd ismrmrd 1.5.0 v
-revision                2
+revision                3
 categories              science
 maintainers             {eborisch @eborisch} openmaintainer
 license                 permissive

--- a/science/lal/Portfile
+++ b/science/lal/Portfile
@@ -5,7 +5,7 @@ PortGroup     compiler_blacklist_versions 1.0
 
 name          lal
 version       7.0.0
-revision      4
+revision      5
 
 description   LSC Algorithm Library
 long_description \

--- a/science/libmed/Portfile
+++ b/science/libmed/Portfile
@@ -6,8 +6,8 @@ PortGroup               cmake     1.1
 
 name                    libmed
 version                 4.0.0
-# 1 rebuild afer upgrading HDF5. Keep revision number even if 0.
-revision                2
+# 2 rebuild afer upgrading HDF5. Keep revision number even if 0.
+revision                3
 patchfiles              patch-hdf5-1.12.diff \
                         patch-test10.diff
 categories              science devel

--- a/science/lscsoft-deps/Portfile
+++ b/science/lscsoft-deps/Portfile
@@ -4,8 +4,8 @@ PortSystem      1.0
 
 name            lscsoft-deps
 version         20200805
-# 1 rebuild afer upgrading HDF5. Keep revision number even if 0.
-revision        4
+# 2 rebuild afer upgrading HDF5. Keep revision number even if 0.
+revision        5
 categories      science
 maintainers     {aronnax @lpsinger} {ligo.org:ed.maros @emaros}
 platforms       darwin

--- a/science/magicspp/Portfile
+++ b/science/magicspp/Portfile
@@ -12,7 +12,7 @@ perl5.branches      5.28
 
 name                magicspp
 version             4.5.1
-revision            5
+revision            6
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             Apache-2

--- a/science/metview/Portfile
+++ b/science/metview/Portfile
@@ -7,7 +7,7 @@ PortGroup boost     1.0
 
 name                metview
 version             5.10.1
-revision            4
+revision            5
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             Apache-2

--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -11,7 +11,7 @@ compilers.allow_arguments_mismatch \
 
 name                        ncarg
 version                     6.6.2
-revision                    9
+revision                    10
 epoch                       1
 set version_no_dot [join [split ${version} "."] ""]
 categories                  science

--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 github.setup        nco nco 5.0.6
-revision            0
+revision            1
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \

--- a/science/ncpp/Portfile
+++ b/science/ncpp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        NCAR ncpp 2.2.6 v
-revision            1
+revision            2
 
 categories          science
 license             permissive

--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -11,7 +11,7 @@ PortGroup                   legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup                Unidata netcdf-c 4.8.1 v
-revision                    0
+revision                    1
 epoch                       3
 name                        netcdf
 maintainers                 {takeshi @tenomoto} openmaintainer

--- a/science/openEMS/Portfile
+++ b/science/openEMS/Portfile
@@ -10,7 +10,7 @@ version             20220215-[string range ${github.version} 0 7]
 checksums           rmd160  671a3209a2a68fcf04cdbb1a6e19a7027c83badc \
                     sha256  50f963d3515b2777139545d4fea1d5cc629861d122359affe5fede0c94d732b5 \
                     size    1727049
-revision            0
+revision            1
 
 platforms           darwin macosx
 categories          science

--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -9,7 +9,7 @@ PortGroup           xcodeversion 1.0
 
 name                paraview
 version             5.6.2
-revision            11
+revision            12
 
 # TODO: Remove, if/when this port is fixed
 known_fail          yes

--- a/science/silo/Portfile
+++ b/science/silo/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 
 name                silo
 version             4.10.2
-revision            12
+revision            13
 categories          science
 platforms           darwin
 license             BSD

--- a/science/stimfit/Portfile
+++ b/science/stimfit/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                stimfit
 version             0.15.8
-revision            6
+revision            7
 categories          science
 platforms           darwin
 license             GPL-2

--- a/science/swarm/Portfile
+++ b/science/swarm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                swarm
 version             2.4.1
-revision            22
+revision            23
 categories          science
 maintainers         nomaintainer
 license             GPL-2

--- a/science/vapor/Portfile
+++ b/science/vapor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                vapor
 version             2.2.4
-revision            25
+revision            26
 categories          science
 maintainers         nomaintainer
 description         interactive 3D scientific visualization environment

--- a/science/wgrib2/Portfile
+++ b/science/wgrib2/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                wgrib2
 version             3.0.2
-revision            0
+revision            1
 platforms           darwin
 maintainers         {takeshi @tenomoto}
 license             public-domain

--- a/science/xdmf/Portfile
+++ b/science/xdmf/Portfile
@@ -6,7 +6,7 @@ PortGroup               boost 1.0
 
 name                    xdmf
 version                 3.0.0
-revision                6
+revision                7
 categories              science devel
 # cannot find license, assume same as ParaView
 license                 BSD

--- a/textproc/CSXCAD/Portfile
+++ b/textproc/CSXCAD/Portfile
@@ -10,7 +10,7 @@ version             20210708-[string range ${github.version} 0 7]
 checksums           rmd160  23fd866935410e9fc15bbb3894bed273128eb685 \
                     sha256  ae6e8e993c40c62f6e23dcaac45ccf60170a91d9cc0a247f8e552f61f5832271 \
                     size    169153
-revision            0
+revision            1
 
 platforms           darwin macosx
 categories          textproc


### PR DESCRIPTION
Maintainer update.

HDF5 1.12.2 and all ports advertising dependency on hdf5.

[Release notes](https://www.hdfgroup.org/2022/04/release-of-hdf5-1-12-2-newsletter-183/).

Tagging listed maintainers:

@BSeppke
@MarcusCalhoun-Lopez
@Schamschula
@Veence
@egull
@emaros
@galexv
@jcupitt
@jjstickel
@johndesanto
@jswhit
@lpsinger
@mf2k
@mtorrent
@neurodroid
@petrrr
@piyushrpt
@ra1nb0w
@ryanvolz
@stromnov
@tenomoto