### PR TITLE
libmd: update to 1.0.4

### DIFF
--- a/devel/libmd/Portfile
+++ b/devel/libmd/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                libmd
 epoch               1
-version             1.0.3
+version             1.0.4
 categories          devel
 license             BSD ISC Permissive
 platforms           darwin
@@ -18,11 +18,12 @@ long_description \
     SHA256, SHA384, SHA512.
 
 homepage            https://www.hadrons.org/software/libmd/
-master_sites        https://archive.hadrons.org/software/libmd/
+master_sites        https://archive.hadrons.org/software/libmd/ \
+                    https://libbsd.freedesktop.org/releases/
 use_xz yes
 
-checksums           rmd160  90f4335f802b30cba2e9020e85871ce054d8b25f \
-                    sha256  5a02097f95cc250a3f1001865e4dbba5f1d15554120f95693c0541923c52af4a \
-                    size    258584
+checksums           rmd160  4a47a01fa2e47d3c9c9bd27ebd55780a3d82fe66 \
+                    sha256  f51c921042e34beddeded4b75557656559cf5b1f2448033b4c1eec11c07e530f \
+                    size    264472
 
 patchfiles          patch-symbol-alias.diff


### PR DESCRIPTION
#### Description
[[ANNOUNCE] libmd 1.0.4 released](https://archive.hadrons.org/software/libmd/libmd-1.0.4.announce)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
