### PR TITLE
rmlint: fix build on old systems, fix universal variant

### DIFF
--- a/sysutils/rmlint/Portfile
+++ b/sysutils/rmlint/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
+PortGroup           muniversal 1.0
 
 github.setup        sahib rmlint 2.10.1 v
-revision            1
+revision            2
 
 homepage            http://rmlint.rtfd.org
 
@@ -33,9 +34,30 @@ depends_build-append \
 depends_lib-append  path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:json-glib
 
+platform darwin {
+    if {${os.major} < 11} {
+        patchfiles-append   patch-darwin-old.diff
+    }
+}
+
 build.cmd           ${prefix}/bin/scons
 build.args          --prefix=${prefix} VERBOSE=1
 build.target
+
+# gcc-4.2 fails to build it
+compiler.blacklist-append   *gcc-4*
+
+if {[variant_isset universal]  && [info exists universal_archs_supported]} {
+    # Without this SCons builds a fake universal with a single arch
+    patchfiles-append   patch-universal.diff
+    post-configure {
+        foreach arch ${universal_archs_supported} {
+            if {[file isfile ${worksrcpath}-${arch}/SConstruct]} {
+                reinplace "s|@ARCH@|${arch}|" ${worksrcpath}-${arch}/SConstruct
+            }
+        }
+    }
+}
 
 use_configure       no
 

--- a/sysutils/rmlint/files/patch-darwin-old.diff
+++ b/sysutils/rmlint/files/patch-darwin-old.diff
@@ -1,0 +1,119 @@
+See: https://gist.github.com/ingramj/1105106/adfad1a7b1f0575dd7737c296d644856f2c2d074
+--- lib/cmdline.c.orig	2020-06-13 17:42:45.000000000 +0800
++++ lib/cmdline.c	2022-05-31 20:35:42.000000000 +0800
+@@ -39,6 +39,97 @@
+ #include <search.h>
+ #include <sys/time.h>
+ 
++#if defined(__APPLE__)
++#if __STDC_VERSION__ >= 199901L
++/* restrict is a keyword */
++#else
++# define restrict
++#endif
++
++#ifndef _POSIX_SOURCE
++typedef long ssize_t;
++#define SSIZE_MAX LONG_MAX
++#endif
++
++ssize_t getdelim(char **restrict lineptr, size_t *restrict n, int delimiter,
++                 FILE *restrict stream);
++ssize_t getline(char **restrict lineptr, size_t *restrict n,
++                FILE *restrict stream);
++
++#define _GETDELIM_GROWBY 128    /* amount to grow line buffer by */
++#define _GETDELIM_MINLEN 4      /* minimum line buffer size */
++
++ssize_t getdelim(char **restrict lineptr, size_t *restrict n, int delimiter,
++                 FILE *restrict stream)
++{
++	char *buf, *pos;
++	int c;
++	ssize_t bytes;
++
++	if (lineptr == NULL || n == NULL) {
++		errno = EINVAL;
++		return -1;
++	}
++	if (stream == NULL) {
++		errno = EBADF;
++		return -1;
++	}
++
++	/* resize (or allocate) the line buffer if necessary */
++	buf = *lineptr;
++	if (buf == NULL || *n < _GETDELIM_MINLEN) {
++		buf = realloc(*lineptr, _GETDELIM_GROWBY);
++		if (buf == NULL) {
++			/* ENOMEM */
++			return -1;
++		}
++		*n = _GETDELIM_GROWBY;
++		*lineptr = buf;
++	}
++
++	/* read characters until delimiter is found, end of file is reached,
++	   or an error occurs. */
++	bytes = 0;
++	pos = buf;
++	while ((c = getc(stream)) != EOF) {
++		if (bytes + 1 >= SSIZE_MAX) {
++			errno = EOVERFLOW;
++			return -1;
++		}
++		bytes++;
++		if (bytes >= *n - 1) {
++			buf = realloc(*lineptr, *n + _GETDELIM_GROWBY);
++			if (buf == NULL) {
++				/* ENOMEM */
++				return -1;
++			}
++			*n += _GETDELIM_GROWBY;
++			pos = buf + bytes - 1;
++			*lineptr = buf;
++		}
++
++		*pos++ = (char) c;
++		if (c == delimiter) {
++			break;
++		}
++	}
++
++	if (ferror(stream) || (feof(stream) && (bytes == 0))) {
++		/* EOF, or an error from getc(). */
++		return -1;
++	}
++
++	*pos = '\0';
++	return bytes;
++}
++
++ssize_t getline(char **restrict lineptr, size_t *restrict n,
++                FILE *restrict stream)
++{
++	return getdelim(lineptr, n, '\n', stream);
++}
++#endif
++
+ #include "cmdline.h"
+ #include "formats.h"
+ #include "hash-utility.h"
+
+
+# See: https://github.com/hboetes/mg/issues/7#issuecomment-475869095
+--- lib/traverse.c.orig	2020-06-13 17:42:45.000000000 +0800
++++ lib/traverse.c	2022-05-31 19:48:09.000000000 +0800
+@@ -41,6 +41,12 @@
+ 
+ #include "fts/fts.h"
+ 
++#if defined(__APPLE__)
++#define st_atim st_atimespec
++#define st_ctim st_ctimespec
++#define st_mtim st_mtimespec
++#endif
++
+ //////////////////////
+ // TRAVERSE SESSION //
+ //////////////////////

--- a/sysutils/rmlint/files/patch-universal.diff
+++ b/sysutils/rmlint/files/patch-universal.diff
@@ -1,0 +1,18 @@
+--- SConstruct.orig	2020-06-13 17:42:45.000000000 +0800
++++ SConstruct	2022-06-01 18:56:53.000000000 +0800
+@@ -686,6 +686,15 @@
+ else:
+     conf.env.Append(CCFLAGS=['-fPIC'])
+ 
++# Universal binaries support
++conf.env.Append(CCFLAGS=[
++    '-arch', '@ARCH@'
++])
++
++conf.env.Append(LINKFLAGS=[
++    '-arch', '@ARCH@'
++])
++
+ # check _mm_crc32_u64 (SSE4.2) support:
+ conf.check_mm_crc32_u64()
+ 


### PR DESCRIPTION
#### Description

As per the title. Fix the build for Leopard and SL, fix universal variant, which otherwise is mishandled by SCons.
(`gcc-4.2` still fails to build `rmlint` even when incompatible optional flag is removed, so blacklist it.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC (10A190)
Xcode 3.2

macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
