### PR TITLE
wezterm: update to 20220624-141144-bd1b7c5d

### DIFF
--- a/aqua/wezterm/Portfile
+++ b/aqua/wezterm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        wez wezterm 20220408-101518-b908e2dd
+github.setup        wez wezterm 20220624-141144-bd1b7c5d
 revision            0
 
 homepage            https://wezfurlong.org/wezterm


### PR DESCRIPTION
#### Description

Update Wezterm to version 20220624-141144-bd1b7c5d

###### Tested on

macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
