### PR TITLE
gobject-introspection: use MacPorts arch settings

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           meson 1.0
 PortGroup           active_variants 1.1
+PortGroup           muniversal 1.1
 
 name                gobject-introspection
 conflicts           gobject-introspection-devel
@@ -53,8 +54,8 @@ patchfiles          patch-fix-rpath-gir-typelib.diff \
 post-patch {
     reinplace "s|libcairo-gobject.2.dylib|${prefix}/lib/libcairo-gobject.2.dylib|g" ${worksrcpath}/gir/meson.build
     reinplace "s|@MP_LIB@|${prefix}/lib/|g" ${worksrcpath}/giscanner/shlibs.py
-    reinplace "s|@MP_PYTHON_CMD@|${configure.python}|g" ${worksrcpath}/tools/meson.build
-    reinplace "s|#!/usr/bin/env python3|#!${configure.python}|g" \
+    reinplace "s|@MP_PYTHON_CMD@|/usr/bin/arch ${configure.python}|g" ${worksrcpath}/tools/meson.build
+    reinplace "s|#!/usr/bin/env python3|#!/usr/bin/arch ${configure.python}|g" \
         ${worksrcpath}/misc/update-glib-annotations.py \
         misc/update-gtkdoc-tests.py \
         misc/update-vulkan-gir.py \
@@ -64,7 +65,21 @@ post-patch {
 configure.python    ${prefix}/bin/python${py_ver}
 
 configure.args      -Ddoctool=enabled \
-                    -Dpython=${configure.python}
+                    -Dpython=${workpath}/python
+
+post-extract {
+    set python_file [open "${workpath}/python" w 0755]
+    puts ${python_file} "#!/bin/sh"
+    puts ${python_file} "exec /usr/bin/arch ${configure.python} \"$@\""
+    close ${python_file}
+}
+
+post-destroot {
+    reinplace "s|#!/usr/bin/arch ${configure.python}|#!${configure.python}|g" \
+        ${destroot}${prefix}/bin/g-ir-annotation-tool \
+        ${destroot}${prefix}/bin/g-ir-doc-tool \
+        ${destroot}${prefix}/bin/g-ir-scanner
+}
 
 # By default, gir will attempt to link programs using
 # the same compiler used to build Python itself. However,
@@ -78,6 +93,12 @@ configure.args      -Ddoctool=enabled \
 # in the gobject_introspection PortGroup, so dependent projects
 # should not require modification.
 build.env-append    CC=${configure.cc}
+
+foreach arch ${muniversal.architectures} {
+    # There seem to be parts of the build system that do not have the `-arch` flag.
+    build.env.${arch}-append    "CFLAGS=${configure.cflags}   [option configure.cc_archflags.${arch}]"
+    build.env.${arch}-append    "LDFLAGS=${configure.ldflags} [option configure.ld_archflags.${arch}]"
+}
 
 platform darwin 8 {
     # Tiger does not support RPATHs at this time


### PR DESCRIPTION
There are parts of the build system that do not respect the `-arch`
flag unless CFLAGS and LDFLAGS are set in the build phase.

Also ensure Python is run as the same architecture as `build_arch`.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L31a i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
