### PR TITLE
openjdk18-temurin: update to 18.0.1 (x86_64)

### DIFF
--- a/java/openjdk18-temurin/Portfile
+++ b/java/openjdk18-temurin/Portfile
@@ -14,8 +14,14 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      18
-set build    36
+if {${configure.build_arch} eq "x86_64"} {
+    version      18.0.1
+    set build    10
+} elseif {${configure.build_arch} eq "arm64"} {
+    version      18
+    set build    36
+}
+
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 18
@@ -25,9 +31,9 @@ master_sites https://github.com/adoptium/temurin18-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK18U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  78ae0d160e4d8881faa149092716195e95d0c36a \
-                 sha256  cdef36a561d7550fb505a9c36fedf363af16a5984c92e74f5abaa25172c12537 \
-                 size    187839669
+    checksums    rmd160  05b2257658a2fa6c18484a2bd526811b717c470e \
+                 sha256  fedb5e61de3ecd1e128fbb0378b2467498cbe731366fb089b2a495cbb7e34e73 \
+                 size    188268875
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK18U-jdk_aarch64_mac_hotspot_${version}_${build}
     checksums    rmd160  50ba39557a02d6fd105e70e1bc5d19023c3ffe02 \


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin x86_64 18.0.1.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?