### PR TITLE
micronaut: update to 3.5.3

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.5.2 v
+github.setup    micronaut-projects micronaut-starter 3.5.3 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  1aec193470fd54faf969773f8a83d5a74a558c52 \
-                sha256  309d2d41b72b5359f76e2ded1209cd60e1c86a3cd77d7497d616a1ad877ea66a \
-                size    21328323
+checksums       rmd160  12dad895ace1fac3a86950c9a39c8263bafeba76 \
+                sha256  bb861ed785d740f34ffe20f826be93ffda55a68985e41b8c732a6f2a83c9211f \
+                size    21342711
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.5.3.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?