### PR TITLE
jdk17: update to 17.0.3.1

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,8 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.3
-set build    8
+version      17.0.3.1
 revision     0
 
 description  Oracle Java SE Development Kit 17
@@ -27,14 +26,14 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  faabac02ab11cebfcc41b0c6af9202d12344f503 \
-                 sha256  dc12044350a5c06d38c1d1d4c33b9855cd954d7cdb10a040f91c332d34213cb4 \
-                 size    178217542
+    checksums    rmd160  b89c9ee434dedde9a19e5a9b46dbdc899685212f \
+                 sha256  4e774c6ebf4c7f3a8511513fa341e5d73c1d27c6e8f1131d0916bf3f2bd3e773 \
+                 size    178220776
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  4824d0cc63ad70569deccce7fc7992b52950cb78 \
-                 sha256  939b32a0e71d54bc9fa48eaf2b551b6c7c7fddbe2d63ec5d2cb618a7a92154d9 \
-                 size    175548784
+    checksums    rmd160  55e1e38de6e46734cea38aa116bca7e7781d3bad \
+                 sha256  241a6ad1ddea0480e7fc6cb2813011b796aa91033d5787857dd16177fa175ea9 \
+                 size    175556313
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle Java SE Development Kit 17.0.3.1.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?