### PR TITLE
spring-boot-cli: update to 2.7.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.6.8
+version         2.7.0
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  8bf1e283b2ba4fcb5b9d0d25df2eebd0b24b36e7 \
-                sha256  5bba575d3b71f2ee619add839da1e5d6b5c1264b5c5aa11e01b7f3d0d07619e0 \
-                size    14306636
+checksums       rmd160  d730cefe1ba6b4dfe3f5e9972309092ec84306f7 \
+                sha256  4c3aa09d20527866bbe0d10897455dcd4e670cb97b6830f9e864d8348377bc70 \
+                size    14306651
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot 2.7.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?