### PR TITLE
xraylib: use newer Perl variants

### DIFF
--- a/science/xraylib/Portfile
+++ b/science/xraylib/Portfile
@@ -53,11 +53,11 @@ configure.ccache    no
 
 perl5.require_variant yes
 perl5.conflict_variants yes
-perl5.branches 5.28 5.30
+perl5.branches 5.28 5.30 5.32 5.34
 perl5.default_branch 5.28
 perl5.create_variants ${perl5.branches}
 
-if {[variant_isset perl5_28] || [variant_isset perl5_30]} {
+if {[variant_isset perl5_28] || [variant_isset perl5_30] || [variant_isset perl5_32] || [variant_isset perl5_34]} {
     configure.perl ${perl5.bin}
     configure.args-delete --disable-perl
     configure.args-append --enable-perl --enable-perl-integration


### PR DESCRIPTION
#### Description

* Remove variants EOL Perl version 5.28 and 5.30.
* Add variants for Perl 5.32 and 5.34.
* Default to variant perl5_34

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6.6 20G624 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
