### PR TITLE
go-devel: set to version 1.17.10

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -28,8 +28,9 @@ revision            0
 
 # Subport for Go Unstable Version
 subport ${name}-devel {
-    version         1.18.1
+    version         1.17.10
     revision        0
+    epoch           1
 }
 
 homepage            https://golang.org
@@ -61,17 +62,17 @@ livecheck.url       ${homepage}/dl/
 if {$subport eq "${name}-devel"} {
     # Go (DEVEL / UNSTABLE)
     checksums       ${go_src_dist} \
-                    rmd160  d50f3a7f449993d6df6c4c62fe0d9dd657bed332 \
-                    sha256  efd43e0f1402e083b73a03d444b7b6576bb4c539ac46208b63a916b69aca4088 \
-                    size    22834149 \
+                    rmd160  b7a893fb09abf0923cbe80b62dcdeeec2049d257 \
+                    sha256  299e55af30f15691b015d8dcf8ecae72412412569e5b2ece20361753a456f2f9 \
+                    size    22196380 \
                     ${go_armbin_dist} \
-                    rmd160  1d5e6f181cbfd49178fd829f0f670df9de4cdd48 \
-                    sha256  6d5641a06edba8cd6d425fb0adad06bad80e2afe0fa91b4aa0e5aed1bc78f58e \
-                    size    137930879 \
+                    rmd160  b63d1c771de821cc1006318199ec345906bc1d81 \
+                    sha256  32098bea40117ea1ec23e7124cd188db6bdddd0ea41e2ec9bea3ba35a487e39c \
+                    size    130379321 \
                     ${go_amdbin_dist} \
-                    rmd160  bcb118333efffbae24b0850876e69727c69ea6fd \
-                    sha256  3703e9a0db1000f18c0c7b524f3d378aac71219b4715a6a4c5683eb639f41a4d \
-                    size    143707786
+                    rmd160  95066d1c18134ad7ccb009f168a29d88c190eadc \
+                    sha256  84979d5985c70cee6f303050a7e811440aad7f304efdf28665b200f096b01945 \
+                    size    136908820
 
     livecheck.regex {go([0-9.A-z]+)\.src\.tar\.gz}
 } else {


### PR DESCRIPTION
Use the `go-devel` port to test Go 1.17.10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
