### PR TITLE
pcre2: fix Tiger build

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -13,6 +13,8 @@ subport pcre2 {
     github.setup    PCRE2Project pcre2 10.40 pcre2-
     github.tarball_from releases
     revision        0
+
+    patchfiles-append no-OSCacheControl-on-tiger.diff
 }
 categories          devel
 license             BSD
@@ -49,7 +51,7 @@ checksums           rmd160  $rmd160(${subport}) \
                     sha256  $sha256(${subport}) \
                     size    $size(${subport})
 
-patchfiles          no-darwin-pthread-flag.patch
+patchfiles-append   no-darwin-pthread-flag.patch
 
 configure.args      --disable-silent-rules \
                     --docdir=${prefix}/share/doc/${subport} \

--- a/devel/pcre/files/no-OSCacheControl-on-tiger.diff
+++ b/devel/pcre/files/no-OSCacheControl-on-tiger.diff
@@ -1,0 +1,13 @@
+--- src/sljit/sljitConfigInternal.h.orig
++++ src/sljit/sljitConfigInternal.h
+@@ -357,7 +357,9 @@
+ /* Not required to implement on archs with unified caches. */
+ #define SLJIT_CACHE_FLUSH(from, to)
+ 
+-#elif defined __APPLE__
++#elif defined __APPLE__ && \
++      defined __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ && \
++      __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+ 
+ /* Supported by all macs since Mac OS 10.5.
+    However, it does not work on non-jailbroken iOS devices,


### PR DESCRIPTION
#### Description

`OSCacheControl.h` is not available on Tiger, so add a platform check before including.

Closes: https://trac.macports.org/ticket/65134

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
