### PR TITLE
audacity: tentative fix for issue 63741 (plugin referencing builddir paths)

### DIFF
--- a/audio/audacity/Portfile
+++ b/audio/audacity/Portfile
@@ -92,7 +92,7 @@ if {${subport} eq "${name}-legacy"} {
     conflicts       "${name}-legacy"
     ## 576b7e66 looks like possibly the last commit before the takeover by the new project owner:
     github.setup    audacity audacity 576b7e66d2b96c39241d3d992259fc2bfa7855b0
-    version         3.0.2.129
+    version         3.0.2.129 ; revision 1
     # this port is intended to facilitate development efforts shared with "upstreams"
     # so using git instead of a tarball fetch type is more appropriate for the current maintainer
     # fetch.type      git
@@ -185,7 +185,8 @@ if {[variant_isset wxsystem]} {
 
 depends_build-append \
                     port:pkgconfig \
-                    port:python37
+                    port:python37 \
+                    port:cctools
 set python_bin      ${prefix}/bin/python3.7
 
 depends_lib-append  port:freetype \
@@ -271,8 +272,30 @@ configure.cxxflags-append \
                     -Wno-inconsistent-missing-override \
                     -Wno-overloaded-virtual
 
+platform darwin {
+    # set the install_rpath first
+    cmake.install_rpath-append \
+                    ${prefix}/lib/audacity \
+                    ${aud_app_path}/Contents/Frameworks
+    if {[variant_isset wxsystem]} {
+        cmake.install_rpath-append \
+                    ${wxWidgets.prefix}/lib
+    } else {
+        configure.ldflags-append \
+                    -Wl,-rpath,${prefix}/lib/audacity \
+                    -Wl,-rpath,${aud_app_path}/Contents/Frameworks
+    }
+    if {${subport} eq "${name}"} {
+        # now change the prefix
+        cmake.install_prefix ${applications_dir}
+    }
+    configure.pre_args-replace \
+                    -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib" \
+                    -DCMAKE_INSTALL_NAME_DIR="${aud_app_path}/Contents/Frameworks"
+}
 set _OPT "audacity_"
 configure.args-append \
+                    -DCMAKE_MACOSX_RPATH=ON \
                     -D${_OPT}lib_preference=system \
                     -D${_OPT}use_audio_units=on \
                     -D${_OPT}use_pa_jack=off \
@@ -289,7 +312,7 @@ configure.args-append \
                     -D${_OPT}use_soundtouch=system \
                     -D${_OPT}use_twolame=system \
                     -D${_OPT}use_midi=local \
-                    -D${_OPT}use_pch=on
+                    -D${_OPT}use_pch=off
 if {${os.arch} ne "arm"} {
     configure.args-append \
                     -D${_OPT}use_mad=system \
@@ -425,15 +448,45 @@ pre-build {
 }
 
 platform darwin {
+    proc fixup_wx_libraries {} {
+        global destroot aud_app_path wxWidgets.prefix
+        if {[variant_isset wxsystem]} {
+            # replace the embedded libraries with symlinks, so they're found via
+            # the @executable_path rpath.
+            foreach lwx [glob ${destroot}${aud_app_path}/Contents/Frameworks/libwx*] {
+                file delete ${lwx}
+                ln -s "${wxWidgets.prefix}/lib/[file tail ${lwx}]" ${lwx}
+            }
+        }
+    }
 
+    if {${subport} eq "${name}" && ![variant_isset wxsystem]} {
+        destroot {
+            # replace the destroot'ed app bundle with the one in ${build.dir}/bin that contains
+            # the right install_name settings in most of the wxWidgets libraries
+            file delete -force ${destroot}${aud_app_path}
+            system "ditto --rsrc ${build.dir}/bin/Audacity.app ${destroot}${aud_app_path}"
+            # this one is skipped
+            system "install_name_tool -id ${aud_app_path}/Contents/Frameworks/libwx_baseu-3.1.dylib \
+                ${destroot}${aud_app_path}/Contents/Frameworks/libwx_baseu-3.1.dylib"
+            foreach lwx {osx_cocoau_adv osx_cocoau_html baseu_net osx_cocoau_qa osx_cocoau_core baseu_xml baseu} {
+                # update the references where necessary:
+                system "install_name_tool -change ${build.dir}/lib/libwx_${lwx}-3.1.dylib \
+                    ${aud_app_path}/Contents/Frameworks/libwx_${lwx}-3.1.dylib \
+                    ${destroot}${aud_app_path}/Contents/modules/mod-script-pipe.so"
+            }
+        }
+    }
     post-destroot {
         if {${subport} eq "${name}-legacy"} {
             file rename ${destroot}${prefix}/Audacity.app ${destroot}${aud_app_path}
             file delete -force ${destroot}${prefix}/share/audacity/plug-ins
             file delete -force ${destroot}${prefix}/share/audacity/nyquist
             file delete -force ${destroot}${prefix}/share/audacity/modules
+            xinstall -m 755 -d ${destroot}${prefix}/share/audacity
             ln -s ${aud_app_path}/Contents/plug-ins ${destroot}${prefix}/share/audacity/
             file delete -force ${destroot}/Resources
+            fixup_wx_libraries
             if {[variant_isset suil]} {
                 xinstall -m 755 -d ${destroot}${aud_app_path}/Contents/Frameworks
                 file rename ${build.dir}/bin/MacPorts/lib/audacity/suil_qt5_in_cocoa.so \
@@ -441,12 +494,7 @@ platform darwin {
                 ln -s suil_qt5_in_cocoa.dylib ${destroot}${aud_app_path}/Contents/Frameworks/suil_qt5_in_cocoa.so
             }
         } else {
-            file rename ${destroot}${prefix}/Audacity.app ${destroot}${aud_app_path}
-            if {[variant_isset wxsystem]} {
-                # I haven't yet figured out how to disable the copying of wx libraries into the bundle
-                # but they can be pruned because CopyLibs.cmake is not invoked.
-                file delete -force ${destroot}${aud_app_path}/Contents/Frameworks
-            }
+            fixup_wx_libraries
             xinstall -m 755 -d ${destroot}${prefix}/share/audacity
             ln -s ${aud_app_path}/Contents/plug-ins ${destroot}${prefix}/share/audacity/
             xinstall -m 755 -d ${destroot}${prefix}/share/mime/packages

--- a/audio/audacity/files/devel/patch-cmakefiles.diff
+++ b/audio/audacity/files/devel/patch-cmakefiles.diff
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a85373670..60aa0c775 100644
+index a853736706cb3c973ec153ce89eac9b70d7fda27..895a18a42fe017e8dccb2b53b82afee77da2020b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -78,7 +78,7 @@ cmake_policy( SET CMP0075 NEW )
@@ -66,6 +66,34 @@ index a85373670..60aa0c775 100644
  
  set( _DEST "${_DESTDIR}" )
  set( _PREFIX "${CMAKE_INSTALL_PREFIX}" )
+@@ -265,9 +269,12 @@ set( _EXEDIR "${_DEST}" )
+ 
+ # Setup RPATH handling
+ set( CMAKE_BUILD_RPATH "${_DEST}/${_PKGLIB}" )
+-set( CMAKE_BUILD_WITH_INSTALL_RPATH FALSE )
+-set( CMAKE_INSTALL_RPATH "${_PREFIX}/${_PKGLIB}" )
+-set( CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE )
++set( CMAKE_BUILD_WITH_INSTALL_RPATH TRUE )
++if (NOT CMAKE_INSTALL_RPATH)
++    set( CMAKE_INSTALL_RPATH "${_PREFIX}/${_PKGLIB}" )
++endif()
++message(STATUS "CMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH}")
++# set( CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE )
+ 
+ # Adjust them for the Mac
+ if( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
+diff --git a/cmake-proxies/cmake-modules/CopyLibs.cmake b/cmake-proxies/cmake-modules/CopyLibs.cmake
+index ddb5d9ae60f576efd893c728009313bd337ca4e8..7044c04d5c0cd784c515e479dcd2bd943986671c 100644
+--- a/cmake-proxies/cmake-modules/CopyLibs.cmake
++++ b/cmake-proxies/cmake-modules/CopyLibs.cmake
+@@ -67,6 +67,7 @@ function( gather_libs src )
+                list( APPEND libs ${lib} )
+ 
+                get_filename_component( refname "${lib}" NAME )
++               list( APPEND postcmds "sh -c 'install_name_tool -id @executable_path/../Frameworks/${refname} ${libname}'" )
+                list( APPEND postcmds "sh -c 'install_name_tool -change ${lib} @executable_path/../Frameworks/${refname} ${libname}'" )
+ 
+                gather_libs( ${lib} )
 diff --git a/cmake-proxies/lv2/CMakeLists.txt b/cmake-proxies/lv2/CMakeLists.txt
 index 5551e5dd8d1fa060a91a00eb9a3bd115c31d7274..db7a5341d0ed22d4f14adb72b4b61fda22a0fd2e 100644
 --- a/cmake-proxies/lv2/CMakeLists.txt
@@ -110,10 +138,22 @@ index 5551e5dd8d1fa060a91a00eb9a3bd115c31d7274..db7a5341d0ed22d4f14adb72b4b61fda
     set( SUIL_MODULE_DIR "" )
     set( SUIL_DIR_SEP "" )
 diff --git a/cmake-proxies/wxWidgets/CMakeLists.txt b/cmake-proxies/wxWidgets/CMakeLists.txt
-index 47b6bd0ee..e957ee666 100644
+index 47b6bd0eed3e1a9626d9b6a99f9a92e5186e413e..3947b7abb57d1d90df10d5e0f7d583374131f06e 100644
 --- a/cmake-proxies/wxWidgets/CMakeLists.txt
 +++ b/cmake-proxies/wxWidgets/CMakeLists.txt
-@@ -240,10 +240,10 @@ file(
+@@ -76,7 +76,10 @@ if( wxWidgets_FOUND )
+    set( toolkit "${wxWidgets_LIBRARIES}" )
+ else()
+    message( STATUS "Using local '${name}' library" )
+-
++   if (APPLE)
++      #set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/Audacity.app/Contents/Frameworks)
++      set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/Audacity.app/Contents/Frameworks)
++   endif()
+    set( WXWIN $ENV{WXWIN} )
+    if( "${WXWIN}" STREQUAL "" )
+       # XXX: Look into importing instead of adding to this project
+@@ -240,10 +243,10 @@ file(
  
  string( REGEX MATCHALL "\".+(Audacity).+\"" ours "${output}")
  if( NOT ours )
@@ -128,7 +168,7 @@ index 47b6bd0ee..e957ee666 100644
        "########################################################################\n"
     )
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index e6dd6cf03..fa2f49b7e 100644
+index e6dd6cf03..385b05793 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -1032,7 +1032,7 @@ list( APPEND DEFINES
@@ -152,47 +192,7 @@ index e6dd6cf03..fa2f49b7e 100644
  
  set( BUILDING_AUDACITY YES )
  set( INSTALL_PREFIX "${_PREFIX}" )
-@@ -1147,22 +1152,23 @@ if( CMAKE_SYSTEM_NAME MATCHES "Windows" )
-       POST_BUILD
-    )
- elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
--   # Bug 2400 workaround
--   #
--   # Replaces the SDK version in the built executable with 10.13 to
--   # prevent high CPU usage and slow drawing on Mojave or newer
--   check_for_platform_version()
--   if( PLATFORM_VERSION_SUPPORTED )
--      list( APPEND LDFLAGS
--         PRIVATE
--            -Wl,-platform_version,macos,${MIN_MACOS_VERSION},${TARGET_MACOS_VERSION}
--      )
--   else()
--      list( APPEND LDFLAGS
--         PRIVATE
--            -Wl,-sdk_version,10.13
--      )
--   endif()
-+## MacPorts will specify the SDK to use itself, thank you very much
-+#    # Bug 2400 workaround
-+#    #
-+#    # Replaces the SDK version in the built executable with 10.13 to
-+#    # prevent high CPU usage and slow drawing on Mojave or newer
-+#    check_for_platform_version()
-+#    if( PLATFORM_VERSION_SUPPORTED )
-+#       list( APPEND LDFLAGS
-+#          PRIVATE
-+#             -Wl,-platform_version,macos,${MIN_MACOS_VERSION},${TARGET_MACOS_VERSION}
-+#       )
-+#    else()
-+#       list( APPEND LDFLAGS
-+#          PRIVATE
-+#             -Wl,-sdk_version,10.13
-+#       )
-+#    endif()
- 
-    # Define Mac specific resources
-    list( APPEND MAC_RESOURCES
-@@ -1206,6 +1212,9 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
+@@ -1206,6 +1211,9 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
           "-framework AudioUnit"
           "-framework CoreAudio"
           "-framework CoreAudioKit"
@@ -202,7 +202,7 @@ index e6dd6cf03..fa2f49b7e 100644
     )
  
     # Use the Aqua theme
-@@ -1317,13 +1326,20 @@ list( APPEND DEFINES PRIVATE "${export_symbol}" INTERFACE "${import_symbol}" )
+@@ -1317,13 +1325,20 @@ list( APPEND DEFINES PRIVATE "${export_symbol}" INTERFACE "${import_symbol}" )
  
  target_sources( ${TARGET} PRIVATE ${HEADERS} ${SOURCES} ${RESOURCES} ${MAC_RESOURCES} ${WIN_RESOURCES} )
  target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )

--- a/audio/audacity/files/patch-cmakefiles.diff
+++ b/audio/audacity/files/patch-cmakefiles.diff
@@ -1,8 +1,8 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index be2646a05b4287aa0d5e34863cb2c4402af73e68..1a018e367f18cacc73472224fc544f8d3bd22e60 100644
---- a/CMakeLists.txt
+diff --git a/CMakeLists.txt.orig b/CMakeLists.txt
+index 4ff5430..08226f6 100644
+--- a/CMakeLists.txt.orig
 +++ b/CMakeLists.txt
-@@ -52,14 +52,14 @@ if( APPLE )
+@@ -47,14 +47,14 @@ if( APPLE )
     # Define the OSX compatibility parameters
     set( CMAKE_OSX_ARCHITECTURES x86_64 CACHE INTERNAL "" )
     set( CMAKE_OSX_DEPLOYMENT_TARGET 10.7 CACHE INTERNAL "" )
@@ -19,7 +19,7 @@ index be2646a05b4287aa0d5e34863cb2c4402af73e68..1a018e367f18cacc73472224fc544f8d
  endif()
  
  # Add our module path
-@@ -74,12 +74,14 @@ set( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake-proxies/cmake-modules)
+@@ -69,12 +69,14 @@ set( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake-proxies/cmake-modules)
  set( CMAKE_CXX_STANDARD 14 )
  set( CMAKE_CXX_STANDARD_REQUIRED ON )
  
@@ -39,17 +39,34 @@ index be2646a05b4287aa0d5e34863cb2c4402af73e68..1a018e367f18cacc73472224fc544f8d
  endif()
  
  # Our very own project
-@@ -203,6 +205,7 @@ if( CMAKE_CONFIGURATION_TYPES )
- else()
-    set( _DESTDIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}" )
+@@ -182,10 +184,12 @@ set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
+ 
+ # Set up RPATH handling
+ set( CMAKE_SKIP_BUILD_RPATH FALSE )
+-set( CMAKE_BUILD_WITH_INSTALL_RPATH FALSE )
+-set( CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}/audacity" )
+-set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
+-set( CMAKE_MACOSX_RPATH FALSE )
++set( CMAKE_BUILD_WITH_INSTALL_RPATH TRUE )
++if (NOT CMAKE_INSTALL_RPATH)
++    set( CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}/audacity" )
++endif()
++# set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
++# set( CMAKE_MACOSX_RPATH FALSE )
+ 
+ # the RPATH to be used when installing, but only if it's not a system directory
+ #list( FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSysDir )
+@@ -198,6 +202,7 @@ check_library_exists( m pow "" HAVE_LIBM )
+ if( HAVE_LIBM )
+    list( APPEND CMAKE_REQUIRED_LIBRARIES -lm )
  endif()
 +set( _DESTDIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" )
  
- set( _DEST "${_DESTDIR}" )
- set( _PREFIX "${CMAKE_INSTALL_PREFIX}" )
-diff --git a/src/orig.CMakeLists.txt b/src/CMakeLists.txt
-index 93dc50c..2a0c014 100644
---- a/src/orig.CMakeLists.txt
+ check_library_exists( atomic __atomic_fetch_add_4 "" HAVE_LIBATOMIC )
+ if( HAVE_LIBATOMIC )
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 93dc50c821cd59b5be4fa74cc4c8e3fee161cfcb..f55beca805f6d33625cf5ea8f68ac60fb7999b40 100644
+--- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -1095,6 +1095,11 @@ list( APPEND LIBRARIES
        $<$<PLATFORM_ID:Linux,FreeBSD,OpenBSD,NetBSD,CYGWIN>:z>
@@ -63,47 +80,7 @@ index 93dc50c..2a0c014 100644
  
  set( BUILDING_AUDACITY YES )
  set( INSTALL_PREFIX "${_PREFIX}" )
-@@ -1182,22 +1187,23 @@ if( CMAKE_SYSTEM_NAME MATCHES "Windows" )
-       POST_BUILD
-    )
- elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
--   # Bug 2400 workaround
--   #
--   # Replaces the SDK version in the built executable with 10.13 to
--   # prevent high CPU usage and slow drawing on Mojave or newer
--   check_for_platform_version()
--   if( PLATFORM_VERSION_SUPPORTED )
--      list( APPEND LDFLAGS
--         PRIVATE
--            -Wl,-platform_version,macos,10.7,10.13
--      )
--   else()
--      list( APPEND LDFLAGS
--         PRIVATE
--            -Wl,-sdk_version,10.13
--      )
--   endif()
-+## MacPorts will specify the SDK to use itself, thank you very much
-+#    # Bug 2400 workaround
-+#    #
-+#    # Replaces the SDK version in the built executable with 10.13 to
-+#    # prevent high CPU usage and slow drawing on Mojave or newer
-+#    check_for_platform_version()
-+#    if( PLATFORM_VERSION_SUPPORTED )
-+#       list( APPEND LDFLAGS
-+#          PRIVATE
-+#             -Wl,-platform_version,macos,10.7,10.13
-+#       )
-+#    else()
-+#       list( APPEND LDFLAGS
-+#          PRIVATE
-+#             -Wl,-sdk_version,10.13
-+#       )
-+#    endif()
- 
-    # Define Mac specific resources
-    list( APPEND MAC_RESOURCES
-@@ -1240,6 +1246,9 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
+@@ -1240,6 +1245,9 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
           "-framework AudioUnit"
           "-framework CoreAudio"
           "-framework CoreAudioKit"
@@ -113,7 +90,7 @@ index 93dc50c..2a0c014 100644
     )
  
     # Use the Aqua theme
-@@ -1365,6 +1374,13 @@ source_group(
+@@ -1365,6 +1373,13 @@ source_group(
  
  target_sources( ${TARGET} PRIVATE ${HEADERS} ${SOURCES} ${RESOURCES} ${MAC_RESOURCES} ${WIN_RESOURCES} )
  target_compile_definitions( ${TARGET} PRIVATE ${DEFINES} )
@@ -127,7 +104,7 @@ index 93dc50c..2a0c014 100644
  target_compile_options( ${TARGET} PRIVATE ${OPTIONS} )
  target_include_directories( ${TARGET} PRIVATE ${INCLUDES} )
  target_link_options( ${TARGET} PRIVATE ${LDFLAGS} )
-@@ -1373,7 +1389,7 @@ target_link_libraries( ${TARGET} PRIVATE ${LIBRARIES} )
+@@ -1373,7 +1388,7 @@ target_link_libraries( ${TARGET} PRIVATE ${LIBRARIES} )
  # If was have cmake 3.16 or higher, we can use precompiled headers, but
  # only use them if ccache is not available and the user hasn't disabled
  # it.
@@ -136,7 +113,7 @@ index 93dc50c..2a0c014 100644
     cmd_option(
        ${_OPT}use_pch
        "Use precompiled headers [yes, no]"
-@@ -1390,10 +1406,9 @@ endif()
+@@ -1390,10 +1405,9 @@ endif()
  
  if( NOT "${CMAKE_GENERATOR}" MATCHES "Xcode|Visual Studio*" )
     if( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
@@ -150,7 +127,7 @@ index 93dc50c..2a0c014 100644
     else()
        install( PROGRAMS "${_EXEDIR}/${AUDACITY_NAME}"
                 TYPE BIN )
-@@ -1403,12 +1418,12 @@ if( NOT "${CMAKE_GENERATOR}" MATCHES "Xcode|Visual Studio*" )
+@@ -1403,12 +1417,12 @@ if( NOT "${CMAKE_GENERATOR}" MATCHES "Xcode|Visual Studio*" )
                 FILES_MATCHING PATTERN "*.so" )
        install( FILES "${_INTDIR}/audacity.desktop"
                 DESTINATION "${_DATADIR}/applications" )
@@ -169,6 +146,22 @@ index 93dc50c..2a0c014 100644
 +            DESTINATION "${_PKGDATA}" )
  endif()
  
+diff --git a/cmake-proxies/wxWidgets/CMakeLists.txt b/cmake-proxies/wxWidgets/CMakeLists.txt
+index 47b6bd0eed3e1a9626d9b6a99f9a92e5186e413e..3947b7abb57d1d90df10d5e0f7d583374131f06e 100644
+--- a/cmake-proxies/wxWidgets/CMakeLists.txt
++++ b/cmake-proxies/wxWidgets/CMakeLists.txt
+@@ -76,7 +76,10 @@ if( wxWidgets_FOUND )
+    set( toolkit "${wxWidgets_LIBRARIES}" )
+ else()
+    message( STATUS "Using local '${name}' library" )
+-
++   if (APPLE)
++      #set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/Audacity.app/Contents/Frameworks)
++      set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/Audacity.app/Contents/Frameworks)
++   endif()
+    set( WXWIN $ENV{WXWIN} )
+    if( "${WXWIN}" STREQUAL "" )
+       # XXX: Look into importing instead of adding to this project
 diff --git a/cmake-proxies/lv2/orig.CMakeLists.txt b/cmake-proxies/lv2/CMakeLists.txt
 index 289688e..af8d37a 100644
 --- a/cmake-proxies/lv2/orig.CMakeLists.txt
@@ -212,3 +205,19 @@ index 289688e..af8d37a 100644
  
     set( SUIL_MODULE_DIR "" )
     set( SUIL_DIR_SEP "" )
+diff --git a/mac/scripts/orig.install_wxlibs.sh b/mac/scripts/install_wxlibs.sh
+index 49e6d44..ae8b5f4 100755
+--- a/mac/scripts/orig.install_wxlibs.sh
++++ b/mac/scripts/install_wxlibs.sh
+@@ -30,8 +30,9 @@ update_paths()
+    do
+       path=$(resolve "${lib}")
+ 
+-      printf "%${indent}.${indent}cChanging '${lib}' to '@loader_path/../Frameworks/${path##*/}'\n" " "
+-      install_name_tool -change "${lib}" "@loader_path/../Frameworks/${path##*/}" "${LIBPATH}/${base}"
++      printf "%${indent}.${indent}cChanging '${lib}' to '@executable_path/../Frameworks/${path##*/}'\n" " "
++      install_name_tool -id "@executable_path/../Frameworks/${path##*/}" "${LIBPATH}/${base}"
++      install_name_tool -change "${lib}" "@executable_path/../Frameworks/${path##*/}" "${LIBPATH}/${base}"
+ 
+       update_paths $((indent + 2)) "${path}"
+    done


### PR DESCRIPTION
This patches the paths post-hoc; I cannot reproduce the issue myself
so have not been able to find a true fix (and the current patch is a
no-op for me).

Fixes: https://trac.macports.org/ticket/63741
- [X] bugfix

###### Tested on
OS X 10.9.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
