### PR TITLE
lang/sbcl: update to sbcl-2.2.9

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -8,14 +8,14 @@ name            sbcl
 #
 # Please bump the revision of math/maxima (and when it exists
 # math/maxima-devel) when this port changes.
-version         2.2.5
+version         2.2.9
 revision        0
 
 categories      lang
 license         BSD
 maintainers     {easieste @easye} openmaintainer
 platforms       darwin
-supported_archs i386 x86_64 arm64
+supported_archs x86_64 arm64
 description     The Steel Bank Common Lisp system
 
 long_description \
@@ -34,15 +34,15 @@ use_bzip2       yes
 
 patchfiles \
     patch-contrib-sb-posix-posix-tests.lisp.diff \
-    patch-sbcl-realtime.diff 
+    patch-sbcl-realtime.diff
 
 distfiles       ${name}-${version}-source${extract.suffix}:sbcl
 worksrcdir      ${name}-${version}
 
 checksums       ${name}-${version}-source${extract.suffix} \
-    rmd160  55225af6c20d39db1b158b7c07685ff6e3a8d5bf \
-    sha256  8584b541370fd6ad6e58d3f97982077dfcab240f30d4e9b18f15da91c2f13ed1 \
-    size    7029912 
+    rmd160  45464c6e31af36acf53c00f2cc5c46706ce4fe65 \
+    sha256  7ebebd6d2023fff7077b0372fa1171f880529bdec6104f20983297c2feb7c172 \
+    size    7258148
 
 # Since SBCL is written in lisp, it requires a running lisp binary to
 # bootstrap from.
@@ -54,18 +54,20 @@ checksums       ${name}-${version}-source${extract.suffix} \
 # However, if someone does come up with a way to support powerpc,
 # duplicating the "if" here would be the way to do it.
 if {${build_arch} eq "x86_64"} {
-    set bootversion 1.2.11
+    set bootversion 2.2.9
+    set conf_prefix x86-64
     master_sites-append sourceforge:project/sbcl/sbcl/${bootversion}:sbcl_amd64
     distfiles-append    ${name}-${bootversion}-x86-64-darwin-binary${extract.suffix}:sbcl_amd64
     checksums-append    ${name}-${bootversion}-x86-64-darwin-binary${extract.suffix} \
-        rmd160  7065f30033c0a38ea4bd5b2bdead76ed12eb8af4 \
-        sha256  057d3a1c033fb53deee994c0135110636a04f92d2f88919679864214f77d0452 \
-        size    10038928
+        rmd160  3c7656d617269a0dd30f783e305f62b8d0da303f \
+        sha256  6f504b9282c83842c0601600f5e0663209b53b133125ec3334ff7a0bd0037ca6 \
+        size    10944221
     global host_lisp
     set host_lisp "\"${workpath}/${name}-${bootversion}-x86-64-darwin/src/runtime/sbcl --core ${workpath}/${name}-${bootversion}-x86-64-darwin/output/sbcl.core --disable-debugger --sysinit /dev/null --userinit /dev/null\" "
 }
 if {${build_arch} eq "arm64"} {
     set bootversion 2.1.2
+    set conf_prefix arm64
     master_sites-append sourceforge:project/sbcl/sbcl/${bootversion}:sbcl_arm64
     distfiles-append    ${name}-${bootversion}-arm64-darwin-binary${extract.suffix}:sbcl_arm64
     checksums-append    ${name}-${bootversion}-arm64-darwin-binary${extract.suffix} \
@@ -74,18 +76,6 @@ if {${build_arch} eq "arm64"} {
         size    9204605
     global host_lisp
     set host_lisp "\"${workpath}/${name}-${bootversion}-arm64-darwin/src/runtime/sbcl --core ${workpath}/${name}-${bootversion}-arm64-darwin/output/sbcl.core --disable-debugger --sysinit /dev/null --userinit /dev/null\" "
-}
-# Note that i386 support is currently untested; build reports welcome
-if {${build_arch} eq "i386"} {
-    set bootversion 1.1.6
-    master_sites-append sourceforge:project/sbcl/sbcl/${bootversion}:sbcl_i386
-    distfiles-append    ${name}-${bootversion}-x86-darwin-binary${extract.suffix}:sbcl_i386
-    checksums-append    ${name}-${bootversion}-x86-darwin-binary${extract.suffix} \
-        rmd160  fb1ab24f3605b29af5716f0ba425ee178c6cfc06 \
-        sha256  5801c60e2a875d263fccde446308b613c0253a84a61ab63569be62eb086718b3 \
-        size    9091955
-    global host_lisp
-    set host_lisp "\"${workpath}/${name}-${bootversion}-x86-darwin/src/runtime/sbcl --core ${workpath}/${name}-${bootversion}-x86-darwin/output/sbcl.core --disable-debugger --sysinit /dev/null --userinit /dev/null\" "
 }
 
 post-patch {
@@ -101,6 +91,10 @@ post-patch {
     # linker. Tested on 10.11 with Xcode 8 beta.
     if {[vercmp "8.0" ${xcodeversion}] >= 0} {
         reinplace "s|0x100000|0x100000 -Wl,-no_pie|g" ${worksrcpath}/src/runtime/Config.x86-64-darwin
+    }
+    if {[variant_isset fancy]} {
+        reinplace -W ${worksrcpath} "s|@@PREFIX@@|${prefix}|g" \
+            src/runtime/Config.${conf_prefix}-darwin
     }
 }
 
@@ -141,6 +135,9 @@ variant threads description {Enable multi-threaded runtime using the Mach pthrea
 
 variant fancy conflicts threads description {Configure SBCL compilation with all available compatible options (including threading).} {
     set make_sh_options --fancy
+    # As of version 2.2.6, zstd is used for core compression.
+    depends_lib-append  port:zstd
+    patchfiles-append   patch-config-darwin-${build_arch}.diff
 }
 
 test.run        yes

--- a/lang/sbcl/files/patch-config-darwin-arm64.diff
+++ b/lang/sbcl/files/patch-config-darwin-arm64.diff
@@ -1,0 +1,13 @@
+--- src/runtime/Config.arm64-darwin.orig  2022-06-30 00:27:00.000000000 -0700
++++ src/runtime/Config.arm64-darwin       2022-07-12 21:45:30.000000000 -0700
+@@ -29,7 +29,9 @@
+   OS_LIBS += -lpthread
+ endif
+ ifdef LISP_FEATURE_SB_CORE_COMPRESSION
+-  OS_LIBS += -lzstd
++  OS_LIBS += -L@@PREFIX@@/lib -lzstd
++  DEPEND_FLAGS += -I@@PREFIX@@/include
++  CFLAGS += -I@@PREFIX@@/include
+ endif
+ ifdef LISP_FEATURE_SB_LINKABLE_RUNTIME
+   LIBSBCL = libsbcl.a

--- a/lang/sbcl/files/patch-config-darwin-x86_64.diff
+++ b/lang/sbcl/files/patch-config-darwin-x86_64.diff
@@ -1,0 +1,13 @@
+--- src/runtime/Config.x86-64-darwin.orig  2022-06-30 00:27:00.000000000 -0700
++++ src/runtime/Config.x86-64-darwin       2022-07-12 21:45:55.000000000 -0700
+@@ -29,7 +29,9 @@
+   OS_LIBS += -lpthread
+ endif
+ ifdef LISP_FEATURE_SB_CORE_COMPRESSION
+-  OS_LIBS += -lzstd
++  OS_LIBS += -L@@PREFIX@@/lib -lzstd
++  DEPEND_FLAGS += -I@@PREFIX@@/include
++  CFLAGS += -I@@PREFIX@@/include
+ endif
+ ifdef LISP_FEATURE_SB_LINKABLE_RUNTIME
+   LIBSBCL = libsbcl.a

--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -39,7 +39,7 @@ subport maxima-devel {
     # Date:  Sun Jan 26 20:10:05 2020 -0800
     # commit 8b2da334e1f6c6b56d90cf3e00c2d67274fa6550
     version     5.43-dev-20200126
-    revision    27
+    revision    28
     fetch.type  git
     git.url     https://git.code.sf.net/p/maxima/code
     git.branch  d806e84c719a9fcf023f8829535f593ce9bb7d0c
@@ -53,7 +53,7 @@ if {${subport} eq ${name}} {
     conflicts   maxima-devel
 
     version     5.45.1
-    revision    9
+    revision    10
     # get the source tarball from sourceforge.
     master_sites    sourceforge:project/maxima/Maxima-source/${version}-source
 


### PR DESCRIPTION
NOTE: This PR used to apply to SBCL 2.2.6 (then 2.2.8). The PR has been modified for SBCL 2.2.9, released on 2022 September 29.

#### Description
* **Removed support for i386.** Support was removed upstream.
* **Added archivers/zstd library dependency.** Core compression in SBCL has changed format from zlib to zstd.
* **Added patches to ensure zstd headers can be found.** Upstream blindly assumes that zstd headers will always be present in /usr/local/include. This is obviously not the case for MacPorts or any package manager that uses a different prefix. Since the archivers/zstd port installs a pkg-config module, I decide to make use of it. This has the side effect of pulling in devel/pkgconfig as a build dependency.
* **Revision bumped math/maxima.** As requested in the Portfile comments.

Note: the addition of pkgconfig and zstd dependencies is only done for the +fancy variant, since that enables all contribs; in particular, the core compression contrib makes use of zstd. I will also note that MacPorts claims the build fails at the very end of testing every single contrib. Some test in SB-POSIX currently fails, and the returned status code leads MacPorts (at least in trace mode) to believe some error occurred in the build process. As far as I know, this is not detrimental to the overall functionality of SBCL.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
