### PR TITLE
openjdk18-temurin: update arm64 to 18.0.1

### DIFF
--- a/java/openjdk18-temurin/Portfile
+++ b/java/openjdk18-temurin/Portfile
@@ -14,14 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-if {${configure.build_arch} eq "x86_64"} {
-    version      18.0.1
-    set build    10
-} elseif {${configure.build_arch} eq "arm64"} {
-    version      18
-    set build    36
-}
-
+version      18.0.1
+set build    10
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 18
@@ -36,9 +30,9 @@ if {${configure.build_arch} eq "x86_64"} {
                  size    188268875
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK18U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  50ba39557a02d6fd105e70e1bc5d19023c3ffe02 \
-                 sha256  ac0beb8843f4bc360656ad828fdc9b06937a2ea67cb4d5ef6e3c37c09f5501d4 \
-                 size    178744694
+    checksums    rmd160  594cbf51b7f63c6df2589a3aa9ced3e93f983d27 \
+                 sha256  4f459195df89e52bbadfb5b7ab8a95030b08fcd84b7e0017eceed00f05ec0458 \
+                 size    178818976
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 18.0.1 for ARM64.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?