### PR TITLE
redis: update to 7.0.1

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -10,7 +10,7 @@ PortGroup           makefile 1.0
 legacysupport.newest_darwin_requires_legacy 15
 
 name                redis
-version             7.0.0
+version             7.0.1
 revision            0
 categories          databases
 platforms           darwin
@@ -25,9 +25,9 @@ set redis_domain    redis.io
 homepage            https://${redis_domain}
 master_sites        https://download.${redis_domain}/releases/
 
-checksums           rmd160  e1f5848d301324f6b4acf52cd26e4f36ce6eecd1 \
-                    sha256  284d8bd1fd85d6a55a05ee4e7c31c31977ad56cbf344ed83790beeb148baa720 \
-                    size    2943054
+checksums           rmd160  1dffffd871e8cee20374b0fe27c08a7d6413a2b8 \
+                    sha256  ca1820d527e4759884620be2917079e61e996fa81da5fbe5c07c4a7b507264dc \
+                    size    2955839
 
 patchfiles          patch-redis.conf.diff \
                     patch-hiredis.diff
@@ -52,6 +52,11 @@ configure.optflags
 configure.cppflags-replace \
                     -I${prefix}/include \
                     -isystem${prefix}/include
+
+# https://trac.macports.org/ticket/58712
+if {${os.major} <= 18} {
+    configure.ldflags-append -latomic
+}
 
 # redis doesn't know about CPPFLAGS so pass it this way
 build.args-append   REDIS_CFLAGS="${configure.cppflags}"


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/62848

#### Description

I think this closes the issue attached but was unable to compile it on an affected system.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1922 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
