### PR TITLE
64tass: Add new port

### DIFF
--- a/devel/64tass/Portfile
+++ b/devel/64tass/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+
+name                64tass
+version             1.56.2625
+categories          devel
+maintainers         {patater.com:jaeden @Patater} \
+                    openmaintainer
+license             GPL-2+ LGPL-2.0+ LGPL-2.1+ MIT
+description         A multi pass optimizing macro assembler for the 65xx series of processors
+
+long_description \
+    64tass, sometimes also known as tass64, is a multi-pass optimizing macro \
+    assembler for the 65xx series of processors written in portable C. tass64 \
+    is syntax compatible with the independent, though similarly named, native \
+    Commodore 64 assembler TurboAssembler by Omicron.
+
+homepage            http://tass64.sourceforge.net/
+master_sites        sourceforge:tass64
+checksums           rmd160  6057e0d12541545a0966e82c9907d277ebf81d26 \
+                    sha256  c4e570c717c9500f3af61a3ad5d536f22415e2b29ed1eb09b1a955d310c9f3d3 \
+                    size    724673
+
+use_zip             yes
+distname            ${name}-${version}-src
+
+makefile.prefix_name prefix
+makefile.override-append PREFIX
+
+livecheck.regex     /${name}-(\[0-9.\]+)-src${extract.suffix}

--- a/devel/64tass/Portfile
+++ b/devel/64tass/Portfile
@@ -29,4 +29,17 @@ distname            ${name}-${version}-src
 makefile.prefix_name prefix
 makefile.override-append PREFIX
 
+# Install docs and syntax files not installed by the Makefile
+post-destroot {
+    set docdir ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} \
+        NEWS \
+        README \
+        ${docdir}
+
+    set sharedir ${destroot}${prefix}/share/${name}
+    xinstall -d ${sharedir}
+    file copy ${worksrcpath}/syntax ${sharedir}/syntax
+}
+
 livecheck.regex     /${name}-(\[0-9.\]+)-src${extract.suffix}


### PR DESCRIPTION
#### Description

Add 64tass, a multi pass optimizing macro assembler for the 65xx series of processors.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
