### PR TITLE
google-cloud-sdk: update to 386.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             385.0.0
+version             386.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  01af97f3689c4560359d3ab8d5687130fb3f2987 \
-                    sha256  37c7035df774cabe4649ab49f2f39d590dd886bc9862f4dbb4730038fe2d39db \
-                    size    106717257
+    checksums       rmd160  b9c3b3c9a248506184881f7a73b550fd12b3d71b \
+                    sha256  77f85b8c6ee66e948899bd6592952d2f33d4d444fbe00ba8e58b8dafabf8a457 \
+                    size    106770646
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8102bdeca712b6404e9e750e27b0f13402fd037b \
-                    sha256  5bd8d8ab17993af650c24e9d2b84ddaa90d750118803dedd5c0e3cbe5192b3a0 \
-                    size    103310171
+    checksums       rmd160  65bb15a44d2be8cdfd0a6d2ff5ff68f1350d2e22 \
+                    sha256  ed266c23437d63097700b3eeda35d77d04ec9b4109528b09b4d59a6c54713a7f \
+                    size    103369466
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  cc1a09cdffc5847db8b966ce4fb14747fd1792e0 \
-                    sha256  fbbfd3b03b92d6b53872e0c99a8f5ddb9f6ae0c75ff992a14e9ba56477c952e6 \
-                    size    101899182
+    checksums       rmd160  105ec9603b096ceb22dab710525a943ef8ff1c7b \
+                    sha256  edb4364ccc4b057014d51e8210e66fef95410da80a2b370003d3ff3313229ac3 \
+                    size    101951190
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 386.0.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?