### PR TITLE
libntlm: update to 1.6

### DIFF
--- a/net/libntlm/Portfile
+++ b/net/libntlm/Portfile
@@ -1,24 +1,30 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name		libntlm
-version		1.2
-revision	0
-categories	net security devel
-license		LGPL-2.1+
-maintainers	nomaintainer
-description	Implement Microsoft's NTLM authentication
-long_description	\
-	NTLM employs a challenge-response mechanism for 	\
-	authentication, in which clients are able to prove 	\
-	their identities without sending a password to the 	\
-	server. It consists of three messages, commonly 	\
-	referred to as Type 1 (negotiation), Type 2 		\
-	(challenge) and Type 3 (authentication).
-homepage	http://josefsson.org/libntlm
-master_sites	http://josefsson.org/libntlm/releases
-platforms	darwin
-checksums	md5 13b40af721b29005652fb429a3ae9582 \
-		sha1 27538a3375690a37574fa991fbd327d150d8b505 \
-		rmd160 b7344213f2510c93e30583fc567961a4e6aedd13
-configure.args	--infodir=${prefix}/share/info \
-		--mandir=${prefix}/share/man
+PortSystem          1.0
+
+name                libntlm
+version             1.2
+revision            0
+categories          net security devel
+license             LGPL-2.1+
+maintainers         nomaintainer
+
+description         Implement Microsoft's NTLM authentication
+long_description    NTLM employs a challenge-response mechanism for     \
+                    authentication, in which clients are able to prove  \
+                    their identities without sending a password to the  \
+                    server. It consists of three messages, commonly     \
+                    referred to as Type 1 (negotiation), Type 2         \
+                    (challenge) and Type 3 (authentication).
+
+homepage            http://josefsson.org/libntlm
+master_sites        http://josefsson.org/libntlm/releases
+
+platforms           darwin
+
+checksums           md5 13b40af721b29005652fb429a3ae9582 \
+                    sha1 27538a3375690a37574fa991fbd327d150d8b505 \
+                    rmd160 b7344213f2510c93e30583fc567961a4e6aedd13
+
+configure.args      --infodir=${prefix}/share/info \
+                    --mandir=${prefix}/share/man

--- a/net/libntlm/Portfile
+++ b/net/libntlm/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libntlm
-version             1.2
+version             1.6
 revision            0
 categories          net security devel
 license             LGPL-2.1+
@@ -17,14 +17,19 @@ long_description    NTLM employs a challenge-response mechanism for     \
                     referred to as Type 1 (negotiation), Type 2         \
                     (challenge) and Type 3 (authentication).
 
-homepage            http://josefsson.org/libntlm
-master_sites        http://josefsson.org/libntlm/releases
+homepage            https://www.nongnu.org/libntlm
+master_sites        ${homepage}/releases
 
-platforms           darwin
+checksums           rmd160  673b3b2d18a8429565c09b52b309f598937ca081 \
+                    sha256  f2376b87b06d8755aa3498bb1226083fdb1d2cf4460c3982b05a9aa0b51d6821 \
+                    size    688608
 
-checksums           md5 13b40af721b29005652fb429a3ae9582 \
-                    sha1 27538a3375690a37574fa991fbd327d150d8b505 \
-                    rmd160 b7344213f2510c93e30583fc567961a4e6aedd13
+test.run            yes
+test.cmd            make
+test.target         check
 
-configure.args      --infodir=${prefix}/share/info \
-                    --mandir=${prefix}/share/man
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -W ${worksrcpath} -m 0644 README NEWS ChangeLog \
+        ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
#### Description

* Fix whitespace and add modeline
* Update to version 1.6 - Fix for CVE-2019-17455
* Enable Test phase

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 11.6.7 20G630 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
