### PR TITLE
magic-wormhole: bump revision number to ensure new build

### DIFF
--- a/net/magic-wormhole/Portfile
+++ b/net/magic-wormhole/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                magic-wormhole
 version             0.12.0
-revision            0
+revision            1
 
 homepage            https://magic-wormhole.readthedocs.io
 


### PR DESCRIPTION
#### Description
magic-wormhole build still uses python3.8, I forgot to bump the revision number. This PR bumps the revision to ensure a new build is created

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<macOS 12.4 21F79 arm64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? https://trac.macports.org/ticket/65303 <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
