### PR TITLE
trafshow: fix build

### DIFF
--- a/net/trafshow/Portfile
+++ b/net/trafshow/Portfile
@@ -14,7 +14,7 @@ long_description	TrafShow continuously displays the information regarding \
 			packet traffic on the configured network interface that \
 			matches the boolean  expression. It periodically sorts \
 			and updates this information. It may be useful for locating \
-			suspicious network traffic on the net. 
+			suspicious network traffic on the net.
 homepage		http://soft.risp.ru/trafshow/index_en.shtml
 platforms		darwin
 master_sites		ftp://ftp.nsk.su/pub/RinetSoftware/
@@ -35,6 +35,7 @@ pre-configure {
 }
 
 configure.cflags-append   "-I${prefix}/include"
+configure.args		ac_cv_have_curses=ncurses
 post-configure		{	reinplace "s;%%PREFIX%%;${prefix};g" ${worksrcpath}/colormask.c
 				reinplace "s;%%PREFIX%%;${prefix};g" ${worksrcpath}/trafshow.c
 				reinplace "s;%%PREFIX%%;${prefix};g" ${worksrcpath}/trafshow.1 }


### PR DESCRIPTION
#### Description

Force ncurses build. If slang2 port is installed trafshow configures itself to build with slang and fails

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
