### PR TITLE
google-cloud-sdk: update to 384.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             383.0.1
+version             384.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f438ef0b5c28c3235a8ed38f9c3a6380927e098c \
-                    sha256  b2af07e82c6ae5adaa0ad22b303d15ea6f2146ad47f26cdb0cd6d753ccee441b \
-                    size    106682635
+    checksums       rmd160  e5f6bd8d572de6d8497ee20fb9a637423eb380b3 \
+                    sha256  cb0d80a70a5fc2d64594267aab3b7a21da0f9eeec8e1ca79fa940c7eb915695d \
+                    size    106733091
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  472272a12aeb655aa4c825c197c828f0dd6d834f \
-                    sha256  88ec9e58b88b4ee8161a9b7e2923495c9302ebd741dd2e77557a2ce895e96ab3 \
-                    size    103276851
+    checksums       rmd160  4abe055edbc13629a13dae4cc4eddfa8e91f6951 \
+                    sha256  a371506ed0bc2cd208dcb9eb27141d32959a9d47bed2775a14d5ef27aba367bb \
+                    size    103326292
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  1df08e88ada6ab91ab1883fb9bc66bce22d89f83 \
-                    sha256  f04ebc3e932c7d5c57af3d82d080af1e13de910059b6516779e790d5e3e1f6a8 \
-                    size    101863708
+    checksums       rmd160  d5224c584fd815a78e2b6638c77819c4ef853814 \
+                    sha256  7fd64baeab4b9cf9d03776419f441704576233d982a3f649aff78e289a8338ec \
+                    size    101914656
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 384.0.0.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?