### PR TITLE
nextcloud-client: update to 3.5.2

### DIFF
--- a/www/nextcloud-client/Portfile
+++ b/www/nextcloud-client/Portfile
@@ -7,10 +7,10 @@ PortGroup               compiler_blacklist_versions 1.0
 PortGroup               github 1.0
 
 epoch                   1
-github.setup            nextcloud desktop 3.4.4 v
-checksums               rmd160  3a1a6ec0bf29efd43f23b4b731935e26cd7f3284 \
-                        sha256  8a3f60a3f7f35f6dbbf975216e194989631596554c09b89b6e38325210585663 \
-                        size    14352115
+github.setup            nextcloud desktop 3.5.2 v
+checksums               rmd160  8175c77b5ad78618740ada31b7531ef57f87a5fb \
+                        sha256  161d82a4db5faabf3c69266b7b3aea1073ad98d14db6e3381fa1ae2a8fdef829 \
+                        size    15432939
 revision                0
 
 name                    nextcloud-client
@@ -40,6 +40,11 @@ patchfiles              patch-use-system-sqlite.diff \
                         patch-add-xcodeflags.diff \
                         patch-no-deployqt.diff \
                         patch-remove-inkscape.diff
+
+# Fix builds pre macOS 11 - may be removed in future release
+# Note that upstream patch doesn't work as-is; required updating to use preprocessor block, rather than runtime
+# https://github.com/nextcloud/desktop/pull/4563/commits/4bdfe5927051741584b86ba6c45054f0679357d4
+patchfiles-append       patch-fix-build-pre-macos-11.diff
 
 cmake.install_prefix    ${applications_dir}
 

--- a/www/nextcloud-client/files/patch-fix-build-pre-macos-11.diff
+++ b/www/nextcloud-client/files/patch-fix-build-pre-macos-11.diff
@@ -1,0 +1,19 @@
+--- src/gui/systray.mm.orig	2022-07-11 15:31:05.040339481 -0400
++++ src/gui/systray.mm	2022-07-11 15:32:04.592952997 -0400
+@@ -18,11 +18,11 @@
+     willPresentNotification:(UNNotification *)notification
+     withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
+ {
+-    if (@available(macOS 11.0, *)) {
+-        completionHandler(UNNotificationPresentationOptionSound + UNNotificationPresentationOptionBanner);
+-    } else {
+-        completionHandler(UNNotificationPresentationOptionSound + UNNotificationPresentationOptionAlert);
+-    }
++#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
++    completionHandler(UNNotificationPresentationOptionSound + UNNotificationPresentationOptionBanner);
++#else
++    completionHandler(UNNotificationPresentationOptionSound + UNNotificationPresentationOptionAlert);
++#endif
+ }
+ 
+ - (void)userNotificationCenter:(UNUserNotificationCenter *)center


### PR DESCRIPTION
#### Description

nextcloud-client: update to 3.5.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
