### PR TITLE
gnupg2: Update to 2.2.36

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 
 set my_name         gnupg
 name                ${my_name}2
-version             2.2.35
+version             2.2.36
 
 # Putting the SHA1 hash because that is published on the website
-checksums           rmd160  49eef0ce78910a4ead37a21226609b901bb7e6ce \
-                    sha1    25449f0417ff0011036b8e48217901222aef7c44 \
-                    sha256  340bc255938971e6e729b3d9956fa2ef4db8215d77693bf300df2bb302498690 \
-                    size    7262687
+checksums           rmd160  106dccf336a05bf6341511d36a7185c9d36a1b96 \
+                    sha1    01e2f80d6579a3b3dc25547ad13632bf87dbc757 \
+                    sha256  bdfe783810fceca9703b9e811817acca63ee9ef0174e616598e8ea6590aa4c9c \
+                    size    7273805
 
 # https://trac.macports.org/ticket/63552
 epoch               1


### PR DESCRIPTION
#### Description

See release announcement for 2.3.7, which explains the CVE: https://lists.gnupg.org/pipermail/gnupg-announce/2022q3/000474.html. There does not seem to be a release announcement for 2.2.36.

I could not find the SHA-1 hash on the website as documented in the Portfile, but I did verify the signature. I kept the SHA-1 digest anyway, since this is an openmaintainer security update and not the place for cleanup.

CVE: CVE-2022-34903

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
