### PR TITLE
podman-compose: use Python 3.10, update py-python-dotenv

### DIFF
--- a/python/podman-compose/Portfile
+++ b/python/podman-compose/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                podman-compose
 version             1.0.3
-revision            0
+revision            1
 
 categories-append   devel
 supported_archs     noarch
@@ -20,7 +20,7 @@ checksums           rmd160  dd21ace3714b9baa9113a9a48fded2ab65f1a2c8 \
                     sha256  9c9fe8249136e45257662272ade33760613e2d9ca6153269e1e970400ea14675 \
                     size    21424
 
-python.default_version 39
+python.default_version 310
 
 depends_build-append \
                 port:py${python.version}-setuptools

--- a/python/py-python-dotenv/Portfile
+++ b/python/py-python-dotenv/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        theskumar python-dotenv 0.17.1 v
+github.setup        theskumar python-dotenv 0.20.0 v
+github.tarball_from archive
 revision            0
 
 name                py-python-dotenv
@@ -20,11 +21,11 @@ long_description    $description \
                     environment variable. It is great for managing app settings \
                     during development and in production using 12-factor principles.
 
-checksums           rmd160  5a44b8efb1e85d3a55e44364df8b2894cd2c6753 \
-                    sha256  9ba2935047e06b23487dbb766f1d680173825f768793c1fb0a1a9e73aaae52da \
-                    size    22310
+checksums           rmd160  38a1b93a1769a10eb9fb6b62806609d4519ea0bf \
+                    sha256  f25324ebe83467c58a089b30cda9775b3e4d4aa727e898dd2373142679807263 \
+                    size    22356
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${subport} ne ${name}} {
     depends_build-append \
@@ -32,6 +33,23 @@ if {${subport} ne ${name}} {
 
     depends_lib-append  \
                     port:py${python.version}-click
+
+    if {${python.version} < 38} {
+        depends_lib-append  \
+                    port:py${python.version}-importlib-metadata
+    }
+
+    # a few tests fail becuase the "dotenv" console_script hasn't been created yet...
+    depends_test-append \
+                    port:py${python.version}-ipython \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-sh
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description
- `podman-compose`: use Python 3.10
- `py-python-dotenv`: update to 0.20.0, add py310 subport

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
