### PR TITLE
nss: fix ppc64 build

### DIFF
--- a/net/nss/Portfile
+++ b/net/nss/Portfile
@@ -46,6 +46,9 @@ depends_lib     port:nspr \
                 port:zlib \
                 port:sqlite3
 
+# Fix for ppc64, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1769063
+patchfiles-append   patch-ppc64.diff
+
 destroot.dir ${destroot.dir}/dist
 build.dir    ${build.dir}/nss
 

--- a/net/nss/files/patch-ppc64.diff
+++ b/net/nss/files/patch-ppc64.diff
@@ -1,0 +1,15 @@
+# See: https://bugzilla.mozilla.org/show_bug.cgi?id=1769063
+--- nss/lib/freebl/mpi/mpcpucache.c.orig	2022-05-26 17:54:33.000000000 +0800
++++ nss/lib/freebl/mpi/mpcpucache.c	2022-06-04 07:52:38.000000000 +0800
+@@ -727,10 +727,7 @@
+ static inline void
+ dcbzl(char *array)
+ {
+-    register char *a asm("r2") = array;
+-    __asm__ __volatile__("dcbzl %0,0"
+-                         : "=r"(a)
+-                         : "0"(a));
++  __asm__ ("dcbzl %0, %1" : /*no result*/ : "b%" (array), "r" (0) : "memory");
+ }
+ 
+ #define PPC_DO_ALIGN(x, y) ((char *)((((long long)(x)) + ((y)-1)) & ~((y)-1)))


### PR DESCRIPTION
#### Description

This PR fixed `ppc64` build (and `+universal` with it).

Closes my own ticket: https://trac.macports.org/ticket/64914
The new patch comes from: https://bugzilla.mozilla.org/show_bug.cgi?id=1769063
Earlier PR: https://github.com/macports/macports-ports/pull/14825 (obsolete)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@kencu @mascguy I can’t force `git` to do what it should in the old PR, so just making a new one. Anyway, both `nss` got updated since then, and the patch is different now.