### PR TITLE
goaccess: Use OpenSSL 3

### DIFF
--- a/www/goaccess/Portfile
+++ b/www/goaccess/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 
 name                goaccess
 version             1.6.1
-revision            0
+revision            1
 categories          www
 license             MIT
 maintainers         {mps @Schamschula} openmaintainer
@@ -23,7 +23,7 @@ checksums           rmd160  bc0eb0d927d9c43b8ddfe5b2260010e6325a286f \
 # strndup
 legacysupport.newest_darwin_requires_legacy 10
 
-openssl.branch      1.1
+openssl.branch      3
 
 configure.args      --enable-geoip=mmdb \
                     --enable-utf8 \


### PR DESCRIPTION
#### Description

Compiles fine, works fine, I've also tested `--real-time-html` with `--ssl-cert` and `--ssl-key`, so I don't see a reason why this should remain with OpenSSL 1.1.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
