### PR TITLE
fzf: update instructions for fish shell

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -116,41 +116,50 @@ Bash
 
 Append this line to ~/.bashrc to enable fzf keybindings for Bash:
 
- source ${prefix}/share/fzf/shell/key-bindings.bash
+    source ${prefix}/share/fzf/shell/key-bindings.bash
 
 Append this line to ~/.bashrc to enable fuzzy auto-completion for Bash:
 
- source ${prefix}/share/fzf/shell/completion.bash
+    source ${prefix}/share/fzf/shell/completion.bash
+
 
 Zsh
 ===
 
 Append this line to ~/.zshrc to enable fzf keybindings for Zsh:
 
- source ${prefix}/share/fzf/shell/key-bindings.zsh
+    source ${prefix}/share/fzf/shell/key-bindings.zsh
 
 Append this line to ~/.zshrc to enable fuzzy auto-completion for Zsh:
 
- source ${prefix}/share/fzf/shell/completion.zsh
+    source ${prefix}/share/fzf/shell/completion.zsh
+
 
 Fish
+====
+
+To enable fzf keybindings for fish, append this line to
+~/.config/fish/config.fish:
+
+    source ${prefix}/share/fzf/shell/key-bindings.fish
+
+and add the following to ~/.config/fish/functions/fish_user_key_bindings.fish:
+
+    function fish_user_key_bindings
+        fzf_key_bindings
+    end
+
+
+Vim
 ===
 
-Append this line to ~/.config/fish/config.fish to enable fzf keybindings for Fish:
+The Vim plugin is located in ${prefix}/share/fzf/vim.
 
- source ${prefix}/share/fzf/shell/key-bindings.fish
-
-
-The Vim plugin is located in:
-
-    ${prefix}/share/fzf/vim
-
-Enable the Vim plugin by adding the following to your
-Vim configuration file (default: ~/.vimrc):
+Enable the Vim plugin by adding the following to your Vim configuration
+file (default: ~/.vimrc):
 
     set rtp+=${prefix}/share/fzf/vim
 
-Documentation for fzf and the Vim plugin is located in:
-
-    ${prefix}/share/doc/fzf
+Documentation for fzf and the Vim plugin is located in
+${prefix}/share/doc/fzf.
 "


### PR DESCRIPTION
#### Description

fzf: update instructions for fish shell
* cleanup and make formatting consistent

Closes: https://trac.macports.org/ticket/65166

Note that revision/epoch isn't bumped as this just updates the port notes.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?