### PR TITLE
lldb-14: add codesign shell script, and mention in notes

### DIFF
--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -28,7 +28,7 @@ name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision 0 }
 subport                 clang-${llvm_version} { revision 0 }
-subport                 lldb-${llvm_version}  { revision 0 }
+subport                 lldb-${llvm_version}  { revision 1 }
 subport                 flang-${llvm_version} { revision 0 }
 
 checksums               rmd160  b840f693d6d39bf194d462136f0979cebe31065f \
@@ -383,6 +383,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     set worksrcpath ${workpath}/${distname}/lldb
 
     notes "Please follow the instructions at https://lldb.llvm.org/resources/build.html#code-signing-on-macos and then codesign lldb-server with:\n--------------------\n"
+    notes-append "sudo ${sub_prefix}/scripts/lldb/macos-setup-codesign.sh"
     if {${os.major} >= 13} {
         notes-append "sudo codesign --force --deep --preserve-metadata=identifier,entitlements,resource-rules,requirements,flags,team-identifier --sign <identity> ${sub_prefix}/bin/lldb-server"
     } else {
@@ -452,6 +453,13 @@ post-destroot {
 
     if {${subport} eq "lldb-${llvm_version}"} {
         delete ${destroot}${prefix}/bin/debugserver-${suffix}
+
+        set lldb_scripts_srcdir ${worksrcpath}/scripts
+        set lldb_scripts_destdir ${destroot}${sub_prefix}/scripts/lldb
+        xinstall -d ${lldb_scripts_destdir}
+        xinstall -m 755 -W ${lldb_scripts_srcdir} \
+            macos-setup-codesign.sh \
+            ${lldb_scripts_destdir}
     }
 }
 


### PR DESCRIPTION
### Description

To improve the user experience when setting up `lldb-14` for the first time, include upstream's script to generate a code-signing certificate. And also mention it in the port notes.

If folks agree with this proposed change, I'll backport it to older LLVM versions too.