### PR TITLE
safeclib: fix build for ppc and ppc64

### DIFF
--- a/devel/safeclib/Portfile
+++ b/devel/safeclib/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           muniversal 1.0
 
 github.setup        rurban safeclib 3.7.1 v
 github.tarball_from releases
@@ -21,11 +22,21 @@ checksums           rmd160  136bbb4c9a5912482ebb219d7b7e0969285039ec \
                     sha256  63a4357f9d3648c1235bd8d369da1d3b456b86d3143dfb92d4849cda6b356029 \
                     size    965289
 
+compiler.c_standard 1999
+
 # for man pages
 depends_build       port:perl5 port:doxygen
 
+patchfiles          patch-perf_private.diff
+
 # build fails otherwise
 configure.args      --disable-hardening
+
+if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+    # doxygen is broken on PPC, see: https://trac.macports.org/ticket/64400
+    configure.args-append   --disable-doc
+    configure.cflags-append -std=c99
+}
 
 test.run            yes
 test.target         check

--- a/devel/safeclib/files/patch-perf_private.diff
+++ b/devel/safeclib/files/patch-perf_private.diff
@@ -1,0 +1,13 @@
+# mftb already refers to time base lower, mftbl is invalid
+
+--- tests/perf_private.h.orig	2022-02-02 04:16:44.000000000 +0800
++++ tests/perf_private.h	2022-05-29 08:01:07.000000000 +0800
+@@ -101,7 +101,7 @@
+     __asm__ volatile (\
+       "0:\n"
+       "mftbu %0\n"
+-      "mftbl %1\n"
++      "mftb %1\n"
+       "mftbu %2\n"
+       "cmpw %0, %2\n"
+       "bne- 0b"


### PR DESCRIPTION
#### Description

This PR fixes the build for `ppc`, `ppc64` and `+universal`.
I have also reported `ppc` assembler error to upstream: https://github.com/rurban/safeclib/pull/117

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC (10A190)
Xcode 3.2

macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
