### PR TITLE
py-barnaba: python39 and 310, updated tests

### DIFF
--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -33,7 +33,7 @@ checksums           rmd160  e57a589dbcaf231e992f0e252517e602495443b6 \
                     sha256  217904208a5efb4dbd04d23910fad1ffe201c3dd7607a8adb08b9583bdd08c58 \
                     size    30260069
 
-python.versions     37 38
+python.versions     39 310
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools_scm \
@@ -46,8 +46,6 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-scikit-learn \
                             port:py${python.version}-scipy
 
-    depends_test-append     port:py${python.version}-nose
     test.run                yes
-    test.cmd                nosetests-${python.branch}
-    test.target
+    python.test_framework   nose
 }


### PR DESCRIPTION
#### Description

Since py-mdtraj is now only being installed with py39 and py310 (#15155), I updated py-barnaba ports (which depends on py-mdtraj) accordingly.

I also fixed the test command. Notice that tests are failing now due to a change in mdtraj. It's not impacting users (it's a change in the format of some output files). I will make sure to have an updated barnaba version upstream with the correct tests. Meanwhile, I would ask to merge this pull request so that at least barnaba can be installed on py39 and py310.

Thanks!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? **Innocuous failure, see comment above**
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
