### PR TITLE
libpoly: fix PPC build

### DIFF
--- a/devel/libpoly/Portfile
+++ b/devel/libpoly/Portfile
@@ -25,6 +25,11 @@ checksums           rmd160  d1328be4467a2a1353e9f7c84ca36352b3a1ace2 \
 
 depends_lib-append  port:gmp
 
+compiler.c_standard 2011
+
+# Fixes build for PPC
+patchfiles          patch-doctest.diff
+
 configure.args-append \
                     -DLIBPOLY_BUILD_STATIC_PIC=OFF \
                     -DLIBPOLY_BUILD_STATIC=OFF \

--- a/devel/libpoly/files/patch-doctest.diff
+++ b/devel/libpoly/files/patch-doctest.diff
@@ -1,0 +1,11 @@
+--- test/polyxx/doctest.h.orig	2021-10-05 03:11:15.000000000 +0800
++++ test/polyxx/doctest.h	2022-05-30 08:56:14.000000000 +0800
+@@ -370,6 +370,8 @@
+ #elif defined(DOCTEST_PLATFORM_MAC)
+ #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
+ #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT (hicpp-no-assembler)
++#elif defined(__ppc__) || defined(__ppc64__)
++#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" : : : "memory","r0","r3","r4" ) /* NOLINT */
+ #else
+ #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT (hicpp-no-assembler)
+ #endif


### PR DESCRIPTION
#### Description

Fixes build for PPC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
