### PR TITLE
qt58, qt59, qt511, qt513, qt5: fix spelling in comment

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1824,7 +1824,7 @@ foreach {module module_info} [array get modules] {
 
                 # In the file config.tests/openal/openal.pro, defining HEADER_OPENAL_PREFIX means
                 #    include directives use macOS OpenAL Framework.
-                # In src/multimedia/configure.json, pkgconfg is relied upon, which finds MacPorts openal
+                # In src/multimedia/configure.json, pkgconfig is relied upon, which finds MacPorts openal
                 #    for linking.
                 # We must choose one or the other.
                 # see https://trac.macports.org/ticket/54592

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -1516,7 +1516,7 @@ foreach {module module_info} [array get modules] {
 
                 # In the file config.tests/openal/openal.pro, defining HEADER_OPENAL_PREFIX means
                 #    include directives use macOS OpenAL Framework.
-                # In src/multimedia/configure.json, pkgconfg is relied upon, which finds MacPorts openal
+                # In src/multimedia/configure.json, pkgconfig is relied upon, which finds MacPorts openal
                 #    for linking.
                 # We must choose one or the other.
                 # see https://trac.macports.org/ticket/54592

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -1538,7 +1538,7 @@ foreach {module module_info} [array get modules] {
 
                 # In the file config.tests/openal/openal.pro, defining HEADER_OPENAL_PREFIX means
                 #    include directives use macOS OpenAL Framework.
-                # In src/multimedia/configure.json, pkgconfg is relied upon, which finds MacPorts openal
+                # In src/multimedia/configure.json, pkgconfig is relied upon, which finds MacPorts openal
                 #    for linking.
                 # We must choose one or the other.
                 # see https://trac.macports.org/ticket/54592

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -1500,7 +1500,7 @@ foreach {module module_info} [array get modules] {
 
                 # In the file config.tests/openal/openal.pro, defining HEADER_OPENAL_PREFIX means
                 #    include directives use macOS OpenAL Framework.
-                # In src/multimedia/configure.json, pkgconfg is relied upon, which finds MacPorts openal
+                # In src/multimedia/configure.json, pkgconfig is relied upon, which finds MacPorts openal
                 #    for linking.
                 # We must choose one or the other.
                 # see https://trac.macports.org/ticket/54592

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -1487,7 +1487,7 @@ foreach {module module_info} [array get modules] {
 
                 # In the file config.tests/openal/openal.pro, defining HEADER_OPENAL_PREFIX means
                 #    include directives use macOS OpenAL Framework.
-                # In src/multimedia/configure.json, pkgconfg is relied upon, which finds MacPorts openal
+                # In src/multimedia/configure.json, pkgconfig is relied upon, which finds MacPorts openal
                 #    for linking.
                 # We must choose one or the other.
                 # see https://trac.macports.org/ticket/54592


### PR DESCRIPTION
[skip ci]

#### Description

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
