### PR TITLE
dcw-gmt: update to 2.1.1

### DIFF
--- a/science/dcw-gmt/Portfile
+++ b/science/dcw-gmt/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dcw-gmt
-version             2.1.0
+version             2.1.1
 categories          science
 platforms           darwin
 supported_archs     noarch
@@ -22,9 +22,9 @@ homepage            http://www.soest.hawaii.edu/pwessel/dcw/index.html
 master_sites        http://www.soest.hawaii.edu/pwessel/dcw \
                     ftp://ftp.soest.hawaii.edu/dcw
 
-checksums           rmd160  4df6dfe2bdc36fc0d8e5a821011ac1801e146b46 \
-                    sha256  e810567cd474d5af9d84751938acb447a8612391ed66190d60d789974a1f9e29 \
-                    size    21994257
+checksums           rmd160  f91648ba0fa3f7315ea1b3236fca3020ef921c2d \
+                    sha256  ab72c8253076380c8477a1225370bc41f4aff811c28d2f64d75052ff3d9003af \
+                    size    21994444
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.1.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 x86_64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
