### PR TITLE
scrcpy: Move libusb dependency from build to lib

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        Genymobile scrcpy 1.24 v
-revision            0
+revision            1
 
 categories          multimedia
 platforms           darwin
@@ -33,11 +33,11 @@ checksums           ${distname}${extract.suffix} \
                     size    41159
 
 depends_build-append \
-                    port:libusb \
                     port:pkgconfig
 
 depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
-                    port:libsdl2
+                    port:libsdl2 \
+                    port:libusb
 
 depends_run-append  port:android-platform-tools
 


### PR DESCRIPTION
#### Description
The scrcpy binary links against libusb, so it should be available at
runtime:

```
$> otool -L /opt/local/bin/scrcpy | grep libusb
  /opt/local/lib/libusb-1.0.0.dylib (compatibility version 4.0.0, current version 4.0.0)
$> port provides /opt/local/lib/libusb-1.0.0.dylib
/opt/local/lib/libusb-1.0.0.dylib is provided by: libusb
```

See https://github.com/Genymobile/scrcpy/issues/2256#issuecomment-1126117503.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.5 20G527 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~ <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] ~tried existing tests with `sudo port test`?~
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
