### PR TITLE
vcsn: set obsolete

### DIFF
--- a/devel/vcsn/Portfile
+++ b/devel/vcsn/Portfile
@@ -1,54 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+# Can be removed after 2023-06-24
 PortSystem          1.0
-PortGroup           active_variants 1.1
+PortGroup           obsolete 1.0
 
 name                vcsn
 version             2.8
+revision            1
+
 categories          devel
 platforms           darwin
-maintainers         {lrde.epita.fr:akim @akimd} openmaintainer
 license             GPL-3+
-
 description         C++ generic automata/transducers and rational expression platform
-
 long_description    Vcsn is a platform for weighted automata and rational expressions. \
                     It consists of an efficient C++ generic library, shell tools, Python \
                     bindings, and a graphical interactive environment on top of IPython.
-
 homepage            http://vcsn.lrde.epita.fr
-master_sites        http://www.lrde.epita.fr/dload/vcsn/${version}/
-
-use_xz              yes
-
-checksums           rmd160  bfa67e399a25473a2c449905c19464f4167dc2cf \
-                    sha256  1fe0afa7a52d211143ef0f15632b777d1137706d66a2accb004447c33b53d1c2 \
-                    size    14837372
-
-compiler.cxx_standard 2011
-
-# python3.x is required - force dependencies to use it as well
-set python_branch   3.6
-set python_version  [join [split ${python_branch} "."] ""]
-
-depends_build-append    path:bin/doxygen:doxygen \
-                        port:flex \
-                        port:libtool
-
-depends_lib-append  port:boost \
-                    path:bin/ccache:ccache \
-                    port:gmp \
-                    port:python${python_version} \
-                    port:yaml-cpp
-
-depends_run         path:bin/dot:graphviz \
-                    port:py${python_version}-ipython
-
-require_active_variants boost python${python_version}
-
-configure.args      --disable-silent-rules
-configure.optflags  -O3 -DNDEBUG
-configure.python    ${prefix}/bin/python${python_branch}
-
-test.run            yes
-test.target         check


### PR DESCRIPTION
Vcsn is no longer maintained

See https://trac.macports.org/ticket/65320#comment:3

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
