### PR TITLE
detekt-cli: Add variant which includes the first party formatting plugin

### DIFF
--- a/java/detekt-cli/Portfile
+++ b/java/detekt-cli/Portfile
@@ -21,6 +21,11 @@ description         CLI tool for detekt
 long_description    Detekt is a static code analysis tool for Kotlin.
 homepage            https://detekt.github.io
 
+variant formatting description {Include the formatting plugin} {
+    build.target-append \
+        detekt-formatting:jar
+}
+
 github.tarball_from archive
 
 distname            v${version}
@@ -41,6 +46,10 @@ destroot {
     set javadir ${destroot}${prefix}/share/java
     xinstall -m 755 -d ${javadir}/${name}
     xinstall -m 644 ${worksrcpath}/${name}/build/libs/${name}-${buildversion}-all.jar ${javadir}/${name}/${name}.jar
+
+    if {[variant_isset formatting]} {
+        xinstall -m 644 ${worksrcpath}/detekt-formatting/build/libs/detekt-formatting-${buildversion}.jar ${javadir}/${name}/detekt-formatting.jar
+    }
 
     # Install the wrapper script
     xinstall -m 755 ${filespath}/detekt ${destroot}${prefix}/bin

--- a/java/detekt-cli/files/detekt
+++ b/java/detekt-cli/files/detekt
@@ -1,2 +1,21 @@
-#!/bin/sh
-java -cp _PREFIX_/share/java/detekt-cli/detekt-cli.jar io.gitlab.arturbosch.detekt.cli.Main "$@"
+#!/bin/bash
+
+OPTS=$@
+
+# Add formatting plugin to the command for the +formatting variant, additionally to user provided plugins.
+if [ -f _PREFIX_/share/java/detekt-cli/detekt-formatting.jar ]; then
+    while [ $# -gt 0 ]; do
+        case $1 in
+            -p | --plugins)
+                ADDITIONAL_PLUGINS=",$2"
+                OPTS=${OPTS/$1/}
+                OPTS=${OPTS/$2/}
+                ;;
+        esac
+        shift
+    done
+
+    PLUGINOPTS="--plugins _PREFIX_/share/java/detekt-cli/detekt-formatting.jar$ADDITIONAL_PLUGINS"
+fi
+
+java -cp _PREFIX_/share/java/detekt-cli/detekt-cli.jar io.gitlab.arturbosch.detekt.cli.Main $PLUGINOPTS $OPTS


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Add a `formatting` variant, so users do not need to download and apply this first party plugin manually on each `detekt-cli` update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
