### PR TITLE
minikube: correct platform for arm64 fix

### DIFF
--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/kubernetes/minikube 1.26.0 v
 go.package          k8s.io/minikube
 github.tarball_from archive
-revision            1
+revision            2
 
 homepage            https://minikube.sigs.k8s.io
 
@@ -32,7 +32,12 @@ depends_build-append \
 
 depends_run         path:${prefix}/bin/kubectl:kubectl-1.24
 
-platform x86_64 {
+# Minikube needs the hyperkit driver on Darwin x86_64 platforms
+platform i386 {
+    default_variants +hyperkit
+}
+
+if {${build_arch} ne "arm64"} {
     default_variants +hyperkit
 }
 


### PR DESCRIPTION
To address @jmroot 's comments [here](https://github.com/macports/macports-ports/commit/9622c5ad52e42a458e4081ba71846f919d1c2cf9#commitcomment-77385053)

`minikube` needs the hyperkit driver when running on Darwin on x86_64.

Original issue: https://trac.macports.org/ticket/65396