### PR TITLE
openjdk11-microsoft: new submission

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -1,0 +1,91 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk11-microsoft
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
+supported_archs  x86_64 arm64
+
+set build 7
+
+version      11.0.14.1
+set build    1
+revision     0
+
+description  Microsoft Build of OpenJDK 11 (Long Term Support)
+long_description The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source \
+    and available for free for anyone to deploy anywhere.
+
+master_sites https://aka.ms/download-jdk/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     microsoft-jdk-${version}_${build}-31205-macOS-x64
+    checksums    rmd160  5928c9a73b7f2d812a675674a48eeda4ce86d02e \
+                 sha256  03a6c1da0d4f8aacf0f01ba7306666251bd3119b4e1b7b049951b5a7505c9894 \
+                 size    186963275
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     microsoft-jdk-${version}_${build}-31206-macOS-aarch64
+    checksums    rmd160  cf9a4eab103bc95bc0988068856421bca23e9aa6 \
+                 sha256  ceaedbed620ec7afda21a37b2884db1f345e67bb6c4deba71965d6e223ef5d43 \
+                 size    184354992
+}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://www.microsoft.com/openjdk
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for the Microsoft build of OpenJDK 11.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?