### PR TITLE
epy: new port (version 2022.4.18)

### DIFF
--- a/python/epy/Portfile
+++ b/python/epy/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        wustho epy 2022.4.18 v
+github.tarball_from archive
+revision            0
+supported_archs     noarch
+license             GPL-3
+
+python.versions     310
+
+maintainers         {gmail.com:srirangav @srirangav} openmaintainer
+
+description         CLI ebook Reader
+long_description    A CLI ebook reader that supports epub (.epub, .epub3), \
+                    FictionBook (.fb2), Mobi, and AZW3 (.azw, .azw3)
+
+homepage            https://github.com/wustho/epy
+
+checksums           rmd160  7e2b41a4163b374d09898bfec6319e4c46309ca0 \
+                    sha256  140225acf0216ce3a7f502adb752c0ee7c189297051d0cb84e65e4fe767add23 \
+                    size    184744
+
+depends_build-append \
+                    port:py${python.version}-setuptools
+


### PR DESCRIPTION
#### Description

epy - new port of a CLI based ebook reader

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6.7 20G630 arm64
Xcode 13.2.1 13C100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
