### PR TITLE
gopass: update to 1.14.3

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.14.2 v
+go.setup            github.com/gopasspw/gopass 1.14.3 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  358ccbee0ada797f05d14a259da8b23269506795 \
-                        sha256  3a6c243621103a7ad1e1c1ac1f8d460ab290b997a8e1e15c4fbf5facf8d76338 \
-                        size    2216740
+                        rmd160  7779654513c630544f675e2bffcd0e0941cefd0f \
+                        sha256  7b5b3fc0271a777f6145d57cb5fc3e2829c2a2b8c5d0cbbb3e4413f20e0f75a0 \
+                        size    2252787
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -33,10 +33,10 @@ go.vendors          rsc.io/qr \
                         sha256  9b17efa7751a66942c72f54e62716574bc34561bdcdaf8337bea3612e85a7025 \
                         size    61955 \
                     gopkg.in/yaml.v3 \
-                        lock    496545a6307b \
-                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
-                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
-                        size    90145 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
                     gopkg.in/check.v1 \
                         lock    10cb98267c6c \
                         rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
@@ -60,30 +60,30 @@ go.vendors          rsc.io/qr \
                         sha256  825a85ed3b123e641b82daecec59a33954393371b3f5e59dc90742a9ec46622f \
                         size    14976 \
                     golang.org/x/sys \
-                        lock    889880a91fd5 \
-                        rmd160  e2b05ff66006e9a8418c7460b001fd6a2d112344 \
-                        sha256  d60667cb2a6191e73587f082d57b86b90342fd2a14e2fdbaab579df183304845 \
-                        size    1292976 \
+                        lock    bc2c85ada10a \
+                        rmd160  c4b2c26618cd3f02fe04653b3a4fbe6707de5716 \
+                        sha256  b2526b52942c803a1687e16f87942bd0f0701b5d260fbaa35d53231e0a520577 \
+                        size    1303117 \
                     golang.org/x/oauth2 \
-                        lock    9780585627b5 \
-                        rmd160  658e6722cf5571bd798e17f7285f07a918459c20 \
-                        sha256  d447c6e834cb1ce33f078df410b897a1db84dd35d70e73666aa23fd4935d1eee \
-                        size    88421 \
+                        lock    622c5d57e401 \
+                        rmd160  5d8bde1bfad6155205b49cd27929e62bda3e2192 \
+                        sha256  f2540be465954c2f9b9507d6ec0f5a009ed65316a1fe94ad3e39a85a6dfa443e \
+                        size    88483 \
                     golang.org/x/net \
-                        lock    290c469a71a5 \
-                        rmd160  e11deb5668ec06a94ecda8c6fc3f7a373ebb35b2 \
-                        sha256  d51af4b91585ee62500a81f634b4060c1d9bc90cf08b5e6e3d1f06f26fe13da1 \
-                        size    1229690 \
+                        lock    1d687d428aca \
+                        rmd160  3b5398a1e78a7dd155c1f2561ce98e19b9a7cbcf \
+                        sha256  7f047e05f77914905c28199e79918f6aa8ac36d09409a6f11681eae22baf3e13 \
+                        size    1228827 \
                     golang.org/x/exp \
-                        lock    7b9b53b0aca4 \
-                        rmd160  162d6202a24486e79a9837e9e0db351e2c9e99e5 \
-                        sha256  054eb051d42c49543634f2934a32d5e61bf3617864e9767afdd4bf14e513edbe \
-                        size    1559584 \
+                        lock    0b5c67f07fdf \
+                        rmd160  6069b3742e7b2a5e0a584e9e2cfce3015a624f47 \
+                        sha256  d67bf520ab8c023637dd665c077daa2766ba9df9998d73c97f59adc6e3201cd3 \
+                        size    1561252 \
                     golang.org/x/crypto \
-                        lock    7b82a4e95df4 \
-                        rmd160  b4f1ba2e353404c6dd4278074d0d348ebb053c60 \
-                        sha256  eeef0fe96ae1565d13d3fde36247d5a5c5da3e2846ac7eac46ca78682814249e \
-                        size    1630512 \
+                        lock    6f7dac969898 \
+                        rmd160  61fb52fa2fae9b5d6b2bcc369d94587f99e20409 \
+                        sha256  c1ba5ecc2d113e2490e89b0fb85cc68bd60139ffe3f05238945d279377925255 \
+                        size    1631350 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -102,10 +102,10 @@ go.vendors          rsc.io/qr \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.7.1 \
-                        rmd160  b6bb4c8e544a0b98123eca6701dcb563dcbb440b \
-                        sha256  7901fad825853e4426d8f68238ceaa9bf63cabde84cd6e82b3e70c786dbbcc25 \
-                        size    3445856 \
+                        lock    v2.8.1 \
+                        rmd160  c25f7ac0b784c027c3d8b8381fe94e128021556f \
+                        sha256  4bcb2b794410cf485a18b89689ff41782482733de938a0f72f16c915759b257f \
+                        size    3448050 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -277,25 +277,25 @@ go.vendors          rsc.io/qr \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.1 \
-                        rmd160  74c013e19d22e56a27d9a3ad61b4bd86975036d1 \
-                        sha256  d23365bceea7382b59ca41ad868a80e34f8066785fb371b85b51ee0b65be6a21 \
-                        size    64243 \
+                        lock    v2.0.2 \
+                        rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
+                        sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
+                        size    64382 \
                     github.com/chzyer/test \
-                        lock    a1ea475d72b1 \
-                        rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
-                        sha256  98d0c7d1dec438459e31886d65190bb45f70c4ed73e35f5ab2f3b8de582ea309 \
-                        size    4007 \
+                        lock    061457976a23 \
+                        rmd160  c699e58ffd3ae3512a7c11a24a6bbac536199306 \
+                        sha256  06993bed996297710c90d23bd91edf8331291da98b96bce266874e33bd5cbca9 \
+                        size    4245 \
                     github.com/chzyer/readline \
-                        lock    2972be24d48e \
-                        rmd160  933f32b684d0af4b8970d964d610918a9f181df6 \
-                        sha256  f5771c6a3d97166a9536f8a45e85e1c40aed9b02089e395d2f4131681cbf692f \
-                        size    36826 \
+                        lock    v1.5.0 \
+                        rmd160  27e26f8769b8ee2193cfd7b2eabf6ad659e84deb \
+                        sha256  57b4a1d8a77799c32e754a0ed5edb7aafbbd22fe81fd2a293b805bed9e7c62a3 \
+                        size    37300 \
                     github.com/chzyer/logex \
-                        lock    v1.1.10 \
-                        rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
-                        sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
-                        size    4351 \
+                        lock    v1.2.0 \
+                        rmd160  d8e2d08f0627240e115a603e1cd1e29b1a9c3ecb \
+                        sha256  a3254fe6ae0c63339d3cb8800193d943978d40257f9fdcbf68c88b2ea24698df \
+                        size    5192 \
                     github.com/cenkalti/backoff \
                         lock    v2.2.1 \
                         rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
@@ -316,22 +316,17 @@ go.vendors          rsc.io/qr \
                         rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
                         sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
                         size    5023 \
-                    github.com/antzucaro/matchr \
-                        lock    b04723ef80f0 \
-                        rmd160  9518c0e67d2719a34d76957e567121a307dfd5ad \
-                        sha256  ad246791e22fd0356a13ed12849ff3ab62ab8ac8df7f63b9587fbcb8293b8b9f \
-                        size    573191 \
                     github.com/ProtonMail/go-crypto \
-                        lock    a94812496cf5 \
-                        rmd160  63b9296476022059a4166f68548549efb21282b8 \
-                        sha256  05113835184fc1991a1a54adbc2c9dd2a71efaba6295315692253761cee418ab \
-                        size    312724 \
+                        lock    88bb52951d5b \
+                        rmd160  a296ce5faf27aa9a1644ba77d74f2306b5e11012 \
+                        sha256  298f607d7869fd0c3a79f0bdde144f7484ae57b0d2da875ee24a92eb8d99d362 \
+                        size    312901 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
-                        lock    v1.0.0-rc.1 \
-                        rmd160  a83aba34025ad1df3a443deb358c11c1239e15ac \
-                        sha256  4bdeff6fc20d81c28a18df76cc982f1fcca03f385dfcc36cf3ddff73b5b2f5fe \
-                        size    39144 \
+                        lock    v1.0.0 \
+                        rmd160  47330d4bd65ec5e115038359a989a1a3f775e130 \
+                        sha256  f9474496e781cc9985cc575fbd108a5ca1992cc9fdfd35ee0efcb2818fab928c \
+                        size    39898 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
                         lock    v1.0.0 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.14.3)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
