### PR TITLE
detekt-cli: update to 1.21.0

### DIFF
--- a/java/detekt-cli/Portfile
+++ b/java/detekt-cli/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 name                detekt-cli
 
-github.setup        detekt detekt 1.20.0 v
+github.setup        detekt detekt 1.21.0 v
 revision            0
 
 # Set the version of the resulting jar. This might be, but is not necessarily identical to ${version}.
@@ -29,9 +29,9 @@ variant formatting description {Include the formatting plugin} {
 github.tarball_from archive
 
 distname            v${version}
-checksums           sha256  9ca2a5e19eccfa30772674f27b40a721146627254a1f971b7c1bcd871bbdb485 \
-                    rmd160  294c24d3f0411bba5f1db947a1d8f67675be29f5 \
-                    size    2700049
+checksums           sha256  ce9aa4fdc122c74a132094a1fe5ad47c33f27e9ed4f5ff614d38965c8ed40d78 \
+                    rmd160  1165b94f987cc703978da2cd9346b27409e7d63c \
+                    size    1711896
 
 java.fallback       openjdk11
 java.version        1.8+


### PR DESCRIPTION
#### Description

See: https://github.com/detekt/detekt/releases/tag/v1.21.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
