### PR TITLE
octave: octave 7.*'s GraphicsMagick configure option changed

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -9,7 +9,7 @@ PortGroup           linear_algebra 1.0
 name                octave
 version             7.1.0
 set package_version 7.x.x
-revision            0
+revision            1
 
 categories          math science
 license             GPL-3+
@@ -610,7 +610,7 @@ if {${configure.cxx_stdlib} eq "libc++"} {
 
 variant graphicsmagick description {use GraphicsMagick for image I/O} conflicts {*}${magickConflict} {
     depends_lib-append port:GraphicsMagick
-    configure.args-replace --without-magick --with-magick=GraphicsMagick
+    configure.args-replace --without-magick --with-magick=GraphicsMagick++
 }
 if {${magickDefault}} {
     default_variants-append +graphicsmagick


### PR DESCRIPTION
From octave 7.* release notes at https://octave.org/NEWS-7.html :
"Octave’s build system no longer appends “++” to the end of the
 “magick++” library name (set with the --with-magick= configure flag).
 The real name of the “magick++” library (including any potentially
 trailing “++”) needs to be set in that option now."

Closes: https://trac.macports.org/ticket/65272

#### Description

fixed configure option by appending "++" as described in octave release notes, see above.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61
  and
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

