### PR TITLE
libstdcxx-docs: update to 12.1.0

### DIFF
--- a/lang/libstdcxx-docs/Portfile
+++ b/lang/libstdcxx-docs/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libstdcxx-docs
-version             11.2.0
+version             12.1.0
 revision            0
 conflicts           stdman
 categories          lang
@@ -24,9 +24,9 @@ distname            gcc-${version}
 set major           [lindex [split ${version} .] 0]
 dist_subdir         gcc${major}
 
-checksums           rmd160  0fdd0b2c0954ccbd32e24f027d7b55fd26dcc627 \
-                    sha256  d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b \
-                    size    80888824
+checksums           rmd160  6cdb114103541230492bbc6093585cb10e5e5ea6 \
+                    sha256  62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b \
+                    size    82701928
 
 use_xz              yes
 


### PR DESCRIPTION
###### Tested on
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?