### PR TITLE
privoxy: Bugfix presence of existing trustedCAs.pem file

### DIFF
--- a/www/privoxy/Portfile
+++ b/www/privoxy/Portfile
@@ -610,6 +610,13 @@ subport ${name}-pki-bundle {
     destroot.keepdirs-append \
                     ${destroot}${privoxy_ca_dir}
 
+    # Please remove this pre-activate block after 2023-07-01; see https://trac.macports.org/ticket/65367
+    pre-activate {
+        if {[file exists ${privoxy_ca_dir}/trustedCAs.pem]} {
+            delete  ${privoxy_ca_dir}/trustedCAs.pem
+        }
+    }
+
     variant user_pki_bundle \
         description "Add user PKI certificates from ${user_pki_bundle}" {
         notes "User PKI certificates will be added from the file\


### PR DESCRIPTION
# privoxy: Bugfix presence of existing trustedCAs.pem file

* Fixes: https://trac.macports.org/ticket/65367

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
