### PR TITLE
postfix: remove obsolete variant mysql55

### DIFF
--- a/mail/postfix/Portfile
+++ b/mail/postfix/Portfile
@@ -270,9 +270,6 @@ variant postgresql14 conflicts postgresql96 postgresql10 postgresql11 postgresql
     set ::named_auxlibs(AUXLIBS_PGSQL) "-L${prefix}/lib/postgresql14 -lpq"
 }
 
-# remove after 2022-05-01
-variant mysql55 requires mysql57 description "Legacy compatibility variant" {}
-
 # remove after 2022-11-08
 variant mariadb requires mariadb10.5 description "Legacy compatibility variant" {}
 variant postgresql94 requires postgresql13 description "Legacy compatibility variant" {}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
