### PR TITLE
devel/nsis: Support building Nsis on macOS versions older than 10.15

### DIFF
--- a/devel/nsis/Portfile
+++ b/devel/nsis/Portfile
@@ -47,6 +47,8 @@ post-extract {
     system -W ${workpath} "unzip ${distpath}/nsis-${version}.zip"
 }
 
+patchfiles          patch-halibut_for_osx_pre10_15.diff
+
 use_configure       no
 
 # https://sourceforge.net/p/nsis/bugs/1251/

--- a/devel/nsis/files/patch-halibut_for_osx_pre10_15.diff
+++ b/devel/nsis/files/patch-halibut_for_osx_pre10_15.diff
@@ -1,0 +1,11 @@
+--- Docs/src/bin/halibut/misc.c.orig	2022-06-08 13:40:13.000000000 +0200
++++ Docs/src/bin/halibut/misc.c	2022-06-08 13:43:24.000000000 +0200
+@@ -367,7 +367,7 @@ unsigned long getutcunixtime()
+   if (0 == clock_gettime(CLOCK_REALTIME, &ts))
+     return ts.tv_sec;
+ #endif
+-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
++#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && defined(TIME_UTC)
+   if (timespec_get(&ts, TIME_UTC)) /* implementation defined epoch :( */
+     return ts.tv_sec;
+ #endif


### PR DESCRIPTION
#### Description

Support building on macOS versions older than 10.15.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
