### PR TITLE
tig: update to 2.5.6

### DIFF
--- a/devel/tig/Portfile
+++ b/devel/tig/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonas tig 2.5.5 tig-
+github.setup        jonas tig 2.5.6 tig-
 github.tarball_from releases
-checksums           rmd160  b1f9ce1c19f5da0c0681542d5be9fecbe09f12f1 \
-                    sha256  24ba2c8beae889e6002ea7ced0e29851dee57c27fde8480fb9c64d5eb8765313 \
-                    size    1175752
+checksums           rmd160  3d3d2b3c45785f3f7041db0c5cc103db6ec17ebd \
+                    sha256  50bb5f33369b50b77748115c730c52b13e79b2de49cba7167bb634eb683d965f \
+                    size    1176006
 
 categories          devel
 maintainers         {cal @neverpanic} \


### PR DESCRIPTION
#### Description

See: https://github.com/jonas/tig/releases/tag/tig-2.5.6

###### Tested on
macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
