### PR TITLE
git: fix destroot on Tiger

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -161,8 +161,14 @@ post-destroot {
     xinstall -m 755 ${worksrcpath}/contrib/subtree/git-subtree.sh \
         ${destroot}${prefix}/libexec/git-core/git-subtree
 
-    system "echo exec wish \"'${guidir}/Resources/Scripts/AppMain.tcl'\" '\"$@\"' > \
-        '${destroot}${guidir}/MacOS/Wish'"
+    # Tiger doesn't build the GUI, so check for its existence before mucking with it
+    if {[file exists "${destroot}${guidir}"]} {
+        # The executable could be "Wish" or "Wish Shell", depending on the OS version
+        set wish_executable [exec defaults read ${destroot}${guidir}/Info CFBundleExecutable]
+        # The system-provided Tk is now deprecated, so use the MacPorts version if available.
+        system "echo exec wish \"'${guidir}/Resources/Scripts/AppMain.tcl'\" '\"$@\"' > \
+            '${destroot}${guidir}/MacOS/${wish_executable}'"
+    }
 
     file delete -force ${share_path}/contrib
     copy ${worksrcpath}/contrib ${share_path}


### PR DESCRIPTION
#### Description

The new Git GUI override logic (https://github.com/macports/macports-ports/commit/4bfc47deb6919ff5a90fdf8c6b90317586324322) fails on Tiger because the application bundle isn't built at all there. Add a check before writing to the executable path, and add some extra logic to ensure the executable name matches the one in Info.plist. (It's "Wish Shell" on 10.4, "Wish" on 10.6+, not sure about 10.5 but this handles either case.)
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
