### PR TITLE
checkssl: update to 0.4.3

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/szazeski/checkssl 0.4.1 v
+go.setup            github.com/szazeski/checkssl 0.4.3 v
 revision            0
 
 homepage            https://www.checkssl.org
@@ -20,9 +20,9 @@ installs_libs       no
 maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 
-checksums           rmd160  1a004c61ba85d5d08f0666b79015d2285696d3f2 \
-                    sha256  6005abcb016cea724c78028c7500e0f613bda59c1701381377477cebda34e9d6 \
-                    size    9593
+checksums           rmd160  00c576877b4459dbb7960f8994615c6a04535af9 \
+                    sha256  e5e5717779b7aa93f5c69b83634a6e335863b42abe61f3a2cdd8a41ea13f61ca \
+                    size    10662
 
 destroot {
     set doc_dir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to checkssl 0.4.3.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?