### PR TITLE
checkssl: update to 0.4.0

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/szazeski/checkssl 0.3.1 v
+go.setup            github.com/szazeski/checkssl 0.4.0 v
 revision            0
 
 homepage            https://www.checkssl.org
@@ -20,9 +20,9 @@ installs_libs       no
 maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 
-checksums           rmd160  c53f2b6f34f9f02f7fe0f45e60cf21685911ace4 \
-                    sha256  1e2db906419b7f91ae3834f62a21fe7892a9e0f1b86f202d70ebf0dde0a8f35f \
-                    size    8156
+checksums           rmd160  db68c2fdba56764082042f1a1ed905f98a8b1fcb \
+                    sha256  7633a3b1f411275361093776cbe516f1ba4dc59aa148cde62daee0c730a25dbb \
+                    size    9531
 
 destroot {
     set doc_dir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to checkssl 0.4.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?