### PR TITLE
mozjs68: Remove mrustc requirement on 10.6

### DIFF
--- a/lang/mozjs68/Portfile
+++ b/lang/mozjs68/Portfile
@@ -57,11 +57,6 @@ if {[regexp {macports-clang-(.*)} ${configure.compiler} -> llvm_ver]} {
 }
 
 if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
-    # Once Snow Leopard gets "real Rust", remove the next 3 lines
-    depends_build-replace port:cargo port:mrustc-rust
-    configure.env-append RUSTC=${prefix}/libexec/mrustc-rust/bin/rustc
-    configure.env-append CARGO=${prefix}/libexec/mrustc-rust/bin/cargo
-
     depends_build-append port:cctools
     configure.env-append AR=${prefix}/bin/ar
 }


### PR DESCRIPTION
#### Description

`mozjs68` currently fails on the 10.6 build bot due to the `mrustc` requirement:

https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/110631

Rust was recently ported to 10.6, so `mrustc` is no longer necessary. Tested locally through the build phase.

Not rev-bumped since it just fixes a failing build.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
