### PR TITLE
libuv: fix ppc64 build on Leopard

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -4,6 +4,7 @@ PortSystem       1.0
 PortGroup        github 1.0
 PortGroup        clang_dependency 1.0
 PortGroup        legacysupport 1.1
+PortGroup        muniversal 1.0
 
 github.setup     libuv libuv 1.44.1 v
 revision         0
@@ -28,7 +29,8 @@ long_description libuv is a multi-platform support library with a \
 homepage         https://libuv.org/
 
 patchfiles       patch-libuv-legacy.diff \
-                 patch-libuv-unix-core-close-nocancel.diff
+                 patch-libuv-unix-core-close-nocancel.diff \
+                 patch-atomic-ops.diff
 
 # strnlen, lutimes
 legacysupport.newest_darwin_requires_legacy 10

--- a/devel/libuv/files/patch-atomic-ops.diff
+++ b/devel/libuv/files/patch-atomic-ops.diff
@@ -1,0 +1,13 @@
+--- src/unix/atomic-ops.h.orig	2021-11-12 00:19:10.000000000 +0800
++++ src/unix/atomic-ops.h	2022-05-24 03:26:31.000000000 +0800
+@@ -55,7 +55,9 @@
+   __asm__ __volatile__ ("rep; nop" ::: "memory");  /* a.k.a. PAUSE */
+ #elif (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__)
+   __asm__ __volatile__ ("yield" ::: "memory");
+-#elif defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__)
++#elif (defined(__ppc__) || defined(__ppc64__)) && defined(__APPLE__)
++  __asm volatile ("" : : : "memory");
++#elif !defined(__APPLE__) && (defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__))
+   __asm__ __volatile__ ("or 1,1,1; or 2,2,2" ::: "memory");
+ #endif
+ }


### PR DESCRIPTION
#### Description

This fixes `ppc64` and `+universal` on Leopard.
Merged into upstream: https://github.com/libuv/libuv/commit/99ab53e9980dc0b2fb31b4615ce754bf1f35826f

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
