### PR TITLE
xapian-omega: requires pcre2

### DIFF
--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -59,7 +59,7 @@ if {${subport} eq ${name}} {
 }
 
 subport xapian-omega {
-    revision                    0
+    revision                    1
     checksums                   rmd160  4e8e517915619b0052fcf4f96a045651ffcd4207 \
                                 sha256  09fd7d6c60b394fd00d84700649969a1fcc3aa2b88bb2c6ca220fdfa8d25881f \
                                 size    563324
@@ -75,7 +75,7 @@ subport xapian-omega {
 
     depends_lib                 port:libiconv \
                                 port:libmagic \
-                                port:pcre \
+                                port:pcre2 \
                                 port:xapian-core \
                                 port:zlib
 


### PR DESCRIPTION
…rather than pcre, as of release 1.4.20
https://trac.xapian.org/wiki/ReleaseOverview/1.4.20

#### Description

Builds of 1.4.20 update failed during configure:

```
checking for pcre2-config... no
configure: error: Can't find pcre2-config.  If the PCRE2 library is installed, you need to add PCRE2_CONFIG=/path/to/pcre2-config to your configure command.
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
~~Untested~~ Activated successfully on macOS 10.15 and macOS 11 CI builders; Destroot completed successfully on macOS 12 CI builder.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
