### PR TITLE
google-cloud-sdk: update to 385.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             384.0.0
+version             385.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e5f6bd8d572de6d8497ee20fb9a637423eb380b3 \
-                    sha256  cb0d80a70a5fc2d64594267aab3b7a21da0f9eeec8e1ca79fa940c7eb915695d \
-                    size    106733091
+    checksums       rmd160  01af97f3689c4560359d3ab8d5687130fb3f2987 \
+                    sha256  37c7035df774cabe4649ab49f2f39d590dd886bc9862f4dbb4730038fe2d39db \
+                    size    106717257
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4abe055edbc13629a13dae4cc4eddfa8e91f6951 \
-                    sha256  a371506ed0bc2cd208dcb9eb27141d32959a9d47bed2775a14d5ef27aba367bb \
-                    size    103326292
+    checksums       rmd160  8102bdeca712b6404e9e750e27b0f13402fd037b \
+                    sha256  5bd8d8ab17993af650c24e9d2b84ddaa90d750118803dedd5c0e3cbe5192b3a0 \
+                    size    103310171
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d5224c584fd815a78e2b6638c77819c4ef853814 \
-                    sha256  7fd64baeab4b9cf9d03776419f441704576233d982a3f649aff78e289a8338ec \
-                    size    101914656
+    checksums       rmd160  cc1a09cdffc5847db8b966ce4fb14747fd1792e0 \
+                    sha256  fbbfd3b03b92d6b53872e0c99a8f5ddb9f6ae0c75ff992a14e9ba56477c952e6 \
+                    size    101899182
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 385.0.0.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?