### PR TITLE
py: jupyterthemes: new port

### DIFF
--- a/python/py-jupyterthemes/Portfile
+++ b/python/py-jupyterthemes/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jupyterthemes
+version             0.20.0
+revision            0
+
+categories-append   devel science
+license             MIT
+maintainers         nomaintainer
+
+description         Select and install a Jupyter notebook theme
+long_description    ${description}
+
+homepage            https://github.com/dunovank/jupyter-themes
+
+checksums           rmd160  ed6b73e604f8ac4c052bbc0cd8d26cc14d741641 \
+                    sha256  2a8ebc0c84b212ab99b9f1757fc0582a3f53930d3a75b2492d91a7c8b36ab41e \
+                    size    6719959
+
+python.versions     39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-ipython \
+                    port:py${python.version}-jupyter_core \
+                    port:py${python.version}-lesscpy \
+                    port:py${python.version}-matplotlib \
+                    port:py${python.version}-notebook
+}

--- a/python/py-lesscpy/Portfile
+++ b/python/py-lesscpy/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-lesscpy
+version             0.15.0
+revision            0
+
+categories-append   lang devel
+license             MIT
+maintainers         nomaintainer
+
+description         Python LESS compiler
+long_description    ${description}
+
+homepage            https://github.com/lesscpy/lesscpy
+
+checksums           rmd160  f6d130c23e996db1896e1f92e9afac5bbe336e75 \
+                    sha256  ef058fb3fca077f0136222c415bc6d20fe256e92648ccbf4b3de874ba03b9b9d \
+                    size    176879
+
+python.versions     39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-ply \
+                    port:py${python.version}-six
+}


### PR DESCRIPTION
#### Description

Jupyter-themes provides a set of themes that can be used with jupyter-notebook.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
