### PR TITLE
tilemaker: init at 2.2.0

### DIFF
--- a/gis/tilemaker/Portfile
+++ b/gis/tilemaker/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           boost 1.0
+
+github.setup        systemed tilemaker 2.2.0 v
+revision            0
+
+categories          gis
+license             FTWPL
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+
+description         Make OpenStreetMap vector tiles without the stack
+long_description    {*}${description}
+
+installs_libs       no
+
+checksums           rmd160  0843f7101651e3b5047ba539bdd4fdd7f9bde11e \
+                    sha256  74b0cc2f0cad5599ae30ceae5d4abbeefada30f0da5e0049efdbf6e7b0dd236a \
+                    size    42969929
+
+depends_build-append \
+                    port:pkgconfig
+
+depends_lib-append \
+                    port:lua \
+                    port:protobuf3-cpp \
+                    port:rapidjson \
+                    port:shapelib \
+                    port:sqlite3 \
+                    port:zlib
+
+compiler.cxx_standard \
+                    2014
+
+post-destroot {
+    set mandir ${destroot}${prefix}/share/man/man1
+    xinstall ${worksrcpath}/docs/man/tilemaker.1 ${mandir}
+}


### PR DESCRIPTION
#### Description
[**Tilemaker**](https://tilemaker.org/) - make OpenStreetMap vector tiles without the stack.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
