### PR TITLE
openjdk*: Variant conflicts; default variants

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -33,12 +33,6 @@ pre-patch {
     reinplace "s|assert|vmassert|g" ${worksrcpath}/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
 }
 
-if {${os.major} < 16} {
-    default_variants    +zero +release
-} else {
-    default_variants    +server +release
-}
-
 set tpath /Library/Java
 use_configure    yes
 configure.cmd       ${prefix}/bin/bash configure
@@ -63,42 +57,50 @@ configure.args      --with-debug-level=release \
                     --with-conf-name=openjdk11
 
 variant release \
+    conflicts debug optimized \
     description {OpenJDK with no debug information, all optimizations and no asserts} {
     configure.args-append   --with-debug-level=release
 }
 
 variant optimized \
+    conflicts debug release \
     description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
     configure.args-append   --with-debug-level=optimized
 }
 
 variant debug \
+    conflicts optimized release \
     description {OpenJDK with debug information, all optimizations and all asserts} {
     configure.args-append   --with-debug-level=fastdebug
     configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \
+    conflicts core minimal server zero \
     description {JVM with normal interpreter, C1 and no C2 compiler} {
     configure.args-append   --with-jvm-variants=client
 }
 
 variant server \
+    conflicts client core minimal zero \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {
     configure.args-append   --with-jvm-variants=server
 }
 
 variant minimal \
+    conflicts client core server zero \
     description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
     configure.args-append   --with-jvm-variants=minimal
 }
 
 variant core \
+    conflicts client minimal server zero \
     description {JVM with normal interpreter only and no compiler} {
     configure.args-append   --with-jvm-variants=core
 }
 
 variant zero \
+    conflicts client core minimal server \
     description {JVM with C++ based interpreter only, no compiler} {
     post-patch {
         reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4
@@ -107,6 +109,18 @@ variant zero \
                             --with-libffi=${prefix} \
                             --enable-libffi-bundling
     depends_lib-append         port:libffi
+}
+
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server] && ![variant_isset zero]} {
+    if {${os.platform} eq "darwin" && ${os.major} < 16} {
+        default_variants-append +zero
+    } else {
+        default_variants-append +server
+    }
 }
 
 if {${configure.build_arch} eq "arm64"} {

--- a/java/openjdk13/Portfile
+++ b/java/openjdk13/Portfile
@@ -29,12 +29,6 @@ depends_build       port:autoconf \
                     port:bash \
                     port:openjdk13-bootstrap
 
-if {${os.major} < 16} {
-    default_variants    +zero +release
-} else {
-    default_variants    +server +release
-}
-
 set tpath /Library/Java
 use_configure    yes
 configure.cmd       ${prefix}/bin/bash configure
@@ -62,42 +56,50 @@ configure.args      --with-debug-level=release \
                     --with-conf-name=openjdk13
 
 variant server \
+    conflicts client core minimal zero \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {
     configure.args-append   --with-jvm-variants=server
 }
 
 variant release \
+    conflicts debug optimized \
     description {OpenJDK with no debug information, all optimizations and no asserts} {
     configure.args-append   --with-debug-level=release
 }
 
 variant optimized \
+    conflicts debug release \
     description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
     configure.args-append   --with-debug-level=optimized
 }
 
 variant debug \
+    conflicts optimized release \
     description {OpenJDK with debug information, all optimizations and all asserts} {
     configure.args-append  --with-debug-level=fastdebug
     configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \
+    conflicts core minimal server zero \
     description {JVM with normal interpreter, C1 and no C2 compiler} {
     configure.args-append   --with-jvm-variants=client
 }
+
 variant minimal \
+    conflicts client core server zero \
     description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
     configure.args-append   --with-jvm-variants=minimal
 }
 
 variant core \
-    conflicts server client minimal \
+    conflicts client minimal server zero \
     description {JVM with normal interpreter only and no compiler} {
     configure.args-append   --with-jvm-variants=core
 }
 
 variant zero \
+    conflicts client core minimal server \
     description {JVM with C++ based interpreter only, no compiler} {
     post-patch {
         reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4
@@ -106,6 +108,18 @@ variant zero \
                             --with-libffi=${prefix} \
                             --enable-libffi-bundling
     depends_lib-append         port:libffi
+}
+
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server] && ![variant_isset zero]} {
+    if {${os.platform} eq "darwin" && ${os.major} < 16} {
+        default_variants-append +zero
+    } else {
+        default_variants-append +server
+    }
 }
 
 build.type          gnu

--- a/java/openjdk15/Portfile
+++ b/java/openjdk15/Portfile
@@ -24,8 +24,6 @@ depends_build       port:autoconf \
                     port:bash \
                     port:openjdk15-bootstrap
 
-default_variants    +server +release
-
 set tpath /Library/Java
 use_configure    yes
 configure.cmd       ${prefix}/bin/bash configure
@@ -59,36 +57,50 @@ configure.args      --with-debug-level=release \
                     --with-conf-name=release
 
 variant server \
+    conflicts client core minimal \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {}
 
 variant release \
+    conflicts debug optimized \
     description {OpenJDK with no debug information, all optimizations and no asserts} {}
 
 variant optimized \
+    conflicts debug release \
     description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
     configure.args-replace   --with-debug-level=release --with-debug-level=optimized
 }
 
 variant debug \
+    conflicts optimized release \
     description {OpenJDK with debug information, all optimizations and all asserts} {
     configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
     configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \
+    conflicts core minimal server \
     description {JVM with normal interpreter, C1 and no C2 compiler} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=client
 }
 
 variant minimal \
+    conflicts client core server \
     description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=minimal
 }
 
 variant core \
-    conflicts server client minimal \
+    conflicts client minimal server \
     description {JVM with normal interpreter only and no compiler} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=core
+}
+
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server]} {
+    default_variants-append +server
 }
 
 build.type          gnu

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -26,8 +26,6 @@ depends_build       port:autoconf \
 patchfiles          patch-openjdk17-build1.diff \
                     0001-8280476-macOS-hotspot-arm64-bug-exposed-by-latest-cl.patch
 
-default_variants    +server +release
-
 set tpath /Library/Java
 use_xcode           yes
 use_configure    yes
@@ -61,36 +59,50 @@ configure.args      --with-debug-level=release \
                     --with-conf-name=release
 
 variant server \
+    conflicts client core minimal \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {}
 
 variant release \
+    conflicts debug optimized \
     description {OpenJDK with no debug information, all optimizations and no asserts} {}
 
 variant optimized \
+    conflicts debug release \
     description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
     configure.args-replace   --with-debug-level=release --with-debug-level=optimized
 }
 
 variant debug \
+    conflicts optimized release \
     description {OpenJDK with debug information, all optimizations and all asserts} {
     configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
     configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \
+    conflicts core minimal server \
     description {JVM with normal interpreter, C1 and no C2 compiler} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=client
 }
 
 variant minimal \
+    conflicts client core server \
     description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=minimal
 }
 
 variant core \
-    conflicts server client minimal \
+    conflicts client minimal server \
     description {JVM with normal interpreter only and no compiler} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=core
+}
+
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server]} {
+    default_variants-append +server
 }
 
 build.type          gnu

--- a/java/openjdk18/Portfile
+++ b/java/openjdk18/Portfile
@@ -22,8 +22,6 @@ depends_build       port:autoconf \
                     port:gmake
 depends_lib         port:openjdk17-bootstrap
 
-default_variants    +server +release
-
 set tpath /Library/Java
 use_xcode           yes
 use_configure    yes
@@ -57,38 +55,51 @@ configure.args      --with-debug-level=release \
                     --with-conf-name=release
 
 variant server \
+    conflicts client core minimal \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {}
 
 variant release \
+    conflicts debug optimized \
     description {OpenJDK with no debug information, all optimizations and no asserts} {}
 
 variant optimized \
+    conflicts debug release \
     description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
     configure.args-replace   --with-debug-level=release --with-debug-level=optimized
 }
 
 variant debug \
+    conflicts optimized release \
     description {OpenJDK with debug information, all optimizations and all asserts} {
     configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
     configure.args-delete   --with-native-debug-symbols=none
 }
 
 variant client \
+    conflicts core minimal server \
     description {JVM with normal interpreter, C1 and no C2 compiler} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=client
 }
 
 variant minimal \
+    conflicts client core server \
     description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=minimal
 }
 
 variant core \
-    conflicts server client minimal \
+    conflicts client minimal server \
     description {JVM with normal interpreter only and no compiler} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=core
 }
 
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server]} {
+    default_variants-append +server
+}
 
 build.type          gnu
 build.target        images

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -29,8 +29,6 @@ depends_build       port:autoconf \
                     port:bash \
                     port:openjdk8-bootstrap
 
-default_variants    +server +release
-
 set tpath /Library/Java
 use_xcode           yes
 use_configure    yes
@@ -61,12 +59,15 @@ configure.args      --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk8-b
                     --with-conf-name=release
 
 variant server \
+    conflicts core \
     description {JVM with normal interpreter and a tiered C1/C2 compiler} {}
 
 variant release \
+    conflicts debug \
     description {OpenJDK with no debug information, all optimizations and no asserts} {}
 
 variant debug \
+    conflicts release \
     description {OpenJDK with debug information, all optimizations and all asserts} {
     configure.args-replace  --with-debug-level=release --with-debug-level=fastdebug
     configure.args-delete   --with-native-debug-symbols=none
@@ -76,6 +77,14 @@ variant core \
     conflicts server \
     description {JVM with interpreter only and no compiler} {
     configure.args-replace   --with-jvm-variants=server --with-jvm-variants=core
+}
+
+if {![variant_isset debug] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset core] && ![variant_isset server]} {
+    default_variants-append +server
 }
 
 build.type          gnu


### PR DESCRIPTION
#### Description

Most of these ports' variants did not declare conflicts with one another but I believe they need to. I am assuming that only one of the variants that sets `--with-debug-level` can be used at a time and only one of the variants that sets `--with-jvm-variants` can be used at a time. I've set the variant conflicts based on that.

I've fixed the usage of `default_variants` so that if a user selects a different variant a conflict will no longer occur.

Closes: https://trac.macports.org/ticket/65038

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
