### PR TITLE
maddy: new port

### DIFF
--- a/mail/maddy/Portfile
+++ b/mail/maddy/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/foxcpp/maddy 0.6.2 v
+github.tarball_from archive
+revision            0
+
+homepage            https://maddy.email
+
+description         Composable all-in-one mail server
+
+long_description    \
+    Maddy Mail Server implements all functionality required to run a e-mail \
+    server. It can send messages via SMTP (works as MTA), accept messages via \
+    SMTP (works as MX) and store messages while providing access to them via \
+    IMAP. In addition to that it implements auxiliary protocols that are \
+    mandatory to keep email reasonably secure (DKIM, SPF, DMARC, DANE, \
+    MTA-STS). It replaces Postfix, Dovecot, OpenDKIM, OpenSPF, OpenDMARC and \
+    more with one daemon with uniform configuration and minimal maintenance \
+    cost.
+
+categories          mail
+installs_libs       no
+license             GPL-3
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  2d61527fdb862d493d04229336ba78cfb26cfbe4 \
+                    sha256  6a29645afd9eb89fcc0fd38238ee9fb87a8ad7e854d0d89aa6da6161b8a2d497 \
+                    size    391366
+
+depends_build-append \
+                    port:scdoc
+
+patchfiles          patch-build.sh.diff
+
+post-patch {
+    reinplace "s|/etc/maddy|${prefix}/etc/maddy|g" ${worksrcpath}/maddy.conf
+}
+
+set maddy_logfile   ${prefix}/var/log/${name}.log
+
+# Allow Go to fetch dependencies at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+build.cmd           ./build.sh
+build.pre_args      --prefix ${prefix} \
+                    --destdir ${destroot}
+build.args          build
+
+destroot.keepdirs   ${destroot}${prefix}/var/lib/maddy \
+                    ${destroot}${prefix}/var/run/maddy \
+                    ${destroot}${prefix}/libexec/maddy
+
+if {"darwin" eq ${os.platform} && ${os.major} > 8} {
+    set svcuser _${name}
+} else {
+    set svcuser ${name}
+}
+
+add_users ${svcuser} group=${svcuser} realname=Maddy\ Email\ Server
+
+startupitem.create  yes
+startupitem.executable \
+                    maddy run
+startupitem.logfile ${maddy_logfile}
+startupitem.user    ${svcuser}
+
+destroot {
+    system -W ${worksrcpath} \
+        "${build.env} ./build.sh --prefix ${prefix} --destdir ${destroot} install"
+
+    xinstall -d -o ${svcuser} -m 0700 ${destroot}${prefix}/var/lib/maddy
+    xinstall -d -o ${svcuser} -m 0700 ${destroot}${prefix}/var/run/maddy
+    xinstall -d ${destroot}${prefix}/libexec/maddy
+
+    touch ${destroot}${maddy_logfile}
+
+    file attributes \
+        ${destroot}${maddy_logfile} -owner ${svcuser} -group ${svcuser}
+}
+
+notes-append "
+    Before loading the maddy service, adjust configuration in ${prefix}/etc/maddy,
+    as well as generating certificates and other necessary prerequisites.
+"

--- a/mail/maddy/files/patch-build.sh.diff
+++ b/mail/maddy/files/patch-build.sh.diff
@@ -1,0 +1,61 @@
+--- ./build.sh	2022-07-04 14:15:21.000000000 -0400
++++ ./build.sh	2022-07-04 14:16:02.000000000 -0400
+@@ -1,4 +1,5 @@
+ #!/bin/sh
++set -x
+
+ destdir=/
+ builddir="$PWD/build"
+@@ -104,9 +105,6 @@
+ 	for f in ./docs/man/*.1.scd; do
+ 		scdoc < "$f" > "${builddir}/man/$(basename "$f" .scd)"
+ 	done
+-	for f in ./docs/man/*.5.scd; do
+-		scdoc < "$f" > "${builddir}/man/$(basename "$f" .scd)"
+-	done
+ }
+ 
+ build() {
+@@ -125,7 +123,19 @@
+ 			-o "${builddir}/maddy" ${GOFLAGS} ./cmd/maddy
+ 	else
+ 		echo "-- Building main server executable..." >&2
+-		go build -tags "$tags" -trimpath -ldflags="-X \"github.com/foxcpp/maddy.Version=${version}\"" -o "${builddir}/maddy" ${GOFLAGS} ./cmd/maddy
++		go build \
++                    -tags "$tags" \
++                    -trimpath \
++                    -ldflags="
++                        -X \"github.com/foxcpp/maddy.ConfigDirectory=${prefix}/etc/maddy\"
++                        -X \"github.com/foxcpp/maddy.DefaultStateDirectory=${prefix}/var/lib/maddy\"
++                        -X \"github.com/foxcpp/maddy.DefaultRuntimeDirectory=${prefix}/var/run/maddy\"
++                        -X \"github.com/foxcpp/maddy.DefaultLibexecDirectory=${prefix}/libexec/maddy\"
++                        -X \"github.com/foxcpp/maddy.Version=${version}\"
++                    " \
++                    -o "${builddir}/maddy" \
++                    ${GOFLAGS} \
++                    ./cmd/maddy
+ 	fi
+ 
+ 	build_man_pages
+@@ -143,8 +153,8 @@
+ 	command install -m 0755 -d "${destdir}/${prefix}/bin/"
+ 	command install -m 0755 "${builddir}/maddy" "${destdir}/${prefix}/bin/"
+ 	command ln -s maddy "${destdir}/${prefix}/bin/maddyctl"
+-	command install -m 0755 -d "${destdir}/etc/maddy/"
+-	command install -m 0644 ./maddy.conf "${destdir}/etc/maddy/maddy.conf"
++	command install -m 0755 -d "${destdir}/${prefix}/etc/maddy/"
++	command install -m 0644 ./maddy.conf "${destdir}/${prefix}/etc/maddy/maddy.conf"
+ 
+ 	# Attempt to install systemd units only for Linux.
+ 	# Check is done using GOOS instead of uname -s to account for possible
+@@ -159,10 +169,6 @@
+ 		for f in "${builddir}"/man/*.1; do
+ 			command install -m 0644 "$f" "${destdir}/${prefix}/share/man/man1/"
+ 		done
+-		command install -m 0755 -d "${destdir}/${prefix}/share/man/man5/"
+-		for f in "${builddir}"/man/*.5; do
+-			command install -m 0644 "$f" "${destdir}/${prefix}/share/man/man5/"
+-		done
+ 	fi
+ }
+ 


### PR DESCRIPTION
New port for [maddy](https://maddy.email/), an all-in-one email server built in Go.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
