### PR TITLE
google-cloud-sdk: update to 393.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             392.0.0
+version             393.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d1473ba8b775344424772c4e9c0c932c2ad189ca \
-                    sha256  c23bb88655a707a62c5d3a645e692816c9f54e1b23eb7fc4252a753cf6bb66de \
-                    size    107893532
+    checksums       rmd160  9b927ef004fdc2d44554dcad7ebe7ac5c9c939e2 \
+                    sha256  929f8cb60732160f6ec5e94b2911b86eed1fe4b7e20320cc4a7f29a1fd3f562d \
+                    size    108016103
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4efd73a664cfa6af853101d5580b1893d0895c78 \
-                    sha256  0987fe197e06a19ddcc49dfaa57e6b60f747998156aa70a0ef20d13c99cee0ab \
-                    size    104641220
+    checksums       rmd160  611f2f264d9238d7e6cf0d5cec05382cee5b4642 \
+                    sha256  e814b48b8d0ad26f8173fb93dec1f382b8395cd4ce09149b41dcf697bfb1177e \
+                    size    104768464
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  7b60d6cc25462cddabbf4863ba1dab18756e564e \
-                    sha256  b9e3bbebd76a82138c33a326eb8f4d87fdcf96f51ea95e798a2b004308a6873d \
-                    size    103250150
+    checksums       rmd160  f8fdb05d6ee59a528cecda4632310975dac83073 \
+                    sha256  a6477ecec26be8675503133752bbe163ffcc2e262c31ec30b08ea7add4feb5a4 \
+                    size    103373140
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 393.0.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?