### PR TITLE
stdman: update to 2022.02.01

### DIFF
--- a/lang/stdman/Portfile
+++ b/lang/stdman/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jeaye stdman 2021.12.21
+github.setup        jeaye stdman 2022.02.01
 github.tarball_from archive
 conflicts           libstdcxx-docs
 categories          lang
@@ -15,8 +15,10 @@ description         cppreference manpages
 
 long_description    Manpages for the C++ standard library from cppreference.com.
 
-checksums           rmd160  18851d70eb3b29292724a49e8d7fcf9778c7f53b \
-                    sha256  5cfea407f0cd6da0c66396814cafc57504e90df518b7c9fa3748edd5cfdd08e3 \
-                    size    4018867
+checksums           rmd160  31ac913fc7c098c25517b8eed361a834c9d75140 \
+                    sha256  84d36791514f20a814f1530e9f4e6ff67e538e0c9b3ef25db4b007f9861c4890 \
+                    size    4172054
+
+patchfiles          patch-install.diff
 
 build {}

--- a/lang/stdman/files/patch-install.diff
+++ b/lang/stdman/files/patch-install.diff
@@ -1,0 +1,12 @@
+--- do_install.orig	2022-04-15 03:25:04.000000000 +0400
++++ do_install	2022-07-09 11:29:31.000000000 +0400
+@@ -14,8 +14,7 @@
+ echo "Installing from $tmp_man to $mandir/man3"
+ mkdir -p $mandir/man3
+ for file in "$tmp_man"/*.3 ; do
+-  out=$mandir/man3/$(basename "$file");
++  out=$mandir/man3/${file##*/};
+   install -m 0644 "$file" "$out";
+-  gzip -f "$out";
+ done
+ echo "Done; it's advised to run 'sudo mandb' (GNU) or 'sudo makewhatis' (BSD) now."


### PR DESCRIPTION
###### Tested on
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?