### PR TITLE
vtk: drop qt4 variant, set GitHub handle for comaintainer

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -22,7 +22,7 @@ license             BSD
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
-maintainers         {stromnov @stromnov} {rubendibattista gmail.com:rubendibattista} openmaintainer
+maintainers         {stromnov @stromnov} {@rdbisme gmail.com:rubendibattista} openmaintainer
 
 description         Visualization Toolkit (VTK)
 

--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -96,15 +96,6 @@ variant ffmpeg description {Add support for ffmpeg} {
         -DModule_vtkIOFFMPEG:BOOL=ON
 }
 
-# As proposed at #46853
-variant qt4 description {Add Qt4 support.} {
-    PortGroup           qt4 1.0
-
-    configure.args-append \
-                        -DQT_QMAKE_EXECUTABLE:PATH=${qt_qmake_cmd} \
-                        -DVTK_Group_Qt:BOOL=ON
-}
-
 variant qt5 description {Add Qt5 support.} {
     PortGroup           qt5 1.0
 


### PR DESCRIPTION
VTK 8.2.0 removed support for Qt4: https://gitlab.kitware.com/vtk/vtk/-/commit/0b27fbc216d9997e3a074ad02b6634d33758eddc

Closes: https://trac.macports.org/ticket/46853
Closes: https://trac.macports.org/ticket/53444 (newer VTK will support Qt6—I leave it to whoever adds a qt6 variant to avoid a similar conflict with the qt5 variant)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### ~~Tested on~~
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Only `port info` is tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
