### PR TITLE
MoltenVK: Update to 1.1.10 & add workaround for 10.11

### DIFF
--- a/graphics/MoltenVK/Portfile
+++ b/graphics/MoltenVK/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        KhronosGroup MoltenVK 1.1.9 v
+github.setup        KhronosGroup MoltenVK 1.1.10 v
 epoch               1
 
-set sdkversion      1.3.211.0
+set sdkversion      1.3.216.0
 categories          graphics
 maintainers         {ryandesign @ryandesign} openmaintainer
 platforms           macosx
@@ -21,52 +21,74 @@ long_description    ${name} is an implementation of the high-performance, \
                     industry-standard Vulkan graphics and compute API, that \
                     runs on Apple's Metal graphics framework.
 
-distname            vulkansdk-macos-${sdkversion}
-use_dmg             yes
+# Repackage the darwin16 package for darwin15, so we can only update the version after that
+# is avalible on packages.macports
+if {${os.major} == 15} {
+    version             1.1.9
+    master_sites        https://packages.macports.org/MoltenVK/
+    distname            MoltenVK-${version}_0.darwin_16.x86_64
+    checksums           sha256  84c49e85712d2bb19f5d00bd91df4dae9518bc31ca3265c56c1fdabae25fcf08 \
+                        rmd160  bf7e89fc3f67c0aeb392149eae4ce51ee06d4f06 \
+                        size    7026887
+    use_bzip2           yes
+    extract.suffix      .tbz2
 
-# url only works for the latest avalible SDK, older versions will 404
-master_sites        https://sdk.lunarg.com/sdk/download/${sdkversion}/mac/
+    use_configure       no
 
-checksums           sha256  bfe654af00030b6e65521f834f0830f15e18c828594226865f15c92a9ea68363 \
-                    rmd160  3674f67b37f7bcc1746d55c3baa975d0cca9dbaa \
-                    size    275553243
+    build {}
 
-depends_build       port:p7zip
-depends_skip_archcheck p7zip
+    destroot {
+        delete ${destroot}${prefix}
+        copy ${workpath}/opt/local ${destroot}${prefix}
+    }
+} else {
+    distname            vulkansdk-macos-${sdkversion}
+    use_dmg             yes
 
-use_configure       no
+    # url only works for the latest avalible SDK, older versions will 404
+    master_sites        https://sdk.lunarg.com/sdk/download/${sdkversion}/mac/
 
-build {
-    # bypass the installer that requires macOS 10.13
-    system "${prefix}/bin/7z x -aoa ${worksrcpath}/InstallVulkan.app/Contents/Resources/installer.dat -o${workpath}/VulkanSDK"
-}
+    checksums           sha256  c896c30dc483aaffd4d7a5ac4c1c9a49552aa3893ab76a1f54be00e72bd2f33f \
+                        rmd160  8b7fe763abb5bc775dd2446e83289c15b0b023b7 \
+                        size    274321502
 
-destroot {
-    set output_dir ${workpath}/VulkanSDK
+    depends_build       port:p7zip
+    depends_skip_archcheck p7zip
 
-    # Xcode11 and later are required to use "xcframework"
-    # Headers currently break build due to Xcode 12 ProcessXCFramework bug:
-    # https://developer.apple.com/forums/thread/651043?answerId=628400022#628400022
-    if {${os.major} >= 18} {
-        file copy ${output_dir}/MoltenVK/MoltenVK.xcframework ${destroot}${frameworks_dir}
+    use_configure       no
+
+    build {
+        # bypass the installer that requires macOS 10.13
+        system "${prefix}/bin/7z x -aoa ${worksrcpath}/InstallVulkan.app/Contents/Resources/installer.dat -o${workpath}/VulkanSDK"
     }
 
-    file copy ${output_dir}/macOS/bin/MoltenVKShaderConverter ${destroot}${prefix}/bin
-    file attributes ${destroot}${prefix}/bin/MoltenVKShaderConverter -permissions +x
-    file copy ${output_dir}/macOS/lib/libMoltenVK.dylib ${destroot}${prefix}/lib
+    destroot {
+        set output_dir ${workpath}/VulkanSDK
 
-    # vulkan and vk_video are provided via vulkan-headers
-    file copy ${output_dir}/MoltenVK/include/MoltenVK ${destroot}${prefix}/include
+        # Xcode11 and later are required to use "xcframework"
+        # Headers currently break build due to Xcode 12 ProcessXCFramework bug:
+        # https://developer.apple.com/forums/thread/651043?answerId=628400022#628400022
+        if {${os.major} >= 18} {
+            file copy ${output_dir}/MoltenVK/MoltenVK.xcframework ${destroot}${frameworks_dir}
+        }
+
+        file copy ${output_dir}/macOS/bin/MoltenVKShaderConverter ${destroot}${prefix}/bin
+        file attributes ${destroot}${prefix}/bin/MoltenVKShaderConverter -permissions +x
+        file copy ${output_dir}/macOS/lib/libMoltenVK.dylib ${destroot}${prefix}/lib
+
+        # vulkan and vk_video are provided via vulkan-headers
+        file copy ${output_dir}/MoltenVK/include/MoltenVK ${destroot}${prefix}/include
+    }
 }
 
 platform darwin {
-    if {${os.major} < 16} {
+    if {${os.major} < 15} {
         archive_sites
         distfiles
         depends_build
         known_fail  yes
         pre-fetch {
-            ui_error "${subport} @${version} requires macOS Sierra or later"
+            ui_error "${subport} @${version} requires OS X El Capitan or later"
             return -code error "incompatible OS X version"
         }
     }


### PR DESCRIPTION
#### Description

- Update to v1.1.10

- Repackage an already built archive this avoids needing to worry about mounting the DMG (v1.1.9 bump after v1.1.10 packages are done)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

(workaround set to darwin 18 while testing)

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
