### PR TITLE
pdfparser: update to 0.7.6

### DIFF
--- a/security/pdfparser/Portfile
+++ b/security/pdfparser/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                pdfparser
-version             0.4.3
+version             0.7.6
 set my_version      [strsed ${version} {g/\./_/}]
 categories          security
 platforms           darwin
@@ -20,8 +20,9 @@ master_sites        http://didierstevens.com/files/software/
 distname            pdf-parser_V${my_version}
 use_zip             yes
 
-checksums           rmd160  e07067992f3f12966565b75d60e7cc8fd8a615ec \
-                    sha256  1416624938359fdd375108d922350d1b7b0e41b3a40a48f778d6d72d8a405de6
+checksums           rmd160  51ce85ee37cb57d52d0fa5c95b98a494bf737d05 \
+                    sha256  34379a9987b2286706af4c43ac72c93611ae3e9c0c571dd729ebb09c7a707a0d \
+                    size    15103
 
 extract.mkdir       yes
 


### PR DESCRIPTION

###### Tested on
macOS 11.6.7 20G630 x86_64
Xcode 13.2.1 13C100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
