### PR TITLE
vigra: add python 3.10; remove python 3.5 and 3.6; change default python to 3.10, to match boost

### DIFF
--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -10,7 +10,7 @@ PortGroup           boost 1.0
 
 github.setup        ukoethe vigra 1-11-1 Version-
 version             [strsed ${github.version} {g/-/./}]
-revision            15
+revision            16
 categories          graphics
 platforms           darwin
 license             MIT
@@ -100,7 +100,7 @@ if {[variant_isset valgrind]} {
     configure.args-append -DWITH_VALGRIND=NO
 }
 
-set py_vers [list 2.7 3.5 3.6 3.7 3.8 3.9]
+set py_vers [list 2.7 3.7 3.8 3.9 3.10]
 
 proc py_conflict_list {py_vers py_ver} {
     set py_conf_vers [lsearch -inline -all -not -exact $py_vers $py_ver]
@@ -132,7 +132,7 @@ foreach py_ver ${py_vers} {
 
 if { ${active_py} eq "" } {
     # default for boost
-    set active_py 3.9
+    set active_py 3.10
     set active_py_nodot [string map {. {}} ${active_py}]
     default_variants +python${active_py_nodot}
 }


### PR DESCRIPTION
### Description

* Add support for Python 3.10
* Remove support for Python 3.5 and 3.6
* Default to Python 3.10, to match Boost

### Tested on

* macOS 10.15