### PR TITLE
py-numba/py-llvmlite: submission of devel port with Python 3.10 variant

### DIFF
--- a/python/py-llvmlite-devel/Portfile
+++ b/python/py-llvmlite-devel/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        numba llvmlite 409cd6d37fe1ba76438aa1a3a9c6a8adcd0ddb9d
+fetch.type          git
+name                py-llvmlite-devel
+conflicts           py310-llvmlite
+set my_name         py310-llvmlite
+revision            0
+categories-append   devel science
+license             BSD
+
+python.versions     310
+
+maintainers         {stromnov @stromnov} openmaintainer
+
+description         A lightweight LLVM python binding for writing JIT compilers
+long_description    ${description}
+
+homepage            https://llvmlite.pydata.org/
+
+checksums           rmd160  1c3a4f915657c5232ba123977a13827b2b1d2645 \
+                    sha256  26af66d1cad247da9554493848dc1c6b49ce427d702c624ad93ab2987d6adb29 \
+                    size    230091
+
+if {${name} ne ${subport}} {
+    patchfiles-append   patch-ffi_Makefile.osx.diff
+
+    set llvmver "11"
+
+    post-patch {
+        reinplace "s|%%CXX%%|clang++-mp-${llvmver}|" ${worksrcpath}/ffi/Makefile.osx
+
+        if {${os.major} <= 10} {
+            # https://trac.macports.org/ticket/61302
+            reinplace "s|%%MP_EXTRA_LDFLAGS%%|-framework CoreFoundation|" \
+                ${worksrcpath}/ffi/Makefile.osx
+        } else {
+            reinplace "s|%%MP_EXTRA_LDFLAGS%%||" ${worksrcpath}/ffi/Makefile.osx
+        }
+    }
+
+    depends_build-append \
+                        port:py${python.version}-setuptools \
+                        port:clang-${llvmver}
+
+    depends_lib-append  port:llvm-${llvmver} \
+                        port:zlib \
+                        port:ncurses \
+                        port:libxml2
+
+    build.env-append    LLVM_CONFIG=llvm-config-mp-${llvmver}
+    destroot.env-append LLVM_CONFIG=llvm-config-mp-${llvmver}
+} else {
+    github.livecheck.regex  {([0-9.]+)}
+}

--- a/python/py-llvmlite-devel/files/patch-ffi_Makefile.osx.diff
+++ b/python/py-llvmlite-devel/files/patch-ffi_Makefile.osx.diff
@@ -1,0 +1,14 @@
+--- ffi/Makefile.osx.orig	2022-04-04 14:36:19.000000000 +0300
++++ ffi/Makefile.osx	2022-04-04 14:37:14.000000000 +0300
+@@ -1,9 +1,9 @@
+ 
+-CXX = clang++ -std=c++11 -stdlib=libc++
++CXX = %%CXX%% -std=c++11 -stdlib=libc++
+ CXXFLAGS = $(LLVM_CXXFLAGS)
+ # Only export the LLVMPY symbols we require and exclude everything else.
+ EXPORT = "-Wl,-exported_symbol,_LLVMPY_*"
+-LDFLAGS :=  $(LDFLAGS) $(EXPORT) $(LLVM_LDFLAGS)
++LDFLAGS :=  $(LDFLAGS) $(EXPORT) $(LLVM_LDFLAGS) %%MP_EXTRA_LDFLAGS%%
+ LIBS = $(LLVM_LIBS)
+ INCLUDE = core.h
+ SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \

--- a/python/py-numba-devel/Portfile
+++ b/python/py-numba-devel/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        numba numba 468647dddde27ee8af124c97dfcd20c35c4a2bc6
+name                py-numba-devel
+conflicts           py-numba
+set my_name         py310-numba
+revision            0
+categories-append   devel
+license             BSD
+
+python.versions     310
+
+maintainers         {stromnov @stromnov} openmaintainer
+
+description         Numba is a NumPy aware dynamic compiler for Python.
+
+long_description    Numba is an Open Source NumPy-aware optimizing compiler \
+                    for Python. It uses the remarkable LLVM compiler \
+                    infrastructure to compile Python syntax to machine code.
+
+homepage            https://numba.pydata.org/
+
+checksums           rmd160  8fd29abb25f70544e0f7f018617a76e1140af623 \
+                    sha256  92e127bbe194a437441d4b1b6c93a74f8dbbe8f2583e0bf5e6695ff1ee5fee25 \
+                    size    2385615
+
+variant tbb description "Add support for TBB" {
+    depends_lib-append  port:tbb
+    build.env-append    TBBROOT=${prefix}
+}
+
+if {${name} ne ${subport}} {
+    use_parallel_build  no
+
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    depends_lib-append  port:py${python.version}-llvmlite-devel \
+                        port:py${python.version}-numpy
+
+} else {
+    github.livecheck.regex  {([0-9.]+)}
+}


### PR DESCRIPTION
#### Description

Numba is currently broken in Macports, because Numpy is too recent for Numba 0.55.1 (only Numpy < 1.22 is supported).
There is also no Python 3.10 variant, and it does not make sense to add it, since it is broken anyway.

One approach would be to wait for the upcoming Numba 0.56 which will support Numpy 1.22.
In a mean time, to address the needs of those who wish to use Numba [Trac #65187](https://trac.macports.org/ticket/65187), I propose to add py-numba-devel and py-llvmlite-devel based on github hashes.
(numba-devel requires llvmlite-devel).

As far as I tested, it solves the problem. I assume that using "random git hash" would be ok for a -devel port ?

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Note: there are no tests.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
