### PR TITLE
redis: only link libatomic on i386

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                redis
 version             7.0.1
-revision            0
+revision            1
 categories          databases
 platforms           darwin
 license             BSD
@@ -52,11 +52,6 @@ configure.optflags
 configure.cppflags-replace \
                     -I${prefix}/include \
                     -isystem${prefix}/include
-
-# https://trac.macports.org/ticket/58712
-if {${os.major} <= 18} {
-    configure.ldflags-append -latomic
-}
 
 # redis doesn't know about CPPFLAGS so pass it this way
 build.args-append   REDIS_CFLAGS="${configure.cppflags}"


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/65311

#### Description

This will at least stop the bleeding but should hopefully resurrect builds on i386 too.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1922 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
