### PR TITLE
cargo: Add rust run dependency

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -8,7 +8,7 @@ PortGroup           cargo   1.0
 name                cargo
 epoch               1
 github.setup        rust-lang ${name} 0.61.0
-revision            3
+revision            4
 
 categories          devel
 license             {MIT Apache-2}
@@ -34,6 +34,8 @@ depends_lib         port:curl \
                     port:libgit2 \
                     port:libssh2 \
                     port:zlib
+
+depends_run         port:rust
 
 depends_skip_archcheck-append \
                     pkgconfig \


### PR DESCRIPTION
#### Description

This dependency got lost with dc6a80cd529d8227dfcfbe5981d97e1202beb5eb when moving to the rust portgroup, but cargo is useless without rust installed, so re-add it as depends_run.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.5 20G527 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
