### PR TITLE
cmake-bootstrap: Backport a fix for find_library

### DIFF
--- a/devel/cmake-bootstrap/Portfile
+++ b/devel/cmake-bootstrap/Portfile
@@ -12,12 +12,12 @@ maintainers         nomaintainer
 dist_subdir         cmake
 
 set branch          3.9
-version             ${branch}.4
+version             ${branch}.6
 distname            cmake-${version}
 
-checksums           rmd160  bb9c30f2726413f0d7d7b92e0294b61438151d62 \
-                    sha256  b5d86f12ae0072db520fdbdad67405f799eb728b610ed66043c20a92b4906ca1 \
-                    size    7705052
+checksums           rmd160  858257d95fde810195e4cf7254072dd8db608cc4 \
+                    sha256  7410851a783a41b521214ad987bb534a7e4a65e059651a2514e6ebfc8f46b218 \
+                    size    7705400
 
 homepage            https://cmake.org
 master_sites        ${homepage}/files/v${branch}/
@@ -35,6 +35,7 @@ patchfiles-append \
     patch-Modules-noArchCheck.release.diff \
     patch-CMakeFindFrameworks.cmake.release.diff \
     patch-Source_CMakeVersionCompute.cmake.release.diff \
+    patch-Source-cmFindLibraryCommand.cxx.diff \
     patch-Source-kwsys-kwsysPlatformTestsCXX.cxx.diff
 
 post-patch {
@@ -47,16 +48,16 @@ configure.cxx_stdlib
 platform darwin {
     configure.env-append   CMAKE_OSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
 
-	if {${configure.sdkroot} eq ""} {
-		configure.env-append SDKROOT=/
-	}
+    if {${configure.sdkroot} eq ""} {
+        configure.env-append SDKROOT=/
+    }
 
-	if {${os.arch} eq "i386" && ${os.major} <= 9} {
-		# The old system headers do some bit shifting on Intel about which newer compilers throw errors:
-		# SecKeychain.h:102:46: error: shift expression '(1853123693 << 8)' overflows [-fpermissive]
-		configure.cflags-append -fpermissive
-		configure.cxxflags-append -fpermissive
-	}
+    if {${os.arch} eq "i386" && ${os.major} <= 9} {
+        # The old system headers do some bit shifting on Intel about which newer compilers throw errors:
+        # SecKeychain.h:102:46: error: shift expression '(1853123693 << 8)' overflows [-fpermissive]
+        configure.cflags-append -fpermissive
+        configure.cxxflags-append -fpermissive
+    }
 }
 
 # Clear CPATH and LIBRARY_PATH as we want to be completely independent of other ports

--- a/devel/cmake-bootstrap/files/patch-Source-cmFindLibraryCommand.cxx.diff
+++ b/devel/cmake-bootstrap/files/patch-Source-cmFindLibraryCommand.cxx.diff
@@ -1,0 +1,14 @@
+diff --git Source/cmFindLibraryCommand.cxx Source/cmFindLibraryCommand.cxx
+index a6b1a2155c..45b14a030a 100644
+--- Source/cmFindLibraryCommand.cxx
++++ Source/cmFindLibraryCommand.cxx
+@@ -387,7 +387,8 @@ bool cmFindLibraryHelper::CheckDirectoryForName(std::string const& path,
+     if (name.Regex.find(testName)) {
+       this->TestPath = path;
+       this->TestPath += origName;
+-      if (!cmSystemTools::FileIsDirectory(this->TestPath)) {
++      // Make sure the path is readable and is not a directory.
++      if (cmSystemTools::FileExists(this->TestPath, true)) {
+         // This is a matching file.  Check if it is better than the
+         // best name found so far.  Earlier prefixes are preferred,
+         // followed by earlier suffixes.  For OpenBSD, shared library


### PR DESCRIPTION
CMake versions older than 3.18 (including `cmake-bootstrap`, pegged at 3.9) have a bug in `find_library` that causes them to find libraries when filesystem nodes are present at a candidate path, even if they are not usable. This can happen “innocently” since macOS 11, where expanded use of the dyld shared cache has caused the removal of most OS dylibs from the filesystem.

For example, when instructed to look for shared library `iodbc.2`, a CMake with this bug running on macOS 11 or later might notice a symbolic link at `/usr/lib/libiodbc.2.dylib` and return it. That dylib is not usable, as it’s “dangling”: it refers to `libiodbc.2.1.18.dylib`, which isn’t present on disk, it’s only in the dyld shared cache. This CMake bug might cause a build to attempt to link against `/usr/lib/libiodbc.2.dylib`, which is, of course, impossible, as the symbolic link points nowhere. The expected behavior is for CMake to discard that unusable path and continue its search, eventually locating `$SDKROOT/usr/lib/libiodbc.2.tbd`.

This backports [the fix present in CMake 3.18](https://gitlab.kitware.com/cmake/cmake/-/commit/f2c903fb9a02) which causes `find_library` to check that a file is readable before returning it. A symbolic link that points nowhere will not pass this check. This improves `cmake-bootstrap`’s reliability on newer OS versions where OS dylibs are only in the dyld shared cache and not in the filesystem.

This also updates `cmake-bootstrap` to 3.9.6. The `cmake-bootstrap` port is intended to be pegged to the last version of CMake to not require C++11. In reality, [the diff between the existing 3.9.4 and 3.9.6](https://gitlab.kitware.com/cmake/cmake/-/compare/v3.9.4...v3.9.6) is minimal and does not introduce a C++11 requirement. There’s no reason for the port not to be at the terminal version on the CMake 3.9 branch, 3.9.6.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@ryandesign (recently touched this port in 5b37f3a51044), @kencu (originated this port in 6d03d8692113).