### PR TITLE
openjdk17-temurin: update to 17.0.3 (arm64)

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,14 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-if {${configure.build_arch} eq "x86_64"} {
-    version      17.0.3
-    set build    7
-} elseif {${configure.build_arch} eq "arm64"} {
-    version      17.0.2
-    set build    8
-}
-
+version      17.0.3
+set build    7
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -36,9 +30,9 @@ if {${configure.build_arch} eq "x86_64"} {
                  size    187277835
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e4063da6a1139c137af930c8cf5c5988bb75354d \
-                 sha256  157518e999d712b541b883c6c167f8faabbef1d590da9fe7233541b4adb21ea4 \
-                 size    182550014
+    checksums    rmd160  cbd5b0f0707f7a3e8f037525c9c767c2f927f3a2 \
+                 sha256  ff42be4d7a348d0d7aee07749e4daec9f427dcc7eb46b343f8131e8f3906c05b \
+                 size    177467402
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.3 (arm64).

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?