### PR TITLE
erlang: Fix compile-time crash on 10.6 and earlier

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -118,6 +118,9 @@ platform darwin {
         # also "-framework Appkit"?
         configure.ldflags-append -framework CoreFoundation
     }
+    if {${os.major} <= 10} {
+        patchfiles-append       patch-erts_emulator_sys_unix_sys_time.c.diff
+    }
 }
 
 variant wxwidgets description {Build wxWidgets support} {

--- a/lang/erlang/files/patch-erts_emulator_sys_unix_sys_time.c.diff
+++ b/lang/erlang/files/patch-erts_emulator_sys_unix_sys_time.c.diff
@@ -1,0 +1,24 @@
+Fix a crash on OS X 10.6 and earlier.
+
+Upstream: https://github.com/erlang/otp/pulls/6103
+
+--- erts/emulator/sys/unix/sys_time.c.orig	2022-06-21 07:49:47.000000000 -0400
++++ erts/emulator/sys/unix/sys_time.c	2022-06-21 07:51:00.000000000 -0400
+@@ -219,7 +219,7 @@
+ #endif
+ 
+     init_resp->os_monotonic_time_info.resolution = (Uint64) 1000*1000*1000;
+-#if defined(ERTS_HAVE_MACH_CLOCK_GETRES) && defined(MONOTONIC_CLOCK_ID)
++#if defined(ERTS_HAVE_MACH_CLOCK_GETRES) && defined(OS_MONOTONIC_TIME_USING_MACH_CLOCK_GET_TIME)
+     init_resp->os_monotonic_time_info.resolution
+ 	= mach_clock_getres(&internal_state.r.o.mach.clock.monotonic);
+ #elif defined(HAVE_CLOCK_GETRES) && defined(MONOTONIC_CLOCK_ID)
+@@ -379,7 +379,7 @@
+ 
+     init_resp->os_system_time_info.locked_use = 0;
+     init_resp->os_system_time_info.resolution = (Uint64) 1000*1000*1000;
+-#if defined(ERTS_HAVE_MACH_CLOCK_GETRES) && defined(WALL_CLOCK_ID)
++#if defined(ERTS_HAVE_MACH_CLOCK_GETRES) && defined(OS_SYSTEM_TIME_USING_MACH_CLOCK_GET_TIME)
+     init_resp->os_system_time_info.resolution
+ 	= mach_clock_getres(&internal_state.r.o.mach.clock.wall);
+ #elif defined(HAVE_CLOCK_GETRES) && defined(WALL_CLOCK_ID)


### PR DESCRIPTION
#### Description

See failing build here: https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/105716

Upstream PR: https://github.com/erlang/otp/pull/6103

Apply the patch conditionally so we don't have to rev-bump.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
