### PR TITLE
creduce: add variants llvm90, llvm11; auto-select llvm11 for Big Sur and later; migrate default to llvm 9

### DIFF
--- a/devel/creduce/Portfile
+++ b/devel/creduce/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               active_variants 1.1
 
 name                    creduce
 version                 2.10.0
-revision                1
+revision                2
 categories              devel
-platforms               darwin
 license                 NCSA
 maintainers             {larryv @larryv}
 
@@ -21,15 +21,44 @@ long_description        C-Reduce is a tool that takes a large C, C++, \
                         process source code.
 homepage                http://embed.cs.utah.edu/creduce
 
+patch.pre_args          -p1
+
 # INSTALL.md notes the specific version of LLVM that is required.
-set llvm_version        8.0
+platform darwin {
+    if { !([variant_isset llvm90] || [variant_isset llvm11]) } {
+        # LLVM-11 needed for Big Sur and later
+        if {${os.major} >= 20} {
+            default_variants    +llvm11
+        } else {
+            default_variants    +llvm90
+        }
+    }
+}
+
+# Note that LLVM 11 and later, each require different upstream patches
+if {[variant_isset llvm90]} {
+    set llvm_version    9.0
+} elseif {[variant_isset llvm11]} {
+    set llvm_version    11
+    patchfiles-append   patch-llvm-11.diff
+} else {
+    error "One variant must be selected"
+}
+
+# Clang must be installed with `+analyzer`, otherwise we'll be missing some required libs
+require_active_variants clang-${llvm_version} analyzer
+
 set perl5.major         5.34
 
+# Build with Clang matching selected LLVM version
+configure.compiler      macports-clang-${llvm_version}
+
 # INSTALL.md mentions flex, but the tarball ships with pregenerated parsers.
-depends_build           port:llvm-${llvm_version}
+depends_build-append    port:llvm-${llvm_version}
 
 # Required by the LLVM static libraries.
-depends_lib             port:ncurses port:zlib
+depends_lib-append      port:ncurses \
+                        port:zlib
 
 # Not required at compile time, but the configure script checks for them.
 depends_lib-append      port:clang-${llvm_version} \
@@ -39,6 +68,7 @@ depends_lib-append      port:clang-${llvm_version} \
                         port:p${perl5.major}-getopt-tabular \
                         port:p${perl5.major}-regexp-common \
                         port:p${perl5.major}-term-readkey
+
 depends_skip_archcheck  clang-${llvm_version} \
                         perl${perl5.major} \
                         p${perl5.major}-term-readkey
@@ -50,21 +80,18 @@ checksums               rmd160  183be95aec282812724ec66204952ad33dbc923b \
 
 compiler.cxx_standard   2011
 
-if {${os.platform} eq "darwin" && ${os.major} <= 9} {
-    known_fail          yes
-    pre-fetch {
-        ui_error "${name} is only supported on Mac OS X 10.6 or newer."
-        return -code error "unsupported Mac OS X version"
+platform darwin {
+    if {${os.major} <= 9} {
+        known_fail          yes
+        pre-fetch {
+            ui_error "${name} is only supported on Mac OS X 10.6 or newer."
+            return -code error "unsupported Mac OS X version"
+        }
+    } elseif {${os.major} <= 12} {
+        # forcing libc++ works on these platforms
+        depends_lib-append      port:libcxx
+        configure.cxx_stdlib    libc++
     }
-}
-
-if {${os.platform} eq "darwin" && ${os.major} <= 12} {
-    # forcing libc++ works on these platforms
-    depends_lib-append      port:libcxx
-    configure.cxx_stdlib    libc++
-    # clang < macOS 10.9 don't work. clang-5.0 tested and works.
-    # just whitelist working compilers rather than a long list of blacklisting and fallback additions
-    compiler.whitelist      macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
 }
 
 configure.perl          ${prefix}/bin/perl${perl5.major}
@@ -79,6 +106,9 @@ post-destroot {
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS COPYING NEWS README.md ${destroot}${docdir}
 }
+
+variant llvm90 conflicts llvm11 description {Use LLVM 9.0} {}
+variant llvm11 conflicts llvm90 description {Use LLVM 11} {}
 
 test.run                yes
 test.dir                ${worksrcpath}/tests

--- a/devel/creduce/files/patch-llvm-11.diff
+++ b/devel/creduce/files/patch-llvm-11.diff
@@ -1,0 +1,137 @@
+# ===========================================================================================================
+# LLVM 11 patch consists of:
+# - https://github.com/csmith-project/creduce/commit/3e1f5a1ec1365fafae965c97603221c9ccbc2d61.patch
+# ===========================================================================================================
+From 3e1f5a1ec1365fafae965c97603221c9ccbc2d61 Mon Sep 17 00:00:00 2001
+From: Yang Chen <chenyang@cs.utah.edu>
+Date: Tue, 13 Oct 2020 00:49:53 -0700
+Subject: [PATCH] Make it compile with LLVM11
+
+Applied the patch provided by Vegard Nossum (vegard@github).
+---
+ clang_delta/CommonRenameClassRewriteVisitor.h |  4 ++--
+ clang_delta/RemoveNamespace.cpp               |  2 +-
+ clang_delta/RewriteUtils.cpp                  |  2 +-
+ clang_delta/Transformation.cpp                |  2 +-
+ clang_delta/TransformationManager.cpp         | 18 ++++++++++--------
+ 5 files changed, 15 insertions(+), 13 deletions(-)
+# ===========================================================================================================
+diff --git a/clang_delta/CommonRenameClassRewriteVisitor.h b/clang_delta/CommonRenameClassRewriteVisitor.h
+index e400f3ff..ba860d9d 100644
+--- a/clang_delta/CommonRenameClassRewriteVisitor.h
++++ b/clang_delta/CommonRenameClassRewriteVisitor.h
+@@ -98,7 +98,7 @@ bool CommonRenameClassRewriteVisitor<T>::VisitUsingDecl(UsingDecl *D)
+     return true;
+ 
+   IdentifierInfo *IdInfo = DeclName.getAsIdentifierInfo();
+-  std::string IdName = IdInfo->getName();
++  std::string IdName = IdInfo->getName().str();
+   std::string Name;
+   if (getNewNameByName(IdName, Name)) {
+     SourceLocation LocStart = NameInfo.getBeginLoc();
+@@ -337,7 +337,7 @@ template<typename T> bool CommonRenameClassRewriteVisitor<T>::
+   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
+ 
+   const IdentifierInfo *IdInfo = DTST->getIdentifier();
+-  std::string IdName = IdInfo->getName();
++  std::string IdName = IdInfo->getName().str();
+   std::string Name;
+   if (getNewNameByName(IdName, Name)) {
+     SourceLocation LocStart = DTSLoc.getTemplateNameLoc();
+diff --git a/clang_delta/RemoveNamespace.cpp b/clang_delta/RemoveNamespace.cpp
+index 71ea5710..867e9c0b 100644
+--- a/clang_delta/RemoveNamespace.cpp
++++ b/clang_delta/RemoveNamespace.cpp
+@@ -458,7 +458,7 @@ bool RemoveNamespaceRewriteVisitor::VisitDependentTemplateSpecializationTypeLoc(
+   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
+ 
+   const IdentifierInfo *IdInfo = DTST->getIdentifier();
+-  std::string IdName = IdInfo->getName();
++  std::string IdName = IdInfo->getName().str();
+   std::string Name;
+ 
+   // FIXME:
+diff --git a/clang_delta/RewriteUtils.cpp b/clang_delta/RewriteUtils.cpp
+index 71e9914c..8c185aaa 100644
+--- a/clang_delta/RewriteUtils.cpp
++++ b/clang_delta/RewriteUtils.cpp
+@@ -748,7 +748,7 @@ std::string RewriteUtils::getStmtIndentString(Stmt *S,
+     ++I;
+   indentSpace = MB.substr(lineOffs, I-lineOffs);
+ 
+-  return indentSpace;
++  return indentSpace.str();
+ }
+ 
+ bool RewriteUtils::addLocalVarToFunc(const std::string &VarStr,
+diff --git a/clang_delta/Transformation.cpp b/clang_delta/Transformation.cpp
+index 9ef79cce..41153f3b 100644
+--- a/clang_delta/Transformation.cpp
++++ b/clang_delta/Transformation.cpp
+@@ -357,7 +357,7 @@ unsigned int Transformation::getConstArraySize(
+   llvm::SmallString<8> IntStr;
+   Result.toStringUnsigned(IntStr);
+ 
+-  std::stringstream TmpSS(IntStr.str());
++  std::stringstream TmpSS(IntStr.str().str());
+ 
+   if (!(TmpSS >> Sz)) {
+     TransAssert(0 && "Non-integer value!");
+diff --git a/clang_delta/TransformationManager.cpp b/clang_delta/TransformationManager.cpp
+index b123632e..98fc67ec 100644
+--- a/clang_delta/TransformationManager.cpp
++++ b/clang_delta/TransformationManager.cpp
+@@ -16,7 +16,9 @@
+ 
+ #include <sstream>
+ 
++#include "clang/Basic/Builtins.h"
+ #include "clang/Basic/Diagnostic.h"
++#include "clang/Basic/FileManager.h"
+ #include "clang/Basic/TargetInfo.h"
+ #include "clang/Lex/Preprocessor.h"
+ #include "clang/Frontend/CompilerInstance.h"
+@@ -101,16 +103,16 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
+   CompilerInvocation &Invocation = ClangInstance->getInvocation();
+   InputKind IK = FrontendOptions::getInputKindForExtension(
+         StringRef(SrcFileName).rsplit('.').second);
+-  if (IK.getLanguage() == InputKind::C) {
+-    Invocation.setLangDefaults(ClangInstance->getLangOpts(), InputKind::C, T, PPOpts);
++  if (IK.getLanguage() == Language::C) {
++    Invocation.setLangDefaults(ClangInstance->getLangOpts(), Language::C, T, PPOpts);
+   }
+-  else if (IK.getLanguage() == InputKind::CXX) {
++  else if (IK.getLanguage() == Language::CXX) {
+     // ISSUE: it might cause some problems when building AST
+     // for a function which has a non-declared callee, e.g.,
+     // It results an empty AST for the caller.
+-    Invocation.setLangDefaults(ClangInstance->getLangOpts(), InputKind::CXX, T, PPOpts);
++    Invocation.setLangDefaults(ClangInstance->getLangOpts(), Language::CXX, T, PPOpts);
+   }
+-  else if(IK.getLanguage() == InputKind::OpenCL) {
++  else if(IK.getLanguage() == Language::OpenCL) {
+     //Commandline parameters
+     std::vector<const char*> Args;
+     Args.push_back("-x");
+@@ -122,7 +124,7 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
+     ClangInstance->createFileManager();
+ 
+     if(CLCPath != NULL && ClangInstance->hasFileManager() &&
+-       ClangInstance->getFileManager().getDirectory(CLCPath, false) != NULL) {
++       ClangInstance->getFileManager().getDirectory(CLCPath, false)) {
+         Args.push_back("-I");
+         Args.push_back(CLCPath);
+     }
+@@ -132,10 +134,10 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
+     Args.push_back("-fno-builtin");
+ 
+     CompilerInvocation::CreateFromArgs(Invocation,
+-                                       &Args[0], &Args[0] + Args.size(),
++		                       ArrayRef<const char*>(&Args[0], &Args[0] + Args.size()),
+                                        ClangInstance->getDiagnostics());
+     Invocation.setLangDefaults(ClangInstance->getLangOpts(),
+-                               InputKind::OpenCL, T, PPOpts);
++                               Language::OpenCL, T, PPOpts);
+   }
+   else {
+     ErrorMsg = "Unsupported file type!";


### PR DESCRIPTION
### Description

Fixes: https://trac.macports.org/ticket/62637

### Tested on macOS Versions

* 10.7.5
* 10.8.6
* 10.9.5
* 10.10.5
* 10.11.6
* 10.12.6
* 10.13.6
* 10.14.6
* 10.15.6; for both `+llvm90` and `+llvm11`