### PR TITLE
asio: update to 1.22.1

### DIFF
--- a/devel/asio/Portfile
+++ b/devel/asio/Portfile
@@ -14,9 +14,9 @@ checksums                   rmd160  389f838bb5dfccb5f86c0dbef35aa517f345d464 \
 
 license                     Boost-1
 description                 Asio C++ Library.
-long_description            Asio is a cross-platform C++ library for network and low-level I/O \
-                            programming that provides developers with a \
-                            consistent asynchronous model using a modern C++ approach.
+long_description            Asio is a cross-platform C++ library for network \
+                            and low-level I/O programming that provides developers \
+                            with a consistent asynchronous model using a modern C++ approach.
 maintainers                 {gmail.com:g.litenstein @Lord-Kamina} openmaintainer
 categories                  devel
 

--- a/devel/asio/Portfile
+++ b/devel/asio/Portfile
@@ -2,13 +2,15 @@
 
 PortSystem                  1.0
 PortGroup                   openssl 1.0
+PortGroup                   muniversal 1.0
+PortGroup                   github 1.0
 
-name                        asio
-version                     1.20.0
+github.setup                chriskohlhoff asio 1-22-1 asio-
+version                     [string map {- .} ${github.version}]
 revision                    0
-checksums                   rmd160  762d0c9dec18b7ce0fdf9069067900ab1345887f \
-                            sha256  204374d3cadff1b57a63f4c343cbadcee28374c072dc04b549d772dbba9f650c \
-                            size    1845826
+checksums                   rmd160  389f838bb5dfccb5f86c0dbef35aa517f345d464 \
+                            sha256  6d84889b15cda57ac77458e21900a30c5c90bc051b64b3e1b29fb4d26ccf15f6 \
+                            size    2850091
 
 license                     Boost-1
 description                 Asio C++ Library.
@@ -19,8 +21,15 @@ maintainers                 {gmail.com:g.litenstein @Lord-Kamina} openmaintainer
 categories                  devel
 
 homepage                    https://think-async.com/Asio/
-master_sites                sourceforge:project/${name}/${name}/${version}%20%28Stable%29
-use_bzip2                   yes
+
+worksrcdir                  ${worksrcdir}/${name}
+use_autoconf                yes
+autoconf.cmd                ./autogen.sh
+
+depends_build-append        port:autoconf \
+                            port:automake \
+                            port:libtool \
+                            port:pkgconfig
 
 compiler.cxx_standard       2014
 configure.cxxflags-append   -std=gnu++14

--- a/devel/asio/Portfile
+++ b/devel/asio/Portfile
@@ -37,5 +37,3 @@ configure.args              --with-boost=no \
                             --with-openssl=[openssl::install_area]
 configure.env-append        ASIO_HAS_STD_CHRONO=1 \
                             ASIO_DISABLE_STD_STRING_VIEW=1
-
-livecheck.regex             ${name}-(\\d+\\.\\d*\[02468\](?:\\.\\d+)+)


### PR DESCRIPTION
#### Description

Update to @1.22.1.
Added a patch to fix an error caused by a missing examples folder (Homebrew did the same).
Added `muniversal` PortGroup to enable `+universal` build (tested on Leopard).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10.6 PPC (10A190)
Xcode 3.2

macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
