### PR TITLE
cfonts: update to 1.0.4

### DIFF
--- a/textproc/cfonts/Portfile
+++ b/textproc/cfonts/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo  1.0
 
-github.setup        DominikWilkowski cfonts 1.0.3 v rust
+github.setup        DominikWilkowski cfonts 1.0.4 v rust
 revision            0
 
 categories          textproc
@@ -17,9 +17,9 @@ long_description    This is a silly little command line tool for sexy fonts in t
                     Give your cli some love.
 
 checksums           ${distfiles} \
-                    rmd160  dc5c554c769d27d47c551683cc837ead26d887c8 \
-                    sha256  d33873ff9c81089b7a3034f4d1244a81aba5a7a6253838c24f6de9103540209e \
-                    size    3311857
+                    rmd160  9bc402d9c18048175ff25079cdbd60c31436ccd8 \
+                    sha256  efe44d74c2a4a9510413ee7429bf248e3bee4e1ae5da17c4ad8b96c1d8606dc1 \
+                    size    3313925
 
 build.dir           ${worksrcpath}/rust
 
@@ -33,23 +33,35 @@ destroot {
 }
 
 cargo.crates \
+    assert_cmd                       2.0.4  93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    bstr                            0.2.17  ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
+    doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
+    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
     enable-ansi-support              0.1.2  28d29d3ca9ba14c336417f8d7bc7f373e8c16d10c30cc0794b09d3cecab631ab \
     exitcode                         1.1.2  de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193 \
     getrandom                        0.2.6  9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad \
     heck                             0.4.0  2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9 \
     hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
     is_ci                            1.1.1  616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb \
+    itertools                       0.10.3  a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3 \
     itoa                             1.0.1  1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     libc                           0.2.125  5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b \
+    memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
     once_cell                       1.10.0  87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9 \
     ppv-lite86                      0.2.16  eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872 \
+    predicates                       2.1.1  a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c \
+    predicates-core                  1.0.3  da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb \
+    predicates-tree                  1.0.5  4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032 \
     proc-macro2                     1.0.37  ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1 \
     quote                           1.0.18  a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.3  d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7 \
+    regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     rustversion                      1.0.6  f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f \
     ryu                              1.0.9  73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f \
     serde                          1.0.136  ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789 \
@@ -61,7 +73,9 @@ cargo.crates \
     syn                             1.0.91  b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d \
     temp-env                         0.2.0  45107136c2ddf8c4b87453c02294fd0adf41751796e81e8ba3f7fd951977ab57 \
     terminal_size                   0.1.17  633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df \
+    termtree                         0.2.4  507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b \
     unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
+    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
     wasi                          0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \


### PR DESCRIPTION
#### Description

Update to cfonts.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
