### PR TITLE
wolfssl: use --enable-all with configure

### DIFF
--- a/devel/wolfssl/Portfile
+++ b/devel/wolfssl/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                wolfssl
 version             5.3.0
+revision            1
 categories          devel security
 platforms           darwin
 maintainers         {wolfssl.com:facts @JacobBarthelmeh} openmaintainer

--- a/devel/wolfssl/Portfile
+++ b/devel/wolfssl/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  490285c39168e8eca0a1d2dfcb1fbe08698fa7ef \
                     sha256  60d9d47b255f05da0c90538b30cd6b43bcbc8a29f057ed41d4dd14aee4dde8bd \
                     size    22125813
 
-configure.args      --enable-distro \
+configure.args      --enable-all \
                     --disable-jobserver \
                     --disable-silent-rules
 


### PR DESCRIPTION
#### Description

Updates Portfile to use --enable-all instead of --enable-distro. Using --enable-all will install a wolfssl/options.h file which has the macros for how wolfSSL was built where --enable-distro does not install the wolfssl/options.h file.

Reported here:
https://trac.macports.org/ticket/65403

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H1323 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
