### PR TITLE
k9s: update to 0.26.0

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.25.21 v
+go.setup            github.com/derailed/k9s 0.26.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {breun.nl:nils @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  2e83cf109d923b80f9b2a44dc662030911d1c005 \
-                    sha256  751525f86cf77f6fa50014dbf69dcc13c55079ffabc467a83c4c592e78479535 \
-                    size    6394511
+checksums           rmd160  8162481921069ed49a889ac95181cb8bdd3e6755 \
+                    sha256  11156e519a77af79671bb34d99d5bcd641ef6a5d1f2d8412d67d53ea0597818f \
+                    size    6400411
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

Update to k9s 0.26.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?