### PR TITLE
openssl11: Update to 1.1.1q, openssl3: Update to 3.0.5

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            5
+revision            6
 
 categories          devel security
 platforms           darwin

--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -8,7 +8,7 @@ name                openssl[string map {. {}} $short_v]
 
 # The revision of the openssl shim port should be bumped whenever
 # the version or revision is changed here.
-version             ${short_v}.1p
+version             ${short_v}.1q
 revision            0
 
 # Please revbump these ports when updating OpenSSL.
@@ -44,9 +44,11 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  d888b653de4e1b95b0bfe0596890b15539ec7842 \
-                    sha256  bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f \
-                    size    9860217
+checksums           rmd160  00bc343e208011ff3814e3006ab8e45a9d6621a2 \
+                    sha256  d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca \
+                    size    9864061
+
+patchfiles-append   18719.patch
 
 platform darwin 8 {
     # No Availability.h on Tiger

--- a/devel/openssl11/files/18719.patch
+++ b/devel/openssl11/files/18719.patch
@@ -1,0 +1,23 @@
+From 7f58de577c05ae0bbd20eee9b2971cfa1cd062c8 Mon Sep 17 00:00:00 2001
+From: Gregor Jasny <gjasny@googlemail.com>
+Date: Tue, 5 Jul 2022 12:57:06 +0200
+Subject: [PATCH] Add missing header for memcmp
+
+CLA: trivial
+Upstream-Status: Submitted [https://patch-diff.githubusercontent.com/raw/openssl/openssl/pull/18719.patch]
+---
+ test/v3ext.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/v3ext.c b/test/v3ext.c
+index 926f3884b138..a8ab64b2714b 100644
+--- ./test/v3ext.c
++++ ./test/v3ext.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include <openssl/x509.h>
+ #include <openssl/x509v3.h>
+ #include <openssl/pem.h>

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 8
 
 set major_v         3
 name                openssl$major_v
-version             ${major_v}.0.4
+version             ${major_v}.0.5
 revision            0
 
 # Please revbump these ports when updating the openssl3 version/revision
@@ -47,9 +47,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  660872ca2bcc5cf05e7dd61b1124d842e6ee3cb1 \
-                    sha256  2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f \
-                    size    15069605
+checksums           rmd160  05b59b3e88da2aea3ea94018d8503161367bcbd1 \
+                    sha256  aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a \
+                    size    15074407
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             9.0p1
-revision            5
+revision            6
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                8
+revision                9
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
#### Description

See https://www.openssl.org/news/secadv/20220705.txt for the advisory.

Note that CVE-2022-2274 did not occur in MacPorts, because we disable AVX512.

CVE: CVE-2022-2274, CVE-2022-2097

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
