### PR TITLE
pipx: use Python 3.10 as default, obsolete pipsi

### DIFF
--- a/python/pipsi/Portfile
+++ b/python/pipsi/Portfile
@@ -1,31 +1,12 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
-PortGroup           github 1.0
+PortGroup           obsolete 1.0
 
-github.setup        mitsuhiko pipsi b43229d8a3da64bc929e05d0735a17a9a3911d11
-revision            1
+name                pipsi
 version             20180610
+revision            2
+
 categories          python sysutils
-license             MIT
-maintainers         {lbschenkel @lbschenkel} openmaintainer
-supported_archs     noarch
-platforms           darwin
 
-description         pip script installer
-long_description    Wrapper around virtualenv and pip which installs scripts \
-                    provided by Python packages into separate virtualenvs to \
-                    shield them from your system and each other.
-
-checksums           rmd160  d91d62a591d11344b1c113d8710ece45b1cd80e9 \
-                    sha256  cbfb5ebc0daf4da1dc88c77c7fc9b2316819a837ca1b9f10014ae588134b9838 \
-                    size    11486
-
-python.default_version 37
-depends_lib         port:py${python.version}-click \
-                    port:py${python.version}-virtualenv
-
-notes-append        \
-    "WARNING: pipsi is no longer being maintained." \
-    "Consider using the pipx port instead (Python 3.3+ virtualenvs)."
+replaced_by         pipx

--- a/python/pipx/Portfile
+++ b/python/pipx/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        pypa pipx 1.0.0
-revision            0
+revision            1
 checksums           rmd160  d92ce539cff9ecb3f7a477963594466dc5316cc4 \
                     sha256  6411399e6d323161983cab9c997e5ad819b7198a9965f0d5797e5e9f7760d908 \
                     size    399078
@@ -27,7 +27,7 @@ if {
     ![variant_isset python39] &&
     ![variant_isset python310]
 } {
-    default_variants +python39
+    default_variants +python310
 }
 
 variant python37 conflicts python38 python39 python310 description {Use Python 3.7} {}
@@ -45,8 +45,17 @@ if {[variant_isset python310]} {
     python.default_version 37
 }
 
-depends_lib-append \
-                    port:py${python.version}-argcomplete \
-                    port:py${python.version}-setuptools \
+python.pep517       yes
+python.pep517_backend hatch
+
+depends_build-append \
+                    port:py${python.version}-wheel
+
+depends_lib-append  port:py${python.version}-argcomplete \
                     port:py${python.version}-packaging \
                     port:py${python.version}-userpath
+
+if {${python.version} < 38} {
+    depends_run-append \
+                    port:py${python.version}-importlib-metadata
+}


### PR DESCRIPTION
#### Description
- `pipx` use Python 3.10 as default
- `pipsi`: obsolete port, replaced_by `pipx`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
