### PR TITLE
ocaml-zarith: do not apply patch on PPC, it breaks build

### DIFF
--- a/ocaml/ocaml-zarith/Portfile
+++ b/ocaml/ocaml-zarith/Portfile
@@ -11,7 +11,6 @@ revision            0
 categories          ocaml devel
 maintainers         {landonf @landonf} openmaintainer
 license             LGPL-2
-platforms           darwin
 
 description         Arbitrary-precision integers for OCaml
 long_description    \
@@ -27,7 +26,11 @@ checksums           rmd160  433a8afe819e703d028afa3eba2fcb7f7c4ada06 \
 depends_build       port:perl5
 depends_lib         port:ocaml port:ocaml-findlib port:gmp
 
-patchfiles          patch-configure.diff
+if {${build_arch} ne "ppc" || ${build_arch} ne "ppc64"} {
+    # The following patch forces ocamlopt to be seen as available, but it is not on PPC
+    # See: https://github.com/ocaml/Zarith/issues/125
+    patchfiles      patch-configure.diff
+}
 
 configure.pre_args
 configure.args       -installdir ${destroot}${ocaml.package_dir} -ocamllibdir ${prefix}/lib/ocaml


### PR DESCRIPTION
#### Description

No idea why someone added a patch to `configure` which makes `configure` behave wrong, but specifically on PPC it breaks the build, since `ocamlopt` is not available presently. This PR adds a condition for the patch not to be applied when the build is for PPC.
See: https://github.com/ocaml/Zarith/issues/125

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
