### PR TITLE
micronaut: update to 3.5.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.4.4 v
+github.setup    micronaut-projects micronaut-starter 3.5.0 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  55c30bbbd04d96b9168968d2cf89c97cdd750351 \
-                sha256  83723f84838740b8c51c992e781b07c5e7ccf29d72fa4d918d0daf2e4384c18c \
-                size    21050148
+checksums       rmd160  947765799da0c92a712290ce74927bbf86cf11f9 \
+                sha256  13de8ceb645020166890603b8429a24094414558e516cc6dfd89729904ce4895 \
+                size    21320562
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.5.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?