### PR TITLE
miniflux: update to 2.0.37

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.36
+go.setup            github.com/miniflux/v2 2.0.37
 go.package          miniflux.app
 name                miniflux
 revision            0
 categories          net
-maintainers         {sikmir @sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 license             Apache-2
 
 description         Minimalist and opinionated feed reader
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  5ecf1e61d67058adf85a4fbe22a723f876be7c46 \
-                        sha256  8b9def8ac294ae920facd8b8dd82b0744141194ed2775f64d55e53fb96e4f15e \
-                        size    548685
+                        rmd160  b789b78000a16e9713b2476217f1b7c46802b505 \
+                        sha256  2f8d0b45bf3c3467e53ba08d1c6d9b169a259b8ba733e25037e00f6abf613896 \
+                        size    555483
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -89,15 +89,15 @@ go.vendors          mvdan.cc/xurls \
                         sha256  521e9c769207c752824fb3f241dcb093f99e33e93c14f52882c07b2c7513dc56 \
                         size    2835 \
                     github.com/tdewolff/parse \
-                        lock    v2.5.27 \
-                        rmd160  75aa5693e9b515f38bb1d89b580af06225db4f16 \
-                        sha256  48626fece66259b874a79e0ad78bfc99e855349ffc4c0c133237bd37e5081224 \
-                        size    101529 \
+                        lock    v2.5.31 \
+                        rmd160  f51ead1f781871324eab0855b45f622122a6f7db \
+                        sha256  e96230011bcf643238bbc319ea887e5391cd084d03ba0a70c74dc10d21e1d946 \
+                        size    102040 \
                     github.com/tdewolff/minify \
-                        lock    v2.10.0 \
-                        rmd160  a0c6274f0f46f370981b7c83d3b56b29a85ecf98 \
-                        sha256  cbc1369eed7f5be7a2df83495790cf7a0ff24ffbed1b1172951bc5a256f6f401 \
-                        size    5202480 \
+                        lock    v2.11.5 \
+                        rmd160  2ffe1316d4b050939000f88f8f4499a7ee0aa673 \
+                        sha256  eb25fb0762d1f0684b1abcfd0e073854797c7a9be557eecc5c49a6ee699cb2b1 \
+                        size    7010890 \
                     github.com/stretchr/testify \
                         lock    v1.6.1 \
                         rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
@@ -124,10 +124,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
                         size    10985 \
                     github.com/prometheus/client_golang \
-                        lock    v1.12.1 \
-                        rmd160  70ab16c13d6f53cf3433dcba4e590cd93b637998 \
-                        sha256  ef1b1e7e68e01cf67193b25d1207bc7771919d81283976b109ec0d56a1e566f0 \
-                        size    194237 \
+                        lock    v1.12.2 \
+                        rmd160  6e2120fbbdd478bcbab9f1a7f014a2f85797db53 \
+                        sha256  df1e3c29b486c86bde89d01588b30c333265f8110a92c44bef38f21e147d2472 \
+                        size    197136 \
                     github.com/pquerna/cachecontrol \
                         lock    1555304b9b35 \
                         rmd160  0a0f37cba23e467f89c717d93a37c5b34005b64e \
@@ -149,10 +149,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
                         size    37197 \
                     github.com/lib/pq \
-                        lock    v1.10.4 \
-                        rmd160  e2f0dde65aa624ff4c99c03a60eb50f9256b1381 \
-                        sha256  ed6e9e981845f012fc0b0acd205581ad133431ed8000719dd3f3435b3fe5114c \
-                        size    108160 \
+                        lock    v1.10.6 \
+                        rmd160  cbacf9eea1412eb3a1c445cfce18310e1e35fd15 \
+                        sha256  1869d0b55f0c9c1cf1f8c0404c7da9c29cb50c406cc676bff00743f779ace42d \
+                        size    110044 \
                     github.com/gorilla/mux \
                         lock    v1.8.0 \
                         rmd160  0671fd049b24cb4c682168aef4e176793dd624a7 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.37)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
