### PR TITLE
kiln: update to 0.3.2

### DIFF
--- a/www/kiln/Portfile
+++ b/www/kiln/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            git.sr.ht/~adnano/kiln 0.3.1
+go.setup            git.sr.ht/~adnano/kiln 0.3.2
 revision            0
 categories          www devel
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -15,9 +15,9 @@ long_description    {*}${description}
 go.package          git.sr.ht/~adnano/kiln
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  71adfa3ee83b54965ed6250d071a77eefc00eb7b \
-                        sha256  5d1c5b3404822228b8b87456271afe3c9a3e9a4df326f99d943003e9b7bea9ca \
-                        size    26493
+                        rmd160  33f9b7862ad80873773392bb07b424ae89863fba \
+                        sha256  da9e8cebc3443f3f6d194bff4ea1af3ef08b2d500340e13dee6c823cef6dfcac \
+                        size    27452
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    496545a6307b \


### PR DESCRIPTION
#### Description
[kiln 0.3.2 announce](https://lists.sr.ht/~adnano/kiln-announce/%3CCL8NC7TE12JA.28GXGFE4Y0POI%40nitro%3E)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
