### PR TITLE
py-monty: update to 2022.4.26, add py310 subport

### DIFF
--- a/python/py-monty/Portfile
+++ b/python/py-monty/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-monty
-version             2021.8.17
+version             2022.4.26
 revision            0
 
 platforms           darwin
@@ -20,11 +20,11 @@ long_description    \
 
 homepage            https://guide.materialsvirtuallab.org/monty/
 
-checksums           rmd160  269b60978d925ea557d0ad98ec94840d4e140569 \
-                    sha256  d4d5b85566bda80360e275e6ffb72228d203de68c5155446a0e09f19c63e8540 \
-                    size    38323
+checksums           rmd160  a9a5d783bca630fbada4f36ab741a2cf8c953719 \
+                    sha256  697daa36f88a261f6c0c15d5ede3f1e3b8ca1b98ee57f16c371bcbbb638ecbb1 \
+                    size    38683
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

* Update py-monty to use upstream version.
* Add sub-port py310-monty for Python 3.10.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6.6 20G624 x86_64
Xcode 13.2.1 13C100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
