### PR TITLE
ocaml: fix build for PPC, bytecode compiler

### DIFF
--- a/lang/ocaml/Portfile
+++ b/lang/ocaml/Portfile
@@ -14,12 +14,12 @@ PortGroup           compiler_blacklist_versions 1.0
 name                ocaml
 epoch               1
 version             4.12.1
-revision            0
+revision            1
 set major_vers      [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
-# Note that i386 on Mac is truly no longer supported by upstream
+# Note that ppc, ppc64 and i386 on Mac are no longer supported by upstream
 # We may have to remove support at some point.
-supported_archs     i386 x86_64 arm64
+supported_archs     i386 x86_64 arm64 ppc ppc64
 maintainers         {pmetzger @pmetzger} openmaintainer
 categories          lang ocaml
 license             LGPL
@@ -47,18 +47,21 @@ compiler.blacklist  gcc-4.0 *gcc-4.2 {clang < 400}
 # debug problems with these patches.
 if {${os.major} < 11} {
     # need to add strnlen patch as not in library
-    patchfiles-append  patch-strnlen-socketaddr.diff
+    patchfiles-append  patch-strnlen-socketaddr.diff \
+                       patch-configure-darwin-ppc.diff
 
+    if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
     # compiler selection pulls in clang-3.4 on 10.6 and less
     # and this compiler is needed for this port to run once installed
     # so force this compiler and require it at runtime
     compiler.whitelist     macports-clang-3.4
     depends_run-append     port:clang-3.4
+    }
 }
 
 # Note: the port maintainer has no access to an i386 host, and cannot
 # debug problems on one.
-if {${build_arch} eq "i386"} {
+if {${build_arch} eq "i386" || ${build_arch} eq "ppc"} {
     patchfiles-append  patch-configure-darwin32.diff
 }
 
@@ -77,7 +80,11 @@ configure.env-append \
 configure.pre_args  --prefix=${prefix} --mandir=${prefix}/share/man
 
 # Building.
-build.target        world.opt
+if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+    build.target    world
+    } else {
+    build.target    world.opt
+}
 
 post-destroot {
     xinstall -d ${destroot}${docdir}

--- a/lang/ocaml/files/patch-configure-darwin-ppc.diff
+++ b/lang/ocaml/files/patch-configure-darwin-ppc.diff
@@ -1,0 +1,60 @@
+--- configure.orig	2021-09-24 21:06:54.000000000 +0800
++++ configure	2022-05-23 22:55:50.000000000 +0800
+@@ -13732,6 +13732,8 @@
+     natdynlink=true ;; #(
+   x86_64-*-darwin*) :
+     natdynlink=true ;; #(
++  powerpc*-*-darwin*) :
++    natdynlink=true ;; #(
+   s390x*-*-linux*) :
+     natdynlink=true ;; #(
+   powerpc*-*-linux*) :
+@@ -13937,6 +13939,12 @@
+     arch=arm64; system=macosx ;; #(
+   x86_64-*-darwin*) :
+     arch=amd64; system=macosx ;; #(
++  powerpc*-*-darwin*) :
++    arch=power; if $arch64; then :
++  model=ppc64
++    else
++  model=ppc
++    fi; system=rhapsody ;; #(
+   x86_64-*-mingw32) :
+     arch=amd64; system=mingw64 ;; #(
+   aarch64-*-linux*) :
+@@ -14071,6 +14079,10 @@
+   case "$arch,$CC,$system,$model" in #(
+   amd64,gcc*,macosx,*) :
+     PACKLD_FLAGS=' -arch x86_64' ;; #(
++  power,*gcc*,rhapsody,ppc) :
++    PACKLD_FLAGS=' -arch ppc' ;; #(
++  power,*gcc*,rhapsody,ppc64) :
++    PACKLD_FLAGS=' -arch ppc64' ;; #(
+   power,gcc*,elf,ppc) :
+     PACKLD_FLAGS=' -m elf32ppclinux' ;; #(
+   power,gcc*,elf,ppc64) :
+@@ -14241,6 +14253,15 @@
+     default_as="${toolpref}as -arch x86_64"
+       default_aspp="${toolpref}gcc -arch x86_64 -c" ;;
+ esac ;; #(
++  power,rhapsody) :
++    case $model in #(
++  ppc64) :
++    default_as="$default_as -m64"
++        default_aspp="$default_as -m64 -c" ;; #(
++  ppc) :
++    default_as="$default_as"
++        default_aspp="$default_as -m32 -c" ;; #(
++esac ;; #(
+   amd64,solaris) :
+     case $ocaml_cv_cc_vendor in #(
+   sunc-*) :
+@@ -15923,7 +15944,7 @@
+ $as_echo_n "checking whether stack overflows can be detected... " >&6; }
+ 
+ case $arch,$system in #(
+-  i386,linux_elf|amd64,linux|amd64,macosx \
++  i386,linux_elf|amd64,linux|amd64,macosx|power,rhapsody \
+     |amd64,openbsd|i386,bsd_elf) :
+     $as_echo "#define HAS_STACK_OVERFLOW_DETECTION 1" >>confdefs.h
+ 


### PR DESCRIPTION
#### Description

This fixed build of `ocaml` @4.1.2 for PPC (bytecode compiler, world target).
Ref from: https://github.com/macports/macports-ports/pull/14691

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
