### PR TITLE
checkssl: update to 0.4.1

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/szazeski/checkssl 0.4.0 v
+go.setup            github.com/szazeski/checkssl 0.4.1 v
 revision            0
 
 homepage            https://www.checkssl.org
@@ -20,9 +20,9 @@ installs_libs       no
 maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 
-checksums           rmd160  db68c2fdba56764082042f1a1ed905f98a8b1fcb \
-                    sha256  7633a3b1f411275361093776cbe516f1ba4dc59aa148cde62daee0c730a25dbb \
-                    size    9531
+checksums           rmd160  1a004c61ba85d5d08f0666b79015d2285696d3f2 \
+                    sha256  6005abcb016cea724c78028c7500e0f613bda59c1701381377477cebda34e9d6 \
+                    size    9593
 
 destroot {
     set doc_dir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to checkssl 0.4.1.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?