### PR TITLE
nco: update to 5.0.7

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.0.6
-revision            1
+github.setup        nco nco 5.0.7
+revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
@@ -21,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  1671b0b9d110628860813f9bc0fcd1944fdf02fc \
-                    sha256  b8f8b02d0eab3be6bac8334cc370ca57ddbdaaffc8219f527b9e35ef4452247e \
-                    size    5772035
+checksums           rmd160  78605b2a1a5b21d29b88f23a3673613879f7cba3 \
+                    sha256  f52e0215d9eead5d97fba87a42216f2143efafe22c85e834340ef3622a2c1559 \
+                    size    5802315
 
 homepage            http://nco.sourceforge.net/
 long_description \
@@ -60,10 +60,7 @@ configure.cppflags-append   -I${prefix}/include/udunits2 \
 configure.ldflags-append    -lxerces-c
 configure.args      --disable-dependency-tracking \
                     --mandir=${prefix}/share/man  \
-                    --enable-udunits2             \
-                    --enable-dap                  \
-                    --enable-netcdf4              \
-                    --disable-esmf                \
+                    --disable-shared              \
                     --disable-openmp
 
 if {[gcc_variant_isset] || [clang_variant_isset]} {
@@ -95,10 +92,7 @@ variant mpich description {enable MPI with mpich (currently MPI is not supported
 variant openmpi description {enable MPI with openmpi (currently MPI is not supported)} {
 }
 
-variant esmf description {use ESMF (Earth System Modeling Framework)} {
-    configure.args-delete   --disable-esmf
-    configure.args-append   --enable-esmf
-    depends_lib-append      port:esmf
+variant esmf description {use ESMF (Earth System Modeling Framework) (is no longer supported)} {
 }
 
 github.livecheck.regex      {([^"rba]+)}


### PR DESCRIPTION
#### Description
Update to upstream version 5.0.7.

En passant:
* esmf variant is no longer supported by nco, so removed --{dis,en}able-esmf
* added --disable-shared, since configure says it is on by default, though it is not
* removed --enable-{udunits2,dap,netcdf4} as they are on by default

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode Command Line Tools 13.3.1.0.1.1648687083

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
