### PR TITLE
py-wxmplot: update to v0.9.50, add py310 support

### DIFF
--- a/python/py-wxmplot/Portfile
+++ b/python/py-wxmplot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-wxmplot
-version             0.9.45
+version             0.9.50
 revision            0
 
 platforms           darwin
@@ -20,20 +20,19 @@ long_description    \
 
 homepage            https://newville.github.io/wxmplot
 
-checksums           rmd160  331be7ac970b45e26fb7c11bb91c1cc495028209 \
-                    sha256  a70a662b0ff10a230bd2c800d2bc0cf69176881f09a5de014abe9a394121ac6b \
-                    size    8250117
+checksums           rmd160  adbc2689512b4fb921cd592bc722777315222659 \
+                    sha256  53c24f37ac0d138f382f8d04cc700aa10ed2508ea37b51755bf5c10da6533e1a \
+                    size    132872
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools_scm
 
     depends_run-append \
                     port:py${python.version}-matplotlib \
                     port:py${python.version}-numpy \
-                    port:py${python.version}-wxpython-4.0
-        
-    livecheck.type  none
+                    port:py${python.version}-wxpython-4.0 \
+                    port:py${python.version}-wxutils
 }


### PR DESCRIPTION
#### Description

py-wxmplot:
* Update to latest version 0.9.50
* Add sub-port for Python 3.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6.6 20G624 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
