### PR TITLE
maven3: update to 3.8.6

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,16 +5,16 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.8.5
+version         3.8.6
 revision        0
 
 categories      java devel
 license         Apache-2
-maintainers     nomaintainer
+maintainers     {breun.nl:nils @breun} openmaintainer
 platforms       darwin
 supported_archs noarch
 
-description     A java-based build and project management environment.
+description     A Java-based build and project management environment.
 long_description \
                 Maven is a Java project management and project \
                 comprehension tool.  Maven is based on the \
@@ -35,9 +35,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  d6dfa569f9d7f1635e27cbd79b1e98fa2d1e8a6a \
-                sha256  88e30700f32a3f60e0d28d0f12a3525d29b7c20c72d130153df5b5d6d890c673 \
-                size    8673123
+checksums       rmd160  84143def64b5a426cdc0b1c6d2a43367a474817f \
+                sha256  c7047a48deb626abf26f71ab3643d296db9b1e67f1faa7d988637deac876b5a9 \
+                size    8676320
 
 java.version    1.7+
 java.fallback   openjdk11


### PR DESCRIPTION
#### Description

Update to Maven 3.8.6 and set myself as maintainer.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?