### PR TITLE
openjdk11-microsoft: update to 11.0.15

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,10 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-set build 7
-
-version      11.0.14.1
-set build    1
+version      11.0.15
+set build    10
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -27,15 +25,15 @@ long_description The Microsoft Build of OpenJDK is a no-cost distribution of Ope
 master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     microsoft-jdk-${version}_${build}-31205-macOS-x64
-    checksums    rmd160  5928c9a73b7f2d812a675674a48eeda4ce86d02e \
-                 sha256  03a6c1da0d4f8aacf0f01ba7306666251bd3119b4e1b7b049951b5a7505c9894 \
-                 size    186963275
+    distname     microsoft-jdk-${version}-macOS-x64
+    checksums    rmd160  b8daf288010149295baa021f1bb177904e0f5952 \
+                 sha256  787b68e250d6aece2c765c49fb00c184ff3e3b87e2bf8320a6b017eece040d78 \
+                 size    186851366
 } elseif {${configure.build_arch} eq "arm64"} {
-    distname     microsoft-jdk-${version}_${build}-31206-macOS-aarch64
-    checksums    rmd160  cf9a4eab103bc95bc0988068856421bca23e9aa6 \
-                 sha256  ceaedbed620ec7afda21a37b2884db1f345e67bb6c4deba71965d6e223ef5d43 \
-                 size    184354992
+    distname     microsoft-jdk-${version}-macOS-aarch64
+    checksums    rmd160  3fda055c54284df3d8ae79b2e69636f89eb08112 \
+                 sha256  083c74fa731e0c514b840479c4c5ba52b69b7a0a17fab1b2a9b09b052bb378ac \
+                 size    184482606
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.15.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?