### PR TITLE
apache ant ports: update apache-ant-1.9 to 1.9.16, other fixes

### DIFF
--- a/devel/apache-ant-1.9/Portfile
+++ b/devel/apache-ant-1.9/Portfile
@@ -23,7 +23,7 @@ platforms               darwin freebsd
 
 distname                apache-ant-${version}-bin
 master_sites            apache:ant/
-master_sites.mirror_subdir        binaries
+master_sites.mirror_subdir  binaries
 
 checksums               rmd160  3b8fb74f30e76c35c7320902e861146b5d141c53 \
                         sha256  57ceb0b249708cb28d081a72045657ab067fc4bc4a0d1e4af252496be44c2e66 \
@@ -40,34 +40,28 @@ conflicts               apache-ant
 build {}
 
 pre-destroot {
-        delete \
-                ${worksrcpath}${workTarget}/bin/ant.bat \
-                ${worksrcpath}${workTarget}/bin/ant.cmd \
-                ${worksrcpath}${workTarget}/bin/antRun.bat \
-                ${worksrcpath}${workTarget}/bin/antenv.cmd \
-                ${worksrcpath}${workTarget}/bin/envset.cmd \
-                ${worksrcpath}${workTarget}/bin/lcp.bat \
-                ${worksrcpath}${workTarget}/bin/runrc.cmd
+    delete \
+        ${worksrcpath}${workTarget}/bin/ant.bat \
+        ${worksrcpath}${workTarget}/bin/ant.cmd \
+        ${worksrcpath}${workTarget}/bin/antRun.bat \
+        ${worksrcpath}${workTarget}/bin/antenv.cmd \
+        ${worksrcpath}${workTarget}/bin/envset.cmd \
+        ${worksrcpath}${workTarget}/bin/lcp.bat \
+        ${worksrcpath}${workTarget}/bin/runrc.cmd
 }
 
-destroot        {
-        xinstall -m 755 -d ${destroot}${prefix}/share/java
-        file copy ${worksrcpath}${workTarget} \
-                ${destroot}${prefix}/share/java/apache-ant
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java
+    file copy ${worksrcpath}${workTarget} \
+        ${destroot}${prefix}/share/java/apache-ant
 
-        xinstall -m 755 -d ${destroot}${prefix}/share/doc/apache-ant
-        foreach f {INSTALL
-                   KEYS
-                   LICENSE
-                   NOTICE
-                   README
-                   WHATSNEW
-                   manual} {
-            file rename ${destroot}${prefix}/share/java/apache-ant/${f} \
-                ${destroot}${prefix}/share/doc/apache-ant/${f}
-        }
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/apache-ant
+    foreach f { INSTALL KEYS LICENSE NOTICE README WHATSNEW manual } {
+        file rename ${destroot}${prefix}/share/java/apache-ant/${f} \
+            ${destroot}${prefix}/share/doc/apache-ant/${f}
+    }
 
-        ln -s ../share/java/apache-ant/bin/ant ${destroot}${prefix}/bin/ant
+    ln -s ../share/java/apache-ant/bin/ant ${destroot}${prefix}/bin/ant
 }
 
 universal_variant       no

--- a/devel/apache-ant-1.9/Portfile
+++ b/devel/apache-ant-1.9/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup               java 1.0
 
 name                    apache-ant-1.9
-version                 1.9.15
+version                 1.9.16
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              devel java
 license                 Apache-2 W3C
@@ -24,10 +24,10 @@ platforms               darwin freebsd
 distname                apache-ant-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
-# Remember also to update the checksums in the source variant below.
-checksums               rmd160  c7dd248c6904ef9709e469f63e25002078fdb48a \
-                        sha256  b91eb0c7412f7d4d7c205ea189cf3bfede4bed6a168144b2a222bcbc352edd79 \
-                        size    4495797
+
+checksums               rmd160  3b8fb74f30e76c35c7320902e861146b5d141c53 \
+                        sha256  57ceb0b249708cb28d081a72045657ab067fc4bc4a0d1e4af252496be44c2e66 \
+                        size    4495811
 
 worksrcdir              apache-ant-${version}
 set workTarget          ""
@@ -38,24 +38,6 @@ use_configure           no
 conflicts               apache-ant
 
 build {}
-
-# Ant is installed from the binary (jar) distribution by default. Due to
-# bootstrapping issues, the source variant generally doesn't build a very
-# usable ant: the ant tasks (such as junit) are non-functional as their
-# dependent support isn't available when ant is built, due to circular
-# dependencies back to ant.
-variant source description "build from source; not recommended" {
-        distname                        apache-ant-${version}-src
-        master_sites.mirror_subdir      source
-        checksums                       rmd160  3544e6c47c8a52d610afafc2a5e92b7c4bb3e55c \
-                                        sha256  7f7251009dc53e60afac47d0df6bd7e7d3cdba9fa7fec67b7a95412e8becdc8b \
-                                        size    3956366
-        set workTarget                  /apache-ant
-
-        build.cmd                       ./build.sh
-        build.args                      -Dchmod.fail=false -Ddist.name=apache-ant
-        build.target                    dist
-}
 
 pre-destroot {
         delete \

--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -37,7 +37,9 @@ use_configure           no
 
 conflicts               apache-ant-1.9
 
-build {}
+java.version            1.8+
+
+build.cmd               true
 
 # Ant is installed from the binary (jar) distribution by default. Due to
 # bootstrapping issues, the source variant generally doesn't build a very
@@ -45,7 +47,6 @@ build {}
 # dependent support isn't available when ant is built, due to circular
 # dependencies back to ant.
 variant source description "build from source; not recommended" {
-        java.version                    1.8+
         distname                        ${name}-${version}-src
         master_sites.mirror_subdir      source
         checksums                       rmd160  06edf46db422a55e754acc13c08182d1f3b2ae52 \


### PR DESCRIPTION
#### Description

apache-ant: set `java.version 1.8+` regardless of variant (the binary distribution of ant 1.10 also requires Java 8 or later)

apache-ant-1.9: Drop source variant, due to difficulties building. (Also, building from source isn't beneficial to Java developers anyway.)

Fixes: https://trac.macports.org/ticket/58787

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
