### PR TITLE
muniversal: strip host information when merging

### DIFF
--- a/_resources/port1.0/group/muniversal-1.0.tcl
+++ b/_resources/port1.0/group/muniversal-1.0.tcl
@@ -599,6 +599,11 @@ variant universal {
             reinplace -q {s:-m32::g} ${tempfile1} ${tempfile2}
             reinplace -q {s:-m64::g} ${tempfile1} ${tempfile2}
 
+            # also strip out host information and stray space runs
+            reinplace -q -E {s:--host=[^ ]+::g}     ${tempfile1} ${tempfile2}
+            reinplace -q -E {s:host_alias=[^ ]+::g} ${tempfile1} ${tempfile2}
+            reinplace -q -E {s:  +: :g}             ${tempfile1} ${tempfile2}
+
             if { ! [catch {system "/usr/bin/cmp -s \"${tempfile1}\" \"${tempfile2}\""}] } {
                 # modified files are identical
                 ui_debug "universal: merge: ${fl} differs in ${dir1} and ${dir2} but are the same when stripping out -m32, -m64, and -arch XXX"

--- a/_resources/port1.0/group/muniversal-1.1.tcl
+++ b/_resources/port1.0/group/muniversal-1.1.tcl
@@ -305,6 +305,11 @@ proc muniversal::strip_arch_flags {dir1 dir2 dir fl} {
     reinplace -q {s:-m32::g} ${tempfile1} ${tempfile2}
     reinplace -q {s:-m64::g} ${tempfile1} ${tempfile2}
 
+    # also strip out host information and stray space runs
+    reinplace -q -E {s:--host=[^ ]+::g}     ${tempfile1} ${tempfile2}
+    reinplace -q -E {s:host_alias=[^ ]+::g} ${tempfile1} ${tempfile2}
+    reinplace -q -E {s:  +: :g}             ${tempfile1} ${tempfile2}
+
     if { ! [catch {system "/usr/bin/cmp -s \"${tempfile1}\" \"${tempfile2}\""}] } {
         # modified files are identical
         ui_debug "universal: merge: ${fl} differs in ${dir1} and ${dir2} but are the same when stripping out -m32, -m64, and -arch XXX"

--- a/devel/jemalloc/Portfile
+++ b/devel/jemalloc/Portfile
@@ -31,23 +31,6 @@ configure.universal_args-delete --disable-dependency-tracking
 
 configure.args-append --with-jemalloc-prefix=
 
-post-build {
-    if {[variant_exists universal] && [variant_isset universal]} {
-        set dirs {}
-        foreach arch ${universal_archs_to_use} {
-            lappend dirs ${worksrcpath}-${arch}
-        }
-    } else {
-        set dirs ${worksrcpath}
-    }
-    foreach dir ${dirs} {
-        # Remove architecture-specific differences to allow merging.
-        reinplace -E -q {s| --host=[^ ]+||g}           ${dir}/bin/jemalloc-config
-        reinplace -E -q {s| host_alias=[^ ]+||g}       ${dir}/bin/jemalloc-config
-        reinplace -E -q {s| -arch +[^ ]+||g}           ${dir}/bin/jemalloc-config
-    }
-}
-
 # provide a compatibility symlink with the older name
 post-destroot {
     ln -s jeprof ${destroot}${prefix}/bin/${name}-prof


### PR DESCRIPTION
for consideration? (by the way, needed the leading space in the search pattern otherwise cmp thinks the files differ based on space runs I believe).

host information can vary from build arch to build arch
depending on the native compiler and the cross build

but this host information is not relevant to the config files and
scripts, and requires stripping it out individually in ports to
facilitate merging

so just always try it when merging suitable files

