### PR TITLE
gingerblue: Update to 4.0.1

### DIFF
--- a/gnome/gingerblue/Portfile
+++ b/gnome/gingerblue/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gingerblue
-version             2.0.1
+version             4.0.1
 revision            0
 set branch          [join [lrange [split $version .] 0 1] .]
 
@@ -23,21 +23,16 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  d1482a8ac4b1fd863f1f4edc267cc7e87e00a49f \
-                    sha256  118dc659d229e2fa7e6c03c8b7aef738f0e9e7e773cc941329b5afbeb82e88a9 \
-                    size    320484
+checksums           rmd160  56a9c1b51324ad82395e683da17ff7164117b0f1 \
+                    sha256  dd63cd1442fd9b8c0c6b31a9c9dc68d9a992a72c0642b0d7942889d8eb280f27 \
+                    size    321940
 
-depends_build       port:autoconf \
-                    port:automake \
-                    port:geocode-glib \
-                    port:geoclue2 \
-                    port:gnome-common \
+depends_build       port:gnome-common \
                     port:gstreamer1-gst-plugins-bad \
                     port:gstreamer1-gst-plugins-good \
                     port:gstreamer1-gst-plugins-ugly \
                     port:gtk-doc \
                     port:intltool \
-                    port:itstool \
                     port:pkgconfig \
                     port:yelp-tools
 

--- a/gnome/gingerblue/files/no-intltool-perl.patch
+++ b/gnome/gingerblue/files/no-intltool-perl.patch
@@ -1,7 +1,7 @@
 https://bugs.launchpad.net/intltool/+bug/1197875
---- configure.orig	2021-10-25 14:27:18.000000000 -0500
-+++ configure	2022-03-13 13:48:33.000000000 -0500
-@@ -634,7 +634,6 @@
+--- configure.orig	2022-04-30 18:26:36.000000000 -0500
++++ configure	2022-05-07 06:43:13.000000000 -0500
+@@ -660,7 +660,6 @@
  PKG_CONFIG
  GETTEXT_PACKAGE
  ALL_LINGUAS
@@ -9,17 +9,18 @@ https://bugs.launchpad.net/intltool/+bug/1197875
  MSGMERGE
  INTLTOOL_POLICY_RULE
  INTLTOOL_SERVICE_RULE
-@@ -5677,69 +5676,6 @@
+@@ -5847,74 +5846,6 @@
      as_fn_error $? "GNU gettext tools not found; required for intltool" "$LINENO" 5
  fi
  
 -# Extract the first word of "perl", so it can be a program name with args.
 -set dummy perl; ac_word=$2
--{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
--$as_echo_n "checking for $ac_word... " >&6; }
--if ${ac_cv_path_INTLTOOL_PERL+:} false; then :
--  $as_echo_n "(cached) " >&6
--else
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-printf %s "checking for $ac_word... " >&6; }
+-if test ${ac_cv_path_INTLTOOL_PERL+y}
+-then :
+-  printf %s "(cached) " >&6
+-else $as_nop
 -  case $INTLTOOL_PERL in
 -  [\\/]* | ?:[\\/]*)
 -  ac_cv_path_INTLTOOL_PERL="$INTLTOOL_PERL" # Let the user override the test with a path.
@@ -29,11 +30,15 @@ https://bugs.launchpad.net/intltool/+bug/1197875
 -for as_dir in $PATH
 -do
 -  IFS=$as_save_IFS
--  test -z "$as_dir" && as_dir=.
+-  case $as_dir in #(((
+-    '') as_dir=./ ;;
+-    */) ;;
+-    *) as_dir=$as_dir/ ;;
+-  esac
 -    for ac_exec_ext in '' $ac_executable_extensions; do
--  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
--    ac_cv_path_INTLTOOL_PERL="$as_dir/$ac_word$ac_exec_ext"
--    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+-    ac_cv_path_INTLTOOL_PERL="$as_dir$ac_word$ac_exec_ext"
+-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
 -    break 2
 -  fi
 -done
@@ -45,33 +50,33 @@ https://bugs.launchpad.net/intltool/+bug/1197875
 -fi
 -INTLTOOL_PERL=$ac_cv_path_INTLTOOL_PERL
 -if test -n "$INTLTOOL_PERL"; then
--  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $INTLTOOL_PERL" >&5
--$as_echo "$INTLTOOL_PERL" >&6; }
+-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $INTLTOOL_PERL" >&5
+-printf "%s\n" "$INTLTOOL_PERL" >&6; }
 -else
--  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
--$as_echo "no" >&6; }
+-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-printf "%s\n" "no" >&6; }
 -fi
 -
 -
 -if test -z "$INTLTOOL_PERL"; then
 -   as_fn_error $? "perl not found" "$LINENO" 5
 -fi
--{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for perl >= 5.8.1" >&5
--$as_echo_n "checking for perl >= 5.8.1... " >&6; }
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for perl >= 5.8.1" >&5
+-printf %s "checking for perl >= 5.8.1... " >&6; }
 -$INTLTOOL_PERL -e "use 5.8.1;" > /dev/null 2>&1
 -if test $? -ne 0; then
 -   as_fn_error $? "perl 5.8.1 is required for intltool" "$LINENO" 5
 -else
 -   IT_PERL_VERSION=`$INTLTOOL_PERL -e "printf '%vd', $^V"`
--   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $IT_PERL_VERSION" >&5
--$as_echo "$IT_PERL_VERSION" >&6; }
+-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $IT_PERL_VERSION" >&5
+-printf "%s\n" "$IT_PERL_VERSION" >&6; }
 -fi
 -if test "x" != "xno-xml"; then
--   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XML::Parser" >&5
--$as_echo_n "checking for XML::Parser... " >&6; }
+-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XML::Parser" >&5
+-printf %s "checking for XML::Parser... " >&6; }
 -   if `$INTLTOOL_PERL -e "require XML::Parser" 2>/dev/null`; then
--       { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
--$as_echo "ok" >&6; }
+-       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+-printf "%s\n" "ok" >&6; }
 -   else
 -       as_fn_error $? "XML::Parser perl module is required for intltool" "$LINENO" 5
 -   fi


### PR DESCRIPTION
#### Description

gingerblue: Update to 4.0.1, renegerate the no-intltool patch, and remove unnecessary and duplicate dependencies.

Closes: https://trac.macports.org/ticket/64796

See #14739 where this was submitted and discussed originally.

I verified that it builds and that the program launches and displays a window.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
