### PR TITLE
google-cloud-sdk: update to 389.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             388.0.0
+version             389.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  2a0728349f9ad2f206d3939af30d993aad03fc57 \
-                    sha256  2e2fbaf1835733093e1b9e9ec04ee85d1261f8332f49d65b562f7b4338458fc6 \
-                    size    106973271
+    checksums       rmd160  34744b549d3b182b12ded134aa48027dd052a0c9 \
+                    sha256  53ab782d503776efb9a37565233a3cc695eea9dade75d1653bd98388f1d01ffd \
+                    size    107100306
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  27297b3a122d5f3529a18fd2a6fcb5b23f966622 \
-                    sha256  5f9b88e1bb2e25eac2d5a46eab76bb97789b5fa468ab9e14b26c405d36f3b5d5 \
-                    size    103563313
+    checksums       rmd160  998da8d516400d6beaf08979c0e69c718c44f757 \
+                    sha256  0bdd6b8e020ba12ff43da745276875df87a5147393f06197f9f74142010674b6 \
+                    size    103693829
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  336cb2449599e02ecc767c4b635885d82335ba2c \
-                    sha256  5800d8ab4f04183480e413bee608dc9cd3e3af8f80150affb1e45007bef640bb \
-                    size    102146350
+    checksums       rmd160  9548dbd809351b29595df558228b73c6a1ede146 \
+                    sha256  05c44ac03b253cab62fa91c9691c255031853354fc960f4707b21025da84972d \
+                    size    102269899
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 389.0.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?