### PR TITLE
openssl3: Update to 3.0.4, CVE-2022-2068; openssl11: Update to 1.1.1p, CVE-2022-2068; Bump openssl, openssh, freeradius

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            4
+revision            5
 
 categories          devel security
 platforms           darwin

--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -8,7 +8,7 @@ name                openssl[string map {. {}} $short_v]
 
 # The revision of the openssl shim port should be bumped whenever
 # the version or revision is changed here.
-version             ${short_v}.1n
+version             ${short_v}.1p
 revision            0
 
 # Please revbump these ports when updating OpenSSL.
@@ -44,9 +44,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  34bded200174b0fdbec22584688869332130ea0c \
-                    sha256  40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a \
-                    size    9850712
+checksums           rmd160  d888b653de4e1b95b0bfe0596890b15539ec7842 \
+                    sha256  bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f \
+                    size    9860217
 
 platform darwin 8 {
     # No Availability.h on Tiger

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 8
 
 set major_v         3
 name                openssl$major_v
-version             ${major_v}.0.3
+version             ${major_v}.0.4
 revision            0
 
 # Please revbump these ports when updating the openssl3 version/revision
@@ -47,9 +47,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  40979ca9ff4a4dd57fdb579ced7124e66885c954 \
-                    sha256  ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b \
-                    size    15058905
+checksums           rmd160  660872ca2bcc5cf05e7dd61b1124d842e6ee3cb1 \
+                    sha256  2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f \
+                    size    15069605
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             9.0p1
-revision            4
+revision            5
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                7
+revision                8
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
#### Description

See https://www.openssl.org/news/secadv/20220621.txt.

CVE: CVE-2022-2068

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 12.4 21F79 x86_64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
