### PR TITLE
Update gopass integrations to 1.14.3

### DIFF
--- a/security/git-credential-gopass/Portfile
+++ b/security/git-credential-gopass/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/git-credential-gopass 1.12.0 v
+go.setup            github.com/gopasspw/git-credential-gopass 1.14.3 v
 revision            0
 categories          security
-maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 license             MIT
 
 description         Gopass git-credentials helper
@@ -14,9 +14,9 @@ long_description    {*}${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  117b89d3a0bb43dcc70fbe14aa610fa4dc33595d \
-                        sha256  8472cee3edec111267f5cff3cbae5497b12e995512df34b92738450b4f41db87 \
-                        size    15564
+                        rmd160  51a6d47b28ab74e39de989c384093bd520c99795 \
+                        sha256  ea978d9be62a87653dc0deeeeea29a004882f6bba89d3f96b46310f1182f1c25 \
+                        size    16704
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -25,90 +25,82 @@ go.vendors          gotest.tools \
                         sha256  9b17efa7751a66942c72f54e62716574bc34561bdcdaf8337bea3612e85a7025 \
                         size    61955 \
                     gopkg.in/yaml.v3 \
-                        lock    eeeca48fe776 \
-                        rmd160  fa7f02bf2d79fd300b4db2107596674b41479412 \
-                        sha256  33580a955d8c31b781de66dbc7a3c9940ab842a39eb3eb92e696a82307f7d570 \
-                        size    88775 \
-                    gopkg.in/yaml.v2 \
-                        lock    v2.3.0 \
-                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
-                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
-                        size    72838 \
-                    gopkg.in/ini.v1 \
-                        lock    v1.60.1 \
-                        rmd160  aea42f00ec6f7c0bdc0cda906257b0b7aba80a37 \
-                        sha256  3db6855d923d5719ddfaa7a3f1a8910723f8bd943692205c045509e797bda82f \
-                        size    49265 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
                     gopkg.in/check.v1 \
-                        lock    8fa46927fb4f \
-                        rmd160  c84f37dc900224c5e9e6e16ed5acc0d625583bc1 \
-                        sha256  c41439b343f3fc3c0b6f943b4aae642f10f19451e945c23dfb324c9c8f87d0b7 \
-                        size    31616 \
-                    golang.org/x/xerrors \
-                        lock    5ec99f83aff1 \
-                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
-                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
-                        size    13667 \
-                    golang.org/x/text \
-                        lock    v0.3.3 \
-                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
-                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
-                        size    7745597 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
+                    golang.org/x/term \
+                        lock    065cf7ba2467 \
+                        rmd160  95091f7614b24ca8ac93c8ea13e65ae54b45a366 \
+                        sha256  6c9130ff4c06205225c64668521b77b93658b384014df1e635f30d17633ec30f \
+                        size    14981 \
                     golang.org/x/sys \
-                        lock    9f70ab9862d5 \
-                        rmd160  7617740f8a6e112a8eb48837273e353f05556026 \
-                        sha256  da1087deb2a30316f657b6792ccbb5881ccf88f0982205a941a3e6a36c44b617 \
-                        size    1072256 \
-                    golang.org/x/net \
-                        lock    f5854403a974 \
-                        rmd160  cfaf8471269327bcdce1142b44ded72a4584ddf9 \
-                        sha256  a1fcb7946757072ba7453de05fa82e9b977318307a88082c5e4b24057885babb \
-                        size    1178342 \
+                        lock    175b2fd9d664 \
+                        rmd160  babb07e01c60fc729853fc06b19e23a176ef4756 \
+                        sha256  02c9a4f95009a49ed23ba2fb9026aac4b7c6713d6e52282515cfbaddd96056fa \
+                        size    1305845 \
+                    golang.org/x/exp \
+                        lock    b0d781184e0d \
+                        rmd160  228a7cd5c3f0d388d5badded570beee09db60c70 \
+                        sha256  e4d4f78921ce99106a52675d75497f76468895bf227d17e3a4e47f78d361aa17 \
+                        size    1556422 \
                     golang.org/x/crypto \
-                        lock    afb6bcd081ae \
-                        rmd160  2a2fa932dfa1539a791ca41226d24f032134d57a \
-                        sha256  1b923ba81aeed05b2ba90627bccc8297a9914c1d708599f1dd3003b843f64115 \
-                        size    1732317 \
+                        lock    05595931fe9d \
+                        rmd160  44b3bff302fe3a679525f5976c210588402572e1 \
+                        sha256  8d3cffb4319b5f3cf4c06199fd0340ee57a49012c2d523a876c8b88c208e4043 \
+                        size    1631395 \
+                    go.uber.org/multierr \
+                        repo    github.com/uber-go/multierr \
+                        lock    v1.8.0 \
+                        rmd160  b09e4eae9a41c2b84204346c264e0749998272f5 \
+                        sha256  b172f7c7e805cfd8e7ec423e19e4ed47fab099fb9ff42b0910876098f557f8ee \
+                        size    15600 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.9.0 \
+                        rmd160  7705959c7053aa8e405560f5ffef3fbca414ee69 \
+                        sha256  8baccde94a6ecaea185ef40b9bdecbd3dd8d8df7cbc50c89856b58c5cd897e40 \
+                        size    21353 \
+                    github.com/xrash/smetrics \
+                        lock    039620a65673 \
+                        rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
+                        sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
+                        size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.3.0 \
-                        rmd160  fec9e73bc45d02b2afe43e8d9c76398722494e4b \
-                        sha256  3138857026c9564559b3e734b9b8abfeda57354fc4aa87717879882bff68ef09 \
-                        size    3408338 \
+                        lock    v2.10.3 \
+                        rmd160  c28d3228d49f0446ccde697a5b9b4d233e60b79b \
+                        sha256  160c91ae1e2cd109ff43be7539959c0f74e9daf9f5dccbe45e96c7518b7f40b4 \
+                        size    3457370 \
+                    github.com/twpayne/go-pinentry \
+                        lock    v0.2.0 \
+                        rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
+                        sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
+                        size    11986 \
                     github.com/stretchr/testify \
-                        lock    v1.6.1 \
-                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
-                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
-                        size    84248 \
-                    github.com/smartystreets/goconvey \
-                        lock    v1.6.4 \
-                        rmd160  a3dfad6131b94d809efad84d30ce45828c6da756 \
-                        sha256  a03963296bb6d031934a651c1e637e8ab2ce9604ce6a16c158ff551e44e7ba79 \
-                        size    1478824 \
-                    github.com/smartystreets/assertions \
-                        lock    v1.0.0 \
-                        rmd160  8fedd5565a5283a7708236397595879588dc9787 \
-                        sha256  0d65770741aba0134c82bdc4a8a7192ca2e17b4f0ea6d9785b811a1c97c8c06f \
-                        size    84426 \
-                    github.com/shurcooL/sanitized_anchor_name \
-                        lock    v1.0.0 \
-                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
-                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
-                        size    2144 \
-                    github.com/sergi/go-diff \
-                        lock    v1.1.0 \
-                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
-                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
-                        size    43569 \
+                        lock    v1.7.4 \
+                        rmd160  ead1da73ad69fb87be0d40619888ecf9650d3438 \
+                        sha256  cf31480faa1c3c0dbfa44395257108884a107f5225f1cd6b8d91e23e5564dccc \
+                        size    94328 \
                     github.com/russross/blackfriday \
-                        lock    v2.0.1 \
-                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
-                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
-                        size    79665 \
-                    github.com/rs/xid \
-                        lock    v1.2.1 \
-                        rmd160  2cff9628752a94fc62ab0e83436c61df7195eed1 \
-                        sha256  38881e009bacdbf91f6e586207b346eb9ec93f06335331c07a5e0b2ad41ee3f6 \
-                        size    9555 \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
+                    github.com/rs/zerolog \
+                        lock    v1.27.0 \
+                        rmd160  434d8ba6beae7657617c2116cb48a358b9cd03ed \
+                        sha256  bae5e650804d95ae57b5729483fc81b30f9deb188474d8598b08c3d0ad5f2a49 \
+                        size    165154 \
+                    github.com/rogpeppe/go-internal \
+                        lock    86f73c517451 \
+                        rmd160  12ae7289b3b9f3f0339d1ffe90bfefdd28944914 \
+                        sha256  243fd03669a7f2563d066de31a537dc3e99fb3180fcf36f1b492f84e3c8dbd76 \
+                        size    131803 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -119,157 +111,133 @@ go.vendors          gotest.tools \
                         rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
-                    github.com/niemeyer/pretty \
-                        lock    a10e7caefd8e \
-                        rmd160  46bcfc3db9e3d98acbacd1f96d9483fa360f88b7 \
-                        sha256  97b952a32175ba84349ef352e523bfa15bf3a06e07e44458a908061fbc519b40 \
-                        size    9405 \
-                    github.com/modern-go/reflect2 \
-                        lock    v1.0.1 \
-                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
-                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
-                        size    14407 \
-                    github.com/modern-go/concurrent \
-                        lock    bacd9c7ef1dd \
-                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
-                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
-                        size    7533 \
+                    github.com/nbutton23/zxcvbn-go \
+                        lock    fa2cb2858354 \
+                        rmd160  17c2ab9843836ee904acced65d6d22f13a4b614c \
+                        sha256  5f33a658c9daf086423450a9ad27297f7589ce58c1e4ddff3bb623ef8da276ae \
+                        size    881860 \
                     github.com/mitchellh/go-homedir \
                         lock    v1.1.0 \
                         rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
                         sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
                         size    3366 \
-                    github.com/minio/sha256-simd \
-                        lock    v0.1.1 \
-                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
-                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
-                        size    65042 \
-                    github.com/minio/minio-go \
-                        lock    v7.0.7 \
-                        rmd160  f7269c3b9de8bf8a2545cb947ff1edc9631b5f19 \
-                        sha256  d23d5ee4dcbec90b8797afee393283558fb81cb7f35bd228003219cad19ff0ec \
-                        size    236183 \
-                    github.com/minio/md5-simd \
-                        lock    v1.1.0 \
-                        rmd160  7929f1dc43d777a143a826c47948490d8ed121e0 \
-                        sha256  49d89141ce43f38098b264acf3b3d9341d553a1f82816485f1c036e18deb2b58 \
-                        size    99242 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
+                        lock    v0.0.14 \
+                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
+                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
+                        size    4705 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.7 \
-                        rmd160  47f774c77efaa0bbcd982cb65bed426d047780ba \
-                        sha256  68de4e31d97da97efc400096c599ea37c6cf1cb91501004f05a1017f4653f926 \
-                        size    9570 \
+                        lock    v0.1.12 \
+                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
+                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
+                        size    9805 \
                     github.com/kr/text \
                         lock    v0.2.0 \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
                         sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
                         size    8702 \
-                    github.com/klauspost/cpuid \
-                        lock    v1.3.1 \
-                        rmd160  0c161f6a90600c80e908141c2a81130ba703307e \
-                        sha256  8db60afc9f494af07150fff47e676377588d36fb5ee3cc181ec59ff35c238c79 \
-                        size    367163 \
-                    github.com/jtolds/gls \
-                        lock    v4.20.0 \
-                        rmd160  31d8656bd6c1426338ceaac9535198244248b254 \
-                        sha256  04069406ca336d355eab62b4ab9e84b820ac968ac1e20bd3777efec2d3843446 \
-                        size    7305 \
-                    github.com/json-iterator/go \
-                        lock    v1.1.10 \
-                        rmd160  963a70cf0a7d056f6b00fb2224687895612a35e2 \
-                        sha256  e82947d6f32c1cf730c796409eabc8051c208c2eafabe793d196d448529a7f0f \
-                        size    83377 \
+                    github.com/kr/pretty \
+                        lock    v0.3.0 \
+                        rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
+                        sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
+                        size    10043 \
                     github.com/hashicorp/golang-lru \
                         lock    v0.5.4 \
                         rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
                         sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
                         size    13435 \
                     github.com/hashicorp/go-multierror \
-                        lock    v1.1.0 \
-                        rmd160  868d9a6f0732cba1b2dfbb73556b6a194c797c03 \
-                        sha256  9bd88c4f96aa4c4dcca5c0124e48f540c59754586653924b5e4b7de3af0f8c4a \
-                        size    12091 \
-                    github.com/hashicorp/errwrap \
-                        lock    v1.0.0 \
-                        rmd160  d9bf75f667d7bec9b4b11ca34de7ca722495b914 \
-                        sha256  49e80cf52f294ce69fcc8cd26f06b8d8cee2623f6e0012df871b355fb7b17787 \
-                        size    8351 \
-                    github.com/gopherjs/gopherjs \
-                        lock    0766667cb4d1 \
-                        rmd160  fe92e39110b5c188dcce98abb3b9aa1b64d68f94 \
-                        sha256  abe56698d0855027a1f6030a44924895d781b19526aa8f9b3ef49ed4199f7c57 \
-                        size    217261 \
-                    github.com/gopasspw/gopass \
-                        lock    ddfe7bfc979f \
-                        rmd160  02b1a9037c034fa114eedc39c0ff7da7ce43f9e7 \
-                        sha256  e2806614c1b7e87b6e7d47d014f4227417c448d35368fb40db97176a3bd23697 \
-                        size    489358 \
-                    github.com/google/uuid \
                         lock    v1.1.1 \
-                        rmd160  69112e9735ecc1d5360a3cc31531f8be661a007f \
-                        sha256  70be7dec37826f2cbe13acfe534ce74cbb2107c1e348eb4e8365f7d900002e40 \
-                        size    13552 \
+                        rmd160  94493cc3074dc39be0de76f04fa2a44a405d0a42 \
+                        sha256  52e986cca6d6335bfcd23b4867f884311cfb5ca060325496b6692029797d64e2 \
+                        size    13805 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.1.0 \
+                        rmd160  25e655fc958685dd949900eea8c3d97f33d85eab \
+                        sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
+                        size    8586 \
+                    github.com/gopasspw/gopass \
+                        lock    v1.14.3 \
+                        rmd160  7779654513c630544f675e2bffcd0e0941cefd0f \
+                        sha256  7b5b3fc0271a777f6145d57cb5fc3e2829c2a2b8c5d0cbbb3e4413f20e0f75a0 \
+                        size    2252787 \
                     github.com/google/go-querystring \
-                        lock    v1.0.0 \
-                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
-                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
-                        size    7536 \
+                        lock    v1.1.0 \
+                        rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
+                        sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
+                        size    10418 \
                     github.com/google/go-github \
                         lock    v17.0.0 \
                         rmd160  2c1917adfc161a2252354d558352180079005d8d \
                         sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
                         size    212064 \
                     github.com/google/go-cmp \
-                        lock    v0.5.2 \
-                        rmd160  5021dfa1c1da165c38f7a1a0b78794204233735f \
-                        sha256  6631e46f37f68fde3c411c90e9b9186526903a2123222f08de658547b1caafca \
-                        size    99774 \
+                        lock    v0.5.8 \
+                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
+                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
+                        size    104650 \
+                    github.com/golang/mock \
+                        lock    v1.6.0 \
+                        rmd160  ed853462703f04ce365bb17b8c88a92994aa5006 \
+                        sha256  4b107f6d26db03f8a36ae38f7b017399ed56571cdbf7b7ebc7bff0006c7dffb5 \
+                        size    69263 \
                     github.com/fatih/color \
-                        lock    v1.9.0 \
-                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
-                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
-                        size    1231337 \
+                        lock    v1.13.0 \
+                        rmd160  0c56533948a292eb8c5181e9a88a45fbd1267bf5 \
+                        sha256  a65b114bfe507384e1660730803ffb4437c63a24dd11a5d7f61c77f048caa55f \
+                        size    10828 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.0 \
-                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
-                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
-                        size    52040 \
-                    github.com/cenkalti/backoff \
-                        lock    v2.2.1 \
-                        rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
-                        sha256  4f6a3d7d9fdc5e02522faed8e96539476f646ab64983633a92ea1b71e18bca4f \
-                        size    8633 \
+                        lock    v2.0.2 \
+                        rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
+                        sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
+                        size    64382 \
                     github.com/caspr-io/yamlpath \
                         lock    502e8d113a9b \
                         rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
                         sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
                         size    6334 \
                     github.com/blang/semver \
-                        lock    1a9109f8c4a1 \
-                        rmd160  b4ebb77c1acc4a111b6f947b959678d88685b475 \
-                        sha256  db45cea3471269c894f1ad024826047b6175f1b87b0c71ac4b12180608a3e07a \
-                        size    15415 \
+                        lock    v4.0.0 \
+                        rmd160  ab0e0d974dcbc784840d4bcc76584242436c51fa \
+                        sha256  bf4d622c039173a4e0903738d8b5c788c3c63bb8cfa7485611f38aece3504d0f \
+                        size    27781 \
                     github.com/atotto/clipboard \
-                        lock    v0.1.2 \
-                        rmd160  4a0617ed814da771a9701f36b2be950301e153df \
-                        sha256  d3923f2514644b13032c76bf75fd66ef4e581afd8a86e186a300d1da12f688b3 \
-                        size    4476 \
+                        lock    v0.1.4 \
+                        rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
+                        sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
+                        size    5023 \
+                    github.com/ProtonMail/go-crypto \
+                        lock    5afb4c282135 \
+                        rmd160  fb2955998045f47e5e9b424d5dfaa136ea29c0cb \
+                        sha256  618b6dcff5b7c3f449249040c800b4e747fa7c9a8fda666754413a65f9d109f5 \
+                        size    313579 \
+                    filippo.io/edwards25519 \
+                        repo    github.com/FiloSottile/edwards25519 \
+                        lock    v1.0.0 \
+                        rmd160  47330d4bd65ec5e115038359a989a1a3f775e130 \
+                        sha256  f9474496e781cc9985cc575fbd108a5ca1992cc9fdfd35ee0efcb2818fab928c \
+                        size    39898 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
-                        lock    v1.0.0-beta4 \
-                        rmd160  40729805449116617866c1b16cf4e588f752a3b3 \
-                        sha256  f0525db9eba63f3163ce8374b9e7f1cf4851bb424d3470db0d04646060879790 \
-                        size    36023
+                        lock    v1.0.0 \
+                        rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
+                        sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
+                        size    59693 \
+                    bitbucket.org/creachadair/stringset \
+                        lock    v0.0.10 \
+                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
+                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
+                        size    19241
 
 build.args          -ldflags '-X main.version=${version}'
 

--- a/security/gopass-hibp/Portfile
+++ b/security/gopass-hibp/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-hibp 1.12.0 v
+go.setup            github.com/gopasspw/gopass-hibp 1.14.3 v
 revision            0
 categories          security
-maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 license             MIT
 
 description         Gopass haveibeenpwnd.com integration
@@ -14,180 +14,198 @@ long_description    ${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  dd68141ca4632fbf68653d77ddec9f2cdf5792b8 \
-                        sha256  5c5b5bd61170c50707eef9d2f1923bdc5eb0b3ee4a3e2b24234b9b66e7ba2ca4 \
-                        size    16587
+                        rmd160  d21690e73f2abbe8f75b70036a30e065072709d5 \
+                        sha256  680b799ec1f66e959bb42d6762ad0d18126acd36d221f29b16646332e51c625b \
+                        size    18767
 
-go.vendors          gopkg.in/yaml.v3 \
-                        lock    496545a6307b \
-                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
-                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
-                        size    90145 \
-                    gopkg.in/yaml.v2 \
-                        lock    v2.3.0 \
-                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
-                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
-                        size    72838 \
-                    gopkg.in/ini.v1 \
-                        lock    v1.60.1 \
-                        rmd160  aea42f00ec6f7c0bdc0cda906257b0b7aba80a37 \
-                        sha256  3db6855d923d5719ddfaa7a3f1a8910723f8bd943692205c045509e797bda82f \
-                        size    49265 \
-                    golang.org/x/text \
-                        lock    v0.3.3 \
-                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
-                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
-                        size    7745597 \
+go.vendors          gotest.tools \
+                        repo    github.com/gotestyourself/gotest.tools \
+                        lock    v3.0.2 \
+                        rmd160  ccc2d160fcdb27d0e8461506d0c38e27487c8bd7 \
+                        sha256  9b17efa7751a66942c72f54e62716574bc34561bdcdaf8337bea3612e85a7025 \
+                        size    61955 \
+                    gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    gopkg.in/check.v1 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
                     golang.org/x/term \
-                        lock    2321bbc49cbf \
-                        rmd160  94c32506cb76cee410574c49d6b4cfe294a8159d \
-                        sha256  3bf7b61de210c621fb70e697c0020789bfbe426754d0f743978e77f84a7472f1 \
-                        size    15286 \
+                        lock    065cf7ba2467 \
+                        rmd160  95091f7614b24ca8ac93c8ea13e65ae54b45a366 \
+                        sha256  6c9130ff4c06205225c64668521b77b93658b384014df1e635f30d17633ec30f \
+                        size    14981 \
                     golang.org/x/sys \
-                        lock    9b0068b26619 \
-                        rmd160  6d61a58b0982fbb00c93307192beb37383faf72c \
-                        sha256  947d8814655ee3607d4b9f8a3e244b352fbf04ed8a6a223b3fd5c20c7f21fd6b \
-                        size    1104270 \
-                    golang.org/x/net \
-                        lock    f5854403a974 \
-                        rmd160  cfaf8471269327bcdce1142b44ded72a4584ddf9 \
-                        sha256  a1fcb7946757072ba7453de05fa82e9b977318307a88082c5e4b24057885babb \
-                        size    1178342 \
+                        lock    175b2fd9d664 \
+                        rmd160  babb07e01c60fc729853fc06b19e23a176ef4756 \
+                        sha256  02c9a4f95009a49ed23ba2fb9026aac4b7c6713d6e52282515cfbaddd96056fa \
+                        size    1305845 \
+                    golang.org/x/exp \
+                        lock    b0d781184e0d \
+                        rmd160  228a7cd5c3f0d388d5badded570beee09db60c70 \
+                        sha256  e4d4f78921ce99106a52675d75497f76468895bf227d17e3a4e47f78d361aa17 \
+                        size    1556422 \
                     golang.org/x/crypto \
-                        lock    eec23a3978ad \
-                        rmd160  098b29e5fb0c1a0fa7a118e433eb5d952053391b \
-                        sha256  da658dad4a60a368edea1cbb28651cf44b46b06fdd726462c5696aa5283f12c2 \
-                        size    1725759 \
+                        lock    05595931fe9d \
+                        rmd160  44b3bff302fe3a679525f5976c210588402572e1 \
+                        sha256  8d3cffb4319b5f3cf4c06199fd0340ee57a49012c2d523a876c8b88c208e4043 \
+                        size    1631395 \
+                    go.uber.org/multierr \
+                        repo    github.com/uber-go/multierr \
+                        lock    v1.8.0 \
+                        rmd160  b09e4eae9a41c2b84204346c264e0749998272f5 \
+                        sha256  b172f7c7e805cfd8e7ec423e19e4ed47fab099fb9ff42b0910876098f557f8ee \
+                        size    15600 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.9.0 \
+                        rmd160  7705959c7053aa8e405560f5ffef3fbca414ee69 \
+                        sha256  8baccde94a6ecaea185ef40b9bdecbd3dd8d8df7cbc50c89856b58c5cd897e40 \
+                        size    21353 \
+                    github.com/xrash/smetrics \
+                        lock    039620a65673 \
+                        rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
+                        sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
+                        size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.3.0 \
-                        rmd160  fec9e73bc45d02b2afe43e8d9c76398722494e4b \
-                        sha256  3138857026c9564559b3e734b9b8abfeda57354fc4aa87717879882bff68ef09 \
-                        size    3408338 \
-                    github.com/shurcooL/sanitized_anchor_name \
-                        lock    v1.0.0 \
-                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
-                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
-                        size    2144 \
+                        lock    v2.10.3 \
+                        rmd160  c28d3228d49f0446ccde697a5b9b4d233e60b79b \
+                        sha256  160c91ae1e2cd109ff43be7539959c0f74e9daf9f5dccbe45e96c7518b7f40b4 \
+                        size    3457370 \
+                    github.com/twpayne/go-pinentry \
+                        lock    v0.2.0 \
+                        rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
+                        sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
+                        size    11986 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.1 \
+                        rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
+                        sha256  27cabaf81344157a188083266cf8ccc19d04c43d9a34b6276b760514b9c880a3 \
+                        size    94020 \
                     github.com/russross/blackfriday \
                         lock    v2.1.0 \
                         rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
                         sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
                         size    92950 \
-                    github.com/rs/xid \
-                        lock    v1.2.1 \
-                        rmd160  2cff9628752a94fc62ab0e83436c61df7195eed1 \
-                        sha256  38881e009bacdbf91f6e586207b346eb9ec93f06335331c07a5e0b2ad41ee3f6 \
-                        size    9555 \
+                    github.com/rs/zerolog \
+                        lock    v1.27.0 \
+                        rmd160  434d8ba6beae7657617c2116cb48a358b9cd03ed \
+                        sha256  bae5e650804d95ae57b5729483fc81b30f9deb188474d8598b08c3d0ad5f2a49 \
+                        size    165154 \
+                    github.com/rogpeppe/go-internal \
+                        lock    86f73c517451 \
+                        rmd160  12ae7289b3b9f3f0339d1ffe90bfefdd28944914 \
+                        sha256  243fd03669a7f2563d066de31a537dc3e99fb3180fcf36f1b492f84e3c8dbd76 \
+                        size    131803 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
                     github.com/pkg/errors \
                         lock    v0.9.1 \
                         rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
-                    github.com/modern-go/reflect2 \
-                        lock    v1.0.1 \
-                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
-                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
-                        size    14407 \
-                    github.com/modern-go/concurrent \
-                        lock    bacd9c7ef1dd \
-                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
-                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
-                        size    7533 \
+                    github.com/nbutton23/zxcvbn-go \
+                        lock    fa2cb2858354 \
+                        rmd160  17c2ab9843836ee904acced65d6d22f13a4b614c \
+                        sha256  5f33a658c9daf086423450a9ad27297f7589ce58c1e4ddff3bb623ef8da276ae \
+                        size    881860 \
                     github.com/mitchellh/go-homedir \
                         lock    v1.1.0 \
                         rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
                         sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
                         size    3366 \
-                    github.com/minio/sha256-simd \
-                        lock    v0.1.1 \
-                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
-                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
-                        size    65042 \
-                    github.com/minio/minio-go \
-                        lock    v7.0.7 \
-                        rmd160  f7269c3b9de8bf8a2545cb947ff1edc9631b5f19 \
-                        sha256  d23d5ee4dcbec90b8797afee393283558fb81cb7f35bd228003219cad19ff0ec \
-                        size    236183 \
-                    github.com/minio/md5-simd \
-                        lock    v1.1.0 \
-                        rmd160  7929f1dc43d777a143a826c47948490d8ed121e0 \
-                        sha256  49d89141ce43f38098b264acf3b3d9341d553a1f82816485f1c036e18deb2b58 \
-                        size    99242 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
+                        lock    v0.0.14 \
+                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
+                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
+                        size    4705 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.8 \
-                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
-                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
-                        size    9576 \
-                    github.com/klauspost/cpuid \
-                        lock    v1.3.1 \
-                        rmd160  0c161f6a90600c80e908141c2a81130ba703307e \
-                        sha256  8db60afc9f494af07150fff47e676377588d36fb5ee3cc181ec59ff35c238c79 \
-                        size    367163 \
-                    github.com/json-iterator/go \
-                        lock    v1.1.10 \
-                        rmd160  963a70cf0a7d056f6b00fb2224687895612a35e2 \
-                        sha256  e82947d6f32c1cf730c796409eabc8051c208c2eafabe793d196d448529a7f0f \
-                        size    83377 \
+                        lock    v0.1.12 \
+                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
+                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
+                        size    9805 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.3.0 \
+                        rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
+                        sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
+                        size    10043 \
                     github.com/hashicorp/golang-lru \
                         lock    v0.5.4 \
                         rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
                         sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
                         size    13435 \
                     github.com/hashicorp/go-multierror \
-                        lock    v1.1.0 \
-                        rmd160  868d9a6f0732cba1b2dfbb73556b6a194c797c03 \
-                        sha256  9bd88c4f96aa4c4dcca5c0124e48f540c59754586653924b5e4b7de3af0f8c4a \
-                        size    12091 \
+                        lock    v1.1.1 \
+                        rmd160  94493cc3074dc39be0de76f04fa2a44a405d0a42 \
+                        sha256  52e986cca6d6335bfcd23b4867f884311cfb5ca060325496b6692029797d64e2 \
+                        size    13805 \
                     github.com/hashicorp/errwrap \
                         lock    v1.1.0 \
                         rmd160  25e655fc958685dd949900eea8c3d97f33d85eab \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.12.0 \
-                        rmd160  4a9bdad822d23c9ef617cd95dd4840211c126df9 \
-                        sha256  0803ca8692be48345c82f04ba9aae414cd5a62a7deb3b55c9880d2741c139117 \
-                        size    2043231 \
-                    github.com/google/uuid \
-                        lock    v1.1.1 \
-                        rmd160  69112e9735ecc1d5360a3cc31531f8be661a007f \
-                        sha256  70be7dec37826f2cbe13acfe534ce74cbb2107c1e348eb4e8365f7d900002e40 \
-                        size    13552 \
+                        lock    v1.14.3 \
+                        rmd160  7779654513c630544f675e2bffcd0e0941cefd0f \
+                        sha256  7b5b3fc0271a777f6145d57cb5fc3e2829c2a2b8c5d0cbbb3e4413f20e0f75a0 \
+                        size    2252787 \
                     github.com/google/go-querystring \
-                        lock    v1.0.0 \
-                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
-                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
-                        size    7536 \
+                        lock    v1.1.0 \
+                        rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
+                        sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
+                        size    10418 \
                     github.com/google/go-github \
                         lock    v17.0.0 \
                         rmd160  2c1917adfc161a2252354d558352180079005d8d \
                         sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
                         size    212064 \
                     github.com/google/go-cmp \
-                        lock    v0.5.4 \
-                        rmd160  e53e85e2f7651ce4e0dd20f8621380a60d9d5cc0 \
-                        sha256  4b3ea98b1c2c83814a405d824c68521315dbddd9dada9a9992d1abebd2cca290 \
-                        size    101028 \
+                        lock    v0.5.8 \
+                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
+                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
+                        size    104650 \
+                    github.com/golang/mock \
+                        lock    v1.6.0 \
+                        rmd160  ed853462703f04ce365bb17b8c88a92994aa5006 \
+                        sha256  4b107f6d26db03f8a36ae38f7b017399ed56571cdbf7b7ebc7bff0006c7dffb5 \
+                        size    69263 \
                     github.com/fatih/color \
-                        lock    v1.10.0 \
-                        rmd160  d33ae416337f02c181700fe76c05aec814791423 \
-                        sha256  2caf3481614a1a3dcbec15506d9549867a8538e60a8f3d057a619557ec6faa9b \
-                        size    1267972 \
+                        lock    v1.13.0 \
+                        rmd160  0c56533948a292eb8c5181e9a88a45fbd1267bf5 \
+                        sha256  a65b114bfe507384e1660730803ffb4437c63a24dd11a5d7f61c77f048caa55f \
+                        size    10828 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.0 \
-                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
-                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
-                        size    52040 \
+                        lock    v2.0.2 \
+                        rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
+                        sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
+                        size    64382 \
                     github.com/cenkalti/backoff \
-                        lock    v2.2.1 \
-                        rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
-                        sha256  4f6a3d7d9fdc5e02522faed8e96539476f646ab64983633a92ea1b71e18bca4f \
-                        size    8633 \
+                        lock    v4.1.3 \
+                        rmd160  440a499ec3b80e7ec9f003924219aba222cd3472 \
+                        sha256  105a8b5dfc4b46016f9efac2940abb78cb9dceca5e0803672039938311fe6d65 \
+                        size    9871 \
                     github.com/caspr-io/yamlpath \
                         lock    502e8d113a9b \
                         rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
@@ -198,18 +216,33 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  ab0e0d974dcbc784840d4bcc76584242436c51fa \
                         sha256  bf4d622c039173a4e0903738d8b5c788c3c63bb8cfa7485611f38aece3504d0f \
                         size    27781 \
+                    github.com/atotto/clipboard \
+                        lock    v0.1.4 \
+                        rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
+                        sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
+                        size    5023 \
+                    github.com/ProtonMail/go-crypto \
+                        lock    5afb4c282135 \
+                        rmd160  fb2955998045f47e5e9b424d5dfaa136ea29c0cb \
+                        sha256  618b6dcff5b7c3f449249040c800b4e747fa7c9a8fda666754413a65f9d109f5 \
+                        size    313579 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
-                        lock    v1.0.0-beta.2 \
-                        rmd160  354dcb123ca7b351468e010b8ddc7af28bc22aa5 \
-                        sha256  9280a341851b2e4a5ef1142a1a38a30e2b66c8bb63b7d7ce8bd2f2b53e0bab89 \
-                        size    77471 \
+                        lock    v1.0.0 \
+                        rmd160  47330d4bd65ec5e115038359a989a1a3f775e130 \
+                        sha256  f9474496e781cc9985cc575fbd108a5ca1992cc9fdfd35ee0efcb2818fab928c \
+                        size    39898 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
-                        lock    v1.0.0-beta7 \
-                        rmd160  42e2be4b481d365ed33b8cad6c10fd091b5dd70e \
-                        sha256  1abc43fe7d6959742cb2e7ef9b8219620325734bb3e926e4b999fe5447a8bf59 \
-                        size    42223
+                        lock    v1.0.0 \
+                        rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
+                        sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
+                        size    59693 \
+                    bitbucket.org/creachadair/stringset \
+                        lock    v0.0.10 \
+                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
+                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
+                        size    19241
 
 build.args          -ldflags '-X main.version=${version}'
 

--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.11.1 v
+go.setup            github.com/gopasspw/gopass-jsonapi 1.14.3 v
+revision            0
 categories          security
-maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 license             MIT
 
 description         Gopass Browser Bindings
@@ -13,9 +14,9 @@ long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  40e637d225158548d4f7bdc778616530263e0cb8 \
-                        sha256  33391c930cacc081e3ee912edda35db99c7c6970b0c31365c2695c79b896519c \
-                        size    30282
+                        rmd160  15d534dacf13db43e3a0355c374020c38d848168 \
+                        sha256  c7759f962b21aed16cd47d90f329ca446554e82a61546b9582aa5824f5ee7e9a \
+                        size    28967
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -23,102 +24,94 @@ go.vendors          rsc.io/qr \
                         rmd160  f642fe01c13937615e5a975e6a1932f8dc25359a \
                         sha256  1d69d5a13366a84a1484abdec5affd7f5781016469f4b43b1a26f5fa5c93497b \
                         size    18816 \
-                    mvdan.cc/unparam \
-                        repo    github.com/mvdan/unparam \
-                        lock    aac4ce9116a7 \
-                        rmd160  5f3b6fdd383e7e1e10178c07c823a60a454946fb \
-                        sha256  3d3d7ed607dd493ad5822f1cad60647850f44a753990d92add18263eafdf526d \
-                        size    18695 \
+                    gotest.tools \
+                        repo    github.com/gotestyourself/gotest.tools \
+                        lock    v3.0.2 \
+                        rmd160  ccc2d160fcdb27d0e8461506d0c38e27487c8bd7 \
+                        sha256  9b17efa7751a66942c72f54e62716574bc34561bdcdaf8337bea3612e85a7025 \
+                        size    61955 \
                     gopkg.in/yaml.v3 \
-                        lock    eeeca48fe776 \
-                        rmd160  fa7f02bf2d79fd300b4db2107596674b41479412 \
-                        sha256  33580a955d8c31b781de66dbc7a3c9940ab842a39eb3eb92e696a82307f7d570 \
-                        size    88775 \
-                    gopkg.in/yaml.v2 \
-                        lock    v2.3.0 \
-                        rmd160  2f8fa56d8a413b6288132eeb7f0d7c64d27d877f \
-                        sha256  a8d1a8bc88239d25507456380b47d59ae3683d4a5f4336da4892db1ce026615f \
-                        size    72838 \
-                    gopkg.in/ini.v1 \
-                        lock    v1.60.1 \
-                        rmd160  aea42f00ec6f7c0bdc0cda906257b0b7aba80a37 \
-                        sha256  3db6855d923d5719ddfaa7a3f1a8910723f8bd943692205c045509e797bda82f \
-                        size    49265 \
-                    golang.org/x/xerrors \
-                        lock    5ec99f83aff1 \
-                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
-                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
-                        size    13667 \
-                    golang.org/x/tools \
-                        lock    v0.1.0 \
-                        rmd160  ed8549ff61216e862597412cca9a2f3cd3448147 \
-                        sha256  7ee4ceea7cc41925aa41c185d17886694bcd611cb9896be15e578a491c8594c0 \
-                        size    2683296 \
-                    golang.org/x/text \
-                        lock    v0.3.3 \
-                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
-                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
-                        size    7745597 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    gopkg.in/check.v1 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
+                    golang.org/x/term \
+                        lock    065cf7ba2467 \
+                        rmd160  95091f7614b24ca8ac93c8ea13e65ae54b45a366 \
+                        sha256  6c9130ff4c06205225c64668521b77b93658b384014df1e635f30d17633ec30f \
+                        size    14981 \
                     golang.org/x/sys \
-                        lock    22da62e12c0c \
-                        rmd160  15c235353d480b46af88f988d1cb58ee77194ea6 \
-                        sha256  2ef3888e228c2e10bd71add7c893d88260477cad9c5d529d95e899e62b57916b \
-                        size    1106946 \
+                        lock    175b2fd9d664 \
+                        rmd160  babb07e01c60fc729853fc06b19e23a176ef4756 \
+                        sha256  02c9a4f95009a49ed23ba2fb9026aac4b7c6713d6e52282515cfbaddd96056fa \
+                        size    1305845 \
                     golang.org/x/net \
-                        lock    f5854403a974 \
-                        rmd160  cfaf8471269327bcdce1142b44ded72a4584ddf9 \
-                        sha256  a1fcb7946757072ba7453de05fa82e9b977318307a88082c5e4b24057885babb \
-                        size    1178342 \
-                    golang.org/x/mod \
-                        lock    v0.4.1 \
-                        rmd160  c96b842a5189b7efca5466e347b279cfeebd8fbf \
-                        sha256  9370678c647c8fbab251e6d06eb6420c7c8be01cd97b5177a7205fce5128205a \
-                        size    102768 \
+                        lock    263ec571b305 \
+                        rmd160  44d64e5c0fee97412b8efd557bcd63bcf8e811b6 \
+                        sha256  a26b89d8ae72495fef04584dff52fb0ca649b39fcf9890a08ee7d472577ba052 \
+                        size    1228295 \
+                    golang.org/x/exp \
+                        lock    b0d781184e0d \
+                        rmd160  228a7cd5c3f0d388d5badded570beee09db60c70 \
+                        sha256  e4d4f78921ce99106a52675d75497f76468895bf227d17e3a4e47f78d361aa17 \
+                        size    1556422 \
                     golang.org/x/crypto \
-                        lock    afb6bcd081ae \
-                        rmd160  2a2fa932dfa1539a791ca41226d24f032134d57a \
-                        sha256  1b923ba81aeed05b2ba90627bccc8297a9914c1d708599f1dd3003b843f64115 \
-                        size    1732317 \
+                        lock    05595931fe9d \
+                        rmd160  44b3bff302fe3a679525f5976c210588402572e1 \
+                        sha256  8d3cffb4319b5f3cf4c06199fd0340ee57a49012c2d523a876c8b88c208e4043 \
+                        size    1631395 \
+                    go.uber.org/multierr \
+                        repo    github.com/uber-go/multierr \
+                        lock    v1.8.0 \
+                        rmd160  b09e4eae9a41c2b84204346c264e0749998272f5 \
+                        sha256  b172f7c7e805cfd8e7ec423e19e4ed47fab099fb9ff42b0910876098f557f8ee \
+                        size    15600 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.9.0 \
+                        rmd160  7705959c7053aa8e405560f5ffef3fbca414ee69 \
+                        sha256  8baccde94a6ecaea185ef40b9bdecbd3dd8d8df7cbc50c89856b58c5cd897e40 \
+                        size    21353 \
                     github.com/xrash/smetrics \
-                        lock    89a2a8a1fb0b \
-                        rmd160  350ca8872823c2d934da9a0da957e1d373542d92 \
-                        sha256  565b0a0b533971f54a767d0709b8370e92f4919f0df83552c2d45ef5f13c95ce \
-                        size    1823868 \
+                        lock    039620a65673 \
+                        rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
+                        sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
+                        size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.3.0 \
-                        rmd160  fec9e73bc45d02b2afe43e8d9c76398722494e4b \
-                        sha256  3138857026c9564559b3e734b9b8abfeda57354fc4aa87717879882bff68ef09 \
-                        size    3408338 \
-                    github.com/stretchr/testify \
-                        lock    v1.6.1 \
-                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
-                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
-                        size    84248 \
-                    github.com/shurcooL/sanitized_anchor_name \
-                        lock    v1.0.0 \
-                        rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
-                        sha256  ed9418de8c92acfbbd8608745855ebfc67fa686c0a0a5245cf8eece8f540baa9 \
-                        size    2144 \
-                    github.com/sergi/go-diff \
-                        lock    v1.1.0 \
-                        rmd160  6449feb5884c316206f256e55b81aba3e6a78a9f \
-                        sha256  026d3d6db40ad086954214a7f3f84b66e352d47ce259bb59b7c2b9bd843b9935 \
-                        size    43569 \
-                    github.com/russross/blackfriday \
-                        lock    v2.0.1 \
-                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
-                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
-                        size    79665 \
-                    github.com/rs/xid \
-                        lock    v1.2.1 \
-                        rmd160  2cff9628752a94fc62ab0e83436c61df7195eed1 \
-                        sha256  38881e009bacdbf91f6e586207b346eb9ec93f06335331c07a5e0b2ad41ee3f6 \
-                        size    9555 \
-                    github.com/rivo/uniseg \
+                        lock    v2.10.3 \
+                        rmd160  c28d3228d49f0446ccde697a5b9b4d233e60b79b \
+                        sha256  160c91ae1e2cd109ff43be7539959c0f74e9daf9f5dccbe45e96c7518b7f40b4 \
+                        size    3457370 \
+                    github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
-                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
-                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
-                        size    44037 \
+                        rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
+                        sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
+                        size    11986 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.4 \
+                        rmd160  ead1da73ad69fb87be0d40619888ecf9650d3438 \
+                        sha256  cf31480faa1c3c0dbfa44395257108884a107f5225f1cd6b8d91e23e5564dccc \
+                        size    94328 \
+                    github.com/russross/blackfriday \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
+                    github.com/rs/zerolog \
+                        lock    v1.27.0 \
+                        rmd160  434d8ba6beae7657617c2116cb48a358b9cd03ed \
+                        sha256  bae5e650804d95ae57b5729483fc81b30f9deb188474d8598b08c3d0ad5f2a49 \
+                        size    165154 \
+                    github.com/rogpeppe/go-internal \
+                        lock    86f73c517451 \
+                        rmd160  12ae7289b3b9f3f0339d1ffe90bfefdd28944914 \
+                        sha256  243fd03669a7f2563d066de31a537dc3e99fb3180fcf36f1b492f84e3c8dbd76 \
+                        size    131803 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -129,26 +122,16 @@ go.vendors          rsc.io/qr \
                         rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
-                    github.com/olekukonko/tablewriter \
-                        lock    v0.0.5 \
-                        rmd160  aa952a560c3aa5102bfb3e55f12facf048379adf \
-                        sha256  830bdee7f05aa76353c113075a864359762a502c6d6a1f72bfb7055247c0539b \
-                        size    19579 \
+                    github.com/nbutton23/zxcvbn-go \
+                        lock    fa2cb2858354 \
+                        rmd160  17c2ab9843836ee904acced65d6d22f13a4b614c \
+                        sha256  5f33a658c9daf086423450a9ad27297f7589ce58c1e4ddff3bb623ef8da276ae \
+                        size    881860 \
                     github.com/muesli/crunchy \
                         lock    v0.4.0 \
                         rmd160  3029073bbcf95a9154c93b01803f3b48d7a3ec7e \
                         sha256  039c5f45b9d1f7a02562cad503749bce7820d510657f720d2db2ea593093d438 \
                         size    7791 \
-                    github.com/modern-go/reflect2 \
-                        lock    v1.0.1 \
-                        rmd160  5cdaa26d1ee453e37f3a26635aac40397e2f28fa \
-                        sha256  5bcbe1f4c0fa1d853c066a4e6f58eaa5d31ac370c97a3c87e99a6ffecf7b5a65 \
-                        size    14407 \
-                    github.com/modern-go/concurrent \
-                        lock    bacd9c7ef1dd \
-                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
-                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
-                        size    7533 \
                     github.com/mitchellh/go-ps \
                         lock    v1.0.0 \
                         rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
@@ -159,101 +142,71 @@ go.vendors          rsc.io/qr \
                         rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
                         sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
                         size    3366 \
-                    github.com/minio/sha256-simd \
-                        lock    v0.1.1 \
-                        rmd160  50654a6c3da3bcc426cb9189299e1d8d76f52a2b \
-                        sha256  ab49163b74a1b89c8ab795eda31cbf65af572fe3f87028cc1234bac2ae45706c \
-                        size    65042 \
-                    github.com/minio/minio-go \
-                        lock    v7.0.7 \
-                        rmd160  f7269c3b9de8bf8a2545cb947ff1edc9631b5f19 \
-                        sha256  d23d5ee4dcbec90b8797afee393283558fb81cb7f35bd228003219cad19ff0ec \
-                        size    236183 \
-                    github.com/minio/md5-simd \
-                        lock    v1.1.0 \
-                        rmd160  7929f1dc43d777a143a826c47948490d8ed121e0 \
-                        sha256  49d89141ce43f38098b264acf3b3d9341d553a1f82816485f1c036e18deb2b58 \
-                        size    99242 \
-                    github.com/mgechev/revive \
-                        lock    v1.0.3 \
-                        rmd160  ae31793eae0b8282d9ef6625bba195297a5995b8 \
-                        sha256  ef458affcef4c0ff5d121c7ec9a93bc506591e1f6689a8f31e0420375f01c025 \
-                        size    671733 \
-                    github.com/mgechev/dots \
-                        lock    c36f7dcfbb81 \
-                        rmd160  0965efd20f37d8b2e22c9fdc3b820a214ef80577 \
-                        sha256  3b1e1c80d3727e2ccdf4e37e3ee7d3d1c3044d7cf40d1e39aed56927da986be6 \
-                        size    6429 \
-                    github.com/mattn/go-runewidth \
-                        lock    v0.0.10 \
-                        rmd160  96c878eca004d6cf8f49ecf3cde98335e7f21499 \
-                        sha256  b78084ce55bc5aaa31d337dcb59624d748fe39006a3df29143fae203065e2a22 \
-                        size    16787 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
+                        lock    v0.0.14 \
+                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
+                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
+                        size    4705 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.8 \
-                        rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
-                        sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
-                        size    9576 \
-                    github.com/klauspost/cpuid \
-                        lock    v1.3.1 \
-                        rmd160  0c161f6a90600c80e908141c2a81130ba703307e \
-                        sha256  8db60afc9f494af07150fff47e676377588d36fb5ee3cc181ec59ff35c238c79 \
-                        size    367163 \
+                        lock    v0.1.12 \
+                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
+                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
+                        size    9805 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.3.0 \
+                        rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
+                        sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
+                        size    10043 \
                     github.com/kballard/go-shellquote \
                         lock    95032a82bc51 \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
                         sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
                         size    4335 \
-                    github.com/json-iterator/go \
-                        lock    v1.1.10 \
-                        rmd160  963a70cf0a7d056f6b00fb2224687895612a35e2 \
-                        sha256  e82947d6f32c1cf730c796409eabc8051c208c2eafabe793d196d448529a7f0f \
-                        size    83377 \
                     github.com/hashicorp/golang-lru \
                         lock    v0.5.4 \
                         rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
                         sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
                         size    13435 \
                     github.com/hashicorp/go-multierror \
-                        lock    v1.1.0 \
-                        rmd160  868d9a6f0732cba1b2dfbb73556b6a194c797c03 \
-                        sha256  9bd88c4f96aa4c4dcca5c0124e48f540c59754586653924b5e4b7de3af0f8c4a \
-                        size    12091 \
-                    github.com/hashicorp/errwrap \
-                        lock    v1.0.0 \
-                        rmd160  d9bf75f667d7bec9b4b11ca34de7ca722495b914 \
-                        sha256  49e80cf52f294ce69fcc8cd26f06b8d8cee2623f6e0012df871b355fb7b17787 \
-                        size    8351 \
-                    github.com/gopasspw/gopass \
-                        lock    ddfe7bfc979f \
-                        rmd160  02b1a9037c034fa114eedc39c0ff7da7ce43f9e7 \
-                        sha256  e2806614c1b7e87b6e7d47d014f4227417c448d35368fb40db97176a3bd23697 \
-                        size    489358 \
-                    github.com/google/uuid \
                         lock    v1.1.1 \
-                        rmd160  69112e9735ecc1d5360a3cc31531f8be661a007f \
-                        sha256  70be7dec37826f2cbe13acfe534ce74cbb2107c1e348eb4e8365f7d900002e40 \
-                        size    13552 \
+                        rmd160  94493cc3074dc39be0de76f04fa2a44a405d0a42 \
+                        sha256  52e986cca6d6335bfcd23b4867f884311cfb5ca060325496b6692029797d64e2 \
+                        size    13805 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.1.0 \
+                        rmd160  25e655fc958685dd949900eea8c3d97f33d85eab \
+                        sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
+                        size    8586 \
+                    github.com/gopasspw/gopass \
+                        lock    v1.14.3 \
+                        rmd160  7779654513c630544f675e2bffcd0e0941cefd0f \
+                        sha256  7b5b3fc0271a777f6145d57cb5fc3e2829c2a2b8c5d0cbbb3e4413f20e0f75a0 \
+                        size    2252787 \
                     github.com/google/go-querystring \
-                        lock    v1.0.0 \
-                        rmd160  48593728f6bf361fa168bdc87737ee30de24f34b \
-                        sha256  0add5428914c2a378cd9e6e120a4b1e84d69df504b983f99a86aea98a52c5a57 \
-                        size    7536 \
+                        lock    v1.1.0 \
+                        rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
+                        sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
+                        size    10418 \
                     github.com/google/go-github \
                         lock    v17.0.0 \
                         rmd160  2c1917adfc161a2252354d558352180079005d8d \
                         sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
                         size    212064 \
                     github.com/google/go-cmp \
-                        lock    v0.5.2 \
-                        rmd160  5021dfa1c1da165c38f7a1a0b78794204233735f \
-                        sha256  6631e46f37f68fde3c411c90e9b9186526903a2123222f08de658547b1caafca \
-                        size    99774 \
+                        lock    v0.5.8 \
+                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
+                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
+                        size    104650 \
+                    github.com/golang/mock \
+                        lock    v1.6.0 \
+                        rmd160  ed853462703f04ce365bb17b8c88a92994aa5006 \
+                        sha256  4b107f6d26db03f8a36ae38f7b017399ed56571cdbf7b7ebc7bff0006c7dffb5 \
+                        size    69263 \
                     github.com/gokyle/twofactor \
                         lock    v1.0.1 \
                         rmd160  639cb3e1e214c43cd212bbec6faae070a2acbc4c \
@@ -264,57 +217,63 @@ go.vendors          rsc.io/qr \
                         rmd160  90cbb8302b7c386e2685633781ec52c8e3f0424f \
                         sha256  54c06c5988808eca9affe01cabe122e02ba4af5763f29fff1c341dce1424aa21 \
                         size    62423 \
-                    github.com/fatih/structtag \
-                        lock    v1.2.0 \
-                        rmd160  dceb529f2caa7a1a18aac46d1b3a54cd374f3f4a \
-                        sha256  105214157a39939be2459ce35cf884c34f5f83069a974865691039110e629353 \
-                        size    5707 \
                     github.com/fatih/color \
-                        lock    v1.10.0 \
-                        rmd160  d33ae416337f02c181700fe76c05aec814791423 \
-                        sha256  2caf3481614a1a3dcbec15506d9549867a8538e60a8f3d057a619557ec6faa9b \
-                        size    1267972 \
+                        lock    v1.13.0 \
+                        rmd160  0c56533948a292eb8c5181e9a88a45fbd1267bf5 \
+                        sha256  a65b114bfe507384e1660730803ffb4437c63a24dd11a5d7f61c77f048caa55f \
+                        size    10828 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.0 \
-                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
-                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
-                        size    52040 \
-                    github.com/cenkalti/backoff \
-                        lock    v2.2.1 \
-                        rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
-                        sha256  4f6a3d7d9fdc5e02522faed8e96539476f646ab64983633a92ea1b71e18bca4f \
-                        size    8633 \
+                        lock    v2.0.2 \
+                        rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
+                        sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
+                        size    64382 \
                     github.com/caspr-io/yamlpath \
                         lock    502e8d113a9b \
                         rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
                         sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
                         size    6334 \
                     github.com/blang/semver \
-                        lock    v3.5.1 \
-                        rmd160  f3746971886e0aa556800bfd543d2f4a89a69767 \
-                        sha256  5f5743805f1baf458ddf2dd8f49c553aa1f5c9667feadf357143602489d3587f \
-                        size    14842 \
+                        lock    v4.0.0 \
+                        rmd160  ab0e0d974dcbc784840d4bcc76584242436c51fa \
+                        sha256  bf4d622c039173a4e0903738d8b5c788c3c63bb8cfa7485611f38aece3504d0f \
+                        size    27781 \
                     github.com/atotto/clipboard \
-                        lock    v0.1.2 \
-                        rmd160  4a0617ed814da771a9701f36b2be950301e153df \
-                        sha256  d3923f2514644b13032c76bf75fd66ef4e581afd8a86e186a300d1da12f688b3 \
-                        size    4476 \
-                    github.com/BurntSushi/toml \
-                        lock    v0.3.1 \
-                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
-                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
-                        size    42087 \
+                        lock    v0.1.4 \
+                        rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
+                        sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
+                        size    5023 \
+                    github.com/ProtonMail/go-crypto \
+                        lock    5afb4c282135 \
+                        rmd160  fb2955998045f47e5e9b424d5dfaa136ea29c0cb \
+                        sha256  618b6dcff5b7c3f449249040c800b4e747fa7c9a8fda666754413a65f9d109f5 \
+                        size    313579 \
+                    filippo.io/edwards25519 \
+                        repo    github.com/FiloSottile/edwards25519 \
+                        lock    v1.0.0 \
+                        rmd160  47330d4bd65ec5e115038359a989a1a3f775e130 \
+                        sha256  f9474496e781cc9985cc575fbd108a5ca1992cc9fdfd35ee0efcb2818fab928c \
+                        size    39898 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
-                        lock    v1.0.0-beta4 \
-                        rmd160  40729805449116617866c1b16cf4e588f752a3b3 \
-                        sha256  f0525db9eba63f3163ce8374b9e7f1cf4851bb424d3470db0d04646060879790 \
-                        size    36023
+                        lock    v1.0.0 \
+                        rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
+                        sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
+                        size    59693 \
+                    bitbucket.org/creachadair/stringset \
+                        lock    v0.0.10 \
+                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
+                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
+                        size    19241
 
 build.args          -ldflags '-X main.version=${version}'
 


### PR DESCRIPTION
#### Description
* git-credential-gopass: update to 1.14.3
* gopass-jsonapi: update to 1.14.3
* gopass-hibp: update to 1.14.3

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
