### PR TITLE
macos-trash: new port

### DIFF
--- a/sysutils/macos-trash/Portfile
+++ b/sysutils/macos-trash/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcodeversion 1.0
+
+github.setup        sindresorhus macos-trash 1.2.0 v
+revision            0
+github.tarball_from archive
+
+categories          sysutils
+license             MIT
+maintainers         {@halostatue macports.halostatue.ca:austin} openmaintainer
+
+conflicts           trash
+
+description         command-line program that moves items to the trash
+
+long_description    ${name} is a small command-line program that moves \
+                    files or folders to the trash, written in Swift
+
+checksums           rmd160  0fc3fbf74364226cf9e8b90bc8fbc1edb509260e \
+                    sha256  c4472b5c8024806720779bc867da1958fe871fbd93d200af8a2cc4ad1941be28 \
+                    size    2986
+
+minimum_xcodeversions {20 13}
+
+if {${os.platform} eq "darwin" && ${os.major} < 20} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} requires macOS 11 or later."
+        return -code error "incompatible macOS version"
+    }
+}
+
+use_configure       no
+use_xcode           yes
+
+build.cmd           swift
+build.target        build
+build.args          --configuration release --disable-sandbox
+
+set builtproductdir     ${worksrcpath}/.build/release
+
+variant universal {
+    build.args-append --arch x86_64 --arch arm64
+    set builtproductdir ${worksrcpath}/.build/apple/Products/Release
+}
+
+destroot {
+    xinstall -m 755 ${builtproductdir}/trash ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

This is a Swift implementation of a command to move files and folders to the MacOS trash.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?