### PR TITLE
google-cloud-sdk: update to 390.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             389.0.0
+version             390.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  34744b549d3b182b12ded134aa48027dd052a0c9 \
-                    sha256  53ab782d503776efb9a37565233a3cc695eea9dade75d1653bd98388f1d01ffd \
-                    size    107100306
+    checksums       rmd160  53778b02a89b07d962bf9a1484f5b4f109686dfd \
+                    sha256  753b4a70766fd654900a71789b423d83adca0d5cba8a257bde3f605a4a128c23 \
+                    size    107728072
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  998da8d516400d6beaf08979c0e69c718c44f757 \
-                    sha256  0bdd6b8e020ba12ff43da745276875df87a5147393f06197f9f74142010674b6 \
-                    size    103693829
+    checksums       rmd160  d57a023c37a62b4d91c61aac9ee55098060411f4 \
+                    sha256  3174926f64018d88c53e21eab6813595db64a1309483406373d8245a3a9324da \
+                    size    104320492
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  9548dbd809351b29595df558228b73c6a1ede146 \
-                    sha256  05c44ac03b253cab62fa91c9691c255031853354fc960f4707b21025da84972d \
-                    size    102269899
+    checksums       rmd160  b9bb2c8ae1d3353785baef3cab22336ee4170abe \
+                    sha256  ca8c8676d16abd28274540e3eb9fdc142a83a52004494b930f0ae1095d0f131d \
+                    size    102898537
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -70,11 +70,12 @@ variant cbt description {Add Cloud Bigtable Command Line Tool} { dict set varian
 variant cloud_build_local description {Add Google Cloud Build Local Builder} { dict set variant_to_component cloud_build_local cloud-build-local }
 variant cloud_datastore_emulator description {Add Cloud Datastore Emulator} { dict set variant_to_component cloud_datastore_emulator cloud-datastore-emulator }
 variant cloud_firestore_emulator description {Add Cloud Firestore Emulator} { dict set variant_to_component cloud_firestore_emulator cloud-firestore-emulator }
+variant cloud_run_proxy description {Add Cloud Run Proxy} { dict set variant_to_component cloud_run_proxy cloud-run-proxy }
 variant cloud_sql_proxy description {Add Cloud SQL Proxy} { dict set variant_to_component cloud_sql_proxy cloud_sql_proxy }
 variant config_connector description {Add config connector} { dict set variant_to_component config_connector config-connector }
 variant datalab description {Add Cloud Datalab Command Line Tool} { dict set variant_to_component datalab datalab }
 variant docker_credential_gcr description {Add Google Container Registry's Docker credential helper} { dict set variant_to_component docker_credential_gcr docker-credential-gcr }
-variant emulator_reverse_proxy description {Add Emulator Reverse Proxy} { dict set variant_to_component emulator_reverse_proxy emulator-reverse-proxy }
+variant gke_gcloud_auth_plugin description {Add GKE Google Cloud auth plugin} { dict set variant_to_component gke_gcloud_auth_plugin gke-gcloud-auth-plugin }
 variant kpt description {Add kpt} { dict set variant_to_component kpt kpt }
 variant kubectl description {Add kubectl} { dict set variant_to_component kubectl kubectl }
 variant kubectl_oidc description {Add kubectl-oidc} { dict set variant_to_component kubectl_oidc kubectl-oidc }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 390.0.0 and update variants to match installable components.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?