### PR TITLE
py-cli-helpers: update to 2.2.1

### DIFF
--- a/python/py-cli-helpers/Portfile
+++ b/python/py-cli-helpers/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cli-helpers
-version             2.2.0
+version             2.2.1
 revision            0
 
 license             BSD
@@ -20,9 +20,9 @@ python.versions     37 38 39 310
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 distname            cli_helpers-${version}
 
-checksums           rmd160  5cf9e096aecf1ba413d7b84ba588874fef88909f \
-                    sha256  733f65d8c921e0cffa8f7ae4c8735bd7ecdffec383c5246f647ddd0fddb33448 \
-                    size    35884
+checksums           rmd160  e7632afc01fef5992582131bac50fda99d95052c \
+                    sha256  0ccc1cfcda1ac64dc7ed83d7013055cf19e5979d29e56c21f3b692de01555aae \
+                    size    36089
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Updates py-cli-helpers to 2.2.1.

This fixes [this issue](https://github.com/dbcli/pgcli/issues/1303) with pgcli that prevented it from displaying results outside of extended output mode.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
