### PR TITLE
openjdk17-sap: update to 17.0.3.0.1

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.3
+version      17.0.3.0.1
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  14df5f12eecd43df3bcf781b4b702a497d463507 \
-                 sha256  eb3dc4f099b3038368e7cd0762d7820f07d64fc6bc880ae5e8606ece1b32b1c0 \
-                 size    180138613
+    checksums    rmd160  b1217f1a052174942bb2b574ff4010103ed3f62e \
+                 sha256  9757e310fdd10183d986b3ce0421b9ab96ceefa97526f5ed90b8cd364abae54e \
+                 size    180146803
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  0425307ac13bf1506ce6e170b977c7fe6af404ba \
-                 sha256  5b1718288aea89aa22db1dc71388a9ffeae9befe2c8a057af4d8103daef5fcdb \
-                 size    177915159
+    checksums    rmd160  2b4a804e27b56054d0ec2a57bf2d3d2e56a446c5 \
+                 sha256  e1653c1ad4bb5fbd317e30796271c6d0cb4e2964efd2c80c07c518ea92127062 \
+                 size    177919228
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.3.0.1.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?