### PR TITLE
cfonts: update to 1.0.4

### DIFF
--- a/textproc/cfonts/Portfile
+++ b/textproc/cfonts/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo  1.0
 
-github.setup        DominikWilkowski cfonts 1.0.3 v rust
+github.setup        DominikWilkowski cfonts 1.0.4 v rust
 revision            0
 
 categories          textproc
@@ -17,9 +17,9 @@ long_description    This is a silly little command line tool for sexy fonts in t
                     Give your cli some love.
 
 checksums           ${distfiles} \
-                    rmd160  dc5c554c769d27d47c551683cc837ead26d887c8 \
-                    sha256  d33873ff9c81089b7a3034f4d1244a81aba5a7a6253838c24f6de9103540209e \
-                    size    3311857
+                    rmd160  f7a2231cef2934eb9ecb04abd0c118acc40db757 \
+                    sha256  c8b82256e74091dc15570ccd1447259d27923cdb2eba16d26487b497518d33cc \
+                    size    3313470
 
 build.dir           ${worksrcpath}/rust
 


### PR DESCRIPTION
#### Description

Update to newest cfonts version.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
