### PR TITLE
.github: update actions to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout ports
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 64
           path: ports
       - name: Checkout mpbb
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: macports/mpbb
           path: mpbb
@@ -181,7 +181,7 @@ jobs:
             -exec chmod -R go+rX {} \;
       - name: Archive build logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs-${{ matrix.os }}.zip
           path: /tmp/mpbb/*/logs


### PR DESCRIPTION
GitHub released them back in March, I haven't noticed any breaking changes.