### PR TITLE
Macfuse: Update to version 4.4.0

### DIFF
--- a/fuse/macfuse/Portfile
+++ b/fuse/macfuse/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        osxfuse osxfuse 4.3.1 macfuse-
-revision            1
+github.setup        osxfuse osxfuse 4.4.0 macfuse-
+revision            0
 name                macfuse
 conflicts           osxfuse
 categories          fuse
@@ -24,9 +24,9 @@ github.tarball_from releases
 distname            ${name}-${version}
 use_dmg             yes
 
-checksums           rmd160  9d492d3a0c5bc92b0be669c4ba684e53b7b88f32 \
-                    sha256  407fb884b57cd2c1437af250ff215d9a5bd80764b489f6389382302e5a00c5eb \
-                    size    5983952
+checksums           rmd160  918121178d831e006b54777993325d7780da2a1e \
+                    sha256  db347d5a57d32d8556e82386eea9ef155fd877890eb3db547e49bb137d976a43 \
+                    size    5981823
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     known_fail yes


### PR DESCRIPTION
#### Description

See: https://github.com/osxfuse/osxfuse/releases/tag/macfuse-4.4.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
