### PR TITLE
rabbitmq-server: Update to version 3.10.0

### DIFF
--- a/net/rabbitmq-server/Portfile
+++ b/net/rabbitmq-server/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rabbitmq rabbitmq-server 3.8.3 v
+github.setup        rabbitmq rabbitmq-server 3.10.0 v
 revision            0
-checksums           rmd160  b0c2f92172d52b19e20c4f61ac30daebc71da0b7 \
-                    sha256  5a2739ed1dba77f88316b4c63393d8037fc4acf51881ba922470453e891875b6 \
-                    size    11958032
+checksums           rmd160  42449bd517d5a254091138db8596ea406ed0b169 \
+                    sha256  5058fc0d33305a016b0c08c9a54e328f63f51267366f07c31ce8d0a9cef508ea \
+                    size    12746956
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.3.1 21E258 arm64
Command Line Tools 13.3.1.0.1.1648687083

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?