### PR TITLE
nss: fix for ppc64 build on Leopard

### DIFF
--- a/net/nss/Portfile
+++ b/net/nss/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                nss
 version             3.78
-revision            0
+revision            1
 set NSS_VMAJOR      [lindex [split ${version} .] 0]
 set NSS_VMINOR      [lindex [split ${version} .] 1]
 set NSS_VPATCH      [lindex [split ${version} .] 2]
@@ -46,11 +46,11 @@ depends_lib     port:nspr \
                 port:zlib \
                 port:sqlite3
 
-destroot.dir ${destroot.dir}/dist
-build.dir    ${build.dir}/nss
+destroot.dir    ${destroot.dir}/dist
+build.dir       ${build.dir}/nss
 
 # external tests require C++11
-build.args   NSS_DISABLE_GTESTS=1
+build.args      NSS_DISABLE_GTESTS=1
 
 # disable use of -Werror
 build.args-append NSS_ENABLE_WERROR=0
@@ -176,6 +176,11 @@ if {${universal_possible} && [variant_isset universal]} {
             system "env DYLD_LIBRARY_PATH=${destroot}${prefix}/lib/nss ${destroot}${prefix}/bin/shlibsign -i ${base}.dylib -o ${chk}"
         }
     }
+}
+
+platform darwin 9 {
+    # PPC64 code in mpcpucache.c is invalid in Mac OSX ABI and causes a build failure
+    patchfiles-append patch-ppc64.diff
 }
 
 platform darwin 8 {

--- a/net/nss/Portfile
+++ b/net/nss/Portfile
@@ -5,8 +5,8 @@ PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                nss
-version             3.78
-revision            1
+version             3.79
+revision            0
 set NSS_VMAJOR      [lindex [split ${version} .] 0]
 set NSS_VMINOR      [lindex [split ${version} .] 1]
 set NSS_VPATCH      [lindex [split ${version} .] 2]
@@ -28,9 +28,9 @@ set my_release      NSS_[strsed ${version} {g/\./_/}]_RTM
 master_sites        https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/${my_release}/src/ \
                     ftp://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/${my_release}/src/
 
-checksums           rmd160  5147da7f09cfa3ae2f1a9937a0b6235c98b52692 \
-                    sha256  f455f341e787c1167328e80a84f77b9a557d595066dda6486a1874d72da68800 \
-                    size    84815720
+checksums           rmd160  5e278dd0eb923f4d19bafa2439e2ce97ca4c7e12 \
+                    sha256  ebdf2d6a96613b6fe70ad579e9f983e0e94e0110171cfb2999db633d3394a514 \
+                    size    84830113
 
 # build fails with gcc-4.2 on Intel, but succeeds with gcc-4.2 on PPC
 # cc1: error: unrecognized command line option "-mpclmul"
@@ -46,11 +46,11 @@ depends_lib     port:nspr \
                 port:zlib \
                 port:sqlite3
 
-destroot.dir    ${destroot.dir}/dist
-build.dir       ${build.dir}/nss
+destroot.dir ${destroot.dir}/dist
+build.dir    ${build.dir}/nss
 
 # external tests require C++11
-build.args      NSS_DISABLE_GTESTS=1
+build.args   NSS_DISABLE_GTESTS=1
 
 # disable use of -Werror
 build.args-append NSS_ENABLE_WERROR=0
@@ -179,7 +179,7 @@ if {${universal_possible} && [variant_isset universal]} {
 }
 
 platform darwin 9 {
-    # PPC64 code in mpcpucache.c is invalid in Mac OSX ABI and causes a build failure
+    # See: https://bugzilla.mozilla.org/show_bug.cgi?id=1769063
     patchfiles-append patch-ppc64.diff
 }
 

--- a/net/nss/files/patch-ppc64.diff
+++ b/net/nss/files/patch-ppc64.diff
@@ -1,0 +1,11 @@
+--- nss/lib/freebl/mpi/mpcpucache.c.orig	1970-01-01 08:00:00.000000000 +0800
++++ nss/lib/freebl/mpi/mpcpucache.c	2022-05-12 21:28:37.000000000 +0800
+@@ -705,7 +705,7 @@
+ #define MPI_GET_PROCESSOR_LINE_SIZE_DEFINED 1
+ #endif
+ 
+-#if defined(__ppc64__)
++#if !defined(__APPLE__) && defined(__ppc64__)
+ /*
+  *  Sigh, The PPC has some really nice features to help us determine cache
+  *  size, since it had lots of direct control functions to do so. The POWER

--- a/net/nss/files/patch-ppc64.diff
+++ b/net/nss/files/patch-ppc64.diff
@@ -1,11 +1,15 @@
---- nss/lib/freebl/mpi/mpcpucache.c.orig	1970-01-01 08:00:00.000000000 +0800
-+++ nss/lib/freebl/mpi/mpcpucache.c	2022-05-12 21:28:37.000000000 +0800
-@@ -705,7 +705,7 @@
- #define MPI_GET_PROCESSOR_LINE_SIZE_DEFINED 1
- #endif
+# See: https://bugzilla.mozilla.org/show_bug.cgi?id=1769063
+--- nss/lib/freebl/mpi/mpcpucache.c.orig	2022-05-26 17:54:33.000000000 +0800
++++ nss/lib/freebl/mpi/mpcpucache.c	2022-06-04 07:52:38.000000000 +0800
+@@ -727,10 +727,7 @@
+ static inline void
+ dcbzl(char *array)
+ {
+-    register char *a asm("r2") = array;
+-    __asm__ __volatile__("dcbzl %0,0"
+-                         : "=r"(a)
+-                         : "0"(a));
++  __asm__ ("dcbzl %0, %1" : /*no result*/ : "b%" (array), "r" (0) : "memory");
+ }
  
--#if defined(__ppc64__)
-+#if !defined(__APPLE__) && defined(__ppc64__)
- /*
-  *  Sigh, The PPC has some really nice features to help us determine cache
-  *  size, since it had lots of direct control functions to do so. The POWER
+ #define PPC_DO_ALIGN(x, y) ((char *)((((long long)(x)) + ((y)-1)) & ~((y)-1)))


### PR DESCRIPTION
#### Description

This finally fixes `nss` for `ppc64` and `+universal` on Leopard.

Closes my own ticket: https://trac.macports.org/ticket/64914
I have reported the problem to upstream, so hopefully we can retire the patch after awhile: https://bugzilla.mozilla.org/show_bug.cgi?id=1769063

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
