### PR TITLE
jdk18: new submission

### DIFF
--- a/java/jdk18/Portfile
+++ b/java/jdk18/Portfile
@@ -1,0 +1,89 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             jdk18
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          NFTC NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://www.oracle.com/java/technologies/downloads/#jdk18-mac
+version      18.0.1.1
+revision     0
+
+description  Oracle Java SE Development Kit 18
+long_description Java Platform, Standard Edition Development Kit (JDK). \
+    The JDK is a development environment for building applications and components using the Java programming language. \
+    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
+
+master_sites https://download.oracle.com/java/18/archive/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     jdk-${version}_macos-x64_bin
+    checksums    rmd160  6d2ef8078d83071789cc0cc2304072cb53c2eb68 \
+                 sha256  32b228166cc176ced7dd699a082e3d520c3ddd499bc138118a045d7279c4042c \
+                 size    178751801
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  3d6805ecbbb2828d65ff87039939bb0a84529734 \
+                 sha256  5bde851b4b666b8d16119f988eb96a83e36de7b4db40f76cf0b39fbe8388eccf \
+                 size    176605563
+}
+
+worksrcdir   jdk-${version}.jdk
+
+homepage     https://www.oracle.com/java/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for the Oracle Java SE 18 Development Kit.

Note that this is not the same as what's provided by the existing `openjdk18-oracle` port. This port is not for the GPL-licensed Oracle OpenJDK, but for the [NFTC](https://java.com/freeuselicense)-licensed Oracle Java SE JDK.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?