### PR TITLE
py-awscli2: update to 2.7.12

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.7.10
+github.setup        aws aws-cli 2.7.12
 revision            0
 
 categories          python devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  3dfa678ef5b3ee86f041b7aefcb150f4839bfe71 \
-                    sha256  86dddfb0fada8b7f73c62c5f09f3e0dcaf5ddf665b5dc1de300738cb7fcd3941 \
-                    size    11188537
+checksums           rmd160  5081b1af8c1491c0752b90d9be57bd35d1734e75 \
+                    sha256  f39109f2ee493270f16af4ff787ea26bd2e1804dce2e82cbaad819f31194ca41 \
+                    size    10987821
 
 python.versions     38 39 310
 

--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -23,9 +23,7 @@ checksums           rmd160  3dfa678ef5b3ee86f041b7aefcb150f4839bfe71 \
                     sha256  86dddfb0fada8b7f73c62c5f09f3e0dcaf5ddf665b5dc1de300738cb7fcd3941 \
                     size    11188537
 
-# This is what Amazon currently supports and there
-# are hard errors with later Pythons right now.
-python.versions     38 39
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     if {${os.platform} eq "darwin" && ${os.major} <= 15} {

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,17 +1,17 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-diff -ru aws-cli-2.7.8-orig/setup.cfg aws-cli-2.7.8/setup.cfg
---- aws-cli-2.7.8-orig/setup.cfg	2022-06-17 10:06:55.376482754 -0400
-+++ aws-cli-2.7.8/setup.cfg	2022-06-17 10:07:55.484117900 -0400
-@@ -28,17 +28,17 @@
+diff -ru aws-cli-2.7.12-orig/setup.cfg aws-cli-2.7.12/setup.cfg
+--- aws-cli-2.7.12-orig/setup.cfg	2022-06-29 15:00:04.000000000 -0400
++++ aws-cli-2.7.12/setup.cfg	2022-06-30 08:25:10.729190844 -0400
+@@ -29,17 +29,17 @@
  python_requires = >=3.8
  include_package_data = True
  install_requires =
 -    colorama>=0.2.5,<0.4.4
 -    docutils>=0.10,<0.16
 -    cryptography>=3.3.2,<37.0.0
--    ruamel.yaml>=0.15.0,<0.16.0
+-    ruamel.yaml>=0.15.0,<=0.17.21
 -    wcwidth<0.2.0
 -    prompt-toolkit>=3.0.24,<3.0.29
 -    distro>=1.5.0,<1.6.0


### PR DESCRIPTION
#### Description

Upstream has finally made its fixes for python 3.10 so the portfile now installs under 3.10 by default.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1922 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
