### PR TITLE
R: fix zoneinfo location on 10.12 and earlier

### DIFF
--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -8,7 +8,7 @@ PortGroup active_variants 1.1
 name                        R
 # Remember to set revision to 0 when bumping version
 version                     4.2.0
-revision                    0
+revision                    1
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
@@ -74,6 +74,13 @@ post-patch {
 
     # Check to see if this is fixed post 3.3.0
     reinplace "s|<libintl.h>|\"libintl.h\"|" "${worksrcpath}/src/include/Defn.h"
+
+    if {${os.platform} eq "darwin" && ${os.major} < 17} {
+        reinplace "s|/var/db/timezone/zoneinfo|/usr/share/zoneinfo|g" \
+            "${worksrcpath}/src/extra/tzone/localtime.c" \
+            "${worksrcpath}/src/library/base/man/timezones.Rd" \
+            "${worksrcpath}/src/library/base/R/datetime.R"
+    }
 }
 
 # Note: gcc cannot be used for the C compiler. It will give:


### PR DESCRIPTION
#### Description

Patch adapted from @kencu's TigerPorts

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
