### PR TITLE
diffutils: fix a build on Rosetta

### DIFF
--- a/sysutils/diffutils/Portfile
+++ b/sysutils/diffutils/Portfile
@@ -62,6 +62,13 @@ configure.args      --program-prefix=g \
                     --infodir=${prefix}/share/info \
                     --mandir=${prefix}/share/man
 
+platform darwin 10 {
+# This is a fix for Rosetta
+    if {${build_arch} eq "ppc"} {
+    configure.args-append --build=powerpc-apple-darwin10
+    }
+}
+
 set docdir          ${prefix}/share/doc/${name}
 
 post-destroot {

--- a/sysutils/diffutils/Portfile
+++ b/sysutils/diffutils/Portfile
@@ -65,7 +65,7 @@ configure.args      --program-prefix=g \
 platform darwin 10 {
 # This is a fix for Rosetta
     if {${build_arch} eq "ppc"} {
-    configure.args-append --build=powerpc-apple-darwin10
+        configure.args-append --build=powerpc-apple-darwin10
     }
 }
 


### PR DESCRIPTION
#### Description

`diffutils` fail on 10.6.8 Rosetta with:
```
sigsegv.c: In function 'sigsegv_handler':
sigsegv.c:940: error: 'struct __darwin_ppc_thread_state' has no member named '__esp'
make[2]: *** [sigsegv.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /usr/include/libkern/OSByteOrder.h:43,
                 from /usr/include/mach/ndr.h:106,
                 from /usr/include/mach/clock_priv.h:7,
                 from /usr/include/mach/mach_interface.h:42,
                 from /usr/include/mach/mach.h:67,
                 from stackvma.c:1363:
/usr/include/libkern/ppc/OSByteOrder.h:184: error: redefinition of '_OSSwapInt16'
/usr/include/libkern/i386/_OSByteOrder.h:49: error: previous definition of '_OSSwapInt16' was here
/usr/include/libkern/ppc/OSByteOrder.h:193: error: redefinition of '_OSSwapInt32'
/usr/include/libkern/i386/_OSByteOrder.h:58: error: previous definition of '_OSSwapInt32' was here
/usr/include/libkern/ppc/OSByteOrder.h:202: error: redefinition of '_OSSwapInt64'
/usr/include/libkern/i386/_OSByteOrder.h:83: error: previous definition of '_OSSwapInt64' was here
make[2]: *** [stackvma.o] Error 1
make[2]: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_sysutils_diffutils/diffutils/work/diffutils-3.8/lib'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_sysutils_diffutils/diffutils/work/diffutils-3.8/lib'
make: *** [all-recursive] Error 1
```

This patch fixes the error.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
