### PR TITLE
nginx: Fix build failure with the +lua variant

### DIFF
--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -77,7 +77,8 @@ configure.args-append \
                     --http-client-body-temp-path=${nginx_rundir}/client_body_temp \
                     --http-proxy-temp-path=${nginx_rundir}/proxy_temp \
                     --http-fastcgi-temp-path=${nginx_rundir}/fastcgi_temp \
-                    --http-uwsgi-temp-path=${nginx_rundir}/uwsgi_temp
+                    --http-uwsgi-temp-path=${nginx_rundir}/uwsgi_temp \
+                    --without-pcre2  # pcre2 breaks the lua module (#65150)
 
 # remove --disable-dependency-tracking
 configure.universal_args-delete   --disable-dependency-tracking

--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -8,7 +8,7 @@ revision            0
 categories          www mail
 platforms           darwin
 license             BSD
-maintainers         {cal @neverpanic} {mps @Schamschula} openmaintainer
+maintainers         {mps @Schamschula} openmaintainer
 
 description         High-performance HTTP(S) server, HTTP(S) reverse proxy and IMAP/POP3 \
                     proxy server


### PR DESCRIPTION
#### Description

The lua module doesn't support PCRE2, but nginx does. Attempting to link them both doesn't seem to work very well. Use PCRE1 for both instead.

Closes: https://trac.macports.org/ticket/65150

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.5 20G527 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
