### PR TITLE
kotlin: update to 1.7.0

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.6.21 v
+github.setup        JetBrains kotlin 1.7.0 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  24a387236d66950984da1c3904fcd234183fcdb6 \
-                    sha256  632166fed89f3f430482f5aa07f2e20b923b72ef688c8f5a7df3aa1502c6d8ba \
-                    size    72467060
+checksums           rmd160  a24c96f7f3cc77516d420db6c73705b727161c94 \
+                    sha256  f5216644ad81571e5db62ec2322fe07468927bda40f51147ed626a2884b55f9a \
+                    size    72953008
 
 java.version        1.8+
 java.fallback       openjdk8


### PR DESCRIPTION
#### Description

Update to Kotlin 1.7.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?