### PR TITLE
submission: speedtest

### DIFF
--- a/net/speedtest/Portfile
+++ b/net/speedtest/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+version             1.1.1.84
+revision            0
+
+name                speedtest
+categories          net
+maintainers         {@linuxgemini linuxgemini.space:macportspackaging} openmaintainer
+
+homepage            https://speedtest.net/apps/cli
+license             restrictive nomirror noncommercial
+
+description         official cli for speedtest.net
+long_description    command line interface for testing internet bandwidth using speedtest.net
+
+master_sites        https://install.speedtest.net/app/cli/
+distname            ookla-speedtest-${version}-macosx-x86_64
+extract.suffix      .tgz
+extract.mkdir       yes
+
+universal_variant   yes
+supported_archs     x86_64 arm64
+
+checksums           rmd160  c16334261d6858b21ef08ebb4886ced3c303420e \
+                    sha256  153f76e4e502a2bb470c7f7c3b4b8afaa50eb98bb11e86216fcb1a8b92676e94 \
+                    size    1019149
+
+use_configure       no
+build {}
+
+destroot {
+    set installdir ${prefix}/bin
+
+    xinstall -m 755 -W ${worksrcpath} \
+        speedtest \
+        ${destroot}${installdir}
+}
+
+post-destroot {
+    set manpagedir ${prefix}/share/man/man5
+
+    xinstall -m 444 -W ${worksrcpath} \
+        speedtest.5 \
+        ${destroot}${manpagedir}
+}
+
+# ookla does not provide a public filetree other than their homebrew pointer file
+# at https://github.com/teamookla/homebrew-speedtest/blob/master/speedtest.rb
+livecheck.type      none


### PR DESCRIPTION
This commit adds the Portfile for Ookla's own Speedtest.net CLI.

Signed-off-by: İlteriş Yağıztegin Eroğlu <ilteris@asenkron.com.tr>

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
