### PR TITLE
python PG: automate setting-up a test phase

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -15,6 +15,10 @@
 #   for py-foo rather than pyXY-foo
 # python.consistent_destroot: set consistent environment values in build and destroot phases
 #
+# python.pep517: build using PEP517 (default is "no")
+# python.pep517_backend: specify the backend to use; one of "setuptools" (default),
+#   "flit", "hatch", or "poetry"
+#
 # Note: setting these options requires name to be set beforehand
 
 PortGroup       compiler_wrapper 1.0

--- a/devel/nvchecker/Portfile
+++ b/devel/nvchecker/Portfile
@@ -32,12 +32,8 @@ depends_run-append  port:py${python.version}-appdirs \
                     port:py${python.version}-tornado
 
 depends_test-append \
-                port:py${python.version}-pytest \
                 port:py${python.version}-pytest-asyncio \
                 port:py${python.version}-pytest-httpbin \
                 port:py${python.version}-flaky
 
 test.run        yes
-test.cmd        py.test-${python.branch}
-test.target
-test.env        PYTHONPATH=${worksrcpath}/build/lib

--- a/python/flynt/Portfile
+++ b/python/flynt/Portfile
@@ -36,10 +36,4 @@ post-destroot {
         ${destroot}${docdir}
 }
 
-depends_test-append \
-                    port:py${python.version}-pytest
-
-test.run            yes
-test.cmd            py.test-${python.branch}
-test.target
-test.env            PYTHONPATH=${worksrcpath}/build/lib
+test.run        yes

--- a/python/py-asteval/Portfile
+++ b/python/py-asteval/Portfile
@@ -38,13 +38,7 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-importlib-metadata
     }
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-asv/Portfile
+++ b/python/py-asv/Portfile
@@ -27,18 +27,5 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-six
 
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-
-    livecheck.type  none
 }

--- a/python/py-atomicwrites/Portfile
+++ b/python/py-atomicwrites/Portfile
@@ -7,7 +7,6 @@ name                py-atomicwrites
 version             1.4.0
 revision            0
 
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {reneeotten @reneeotten} openmaintainer
@@ -27,13 +26,5 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-    livecheck.type  none
 }

--- a/python/py-backports.entry-points-selectable/Portfile
+++ b/python/py-backports.entry-points-selectable/Portfile
@@ -43,12 +43,6 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-backports
 
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-    depends_test-append \
-                    port:py${python.version}-pytest
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
@@ -63,6 +57,4 @@ if {${name} ne ${subport}} {
             }
         }
     }
-
-    livecheck.type  none
 }

--- a/python/py-bigfloat/Portfile
+++ b/python/py-bigfloat/Portfile
@@ -8,7 +8,6 @@ version             0.4.0
 revision            0
 
 categories-append   math
-platforms           darwin
 license             LGPL-3
 maintainers         {reneeotten @reneeotten} openmaintainer
 
@@ -38,13 +37,8 @@ if {${name} ne ${subport}} {
                     port:gmp \
                     port:mpfr
 
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
     test.run        yes
-    test.cmd        ${python.bin} -m unittest discover bigfloat
-    test.target
+    python.test_framework unittest
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
@@ -54,6 +48,4 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 {*}[glob ${worksrcpath}/examples/*] \
             ${destroot}${prefix}/share/doc/${subport}/examples
     }
-
-    livecheck.type  none
 }

--- a/python/py-cachetools/Portfile
+++ b/python/py-cachetools/Portfile
@@ -27,13 +27,7 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-cairocffi/Portfile
+++ b/python/py-cairocffi/Portfile
@@ -34,15 +34,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-cffi
 
     depends_test-append \
-                    port:py${python.version}-pytest \
                     port:py${python.version}-numpy
 
     test.run        yes
     test.dir        ${worksrcpath}/build/lib/cairocffi
-    test.cmd        py.test-${python.branch}
-    test.args       -o addopts=''
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-    livecheck.type  none
 }

--- a/python/py-cftime/Portfile
+++ b/python/py-cftime/Portfile
@@ -30,17 +30,7 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-numpy
 
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.args       -o addopts=''
-    test.target
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-colorlog/Portfile
+++ b/python/py-colorlog/Portfile
@@ -33,13 +33,5 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} LICENSE README.md ${destroot}${docdir}
     }
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-    livecheck.type  none
 }

--- a/python/py-columnize/Portfile
+++ b/python/py-columnize/Portfile
@@ -28,14 +28,8 @@ if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-mock \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
-    livecheck.type  none
+    depends_test-append \
+                    port:py${python.version}-mock
 }

--- a/python/py-coverage/Portfile
+++ b/python/py-coverage/Portfile
@@ -59,11 +59,6 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-importlib-metadata
     }
 
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*] \
-                    PATH=[glob -nocomplain ${worksrcpath}/build/bin*]
-    }
-
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}

--- a/python/py-cppy/Portfile
+++ b/python/py-cppy/Portfile
@@ -36,13 +36,7 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools_scm
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-cssselect2/Portfile
+++ b/python/py-cssselect2/Portfile
@@ -31,12 +31,5 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-tinycss2 \
                     port:py${python.version}-webencodings
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.args       -o addopts=''
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 }

--- a/python/py-cycler/Portfile
+++ b/python/py-cycler/Portfile
@@ -39,13 +39,7 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-six
     }
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }

--- a/python/py-filetype/Portfile
+++ b/python/py-filetype/Portfile
@@ -40,8 +40,5 @@ if {${name} ne ${subport}} {
     }
 
     test.run        yes
-    test.cmd        ${python.bin}
-    test.args       -m unittest discover
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
+    python.test_framework unittest
 }

--- a/python/py-inflection/Portfile
+++ b/python/py-inflection/Portfile
@@ -27,13 +27,7 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-intervaltree/Portfile
+++ b/python/py-intervaltree/Portfile
@@ -40,12 +40,5 @@ if {${name} ne ${subport}} {
             LICENSE.txt README.md ${destroot}${docdir}
     }
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.args       -o addopts=''
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 }

--- a/python/py-kiwisolver/Portfile
+++ b/python/py-kiwisolver/Portfile
@@ -63,16 +63,7 @@ if {${name} ne ${subport}} {
             ${destroot}${docdir}
     }
 
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
 
     livecheck.type  none
 }

--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -37,14 +37,7 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-scipy \
                     port:py${python.version}-uncertainties
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.args       -o addopts=""
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
        xinstall -d ${destroot}${prefix}/share/doc/${subport}
@@ -53,6 +46,4 @@ if {${subport} ne ${name}} {
        xinstall -m 0644 {*}[glob ${worksrcpath}/examples/*] \
           ${destroot}${prefix}/share/doc/${subport}/examples
        }
-
-    livecheck.type  none
 }

--- a/python/py-mock/Portfile
+++ b/python/py-mock/Portfile
@@ -8,7 +8,6 @@ version             4.0.3
 revision            0
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             BSD
 maintainers         {reneeotten @reneeotten} openmaintainer
@@ -36,20 +35,14 @@ if {${name} ne ${subport}} {
                     size    28126
 
         depends_lib-append \
-                     port:py${python.version}-six
+                    port:py${python.version}-six
 
         if {${python.version} eq 27} {
             depends_lib-append \
-                         port:py${python.version}-funcsigs
+                        port:py${python.version}-funcsigs
         }
     } else {
-        depends_test-append \
-                        port:py${python.version}-pytest
-
-        test.run        yes
-        test.cmd        py.test-${python.branch}
-        test.target
-        test.env        PYTHONPATH=${worksrcpath}/build/lib
+        test.run    yes
     }
 
     post-destroot {

--- a/python/py-natsort/Portfile
+++ b/python/py-natsort/Portfile
@@ -38,13 +38,9 @@ if {${subport} ne ${name}} {
 
     depends_test-append \
                     port:py${python.version}-hypothesis \
-                    port:py${python.version}-pytest \
                     port:py${python.version}-pytest-mock
 
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
@@ -52,6 +48,4 @@ if {${subport} ne ${name}} {
         xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE \
             CHANGELOG.md ${destroot}${docdir}
     }
-
-    livecheck.type  none
 }

--- a/python/py-nmrglue/Portfile
+++ b/python/py-nmrglue/Portfile
@@ -48,14 +48,8 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-numpy \
                     port:py${python.version}-scipy
 
-    depends_test-append  \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
     test.args       --pyargs nmrglue
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${subport}

--- a/python/py-parsing/Portfile
+++ b/python/py-parsing/Portfile
@@ -51,9 +51,7 @@ if {${name} ne ${subport}} {
     }
 
     test.run        yes
-    test.cmd        ${python.bin} -m unittest
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
+    python.test_framework unittest
 
     livecheck.type  none
 }

--- a/python/py-poyo/Portfile
+++ b/python/py-poyo/Portfile
@@ -27,13 +27,7 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-pyficache/Portfile
+++ b/python/py-pyficache/Portfile
@@ -24,6 +24,8 @@ checksums           rmd160  7b0d58c8f9a9764eef1ab6b54f9d62c08b3509ca \
 
 python.versions     37 38 39 310
 
+github.livecheck.regex  (\[0-9\.\]+)
+
 if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-setuptools
@@ -32,13 +34,7 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-pygments \
                     port:py${python.version}-xdis
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
@@ -46,6 +42,4 @@ if {${subport} ne ${name}} {
         xinstall -m 0644 -W ${worksrcpath} COPYING ChangeLog \
            NEWS.md README.rst ${destroot}${docdir}
     }
-} else {
-    github.livecheck.regex  (\[0-9\.\]+)
 }

--- a/python/py-python-jsonrpc-server/Portfile
+++ b/python/py-python-jsonrpc-server/Portfile
@@ -38,14 +38,9 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-futures
     }
 
-    depends_test-append port:py${python.version}-pytest \
-                        port:py${python.version}-mock
-
     test.run            yes
-    test.cmd            py.test-${python.branch}
-    test.args           -o addopts=''
-    test.target
-    test.env            PYTHONPATH=${worksrcpath}/build/lib
+
+    depends_test-append port:py${python.version}-mock
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-python-lsp-jsonrpc/Portfile
+++ b/python/py-python-lsp-jsonrpc/Portfile
@@ -29,14 +29,8 @@ if {${name} ne ${subport}} {
 
     depends_lib-append  port:py${python.version}-ujson
 
-    depends_test-append port:py${python.version}-pytest \
-                        port:py${python.version}-mock
-
     test.run            yes
-    test.cmd            py.test-${python.branch}
-    test.args           -o addopts=''
-    test.target
-    test.env            PYTHONPATH=${worksrcpath}/build/lib
+    depends_test-append port:py${python.version}-mock
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-python-lsp-server/Portfile
+++ b/python/py-python-lsp-server/Portfile
@@ -55,16 +55,11 @@ if {${subport} ne ${name}} {
         reinplace "s|@@PYTHON_BIN@@|${python.bin}|g" ${worksrcpath}/pylsp/plugins/flake8_lint.py
     }
 
+    test.run        yes
+
     depends_test-append \
-                    port:py${python.version}-pytest \
                     port:py${python.version}-mock \
                     port:py${python.version}-flaky
-
-    test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.args       -o addopts=''
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-pythran/Portfile
+++ b/python/py-pythran/Portfile
@@ -24,7 +24,6 @@ python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-pytest-runner \
                     port:py${python.version}-setuptools
 
     depends_lib-append \
@@ -44,12 +43,4 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} README.rst Changelog \
             LICENSE ${destroot}${docdir}
     }
-
-    depends_test-append \
-                    port:py${python.version}-pytest
-
-    test.run        yes
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-    livecheck.type  none
 }

--- a/python/py-qstylizer/Portfile
+++ b/python/py-qstylizer/Portfile
@@ -36,14 +36,10 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-inflection \
                     port:py${python.version}-tinycss2
 
-  depends_test-append \
-                    port:py${python.version}-pytest \
+    depends_test-append \
                     port:py${python.version}-pytest-mock
 
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-qtawesome/Portfile
+++ b/python/py-qtawesome/Portfile
@@ -32,13 +32,9 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools \
 
     depends_test-append \
-                    port:py${python.version}-pytest \
                     port:py${python.version}-pytest-qt
 
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-qtpy/Portfile
+++ b/python/py-qtpy/Portfile
@@ -27,15 +27,10 @@ python.pep517       yes
 
 if {${name} ne ${subport}} {
     depends_test-append \
-                    port:py${python.version}-pytest \
                     port:py${python.version}-pytest-qt \
                     port:py${python.version}-mock
 
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.args       -o addopts=''
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-rope/Portfile
+++ b/python/py-rope/Portfile
@@ -38,13 +38,8 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib:${worksrcpath}
+    test.env-append PYTHONPATH=${worksrcpath}
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-selectors2/Portfile
+++ b/python/py-selectors2/Portfile
@@ -8,7 +8,6 @@ version             2.0.2
 revision            0
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {reneeotten @reneeotten} openmaintainer
@@ -30,13 +29,10 @@ if {${name} ne ${subport}} {
 
     depends_test-append \
                     port:py${python.version}-mock \
-                    port:py${python.version}-nose \
                     port:py${python.version}-psutil
 
     test.run        yes
-    test.cmd        nosetests-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
+    python.test_framework nose
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
@@ -44,6 +40,4 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE \
             CHANGELOG.rst ${destroot}${docdir}
     }
-
-    livecheck.type  none
 }

--- a/python/py-term-background/Portfile
+++ b/python/py-term-background/Portfile
@@ -10,7 +10,6 @@ name                py-term-background
 revision            0
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             GPL-2+
 maintainers         {reneeotten @reneeotten} openmaintainer
@@ -28,13 +27,5 @@ if {${subport} ne ${name}} {
     depends_lib-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-    livecheck.type  none
 }

--- a/python/py-text-unidecode/Portfile
+++ b/python/py-text-unidecode/Portfile
@@ -27,11 +27,5 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 }

--- a/python/py-trepan3k/Portfile
+++ b/python/py-trepan3k/Portfile
@@ -9,7 +9,6 @@ version             1.2.7
 revision            0
 
 categories-append   devel
-platforms           darwin
 supported_archs     noarch
 license             GPL-3+
 maintainers         {reneeotten @reneeotten} openmaintainer
@@ -43,11 +42,10 @@ if {${subport} ne ${name}} {
                     port:trepan3k_select
 
     depends_test-append \
-                    port:py${python.version}-nose \
                     port:py${python.version}-pyficache
 
     test.run        yes
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
+    python.test_framework nose
 
     select.group    trepan3k
     select.file     ${filespath}/trepan${python.version}
@@ -58,5 +56,4 @@ when you execute the commands without a version suffix, e.g. '${python.rootname}
 
 sudo port select --set ${select.group} [file tail ${select.file}]
 "
-    livecheck.type  none
 }

--- a/python/py-typed-ast/Portfile
+++ b/python/py-typed-ast/Portfile
@@ -27,16 +27,7 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-ujson/Portfile
+++ b/python/py-ujson/Portfile
@@ -27,16 +27,7 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools_scm
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -29,13 +29,8 @@ if {${name} ne ${subport}} {
 
     depends_lib-append  port:py${python.version}-future
 
-    depends_test-append port:py${python.version}-pytest \
-                        port:py${python.version}-numpy
-
     test.run            yes
-    test.cmd            pytest-${python.branch}
-    test.target
-    test.env            PYTHONPATH=${worksrcpath}/build/lib
+    depends_test-append port:py${python.version}-numpy
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-wurlitzer/Portfile
+++ b/python/py-wurlitzer/Portfile
@@ -28,13 +28,10 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools
 
     depends_test-append \
-                    port:py${python.version}-pytest \
                     port:py${python.version}-mock
 
     test.run        yes
-    test.cmd        py.test-${python.branch}
     test.target     test.py
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description
This PR adds two options  "python.test" and "python.test_framework" to the `python` PG to reduce code duplication in individual Portfiles and make it easier to set-up a test phase. 

- `python.test`: default is "no", set to "yes" when you want to have a test-phase
- `python.test_framework`: default is "pytest", other options are "nose" and "unittest"

 It will set-up a test-phase, add required dependency for the testing framework, set `PYTHONPATH` and when building with `python.pep517` for `noarch` ports, it will unpack the ".whl" file so that the tests can be run without installing the port.

Closes: https://trac.macports.org/ticket/64241

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1922 x86_64
Xcode 12.4 12D4e


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->