### PR TITLE
sslscan: update to 2.0.13

### DIFF
--- a/net/sslscan/Portfile
+++ b/net/sslscan/Portfile
@@ -3,8 +3,8 @@
 PortSystem 1.0
 PortGroup github 1.0
 
-github.setup    rbsec sslscan 2.0.10
-revision        1
+github.setup    rbsec sslscan 2.0.13
+revision        0
 categories      net
 maintainers     {raimue @raimue} \
                 openmaintainer
@@ -19,9 +19,9 @@ license         {GPL-3+ OpenSSLException}
 
 depends_lib     port:openssl
 
-checksums       rmd160  f17e0b1219700ecc03af091b0bada30407c12b30 \
-                sha256  9d2d0400af0a50da1fdfe6791d1edabc9cff118f425b811e5a8a2b52077ecb8c \
-                size    110419
+checksums       rmd160  0d33ba516da409ec4b12227ff607f56d0d5fa236 \
+                sha256  f8ad76e53a745b1c7d76e79e7f5a8ca0a26831da2449c8edfa2d7d674587f4e5 \
+                size    111155
 
 # implicit declaration of inet_ntop
 patchfiles      sslscan.c.patch


### PR DESCRIPTION
#### Description

Update to sslscan 2.0.13.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?