### PR TITLE
ocaml-findlib: allow build on PPC

### DIFF
--- a/ocaml/ocaml-findlib/Portfile
+++ b/ocaml/ocaml-findlib/Portfile
@@ -44,7 +44,12 @@ configure.args      -bindir ${prefix}/bin \
 configure.pre_args
 
 use_parallel_build  no
-build.target        all opt
+
+if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+    build.target    all
+    } else {
+    build.target    all opt
+}
 
 universal_variant   no
 


### PR DESCRIPTION
#### Description

This fix allows `ocaml-findlib` to build on PPC with bytecode compiler. The latter requires the following PR on PPC: https://github.com/macports/macports-ports/pull/14845
Nothing changed for other targets.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
