### PR TITLE
python310: fix universal build on older systems

### DIFF
--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -153,7 +153,7 @@ platform darwin {
         reinplace "s|-lintl ||" \
             ${destroot}${framewdir}/lib/python${branch}/_sysconfigdata__darwin_darwin.py
 
-        system -W ${worksrcpath} "env DYLD_FRAMEWORK_PATH=. python.exe -E -m compileall -d [shellescape ${framewdir}/lib/python${branch}] -o 0 -o 1 -o 2 [shellescape ${destroot}${framewdir}/lib/python${branch}/_sysconfigdata__darwin_darwin.py]"
+        system -W ${worksrcpath} "env DYLD_FRAMEWORK_PATH=. ./python.exe -E -m compileall -d [shellescape ${framewdir}/lib/python${branch}] -o 0 -o 1 -o 2 [shellescape ${destroot}${framewdir}/lib/python${branch}/_sysconfigdata__darwin_darwin.py]"
     }
 }
 

--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -153,7 +153,7 @@ platform darwin {
         reinplace "s|-lintl ||" \
             ${destroot}${framewdir}/lib/python${branch}/_sysconfigdata__darwin_darwin.py
 
-        system -W ${destroot}${framewdir} "env DYLD_LIBRARY_PATH=. bin/python3 -m compileall -o 0 -o 1 -o 2 lib/python${branch}/_sysconfigdata__darwin_darwin.py"
+        system -W ${worksrcpath} "env DYLD_FRAMEWORK_PATH=. python.exe -E -m compileall -d [shellescape ${framewdir}/lib/python${branch}] -o 0 -o 1 -o 2 [shellescape ${destroot}${framewdir}/lib/python${branch}/_sysconfigdata__darwin_darwin.py]"
     }
 }
 

--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -8,6 +8,7 @@ name                python310
 
 # Remember to keep py310-tkinter and py310-gdbm's versions sync'd with this
 version             3.10.4
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang
@@ -114,33 +115,6 @@ platform darwin {
         }
     }
 
-    post-build {
-        set buildlibdir [lindex [glob -directory ${worksrcpath}/build lib.*-*-*-${branch}] 0]
-        # preserve mtime of sysconfig data file to avoid rebuilding things after changing it
-        set oldmtime [file mtime ${buildlibdir}/_sysconfigdata__darwin_darwin.py]
-
-        # Without this, LINKFORSHARED is set to
-        # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
-        # (this becomes Python.framework/Versions/3.10/Python) which doesn't
-        # work for dependents that incorrectly use this variable to find out
-        # how to link against python (see ticket #15099); instead we mirror
-        # the behavior of `python-config --ldflags` here.
-        set lfs_pattern {^([[:space:]]*'LINKFORSHARED':).*}
-        set lfs_replacement "\\1 '-L${framewdir}/lib/python${branch}/${confdir} -lpython${branch} -ldl -framework CoreFoundation',"
-        reinplace -E s|${lfs_pattern}|${lfs_replacement}| \
-            ${buildlibdir}/_sysconfigdata__darwin_darwin.py
-
-        # remove -arch flags from the config
-        reinplace -E {s|-arch [a-z0-9_]+||g} \
-            ${buildlibdir}/_sysconfigdata__darwin_darwin.py
-
-        # also remove gettext overlinking
-        reinplace "s|-lintl||" \
-            ${buildlibdir}/_sysconfigdata__darwin_darwin.py
-
-        file mtime ${buildlibdir}/_sysconfigdata__darwin_darwin.py $oldmtime
-    }
-
     post-destroot {
         foreach dir { Headers Resources Python Versions/Current } {
             file delete ${destroot}${framewpath}/${dir}
@@ -159,6 +133,27 @@ platform darwin {
 
         reinplace "s|-lintl||" \
            ${destroot}${framewdir}/lib/python${branch}/${confdir}/Makefile
+
+        # Without this, LINKFORSHARED is set to
+        # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
+        # (this becomes Python.framework/Versions/3.10/Python) which doesn't
+        # work for dependents that incorrectly use this variable to find out
+        # how to link against python (see ticket #15099); instead we mirror
+        # the behavior of `python-config --ldflags` here.
+        set lfs_pattern {^([[:space:]]*'LINKFORSHARED':).*}
+        set lfs_replacement "\\1 '-L${framewdir}/lib/python${branch}/${confdir} -lpython${branch} -ldl -framework CoreFoundation',"
+        reinplace -E s|${lfs_pattern}|${lfs_replacement}| \
+            ${destroot}${framewdir}/lib/python${branch}/_sysconfigdata__darwin_darwin.py
+
+        # remove -arch flags from the config
+        reinplace -E {s|-arch [a-z0-9_]+||g} \
+            ${destroot}${framewdir}/lib/python${branch}/_sysconfigdata__darwin_darwin.py
+
+        # also remove gettext overlinking
+        reinplace "s|-lintl ||" \
+            ${destroot}${framewdir}/lib/python${branch}/_sysconfigdata__darwin_darwin.py
+
+        system -W ${destroot}${framewdir} "env DYLD_LIBRARY_PATH=. bin/python3 -m compileall -o 0 -o 1 -o 2 lib/python${branch}/_sysconfigdata__darwin_darwin.py"
     }
 }
 


### PR DESCRIPTION
It seems that the build system assumes that the default compiler
build architecture is the same as the default run architecture.

Revbump is needed since the universal build can be incorrect
on older systems.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L31a i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
