### PR TITLE
google-cloud-sdk: update to 387.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             386.0.0
+version             387.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  b9c3b3c9a248506184881f7a73b550fd12b3d71b \
-                    sha256  77f85b8c6ee66e948899bd6592952d2f33d4d444fbe00ba8e58b8dafabf8a457 \
-                    size    106770646
+    checksums       rmd160  54321692f592930cb836eb79b887c834541ad6f3 \
+                    sha256  689bb6035b38cb14005890f60a323cb5411b669d50769d9d667aee65e5e04feb \
+                    size    106828047
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  65bb15a44d2be8cdfd0a6d2ff5ff68f1350d2e22 \
-                    sha256  ed266c23437d63097700b3eeda35d77d04ec9b4109528b09b4d59a6c54713a7f \
-                    size    103369466
+    checksums       rmd160  58df068f277474c03967266d9e3b9c741e66455b \
+                    sha256  5d92746506695792b03cc9067db3d62b1716630f0c26ab21d5a059caca37cd63 \
+                    size    103416284
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  105ec9603b096ceb22dab710525a943ef8ff1c7b \
-                    sha256  edb4364ccc4b057014d51e8210e66fef95410da80a2b370003d3ff3313229ac3 \
-                    size    101951190
+    checksums       rmd160  55c399546d1150f092685e62aae91a0d0a526b04 \
+                    sha256  e24cc22d208bc2cf978bf1990d20df96f39d1b3e1a23dd7cd549484ec9988408 \
+                    size    102000169
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 387.0.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?