### PR TITLE
gcc-devel: fix --with-darwin-extra-rpath

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -34,14 +34,12 @@ if {${os.arch} eq "arm"} {
 
     # Version must follow same scheme as with GCC snapshots below <version>-<commit-date>
     version         12-20220615
-    revision        0
+    revision        1
     subport         libgcc-devel { revision 0 }
 
     checksums       rmd160  49d5ea553c6a8e38eec8f2c4c3ce0706bd971cf8 \
                     sha256  bcf82d6120b3be42fbdae7f31da0c653c3a8f55a4b686516f9793ccd6753a10a \
                     size    131005938
-
-    configure.args-append --with-darwin-extra-rpath=${prefix}/lib/libgcc
 
 } else {
     # Use regular GCC releases and snapshsots
@@ -146,6 +144,10 @@ configure.args      --enable-languages=[join ${gcc_configure_langs} ","] \
                     --with-ar=${prefix}/bin/ar \
                     --with-bugurl=https://trac.macports.org/newticket \
                     --enable-host-shared
+
+if {${os.arch} eq "arm"} {
+    configure.args-append --with-darwin-extra-rpath=${prefix}/lib/libgcc
+}
 
 if { ${os.major} < 15 } {
     # see https://lists.macports.org/pipermail/macports-dev/2017-August/036209.html


### PR DESCRIPTION
https://github.com/macports/macports-ports/commit/5dd9d9b0db023bcdfe2d7751976636b72cd56af4#commitcomment-76812505

#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@kencu

```
mark@arm-and-hammer zsh% gcc-mp-devel --version
gcc-mp-devel (MacPorts gcc-devel 12-20220615_1+enable_stdlib_flag) 12.1.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

mark@arm-and-hammer zsh% gcc-mp-devel -v -x c - <<< 'int main(int argc, char *argv[]) { return 0; }'
Using built-in specs.
COLLECT_GCC=gcc-mp-devel
COLLECT_LTO_WRAPPER=/opt/local/libexec/gcc/aarch64-apple-darwin21/12.1.0/lto-wrapper
Target: aarch64-apple-darwin21
Configured with: /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_gcc-devel/gcc-devel/work/gcc-12-branch-a613c586b5461d7fb99fa076ef7e59eca4227fae/configure --prefix=/opt/local --build=aarch64-apple-darwin21 --enable-languages=c,c++,objc,obj-c++,lto,fortran,jit --libdir=/opt/local/lib/gcc-devel --includedir=/opt/local/include/gcc-devel --infodir=/opt/local/share/info --mandir=/opt/local/share/man --datarootdir=/opt/local/share/gcc-devel --with-local-prefix=/opt/local --with-system-zlib --disable-nls --program-suffix=-mp-devel --with-gxx-include-dir=/opt/local/include/gcc-devel/c++/ --with-gmp=/opt/local --with-mpfr=/opt/local --with-mpc=/opt/local --with-isl=/opt/local --with-zstd=/opt/local --enable-stage1-checking --disable-multilib --enable-lto --enable-libstdcxx-time --with-build-config=bootstrap-debug --with-as=/opt/local/bin/as --with-ld=/opt/local/bin/ld --with-ar=/opt/local/bin/ar --with-bugurl=https://trac.macports.org/newticket --enable-host-shared --with-darwin-extra-rpath=/opt/local/lib/libgcc --with-gxx-libcxx-include-dir=/opt/local/libexec/llvm-13/include/c++/v1 --with-pkgversion='MacPorts gcc-devel 12-20220615_1+enable_stdlib_flag' --with-sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.1.0 (MacPorts gcc-devel 12-20220615_1+enable_stdlib_flag) 
COLLECT_GCC_OPTIONS='-v' '-mmacosx-version-min=12.0.0' '-asm_macosx_version_min=12.0' '-nodefaultexport' '-mlittle-endian' '-mabi=lp64' '-dumpdir' 'a-'
 /opt/local/libexec/gcc/aarch64-apple-darwin21/12.1.0/cc1 -quiet -v -D__DYNAMIC__ - -fPIC -quiet -dumpdir a- -dumpbase - -mmacosx-version-min=12.0.0 -mlittle-endian -mabi=lp64 -version -o /var/folders/mf/9pchv2l11tjgvvxs6n0sxnyc0000gp/T//ccdDXgqa.s
GNU C17 (MacPorts gcc-devel 12-20220615_1+enable_stdlib_flag) version 12.1.0 (aarch64-apple-darwin21)
	compiled by GNU C version 12.1.0, GMP version 6.2.1, MPFR version 4.1.0, MPC version 1.2.1, isl version isl-0.24-GMP

GGC heuristics: --param ggc-min-expand=100 --param ggc-min-heapsize=131072
ignoring nonexistent directory "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/opt/local/include"
ignoring nonexistent directory "/opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0/../../../../../aarch64-apple-darwin21/include"
ignoring nonexistent directory "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/Library/Frameworks"
#include "..." search starts here:
#include <...> search starts here:
 /opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0/include
 /opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0/include-fixed
 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks
End of search list.
GNU C17 (MacPorts gcc-devel 12-20220615_1+enable_stdlib_flag) version 12.1.0 (aarch64-apple-darwin21)
	compiled by GNU C version 12.1.0, GMP version 6.2.1, MPFR version 4.1.0, MPC version 1.2.1, isl version isl-0.24-GMP

GGC heuristics: --param ggc-min-expand=100 --param ggc-min-heapsize=131072
Compiler executable checksum: 65de37009ec59d9207756b588f37a225
COLLECT_GCC_OPTIONS='-v' '-mmacosx-version-min=12.0.0'  '-nodefaultexport' '-mlittle-endian' '-mabi=lp64' '-dumpdir' 'a-'
 /opt/local/bin/as -arch arm64 -v -mmacosx-version-min=12.0 -o /var/folders/mf/9pchv2l11tjgvvxs6n0sxnyc0000gp/T//cc7y6HrU.o /var/folders/mf/9pchv2l11tjgvvxs6n0sxnyc0000gp/T//ccdDXgqa.s
Apple clang version 13.1.6 (clang-1316.0.21.2.5)
Target: arm64-apple-darwin21.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" -cc1as -triple arm64-apple-macosx12.0.0 -filetype obj -main-file-name ccdDXgqa.s -target-cpu apple-m1 -target-feature +v8.5a -target-feature +fp-armv8 -target-feature +neon -target-feature +crc -target-feature +crypto -target-feature +dotprod -target-feature +fp16fml -target-feature +ras -target-feature +lse -target-feature +rdm -target-feature +rcpc -target-feature +zcm -target-feature +zcz -target-feature +fullfp16 -target-feature +sm4 -target-feature +sha3 -target-feature +sha2 -target-feature +aes -fdebug-compilation-dir=… -dwarf-debug-producer "Apple clang version 13.1.6 (clang-1316.0.21.2.5)" -dwarf-version=4 -mrelocation-model pic --mrelax-relocations -mllvm -disable-aligned-alloc-awareness=1 -o /var/folders/mf/9pchv2l11tjgvvxs6n0sxnyc0000gp/T//cc7y6HrU.o /var/folders/mf/9pchv2l11tjgvvxs6n0sxnyc0000gp/T//ccdDXgqa.s
COMPILER_PATH=/opt/local/libexec/gcc/aarch64-apple-darwin21/12.1.0/:/opt/local/libexec/gcc/aarch64-apple-darwin21/12.1.0/:/opt/local/libexec/gcc/aarch64-apple-darwin21/:/opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0/:/opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/
LIBRARY_PATH=/opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0/:/opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0/../../../
COLLECT_GCC_OPTIONS='-v' '-mmacosx-version-min=12.0.0'  '-nodefaultexport' '-mlittle-endian' '-mabi=lp64' '-dumpdir' 'a.'
 /opt/local/libexec/gcc/aarch64-apple-darwin21/12.1.0/collect2 -syslibroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/ -dynamic -arch arm64 -macosx_version_min 12.0.0 -o a.out -L/opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0 -L/opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0/../../.. /var/folders/mf/9pchv2l11tjgvvxs6n0sxnyc0000gp/T//cc7y6HrU.o -lemutls_w -lgcc -lSystem -lgcc -no_compact_unwind -rpath /opt/local/lib/libgcc -rpath @loader_path -rpath /opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0 -rpath /opt/local/lib/gcc-devel
mark@arm-and-hammer zsh% otool -l a.out | grep -A 2 -B 1 LC_RPATH
Load command 13
          cmd LC_RPATH
      cmdsize 40
         path /opt/local/lib/libgcc (offset 12)
Load command 14
          cmd LC_RPATH
      cmdsize 32
         path @loader_path (offset 12)
Load command 15
          cmd LC_RPATH
      cmdsize 72
         path /opt/local/lib/gcc-devel/gcc/aarch64-apple-darwin21/12.1.0 (offset 12)
Load command 16
          cmd LC_RPATH
      cmdsize 40
         path /opt/local/lib/gcc-devel (offset 12)
```

This shows:

1. `gcc-devel` was configured with `--with-darwin-extra-rpath=/opt/local/lib/libgcc`.
2. `ld` (via `collect2`) was invoked with an extra `-rpath /opt/local/lib/libgcc` argument.
3. `otool -l` verifies the presence of an `LC_RPATH` entry naming `/opt/local/lib/libgcc`.