### PR TITLE
upt: switch to python310

### DIFF
--- a/python/py-upt-cpan/Portfile
+++ b/python/py-upt-cpan/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  c31384f3f622e348d7c15b786e5e68a101823751 \
                     sha256  de06eda9b6805f1099a806a874c6a812c5b1a8d73108b2dc79f041c0b9943a78 \
                     size    6320
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-upt-macports/Portfile
+++ b/python/py-upt-macports/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  81577cf0aec69c6330ccd5aaaea262bdeacfb0e5 \
                     sha256  c401c757d93679058e079236fac99daecbc813d8e03d6b1a97fd579a7e15d767 \
                     size    11680
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-upt-pypi/Portfile
+++ b/python/py-upt-pypi/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  715551cd10a65462277cce62201041c71d8f1930 \
                     sha256  c4d991917d6f7990815ed99d8bd2f1ea9c9da290e4f540dc370eaac47f39088b \
                     size    13103
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-upt-rubygems/Portfile
+++ b/python/py-upt-rubygems/Portfile
@@ -21,7 +21,7 @@ checksums           sha256  4bf9988ae2d42d30e50cb85e34f3b8a4a0ef298c9710561fb0ec
                     rmd160  fa8accf7092b44a05273932de18df0282586976e \
                     size    5795
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/sysutils/upt/Portfile
+++ b/sysutils/upt/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                upt
 version             0.12
-revision            0
+revision            1
 
 categories-prepend  sysutils
 platforms           darwin
@@ -22,7 +22,7 @@ checksums           rmd160  78dbb0c3a26ff4062ae1b2f735ce2fe54e2d10f6 \
                     sha256  9bd23c7f7c277f2efab3d6ffcaffbfcb47c696dbfb4fe41eea4ae2dc58e774c2 \
                     size    32410
 
-python.default_version  39
+python.default_version  310
 
 depends_lib-append \
                 port:py${python.version}-colorlog \


### PR DESCRIPTION
#### Description

These changes update upt to use python 3.10, but upt-pypi needs to generate ports defaulting to python 3.10 too, and that update is still missing.

In theory we can also merge this PR without upgrading upt-pypi, but if there's a volunteer to take care of upt-pypi, that would be awesome.

(I just created this PR because I wanted to get rid of python 3.9 on my machine. I was later able to manually modify the output from upt-pypi, so I didn't feel the strong urgency to fix everything at once. We may at some point need to update upt-cpan as well.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
