### PR TITLE
cargo, rust: Use OpenSSL 3

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -8,7 +8,7 @@ PortGroup           cargo   1.0
 name                cargo
 epoch               1
 github.setup        rust-lang ${name} 0.62.0
-revision            0
+revision            1
 
 categories          devel
 license             {MIT Apache-2}
@@ -25,7 +25,7 @@ github.tarball_from archive
 
 installs_libs       no
 
-openssl.branch      1.1
+openssl.branch      3
 
 # can use cmake or cmake-devel; default to cmake.
 depends_build       port:pkgconfig \

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -8,7 +8,7 @@ name                        rust
 
 # keep in mind that you also need to update cargo.crates at the end of this file
 version                     1.61.0
-revision                    0
+revision                    1
 
 categories                  lang devel
 license                     {MIT Apache-2} BSD zlib NCSA Permissive
@@ -46,7 +46,7 @@ depends_lib-append          port:curl \
                             port:libiconv \
                             port:libgit2 \
                             port:zlib
-openssl.branch              1.1
+openssl.branch              3
 
 depends_skip_archcheck      cmake \
                             python${py_ver_nodot} \


### PR DESCRIPTION
#### Description

I compiled both rust and cargo against OpenSSL 3 and compiled a few test projects of mine using it, and also made sure to test cargo communication to crates.io, all of which worked as expected. It seems cargo and rust are now ready for OpenSSL 3.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
