### PR TITLE
cgal5: update to 5.4.1

### DIFF
--- a/gis/cgal5/Portfile
+++ b/gis/cgal5/Portfile
@@ -17,7 +17,7 @@ long_description        The goal of the ${description} is to provide easy access
 
 platforms               darwin
 
-github.setup            CGAL cgal 5.3.1 v
+github.setup            CGAL cgal 5.4.1 v
 revision                0
 conflicts               cgal4
 github.tarball_from     releases
@@ -31,9 +31,9 @@ use_xz                  yes
 
 homepage                http://www.cgal.org/
 
-checksums               rmd160  ca512e541cc990793b2f7759d795685ec675c687 \
-                        sha256  ab76633b023d72ea3ca9ad22e2fa39ed3b5c8fb4e2c091a78035fabb5eb3fccf \
-                        size    23295932
+checksums           rmd160  dc23065b0c2827aff91f6cc611ea7c185f0d7e0c \
+                    sha256  4c3dd7ee4d36d237111a4d72b6e14170093271595d5b695148532daa95323d76 \
+                    size    24110884
 
 worksrcdir              CGAL-${version}
 depends_lib-append      port:mpfr \


### PR DESCRIPTION
#### Description

Update cgal5 to latest upstream stable version, 5.4.1 (bugfix).

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
