### PR TITLE
micronaut: update to 3.5.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.5.1 v
+github.setup    micronaut-projects micronaut-starter 3.5.2 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  3a865600706e77c438083b8f2f1bb1b75bf6655a \
-                sha256  35b68b91067a60959cfd690f36c955a92ac04335173ffb204bc6989822bb4322 \
-                size    21321597
+checksums       rmd160  1aec193470fd54faf969773f8a83d5a74a558c52 \
+                sha256  309d2d41b72b5359f76e2ded1209cd60e1c86a3cd77d7497d616a1ad877ea66a \
+                size    21328323
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.5.2.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?