### PR TITLE
aerc: update to 0.10.0

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                aerc
-version             0.7.1
+version             0.10.0
 revision            0
 categories          mail
 license             MIT
@@ -19,9 +19,9 @@ master_sites        https://git.sr.ht/~rjarry/aerc/archive/
 distname            ${version}
 worksrcdir          ${name}-${distname}
 
-checksums           rmd160  13d2b627b7ba7708f51f5028be7e14993cd05192 \
-                    sha256  e149236623c103c8526b1f872b4e630e67f15be98ac604c0ea0186054dbef0cc \
-                    size    168105
+checksums           rmd160  5831c2ec474fcc56435daa3e41e776bdbf468236 \
+                    sha256  14d6c622a012069deb1a31b51ecdd187fd11041c8e46f396ac22830b00e4c114 \
+                    size    209836
 
 depends_build       port:go \
                     port:scdoc
@@ -34,6 +34,10 @@ variant notmuch description {Enable support for notmuch integration} {
 }
 
 build.target
+
+post-destroot {
+    delete ${destroot}${prefix}/share/applications/aerc.desktop
+}
 
 livecheck.url       https://git.sr.ht/~rjarry/aerc/refs
 livecheck.regex     {aerc (\d+(?:\.\d+)*)}


### PR DESCRIPTION
#### Description
[Release announcements](https://lists.sr.ht/~rjarry/aerc-announce)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
