### PR TITLE
py-fonttools: add py-cython build dependency for ReproducibleBuilds

### DIFF
--- a/python/py-fonttools/Portfile
+++ b/python/py-fonttools/Portfile
@@ -16,7 +16,7 @@ long_description    TTX is a tool to convert OpenType and TrueType fonts to \
 
 homepage            https://github.com/fonttools/fonttools
 
-categories          python print
+categories-append   print
 license             MIT
 maintainers         {amake @amake} openmaintainer
 
@@ -29,60 +29,62 @@ python.versions     37 38 39 310
 if {${name} ne ${subport}} {
     use_zip         yes
 
-    depends_build-append port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    depends_run-append   port:${python.rootname}_select
+    depends_run-append \
+                    port:${python.rootname}_select
 
     default_variants +lxml +woff +unicode
 
     variant lxml description {Install preferred backend for XML reading/writing} {
-        depends_run-append port:py${python.version}-lxml
+        depends_run-append  port:py${python.version}-lxml
     }
 
     variant ufo description {Install dependencies for UFO font support} {
-        depends_run-append port:py${python.version}-fs
+        depends_run-append  port:py${python.version}-fs
     }
 
     variant woff description {Install dependencies for WOFF 1.0 & 2.0 font support} {
-        depends_run-append port:py${python.version}-brotli \
-                           port:py${python.version}-zopfli
+        depends_run-append  port:py${python.version}-brotli \
+                            port:py${python.version}-zopfli
     }
 
     variant unicode description {Install dependencies for up-to-date Unicode support} {
         # Whether this is needed depends on the Python runtime version: Python 3.9
         # includes Unicode 13.0 data, so unicodedata2 v13.0.0 is not needed in that
         # case, while older Pythons would benefit from having it.
-        depends_run-append port:py${python.version}-unicodedata2
+        depends_run-append  port:py${python.version}-unicodedata2
     }
 
     # TODO: `interpolatable` extra: requires scipy and munkres (not yet in MacPorts)
 
     variant plot description {Install dependencies for plot visualizations} {
-        depends_run-append port:py${python.version}-matplotlib
+        depends_run-append  port:py${python.version}-matplotlib
     }
 
     variant symfont description {Install dependencies for symbolic font statistics analysis} {
-        depends_run-append port:py${python.version}-sympy
+        depends_run-append  port:py${python.version}-sympy
     }
 
     # TODO: `type1` extra: requires xattr (not yet in MacPorts)
 
     variant cocoa description {Install dependencies for Cocoa glyph drawing} {
-        depends_run-append port:py${python.version}-pyobjc
+        depends_run-append  port:py${python.version}-pyobjc
     }
 
     variant qt description {Install dependencies for Qt glyph drawing} {
-        depends_run-append port:py${python.version}-pyqt5
+        depends_run-append  port:py${python.version}-pyqt5
     }
 
     variant png description {Install dependencies for PNG glyph drawing} {
-        depends_run-append port:py${python.version}-reportlab
+        depends_run-append  port:py${python.version}-reportlab
     }
 
     variant all requires lxml ufo woff unicode plot symfont cocoa qt png description {Install all available optional dependencies} {}
 
-    select.group     ${python.rootname}
-    select.file      ${filespath}/${python.rootname}-${python.version}
+    select.group    ${python.rootname}
+    select.file     ${filespath}/${python.rootname}-${python.version}
 
     notes "
 To make the Python ${python.branch} version of fonttools the one that is run\

--- a/python/py-fonttools/Portfile
+++ b/python/py-fonttools/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-fonttools
 version             4.33.3
-revision            1
+revision            2
 
 description         XML<->TrueType/OpenType Converter
 long_description    TTX is a tool to convert OpenType and TrueType fonts to \
@@ -30,6 +30,7 @@ if {${name} ne ${subport}} {
     use_zip         yes
 
     depends_build-append \
+                    port:py${python.version}-cython \
                     port:py${python.version}-setuptools
 
     depends_run-append \


### PR DESCRIPTION
#### Description
- add py-cython build dependency for ReproducibleBuilds ; see https://github.com/macports/macports-ports/commit/14763ff58b06cd886c254688c75aba30d82a7627#commitcomment-7407861
- conform to modeline

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
