### PR TITLE
ld64-274: allow build on Mac OS X Leopard

### DIFF
--- a/_resources/port1.0/group/rust-1.0.tcl
+++ b/_resources/port1.0/group/rust-1.0.tcl
@@ -729,10 +729,9 @@ proc rust::rust_pg_callback {} {
         depends_lib-append              port:openssl${openssl_ver}
     }
 
-    if { [string match "macports-clang*" [option configure.compiler]] && [option os.major] == 10 } {
+    if { [string match "macports-clang*" [option configure.compiler]] && [option os.major] < 11 } {
         # by default, ld64 uses ld64-127 when 9 <= ${os.major} < 11
-        # Rust fails to build when ${os.major} >= 10 and ld64 uses ld64-127
-        # ld64-274 does not seem to build when ${os.major} < 10
+        # Rust fails to build when architecture is x86_64 and ld64 uses ld64-127
         depends_build-delete            port:ld64-274
         depends_build-append            port:ld64-274
         depends_skip_archcheck-delete   ld64-274

--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -157,6 +157,8 @@ subport ld64-236 {
 }
 
 subport ld64-274 {
+    PortGroup legacysupport 1.1
+
     # Xcode 8.2.1
     version             274.2
     revision            0
@@ -185,6 +187,15 @@ subport ld64-274 {
     depends_lib-append port:libcxx
     configure.cxx_stdlib libc++
     configure.cxxflags-append -std=c++11
+
+    # Avoid `error: unknown type name 'uuid_string_t'`
+    legacysupport.newest_darwin_requires_legacy 9
+
+    if { ${os.platform} eq "darwin" && ${os.major} <= 9 } {
+        depends_lib-append          port:libblocksruntime
+        configure.cxxflags-append   -fblocks
+        configure.ldflags-append    -lBlocksRuntime
+    }
 
     supported_archs i386 x86_64
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L31a i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
