### PR TITLE
qmake5 PortGroup: improve sdk detection

### DIFF
--- a/_resources/port1.0/group/qmake5-1.0.tcl
+++ b/_resources/port1.0/group/qmake5-1.0.tcl
@@ -57,8 +57,16 @@ pre-configure {
     #
     # avoid --show-sdk-path since it is not available on all platforms
     # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
-    if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld} result]} {
-        configure.sdk_version
+    if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+        # if no specific sdk can be found, check for a generic macosx sdk
+        if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+            ui_error "qmake5 PortGroup: no usable SDK can be found"
+            return -code error "no usable SDK can be found"
+        } else {
+            ui_debug "qmake5 PortGroup: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+            configure.sdk_version
+        }
     }
 
     # set QT and QMAKE values in a cache file


### PR DESCRIPTION
- hide output from sdk-finding command

the xcrun command is supposed to fail if the specific
sdk macosx${configure.sdk_version} is not found. However,
this error shows up on user's screens causing considerable
confusion about what the true build error is.

- ensure sdk macosx is found if we are going to use it
