### PR TITLE
libutf8proc: Fix build with GCC 4.2

### DIFF
--- a/textproc/libutf8proc/Portfile
+++ b/textproc/libutf8proc/Portfile
@@ -23,6 +23,8 @@ use_configure       no
 
 variant universal   {}
 
+patchfiles          remove-Wsign-conversion.diff
+
 build.args          prefix="${prefix}" \
                     CC=${configure.cc} \
                     CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \

--- a/textproc/libutf8proc/files/remove-Wsign-conversion.diff
+++ b/textproc/libutf8proc/files/remove-Wsign-conversion.diff
@@ -1,0 +1,13 @@
+The -Wsign-conversion flag is not supported in GCC 4.2
+
+--- Makefile.orig
++++ Makefile
+@@ -11,7 +11,7 @@
+ CFLAGS ?= -O2
+ PICFLAG = -fPIC
+ C99FLAG = -std=c99
+-WCFLAGS = -Wsign-conversion -Wall -Wextra -pedantic
++WCFLAGS = -Wall -Wextra -pedantic
+ UCFLAGS = $(CPPFLAGS) $(CFLAGS) $(PICFLAG) $(C99FLAG) $(WCFLAGS) -DUTF8PROC_EXPORTS $(UTF8PROC_DEFINES)
+ LDFLAG_SHARED = -shared
+ SOFLAG = -Wl,-soname


### PR DESCRIPTION
#### Description

GCC 4.2 doesn't support `-Wsign-conversion`. Remove it.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.111
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
