### PR TITLE
ddrescue: update to 1.26

### DIFF
--- a/sysutils/ddrescue/Portfile
+++ b/sysutils/ddrescue/Portfile
@@ -2,8 +2,8 @@ PortSystem 1.0
 PortGroup       gnu_info 1.0
 
 name            ddrescue
-version         1.25
-revision        1
+version         1.26
+revision        0
 categories      sysutils
 platforms       darwin
 license         GPL-2+
@@ -20,9 +20,9 @@ master_sites    gnu:ddrescue
 
 use_lzip        yes
 
-checksums       rmd160  f34748e1cbf7be897be7051e162d279fa6f2cdb7 \
-                sha256  ce538ebd26a09f45da67d3ad3f7431932428231ceec7a2d255f716fa231a1063 \
-                size    87001
+checksums       rmd160  d2474a3bc4e5d9b11a4b76e1edce70a93ec1df96 \
+                sha256  e513cd3a90d9810dfdd91197d40aa40f6df01597bfb5ecfdfb205de1127c551f \
+                size    91930
 
 variant universal {}
 configure.args  CXX="${configure.cxx}" \


### PR DESCRIPTION
#### Description

Update to 1.26

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.6 20G624 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
