### PR TITLE
cmake: update to 3.23.2

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -33,10 +33,10 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake 3.22.4 v
-checksums           rmd160  98e98f7ae64237231f0b28a41584cd0b50dcc4f6 \
-                    sha256  1f165a3dd1bb4e60d06272bfa5c453c1b4d33a033f9f8962530d9f61b81c3d65 \
-                    size    7531860
+gitlab.setup        cmake   cmake 3.23.2 v
+checksums           rmd160  00b2b8cf5813ddef5a4688fea436902afc5b9ee9 \
+                    sha256  4c6a3ec013f5c6c3725ba89048d3e2ef4cde335afee91fc9e7a4c6ddb264fbe5 \
+                    size    7653721
 revision            0
 
 gitlab.livecheck.regex {([0-9.]+)}

--- a/devel/cmake/files/patch-cmake-leopard-tiger.diff
+++ b/devel/cmake/files/patch-cmake-leopard-tiger.diff
@@ -1,16 +1,6 @@
---- Source/cmMachO.h
-+++ Source/cmMachO.h
-@@ -6,6 +6,7 @@
-
- #include <iosfwd>
- #include <string>
-+#include <memory>
-
- #if !defined(CMake_USE_MACH_PARSER)
- #  error "This file may be included only if CMake_USE_MACH_PARSER is enabled."
 --- Utilities/cmlibuv/src/unix/core.c
 +++ Utilities/cmlibuv/src/unix/core.c
-@@ -533,10 +533,24 @@
+@@ -537,10 +537,24 @@
   * will unwind the thread when it's in the cancel state. Work around that
   * by making the system call directly. Musl libc is unaffected.
   */
@@ -36,19 +26,17 @@
  #if defined(__LP64__) || TARGET_OS_IPHONE
    extern int close$NOCANCEL(int);
    return close$NOCANCEL(fd);
-@@ -544,7 +558,11 @@
+@@ -548,7 +562,9 @@
    extern int close$NOCANCEL$UNIX2003(int);
    return close$NOCANCEL$UNIX2003(fd);
  #endif
-+
 +#if defined(GCC_DIAGNOSTIC_AVAILABLE)
  #pragma GCC diagnostic pop
 +#endif
-+
- #elif defined(__linux__)
-   return syscall(SYS_close, fd);
- #else
-@@ -1355,8 +1373,12 @@
+ #elif defined(__linux__) && defined(__SANITIZE_THREAD__) && defined(__clang__)
+   long rc;
+   __sanitizer_syscall_pre_close(fd);
+@@ -1365,8 +1381,12 @@
    if (name == NULL)
      return UV_EINVAL;
  
@@ -63,7 +51,7 @@
  }
 --- Utilities/cmlibuv/src/unix/fs.c
 +++ Utilities/cmlibuv/src/unix/fs.c
-@@ -951,7 +951,7 @@
+@@ -1071,7 +1071,7 @@
  
      return -1;
    }
@@ -72,7 +60,7 @@
        defined(__DragonFly__)       || \
        defined(__FreeBSD__)         || \
        defined(__FreeBSD_kernel__)
-@@ -1067,7 +1067,7 @@
+@@ -1184,7 +1184,7 @@
    ts[0] = uv__fs_to_timespec(req->atime);
    ts[1] = uv__fs_to_timespec(req->mtime);
    return utimensat(AT_FDCWD, req->path, ts, AT_SYMLINK_NOFOLLOW);
@@ -81,7 +69,7 @@
        defined(__DragonFly__)      ||                                          \
        defined(__FreeBSD__)        ||                                          \
        defined(__FreeBSD_kernel__) ||                                          \
-@@ -1328,7 +1328,7 @@
+@@ -1438,7 +1438,7 @@
    dst->st_blksize = src->st_blksize;
    dst->st_blocks = src->st_blocks;
  

--- a/devel/cmake/files/patch-qt5gui.diff
+++ b/devel/cmake/files/patch-qt5gui.diff
@@ -53,7 +53,7 @@
  	<key>CFBundleSignature</key>
 --- CMakeLists.txt.orig
 +++ CMakeLists.txt
-@@ -780,13 +780,20 @@
+@@ -795,13 +795,20 @@
      if(APPLE)
        set(CMAKE_BUNDLE_VERSION
          "${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}")


### PR DESCRIPTION
#### Description

With cmake-devel updated to [3.24.0-rc1](https://github.com/macports/macports-ports/commit/551529592370dedb31ec07c02bbe18a470cc9bf7), I think it's time to update cmake to the latest 3.23 release. Doing this PR to make sure CI/QA is happy & to give others a chance to chime in.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6.8 20G715
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
