### PR TITLE
tmux: Update to 3.3a

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -7,7 +7,7 @@ PortGroup       legacysupport 1.1
 # Availability.h
 legacysupport.newest_darwin_requires_legacy 8
 
-github.setup    tmux tmux 3.2a
+github.setup    tmux tmux 3.3a
 if {${subport} eq ${name}} {
     revision        0
     conflicts       tmux-devel
@@ -34,9 +34,12 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  36ae9170204ff723acc56036ce449854a88cb4ca \
-                            sha256  551553a4f82beaa8dadc9256800bcc284d7c000081e47aa6ecbb6ff36eacd05f \
-                            size    648394
+    checksums               rmd160  be6c4fd40bc0c4e77e296639c15e3f009bd0396a \
+                            sha256  e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f \
+                            size    677448
+
+    depends_lib-append      port:libutf8proc
+    configure.args-append   --enable-utf8proc
 }
 subport tmux-devel {
     checksums               rmd160  b4ef42164a1bf711db984242ed36bc97f2297f53 \


### PR DESCRIPTION
#### Description
Add the `libutf8proc` dependency, because configure forces using either `--enable-utf8proc` or `--disable-utf8proc`, but warns that utf8 processing on macOS is buggy and recommends the former.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
