### PR TITLE
libutf8proc: update to 2.7.0

### DIFF
--- a/textproc/libutf8proc/Portfile
+++ b/textproc/libutf8proc/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JuliaStrings utf8proc 2.6.1 v
+github.setup        JuliaStrings utf8proc 2.7.0 v
 revision            0
 name                libutf8proc
 categories          textproc
@@ -15,9 +15,9 @@ long_description    ${description}
 
 homepage            https://julialang.org/utf8proc/
 
-checksums           rmd160  560c11179579f152baac89c1ad0e47e6cd336c18 \
-                    sha256  130c67add02559f7b04b96bc11a3529a41d078f0b5acf2047aa92438d10b206d \
-                    size    182914
+checksums           rmd160  2fa1279b627fe6ef85e242e969b820d31d68fc85 \
+                    sha256  13842720fd906a19dded03d0d152ecab25015908feba18fdd969e3a5f72f04dd \
+                    size    187944
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Tested with `port -d test libutf8proc`. Also no ABI changes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1922 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
