### PR TITLE
GitUp: update to 1.3.2

### DIFF
--- a/devel/GitUp/Portfile
+++ b/devel/GitUp/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            git-up GitUp 1.2 v
-revision                1
+github.setup            git-up GitUp 1.3.2 v
+revision                0
 categories              devel
 platforms               darwin
 license                 GPL-3
@@ -15,9 +15,9 @@ long_description        GitUp provides features such as a live and interactive r
                         splitter and many more
 homepage                https://gitup.co
 
-checksums               rmd160  c8c5eab4cf5bfed8abe934d57ea34cb8b8b769f4 \
-                        sha256  3b8934cfd72f6fad899bf95e7e5b983e6a3543e2ce2226005463b5e7f872e216 \
-                        size    21309896
+checksums               rmd160  fd7fb6d650908bad247c8f6a1442cba3ff8f15ec \
+                        sha256  34856e9a3b2029e82e33318043a89439ea22c00181e26574448c0738b95001d8 \
+                        size    21312701
 
 fetch.type              git
 

--- a/devel/GitUp/files/patch-disable-clt-install.diff
+++ b/devel/GitUp/files/patch-disable-clt-install.diff
@@ -1,11 +1,11 @@
 diff --git GitUp/Application/AppDelegate.m GitUp/Application/AppDelegate.m
-index 2efe0c1..1b0daec 100644
+index 1042982..578dd3e 100644
 --- GitUp/Application/AppDelegate.m
 +++ GitUp/Application/AppDelegate.m
-@@ -265,6 +265,9 @@ - (void)applicationDidFinishLaunching:(NSNotification*)notification {
+@@ -253,6 +253,9 @@ - (void)applicationDidFinishLaunching:(NSNotification*)notification {
    // First launch has completed
    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kUserDefaultsKey_FirstLaunch];
- 
+
 +  // Skip command line tool installation
 +  [[NSUserDefaults standardUserDefaults] setBool:true forKey:kUserDefaultsKey_SkipInstallCLT];
 +

--- a/devel/GitUp/files/patch-disable-sparkle.diff
+++ b/devel/GitUp/files/patch-disable-sparkle.diff
@@ -1,29 +1,28 @@
 diff --git GitUp/Application/AppDelegate.m GitUp/Application/AppDelegate.m
-index 4ef4dcb..694fd63 100644
+index 1042982..a07370e 100644
 --- GitUp/Application/AppDelegate.m
 +++ GitUp/Application/AppDelegate.m
-@@ -42,7 +42,7 @@
+@@ -41,7 +41,7 @@
  #define kToolName @"gitup"
  #define kToolInstallPath @"/usr/local/bin/" kToolName
- 
+
 -@interface AppDelegate () <NSUserNotificationCenterDelegate, SUUpdaterDelegate>
 +@interface AppDelegate () <NSUserNotificationCenterDelegate>
  @property(nonatomic, strong) AboutWindowController* aboutWindowController;
  @property(nonatomic, strong) CloneWindowController* cloneWindowController;
  @property(nonatomic, strong) PreferencesWindowController* preferencesWindowController;
-@@ -50,8 +50,6 @@ @interface AppDelegate () <NSUserNotificationCenterDelegate, SUUpdaterDelegate>
+@@ -49,7 +49,6 @@ @interface AppDelegate () <NSUserNotificationCenterDelegate, SUUpdaterDelegate>
  @end
- 
+
  @implementation AppDelegate {
 -  SUUpdater* _updater;
--  BOOL _updatePending;
    BOOL _manualCheck;
- 
+
    CFMessagePortRef _messagePort;
-@@ -73,20 +71,9 @@ - (CloneWindowController*)cloneWindowController {
+@@ -71,20 +70,9 @@ - (CloneWindowController*)cloneWindowController {
    return _cloneWindowController;
  }
- 
+
 -- (void)didChangeReleaseChannel:(BOOL)didChange {
 -  if (didChange) {
 -    _manualCheck = NO;
@@ -41,7 +40,7 @@ index 4ef4dcb..694fd63 100644
    }
    return _preferencesWindowController;
  }
-@@ -112,7 +99,6 @@ + (void)initialize {
+@@ -110,7 +98,6 @@ + (void)initialize {
      GICommitMessageViewUserDefaultKey_ShowMargins : @(YES),
      GICommitMessageViewUserDefaultKey_EnableSpellChecking : @(YES),
      GIUserDefaultKey_FontSize : @(GIDefaultFontSize),
@@ -49,48 +48,39 @@ index 4ef4dcb..694fd63 100644
      kUserDefaultsKey_CheckInterval : @(15 * 60),
      kUserDefaultsKey_FirstLaunch : @(YES),
      kUserDefaultsKey_DiffWhitespaceMode : @(kGCLiveRepositoryDiffWhitespaceMode_Normal),
-@@ -193,19 +179,6 @@ - (void)applicationWillFinishLaunching:(NSNotification*)notification {
+@@ -196,18 +183,6 @@ - (void)applicationWillFinishLaunching:(NSNotification*)notification {
  }
- 
+
  - (void)applicationDidFinishLaunching:(NSNotification*)notification {
 -#if !DEBUG
 -  // Initialize Sparkle and check for update immediately
 -  if (![[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsKey_DisableSparkle]) {
 -    _updater = [SUUpdater sharedUpdater];
 -    _updater.delegate = self;
--    _updater.automaticallyChecksForUpdates = NO;
+-    _updater.automaticallyChecksForUpdates = YES;
 -    _updater.sendsSystemProfile = NO;
--    _updater.automaticallyDownloadsUpdates = YES;
 -
 -    _manualCheck = NO;
 -    [_updater checkForUpdatesInBackground];
 -  }
 -#endif
- 
+
    // Locate installed apps.
    [GILaunchServicesLocator setup];
-@@ -367,9 +340,6 @@ - (NSDictionary*)_processToolCommand:(NSDictionary*)input {
+@@ -354,9 +329,6 @@ - (NSDictionary*)_processToolCommand:(NSDictionary*)input {
  #pragma mark - Actions
- 
- - (BOOL)validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)anItem {
--  if (anItem.action == @selector(checkForUpdates:)) {
--    return _updater && !_updatePending && ![_updater updateInProgress];
+
+ - (BOOL)validateMenuItem:(NSMenuItem*)menuItem {
+-  if (menuItem.action == @selector(checkForUpdates:)) {
+-    return [_updater validateMenuItem:menuItem];
 -  }
    return YES;
  }
- 
-@@ -390,7 +360,6 @@ - (IBAction)viewIssues:(id)sender {
- }
- 
- - (IBAction)showAboutPanel:(id)sender {
--  self.aboutWindowController.updatePending = _updatePending;
-   [self.aboutWindowController showWindow:nil];
- }
- 
-@@ -472,11 +441,6 @@ - (IBAction)dimissModal:(id)sender {
+
+@@ -462,11 +434,6 @@ - (IBAction)dimissModal:(id)sender {
    [[(NSButton*)sender window] orderOut:nil];
  }
- 
+
 -- (IBAction)checkForUpdates:(id)sender {
 -  _manualCheck = YES;
 -  [_updater checkForUpdatesInBackground];
@@ -99,10 +89,10 @@ index 4ef4dcb..694fd63 100644
  - (IBAction)installTool:(id)sender {
    AuthorizationRef authorization;
    OSStatus status = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &authorization);
-@@ -536,55 +500,4 @@ - (void)userNotificationCenter:(NSUserNotificationCenter*)center didActivateNoti
+@@ -526,46 +493,4 @@ - (void)userNotificationCenter:(NSUserNotificationCenter*)center didActivateNoti
    }
  }
- 
+
 -#pragma mark - SUUpdaterDelegate
 -
 -- (NSString*)feedURLStringForUpdater:(SUUpdater*)updater {
@@ -113,14 +103,6 @@ index 4ef4dcb..694fd63 100644
 -- (void)updater:(SUUpdater*)updater didFindValidUpdate:(SUAppcastItem*)item {
 -  NSString* channel = [[NSUserDefaults standardUserDefaults] stringForKey:kUserDefaultsKey_ReleaseChannel];
 -  XLOG_INFO(@"Did find app update on channel '%@' for version %@", channel, item.versionString);
--  if (_manualCheck) {
--    NSAlert* alert = [[NSAlert alloc] init];
--    alert.messageText = NSLocalizedString(@"A GitUp update is available!", nil);
--    alert.informativeText = NSLocalizedString(@"The update will download automatically in the background and be installed when you quit GitUp.", nil);
--    [alert addButtonWithTitle:NSLocalizedString(@"OK", nil)];
--    alert.type = kGIAlertType_Note;
--    [alert runModal];
--  }
 -}
 -
 -- (void)updaterDidNotFindUpdate:(SUUpdater*)updater {
@@ -148,7 +130,6 @@ index 4ef4dcb..694fd63 100644
 -
 -- (void)updater:(SUUpdater*)updater willInstallUpdateOnQuit:(SUAppcastItem*)item immediateInstallationInvocation:(NSInvocation*)invocation {
 -  XLOG_INFO(@"Will install app update for version %@ on quit", item.versionString);
--  _updatePending = YES;
 -  [self _showNotificationWithTitle:NSLocalizedString(@"Update Available", nil)
 -                            action:NULL
 -                           message:NSLocalizedString(@"Relaunch GitUp to update to version %@ (%@).", nil), item.displayVersionString, item.versionString];


### PR DESCRIPTION
#### Description

update GitUp to 1.3.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
