### PR TITLE
openjdk11-openj9: update to 11.0.15

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -246,13 +246,13 @@ subport openjdk11-graalvm {
 
 subport openjdk11-openj9 {
     # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
-    supported_archs  x86_64
+    supported_archs  x86_64 arm64
 
-    version      11.0.14.1
+    version      11.0.15
     revision     0
 
-    set build    1
-    set openj9_version 0.30.1
+    set build    10
+    set openj9_version 0.32.0
 
     homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
@@ -261,11 +261,20 @@ subport openjdk11-openj9 {
 
     master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}
 
-    checksums    rmd160  d434bc2fdc141267e2b46862494a2aedeac05327 \
-                 sha256  215e1ff6fa821309548253653e74025d6a830180abe6001db7717fde4eb991d9 \
-                 size    203401477
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
+        checksums    rmd160  2d8d7a2633be194c0975642e9b3ef070c9f55a97 \
+                     sha256  53d18ed227d02ebc73344255a07b6331aa7d990abfd12fce1396376afcfd17cc \
+                     size    203564021
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
+        checksums    rmd160  5c09b0cd81b4466b320a7c997c9ba2eaf67933f6 \
+                     sha256  f71a81f3496ad5cda9bb1f2f23dbb47360202dedca126cf8e92437b3f017d11e \
+                     size    180597648
+    }
+
+    worksrcdir   jdk-${version}+${build}
 }
 
 subport openjdk11-sap {


### PR DESCRIPTION
#### Description

Update to IBM Semeru with Eclipse OpenJ9, based on OpenJDK 11.0.15. This version also adds ARM64 support.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?