### PR TITLE
google-cloud-sdk: update to 388.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             387.0.0
+version             388.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  54321692f592930cb836eb79b887c834541ad6f3 \
-                    sha256  689bb6035b38cb14005890f60a323cb5411b669d50769d9d667aee65e5e04feb \
-                    size    106828047
+    checksums       rmd160  2a0728349f9ad2f206d3939af30d993aad03fc57 \
+                    sha256  2e2fbaf1835733093e1b9e9ec04ee85d1261f8332f49d65b562f7b4338458fc6 \
+                    size    106973271
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  58df068f277474c03967266d9e3b9c741e66455b \
-                    sha256  5d92746506695792b03cc9067db3d62b1716630f0c26ab21d5a059caca37cd63 \
-                    size    103416284
+    checksums       rmd160  27297b3a122d5f3529a18fd2a6fcb5b23f966622 \
+                    sha256  5f9b88e1bb2e25eac2d5a46eab76bb97789b5fa468ab9e14b26c405d36f3b5d5 \
+                    size    103563313
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  55c399546d1150f092685e62aae91a0d0a526b04 \
-                    sha256  e24cc22d208bc2cf978bf1990d20df96f39d1b3e1a23dd7cd549484ec9988408 \
-                    size    102000169
+    checksums       rmd160  336cb2449599e02ecc767c4b635885d82335ba2c \
+                    sha256  5800d8ab4f04183480e413bee608dc9cd3e3af8f80150affb1e45007bef640bb \
+                    size    102146350
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 388.0.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?