### PR TITLE
caddy: update to 2.5.1

### DIFF
--- a/www/caddy/Portfile
+++ b/www/caddy/Portfile
@@ -3,10 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/caddyserver/caddy 2.4.3 v
+go.setup            github.com/caddyserver/caddy 2.5.1 v
 revision            0
 categories          www
-platforms           darwin
 license             Apache-2
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 
@@ -18,16 +17,16 @@ long_description    Caddy 2 is a powerful, enterprise-ready, open source web \
 homepage            https://caddyserver.com/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  b4f31316662fb3e6d69971b5672f6a31c752dc58 \
-                        sha256  ef8dd080b6b6d4f4747bdbad56281e6543de57c22a750b86d378cdcf28e0c0f1 \
-                        size    448429
+                        rmd160  5c73c9fc576acff2f04ded61154e9ae525d62af7 \
+                        sha256  1f542e14bb1125b6369a8b8e08ae04eb3f288b79b5dc1dbb1441840bcd9e2be0 \
+                        size    524849
 
 go.vendors          howett.net/plist \
                         repo    github.com/DHowett/go-plist \
-                        lock    591f970eefbb \
-                        rmd160  669b6f3406b2dc1452855c0b02d337ed7048b4f6 \
-                        sha256  ebbd86709854778a3acbceac19cd5f96bc9ef6ffd83731fb9e164faa18b5e7d0 \
-                        size    49101 \
+                        lock    v1.0.0 \
+                        rmd160  5566fa84f55c7c4fba17982afcdd00567e453266 \
+                        sha256  881f9c6bcb814fdfe2d51da53f75ffd28bd9d2149c9c7cc1e783bc5a54c9f9e8 \
+                        size    52994 \
                     gopkg.in/yaml.v3 \
                         lock    496545a6307b \
                         rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
@@ -44,197 +43,253 @@ go.vendors          howett.net/plist \
                         sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
                         size    3636 \
                     gopkg.in/square/go-jose.v2 \
-                        lock    v2.5.1 \
-                        rmd160  10a379638c09a20ade414966ef16fe39c0c5b9fc \
-                        sha256  e37bde7e74fe293083f1194e1317244286c5a6ef1b7c641946496077cfb74610 \
-                        size    309912 \
+                        lock    v2.6.0 \
+                        rmd160  56e581a46f0364551657e2b7698bd022973e9d7c \
+                        sha256  565d45760f1ee44d3c076b9f5ee46e14e046c00304ddfab345fc48443fd6031c \
+                        size    310376 \
                     gopkg.in/natefinch/lumberjack.v2 \
                         lock    v2.0.0 \
                         rmd160  931b7db0e3893f0f6515a8113e7c35aa3e45c9da \
                         sha256  1f7796430424a4dd4c74f73929e7e82384672f6c2c311c5b671e6c36353780f3 \
                         size    12640 \
                     gopkg.in/check.v1 \
-                        lock    41f04d3bba15 \
-                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
-                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
-                        size    31612 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.26.0 \
-                        rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
-                        sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
-                        size    1270531 \
+                        lock    v1.27.1 \
+                        rmd160  a4ac7b66fd88a34a9ea447476d19ff3c1f2b57dd \
+                        sha256  fe1055b9bf6b8792aed1771f56c31f836c24a18d69eaeb13c88990db3d9da7ce \
+                        size    1278850 \
                     google.golang.org/grpc \
                         repo    github.com/grpc/grpc-go \
-                        lock    v1.38.0 \
-                        rmd160  0deee28ffc0af5e2da62aedb7f9059ac6cd7dda6 \
-                        sha256  6fe8dc90c25e88308de961b250c3378eb778e706dc9508f0faa28f73d0e21d02 \
-                        size    1253257 \
+                        lock    v1.44.0 \
+                        rmd160  aa75e5c88543c1c25e3b9b352dfb90a9278893ac \
+                        sha256  02acc338a51f8eb106f88c449df1dc653e624459312fe38ae2710ed48fdb3248 \
+                        size    1399756 \
                     google.golang.org/genproto \
                         repo    github.com/googleapis/go-genproto \
-                        lock    f16073e35f0c \
-                        rmd160  15dd4e630e188ad3b54e67648da803c97bf596ba \
-                        sha256  125d8d8c7172fc98cd9db6499113efac358081cec97fa7cabdcd69068246bc2d \
-                        size    9269214 \
+                        lock    43724f9ea8cf \
+                        rmd160  f3f3004cb5a5921e5d4941197833cf98b2f009b5 \
+                        sha256  d197ad56800b82be475a3f6eb91ffc9501cd4f1cf6dd4ea0229c358555f8eb63 \
+                        size    12783788 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
-                        lock    v1.6.6 \
-                        rmd160  ee3e5a6d2742607fd310e18634c1268156f39ad4 \
-                        sha256  084ba3a248eccd0c7606dc6cff3918326a0adb2e8d30babcbaf6f1c00e1d28f9 \
-                        size    333013 \
+                        lock    v1.6.7 \
+                        rmd160  32e6de431630b8126df1d04e36eba2abb57626f1 \
+                        sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
+                        size    333026 \
                     google.golang.org/api \
                         repo    github.com/googleapis/google-api-go-client \
-                        lock    v0.33.0 \
-                        rmd160  d969ce5c03520741a4aa29c1615d9031d8af959e \
-                        sha256  dc8b4d631a149bd2ecf6b1a2f8be4bbbe8ac4dd4cb624be912194e7fd0be1220 \
-                        size    16654438 \
+                        lock    v0.70.0 \
+                        rmd160  c54a796e980a398e52e169389d0fc908604ab1ae \
+                        sha256  9d61191ea5784cc27992d7b92aa85d500edfa882103fa947134000470509a24b \
+                        size    23873826 \
                     golang.org/x/xerrors \
                         lock    5ec99f83aff1 \
                         rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
+                    golang.org/x/tools \
+                        lock    v0.1.7 \
+                        rmd160  8ae3eece96ce5d618f012a71e4603c4d7e5f0b1f \
+                        sha256  a4ad7b10e5f5d4de2628602b5998601547d386eca0444666b9220076f355a5ea \
+                        size    2884433 \
                     golang.org/x/text \
-                        lock    v0.3.6 \
-                        rmd160  e3da48fcc60d98e202458228188bf6dac408e309 \
-                        sha256  6b2d69df22b5ba1634bc6730c3f03404db499536a96c48b8016da80ced804450 \
-                        size    8356058 \
+                        lock    5bd84dd9b33b \
+                        rmd160  04b1ef275c8ad672175b805f587385082b0b1f00 \
+                        sha256  156741908e4afc594e7de5b52678c64151baf300c4274e71863b743267395123 \
+                        size    8353754 \
                     golang.org/x/term \
-                        lock    a79de5458b56 \
-                        rmd160  e63db44475121302abe1708b22f911b6b0804287 \
-                        sha256  2635dd28e6feb9483de03a276491cd8e8c72c30b902fe731be96f862a2385601 \
-                        size    14943 \
+                        lock    03fcf44c2211 \
+                        rmd160  a1b9592e95373ba617ef579a2f7015cfdc871343 \
+                        sha256  3673415a6d3d106d49b487715e151fc64245502ef547c16e8e13edb6b8f2f492 \
+                        size    14975 \
                     golang.org/x/sys \
-                        lock    ebe580a85c40 \
-                        rmd160  78625a7a7e6b068ef953c011958b63aea6fd8795 \
-                        sha256  3247ddb4c8e9b921acd2ff9d6ee6d356eb7eb2254adc7352c2a96cc348366871 \
-                        size    1197584 \
+                        lock    3681064d5158 \
+                        rmd160  dbf3935cbe2734d9189231077c342e7ae0c81457 \
+                        sha256  272c29ef9518ba877e16372f78d757e7b0d05abd87226fdcbe251992bf5b776c \
+                        size    1258642 \
                     golang.org/x/sync \
                         lock    036812b2e83c \
                         rmd160  f42be6eb3565d2ed3d1066ea1a7f69437c8bb1e6 \
                         sha256  6f1daceb16cd75bdbf35da6c50aa352d1995d68ccd0049851d27686f451fad92 \
                         size    18756 \
                     golang.org/x/oauth2 \
-                        lock    5d25da1a8d43 \
-                        rmd160  32d43c197a403ca59ccb604d752a2ee272ef9c1c \
-                        sha256  7d815f226abc979f687c3a2275173a5cf6a07a65af27f4343f58ea21114132dd \
-                        size    59449 \
+                        lock    d3ed0bb246c8 \
+                        rmd160  d66bbada6578d17da9208ee8c215d4e1ead6aef7 \
+                        sha256  7a0c986063c9580fed9223411152d3ea8126d54597be8184fe613097b95d7489 \
+                        size    87604 \
                     golang.org/x/net \
-                        lock    abc453219eb5 \
-                        rmd160  22a39345610f64ddadd6778a0d0a80beecd93d48 \
-                        sha256  8f0f8e126d014d7c29f832abcb44ff1783c92fcf57d1e6234aad2bebb4dc7bd2 \
-                        size    1252607 \
+                        lock    cd36cc0744dd \
+                        rmd160  20670d7362e8b4ecb15f3c220c90bd3d1d32a610 \
+                        sha256  26df4f12cff0b1a98eb9376669e40e1a839fae744d9c0fc84e4fe3153961fe33 \
+                        size    1228706 \
+                    golang.org/x/mod \
+                        lock    v0.4.2 \
+                        rmd160  0f3ca57198b4de4eb89b2c1a2bdb01af040d1f36 \
+                        sha256  e2e4cba5719f804f2ec901b4ccdf6d3abf05521868ed54f271be7c1bf6c48549 \
+                        size    104573 \
                     golang.org/x/crypto \
-                        lock    c07d793c2f9a \
-                        rmd160  bd005f5fd86d9021e5da5d606b5a0b0091f27476 \
-                        sha256  cfd0c4c624ae799ae9dae5ac2b1ca48c054c8db8b2f281be6c7bd6a7ee277919 \
-                        size    1732033 \
+                        lock    f4118a5b28e2 \
+                        rmd160  0701294f80df78857569a45a4ac5135f7ff64116 \
+                        sha256  7b96f88553b358931b070cf9daccfd94bd63b977d94df028cbc278a3ce5ffd27 \
+                        size    1626969 \
                     go.uber.org/zap \
                         repo    github.com/uber-go/zap \
-                        lock    v1.17.0 \
-                        rmd160  cb23224e75a92136e4095381052ce87d3bad8073 \
-                        sha256  c55e23096f9d58b3cc4cb6ff207c407b646c4eda305077fdf0051f3a9da8bb88 \
-                        size    142763 \
+                        lock    v1.21.0 \
+                        rmd160  ba2ba8266dcf78e491192ea65fa7360094a66444 \
+                        sha256  c68a8d1b5b0255a5690840684f21239d7792e1bba91dcc298c66ae327d67d384 \
+                        size    183681 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.6.0 \
                         rmd160  d132836fdf8d1853ddff41df3b06d2574b03a768 \
                         sha256  87ee707f3e3930098315c9045cc651347c7d689d6dec6d9a1424200c20cc17d4 \
                         size    12375 \
+                    go.uber.org/goleak \
+                        repo    github.com/uber-go/goleak \
+                        lock    v1.1.12 \
+                        rmd160  ad0958815f494323f482a105cccd9bb0540195e1 \
+                        sha256  49886a0ea380a7aa51386eed913e7b411c3b3dff8bca7a607f16265d0cd64e0c \
+                        size    13689 \
                     go.uber.org/atomic \
                         repo    github.com/uber-go/atomic \
-                        lock    v1.7.0 \
-                        rmd160  90f5738aeea3515c0084dc76639a87de557e8a74 \
-                        sha256  9aa45eeb415a1d252b03d08d46dc1e186f4a8a37ce9dd2c5f9fb61602cade57b \
-                        size    18573 \
+                        lock    v1.9.0 \
+                        rmd160  7705959c7053aa8e405560f5ffef3fbca414ee69 \
+                        sha256  8baccde94a6ecaea185ef40b9bdecbd3dd8d8df7cbc50c89856b58c5cd897e40 \
+                        size    21353 \
+                    go.step.sm/linkedca \
+                        repo    github.com/smallstep/linkedca \
+                        lock    v0.15.0 \
+                        rmd160  90d3ea0cfdbdcaffa4300f174c7e1e55243d213b \
+                        sha256  7d81cbf254cb98b6a4fb3db228d2eaee74cbc42dfec8e021fa71e8baba7c5f11 \
+                        size    54244 \
                     go.step.sm/crypto \
                         repo    github.com/smallstep/crypto \
-                        lock    v0.8.0 \
-                        rmd160  33f160aa060f0c77418a9ccc1409952298ba51c1 \
-                        sha256  6c1a0348e4d792777d7f45d0cba162be2e22cee42db0f1b891890839e5774c63 \
-                        size    140509 \
+                        lock    v0.16.1 \
+                        rmd160  a8659ab02190032328111551c3eac04d69a9027d \
+                        sha256  1177fe6e65e596cf3f0c490255d17e08b314aea4381883220ea94f0408e9aeea \
+                        size    166553 \
                     go.step.sm/cli-utils \
                         repo    github.com/smallstep/cli-utils \
-                        lock    v0.2.0 \
-                        rmd160  475c0dfbb393e9db2d6c23050391809d35dbd671 \
-                        sha256  3b6a045f91f68cbf35d89b8ab20a64577597ffb31f7a4b46e0d19aabcaad975c \
-                        size    134113 \
+                        lock    v0.7.0 \
+                        rmd160  f78021ec73d1a6b3ab58d8b597f16b0b18aebb01 \
+                        sha256  d6fa55c4f9ca9d90ad5c1433b2564b045d1a6797ef334fa4559ceb6dcc312eef \
+                        size    139631 \
+                    go.opentelemetry.io/proto \
+                        repo    github.com/open-telemetry/opentelemetry-proto-go \
+                        lock    v0.12.0 \
+                        rmd160  2dc48f0d9ce383111edb18e20665b598760beea2 \
+                        sha256  d8998c9bb43e606c6c597d2abcb3d1bfabdd1eab261b6ae248e6b8f8a2836515 \
+                        size    63540 \
+                    go.opentelemetry.io/otel \
+                        repo    github.com/open-telemetry/opentelemetry-go \
+                        lock    v1.4.0 \
+                        rmd160  14b706ac13f8daf80730663092890efa01b76022 \
+                        sha256  84b1384c7d1996d430b9ed42cf33be8a67e0ebbe71e59ee774d4c59a3593393c \
+                        size    813937 \
+                    go.opentelemetry.io/contrib \
+                        repo    github.com/open-telemetry/opentelemetry-go-contrib \
+                        lock    v1.4.0 \
+                        rmd160  0d2b2a788c0b5479648a64f6d7690811a6874615 \
+                        sha256  ec7de3a8da8cbdc41ce32f3d0d0a26c09d891e773613a5d66a453c47a2cf6748 \
+                        size    772286 \
                     go.opencensus.io \
                         repo    github.com/census-instrumentation/opencensus-go \
-                        lock    v0.22.5 \
-                        rmd160  42d6da422ed33a4d60ad8c73fb4dedbc74e48b4d \
-                        sha256  646fa9bb863465c081b3f979815bcfe6e9b17f7eca6eb4fc62172af11e19d75b \
-                        size    171344 \
+                        lock    v0.23.0 \
+                        rmd160  9d77906343a59654c68ceb858891e4070d663d3f \
+                        sha256  55d38d8243e32277b848b3d9ac5858ffd08e82b54c165e7bfbeaed7f4dc408ff \
+                        size    176412 \
+                    go.mozilla.org/pkcs7 \
+                        repo    github.com/mozilla-services/pkcs7 \
+                        lock    33d05740a352 \
+                        rmd160  e9e90146753e99ebb28c642f4640920fa050ec0a \
+                        sha256  aa82fa2ee6530ad3258bcfae7fafbaefdf6752f0e2b11e88e3c496ff7b1849d4 \
+                        size    48555 \
                     go.etcd.io/bbolt \
                         repo    github.com/etcd-io/bbolt \
-                        lock    v1.3.5 \
-                        rmd160  95dffb4bbbeec637c46a4ddd0ee218fa2fa4c3c8 \
-                        sha256  ca218846d724343915b264d1c246c34eb39e81ed14535931f370c2db838d4d99 \
-                        size    96543 \
+                        lock    v1.3.6 \
+                        rmd160  934af729b47e620f5cd9dc35df49aa25ee1d4132 \
+                        sha256  9a4df17332a1e279b44a288d33dfbdb151ecf5be825ce5075fa97d7d7e930ec6 \
+                        size    98074 \
                     github.com/yuin/goldmark-highlighting \
-                        lock    9216f9c5aa01 \
-                        rmd160  c25e0799e22523e12c0b3659e2cb1ebbcec03474 \
-                        sha256  ecf4124df77c69def143614cc86649c4bf2bca187b3c4d6f60df0689dc4b3111 \
-                        size    10634 \
+                        lock    594be1970594 \
+                        rmd160  01cfe701b68b7b21265dea072a8cc89069eec09c \
+                        sha256  c121c3e8258ba20e1dbfcf51e4bc31fdf351d28f419c493b52487c10e91795e3 \
+                        size    10046 \
                     github.com/yuin/goldmark \
-                        lock    v1.3.7 \
-                        rmd160  cda30a1ebae8d54afc7a39d7dcb9990ecfcc6142 \
-                        sha256  26d62c1a6dd98aa508fce857371c7b4296180e5ce35f905b456831df2026eec0 \
-                        size    233758 \
+                        lock    v1.4.8 \
+                        rmd160  c3470d2560a752567f88f8d86ba2e3977e78f18a \
+                        sha256  70dce22832bef2f6336bfa23b4ae6172dc93bec0499831b64b4e9294639bb1e6 \
+                        size    257417 \
                     github.com/urfave/cli \
-                        lock    v1.22.4 \
-                        rmd160  fc14cf328e371c1f0f3baceea5df4d4de63ca134 \
-                        sha256  60f4eecd8fe79ace077fe6517f0d4f3950901bfbcc66ddc83cd944e7ddab4c79 \
-                        size    78058 \
+                        lock    v1.22.5 \
+                        rmd160  f26fef0516efcbf556d953be02bcfb0ae60a9c22 \
+                        sha256  2122a2b193a2d096f3792e4f8d6a7bb2a504a0d5bba7b0d1bfe81707917831a3 \
+                        size    78154 \
+                    github.com/tailscale/tscert \
+                        lock    4509a5fbaf74 \
+                        rmd160  bfdce82b8e25b779d9a0efdece17ce53819700df \
+                        sha256  1af954404d0d96947164bd7248656781a44a8f6f24f84b9a4957211e08c6d817 \
+                        size    13793 \
                     github.com/stretchr/testify \
-                        lock    v1.7.0 \
-                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
-                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
-                        size    91096 \
+                        lock    v1.7.1 \
+                        rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
+                        sha256  27cabaf81344157a188083266cf8ccc19d04c43d9a34b6276b760514b9c880a3 \
+                        size    94020 \
                     github.com/stoewer/go-strcase \
                         lock    v1.2.0 \
                         rmd160  b8c644b1233496ac620e667bd8578079b7dcda04 \
                         sha256  b7b4dec40c80d32a53d9ac2c22e6b8db854c98e2b1c244fc7789e0ba2c8760ee \
                         size    5295 \
                     github.com/spf13/cast \
-                        lock    v1.3.1 \
-                        rmd160  d4ab928edfe2ad8aafbc3248287b788c65ec155f \
-                        sha256  a33b9fbe9c9dd9cc2bb54f43bcd9a4b5503666c028448bc1b600d46961ffb604 \
-                        size    11103 \
+                        lock    v1.4.1 \
+                        rmd160  cb1d2c13bdd8a4aafd7c4e768554bab0a65c5759 \
+                        sha256  9e7890d9db7948b57974a86df8a23f235327990227c7d8f200fd1d114fa9ad07 \
+                        size    13391 \
                     github.com/spaolacci/murmur3 \
                         lock    v1.1.0 \
                         rmd160  53215abb0d59b6c64e926e90fb33da1906a1a525 \
                         sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
                         size    7396 \
                     github.com/smallstep/truststore \
-                        lock    v0.9.6 \
-                        rmd160  9c18522f47943bceb579fc857a456c3e3f5bc6ef \
-                        sha256  4fc59fde01c39c3268a929475df8a9894e23847ab52f5066a5673ee8067dcdcc \
-                        size    12756 \
+                        lock    v0.11.0 \
+                        rmd160  2ad8b41971ed226b328713bc5c20753c84b4a3c5 \
+                        sha256  786e983b58f7727d8001f7372b051a0b723512a4e04302fd411ba7bd1b1b9889 \
+                        size    12976 \
                     github.com/smallstep/nosql \
-                        lock    v0.3.6 \
-                        rmd160  8bb1cb60dce6a1bc46e32cc92f1fed721f4f988c \
-                        sha256  e3660947af13bb30013ea153257cdc15a633fbc5d0773cfe6d8db5b14da6ac08 \
-                        size    26544 \
+                        lock    v0.4.0 \
+                        rmd160  fb1ad42540a93a1af86b7dff7c876898e81d2654 \
+                        sha256  edf3d61054a66e3c620185711042af2057c99009073e741bc42282191b0bd82f \
+                        size    33740 \
                     github.com/smallstep/cli \
-                        lock    v0.15.16 \
-                        rmd160  262aee46f3437b1f09aa4cb60740b0b07551f658 \
-                        sha256  46cdf32fcaa4ecf070a7d788eaa245f638e4097d0cb15f4548fb152e1720257a \
-                        size    1767835 \
+                        lock    v0.18.0 \
+                        rmd160  01fc1cc23f781b058bc332fae593eb81dcbaf5d9 \
+                        sha256  1db94da704a46b454c6abbf3667ac8df2a7188b6766c47547a065827c998dfe3 \
+                        size    1804531 \
                     github.com/smallstep/certificates \
-                        lock    v0.15.15 \
-                        rmd160  d2cb785b8d004a042a9a19fd2dde314c70c67d2f \
-                        sha256  ae73c82f4b7276bddb485c707972c108681b4c5cbb2515060fca8212c7f64858 \
-                        size    17650207 \
+                        lock    v0.19.0 \
+                        rmd160  b118e0b6edff9360be538dd7ec86c12402cfe6cd \
+                        sha256  cddc6c9aaf6b3fa3d3dd483c663353df0109ac4029520d30a00a098d4487c96d \
+                        size    17920186 \
                     github.com/smallstep/assert \
                         lock    82e2b9b3b262 \
                         rmd160  c53f5cc57f5f31670d4d5564ec080febd65910af \
                         sha256  63a6dc29bd27edaae8897ae15fd8dc6324c363809d690c6fd40179099cc64783 \
                         size    4080 \
+                    github.com/slackhq/nebula \
+                        lock    v1.5.2 \
+                        rmd160  7d606cc6e1959423590923b197e021ddfb241245 \
+                        sha256  40e9626338aa94f1efcd24d1e9640d748c120405e6ba416f3c8dfd55f731b197 \
+                        size    946083 \
                     github.com/sirupsen/logrus \
-                        lock    v1.6.0 \
-                        rmd160  86f47e96e9adaa208f0bc5f7e8b0591e76f2d73c \
-                        sha256  2810c27a2d1927be0a7bd542443af5a0230680a38423d4c0e4906a7ace4d6387 \
-                        size    45760 \
+                        lock    v1.8.1 \
+                        rmd160  aeb4e5f2ea8112e787a72fba611605c4c87f42b5 \
+                        sha256  931c31f624d05136760b41a63f6bc146b79ac91776b4642cbd2026c2792e3aca \
+                        size    47184 \
                     github.com/shurcooL/sanitized_anchor_name \
                         lock    v1.0.0 \
                         rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
@@ -245,16 +300,6 @@ go.vendors          howett.net/plist \
                         rmd160  816b30c16e4272887fdb54cdb31edf8d0518cbb6 \
                         sha256  efa72d6c6d5a261d614ac11ce5db7c2a76d671866300f087f4f4225b4b11f500 \
                         size    37774 \
-                    github.com/sergi/go-diff \
-                        lock    v1.0.0 \
-                        rmd160  c5ac5f7253544101282f5477a71560d1fd6c3e58 \
-                        sha256  147eecf13dff7c6715ada19e097d4c3b7d20b169b475861a98e41e27b891d062 \
-                        size    41633 \
-                    github.com/samfoo/ansi \
-                        lock    b6bd2ded7189 \
-                        rmd160  819c3746936a2fa19c3a739bf3104d45921a11ac \
-                        sha256  bba7c251c32541a80706ae46a6ee1b0729d0278b751dc1bc3173bcaa646be244 \
-                        size    4576 \
                     github.com/russross/blackfriday \
                         lock    v2.0.1 \
                         rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
@@ -266,25 +311,25 @@ go.vendors          howett.net/plist \
                         sha256  38881e009bacdbf91f6e586207b346eb9ec93f06335331c07a5e0b2ad41ee3f6 \
                         size    9555 \
                     github.com/prometheus/procfs \
-                        lock    v0.6.0 \
-                        rmd160  ae0e0bcf1c664eacc18c03ec77973f0212dce472 \
-                        sha256  4ffc099c6f2ce85a7681e09462e465b140556743a248f4b3bdc665498f3380b1 \
-                        size    169970 \
+                        lock    v0.7.3 \
+                        rmd160  22af59de47369bf8ac95300e14ef8b1d370712a5 \
+                        sha256  40015c2a7a52b34e6502d2fc17458c30c3ee23f9c2246269d878ab0f96ca3177 \
+                        size    179014 \
                     github.com/prometheus/common \
-                        lock    v0.26.0 \
-                        rmd160  6767da5e89b5aa9e4872df991afdd96abbb0c872 \
-                        sha256  7f1004d8c389191b2c918e267807b6fee0e24d0073de5fa87e47e0798ef13644 \
-                        size    116913 \
+                        lock    v0.32.1 \
+                        rmd160  a6acf4fa8fde63b73fdce283bf384bf0ef1beae8 \
+                        sha256  a6f193ddcbff86669bc3b3b88681dc45e456042b8d54bbd318a708c8761d7110 \
+                        size    146608 \
                     github.com/prometheus/client_model \
                         lock    v0.2.0 \
                         rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
                         sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
                         size    10985 \
                     github.com/prometheus/client_golang \
-                        lock    253906201bda \
-                        rmd160  d1530eb6fef2a2e0fb9e8e8883b3ae0927273712 \
-                        sha256  0bf14991a8c8fee74cb7e66afd03c5d160d449ba33458c1c4583c44550e8b8c1 \
-                        size    168699 \
+                        lock    v1.12.1 \
+                        rmd160  70ab16c13d6f53cf3433dcba4e590cd93b637998 \
+                        sha256  ef1b1e7e68e01cf67193b25d1207bc7771919d81283976b109ec0d56a1e566f0 \
+                        size    194237 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -296,210 +341,290 @@ go.vendors          howett.net/plist \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
                     github.com/onsi/gomega \
-                        lock    v1.10.1 \
-                        rmd160  fbdb25ab0da7cc358134327f3bf7390aae2a9e7f \
-                        sha256  f5d901f5a7321a7ed7317d1ae305bb27b7c3febc3cede1c887e2d76a8e995da6 \
-                        size    97315 \
+                        lock    v1.13.0 \
+                        rmd160  dc92bda8de121272ba08a6fd53d305f86af161fb \
+                        sha256  84bb470e2662d0243c708df882666f82aa735376b837fa3edecea02ede08efac \
+                        size    127847 \
                     github.com/onsi/ginkgo \
-                        lock    v1.14.0 \
-                        rmd160  a1ff8b445c4b593fc8c399993c90f8ff423260fa \
-                        sha256  5aec86ace19613b3976cdadf587d42461d47b89b9b02c5dabafa05a86f704fb2 \
-                        size    145828 \
+                        lock    v1.16.4 \
+                        rmd160  e0c7145b2a5a9fa39d1883b7ceb788af8a3dd4db \
+                        sha256  1cf29213663b89b7578f41a0185b814dab82d40fb5233bf0fe951591ce32ab10 \
+                        size    164059 \
                     github.com/nxadm/tail \
-                        lock    v1.4.4 \
-                        rmd160  33d7373bd1b164159b9032fc8595bb09b25598f6 \
-                        sha256  16d8773e0be69469d3c296ee785bbef433c3442defb68760682cdbcf80ba40ee \
-                        size    1238830 \
-                    github.com/naoina/toml \
-                        lock    v0.1.1 \
-                        rmd160  e7a8880ff4d0221e568bad1baf067b257648fb0c \
-                        sha256  be72d7229a916702b7400e1435c73a7b49cb11249a29d1d8483d1f018750a8b6 \
-                        size    41288 \
-                    github.com/naoina/go-stringutil \
-                        lock    v0.1.0 \
-                        rmd160  04a1e33ced0b934eb4fe627d2c47bb0d0f4b72fa \
-                        sha256  192d38bb514eb2b4a433e7de124f36e9571003f9dd5791def4f8403f501eaa19 \
-                        size    6140 \
+                        lock    v1.4.8 \
+                        rmd160  bb6c5515804a1d141478074ba9a4f836fa51fb71 \
+                        sha256  a4e98c422980433e9a9830f16b4155836baba4c3e3aa387f03840e5cb608c84d \
+                        size    1256274 \
                     github.com/mitchellh/reflectwalk \
+                        lock    v1.0.2 \
+                        rmd160  0371e346bfe14926662afff3eeda22ce6dc6d2a4 \
+                        sha256  472ea8302bfe36cd5ea5a66cb9ee996d6984ce74bfc9b7c15e763f21687b3eff \
+                        size    6863 \
+                    github.com/mitchellh/go-ps \
                         lock    v1.0.0 \
-                        rmd160  c8f3f4a948ebfd3f69f22663f856e7309877ba8d \
-                        sha256  117a3a92d72f36187cd4aa728890538c9637be7d4ba9a8d7a777c51a15ea8015 \
-                        size    6149 \
+                        rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
+                        sha256  8e158a59a9b7e407b27a4cf6100f33648b7c8bffb4ac07bd074f43d4796afa87 \
+                        size    7631 \
                     github.com/mitchellh/copystructure \
-                        lock    v1.0.0 \
-                        rmd160  f302c41c8c05f9f254b5c1354e8aa7ba099fc81b \
-                        sha256  5306cd122f11f481baa0b4c17437dd816e9449c8b91d59475c5e1f5b5edc1a9a \
-                        size    8897 \
+                        lock    v1.2.0 \
+                        rmd160  401559c8d2db7a6becabf583dca6843e5cd3c5ac \
+                        sha256  e6cbd00eca63c91837cd094e89bda52d067163dc5b5db12758b8995c75fd3377 \
+                        size    9936 \
                     github.com/miekg/dns \
-                        lock    v1.1.42 \
-                        rmd160  8e95ac8998a332ba7256caf048877458623e673a \
-                        sha256  b093d2fbc847958a2d6f84af4b256bbe9fda1b7eaaf8fa6fcc6b6994bc268e8f \
-                        size    200869 \
+                        lock    v1.1.46 \
+                        rmd160  9a147f31793821eb5966787c67f8efc569a3bf90 \
+                        sha256  32950b2e11cc60d57f18d84a535590c998bcd65c4b66f39e39a99615abed6ff0 \
+                        size    204223 \
+                    github.com/micromdm/scep \
+                        lock    v2.1.0 \
+                        rmd160  642db3182defb9403953730d98bda3874659daa3 \
+                        sha256  0120218fb1bdbadb6559516169f8281dc457806b7784793c572356575069c25a \
+                        size    64304 \
                     github.com/mholt/acmez \
-                        lock    v0.1.3 \
-                        rmd160  befe620cbb048014af2db48818346313a0095dfe \
-                        sha256  764bb4706fa910ace2f9ede1215eacb3293683ccedae7fda00f6b7094eda54e1 \
-                        size    50422 \
+                        lock    v1.0.2 \
+                        rmd160  e0b9c443a36e53e77c0a36dcc360d7431110c013 \
+                        sha256  8fd52d7590d5328942813c663c632393781bb83bed6122bb078e4b68691b788c \
+                        size    50819 \
+                    github.com/mgutz/ansi \
+                        lock    d51e80ef957d \
+                        rmd160  a32d3fd46ae68cfd82f31fadc3dfe551966f6a5b \
+                        sha256  27808fbee08992bde76012200be0e24cb1017d39f3c228cc5805875993334b83 \
+                        size    5102 \
                     github.com/matttproud/golang_protobuf_extensions \
                         lock    v1.0.1 \
                         rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
                         sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
                         size    37197 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
+                        lock    v0.0.13 \
+                        rmd160  91c4e10ae78db94432a94bc7f9816df4093ec8d7 \
+                        sha256  6a6b35588efb0abec5a951246775a4cb47fab11ff161715875de4c02c9cdf309 \
+                        size    4445 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.6 \
-                        rmd160  3c6531ff68909aacc83a16f92149722803b465a7 \
-                        sha256  3f3b5a79ae9511dd610d288768d782faffa27bf92ad1d6c8be3f37aa9d3bc975 \
-                        size    9477 \
+                        lock    v0.1.8 \
+                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
+                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
+                        size    9576 \
+                    github.com/marten-seemann/qtls-go1-18 \
+                        lock    v0.1.1 \
+                        rmd160  5b98fd23d9def1ce7712c87868f54fac4b4d84f4 \
+                        sha256  1b2e0686b31bbf80177f2468e98041f68c2a96ab90f714ccc2f7c8b9a08e641c \
+                        size    422116 \
                     github.com/marten-seemann/qtls-go1-17 \
-                        lock    v0.1.0-alpha.1 \
-                        rmd160  b9cffd612d4c84d0f0f811f09e4d354da6a89991 \
-                        sha256  6a40c9e27818bdbca8e5d6cda170a1dba3090b8ee855fbd0976308444b8e5a84 \
-                        size    416016 \
+                        lock    v0.1.1 \
+                        rmd160  5769d30553c8a7e07bd86c7f6f06c0dea24e59b6 \
+                        sha256  61e20fe7c825db70c3355ff58f02518d64733ca5e74df1e1733daf9ad4278c7f \
+                        size    421546 \
                     github.com/marten-seemann/qtls-go1-16 \
-                        lock    v0.1.3 \
-                        rmd160  caa1df0822fb664a6e022b087ec9f8b1ec599bb3 \
-                        sha256  507a93b461f736af86e406b8ce6aa5c9d6321d5d6edebad68a3261f4268df92e \
-                        size    415463 \
-                    github.com/marten-seemann/qtls-go1-15 \
-                        lock    v0.1.4 \
-                        rmd160  370ab7801f30cbfdf823274dc0ad68c6b492b969 \
-                        sha256  e0e690f3333659b7732af5ccab65044f09aa89dafa7158410c5f8ca5e451fe13 \
-                        size    413757 \
+                        lock    v0.1.5 \
+                        rmd160  b637315f29e75067cf7180257d64d65406967d04 \
+                        sha256  e7ca61ec715b8784521b1622f2b7ca0bc517b443a2c7e99b6f07689adf096132 \
+                        size    415747 \
                     github.com/marten-seemann/qpack \
                         lock    v0.2.1 \
                         rmd160  64b0f70c593a63c55ec82047643ab2a8bbebb26b \
                         sha256  d95f2637db0b9dcbb2fb8c8a284d138354b249a021b2e6e3e41824b7c1697e4e \
                         size    42753 \
                     github.com/manifoldco/promptui \
-                        lock    v0.8.0 \
-                        rmd160  b3abf944b60f65b571d2f068df7061e1843473f7 \
-                        sha256  e2513c9f17dc87ab347916b523686517d031a2ad8f9c9db32cbbd32fc3bbe49c \
-                        size    26838 \
-                    github.com/lunixbochs/vtclean \
-                        lock    v1.0.0 \
-                        rmd160  28eb7432d03d69a0e3484c49341dd876769ebe55 \
-                        sha256  f6cbd000c28785924742401aa071061b71e321490cc9bea1cec77bfd2c40eb84 \
-                        size    4223 \
+                        lock    v0.9.0 \
+                        rmd160  0557a766a57005f08f096935e894bfb34a7b0e03 \
+                        sha256  bb66c3deb1709d13f67a00ec2421185792f7a1efc5836e7a1607639a46ce1178 \
+                        size    25927 \
                     github.com/lucas-clemente/quic-go \
-                        lock    v0.21.0 \
-                        rmd160  5b1fa51714048955706410062339cf80d796e7c0 \
-                        sha256  4177fded1f7af9a023e479fa0b06b7fcb0c515e841c48c7e5390c941baaff5ef \
-                        size    505469 \
+                        lock    v0.26.0 \
+                        rmd160  c4ec8645b473b4772b67ddcf4ad3d46023269be9 \
+                        sha256  9feba2cd3de57559b7073202778ffe194ea7a0795970d063500f7ed5ad0822c0 \
+                        size    527240 \
                     github.com/libdns/libdns \
                         lock    v0.2.1 \
                         rmd160  7cd2eb2452f9767d17aac199550e8fd4b2076ffb \
                         sha256  66022788fd014e2d6da6ef43eb7360d5adc6d59b635f93f601b3415c6720a9be \
                         size    5833 \
-                    github.com/kylelemons/godebug \
-                        lock    v1.1.0 \
-                        rmd160  917ada648e70d2e339b8ff36d2f86882d0d2efa1 \
-                        sha256  6151c487936ab72cffbf804626228083c9b3abfc908a2bb41b1160e1e5780aaf \
-                        size    17641 \
+                    github.com/lib/pq \
+                        lock    v1.10.2 \
+                        rmd160  897dd4800e3f5b67de347e8f0c1d56c02e0e1d64 \
+                        sha256  d832c980eb73ea08aef0bd153646cc5230995ce2c457ea55576e4b13f71afe34 \
+                        size    103840 \
                     github.com/kr/text \
-                        lock    v0.1.0 \
-                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
-                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
-                        size    8691 \
-                    github.com/kr/pretty \
                         lock    v0.2.0 \
-                        rmd160  45bbf0be7a3328e33186718ab12cb506c0f5a073 \
-                        sha256  35fb1f8788552fc7df2120bc06dd34e00aa3284d23c250fc1f143eef51d08586 \
-                        size    8762 \
-                    github.com/konsorten/go-windows-terminal-sequences \
-                        lock    v1.0.3 \
-                        rmd160  26e90ab69813fa0a56d0dae2738c5289487932bb \
-                        sha256  56dd8452636a977fecbd826fc89a8d00b54a481a5c59e9b47e68a8ae6fc2c175 \
-                        size    1982 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.2.1 \
+                        rmd160  eaf5b58a46b962079cbafddbc3ef83bdbf02b31e \
+                        sha256  253c4a190c9337800e08aba66b77ea3db0835e3ae61289d80093995a649eb7ae \
+                        size    8769 \
                     github.com/klauspost/cpuid \
-                        lock    v2.0.6 \
-                        rmd160  d6973fc3d7158db97407b1456195822b8e84008a \
-                        sha256  3a8fe2a0c4424273a5fa76c9eb437e53e8dd9c506a1b0ee48669f02c20d58d1b \
-                        size    341436 \
+                        lock    v2.0.11 \
+                        rmd160  f616c19e05db995e802448819c7584121af0b7b9 \
+                        sha256  f15f92c1c88bfcc86015c14550106be3ae1efea5cd6d299a0eabac549c141751 \
+                        size    343083 \
                     github.com/klauspost/compress \
-                        lock    v1.13.0 \
-                        rmd160  f256299a10bf2d830a856b8cc914d81e70d09794 \
-                        sha256  da2be6f8b7ca8c915ec53d4d15863c986ae8797483733e2161e1c08a3e3c23c8 \
-                        size    15405520 \
-                    github.com/juju/ansiterm \
-                        lock    720a0952cc2a \
-                        rmd160  c3c15da3b3d62f7caa467b66f45b251e2e868626 \
-                        sha256  a0efc9542e6fe50c97cdd999685ddda6069ab44754a6b3c87c6b18b21899e05b \
-                        size    15418 \
+                        lock    v1.15.0 \
+                        rmd160  ce1a573a8e4e91276d113bef74020ce1b3064a99 \
+                        sha256  fc7dc5c49a9f305058c68cecee1c04c118f6fdf252e1c2f058a31db9e77b74c0 \
+                        size    15633291 \
                     github.com/jmespath/go-jmespath \
-                        lock    v0.3.0 \
-                        rmd160  710bef6993ab35c6f9fe4117b552c30bac13f868 \
-                        sha256  035448de7386e3f5a3910fa306ee4c53b83b9e32af7adaf26896b9cc53178c1e \
-                        size    49929 \
+                        lock    v0.4.0 \
+                        rmd160  ca4955ff89de514b5eff01a7a244626cecf0927e \
+                        sha256  0fe6d784c9c75ae5aa25396283a07f94c06955a4ed775990149c17caee4112c4 \
+                        size    128827 \
+                    github.com/jackc/pgx \
+                        lock    v4.14.0 \
+                        rmd160  86df0ec5056dec8066ab6f0b53eb67a11070060b \
+                        sha256  5d8e81f196fe64f6d84207f23c959408dd3486cc74397fa1f3ecdcc23cdbc1bd \
+                        size    110550 \
+                    github.com/jackc/pgtype \
+                        lock    v1.9.0 \
+                        rmd160  9ba7ced9f2b879f3ce03da4786c50243ea06dadd \
+                        sha256  14c5b19256c77318ecae74656cc0d73d8835d52b081dd93778525a27af3d56fe \
+                        size    177370 \
+                    github.com/jackc/pgservicefile \
+                        lock    2b9c44734f2b \
+                        rmd160  5f6e8872c0b2e8e21f4656c545c656332a5b3d0d \
+                        sha256  d40a3d40571d28db4338be116fb24ae861c960f465cf15443986d7f82336629f \
+                        size    2998 \
+                    github.com/jackc/pgproto3 \
+                        lock    v2.2.0 \
+                        rmd160  65c47143ae52c875ff90644de8f3a7c7b1f29d1b \
+                        sha256  48d417218bb1d2ea8a30c5586b067c9cde71da2ae82773c0bbe0a203fa7e15d3 \
+                        size    23703 \
+                    github.com/jackc/pgpassfile \
+                        lock    v1.0.0 \
+                        rmd160  7054f5083a15e2d97da032fa1844b75f9a11c9de \
+                        sha256  1793f9fc162dfc416bef7be85e3cbc1c28610eb39cef051ac8e249eb90099ece \
+                        size    3259 \
+                    github.com/jackc/pgmock \
+                        lock    4ad1a8207f65 \
+                        rmd160  da8d31edc5b1c261f9902a98e592a96ae2b85d99 \
+                        sha256  6b816c4a43e85578b9a13ff923caddca4399631ccd13d6965adbb4fc2d111114 \
+                        size    9963 \
+                    github.com/jackc/pgio \
+                        lock    v1.0.0 \
+                        rmd160  c17a005b313f01d6925c30e299e7abf446d36542 \
+                        sha256  a8e23d5f16ef8e7aade48d15768c9ea24fcd5eb2e65b1d1211966fa7acdc3ddc \
+                        size    1885 \
+                    github.com/jackc/pgconn \
+                        lock    v1.10.1 \
+                        rmd160  03d74af574c634287dde0ce47b98f86d4e480359 \
+                        sha256  c75e8b1cc2706f41413f83e01007e9fc528c050dc59cf72085bb0114eccf45f4 \
+                        size    54216 \
+                    github.com/jackc/chunkreader \
+                        lock    v2.0.1 \
+                        rmd160  546d596d7e2c661b8f9086a1bbae8ff4ab945280 \
+                        sha256  bc2ead05f2d930b05522ee6a70378c0937994c353cbf0bd891c835e22c743adc \
+                        size    3043 \
                     github.com/imdario/mergo \
-                        lock    v0.3.11 \
-                        rmd160  8b9ee50b62ecc6c7db250e5f79227c45d30e9099 \
-                        sha256  98e213812b15d8edf13ba17b6011af1ddc7432cd5d3781e2e88c94fcc355c43b \
-                        size    22076 \
+                        lock    v0.3.12 \
+                        rmd160  44dbd1f58fd9ea7697f302c86f110ab796b5a041 \
+                        sha256  dadb5b52d2de5fe7336eda4c331eefb0d4be716a5844cc7ab15c96b9b6e07b2d \
+                        size    22341 \
                     github.com/huandu/xstrings \
-                        lock    v1.3.1 \
-                        rmd160  0c4b67d0c397ae36ef82fc26013ec5bef50e59e6 \
-                        sha256  75b35332bfd89f181e70dca79473c9b10dff7ec89f2df3bc2ff8f4bbe9e9820c \
-                        size    17803 \
+                        lock    v1.3.2 \
+                        rmd160  b92c0e29b345b7f7cbe79e773f9855375e7bcb2c \
+                        sha256  97bda2aeca4ae1b66f4113ce16d5d861c124baf8f38e22064f5dbd0accb04c57 \
+                        size    17916 \
+                    github.com/grpc-ecosystem/grpc-gateway \
+                        lock    v1.16.0 \
+                        rmd160  ee1c4871aeff641fea75ae5034c3c6c1171ef5be \
+                        sha256  7cc75b3dae4e1f22f3126741a161aaf3d5b74ee310e2d1cda2eb58e9f0836424 \
+                        size    521548 \
                     github.com/googleapis/gax-go \
-                        lock    v2.0.5 \
-                        rmd160  51d16b7dba4977419402a29e93c4526bf2828937 \
-                        sha256  56ab19319dfb8cc80bc1a437317f6d861ca3597c986d9d5fd4de4523ef6fc8e8 \
-                        size    15336 \
+                        lock    v2.1.1 \
+                        rmd160  aeaa07a395820f1d6a94b21fb39c2abd04c832d9 \
+                        sha256  565a8ea94ce80fe38479c1c10b2f774a0b46297000748525a7e099ec1e406418 \
+                        size    70036 \
                     github.com/google/uuid \
-                        lock    v1.2.0 \
-                        rmd160  9717876312bfbe146a478d24bdb41bf8bb4a6ade \
-                        sha256  ddfae8a6ac3b56a02db288778b424a123c14efe44cdab70e4bab0b1e6dd13114 \
-                        size    14154 \
+                        lock    v1.3.0 \
+                        rmd160  300ea34c54ab7ce9d2a4bbd84a4fb49f11db02f8 \
+                        sha256  ef8b7d74d99c8abd9706909eb3bbd063460d1970fbf62619599b78092b8687db \
+                        size    16215 \
                     github.com/google/go-cmp \
-                        lock    v0.5.5 \
-                        rmd160  5caef57da3ce09c102ed270168afa2a5200c2c47 \
-                        sha256  be284023d91976ef03d13cb5670e338c09a0a0da9925d7de457f44e33aebb724 \
-                        size    102365 \
+                        lock    v0.5.7 \
+                        rmd160  f8dffbbc09f05eff889202ab37f473e314ae1b09 \
+                        sha256  7fba30fac1ae84c4dc8c8592936e3fb4ada1f1985803005225e7d61d4159bcff \
+                        size    104517 \
                     github.com/google/cel-go \
                         lock    v0.7.3 \
                         rmd160  79a5c8b1d680a99a0def566e2f68db748ff73626 \
                         sha256  99b0ea925ba782ce0b3f36c7d63e0b3b4a210094b6171bc6a584435253c20f33 \
                         size    2152002 \
                     github.com/golang/snappy \
-                        lock    v0.0.3 \
-                        rmd160  171e3de70a1e477829c27cf67e87d29ee461e043 \
-                        sha256  5d2b36b275164254106f20d2843ff65a4e3fccca5aaf0f9a50aa875b59add4f3 \
-                        size    65996 \
+                        lock    v0.0.4 \
+                        rmd160  23c095b7e2bc6f5a978d771e4ecc9f7b0f204491 \
+                        sha256  6a2d69e63124670c8b8105fb34d32f3f34f6816f93bf5a6e28f85c428c5b40ae \
+                        size    66136 \
                     github.com/golang/protobuf \
                         lock    v1.5.2 \
                         rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
                         sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
                         size    171736 \
                     github.com/golang/mock \
-                        lock    v1.5.0 \
-                        rmd160  d52e6bcf001864ba50f79333a8d5aa60aedb3d97 \
-                        sha256  9ab3a093ccfb9d18118ebf969153ea1a350a530be7cf647bbc73ac7a4e018cf8 \
-                        size    66435 \
+                        lock    v1.6.0 \
+                        rmd160  ed853462703f04ce365bb17b8c88a92994aa5006 \
+                        sha256  4b107f6d26db03f8a36ae38f7b017399ed56571cdbf7b7ebc7bff0006c7dffb5 \
+                        size    69263 \
                     github.com/golang/groupcache \
-                        lock    8c9f03a8e57e \
-                        rmd160  b2514822acfad511ef9c9909f251cf18a3347ccd \
-                        sha256  ba910d9b0c49b9e15e605c6f5f373e2a2eeae2e7c59ed72bd6866446f6a5f94e \
-                        size    26050 \
+                        lock    41bb18bfe9da \
+                        rmd160  dba4526dc11102f7cfc3ee7be23cb1416793e35b \
+                        sha256  03b46be967afa501b74a1bf72211b08d6e8f6b2a3b42335105480b6df6e51980 \
+                        size    26110 \
+                    github.com/gofrs/uuid \
+                        lock    v4.0.0 \
+                        rmd160  75b7040c970e33106e7b63902344935083e60ff9 \
+                        sha256  b3ead9cf56919185660f9b726c990582590547cedaf105bf2a0fdc4ccbb40479 \
+                        size    17838 \
+                    github.com/go-task/slim-sprig \
+                        lock    348f09dbbbc0 \
+                        rmd160  7cc4d26be51d6fdf2b54b1fd1506b58c58317303 \
+                        sha256  94d84e08cdff9c92c5cf526f0ec803f46593247f8e0d4b19b30c9df1819c933d \
+                        size    40027 \
+                    github.com/go-stack/stack \
+                        lock    v1.8.0 \
+                        rmd160  0d04714d21334cb77338bae7ccf0a8eb141cf622 \
+                        sha256  b754cf68628b6ca2f89bb89ff9a68426e5bed296d764a5a7944648325ed13ce9 \
+                        size    8045 \
                     github.com/go-sql-driver/mysql \
-                        lock    v1.5.0 \
-                        rmd160  c619fb55acd917f9b80c568f54b829836dd757e1 \
-                        sha256  cedc3d58292b89f2d5015dcfb6c7ab41c514cf9ce1b3733285743dc676ec8733 \
-                        size    90506 \
+                        lock    v1.6.0 \
+                        rmd160  e626beda6251efcf57f4f474d8a018a2e52f0299 \
+                        sha256  a8182db7c49cb5f1542621e651d31f13cd73dc5f9f2a161799728d23c7ef6b7f \
+                        size    94200 \
+                    github.com/go-logr/stdr \
+                        lock    v1.2.2 \
+                        rmd160  2f24ba9c61d88475841e65ea6109c189fcb6de3c \
+                        sha256  694ed0928bb3e77d98e90d48e970dd2750b8fee1170a85897a5f256c3f459a1c \
+                        size    9105 \
+                    github.com/go-logr/logr \
+                        lock    v1.2.2 \
+                        rmd160  1ddc3393be8264eda110e19f1bd898b609d72a95 \
+                        sha256  073678e3a63e73699c334b4980d9f069b331dad2919146b08d1b873e3ad6ac47 \
+                        size    37113 \
+                    github.com/go-logfmt/logfmt \
+                        lock    v0.5.0 \
+                        rmd160  bd625ba006d96954552800120b01c9263d6e9103 \
+                        sha256  93ae91d57f7940852f5607f860d1d6286240c44abfbbc5d02882040425b7289e \
+                        size    11754 \
+                    github.com/go-kit/kit \
+                        lock    v0.10.0 \
+                        rmd160  0a46d29837e966a86d2e9064a86dccda428fd6d0 \
+                        sha256  2d10b52441ca9f6b468af04e74176522e5192285157d3f7d5d98bbb883a22642 \
+                        size    274363 \
                     github.com/go-chi/chi \
                         lock    v4.1.2 \
                         rmd160  a77a9665c6582973304e9e9b67707a4a989b0cb3 \
                         sha256  91a9f199d25c1fe4b2ceb8efa50316073966fc147b08288c458eefe6abb2a82a \
                         size    75954 \
                     github.com/fsnotify/fsnotify \
-                        lock    v1.4.9 \
-                        rmd160  4660b5721da8aea4c890786e49d7cec39c2e04d3 \
-                        sha256  7920cf1e5ccf268962fcff0b501398ed6c28ed75b1e1281fb17b19a8b0e4db5c \
-                        size    31910 \
+                        lock    v1.5.1 \
+                        rmd160  c99fbad44a371ce38eb2bd5c6ef70fb4537952e3 \
+                        sha256  699405dfda2fe02a305bee66f58046adb43f426ac905f85d80710e36846b3768 \
+                        size    32714 \
+                    github.com/felixge/httpsnoop \
+                        lock    v1.0.2 \
+                        rmd160  8831d9282455fcf0913da2c09c491e529c78a0ac \
+                        sha256  d401a3b5b97c9668ea326d7da0d664a4aaa84af523c3ccc6afe7ad5e2b74915f \
+                        size    11593 \
                     github.com/dustin/go-humanize \
                         lock    afde56e7acac \
                         rmd160  ebea78b8985e3737bb3f84bb89cfe06e27ce5cb1 \
@@ -521,25 +646,25 @@ go.vendors          howett.net/plist \
                         sha256  89d4db120fdc5cd9bf28cf46003bbc741c540a13914f6a64a5eb0e37fa03e3d0 \
                         size    277963 \
                     github.com/dgraph-io/badger \
-                        lock    5d1bab4fc658 \
-                        rmd160  2a49cfde78e3ae6b142682fe3c0a04e6299d9d0c \
-                        sha256  06c2851e4d724f27b70c7017e1ac67f9302131b514ea30d9338a23c86fda0da9 \
-                        size    2537260 \
+                        lock    v2.2007.4 \
+                        rmd160  2ce41beeef82916cfc21fe674e223fe85bdb1f69 \
+                        sha256  a15cd23cdc0d60c5275fda10494cdfc164d9797ae3d99c847e559e9a52ad011c \
+                        size    348610 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
-                    github.com/danwakefield/fnmatch \
-                        lock    cbb64ac3d964 \
-                        rmd160  19ae7b520847e16b0e8ac23ee5e6c51db3831f46 \
-                        sha256  2b045b8a716e3ca32d2a930781cd421b042d0e861fa3d36a79ed5535b2e5308a \
-                        size    4960 \
                     github.com/cpuguy83/go-md2man \
                         lock    v2.0.0 \
                         rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
                         sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
                         size    52040 \
+                    github.com/cockroachdb/apd \
+                        lock    v1.1.0 \
+                        rmd160  3753e33b093067db91575bd174f3061662346c1e \
+                        sha256  5498cc67da99998c9b42b720f1adc2fb931a8de10720504982c87fb10f6631a2 \
+                        size    304227 \
                     github.com/chzyer/test \
                         lock    a1ea475d72b1 \
                         rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
@@ -561,25 +686,35 @@ go.vendors          howett.net/plist \
                         sha256  528d149522e053aed14048608751da8ace5b44466038b1a8d47d04a050d81bdc \
                         size    15585 \
                     github.com/cespare/xxhash \
-                        lock    v2.1.1 \
-                        rmd160  0c0da0840864215209db2afcd2ee92a52ca2d4d1 \
-                        sha256  7416baf9eeefe07e3c50c57826d839cdbba125ea0a6d74af378e865df4f25e00 \
-                        size    9300 \
+                        lock    v2.1.2 \
+                        rmd160  aa8f44c877aeb7a980aba19d9d84e6b20e52560d \
+                        sha256  4bc66a9c435d9fa48cc9f8cb72c402a863943d594c1b1f8b5f421541c58150d2 \
+                        size    11252 \
+                    github.com/cenkalti/backoff \
+                        lock    v4.1.2 \
+                        rmd160  1047a62c90ab24cd939c3abaa0e05d92ab978c5c \
+                        sha256  9dd966323058af72dedc32d2f2da9123c5c899575b6a735cdd49d4bf963101cd \
+                        size    9833 \
                     github.com/caddyserver/certmagic \
-                        lock    v0.14.0 \
-                        rmd160  140b3aa58d694a7b1ca97d9c0cabebdac21d6bef \
-                        sha256  77750113d14593c5c56a6ab5b110f25fb5406104df2ce72490ef80c5e218157c \
-                        size    103228 \
+                        lock    v0.16.1 \
+                        rmd160  e15bebfac11bda5840eef963aac7ccfa603771ca \
+                        sha256  c30433f9543df79c0cffefb4b58b108d691c6d8f5abf6df0f538474b0a3cd48c \
+                        size    109319 \
                     github.com/beorn7/perks \
                         lock    v1.0.1 \
                         rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
                         sha256  78da4421e9f9fa2ee5e3855bdd31cfb04c7e823d9c0ec385cc2c008132d98b96 \
                         size    10874 \
+                    github.com/benbjohnson/clock \
+                        lock    v1.1.0 \
+                        rmd160  492f0b608a73813940fd0b31ffe6ad58cacd2bc9 \
+                        sha256  5831da7b061e87d30d7eb50ecc5a340af9ad0d8568ed4e741015288688d922ed \
+                        size    6323 \
                     github.com/aws/aws-sdk-go \
-                        lock    v1.30.29 \
-                        rmd160  d4f4df4e38a1ebace6eeb293a826e9224f9b6f3b \
-                        sha256  466c83cc072c324d7c0908ab5a7a08b61615f2f7b868f88e6fe9e1d327f4fdc0 \
-                        size    14814028 \
+                        lock    v1.37.0 \
+                        rmd160  d93aacd5cd980ef704e93dc221b8c0e307a3a022 \
+                        sha256  f163ad6a1ed1947ecad5f4e3640fb2900ee791690df214e94e87665e6a1714a3 \
+                        size    18129497 \
                     github.com/aryann/difflib \
                         lock    ff5ff6dc229b \
                         rmd160  0fe41eb245a01a9be0f44ff5316c1aa2349ca37f \
@@ -590,26 +725,11 @@ go.vendors          howett.net/plist \
                         rmd160  2e69e367cde536868493d68a1ccdc6e7e2f65b03 \
                         sha256  1dc72feb97c7365f08c6461219ba6f0b2533181efa3d7000459cb4007ec8a5b7 \
                         size    4328303 \
-                    github.com/alecthomas/repr \
-                        lock    117648cd9897 \
-                        rmd160  1f78bc0844f7ca6ccb93808bb367080e4c3accf8 \
-                        sha256  6715287714f895ceeed848842618084ea0fb4a53f0b904d9c456bea28ea31e16 \
-                        size    4649 \
-                    github.com/alecthomas/colour \
-                        lock    60882d9e2721 \
-                        rmd160  9f588ca134237b19f19199a088974aefebe3b301 \
-                        sha256  9178279e7dbff10a8325724c84b344dfcf365578d30d3f436db5fb1cba1030d5 \
-                        size    3484 \
                     github.com/alecthomas/chroma \
-                        lock    v0.9.1 \
-                        rmd160  7925872e9e0ad56c9d4021be4d75c624b51a0e74 \
-                        sha256  0d16603bc0406878f49b59d5a93828fa4b5143fd524f1124e9a0bcd8ede9b03f \
-                        size    655675 \
-                    github.com/alecthomas/assert \
-                        lock    405dbfeb8e38 \
-                        rmd160  5d141a90e1e313657b558c19d51c3bdd65b0e5e5 \
-                        sha256  8c445be2c7daa6b680bfbf96823192076bbf9c0f514642687d6487fd95630a5e \
-                        size    71075 \
+                        lock    v0.10.0 \
+                        rmd160  41ff8340ec3b18ff636e56c5237ebb526d722150 \
+                        sha256  0f448cf1747a75f13b6cfe78d5cb3b2c5e0fd28a53d73c0bc9d6371621e333a3 \
+                        size    798426 \
                     github.com/OneOfOne/xxhash \
                         lock    v1.2.2 \
                         rmd160  35e2c7b623c069fc08aec00990ca5c82ad831a22 \
@@ -630,34 +750,34 @@ go.vendors          howett.net/plist \
                         rmd160  d50d8300ab7418bf2fe5bd0e7a5889f7906d082a \
                         sha256  9c750be5c0666f133c0bf8d9439a2e428b800276d4ab28dfc406fad8d66face6 \
                         size    14849 \
-                    github.com/DataDog/zstd \
-                        lock    v1.4.5 \
-                        rmd160  3b30f765dd14af12666aa9bec66906a5f03340ab \
-                        sha256  8769ae35701f602acc1da4c691c0c7c7dc4d43693bc08514354c588eb93aa2ca \
-                        size    512878 \
                     github.com/BurntSushi/toml \
-                        lock    v0.3.1 \
-                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
-                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
-                        size    42087 \
+                        lock    v1.0.0 \
+                        rmd160  cc46ecb976a41c9693f36914ba01bbe62a8c1b93 \
+                        sha256  f1c66e8a6c5bc63606d31bdfd4a89342256442fac49882a2150bf94de032ab00 \
+                        size    90406 \
                     github.com/AndreasBriese/bbloom \
                         lock    46b345b51c96 \
                         rmd160  37888ae5d833661314a5d2c0ee6ac65021e4cf85 \
                         sha256  8e56a682fb2b1bf77e6c8e9913f483533fe1b86700fb751105ef085eed89a45a \
                         size    8009 \
+                    filippo.io/edwards25519 \
+                        repo    github.com/FiloSottile/edwards25519 \
+                        lock    v1.0.0-rc.1 \
+                        rmd160  a83aba34025ad1df3a443deb358c11c1239e15ac \
+                        sha256  4bdeff6fc20d81c28a18df76cc982f1fcca03f385dfcc36cf3ddff73b5b2f5fe \
+                        size    39144 \
                     cloud.google.com/go \
                         repo    github.com/googleapis/google-cloud-go \
-                        lock    v0.70.0 \
-                        rmd160  9d89467600ca0303c380b42e32e189cbf2712989 \
-                        sha256  f92391f983bd1e84f4df2a3f30cbdbdedc41a88d8e6c791ab024be7f9944ca35 \
-                        size    3076361
+                        lock    v0.100.2 \
+                        rmd160  3c65edd6215509ff39dbfc45329347a0da7f650a \
+                        sha256  5b4b9ff34231611bd7276be629ab4f8f7f4a507751ba26d56724c56bff652040 \
+                        size    6906445
 
 patch.dir           ${gopath}/src
-patchfiles          patch-nosql.diff
+patchfiles          patch-nosql.diff patch-version.diff
 
 configure {
-    reinplace -E "s|(mod\\.Version = )\"unknown\"|\\1\"v${version}\"|" \
-        ${worksrcpath}/caddy.go
+    reinplace "s|@VERSION@|v${version}|" ${worksrcpath}/caddy.go
 }
 
 build.dir           ${worksrcpath}/cmd/${name}

--- a/www/caddy/files/patch-version.diff
+++ b/www/caddy/files/patch-version.diff
@@ -1,0 +1,10 @@
+--- github.com/caddyserver/caddy/caddy.go.orig	2022-05-06 20:25:31.000000000 +0400
++++ github.com/caddyserver/caddy/caddy.go	2022-05-21 22:58:32.000000000 +0400
+@@ -778,6 +778,7 @@
+ 				return dep
+ 			}
+ 		}
++		bi.Main.Version = "@VERSION@"
+ 		return &bi.Main
+ 	}
+ 	return mod


### PR DESCRIPTION
###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.3.1 13E500a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?