### PR TITLE
openjdk-distributions: move openjdk11-corretto to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -187,33 +187,6 @@ subport openjdk8-temurin {
                  size    107924497
 }
 
-subport openjdk11-corretto {
-    # https://github.com/corretto/corretto-11/releases
-    supported_archs  x86_64 arm64
-
-    version      11.0.15.9.1
-    revision     0
-
-    description  Amazon Corretto OpenJDK 11 (Long Term Support)
-    long_description ${long_description_corretto}
-
-    master_sites https://corretto.aws/downloads/resources/${version}/
-
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     amazon-corretto-${version}-macosx-x64
-        checksums    rmd160  752d92e2e87d3feda836e7c7afa39982ea6b24f3 \
-                     sha256  36afb7f091cd9b986a50c3f878f167c59eae615f004b2cb1c5c394f9f2fc215a \
-                     size    187526579
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     amazon-corretto-${version}-macosx-aarch64
-        checksums    rmd160  d1980a49d5539b892a6ed09f7d100501da1c7d80 \
-                     sha256  939f0cc40f4dd749647e352ea2759fbf73c8c59662476ca237113abf9eed0710 \
-                     size    185394420
-    }
-
-    worksrcdir   amazon-corretto-11.jdk
-}
-
 # Remove after 2022-09-14
 subport openjdk16 {
     version      16.0.2

--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -1,0 +1,97 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk11-corretto
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://github.com/corretto/corretto-11/releases
+supported_archs  x86_64 arm64
+
+version      11.0.15.9.1
+revision     0
+
+description  Amazon Corretto OpenJDK 11 (Long Term Support)
+long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
+
+master_sites https://corretto.aws/downloads/resources/${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     amazon-corretto-${version}-macosx-x64
+    checksums    rmd160  752d92e2e87d3feda836e7c7afa39982ea6b24f3 \
+                 sha256  36afb7f091cd9b986a50c3f878f167c59eae615f004b2cb1c5c394f9f2fc215a \
+                 size    187526579
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     amazon-corretto-${version}-macosx-aarch64
+    checksums    rmd160  d1980a49d5539b892a6ed09f7d100501da1c7d80 \
+                 sha256  939f0cc40f4dd749647e352ea2759fbf73c8c59662476ca237113abf9eed0710 \
+                 size    185394420
+}
+
+worksrcdir   amazon-corretto-11.jdk
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    # See https://github.com/corretto/corretto-11/blob/release-11.0.15.9.1/CHANGELOG.md
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.13 High Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://aws.amazon.com/corretto/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk11-corretto` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?