### PR TITLE
howdoi: update to 2.0.19; py-keep: new port, needed dependency

### DIFF
--- a/devel/howdoi/Portfile
+++ b/devel/howdoi/Portfile
@@ -4,33 +4,38 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                howdoi
-version             1.1.9
+version             2.0.19
+revision            0
+
 categories          devel python
-platforms           darwin
 license             MIT
 supported_archs     noarch
-
-python.default_version 27
-
 maintainers         nomaintainer
 
 description         instant coding answers via the command line
 long_description    {*}${description}
-homepage            https://pypi.python.org/pypi/howdoi
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
-distname            ${python.rootname}-${version}
+homepage            https://github.com/gleitz/howdoi
 
-checksums           rmd160  9c1fdc3dfd03fd717b4978b05928bc0d565f6f10 \
-                    sha256  2b4a0ebc39c9e0489a17ef73e3eec7dd4a2975e07b995406887c639481da2bb5
+checksums           rmd160  bb99d6f9638be1ea3e3e51bca244e1c66ef76164 \
+                    sha256  4baa5270a98e9d001094d873a5a1b6a32eac021009cfc40cd9aeede633cb7556 \
+                    size    27109
+
+python.default_version 310
 
 depends_build-append \
-    port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
 
-depends_lib-append \
-    port:py${python.version}-requests \
-    port:py${python.version}-requests-cache \
-    port:py${python.version}-pygments \
-    port:py${python.version}-pyquery
+depends_lib-append  port:py${python.version}-appdirs \
+                    port:py${python.version}-cachelib \
+                    port:py${python.version}-cssselect \
+                    port:py${python.version}-keep \
+                    port:py${python.version}-lxml \
+                    port:py${python.version}-pygments \
+                    port:py${python.version}-pyquery \
+                    port:py${python.version}-requests
 
-livecheck.type      pypi
+test.run            yes
+test.cmd            ${python.bin} test_howdoi.py
+test.target
+test.env            PYTHONPATH=${worksrcpath}/build/lib

--- a/python/py-keep/Portfile
+++ b/python/py-keep/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-keep
+version             2.10.1
+revision            0
+
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         A Meta CLI toolkit
+long_description    A Meta CLI toolkit: your personal shell command keeper
+
+homepage            https://github.com/orkohunter/keep
+
+checksums           rmd160  5bef8733deb9231da85b96993d381eb169533909 \
+                    sha256  3abbe445347711cecd9cbb80dab4a0777418972fc14a14e9387d0d2ae4b6adb7 \
+                    size    13044
+
+python.versions     39 310
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    depends_lib-append  port:py${python.version}-click \
+                        port:py${python.version}-pygithub \
+                        port:py${python.version}-requests \
+                        port:py${python.version}-terminaltables
+}


### PR DESCRIPTION
#### Description

Update to @2.0.19, corresponding changes in portfile. `python27` support has been dropped by the developer, so move to `python39`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC (10A190)
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
