### PR TITLE
gobject_introspection-1.0.tcl: fix meson options

### DIFF
--- a/_resources/port1.0/group/gobject_introspection-1.0.tcl
+++ b/_resources/port1.0/group/gobject_introspection-1.0.tcl
@@ -37,7 +37,7 @@ proc gobject_introspection_pg::gobject_introspection_setup {} {
         if { [string match *cmake* [option configure.cmd] ] } {
             configure.args-append   -DENABLE_GOBJECT_INTROSPECTION=OFF
         } elseif { [string match *meson* [option configure.cmd] ] } {
-            configure.args-append   -Dintrospection=false
+            configure.args-append   -Dintrospection=disabled
         } else {
             configure.args-append   --disable-introspection
         }
@@ -56,7 +56,7 @@ proc gobject_introspection_pg::gobject_introspection_setup {} {
         if { [string match *cmake* [option configure.cmd] ] } {
             configure.args-append   -DENABLE_GOBJECT_INTROSPECTION=ON
         } elseif { [string match *meson* [option configure.cmd] ] } {
-            configure.args-append   -Dintrospection=true
+            configure.args-append   -Dintrospection=enabled
         } else {
             configure.args-append   --enable-introspection
         }


### PR DESCRIPTION
meson only accepts enabled/disabled not true/false

#### Description

Noticed this problem while working on gstreamer1 Portfiles again.

```
meson.build:1:0: ERROR: Value "true" (of type "string") for combo option "Generate gobject-introspection bindings" is not one of the choices. Possible choices are (as string): "enabled", "disabled", "auto".
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
