### PR TITLE
ccrypt: update to 1.11

### DIFF
--- a/security/ccrypt/Portfile
+++ b/security/ccrypt/Portfile
@@ -2,7 +2,7 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 
 name                    ccrypt
-version                 1.10
+version                 1.11
 categories              security
 platforms               darwin
 license                 GPL-2+
@@ -28,10 +28,11 @@ long_description        Utility for encrypting and decrypting files and streams.
                         files around. In addition, there is a compatibility mode \
                         for decrypting legacy unix crypt files.
 
-master_sites            sourceforge:project/ccrypt/ccrypt/${version}
+master_sites            sourceforge:project/ccrypt/${version}
 
-checksums               rmd160  b3b07d2e788f8ba04712879150b609a8c55f0dc5 \
-                        sha256  87d66da2170facabf6f2fc073586ae2c7320d4689980cfca415c74688e499ba0
+checksums               rmd160  0515bdaad2dbf9f029acb6361b26be4c280d2a2a \
+                        sha256  b19c47500a96ee5fbd820f704c912f6efcc42b638c0a6aa7a4e3dc0a6b51a44f \
+                        size    834575
 
 depends_lib             port:gettext
 


### PR DESCRIPTION
###### Tested on
macOS 11.6.7 20G630 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
