### PR TITLE
nginx: Make variants work again

### DIFF
--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 
 name                nginx
 version             1.21.6
-revision            0
+revision            1
 categories          www mail
-platforms           darwin
 license             BSD
 maintainers         {mps @Schamschula} openmaintainer
 
@@ -78,7 +77,10 @@ configure.args-append \
                     --http-proxy-temp-path=${nginx_rundir}/proxy_temp \
                     --http-fastcgi-temp-path=${nginx_rundir}/fastcgi_temp \
                     --http-uwsgi-temp-path=${nginx_rundir}/uwsgi_temp \
-                    --without-pcre2  # pcre2 breaks the lua module (#65150)
+
+# pcre2 breaks the lua module (https://trac.macports.org/ticket/65150)
+configure.args-append \
+                    --without-pcre2
 
 # remove --disable-dependency-tracking
 configure.universal_args-delete   --disable-dependency-tracking


### PR DESCRIPTION
#### Description

The fix for https://trac.macports.org/ticket/65150 had the unintended consequence that the configure arguments from all variants were ignored.

In Tcl, "#" only starts a comment at the beginning of a line, so the "# pcre2 breaks the lua module" comment was added to the configure args literally. Configure args for the variants were added after that, but because the shell recognizes "#" as a comment character anywhere in the line, all those added configure args were ignored.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
