### PR TITLE
openjdk17-openj9: update to 17.0.3

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -12,13 +12,13 @@ license          GPL-2 NoMirror
 universal_variant no
 
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
-supported_archs  x86_64
+supported_archs  x86_64 arm64
 
-version      17.0.2
+version      17.0.3
 revision     0
 
-set build    8
-set openj9_version 0.30.0
+set build    7
+set openj9_version 0.32.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -26,10 +26,17 @@ long_description The IBM Semeru Runtimes are free production-ready open source b
 
 master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
 
-distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-checksums    rmd160  501fdff9007a1333496e86dd49275d4dc5d11735 \
-             sha256  fbbc233c187b6cbc9c62a850617fc9a7764686ed2686c9c106ca98f9f1d24e59 \
-             size    207963045
+if {${configure.build_arch} eq "x86_64"} {
+    distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
+    checksums    rmd160  60056a13b8e1b82d6e892a410d9902aac0f8ab17 \
+                 sha256  b4439c09ee0916a328f8aa8e4bd98e45b3621bbb3e2ecc59b81f98fa2ec7704a \
+                 size    208108149
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
+    checksums    rmd160  6b81cbede0f3116a9c73f8db3a76084da6a5ffa2 \
+                 sha256  14d7a9f8aed106bdf964882fe693073ee73dffa06fe3878ce57a8c0e5737364b \
+                 size    184852257
+}
 
 worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.3, which also adds ARM64 support.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?