### PR TITLE
libomp: 14.0.4 (no change, but tracking latest clang)

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -30,16 +30,16 @@ subport                 libomp-devel {}
 
 if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
     if { ${subport} eq "libomp-devel" } {
-        version         14.0.3
-        checksums       rmd160  91f5b260baa5dc886f59f04e9fde27f11d680c67 \
-                        sha256  0534ab5ce578db604a46eca56e4f83b46f26fbe4dd837abb79ed04c5543be379 \
-                        size    1205324
+        version         14.0.4
+        checksums       rmd160  75ad369911d553c6770420b9e6910ca5aad26f72 \
+                        sha256  d4b627e2668c3c1001b6c772297273dc67b42f2deec934a59650a55731f8d411 \
+                        size    1205512
         livecheck.regex {"llvmorg-([0-9.rc-]+)".*}
     } else {
-        version         14.0.3
-        checksums       rmd160  91f5b260baa5dc886f59f04e9fde27f11d680c67 \
-                        sha256  0534ab5ce578db604a46eca56e4f83b46f26fbe4dd837abb79ed04c5543be379 \
-                        size    1205324
+        version         14.0.4
+        checksums       rmd160  75ad369911d553c6770420b9e6910ca5aad26f72 \
+                        sha256  d4b627e2668c3c1001b6c772297273dc67b42f2deec934a59650a55731f8d411 \
+                        size    1205512
         livecheck.regex {"llvmorg-([0-9.]+)".*}
     }
 


### PR DESCRIPTION
Maintainer update.