### PR TITLE
Libvidstab

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               0
 version             5.0.1
-revision            0
+revision            1
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} {mascguy @mascguy} openmaintainer
@@ -356,9 +356,11 @@ variant darwinssl description {Enable https support using Apple built-in TLS lib
 variant gpl2 description {Enable GPL code, license will be GPL-2+} {
     configure.args-append   --enable-gpl \
                             --enable-postproc \
+                            --enable-libvidstab \
                             --enable-libx264 \
                             --enable-libxvid
-    depends_lib-append      port:XviD \
+    depends_lib-append      port:libvidstab \
+                            port:XviD \
                             port:x264
 
     license                 GPL-2+
@@ -404,6 +406,7 @@ This build of ${name} includes GPLed code and is therefore licensed under GPL v3
 The following modules are GPLed:
   postproc
   libsambaclient
+  libvidstab
   libx264
   libx265
   libxvid
@@ -415,6 +418,7 @@ notes "
 This build of ${name} includes GPLed code and is therefore licensed under GPL v2 or later.
 The following modules are GPLed:
   postproc
+  libvidstab
   libx264
   libx265
   libxvid

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg-devel
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               1
 version             4.4.1
-revision            4
+revision            5
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} {mascguy @mascguy} openmaintainer
@@ -363,9 +363,11 @@ variant darwinssl description {Enable https support using Apple built-in TLS lib
 variant gpl2 description {Enable GPL code, license will be GPL-2+} {
     configure.args-append   --enable-gpl \
                             --enable-postproc \
+                            --enable-libvidstab \
                             --enable-libx264 \
                             --enable-libxvid
-    depends_lib-append      port:XviD \
+    depends_lib-append      port:libvidstab \
+                            port:XviD \
                             port:x264
 
     license                 GPL-2+
@@ -411,6 +413,7 @@ This build of ${name} includes GPLed code and is therefore licensed under GPL v3
 The following modules are GPLed:
   postproc
   libsambaclient
+  libvidstab
   libx264
   libx265
   libxvid
@@ -422,6 +425,7 @@ notes "
 This build of ${name} includes GPLed code and is therefore licensed under GPL v2 or later.
 The following modules are GPLed:
   postproc
+  libvidstab
   libx264
   libx265
   libxvid

--- a/multimedia/libvidstab/Portfile
+++ b/multimedia/libvidstab/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+github.setup        georgmartius vid.stab 1.1.0 v
+
+PortGroup           cmake 1.1
+cmake.out_of_source no
+
+name                libvidstab
+revision            1
+categories          multimedia
+maintainers         nomaintainer
+description         Video stabilization library
+long_description    Vidstab is a video stabilization library which can be \
+                    used with Ffmpeg and Transcode.
+platforms           darwin
+license             GPL-2
+
+checksums           sha256 133f7b0868d07c7ed986a9eaa12ad62e1254eb63778210d9f49f97f99fc4587c
+
+patchfiles          patch-cmake-quoting-fix.diff
+configure.args-append -DUSE_OMP=OFF

--- a/multimedia/libvidstab/files/patch-cmake-quoting-fix.diff
+++ b/multimedia/libvidstab/files/patch-cmake-quoting-fix.diff
@@ -1,0 +1,97 @@
+From 37e3d48948f27f09d9ba31d8c6acb765b7abf12b Mon Sep 17 00:00:00 2001
+From: Misty De Meo <mistydemeo@gmail.com>
+Date: Tue, 15 Sep 2020 17:30:46 -0700
+Subject: [PATCH] FindSSE: ensure ${CPUINFO} is quoted
+
+If ${CPUINFO} isn't quoted, and it's an empty string, CMake's STRING
+REPLACE function will error with a note it's being called with too few
+arguments. Fixes:
+
+CMake Error at CMakeModules/FindSSE.cmake:47 (STRING):
+  STRING sub-command REGEX, mode REPLACE needs at least 6 arguments total to
+  command.
+Call Stack (most recent call first):
+  CMakeLists.txt:8 (include)
+---
+ CMakeModules/FindSSE.cmake | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/CMakeModules/FindSSE.cmake b/CMakeModules/FindSSE.cmake
+index 6ece876..f6ad475 100644
+--- CMakeModules/FindSSE.cmake.orig
++++ CMakeModules/FindSSE.cmake
+@@ -4,7 +4,7 @@
+ IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
+ 
+-   STRING(REGEX REPLACE "^.*(sse2).*$" "\\1" SSE_THERE ${CPUINFO})
++   STRING(REGEX REPLACE "^.*(sse2).*$" "\\1" SSE_THERE "${CPUINFO}")
+    STRING(COMPARE EQUAL "sse2" "${SSE_THERE}" SSE2_TRUE)
+    IF (SSE2_TRUE)
+       set(SSE2_FOUND true CACHE BOOL "SSE2 available on host")
+@@ -13,14 +13,14 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    ENDIF (SSE2_TRUE)
+ 
+    # /proc/cpuinfo apparently omits sse3 :(
+-   STRING(REGEX REPLACE "^.*[^s](sse3).*$" "\\1" SSE_THERE ${CPUINFO})
++   STRING(REGEX REPLACE "^.*[^s](sse3).*$" "\\1" SSE_THERE "${CPUINFO}")
+    STRING(COMPARE EQUAL "sse3" "${SSE_THERE}" SSE3_TRUE)
+    IF (NOT SSE3_TRUE)
+-      STRING(REGEX REPLACE "^.*(T2300).*$" "\\1" SSE_THERE ${CPUINFO})
++      STRING(REGEX REPLACE "^.*(T2300).*$" "\\1" SSE_THERE "${CPUINFO}")
+       STRING(COMPARE EQUAL "T2300" "${SSE_THERE}" SSE3_TRUE)
+    ENDIF (NOT SSE3_TRUE)
+ 
+-   STRING(REGEX REPLACE "^.*(ssse3).*$" "\\1" SSE_THERE ${CPUINFO})
++   STRING(REGEX REPLACE "^.*(ssse3).*$" "\\1" SSE_THERE "${CPUINFO}")
+    STRING(COMPARE EQUAL "ssse3" "${SSE_THERE}" SSSE3_TRUE)
+    IF (SSE3_TRUE OR SSSE3_TRUE)
+       set(SSE3_FOUND true CACHE BOOL "SSE3 available on host")
+@@ -33,7 +33,7 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
+       set(SSSE3_FOUND false CACHE BOOL "SSSE3 available on host")
+    ENDIF (SSSE3_TRUE)
+ 
+-   STRING(REGEX REPLACE "^.*(sse4_1).*$" "\\1" SSE_THERE ${CPUINFO})
++   STRING(REGEX REPLACE "^.*(sse4_1).*$" "\\1" SSE_THERE "${CPUINFO}")
+    STRING(COMPARE EQUAL "sse4_1" "${SSE_THERE}" SSE41_TRUE)
+    IF (SSE41_TRUE)
+       set(SSE4_1_FOUND true CACHE BOOL "SSE4.1 available on host")
+@@ -44,7 +44,7 @@ ELSEIF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    EXEC_PROGRAM("/usr/sbin/sysctl -n machdep.cpu.features" OUTPUT_VARIABLE
+       CPUINFO)
+ 
+-   STRING(REGEX REPLACE "^.*[^S](SSE2).*$" "\\1" SSE_THERE ${CPUINFO})
++   STRING(REGEX REPLACE "^.*[^S](SSE2).*$" "\\1" SSE_THERE "${CPUINFO}")
+    STRING(COMPARE EQUAL "SSE2" "${SSE_THERE}" SSE2_TRUE)
+    IF (SSE2_TRUE)
+       set(SSE2_FOUND true CACHE BOOL "SSE2 available on host")
+@@ -52,7 +52,7 @@ ELSEIF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+       set(SSE2_FOUND false CACHE BOOL "SSE2 available on host")
+    ENDIF (SSE2_TRUE)
+ 
+-   STRING(REGEX REPLACE "^.*[^S](SSE3).*$" "\\1" SSE_THERE ${CPUINFO})
++   STRING(REGEX REPLACE "^.*[^S](SSE3).*$" "\\1" SSE_THERE "${CPUINFO}")
+    STRING(COMPARE EQUAL "SSE3" "${SSE_THERE}" SSE3_TRUE)
+    IF (SSE3_TRUE)
+       set(SSE3_FOUND true CACHE BOOL "SSE3 available on host")
+@@ -60,7 +60,7 @@ ELSEIF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+       set(SSE3_FOUND false CACHE BOOL "SSE3 available on host")
+    ENDIF (SSE3_TRUE)
+ 
+-   STRING(REGEX REPLACE "^.*(SSSE3).*$" "\\1" SSE_THERE ${CPUINFO})
++   STRING(REGEX REPLACE "^.*(SSSE3).*$" "\\1" SSE_THERE "${CPUINFO}")
+    STRING(COMPARE EQUAL "SSSE3" "${SSE_THERE}" SSSE3_TRUE)
+    IF (SSSE3_TRUE)
+       set(SSSE3_FOUND true CACHE BOOL "SSSE3 available on host")
+@@ -68,7 +68,7 @@ ELSEIF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+       set(SSSE3_FOUND false CACHE BOOL "SSSE3 available on host")
+    ENDIF (SSSE3_TRUE)
+ 
+-   STRING(REGEX REPLACE "^.*(SSE4.1).*$" "\\1" SSE_THERE ${CPUINFO})
++   STRING(REGEX REPLACE "^.*(SSE4.1).*$" "\\1" SSE_THERE "${CPUINFO}")
+    STRING(COMPARE EQUAL "SSE4.1" "${SSE_THERE}" SSE41_TRUE)
+    IF (SSE41_TRUE)
+       set(SSE4_1_FOUND true CACHE BOOL "SSE4.1 available on host")
+-- 
+2.28.0
+


### PR DESCRIPTION
#### Description

* Add library [`vid.stab`](https://github.com/georgmartius/vid.stab), a video stabilization library.
* Add `vid.stab` support to `ffmpeg` and `ffmpeg-devel`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [n/a] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
