### PR TITLE
mkvtoolnix 41.0: fix header error, enabled build for PPC

### DIFF
--- a/multimedia/mkvtoolnix/Portfile
+++ b/multimedia/mkvtoolnix/Portfile
@@ -66,6 +66,7 @@ if {${os.platform} ne "darwin" || ${os.major} >= 19} {
     checksums       rmd160  17b2f3b7d6eb87e9d9d4aac536b66705c18d497f \
                     sha256  7cdd6ad9144324162604172b7e96cb13cdbb7913e07c4ad7633344aac20e4103 \
                     size    7401548
+    patchfiles      patch-mm_text_io.diff
 }
 
 distname            ${my_name}-${version}

--- a/multimedia/mkvtoolnix/files/patch-mm_text_io.diff
+++ b/multimedia/mkvtoolnix/files/patch-mm_text_io.diff
@@ -1,0 +1,11 @@
+--- tests/unit/common/mm_text_io.cpp.orig	2019-12-07 01:32:54.000000000 +0800
++++ tests/unit/common/mm_text_io.cpp	2022-05-30 04:19:07.000000000 +0800
+@@ -8,6 +8,8 @@
+ #include "common/mm_proxy_io.h"
+ #include "common/mm_text_io.h"
+ 
++#include <boost/optional/optional_io.hpp>
++
+ namespace {
+ 
+ TEST(MmTextIo, BomUtf8) {


### PR DESCRIPTION
#### Description

This fixes an error with a missing Boost header in version 41.0. _Only relevant for old systems_.

I am not sure Macports stats is representative, but judging by it v. 41.0 has been failing for OS <10.9: https://ports.macports.org/port/mkvtoolnix/stats/?days=365&days_ago=0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC (10A190)
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. Specifically, the error in question:
```
tests/unit/common/mm_text_io.cpp:17:3:   required from here
/opt/local/libexec/boost/1.76/include/boost/optional/optional.hpp:1596:44: error: static assertion failed: If you want to output boost::optional, include header <boost/optional/optional_io.hpp>
 1596 |   BOOST_STATIC_ASSERT_MSG(sizeof(CharType) == 0, "If you want to output boost::optional, include header <boost/optional/optional_io.hpp>");
      |                           ~~~~~~~~~~~~~~~~~^~~~
/opt/local/libexec/boost/1.76/include/boost/static_assert.hpp:31:59: note: in definition of macro 'BOOST_STATIC_ASSERT_MSG'
   31 | #     define BOOST_STATIC_ASSERT_MSG( ... ) static_assert(__VA_ARGS__)
      |                                                           ^~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```
