### PR TITLE
MoltenVK: update to v1.1.9

### DIFF
--- a/graphics/MoltenVK/Portfile
+++ b/graphics/MoltenVK/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        KhronosGroup MoltenVK 1.1.17 v
+github.setup        KhronosGroup MoltenVK 1.1.9 v
+epoch               1
 
-set sdkversion      1.3.204.0
+set sdkversion      1.3.211.0
 categories          graphics
 maintainers         {ryandesign @ryandesign} openmaintainer
 platforms           macosx
@@ -26,9 +27,9 @@ use_dmg             yes
 # url only works for the latest avalible SDK, older versions will 404
 master_sites        https://sdk.lunarg.com/sdk/download/${sdkversion}/mac/
 
-checksums           sha256  476d451930a1a7faf358c5dcf603fe13c608e6b3e6805e7819ea75de88650aa6 \
-                    rmd160  212106347414e738d26922050e518647d384ed96 \
-                    size    265266478
+checksums           sha256  bfe654af00030b6e65521f834f0830f15e18c828594226865f15c92a9ea68363 \
+                    rmd160  3674f67b37f7bcc1746d55c3baa975d0cca9dbaa \
+                    size    275553243
 
 depends_build       port:p7zip
 depends_skip_archcheck p7zip
@@ -59,13 +60,13 @@ destroot {
 }
 
 platform darwin {
-    if {${os.major} < 15} {
+    if {${os.major} < 16} {
         archive_sites
         distfiles
         depends_build
         known_fail  yes
         pre-fetch {
-            ui_error "${subport} @${version} requires OS X El Capitan or later"
+            ui_error "${subport} @${version} requires macOS Sierra or later"
             return -code error "incompatible OS X version"
         }
     }


### PR DESCRIPTION
Supersedes https://github.com/macports/macports-ports/pull/14071

The VulkanSDK packages are using APFS so this method won’t work on on. OS X 10.11

Version was wrong so this was also corrected

Bumped the most recent VulkanSDK

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6.5 20G527 arm64
Xcode 13.2.1 13C100

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
