### PR TITLE
pngcheck: update to 3.0.3

### DIFF
--- a/graphics/pngcheck/Portfile
+++ b/graphics/pngcheck/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                pngcheck
-version             3.0.2
+version             3.0.3
 revision            0
 categories          graphics
 license             MIT GPL-2
@@ -21,11 +21,11 @@ long_description    pngcheck verifies the integrity of PNG, JNG and MNG files \
                     embedded text annotations. This is a command-line program \
                     with batch capabilities.
 homepage            http://www.libpng.org/pub/png/apps/pngcheck.html
-master_sites        sourceforge:project/png-mng/pngcheck/${version}
+master_sites        http://www.libpng.org/pub/png/src/
 
-checksums           rmd160  7c9b7b40b73fa930d699e100eacb254d07f0455e \
-                    sha256  0d7e262f24116fddf2847a8ceb5c92d9f5f26efb42e9fff63ec2bb7676131ca7 \
-                    size    63202
+checksums           rmd160  c772a7e562c471c25a6150f857cddd89d8053f20 \
+                    sha256  c36a4491634af751f7798ea421321642f9590faa032eccb0dd5fb4533609dee6 \
+                    size    63766
 
 depends_lib         port:zlib
 


### PR DESCRIPTION
#### Description
From changelog:
```
 * 20210416 BB:  fixed a divide-by-zero crash bug (and probable vulnerability)
 *               in interlaced images with extra compressed data beyond the
 *               nominal end of the image data (found by "chiba of topsec alpha
 *               lab")
 * 20210425 GRR: released version 3.0.3
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H1922 x86_64
Command Line Tools 12.4.0.0.1.1610135815

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
