### PR TITLE
mozjs91: Fix build on Snow Leopard

### DIFF
--- a/lang/mozjs91/Portfile
+++ b/lang/mozjs91/Portfile
@@ -55,17 +55,14 @@ if {[regexp {macports-clang-(.*)} ${configure.compiler} -> llvm_ver]} {
 }
 
 if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
-    # Once Snow Leopard gets "real Rust", remove the next 3 lines
-    depends_build-replace port:cargo port:mrustc-rust
-    configure.env-append RUSTC=${prefix}/libexec/mrustc-rust/bin/rustc
-    configure.env-append CARGO=${prefix}/libexec/mrustc-rust/bin/cargo
-
     depends_build-append port:cctools
     configure.env-append AR=${prefix}/bin/ar
 }
 
-patchfiles          patch-skip-sdk-check.diff \
-                    patch-mozglue-clock_gettime.diff
+patchfiles-append   patch-skip-sdk-check.diff \
+                    patch-mozglue-clock_gettime.diff \
+                    patch-mozglue-snow-leopard.diff
+
 
 # Use absolute path for install_name
 post-patch {

--- a/lang/mozjs91/files/patch-mozglue-snow-leopard.diff
+++ b/lang/mozjs91/files/patch-mozglue-snow-leopard.diff
@@ -1,0 +1,24 @@
+Fix build errors on 10.6
+
+--- mozglue/misc/Mutex_posix.cpp.orig	2022-07-09 14:28:00.000000000 -0400
++++ mozglue/misc/Mutex_posix.cpp	2022-07-09 14:31:34.000000000 -0400
+@@ -11,7 +11,10 @@
+ #include <stdio.h>
+ 
+ #if defined(XP_DARWIN)
++#  include <Availability.h>
++#  if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+ #  include <pthread_spis.h>
++#  endif
+ #endif
+ 
+ #include "mozilla/PlatformMutex.h"
+@@ -65,7 +68,7 @@
+   TRY_CALL_PTHREADS(pthread_mutexattr_settype(&attr, MUTEX_KIND),
+                     "mozilla::detail::MutexImpl::MutexImpl: "
+                     "pthread_mutexattr_settype failed");
+-#  elif defined(POLICY_KIND)
++#  elif defined(POLICY_KIND) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+   if (__builtin_available(macOS 10.14, *)) {
+     TRY_CALL_PTHREADS(pthread_mutexattr_setpolicy_np(&attr, POLICY_KIND),
+                       "mozilla::detail::MutexImpl::MutexImpl: "


### PR DESCRIPTION
#### Description

`<pthread_spis.h>` is not available on 10.6. Add some macros to enable an unconditional patch to work around its absence. Also remove the obsolete dependency on `mrustc`.

Tested through install.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
