### PR TITLE
openjdk-distributions: move openjdk11-temurin to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -297,28 +297,6 @@ subport openjdk11-sap {
 
 }
 
-subport openjdk11-temurin {
-    # https://adoptium.net/temurin/releases/
-    supported_archs  x86_64
-
-    version      11.0.15
-    revision     0
-
-    set build    10
-
-    description  Eclipse Temurin, based on OpenJDK 11
-    long_description ${long_description_temurin}
-
-    master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${version}%2B${build}/
-
-    distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    worksrcdir   jdk-${version}+${build}
-
-    checksums    rmd160  5d66fe3d953619e7a6ca326110654344f1883773 \
-                 sha256  ebd8b9553a7b4514599bc0566e108915ce7dc95d29d49a9b10b8afe4ab7cc9db \
-                 size    186328533
-}
-
 # Remove after 2022-09-14
 subport openjdk16 {
     version      16.0.2

--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -1,0 +1,86 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk11-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/
+supported_archs  x86_64
+
+version      11.0.15
+set build    10
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK 11
+long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${version}%2B${build}/
+
+distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
+
+checksums    rmd160  5d66fe3d953619e7a6ca326110654344f1883773 \
+             sha256  ebd8b9553a7b4514599bc0566e108915ce7dc95d29d49a9b10b8afe4ab7cc9db \
+             size    186328533
+
+worksrcdir   jdk-${version}+${build}
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # See https://adoptium.net/supported_platforms.html
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://adoptium.net
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk11-temurin` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?