### PR TITLE
crystal: update to 1.5.0

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 1.4.1
+github.setup        crystal-lang crystal 1.5.0
 github.tarball_from archive
 revision            0
 categories          lang
@@ -40,13 +40,13 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  08bda39d6c037f3df9059ebfe405d29be9a8d7db \
-                    sha256  97466656adede19943619e18af030c1d542c2c3dd1f36f3a422310bd8b53f5e0 \
-                    size    2880860 \
+                    rmd160  e9b19bf3e1ea50f96478d366ee8ed3eb604b3661 \
+                    sha256  f53e459ef6c7227df922a76fb62e350c90d52d30bfaa84b90feda9731bb98655 \
+                    size    2909586 \
                     ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix} \
-                    rmd160  724257b84e792e2f79070fab1b7c9b673c4e2d12 \
-                    sha256  e7f9b3e1e866dc909a0a310238907182f1ee8b3c09bd8da5ecd0072d99c1fc5c \
-                    size    46117308
+                    rmd160  420ad659f69828e0fc61546ac78f7b5431d6ca99 \
+                    sha256  294ebe1cb165a58252252e05d7394705e06dfebcf16fb539ec69aa4509cb9b46 \
+                    size    46174958
 
 patchfiles          patch-static.diff
 


### PR DESCRIPTION
###### Tested on
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?