### PR TITLE
openjdk18-openj9: update to 18.0.1.1

### DIFF
--- a/java/openjdk18-openj9/Portfile
+++ b/java/openjdk18-openj9/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      18.0.1
+version      18.0.1.1
 revision     0
 
-set build    10
+set build    2
 set openj9_version 0.32.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 18
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru18-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  aa9cc52eda998d7e212598277611f90d5946fe04 \
-                 sha256  b34d48236e12ac96c136dd09643b8794e2ec6f1f21d4c3ab3570d32dfc4db4a1 \
-                 size    209571971
+    checksums    rmd160  f558c50664ca6956526dc86de154155ba56a75f3 \
+                 sha256  d6f262cb6077af35d18f0405b4133c9cf4014d4909589d8bdf0af0f350be9abc \
+                 size    209566466
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  0b6559622826b32f28b482f8511802a418ba7735 \
-                 sha256  ef3ea71942039c5d2607ba5281fdc29431bf7bed9e6265463c78505f516b3ae5 \
-                 size    186321588
+    checksums    rmd160  4db1c989eaf310956dd9764b03be8d2cf4e1b142 \
+                 sha256  38f9b44bcaf1d472720beac31f6b76b29b6a73db8e5631f685eca70787c58200 \
+                 size    186329294
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to OpenJDK 18.0.1.1.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?