### PR TITLE
google-cloud-sdk: update to 392.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             391.0.0
+version             392.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  b80ff77e5c3738c3bcd45224d5fc158da00ec0ab \
-                    sha256  9cb10d187a02d95914b99caadc57a7744b7b5c238c0648a1d83a69e02fb9c7d4 \
-                    size    107776757
+    checksums       rmd160  d1473ba8b775344424772c4e9c0c932c2ad189ca \
+                    sha256  c23bb88655a707a62c5d3a645e692816c9f54e1b23eb7fc4252a753cf6bb66de \
+                    size    107893532
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  79b1e373286a81d060f054530751f2fb13791c52 \
-                    sha256  98f3519e8746e4cb79e43697b66c92a4c02ee735eda5a6f7b1532fef2dc9fde9 \
-                    size    104526680
+    checksums       rmd160  4efd73a664cfa6af853101d5580b1893d0895c78 \
+                    sha256  0987fe197e06a19ddcc49dfaa57e6b60f747998156aa70a0ef20d13c99cee0ab \
+                    size    104641220
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  3f62b01955630f53d742b049b63d1454dafa8638 \
-                    sha256  1c56bee317aad006aceeb27a55b42b16125516e12192d92fffb977d05b77fc32 \
-                    size    103132689
+    checksums       rmd160  7b60d6cc25462cddabbf4863ba1dab18756e564e \
+                    sha256  b9e3bbebd76a82138c33a326eb8f4d87fdcf96f51ea95e798a2b004308a6873d \
+                    size    103250150
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 392.0.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?