### PR TITLE
luajit-openresty: Update to 2.1-20220411

### DIFF
--- a/lang/luajit-openresty/Portfile
+++ b/lang/luajit-openresty/Portfile
@@ -5,25 +5,22 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           xcode_workaround 1.0
 PortGroup           github 1.0
 
-github.setup        openresty luajit2 2.1-20210510 v
+github.setup        openresty luajit2 2.1-20220411 v
 name                luajit-openresty
-revision            1
+revision            0
+checksums           rmd160  9e77865de5b7731d4acc620695e1fb427f2d349f \
+                    sha256  d3f2c870f8f88477b01726b32accab30f6e5d57ae59c5ec87374ff73d0794316 \
+                    size    1141007
+
 categories          lang
-platforms           darwin
 license             MIT
 maintainers         {l2dy @l2dy} openmaintainer
 description         OpenResty's maintained branch of LuaJIT
 long_description    ${description}. LuaJIT is a Just-In-Time Compiler for the Lua programming language.
 
+github.tarball_from archive
+
 conflicts           luajit
-
-checksums           rmd160  0c5a810087289b29d8d5832e5576c792a85b2a67 \
-                    sha256  18707f58618830fd452fbb2a5fc9d8e84982c6d7778ed5c933ba02c75222c263 \
-                    size    1106399
-
-post-patch {
-    reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/etc/luajit.pc
-}
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

luajit-openresty: Update to 2.1-20220411

The post-patch reinplace of the prefix in luajit.pc is removed because the Makefile does that for you.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
