### PR TITLE
python39-310: fix +lto PPC, python38-310: add SLPPC case

### DIFF
--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -42,6 +42,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
                        patch-threadid-older-systems.diff
 }
 
+if {${os.platform} eq "darwin" && ${os.major} == 10 && ${build_arch} eq "ppc"} {
+    # this is needed for a PPC build on SL
+    patchfiles-append  patch-threadid-older-systems.diff
+}
+
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \
                     port:expat \
@@ -242,6 +247,10 @@ variant optimizations description {enable expensive, stable optimizations (inclu
 
 variant lto description {enable Link-Time Optimization} {
     configure.args-append   --with-lto
+    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+        compiler.blacklist-append *gcc-4.*
+        patchfiles-append   patch-enable_dynamic.diff
+    }
 }
 
 platform darwin {

--- a/lang/python310/files/patch-enable_dynamic.diff
+++ b/lang/python310/files/patch-enable_dynamic.diff
@@ -1,0 +1,20 @@
+--- configure.orig	2022-03-24 04:12:04.000000000 +0800
++++ configure	2022-03-29 15:03:21.000000000 +0800
+@@ -6755,7 +6755,7 @@
+       case $ac_sys_system in
+         Darwin*)
+           # Any changes made here should be reflected in the GCC+Darwin case below
+-          LTOFLAGS="-flto -Wl,-export_dynamic"
++          LTOFLAGS="-flto"
+           LTOCFLAGS="-flto"
+           ;;
+         *)
+@@ -6766,7 +6766,7 @@
+     *gcc*)
+       case $ac_sys_system in
+         Darwin*)
+-          LTOFLAGS="-flto -Wl,-export_dynamic"
++          LTOFLAGS="-flto"
+           LTOCFLAGS="-flto"
+           ;;
+         *)

--- a/lang/python38/Portfile
+++ b/lang/python38/Portfile
@@ -47,6 +47,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
                        patch-threadid-older-systems.diff
 }
 
+if {${os.platform} eq "darwin" && ${os.major} == 10 && ${build_arch} eq "ppc"} {
+     # this is needed for a PPC build on SL
+     patchfiles-append  patch-threadid-older-systems.diff
+}
+
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \
                     port:expat \

--- a/lang/python39/Portfile
+++ b/lang/python39/Portfile
@@ -42,6 +42,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
                        patch-threadid-older-systems.diff
 }
 
+if {${os.platform} eq "darwin" && ${os.major} == 10 && ${build_arch} eq "ppc"} {
+    # this is needed for a PPC build on SL
+    patchfiles-append  patch-threadid-older-systems.diff
+}
+
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \
                     port:expat \
@@ -241,6 +246,10 @@ variant optimizations description {enable expensive, stable optimizations (inclu
 
 variant lto description {enable Link-Time Optimization} {
     configure.args-append   --with-lto
+    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+        compiler.blacklist-append *gcc-4.*
+        patchfiles-append   patch-enable_dynamic.diff
+    }
 }
 
 platform darwin {

--- a/lang/python39/files/patch-enable_dynamic.diff
+++ b/lang/python39/files/patch-enable_dynamic.diff
@@ -1,0 +1,20 @@
+--- configure.orig	2022-03-24 05:12:08.000000000 +0800
++++ configure	2022-03-29 14:21:47.000000000 +0800
+@@ -6696,7 +6696,7 @@
+       case $ac_sys_system in
+         Darwin*)
+           # Any changes made here should be reflected in the GCC+Darwin case below
+-          LTOFLAGS="-flto -Wl,-export_dynamic"
++          LTOFLAGS="-flto"
+           LTOCFLAGS="-flto"
+           ;;
+         *)
+@@ -6707,7 +6707,7 @@
+     *gcc*)
+       case $ac_sys_system in
+         Darwin*)
+-          LTOFLAGS="-flto -Wl,-export_dynamic"
++          LTOFLAGS="-flto"
+           LTOCFLAGS="-flto"
+           ;;
+         *)


### PR DESCRIPTION
#### Description

Fixes `+lto` variant for PPC, adds a case of building for `ppc` on 10.6.x.
My trac ticket : https://trac.macports.org/ticket/64904

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10.6 PPC (10A190)
Xcode 3.2

macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
