### PR TITLE
openssl3: Update to 3.0.3

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            3
+revision            4
 
 categories          devel security
 platforms           darwin

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 8
 
 set major_v         3
 name                openssl$major_v
-version             ${major_v}.0.2
+version             ${major_v}.0.3
 revision            0
 
 # Please revbump these ports when updating the openssl3 version/revision
@@ -47,9 +47,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  e85a309de8dbb06553f24c297635539ffa09c643 \
-                    sha256  98e91ccead4d4756ae3c9cde5e09191a8e586d9f4d50838e7ec09d6411dfdb63 \
-                    size    15038141
+checksums           rmd160  40979ca9ff4a4dd57fdb579ced7124e66885c954 \
+                    sha256  ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b \
+                    size    15058905
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             9.0p1
-revision            3
+revision            4
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                6
+revision                7
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
#### Description

This additionally fixes a crash when using the tr_TR locale.

See https://www.openssl.org/news/secadv/20220503.txt for the advisory.

CVE: CVE-2022-1292, CVE-2022-1343, CVE-2022-1434, CVE-2022-1473

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.5 20G527 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~ <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] ~tried existing tests with `sudo port test`?~
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
