### PR TITLE
lagrange: update to 1.13.5

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        skyjake lagrange 1.13.2 v
+github.setup        skyjake lagrange 1.13.5 v
 revision            0
 github.tarball_from releases
 categories          net gemini
@@ -20,9 +20,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  69b08c8eee8b096e6b4dfd323374e685924932b5 \
-                    sha256  f84c5fe078734df06ada747f87760ea8863369be5519d1e56992c7c5278395da \
-                    size    9858472
+checksums           rmd160  f7ad358149734f07d7009e31d47c3b78337765a5 \
+                    sha256  a9c3175acdc7bfd228cb4d24d68c4cfabe9a4fd79f821d631d556e8434749548 \
+                    size    9869222
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
