### PR TITLE
gnupg-pkcs11-scd: submission

### DIFF
--- a/security/gnupg-pkcs11-scd/Portfile
+++ b/security/gnupg-pkcs11-scd/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+name                    gnupg-pkcs11-scd
+github.setup            alonbl ${name} 0.10.0 ${name}-
+
+categories              security
+license                 BSD
+maintainers             {@sstallion gmail.com:sstallion} openmaintainer
+
+description             GnuPG PKCS#11 Smart-Card Daemon
+long_description        gnupg-pkcs11 is a project to implement a BSD-licensed           \
+                        smart-card daemon to enable the use of PKCS#11 tokens with      \
+                        GnuPG
+
+github.tarball_from     releases
+use_bzip2               yes
+
+checksums               rmd160  1a8781ce0c017731b81fda7a3660fb3d9a10c313 \
+                        sha256  29bf29e7780f921c6d3a11f608e2b0483c1bb510c5afa8473090249dd57c5249 \
+                        size    149036
+
+depends_lib             port:gnupg2         \
+                        port:libgcrypt      \
+                        port:pkcs11-helper
+
+configure.args-append   --with-libgpg-error-prefix=${prefix}    \
+                        --with-libassuan-prefix=${prefix}       \
+                        --with-libgcrypt-prefix=${prefix}


### PR DESCRIPTION
#### Description

New port submission for gnupg-pkcs11-scd. The latest release is relatively old (~3 years), however it is still functional and appears stable.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

submission

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
