### PR TITLE
rebar3: Update to 3.18.0

### DIFF
--- a/erlang/rebar3/Portfile
+++ b/erlang/rebar3/Portfile
@@ -3,9 +3,13 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    erlang rebar3 3.12.0
+github.setup        erlang rebar3 3.18.0
+revision            0
+checksums           rmd160  a25d6e2b2c2ce07c2eb2ae99d2af669c8770ba15 \
+                    sha256  cce1925d33240d81d0e4d2de2eef3616d4c17b0532ed004274f875e6607d25d2 \
+                    size    436403
+
 categories      erlang devel
-platforms       darwin
 maintainers     {ciserlohn @ci42}
 supported_archs noarch
 license         Apache-2
@@ -24,18 +28,15 @@ long_description    Rebar3 will: respect and enforce standard Erlang/OTP \
                     treat documentation as a feature, and errors or lack of \
                     documentation as a bug.
 
-checksums           rmd160  fa943d981ba8bec93198355b91fc5af1b59bd2e2 \
-                    sha256  b90a29b88fdacc5eecac47e0ef0c0ac213925088221a4625d665a28402f56870 \
-                    size    378085
+github.tarball_from archive
 
 depends_lib         port:erlang
 
-# configure and build phase
 use_configure       no
+
 build.cmd           ${worksrcpath}/bootstrap
 build.target
 
-# destroot phase
 destroot {
     xinstall -m 755 ${worksrcpath}/rebar3 ${destroot}${prefix}/bin
 }


### PR DESCRIPTION
#### Description

This updates rebar3 to the latest version because the previous version did not build anymore.

This builds for me in trace mode but I have not tested it beyond running `rebar3 --help` and `rebar3 --version`.

I skimmed the changes (from the rebar3 github releases page) between the old and new versions and didn't see anything about new dependencies or any Mac-specific issues, but most of the changes are greek to me as I'm not familiar with rebar3 or erlang.

Closes: https://trac.macports.org/ticket/62962

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
