### PR TITLE
php: add php-ffi extension subport

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -926,6 +926,8 @@ subport ${php}-ffi {
 
     long_description        ${description}
 
+    depends_build-append    port:pkgconfig
+
     depends_lib-append      port:libffi
 
     configure.args-append   --with-ffi

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -912,6 +912,26 @@ subport ${php}-exif {
     long_description        ${description}
 }
 
+if {[vercmp ${branch} 7.4] >= 0} {
+subport ${php}-ffi {
+    switch -- ${version} {
+        7.4.29              {revision 0}
+        8.0.19              {revision 0}
+        8.1.6               {revision 0}
+    }
+
+    categories-append       devel
+
+    description             a PHP interface to allow loading of shared libraries
+
+    long_description        ${description}
+
+    depends_lib-append      port:libffi
+
+    configure.args-append   --with-ffi
+}
+}
+
 subport ${php}-ftp {
     switch -- ${version} {
         5.2.17              {revision 3}


### PR DESCRIPTION
#### Description

Added the php-ffi extension (added in PHP 7.4.0) subport

https://www.php.net/manual/en/book.ffi.php
https://www.php.net/ChangeLog-7.php#7.4.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.3.1 21E258 arm64
Xcode 13.3.1 13E500a


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
