### PR TITLE
added draft first Portfile for cfonts

### DIFF
--- a/textproc/cfonts/Portfile
+++ b/textproc/cfonts/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo  1.0
+
+github.setup        DominikWilkowski cfonts 1.0.2rust v
+revision            0
+
+categories          textproc
+license             GPL-3+
+maintainers         {DominikWilkowski @DominikWilkowski}
+
+description         Sexy ANSI fonts for the console
+long_description    This is a silly little command line tool for sexy fonts in the console. \
+                    Give your cli some love.
+homepage            https://github.com/dominikwilkowski/cfonts
+
+checksums           ${distfiles} \
+                    rmd160  6f5bedcb0e1cb54faf9efb2b4e34dbe6105152ea \
+                    sha256  33c14dda907c4f3c046a40644c8856f6debb87b58ee6fbaab2b8d7af14ce8b6e \
+                    size    3312272
+
+post-extract {
+    cd rust/
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

Added cfonts Portfile.

**Please note**: there are things missing and I can't find the docs for making this work. What still needs to be done I could use help with is:
- changing working directory after unpacking to `rust/` to run `cargo` there.
- possibly listing cargo dependencies?

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
