### PR TITLE
josm: update to 18513

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18463
+version             18513
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  aeba5d1be2e411c9e964fe20441965b383ca12d9 \
-                    sha256  9fb1a551660e017c381b9f5206c3bc1d9d4e6a2516c333ac89444f14162adf51 \
-                    size    77929002
+checksums           rmd160  f60a887dbd56ce2dec194460cbf84c44147d69fa \
+                    sha256  33c655dc55d9247a9a7a03ca4278d090c60c5add815222b333c4e2b7836ab54e \
+                    size    77882710
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2022-07-07: Stable release 18513](https://josm.openstreetmap.de/wiki/Changelog#stable-release-22.06)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
