### PR TITLE
openjdk17-temurin: update 17.0.3 (x86_64)

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -11,11 +11,17 @@ license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
 universal_variant no
 
-# https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
+# https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.2
-set build    8
+if {${configure.build_arch} eq "x86_64"} {
+    version      17.0.3
+    set build    7
+} elseif {${configure.build_arch} eq "arm64"} {
+    version      17.0.2
+    set build    8
+}
+
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,9 +31,9 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  90939e1b687b025674faf1f45b1274fe2e420109 \
-                 sha256  3630e21a571b7180876bf08f85d0aac0bdbb3267b2ae9bd242f4933b21f9be32 \
-                 size    192611208
+    checksums    rmd160  2ab1be7abe66d2f1fcdc75853098981bf2debb50 \
+                 sha256  a5db5927760d2864316354d98ff18d18bec2e72bfac59cd25a416ed67fa84594 \
+                 size    187277835
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
     checksums    rmd160  e4063da6a1139c137af930c8cf5c5988bb75354d \


### PR DESCRIPTION
#### Description

Update Eclipse Temurin x86_64 to 17.0.3.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?