### PR TITLE
cpprestsdk: update to 2.10.18

### DIFF
--- a/www/cpprestsdk/Portfile
+++ b/www/cpprestsdk/Portfile
@@ -5,11 +5,10 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
-github.setup        Microsoft cpprestsdk 2.10.16 v
-revision            2
+github.setup        microsoft cpprestsdk 2.10.18 v
+github.tarball_from archive
+revision            0
 categories          www devel
-platforms           darwin
-supported_archs     i386 x86_64
 license             MIT
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 
@@ -19,9 +18,9 @@ long_description    The C++ REST SDK is a Microsoft project for cloud-based \
                     client-server communication in native code using a modern \
                     asynchronous C++ API design.
 
-checksums           rmd160  e511f5cb2c24ab3cbeff3ff53ace9bdf9e81ea68 \
-                    sha256  022646b394261c640d8dbd95a6b215540fa951b98069fe8cb03377ac9e470132 \
-                    size    1768483
+checksums           rmd160  896c15e32b709b88b72988b4ad412334b33578f4 \
+                    sha256  6bd74a637ff182144b6a4271227ea8b6b3ea92389f88b25b215e6f94fd4d41cb \
+                    size    1747792
 
 depends_lib-append  port:libiconv \
                     path:lib/libssl.dylib:openssl \
@@ -30,7 +29,7 @@ depends_lib-append  port:libiconv \
 compiler.cxx_standard  2011
 
 configure.args-append -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF \
-    -DOPENSSL_ROOT_DIR=${prefix}
+    -DOPENSSL_ROOT_DIR=${prefix} -DWERROR=OFF
 
 variant tests description {build tests.} {
     configure.args-replace      -DBUILD_TESTS=OFF -DBUILD_TESTS=ON


### PR DESCRIPTION
###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?