### PR TITLE
nhc98: enable tests

### DIFF
--- a/lang/nhc98/Portfile
+++ b/lang/nhc98/Portfile
@@ -48,7 +48,7 @@ compiler.blacklist  *clang*
 # Donʼt build in parallel, seriously
 use_parallel_build no
 
-patchfiles      patch-ppc.diff patch-modern-gcc.diff
+patchfiles      patch-ppc.diff patch-modern-gcc.diff patch-tests.diff
 
 configure.args  --buildwith=gcc \
                 +docs \
@@ -66,6 +66,11 @@ post-destroot {
     set rfile "${destroot}${prefix}/lib/hmake/`${worksrcpath}/script/harch`/hmakerc"
     system "sed -i '' -e ${rexp1} -e ${rexp2} ${rfile}"
 }
+
+test.run         yes
+test.dir         ${worksrcpath}/tests
+test.cmd         ./runtests
+test.target
 
 livecheck.type   regex
 livecheck.regex  "Version (.*) released"

--- a/lang/nhc98/files/patch-tests.diff
+++ b/lang/nhc98/files/patch-tests.diff
@@ -1,0 +1,12 @@
+We want the tests to exit with an error code if they fail
+
+--- tests/runtests.orig	2022-06-09 09:23:35.000000000 -0400
++++ tests/runtests	2022-06-09 09:26:45.000000000 -0400
+@@ -71,6 +71,7 @@
+   echo >&2 "                  / of which $hmakeok known / $hmakebad bad"
+   echo >&2 "$outok outputs match / $outbad outputs differ"
+   echo >&2 "$errok errors  match / $errbad errors  differ"
++  if [[ $outbad -gt 0 || $errbad -gt 0 || $hmakebad -gt 0 ]]; then exit 1; fi
+ }
+ 
+ clean () {


### PR DESCRIPTION
#### Description

Enable nhc98's built-in test suite. Patch the test script to return non-zero when tests fail.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
