### PR TITLE
llvm-14: update to 14.0.4

### DIFF
--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -22,7 +22,7 @@ license                 NCSA
 maintainers             nomaintainer
 
 set llvm_version        14
-version                 ${llvm_version}.0.3
+version                 ${llvm_version}.0.4
 
 name                    llvm-${llvm_version}
 revision                0
@@ -31,9 +31,9 @@ subport                 clang-${llvm_version} { revision 0 }
 subport                 lldb-${llvm_version}  { revision 0 }
 subport                 flang-${llvm_version} { revision 0 }
 
-checksums               rmd160  6fa1af946f86123f7035b1b2fdb64e8ff2ef9e6c \
-                        sha256  44d3e7a784d5cf805e72853bb03f218bd1058d448c03ca883dabbebc99204e0c \
-                        size    105600488
+checksums               rmd160  a30c42740692bb57f7ccf67711094c3c23b80c9c \
+                        sha256  f40c77ceff02ae3873d273a51b0f93cd8e6409576f771d860d75835335522052 \
+                        size    105611808
 
 master_sites            https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}
 distname                llvm-project-${version}.src


### PR DESCRIPTION
#### Description

Update LLVM-14 and Friends, to 14.0.4.

Submitting a PR for this change, to ensure pre-commit review and visibility. As well as to avoid potentially breaking our foundational toolchain components, which I _really_ want to avoid.

Related ticket:
[65246 - clang-14 @14.0.3: crash during compilation of darktable 3.8.1](https://trac.macports.org/ticket/65246)

###### Tested on
macOS 10.15.6 / 19G2021
Xcode 12.0 / CLT 12.0
