### PR TITLE
openjdk-distributions: move openjdk11-sap to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -22,9 +22,6 @@ set long_description_ibm_semeru \
     "The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications built with\
 the OpenJDK class libraries and the Eclipse OpenJ9 JVM."
 
-set long_description_sap \
-    "Sap builds of openjdk for everyone who wish to use OpenJDK to run their applications."
-
 set long_description_temurin \
     "Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes."
 
@@ -277,26 +274,6 @@ subport openjdk11-openj9 {
     worksrcdir   jdk-${version}+${build}
 }
 
-subport openjdk11-sap {
-    # https://sap.github.io/SapMachine/latest/11
-    supported_archs  x86_64
-
-    version      11.0.15.0.1
-    revision     0
-    
-    description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
-    long_description ${long_description_sap}
-    
-    master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
-    distname     sapmachine-jdk-${version}_osx-x64_bin
-    worksrcdir   sapmachine-jdk-${version}.jdk
-    
-    checksums    rmd160  c5cb8d973381ee35aaab6f11367c1f41bfa7e5af \
-                 sha256  7744b3632fba1c6e8339b9fb74c46728f8109c07070df49d898799832a934abd \
-                 size    186905770
-
-}
-
 # Remove after 2022-09-14
 subport openjdk16 {
     version      16.0.2
@@ -355,8 +332,6 @@ if {[string match *-graalvm ${subport}]} {
     homepage     https://www.graalvm.org
 } elseif {[string match *-zulu ${subport}]} {
     homepage     https://www.azul.com/downloads/
-} elseif {[string match *-sap ${subport}]} {
-    homepage     https://sapmachine.io/
 } elseif {[string match *-temurin ${subport}]} {
     homepage     https://adoptium.net
 } elseif {[string match *-corretto ${subport}]} {

--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -1,0 +1,80 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk11-sap
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://sap.github.io/SapMachine/latest/11
+supported_archs  x86_64
+
+version      11.0.15.0.1
+revision     0
+
+description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
+long_description Sap builds of OpenJDK for everyone who wish to use OpenJDK to run their applications.
+
+master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
+
+distname     sapmachine-jdk-${version}_osx-x64_bin
+checksums    rmd160  c5cb8d973381ee35aaab6f11367c1f41bfa7e5af \
+             sha256  7744b3632fba1c6e8339b9fb74c46728f8109c07070df49d898799832a934abd \
+             size    186905770
+
+worksrcdir   sapmachine-jdk-${version}.jdk
+
+homepage     https://sapmachine.io
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk11-sap` to its own portfile. I plan to do this for all subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?