### PR TITLE
google-cloud-sdk: python310 dependency

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                google-cloud-sdk
 version             389.0.0
-revision            0
+revision            1
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -41,7 +41,7 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 
 worksrcdir          ${name}
 
-python.default_version 39
+python.default_version 310
 
 post-patch {
     reinplace "s|\"disable_updater\": false|\"disable_updater\": true|" ${worksrcpath}/lib/googlecloudsdk/core/config.json


### PR DESCRIPTION
#### Description

Updates google-cloud-sdk port to depend on python3.10 instead of python3.9. This had already been attempted in the past, but failed.

[The bug](https://issuetracker.google.com/issues/205005959) that prevented [this PR](https://github.com/macports/macports-ports/pull/13936) from being merged has been marked duplicate of a fixed bug [here](https://issuetracker.google.com/issues/202172882)
Also, as I pointed out [here](https://github.com/macports/macports-ports/pull/13936#issuecomment-1034485449), the dependency version in the portfile is actually ignored: the shellscript shipped in this package just invokes whatever python3 it can find on the system.
I believe it's time to reconsider this change.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 x86_64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
