### PR TITLE
erlang: Update to 25.0

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                erlang
-version             24.3
+version             25.0
 revision            0
 
 categories          lang erlang
@@ -47,17 +47,17 @@ distfiles           otp_src_${version}${extract.suffix}                    \
                     otp_doc_html_${version}${extract.suffix}
 
 checksums           otp_src_${version}.tar.gz \
-                    rmd160  96168a082808e5a8ae72b55a57e47436a7d97caa \
-                    sha256  ee8dd101af68ba175deec1844059ed287a22f7f46e72915631c965cc8be331f9 \
-                    size    107425200 \
+                    rmd160  f977fc3a893525b668508e54db5a38cc6a084f26 \
+                    sha256  3e1e2e55409e9484e69b316fcd00ff7e2ed606bcfb2c7cac514f9b9aeb9651e8 \
+                    size    102972543 \
                     otp_doc_man_${version}.tar.gz \
-                    rmd160  59a89d5c59555a64b67b300fc3b658e2ae9686c9 \
-                    sha256  68ad2222eef77310c286411ad0e580865f3ba273e9fe42516ade0e5310cff614 \
-                    size    1680242 \
+                    rmd160  84029a74a10510b9cb3c5b604ccdcd85d985fbec \
+                    sha256  3edce27340f30019d7a2c6aeda7744cf864b0a7c8314360265152fcad524579d \
+                    size    1708111 \
                     otp_doc_html_${version}.tar.gz \
-                    rmd160  5d5a28d65852d5d3c50db6ee2ad625149acbe30e \
-                    sha256  7a247113a0f90514aacb0656e98a1e4d63e2ebf4ac9981002d046599147dc177 \
-                    size    36645792
+                    rmd160  bc662efd0b3b036a4fc0223c8c013f5f2e82f9bd \
+                    sha256  0b8a751757d3c72f5def862d258e32de626a8fa9453c8493b9a0255d98f524f9 \
+                    size    40951434
 
 worksrcdir          otp_src_${version}
 


### PR DESCRIPTION
#### Description

erlang: update to 25.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
