### PR TITLE
jenv: update to 0.5.5

### DIFF
--- a/java/jenv/Portfile
+++ b/java/jenv/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    jenv jenv 0.5.4
+github.setup    jenv jenv 0.5.5
 revision        0
 
 categories      java
@@ -19,9 +19,9 @@ long_description jEnv is a command line tool to help you forget how to set the J
 homepage        https://www.jenv.be
 github.tarball_from archive
 
-checksums       rmd160  c08d732f50377a7fd2a38d3f77218e5fed336bf8 \
-                sha256  15a78dab7310fb487d2c2cad7f69e05d5d797dc13f2d5c9e7d0bbec4ea3f2980 \
-                size    21331
+checksums       rmd160  db57dbcc312c871785713e98caced77546111cf8 \
+                sha256  691e819e5a803054d4714539bd5ee5de73d6c3b2bcbee825f5013a7f75930493 \
+                size    22664
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

Update to jEnv 0.5.5.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?