### PR TITLE
akonadi: remove check for variant mysql5

### DIFF
--- a/devel/akonadi/Portfile
+++ b/devel/akonadi/Portfile
@@ -169,7 +169,7 @@ variant sqlite \
                            -DMYSQLD_EXECUTABLE=Off
 }
 
-if {![variant_isset mysql5] && ![variant_isset mysql51] && ![variant_isset mysql55] \
+if {![variant_isset mysql51] && ![variant_isset mysql55] \
     && ![variant_isset mysql56] && ![variant_isset mariadb55] && ![variant_isset percona55] \
     && ![variant_isset sqlite]} {
     default_variants +mariadb55


### PR DESCRIPTION
Variant mysql5 was removed in 51ff745c4860

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
