### PR TITLE
gopass: update to 1.14.1

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.14.0 v
+go.setup            github.com/gopasspw/gopass 1.14.1 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  995a213908b3a1c055549eaff1e20ad9dde47154 \
-                        sha256  bece68def504fba984758106580e5e9df80975a1cbd417989cc40b4a8f4d991c \
-                        size    2209420
+                        rmd160  85bdc852a714df87fc2613bec37b3afe5651c6c3 \
+                        sha256  47f5f19f4fba370308b9272bbe03eae93fce6baa642d2360bdf2062b1eb2eb8b \
+                        size    2214786
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -44,10 +44,10 @@ go.vendors          rsc.io/qr \
                         size    32368 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.27.1 \
-                        rmd160  a4ac7b66fd88a34a9ea447476d19ff3c1f2b57dd \
-                        sha256  fe1055b9bf6b8792aed1771f56c31f836c24a18d69eaeb13c88990db3d9da7ce \
-                        size    1278850 \
+                        lock    v1.28.0 \
+                        rmd160  076cb79b7651b0fdc12168a43cdc613d111fb371 \
+                        sha256  7efea04ee3dd363a74c04a25473bcc2361d669011086c85a8b04e0c0639ad432 \
+                        size    1280082 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.7 \
@@ -60,35 +60,35 @@ go.vendors          rsc.io/qr \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
                     golang.org/x/term \
-                        lock    03fcf44c2211 \
-                        rmd160  a1b9592e95373ba617ef579a2f7015cfdc871343 \
-                        sha256  3673415a6d3d106d49b487715e151fc64245502ef547c16e8e13edb6b8f2f492 \
-                        size    14975 \
+                        lock    e5f449aeb171 \
+                        rmd160  815a83a4b9782102c3877cf61ee45ab5f8f89f4f \
+                        sha256  825a85ed3b123e641b82daecec59a33954393371b3f5e59dc90742a9ec46622f \
+                        size    14976 \
                     golang.org/x/sys \
-                        lock    b874c991c1a5 \
-                        rmd160  04252786eec583af7d21b0ad662307bfdc8a6a8c \
-                        sha256  076a4ddff9240d08b1ead640a98f1eacc7122a859044e0628498621adede14c6 \
-                        size    1288590 \
+                        lock    889880a91fd5 \
+                        rmd160  e2b05ff66006e9a8418c7460b001fd6a2d112344 \
+                        sha256  d60667cb2a6191e73587f082d57b86b90342fd2a14e2fdbaab579df183304845 \
+                        size    1292976 \
                     golang.org/x/oauth2 \
-                        lock    6242fa91716a \
-                        rmd160  ea459b0a4691cf8f07da62298ed90326cb9e4782 \
-                        sha256  3bf873e3378b4c1ced4ac94845f07527b4b61a310fbed7233ddf217f044888af \
-                        size    88419 \
+                        lock    9780585627b5 \
+                        rmd160  658e6722cf5571bd798e17f7285f07a918459c20 \
+                        sha256  d447c6e834cb1ce33f078df410b897a1db84dd35d70e73666aa23fd4935d1eee \
+                        size    88421 \
                     golang.org/x/net \
-                        lock    27dd8689420f \
-                        rmd160  d7b9477ec487c7f547c2d6669088f0b77c4ecd3f \
-                        sha256  53a566616d208e83a2ec4a58651a450187a3bef980128571a04b01f6231e162d \
-                        size    1229543 \
+                        lock    290c469a71a5 \
+                        rmd160  e11deb5668ec06a94ecda8c6fc3f7a373ebb35b2 \
+                        sha256  d51af4b91585ee62500a81f634b4060c1d9bc90cf08b5e6e3d1f06f26fe13da1 \
+                        size    1229690 \
                     golang.org/x/exp \
-                        lock    20fd27f61765 \
-                        rmd160  525b884a0c777811f5d3534552ed856a5b348d57 \
-                        sha256  3c8d4c635b272d8ba0c1b023f17ea58d3b99aa34b5156ae64162b356fedea671 \
-                        size    1761087 \
+                        lock    7b9b53b0aca4 \
+                        rmd160  162d6202a24486e79a9837e9e0db351e2c9e99e5 \
+                        sha256  054eb051d42c49543634f2934a32d5e61bf3617864e9767afdd4bf14e513edbe \
+                        size    1559584 \
                     golang.org/x/crypto \
-                        lock    6068a2e6cfdc \
-                        rmd160  df9e47447ba5bb41d298e658cd038c9ddbdc068a \
-                        sha256  5d083db4aee3736c9c126eef94549651359b2eb494427014043cfab22760602f \
-                        size    1628196 \
+                        lock    7b82a4e95df4 \
+                        rmd160  b4f1ba2e353404c6dd4278074d0d348ebb053c60 \
+                        sha256  eeef0fe96ae1565d13d3fde36247d5a5c5da3e2846ac7eac46ca78682814249e \
+                        size    1630512 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -107,20 +107,20 @@ go.vendors          rsc.io/qr \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.4.0 \
-                        rmd160  08728bda2dd6a9bc445ea4bc7dff4a5184953560 \
-                        sha256  3a3f761b8571fea2a1f38cbed051a70e167bc959774dc32b6413289f65ba578b \
-                        size    3410417 \
+                        lock    v2.5.1 \
+                        rmd160  e28c2ffd83dee554eb4fada96dd4c1be6ea4a13f \
+                        sha256  fb79863f364131e179289ab3cc55d8fb71254255977e5a93975d74bf18781306 \
+                        size    3414167 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
                         sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
                         size    11986 \
                     github.com/stretchr/testify \
-                        lock    v1.7.0 \
-                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
-                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
-                        size    91096 \
+                        lock    v1.7.1 \
+                        rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
+                        sha256  27cabaf81344157a188083266cf8ccc19d04c43d9a34b6276b760514b9c880a3 \
+                        size    94020 \
                     github.com/skip2/go-qrcode \
                         lock    da1b6568686e \
                         rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
@@ -192,10 +192,10 @@ go.vendors          rsc.io/qr \
                         sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
                         size    9805 \
                     github.com/martinhoefling/goxkcdpwgen \
-                        lock    7dc3d102eca3 \
-                        rmd160  f8b32dbe86765d33f5f6e57cc3047f6951bd6957 \
-                        sha256  6a8aa5b817f6bf895b32995360380e8382059965e56aabd1bc997ec36b612ff4 \
-                        size    287962 \
+                        lock    v0.1.1 \
+                        rmd160  56164d6a8b2620f53897f85abe3ff7659e0aa0c5 \
+                        sha256  0ee21438461014724b2a3afe08e6db51649748ff23f7f90705b2617d80e568a6 \
+                        size    89925 \
                     github.com/kr/text \
                         lock    v0.2.0 \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
@@ -242,10 +242,10 @@ go.vendors          rsc.io/qr \
                         sha256  a053e731deda2d4baf00b362a8f55f7eeac5528115468013aeccb4acf05f2bd3 \
                         size    397048 \
                     github.com/google/go-cmp \
-                        lock    v0.5.7 \
-                        rmd160  f8dffbbc09f05eff889202ab37f473e314ae1b09 \
-                        sha256  7fba30fac1ae84c4dc8c8592936e3fb4ada1f1985803005225e7d61d4159bcff \
-                        size    104517 \
+                        lock    v0.5.8 \
+                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
+                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
+                        size    104650 \
                     github.com/golang/protobuf \
                         lock    v1.5.2 \
                         rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
@@ -321,6 +321,11 @@ go.vendors          rsc.io/qr \
                         rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
                         sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
                         size    5023 \
+                    github.com/ProtonMail/go-crypto \
+                        lock    a94812496cf5 \
+                        rmd160  63b9296476022059a4166f68548549efb21282b8 \
+                        sha256  05113835184fc1991a1a54adbc2c9dd2a71efaba6295315692253761cee418ab \
+                        size    312724 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
                         lock    v1.0.0-rc.1 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.14.1)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
