### PR TITLE
ddrescue: fix compilation error related to std::exit

### DIFF
--- a/sysutils/ddrescue/Portfile
+++ b/sysutils/ddrescue/Portfile
@@ -26,6 +26,12 @@ checksums       rmd160  d2474a3bc4e5d9b11a4b76e1edce70a93ec1df96 \
                 sha256  e513cd3a90d9810dfdd91197d40aa40f6df01597bfb5ecfdfb205de1127c551f \
                 size    91930
 
+# Fix compilation:
+#   error: no member named 'exit' in namespace 'std'
+# See: https://trac.macports.org/ticket/65300
+patchfiles-append \
+                patch-loggers.cc-cstdlib.diff
+
 variant universal {}
 configure.args  CXX="${configure.cxx}" \
                 CPPFLAGS="${configure.cppflags}" \

--- a/sysutils/ddrescue/Portfile
+++ b/sysutils/ddrescue/Portfile
@@ -1,4 +1,6 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
 PortGroup       gnu_info 1.0
 
 name            ddrescue

--- a/sysutils/ddrescue/files/patch-loggers.cc-cstdlib.diff
+++ b/sysutils/ddrescue/files/patch-loggers.cc-cstdlib.diff
@@ -1,0 +1,14 @@
+--- loggers.cc.orig	2022-06-06 16:38:44.915067860 -0400
++++ loggers.cc	2022-06-06 16:39:24.205196043 -0400
+@@ -17,10 +17,11 @@
+ 
+ #define _FILE_OFFSET_BITS 64
+ 
+ #include <algorithm>
+ #include <cstdio>
++#include <cstdlib>
+ #include <cstring>
+ #include <string>
+ #include <vector>
+ #include <sys/stat.h>
+ 


### PR DESCRIPTION
### Description

File `loggers.cc` references `std::exit`, without including `cstdlib`. This works with some compilers, but not others.

Fixes: https://trac.macports.org/ticket/65300

### Tested on

* macOS 10.7
* macOS 10.9
* macOS 10.11