### PR TITLE
ninja: support installing `libninja.a`

### DIFF
--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 epoch               1
 github.setup        ninja-build ninja 1.11.0 v
-revision            0
+revision            1
 
 checksums           rmd160  887b9248abc0ba76de771092d70ef13e93ccc5b6 \
                     sha256  3c6ba2e66400fe3f1ae83deb4b235faf3137ec20bd5b08c29bfc368db143e4c6 \
@@ -64,6 +64,8 @@ build.args          -v
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+    xinstall -m 0755 ${worksrcpath}/build/libninja.a ${destroot}${prefix}/lib
+
     xinstall -d ${destroot}${prefix}/share/bash-completion/completions
     xinstall -m 0644 ${worksrcpath}/misc/bash-completion ${destroot}${prefix}/share/bash-completion/completions/ninja
 

--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -64,7 +64,7 @@ build.args          -v
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
-    xinstall -m 0755 ${worksrcpath}/build/libninja.a ${destroot}${prefix}/lib
+    xinstall -m 0644 ${worksrcpath}/build/libninja.a ${destroot}${prefix}/lib
 
     xinstall -d ${destroot}${prefix}/share/bash-completion/completions
     xinstall -m 0644 ${worksrcpath}/misc/bash-completion ${destroot}${prefix}/share/bash-completion/completions/ninja


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

---

This PR allows us to install `libninja.a`, a library of Ninja, as well.