### PR TITLE
GPXSee: update to 11.1

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 10.7
+github.setup        tumic0 GPXSee 11.1
 revision            0
 
-checksums           rmd160  5d22637eb6fcb1d499a99d1c61dc82b1c54cc9b7 \
-                    sha256  2518a01a7d980b4e5f3b92691f20553394cd1ff505c6230052e71bc93754ab27 \
-                    size    5123623
+checksums           rmd160  725d290c1629cd2c782ba7a3f5063944f0189c5a \
+                    sha256  dce4c55c6ed9ee555c3ed5d32fb29ccd6f8163887d33f9740cf9a9d6846d4ecb \
+                    size    5168543
 
 categories          gis graphics
 platforms           darwin

--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -23,3 +23,5 @@ configure.args-append \
 
 depends_lib-append  port:protobuf3-cpp \
                     port:zlib
+
+use_xcode           yes


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
