### PR TITLE
gcc11/libgcc11: skip bootstrap comparison for 10.6 and earlier

### DIFF
--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -170,10 +170,13 @@ configure.ccache    no
 
 if { ${os.platform} eq "darwin" } {
     # gcc has build issues on macOS 11.3 with the use of Xcode 12.5 clang via cctools for ld
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
-    # https://trac.macports.org/ticket/62775
+    #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
+    #   https://trac.macports.org/ticket/62775
+    # Bootstrap comparison fails on 10.6, so disable for that case too
+    #   https://trac.macports.org/ticket/65149
     if { ([vercmp ${xcodeversion} 12.5] >= 0 && [vercmp ${xcodeversion} 13] < 0) || \
-         ([vercmp ${cltversion} 12.5] >= 0 && [vercmp ${cltversion} 13] < 0) } \
+         ([vercmp ${cltversion} 12.5] >= 0 && [vercmp ${cltversion} 13] < 0) || \
+         (${os.major} <= 10) } \
     {
         # Skip bootstrap comparison entirely
         post-patch {


### PR DESCRIPTION
#### Description

Fix build failure for `libgcc11` on macOS 10.6, by disabling bootstrap comparison.

See: https://trac.macports.org/ticket/65149

NOTE: Change hasn't been tested locally yet: Goal is to first ensure this is the right approach, before waiting an eternity for a build test. (Likewise, CI is being skipped at the moment, to avoid wasting resources.)