### PR TITLE
mle: new port

### DIFF
--- a/editors/mle/Portfile
+++ b/editors/mle/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        adsr mle 1.5.0 v
+revision            0
+
+categories          editors
+license             Apache-2
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+
+description         Small, flexible, terminal-based text editor
+long_description    {*}${description}
+
+checksums           rmd160  03ad1827453218631d91d771d6d37f2c4539e815 \
+                    sha256  1c714ce296c881c0fc9ae020ee17698001b964456d61e2d2d0e5ead839310e14 \
+                    size    135507
+
+post-patch {
+    reinplace "s|-llua5.4|-llua|g" ${worksrcpath}/Makefile
+    reinplace "s|<lua5.4/|<|g" ${worksrcpath}/mle.h
+}
+
+configure.cflags-append \
+                    -DTB_OPT_SELECT \
+                    -I${prefix}/include/uthash
+
+depends_lib-append  port:lua \
+                    port:pcre \
+                    port:uthash
+
+post-destroot {
+    set mandir ${destroot}${prefix}/share/man/man1
+    xinstall ${worksrcpath}/mle.1 ${mandir}
+}


### PR DESCRIPTION
#### Description
[**mle**](https://github.com/adsr/mle) is a small, flexible, terminal-based text editor written in C.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
