### PR TITLE
erlang: Update to 24.3

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -9,8 +9,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                erlang
-version             24.2
-revision            1
+version             24.3
+revision            0
 
 categories          lang erlang
 maintainers         {ciserlohn @ci42}
@@ -47,17 +47,17 @@ distfiles           otp_src_${version}${extract.suffix}                    \
                     otp_doc_html_${version}${extract.suffix}
 
 checksums           otp_src_${version}.tar.gz \
-                    rmd160  76869bd1409820431738854d93ca31196c772717 \
-                    sha256  af0f1928dcd16cd5746feeca8325811865578bf1a110a443d353ea3e509e6d41 \
-                    size    107224843 \
+                    rmd160  96168a082808e5a8ae72b55a57e47436a7d97caa \
+                    sha256  ee8dd101af68ba175deec1844059ed287a22f7f46e72915631c965cc8be331f9 \
+                    size    107425200 \
                     otp_doc_man_${version}.tar.gz \
-                    rmd160  2c45d573662b2b13125fae083ecea4d76a53e12c \
-                    sha256  56ae4b13fc7c003f4dd9951a9ff2a0bae0b38473df2c078d79c8553c277c5f4c \
-                    size    1673926 \
+                    rmd160  59a89d5c59555a64b67b300fc3b658e2ae9686c9 \
+                    sha256  68ad2222eef77310c286411ad0e580865f3ba273e9fe42516ade0e5310cff614 \
+                    size    1680242 \
                     otp_doc_html_${version}.tar.gz \
-                    rmd160  70a2e8149379232c0bbdd778a2172569d6538089 \
-                    sha256  f479cbc8a28532fd6a0a55fc26684b4e79312da4f86ee0735d0757f936672bbc \
-                    size    36604264
+                    rmd160  5d5a28d65852d5d3c50db6ee2ad625149acbe30e \
+                    sha256  7a247113a0f90514aacb0656e98a1e4d63e2ebf4ac9981002d046599147dc177 \
+                    size    36645792
 
 worksrcdir          otp_src_${version}
 


### PR DESCRIPTION
#### Description

erlang: update to 24.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
