### PR TITLE
qt*-qtbase: improve SDK detection

### DIFF
--- a/aqua/phantomjs-qt/Portfile
+++ b/aqua/phantomjs-qt/Portfile
@@ -368,17 +368,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1178,17 +1178,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -999,17 +999,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -1002,17 +1002,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -851,17 +851,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -863,17 +863,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -908,17 +908,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -978,17 +978,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -974,17 +974,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -997,17 +997,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                if {[vercmp $xcodeversion 4.3] < 0} {
-                    set sdks_dir ${configure.developer_dir}/SDKs
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
                 } else {
-                    set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
                 }
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
             }
 
             # respect configure.sdk_version

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -668,13 +668,19 @@ foreach {module module_info} [array get modules] {
 
             # starting with Xcode 7.0, the SDK for build OS version might not be available
             # see https://trac.macports.org/ticket/53597
-            if { ${use_xcode} } {
-                set sdks_dir ${configure.developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
-            } else {
-                set sdks_dir ${configure.developer_dir}/SDKs
-            }
-            if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
-                configure.sdk_version
+            #
+            # avoid --show-sdk-path since it is not available on all platforms
+            # see https://github.com/macports/macports-ports/commit/9887e90d69f4265f9056cddc45e41551d7400235#commitcomment-49824261
+            if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
+
+                # if no specific sdk can be found, check for a generic macosx sdk
+                if {[catch {exec -ignorestderr /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
+                    ui_error "${subport}: no usable SDK can be found"
+                    return -code error "no usable SDK can be found"
+                } else {
+                    ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} does not exist"
+                    configure.sdk_version
+                }
             }
 
             # respect configure.sdk_version


### PR DESCRIPTION
The `qt*-qtbase` ports attempted to build a valid SDK name as `macosx${configure.sdk_version}`. This candidate SDK was validated by checking whether `MacOSX${configure.sdk_version}.sdk` exists in the SDKs directory within the developer directory.

In 9887e90d69f4265f9056cddc45e41551d7400235, identical logic in the `qmake5` port group was revised to instead check for a valid SDK based on `${configure.sdk_version}` by running `xcrun --sdk macosx${configure.sdk_version} --show-sdk-path`. This was later revised by be588d4c1b8bf39b090c7b44cb1e5ef9ecda0dfd to use `--find ld` instead of `--show-sdk-path`, which is a newer option not honored by all versions of `xcrun`.

This change brings the improved logic from the `qmake5` port group (and later updates) to the various `qt*-qtbase` subports, which build via the Qt `configure` script and not `qmake`, and do not otherwise benefit from the improvements already made to the `qmake5` port group.

This is necessary because unlike other recent versions of Xcode, Xcode 14.0b1 14A5228q contains a `MacOSX13.sdk` symbolic link in addition to the expected `MacOSX13.0.sdk` symbolic link. This means that the path existence check for `MacOSX${configure.sdk_version}.sdk` succeeded in this configuration when `configure.sdk_version` was 13, as it will be by default on macOS 13. This resulted in Qt being configured with an SDK identifier of `macosx13`. Although the `MacOSX13.sdk` symbolic link was present, `xcrun` and other Xcode tools do not recognize `macosx13` as a valid SDK identifier, causing a build configured in this way to fail.

The expectation based on other recent versions of Xcode (since Xcode 12 and the macOS 11 SDK) is for the existence check to fail, causing the build to fall back to the generic `macosx` SDK. By instead using `xcrun` with a candidate SDK name (`xcrun --sdk macosx13`), these ports can now check to see whether the SDK identifier to be given to the Qt build is considered valid by the Developer Tools installation. This is much more accurate than the path existence check.

The `qt*-qtbase` build winds up encoding the SDK identifier into its installed files for its own use during `qmake`-based builds as `QMAKE_MAC_SDK`, so it’s most desirable for MacPorts’ purposes to track the SDK major version when possible, but it’s absolutely undesirable to track the SDK minor version, as it will cause `qmake` to fail if a Developer Tools update changes the SDK’s minor version. These minor version bumps have occurred in recent Developer Tools updates that identify SDKs by both major and minor version numbers. Because `QMAKE_MAC_SDK` may only be set to a short identifier (`macosx10.15` or `macosx`) and not a pathname, there is no way to currently identify such SDKs to the tools by just a major version number. The only remaining option is to specify the SDK as the most generic `macosx`. However, if the developer tools do eventually regain the capability to properly specify an SDK by just major version (`macosx13`), the strategy implemented here will allow these ports to take advantage of it.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0 22A5266r arm64
Xcode 14.0 14A5228q

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@landonf (9887e90d69f4265f9056cddc45e41551d7400235)
@MarcusCalhoun-Lopez (be588d4c1b8bf39b090c7b44cb1e5ef9ecda0dfd)
@kencu (fbdae6e6c2cc9c2a8b8a625e322aeee6bd00e610)