### PR TITLE
volk: try to tweak compilers to enforce actual c++17 std::filesystem …

### DIFF
--- a/science/volk/Portfile
+++ b/science/volk/Portfile
@@ -9,15 +9,16 @@ PortGroup           boost 1.0
 
 compiler.c_standard   2011
 compiler.cxx_standard 2017
-
-# some older Clang say they support SIMD when they don't
-compiler.blacklist-append {clang < 900}
+# requires working std::filesystem, above is not enough :(
+compiler.blacklist-append {clang < 1100} {macports-clang-[4-9].0} {macports-gcc-[3-7]}
 
 name                volk
 categories          science comms
 maintainers         {michaelld @michaelld}
 description         Vector-Optimized Library of Kernels
 long_description    VOLK is the Vector-Optimized Library of Kernels, a library that contains kernels of hand-written single-instruction multiple data (SIMD) code for different mathematical operations, providing portable SIMD code that is optimized for a variety of platforms.
+long_description {*}${long_description} ${subport} \
+    provides the release version, which is typically updated every month or so.
 license             GPL-3
 platforms           darwin
 homepage            https://libvolk.org/
@@ -27,8 +28,6 @@ revision            0
 
 # bump the epoch because I moved the version from 20150707 to 1.0.1
 epoch 1
-long_description {*}${long_description} ${subport} \
-    provides the release version, which is typically updated every month or so.
 
 # Volk requires the submodule "cpu_features" as found here: <
 # https://github.com/google/cpu_features >.  Because we're not


### PR DESCRIPTION
#### Description

volk: try to tweak compilers to enforce actual c++17 std::filesystem support

This is currently a test PR to see how QA/CI responds to the tweaks. Once we determine the correct settings, maybe try to move them into the compilers PG?

Closes: https://trac.macports.org/ticket/65377

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6.8 20G715
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
