### PR TITLE
openjdk8-temurin: update to 8u332

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -170,13 +170,13 @@ subport openjdk8-openj9 {
 }
 
 subport openjdk8-temurin {
-    # https://adoptium.net/releases.html?variant=openjdk8&jvmVariant=hotspot
+    # https://adoptium.net/temurin/releases/
     supported_archs  x86_64
 
-    version      8u322
+    version      8u332
     revision     0
 
-    set build    06
+    set build    09
 
     description  Eclipse Temurin, based on OpenJDK 8
     long_description ${long_description_temurin}
@@ -185,9 +185,9 @@ subport openjdk8-temurin {
     distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  335f1bfa3cee50eee7da9d78514dd28e665ae553 \
-                 sha256  96a3124bf0f5ca777954239893cc89ea34c4bc9a9b7c1559aa2c69baa0ee84e3 \
-                 size    108075347
+    checksums    rmd160  20fa5b11b34ee833b62cca7d9d7d6f76b9047759 \
+                 sha256  a75e8182bb8e77a02c7b4d9f93120c64c1988e2c415b3646d4f4496544e87291 \
+                 size    107924497
 }
 
 subport openjdk11-corretto {


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin based on OpenJDK 8u332.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?