### PR TITLE
google-cloud-sdk: update to 391.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             390.0.0
-revision            1
+version             391.0.0
+revision            0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  53778b02a89b07d962bf9a1484f5b4f109686dfd \
-                    sha256  753b4a70766fd654900a71789b423d83adca0d5cba8a257bde3f605a4a128c23 \
-                    size    107728072
+    checksums       rmd160  b80ff77e5c3738c3bcd45224d5fc158da00ec0ab \
+                    sha256  9cb10d187a02d95914b99caadc57a7744b7b5c238c0648a1d83a69e02fb9c7d4 \
+                    size    107776757
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d57a023c37a62b4d91c61aac9ee55098060411f4 \
-                    sha256  3174926f64018d88c53e21eab6813595db64a1309483406373d8245a3a9324da \
-                    size    104320492
+    checksums       rmd160  79b1e373286a81d060f054530751f2fb13791c52 \
+                    sha256  98f3519e8746e4cb79e43697b66c92a4c02ee735eda5a6f7b1532fef2dc9fde9 \
+                    size    104526680
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  b9bb2c8ae1d3353785baef3cab22336ee4170abe \
-                    sha256  ca8c8676d16abd28274540e3eb9fdc142a83a52004494b930f0ae1095d0f131d \
-                    size    102898537
+    checksums       rmd160  3f62b01955630f53d742b049b63d1454dafa8638 \
+                    sha256  1c56bee317aad006aceeb27a55b42b16125516e12192d92fffb977d05b77fc32 \
+                    size    103132689
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 391.0.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?