### PR TITLE
lagrange: update to 1.13.6

### DIFF
--- a/devel/sealcurses/Portfile
+++ b/devel/sealcurses/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           gitea 1.0
+
+gitea.domain        git.skyjake.fi
+gitea.setup         skyjake sealcurses d64caa13bc06b68906bb0a5cc87f1896226b0918
+version             2022-05-23
+revision            0
+categories          devel
+license             BSD
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+
+description         SDL Emulation and Adaptation Layer for Curses (ncursesw)
+long_description    {*}${description}
+
+checksums           rmd160  053a2bdbab956a04dcbd69f51efea99df5b45320 \
+                    sha256  2162170d907c454c2594f764a4109e5621760a107c5d75d3692a9bca59ffdc78 \
+                    size    22284
+
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:ncurses \
+                    port:the_Foundation
+
+compiler.c_standard 2011

--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           gitea 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
+
+gitea.domain        git.skyjake.fi
+gitea.setup         skyjake the_Foundation 1.4.0 v
+revision            0
+categories          devel
+license             BSD
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+
+description         Opinionated C11 library for low-level functionality
+long_description    {*}${description}
+
+checksums           rmd160  1468f4e59a84b3d3044de6ad33247c72931378b2 \
+                    sha256  dabed30250ca9f3da0a7930aeea8a7092f9946a37f85a04252eb0d3a363cd13d \
+                    size    210489
+
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:curl \
+                    port:libunistring \
+                    path:lib/libssl.dylib:openssl \
+                    port:pcre \
+                    port:zlib
+
+compiler.c_standard 2011

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -2,44 +2,57 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           github 1.0
-PortGroup           legacysupport 1.1
+PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-# clock_gettime
-legacysupport.newest_darwin_requires_legacy 15
-
-github.setup        skyjake lagrange 1.13.5 v
+gitea.domain        git.skyjake.fi
+gitea.setup         gemini lagrange 1.13.6 v
 revision            0
-github.tarball_from releases
 categories          net gemini
-platforms           darwin
 license             BSD
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  f7ad358149734f07d7009e31d47c3b78337765a5 \
-                    sha256  a9c3175acdc7bfd228cb4d24d68c4cfabe9a4fd79f821d631d556e8434749548 \
-                    size    9869222
+checksums           rmd160  42f5dc4cfc7a5aad01f245211c586a0756d69242 \
+                    sha256  a95638d7d7bba2720fa896996c2393b02e03a01987bbe71fe126d88c70639ba7 \
+                    size    7415036
 
 depends_build-append \
                     port:pkgconfig \
                     port:zip
-depends_lib-append  port:fribidi \
+depends_lib-append  port:the_Foundation
+
+variant gui conflicts tui description {Build the GUI interface} {
+    depends_lib-append \
+                    port:fribidi \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:libsdl2 \
-                    port:libunistring \
-                    path:lib/libssl.dylib:openssl \
                     port:mpg123 \
-                    port:pcre \
-                    port:webp \
-                    port:zlib
+                    port:webp
+
+    destroot {
+        copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}
+    }
+}
+
+variant tui conflicts gui description {Build the TUI interface} {
+    configure.args-append \
+                    -DENABLE_TUI=YES \
+                    -DENABLE_MPG123=NO \
+                    -DENABLE_WEBP=NO \
+                    -DENABLE_FRIBIDI=NO \
+                    -DENABLE_HARFBUZZ=NO \
+                    -DENABLE_POPUP_MENUS=NO \
+                    -DENABLE_IDLE_SLEEP=NO
+
+    depends_lib-append \
+                    port:ncurses \
+                    port:sealcurses
+}
+
+default_variants    +gui
 
 compiler.c_standard 2011
 compiler.blacklist-append {clang < 800}
-
-destroot {
-    copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}
-}


### PR DESCRIPTION
#### Description
* [Changelog](https://github.com/skyjake/lagrange/releases)
* Add variants: `gui` (default) and `tui`.
* Added dependencies:
  * `the_Foundation` library
  * `sealcurses` library

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
