### PR TITLE
openjdk-distributions: remove replaced distributions

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -190,13 +190,6 @@ subport openjdk8-temurin {
                  size    108075347
 }
 
-# Remove after 2022-04-30
-subport openjdk8-openj9-large-heap {
-    version      8u282
-    revision     2
-    replaced_by  openjdk8-openj9
-}
-
 subport openjdk11-corretto {
     # https://github.com/corretto/corretto-11/releases
     supported_archs  x86_64 arm64
@@ -273,13 +266,6 @@ subport openjdk11-openj9 {
     checksums    rmd160  d434bc2fdc141267e2b46862494a2aedeac05327 \
                  sha256  215e1ff6fa821309548253653e74025d6a830180abe6001db7717fde4eb991d9 \
                  size    203401477
-}
-
-# Remove after 2022-04-30
-subport openjdk11-openj9-large-heap {
-    version      11.0.10
-    revision     2
-    replaced_by  openjdk11-openj9
 }
 
 subport openjdk11-sap {


### PR DESCRIPTION
#### Description

Remove `openjdk8-openj9-large-heap` and `openjdk11-openj9-large-heap`, which were previously marked as replaced.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?