### PR TITLE
libdvdread: update to 6.1.3

### DIFF
--- a/devel/libdvdread/Portfile
+++ b/devel/libdvdread/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            libdvdread
-version         6.1.2
+version         6.1.3
 revision        0
 categories      devel multimedia
 platforms       darwin
@@ -28,9 +28,9 @@ master_sites        https://download.videolan.org/pub/videolan/${name}/${version
 
 use_bzip2           yes
 
-checksums           rmd160  4750acb03431915ce1534110b1705b874e0838de \
-                    sha256  cc190f553758ced7571859e301f802cb4821f164d02bfacfd320c14a4e0da763 \
-                    size    391536
+checksums           rmd160  218d1bffe35f800d114be6e0c06dd6429d32be19 \
+                    sha256  ce35454997a208cbe50e91232f0e73fb1ac3471965813a13b8730a8f18a15369 \
+                    size    395439
 
 depends_lib     port:libdvdcss
 
@@ -39,8 +39,7 @@ post-patch {
     reinplace -locale C "s|@@PREFIX@@|${prefix}|" ${worksrcpath}/src/dvd_input.c
 }
 
-# src/ifo_read.c:56: error: ‘for’ loop initial declaration used outside C99 mode
-configure.cflags-append -std=c99
+compiler.c_standard 1999
 
 configure.args-append   --disable-silent-rules
 


### PR DESCRIPTION
Upstream uses `AC_PROG_CC_C99` as of 6.1.2: drop `configure.c_flags-append -std=c99`, set `compiler.c_standard 1999` instead

#### Description
From NEWS:
```
 * Fix crashes on some DVD (0 PCGI SRP)
 * Misc source fixes and cleanups, including fixes for recent toolchains
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H1922 x86_64
Command Line Tools 12.4.0.0.1.1610135815

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
