### PR TITLE
spatialite: blacklist old gcc on PPC systems, as it fails

### DIFF
--- a/databases/spatialite/Portfile
+++ b/databases/spatialite/Portfile
@@ -64,6 +64,10 @@ if {![variant_isset proj8] && ![variant_isset proj6] && ![variant_isset proj7]} 
     default_variants +proj8
 }
 
+platform darwin powerpc {
+    compiler.blacklist-append  *gcc-4* *clang*
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     {current version is <b>(\d+\.\d+\.\d+)}


### PR DESCRIPTION
#### Description

A minor fix, addressing an odd failure on PPC systems with default compiler. The error was observed on 10.4.11 and 10A190.
Revision unchanged, since no need to rebuild the port.
Closes my own ticket: https://trac.macports.org/ticket/65132
_Nomaintainer, so why not fix it myself._

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC (10A190)
Xcode 3.2

macOS 10.4.11
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
