### PR TITLE
skaffold: update to 1.39.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.38.0 v
+github.setup        GoogleContainerTools skaffold 1.39.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  3d8c15e5d8d81926799fcf1cb2e65f68dd5ef977 \
-                    sha256  42f8f8a6f8f55f8031c87de3c3d35334f2e1f71c2a2120d3cc1a15f8ed71ba31 \
-                    size    21311034
+checksums           rmd160  bac44dbe914c860f4e721e2342a84f0d395565c3 \
+                    sha256  f285e554257c914c5ab247a0a1a2e28e66926c6cda8959365869328b2af61c51 \
+                    size    21358050
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 1.39.1.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?