### PR TITLE
aerc: update to 0.11.0

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                aerc
-version             0.10.0
+version             0.11.0
 revision            0
 categories          mail
 license             MIT
@@ -19,9 +19,9 @@ master_sites        https://git.sr.ht/~rjarry/aerc/archive/
 distname            ${version}
 worksrcdir          ${name}-${distname}
 
-checksums           rmd160  5831c2ec474fcc56435daa3e41e776bdbf468236 \
-                    sha256  14d6c622a012069deb1a31b51ecdd187fd11041c8e46f396ac22830b00e4c114 \
-                    size    209836
+checksums           rmd160  59eb97688d7f533382abd184e4a31bd6c6f43fa2 \
+                    sha256  3d8f3a2800946fce070e3eb02122e77c427a61c670a06337539b3e7f09e57861 \
+                    size    230891
 
 depends_build       port:go \
                     port:scdoc


### PR DESCRIPTION
#### Description
[Release announcement](https://lists.sr.ht/~rjarry/aerc-announce/%3C20220711214039.ICcnSvty6Blj/mNh/HcM%40marty%3E)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
