### PR TITLE
openldap: conditionally declare build dependency on groff

### DIFF
--- a/databases/openldap/Portfile
+++ b/databases/openldap/Portfile
@@ -48,6 +48,12 @@ platform darwin {
     if {${os.major} <= 9} {
         configure.cppflags-append -DMDB_DSYNC=O_SYNC
     }
+
+    if {${os.major} >= 22} {
+	# The openldap build uses soelim from groff, and newer OS versions do
+	# not provide groff as part of the base OS install.
+        depends_build-append port:groff
+    }
 }
 
 configure.ldflags-append    -L${prefix}/lib/db48


### PR DESCRIPTION
The `openldap` build uses `soelim` from `groff`, and `groff` is not expected to be a part of the base OS in macOS 13 (Darwin 22).

When building on that OS version or newer, declare a build dependency on the `groff` port, so that `soelim` will be available.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0 22A5266r arm64
Xcode 14.0 14A5228q

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
