### PR TITLE
ki-shell: update to 0.5.2

### DIFF
--- a/java/ki-shell/Portfile
+++ b/java/ki-shell/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            ki-shell
-version         0.5.1
+version         0.5.2
 revision        0
 
 categories      java
@@ -27,9 +27,9 @@ master_sites    https://search.maven.org/remotecontent?filepath=org/jetbrains/ko
 
 distname        ${name}-${version}-archive
 
-checksums       rmd160  62abbcbee14c1944589a6925474bdc8e8edc3ac4 \
-                sha256  470f765d2b58c9a57c5b041af765adb3f5ae858a35a6a33e06813034c4fa3443 \
-                size    64151253
+checksums       rmd160  95ae27c30a938e3d3bd04d35e231446a89161c1b \
+                sha256  4c1269882f4da8647cb0ad436cc84acf9c2b5f403175de94cc16326dd8b2eb13 \
+                size    64151244
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Kotlin Interactive Shell 0.5.2.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?