### PR TITLE
openjdk17-oracle: obsolete, replaced by openjdk18-oracle

### DIFF
--- a/java/openjdk17-oracle/Portfile
+++ b/java/openjdk17-oracle/Portfile
@@ -1,88 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+# Remove after 2023-05-12
+# https://jdk.java.net/17/
 PortSystem       1.0
+PortGroup        obsolete 1.0
 
 name             openjdk17-oracle
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://jdk.java.net/17/
-version      17.0.2
-set build    8
-revision     0
-
-description  Oracle OpenJDK 17
-long_description Open-source Oracle build of OpenJDK 17, the Java Development Kit, an implementation of the Java SE Platform.
-
-master_sites https://download.java.net/java/GA/jdk${version}/dfd4a8d0985749f896bed50d7138ee7f/${build}/GPL/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  3c89d3464a2c5e5e62af2153101d19f6023f1410 \
-                 sha256  b85c4aaf7b141825ad3a0ea34b965e45c15d5963677e9b27235aa05f65c6df06 \
-                 size    184480668
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  79b88f39a4321cafe5b652b1c9fe6a92966b0de8 \
-                 sha256  602d7de72526368bb3f80d95c4427696ea639d2e0cc40455f53ff0bbb18c27c8 \
-                 size    182209404
-}
-
-worksrcdir   jdk-${version}.jdk
-
-homepage     https://jdk.java.net/17/
-
-livecheck.type  none
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+replaced_by      openjdk18-oracle
+version          17.0.2
+revision         1


### PR DESCRIPTION
#### Description

Unlike other OpenJDK vendors and Oracle Java SE, Oracle OpenJDK does not provide Long Term Support updates for Java 17. Oracle OpenJDK 17 is no longer receiving updates and has been superseded by Oracle OpenJDK 18.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?