### PR TITLE
openjdk-distributions: move openjdk11-graalvm to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -214,33 +214,6 @@ subport openjdk11-corretto {
     worksrcdir   amazon-corretto-11.jdk
 }
 
-subport openjdk11-graalvm {
-    # https://github.com/graalvm/graalvm-ce-builds/releases
-    supported_archs  x86_64 arm64
-
-    version      22.1.0
-    revision     0
-
-    description  GraalVM Community Edition based on OpenJDK 11
-    long_description ${long_description_graalvm}
-
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     graalvm-ce-java11-darwin-amd64-${version}
-        checksums    rmd160  6c4afee0143d6cf4373fa8faf36a6e3eeb4bce22 \
-                     sha256  c4c9df94ca47b83b582758b87d39042732ba0193fc63f1ab93f6818005a1fe6b \
-                     size    435795441
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     graalvm-ce-java11-darwin-aarch64-${version}
-        checksums    rmd160  5e834b8bc8ea1150e1f8f95bdc623a81d904fddc \
-                     sha256  06bc19a0b1e93aa3df5e15c08e97f8cef624cb6070eeae40a69a51ec7fd41152 \
-                     size    404445467
-    }
-
-    worksrcdir   graalvm-ce-java11-${version}
-}
-
 # Remove after 2022-09-14
 subport openjdk16 {
     version      16.0.2

--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk11-graalvm
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://github.com/graalvm/graalvm-ce-builds/releases
+supported_archs  x86_64 arm64
+
+version      22.1.0
+revision     0
+
+description  GraalVM Community Edition based on OpenJDK 11
+long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
+                 JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
+
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     graalvm-ce-java11-darwin-amd64-${version}
+    checksums    rmd160  6c4afee0143d6cf4373fa8faf36a6e3eeb4bce22 \
+                 sha256  c4c9df94ca47b83b582758b87d39042732ba0193fc63f1ab93f6818005a1fe6b \
+                 size    435795441
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     graalvm-ce-java11-darwin-aarch64-${version}
+    checksums    rmd160  5e834b8bc8ea1150e1f8f95bdc623a81d904fddc \
+                 sha256  06bc19a0b1e93aa3df5e15c08e97f8cef624cb6070eeae40a69a51ec7fd41152 \
+                 size    404445467
+}
+
+worksrcdir   graalvm-ce-java11-${version}
+
+homepage     https://www.graalvm.org
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk11-graalvm` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?