### PR TITLE
exiv2: enable BMFF support

### DIFF
--- a/graphics/exiv2/Portfile
+++ b/graphics/exiv2/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        Exiv2 exiv2 0.27.5 v
-revision            0
+revision            1
 checksums           rmd160  15486a2b4d13db80709318d3d0f70140de2de434 \
                     sha256  1da1721f84809e4d37b3f106adb18b70b1b0441c860746ce6812bb3df184ed6c \
                     size    32407707
@@ -43,6 +43,7 @@ patchfiles-append   patch-remove-no-format-overflow.diff
 configure.args-append \
                     -DIconv_INCLUDE_DIR=${prefix}/include \
                     -DIconv_LIBRARY=${prefix}/lib/libiconv.dylib \
-                    -DZLIB_ROOT=${prefix}
+                    -DZLIB_ROOT=${prefix} \
+                    -DEXIV2_ENABLE_BMFF=ON
 
 github.livecheck.regex  {(\d+(?:\.\d+)+)}

--- a/graphics/exiv2/Portfile
+++ b/graphics/exiv2/Portfile
@@ -41,9 +41,9 @@ compiler.blacklist-append \
 patchfiles-append   patch-remove-no-format-overflow.diff
 
 configure.args-append \
+                    -DEXIV2_ENABLE_BMFF=ON \
                     -DIconv_INCLUDE_DIR=${prefix}/include \
                     -DIconv_LIBRARY=${prefix}/lib/libiconv.dylib \
-                    -DZLIB_ROOT=${prefix} \
-                    -DEXIV2_ENABLE_BMFF=ON
+                    -DZLIB_ROOT=${prefix}
 
 github.livecheck.regex  {(\d+(?:\.\d+)+)}


### PR DESCRIPTION
### Description

Enable BMFF support, to improve functionality in dependent ports like `darktable`.

Thus far, upstream releases haven't enabled this by default, due to potential concerns related to patents. However, the topic has been thoroughly discussed and vetted, enough so that upstream has now enabled by default on Master.

Patent-related discussions: https://github.com/Exiv2/exiv2/issues/1679

### Tested on macOS Releases

* Intel x86_64: 10.6 through Monterey
* PPC: 10.5