### PR TITLE
cfonts: update minor 1.0.2 > 1.0.3

### DIFF
--- a/textproc/cfonts/Portfile
+++ b/textproc/cfonts/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo  1.0
 
-github.setup        DominikWilkowski cfonts 1.0.2 v rust
+github.setup        DominikWilkowski cfonts 1.0.3 v rust
 revision            0
 
 categories          textproc
@@ -17,9 +17,9 @@ long_description    This is a silly little command line tool for sexy fonts in t
                     Give your cli some love.
 
 checksums           ${distfiles} \
-                    rmd160  6f5bedcb0e1cb54faf9efb2b4e34dbe6105152ea \
-                    sha256  33c14dda907c4f3c046a40644c8856f6debb87b58ee6fbaab2b8d7af14ce8b6e \
-                    size    3312272
+                    rmd160  dc5c554c769d27d47c551683cc837ead26d887c8 \
+                    sha256  d33873ff9c81089b7a3034f4d1244a81aba5a7a6253838c24f6de9103540209e \
+                    size    3311857
 
 build.dir           ${worksrcpath}/rust
 


### PR DESCRIPTION
#### Description

Update `cfonts` to a version with a fix to `NO_COLOR` env var. This shouldn't happen too often and I tried finding more infos about minor or patch upgrades in the docs. If there is another way to do this do let me know.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
