### PR TITLE
gopass: update to 1.14.2

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.14.1 v
+go.setup            github.com/gopasspw/gopass 1.14.2 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  85bdc852a714df87fc2613bec37b3afe5651c6c3 \
-                        sha256  47f5f19f4fba370308b9272bbe03eae93fce6baa642d2360bdf2062b1eb2eb8b \
-                        size    2214786
+                        rmd160  358ccbee0ada797f05d14a259da8b23269506795 \
+                        sha256  3a6c243621103a7ad1e1c1ac1f8d460ab290b997a8e1e15c4fbf5facf8d76338 \
+                        size    2216740
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -54,11 +54,6 @@ go.vendors          rsc.io/qr \
                         rmd160  32e6de431630b8126df1d04e36eba2abb57626f1 \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
-                    golang.org/x/xerrors \
-                        lock    5ec99f83aff1 \
-                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
-                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
-                        size    13667 \
                     golang.org/x/term \
                         lock    e5f449aeb171 \
                         rmd160  815a83a4b9782102c3877cf61ee45ab5f8f89f4f \
@@ -107,10 +102,10 @@ go.vendors          rsc.io/qr \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.5.1 \
-                        rmd160  e28c2ffd83dee554eb4fada96dd4c1be6ea4a13f \
-                        sha256  fb79863f364131e179289ab3cc55d8fb71254255977e5a93975d74bf18781306 \
-                        size    3414167 \
+                        lock    v2.7.1 \
+                        rmd160  b6bb4c8e544a0b98123eca6701dcb563dcbb440b \
+                        sha256  7901fad825853e4426d8f68238ceaa9bf63cabde84cd6e82b3e70c786dbbcc25 \
+                        size    3445856 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -321,6 +316,11 @@ go.vendors          rsc.io/qr \
                         rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
                         sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
                         size    5023 \
+                    github.com/antzucaro/matchr \
+                        lock    b04723ef80f0 \
+                        rmd160  9518c0e67d2719a34d76957e567121a307dfd5ad \
+                        sha256  ad246791e22fd0356a13ed12849ff3ab62ab8ac8df7f63b9587fbcb8293b8b9f \
+                        size    573191 \
                     github.com/ProtonMail/go-crypto \
                         lock    a94812496cf5 \
                         rmd160  63b9296476022059a4166f68548549efb21282b8 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.14.2)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
