### PR TITLE
mvnd: update to 0.8.0

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    apache maven-mvnd 0.7.1
+version         0.8.0
 revision        0
 name            mvnd
 categories      java
@@ -31,12 +30,15 @@ long_description mvnd aims at providing faster Maven builds using techniques kno
                 This applies not only to the code coming from Maven plugins and Maven Core,\
                 but also to all code coming from the JDK itself.
 
-github.tarball_from releases
-distname        ${name}-${version}-darwin-amd64
+homepage        https://github.com/apache/maven-mvnd
+supported_archs x86_64
 
-checksums       rmd160  a20216cb788f0182c4af3249a4a2a8af4ca1a50a \
-                sha256  7a0de6107b9e19290ccc6853ea93a087e5fe1558f64eab66a9e803a03afedc3c \
-                size    26546783
+master_sites    https://downloads.apache.org/maven/mvnd/${version}/
+distname        maven-mvnd-${version}-darwin-amd64
+
+checksums       rmd160  088ea924584215c123114b401c06e1b88c570325 \
+                sha256  b81c78393ec00104f55983b0944e941d2702a8d82d5517f20287d6486a514ca0 \
+                size    20710406
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Apache Maven mvnd 0.8.0.

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?