### PR TITLE
nspr: enable ppc64 build on Leopard

### DIFF
--- a/devel/nspr/Portfile
+++ b/devel/nspr/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                nspr
 version             4.33
-revision            0
+revision            1
 categories          devel
 maintainers         nomaintainer
 license             {MPL-1.1 GPL-2+ LGPL-2.1+}
@@ -33,6 +33,16 @@ configure.args \
     --disable-debug \
     --enable-optimize='${configure.optflags}' \
     --libdir=${prefix}/lib/nspr
+
+platform darwin 9 {
+    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+    # We need to enable missing ppc64 atomics
+    post-extract {
+        copy ${worksrcpath}/pr/src/md/unix/os_Darwin_ppc.s ${worksrcpath}/pr/src/md/unix/os_Darwin_ppc64.s
+        }
+    patchfiles-append      patch-darwin-ppc64.diff
+    }
+}
 
 if {(!${universal_possible} || ![variant_isset universal]) && ${configure.build_arch} in [list arm64 ppc64 x86_64]} {
     configure.args-append --enable-64bit

--- a/devel/nspr/files/patch-darwin-ppc64.diff
+++ b/devel/nspr/files/patch-darwin-ppc64.diff
@@ -1,0 +1,173 @@
+--- configure.orig	2021-12-17 23:29:39.000000000 +0800
++++ configure	2022-05-07 14:46:05.000000000 +0800
+@@ -5318,7 +5318,7 @@
+ rm -f a.out
+ 
+ case "$build:$target" in
+-    i?86-apple-darwin*:powerpc-apple-darwin*)
++    i?86-apple-darwin*:powerpc*-apple-darwin*)
+                                 cross_compiling=yes
+         ;;
+ esac
+@@ -6461,8 +6461,12 @@
+         aarch64)
+             CPU_ARCH=aarch64
+             ;;
+-        *)
+-            CPU_ARCH=ppc
++        powerpc*|ppc*)
++            if test -n "$USE_64"; then
++                CPU_ARCH=ppc64
++            else
++                CPU_ARCH=ppc
++            fi
+             ;;
+     esac
+     if test "`echo $CC | grep -c '\-arch '`" = "0"; then
+
+
+--- pr/include/md/_darwin.h.orig	2021-12-17 23:29:39.000000000 +0800
++++ pr/include/md/_darwin.h	2022-05-07 14:32:28.000000000 +0800
+@@ -24,6 +24,8 @@
+ #define _PR_SI_ARCHITECTURE "x86-64"
+ #elif defined(__ppc__)
+ #define _PR_SI_ARCHITECTURE "ppc"
++#elif defined(__ppc64__)
++#define _PR_SI_ARCHITECTURE "ppc64"
+ #elif defined(__arm__)
+ #define _PR_SI_ARCHITECTURE "arm"
+ #elif defined(__aarch64__)
+@@ -94,6 +96,19 @@
+ #define _MD_ATOMIC_ADD(ptr, val)    _PR_DarwinPPC_AtomicAdd(ptr, val)
+ #endif /* __ppc__ */
+ 
++#ifdef __ppc64__
++#define _PR_HAVE_ATOMIC_OPS
++#define _MD_INIT_ATOMIC()
++extern PRInt32 _PR_DarwinPPC64_AtomicIncrement(PRInt32 *val);
++#define _MD_ATOMIC_INCREMENT(val)   _PR_DarwinPPC64_AtomicIncrement(val)
++extern PRInt32 _PR_DarwinPPC_AtomicDecrement(PRInt32 *val);
++#define _MD_ATOMIC_DECREMENT(val)   _PR_DarwinPPC64_AtomicDecrement(val)
++extern PRInt32 _PR_DarwinPPC64_AtomicSet(PRInt32 *val, PRInt32 newval);
++#define _MD_ATOMIC_SET(val, newval) _PR_DarwinPPC64_AtomicSet(val, newval)
++extern PRInt32 _PR_DarwinPPC64_AtomicAdd(PRInt32 *ptr, PRInt32 val);
++#define _MD_ATOMIC_ADD(ptr, val)    _PR_DarwinPPC64_AtomicAdd(ptr, val)
++#endif /* __ppc64__ */
++
+ #ifdef __i386__
+ #define _PR_HAVE_ATOMIC_OPS
+ #define _MD_INIT_ATOMIC()
+
+
+--- pr/src/md/unix/os_Darwin.s.orig	2021-12-17 23:29:39.000000000 +0800
++++ pr/src/md/unix/os_Darwin.s	2022-05-07 14:10:47.000000000 +0800
+@@ -10,4 +10,6 @@
+ #include "os_Darwin_x86_64.s"
+ #elif defined(__ppc__)
+ #include "os_Darwin_ppc.s"
++#elif defined(__ppc64__)
++#include "os_Darwin_ppc64.s"
+ #endif
+
+
+--- pr/src/md/unix/os_Darwin_ppc64.s.orig	2021-12-17 23:29:39.000000000 +0800
++++ pr/src/md/unix/os_Darwin_ppc64.s	2022-05-07 14:32:22.000000000 +0800
+@@ -13,56 +13,56 @@
+ .text
+ 
+ #
+-# PRInt32 __PR_DarwinPPC_AtomicIncrement(PRInt32 *val);
++# PRInt32 __PR_DarwinPPC64_AtomicIncrement(PRInt32 *val);
+ #
+         .align  2
+-        .globl  __PR_DarwinPPC_AtomicIncrement
+-        .private_extern __PR_DarwinPPC_AtomicIncrement
+-__PR_DarwinPPC_AtomicIncrement:
+-        lwarx   r4,0,r3
++        .globl  __PR_DarwinPPC64_AtomicIncrement
++        .private_extern __PR_DarwinPPC64_AtomicIncrement
++__PR_DarwinPPC64_AtomicIncrement:
++        ldarx   r4,0,r3
+         addi    r0,r4,1
+-        stwcx.  r0,0,r3
+-        bne-    __PR_DarwinPPC_AtomicIncrement
++        stdcx.  r0,0,r3
++        bne-    __PR_DarwinPPC64_AtomicIncrement
+         mr      r3,r0
+         blr
+ 
+ #
+-# PRInt32 __PR_DarwinPPC_AtomicDecrement(PRInt32 *val);
++# PRInt32 __PR_DarwinPPC64_AtomicDecrement(PRInt32 *val);
+ #
+         .align  2
+-        .globl  __PR_DarwinPPC_AtomicDecrement
+-        .private_extern __PR_DarwinPPC_AtomicDecrement
+-__PR_DarwinPPC_AtomicDecrement:
+-        lwarx   r4,0,r3
++        .globl  __PR_DarwinPPC64_AtomicDecrement
++        .private_extern __PR_DarwinPPC64_AtomicDecrement
++__PR_DarwinPPC64_AtomicDecrement:
++        ldarx   r4,0,r3
+         addi    r0,r4,-1
+-        stwcx.  r0,0,r3
+-        bne-    __PR_DarwinPPC_AtomicDecrement
++        stdcx.  r0,0,r3
++        bne-    __PR_DarwinPPC64_AtomicDecrement
+         mr      r3,r0
+         blr
+ 
+ #
+-# PRInt32 __PR_DarwinPPC_AtomicSet(PRInt32 *val, PRInt32 newval);
++# PRInt32 __PR_DarwinPPC64_AtomicSet(PRInt32 *val, PRInt32 newval);
+ #
+         .align  2
+-        .globl  __PR_DarwinPPC_AtomicSet
+-        .private_extern __PR_DarwinPPC_AtomicSet
+-__PR_DarwinPPC_AtomicSet:
+-        lwarx   r5,0,r3
+-        stwcx.  r4,0,r3
+-        bne-    __PR_DarwinPPC_AtomicSet
++        .globl  __PR_DarwinPPC64_AtomicSet
++        .private_extern __PR_DarwinPPC64_AtomicSet
++__PR_DarwinPPC64_AtomicSet:
++        ldarx   r5,0,r3
++        stdcx.  r4,0,r3
++        bne-    __PR_DarwinPPC64_AtomicSet
+         mr      r3,r5
+         blr
+ 
+ #
+-# PRInt32 __PR_DarwinPPC_AtomicAdd(PRInt32 *ptr, PRInt32 val);
++# PRInt32 __PR_DarwinPPC64_AtomicAdd(PRInt32 *ptr, PRInt32 val);
+ #
+         .align  2
+-        .globl  __PR_DarwinPPC_AtomicAdd
+-        .private_extern __PR_DarwinPPC_AtomicAdd
+-__PR_DarwinPPC_AtomicAdd:
+-        lwarx   r5,0,r3
++        .globl  __PR_DarwinPPC64_AtomicAdd
++        .private_extern __PR_DarwinPPC64_AtomicAdd
++__PR_DarwinPPC64_AtomicAdd:
++        ldarx   r5,0,r3
+         add     r0,r4,r5
+-        stwcx.  r0,0,r3
+-        bne-    __PR_DarwinPPC_AtomicAdd
++        stdcx.  r0,0,r3
++        bne-    __PR_DarwinPPC64_AtomicAdd
+         mr      r3,r0
+         blr
+
+
+--- pr/include/pratom.h.orig	2021-12-17 23:29:39.000000000 +0800
++++ pr/include/pratom.h	2022-05-07 14:10:22.000000000 +0800
+@@ -99,7 +99,7 @@
+ 
+ #elif ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)) && \
+       ((defined(__APPLE__) && \
+-           (defined(__ppc__) || defined(__i386__) || defined(__x86_64__))) || \
++           (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))) || \
+        (defined(__linux__) && \
+            ((defined(__i386__) && \
+            defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4)) || \
+


### PR DESCRIPTION
#### Description

This enables `nspr` to build for ppc64 and universal (ppc+ppc64) on Leopard.
Closes my own ticket: https://trac.macports.org/ticket/64440

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

_Nomaintainer,_ so tagging @ryandesign and @kencu who responded in the ticket.
