### PR TITLE
hilite: new port

### DIFF
--- a/sysutils/hilite/Portfile
+++ b/sysutils/hilite/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                hilite
+version             1.5
+categories          sysutils
+platforms           darwin freebsd linux netbsd openbsd solaris sunos
+license             GPL-2+
+maintainers         nomaintainer
+description         highlight stderr text in red
+long_description    hilite is a tiny utility which executes the command you \
+                    specify, highlighting anything printed to stderr. It is \
+                    designed mainly for use with builds, to make warnings and \
+                    errors stick out like a sore cliche.
+homepage            https://sourceforge.net/projects/hilite/
+master_sites        sourceforge:project/hilite/hilite/${version}
+
+distfiles           hilite.c
+checksums           rmd160  e969094546997199a98268af4333ec874c6dcf6e \
+                    sha256  e15bdff2605e8d23832d6828a62194ca26dedab691c9d75df2877468c2f6aaeb \
+                    size    2872
+
+use_configure       no
+
+extract {
+    file mkdir ${worksrcpath}
+    file copy ${distpath}/${distfiles} ${worksrcpath}/hilite.c
+}
+build {
+    system -W ${worksrcpath} "${configure.cc} ${configure.cflags} [get_canonical_archflags cc] -I ${prefix}/include -o hilite hilite.c"
+}
+destroot {
+    set bin_dir ${destroot}${prefix}/bin
+    xinstall -m 0755 -d ${bin_dir}
+    xinstall -m 0755 ${worksrcpath}/hilite ${bin_dir}
+}


### PR DESCRIPTION
#### Description

Adds a new port `hilite`.
hilite is a simple utility which highlights the lines of a sub command printed to stderr.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
