### PR TITLE
fx: update to 24.0.0

### DIFF
--- a/sysutils/fx/Portfile
+++ b/sysutils/fx/Portfile
@@ -1,36 +1,168 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        antonmedv fx 20.0.2
+go.setup            github.com/antonmedv/fx 24.0.0
 revision            0
-
-homepage            https://fx.wtf
-
 categories          sysutils textproc
-platforms           darwin
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 license             MIT
-maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 
-description         Command-line tool and terminal JSON viewer
-long_description    ${description}
+description         Terminal JSON viewer
+long_description    {*}${description}
 
-checksums           rmd160  daebd75243af12348f480770503c1dca825e663c \
-                    sha256  edc7548edb1af0adca18ac9dbdf45e6455eb0778c07405c2a835dd5593fb099c \
-                    size    28004146
+checksums           ${distname}${extract.suffix} \
+                        rmd160  948050663d3ff3b6ee2168298ab47cbb0cf8875a \
+                        sha256  de166d4bf1d38be9e7736b1a93267b7debe65206ff7cb53097565993690d880f \
+                        size    1033494
 
-github.tarball_from releases
-distname            ${name}-macos
-dist_subdir         ${name}/${version}
-
-extract.mkdir       yes
-
-use_configure       no
-use_zip             yes
-
-build {}
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
+                    gopkg.in/check.v1 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
+                    golang.org/x/text \
+                        lock    v0.3.7 \
+                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
+                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
+                        size    8356115 \
+                    golang.org/x/term \
+                        lock    e5f449aeb171 \
+                        rmd160  815a83a4b9782102c3877cf61ee45ab5f8f89f4f \
+                        sha256  825a85ed3b123e641b82daecec59a33954393371b3f5e59dc90742a9ec46622f \
+                        size    14976 \
+                    golang.org/x/sys \
+                        lock    988cb79eb6c6 \
+                        rmd160  2a811d9ad19b374e9fa643a4b36cff0759f8c973 \
+                        sha256  61e5f6e725d3a5ad7b647ddc01cfeae284330a078846982aced0a2e2ec3b5eb5 \
+                        size    1303231 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.1 \
+                        rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
+                        sha256  27cabaf81344157a188083266cf8ccc19d04c43d9a34b6276b760514b9c880a3 \
+                        size    94020 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.6.1 \
+                        rmd160  60a7c8a40bd73160f7a61ab365d9ebab06ff90a1 \
+                        sha256  ccd0e3ec65e987ddb9719f0e1db82aee660db3bfcfc7bd031bcccc1df0d1fc85 \
+                        size    123139 \
+                    github.com/rivo/uniseg \
+                        lock    v0.2.0 \
+                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
+                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
+                        size    44037 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/muesli/termenv \
+                        lock    44cd13922739 \
+                        rmd160  e31c6ee43ba7a1b5b523da9e4ae4986868175857 \
+                        sha256  51ddb46438edd4eda1564f6743d6b710bd010a1623ad331de11c11423b42d6a4 \
+                        size    412111 \
+                    github.com/muesli/reflow \
+                        lock    v0.3.0 \
+                        rmd160  8941f9c5aa79468e9280c3727c7eafa4f00f748d \
+                        sha256  67ed2e1490730fc629238aa847fdd863acefda8b0d35d689bbd88ced8c0f80ca \
+                        size    21257 \
+                    github.com/muesli/ansi \
+                        lock    c9f0611b6c70 \
+                        rmd160  b4e973867b185963dba064fdda31cbc3df37e4e9 \
+                        sha256  69b20c11994dd2f52dbe30d14e6fcc6596b1bcf09f5ead5339ce55a1950dd411 \
+                        size    5129 \
+                    github.com/mazznoer/csscolorparser \
+                        lock    v0.1.2 \
+                        rmd160  01441e6effb91474c7b8808070cf29639bfa44fd \
+                        sha256  98f5363394be83080e5637de4896e0543d5f33fdcf465150dc80c8ff5501ceaa \
+                        size    16615 \
+                    github.com/mazznoer/colorgrad \
+                        lock    v0.8.1 \
+                        rmd160  72fc0d973c9b546c63213e125037d70588e98301 \
+                        sha256  6ed9d0793de7a9d2351e5b3959fd6178566bf8493f5f29258fe95aad361172cf \
+                        size    192552 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.13 \
+                        rmd160  e177edb4dc4702ae2b23704934ff31cc6561bbd0 \
+                        sha256  dcd3ccbd956a6f53bc106b79489d0303a237c21d858d23250e3e1d7284b72b86 \
+                        size    17363 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.14 \
+                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
+                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
+                        size    4705 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.2.0 \
+                        rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \
+                        sha256  fbad1aade4444bf51409f5b6a008cc14c7a7cdd1af856841fc1170605fae3914 \
+                        size    970841 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.3.0 \
+                        rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
+                        sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
+                        size    10043 \
+                    github.com/go-sourcemap/sourcemap \
+                        lock    v2.1.3 \
+                        rmd160  5c0ca4bf07713d7a1fe3d18f20383a43b72238e3 \
+                        sha256  3012001cf5d369398deda6feb4b8ef7806680ace0909615262089e4276235c45 \
+                        size    6481 \
+                    github.com/dop251/goja \
+                        lock    e1eca0b61fa9 \
+                        rmd160  c527122b5356cd6b4c30ff5a11c945d7d9d9bf30 \
+                        sha256  d73b4468cc75217ffb3b631dbaaed7f2e6adab1e1b6a9802e7a6182bc0cd9fb0 \
+                        size    341742 \
+                    github.com/dlclark/regexp2 \
+                        lock    a2a8dda75c91 \
+                        rmd160  b98117d8ee923adf0b36bc66bbfac667d5b211a3 \
+                        sha256  21a5736eb79dfb44f2fa6b2f4254759121adf6715e55c53e702eba44e7aef849 \
+                        size    206229 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.0 \
+                        rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \
+                        sha256  810a597004388d68bb92d8aa612375419ba1080dd5fc2c66dd41b58f0ba4442c \
+                        size    42348 \
+                    github.com/containerd/console \
+                        lock    v1.0.3 \
+                        rmd160  0ddcc08a0582fd25a653a0a6a599c0f9eed7538e \
+                        sha256  a032c6f2eecefbeb998ef96bb92f65423552f8e0ac7c410ec0f8c5829af704ea \
+                        size    13726 \
+                    github.com/charmbracelet/lipgloss \
+                        lock    v0.5.0 \
+                        rmd160  a63f508c630e9b9700102538cb65e4732130f914 \
+                        sha256  2df51ce2b10fc945cf69c21be3b3bbf141f90f7350bcc16d5d3998824b365f44 \
+                        size    27292 \
+                    github.com/charmbracelet/bubbletea \
+                        lock    v0.20.0 \
+                        rmd160  320e5a00f7ee43bed9e58a048dc100733740156b \
+                        sha256  6870f707dd15f420cb149d4babb2a4055aeb1336003a731ab0ff30661f533d27 \
+                        size    65945 \
+                    github.com/charmbracelet/bubbles \
+                        lock    v0.10.3 \
+                        rmd160  4a380ad8fc02cf6917e01dd52b522695fe6cb936 \
+                        sha256  e4c30269e1a865a7320544969141c8b6b73f8dc92d8b3c077af6603a337d0603 \
+                        size    35716 \
+                    github.com/atotto/clipboard \
+                        lock    v0.1.4 \
+                        rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
+                        sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
+                        size    5023
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${name}-macos ${destroot}${prefix}/bin/${name}
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/antonmedv/fx/releases)
(re-implemented in go)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
