### PR TITLE
kustomize: update to 4.5.5

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,14 +3,16 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.5.4 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.5.5 kustomize/v
+github.tarball_from archive
 revision            0
 
 categories          devel
 installs_libs       no
-maintainers         {breun.nl:nils @breun} openmaintainer
-platforms           darwin
 license             Apache-2
+maintainers         {breun.nl:nils @breun} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         Customize raw, template-free YAML files for multiple purposes, like Kubernetes
 
@@ -23,9 +25,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  a6dcc22c9941ede08d3fe42b4a05e0316ac3c1d6 \
-                    sha256  7fbf59db6880a1c088cd394668078c48c3949d31331b0821001833170d8eae1f \
-                    size    4711002
+checksums           rmd160  50f28e82ff26d1bace8d8633344abb93202ffb2b \
+                    sha256  70fd536380b7925e345f2fee1681f0a4a19082e480c0e6668d9e724a161ecb2e \
+                    size    4049754
 
 build.dir           ${worksrcpath}/${name}
 
@@ -40,8 +42,6 @@ build.args          -ldflags \" \
 # dependencies during the build phase. See
 # https://trac.macports.org/ticket/61192
 build.env-delete    GOPROXY=off GO111MODULE=off
-
-github.tarball_from archive
 
 destroot {
     xinstall -m 0755 ${build.dir}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
- Add self as co-maintainer

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
