### PR TITLE
jdk17: update to 17.0.4

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.3.1
+version      17.0.4
 revision     0
 
 description  Oracle Java SE Development Kit 17
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  b89c9ee434dedde9a19e5a9b46dbdc899685212f \
-                 sha256  4e774c6ebf4c7f3a8511513fa341e5d73c1d27c6e8f1131d0916bf3f2bd3e773 \
-                 size    178220776
+    checksums    rmd160  126a6e3a657c1a5bd803d31758d85c056d6c46d4 \
+                 sha256  d39ee8290d65c53db4919733d1c6c8c7a6f1641569087f2c619f631ac95c63d6 \
+                 size    178252857
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  55e1e38de6e46734cea38aa116bca7e7781d3bad \
-                 sha256  241a6ad1ddea0480e7fc6cb2813011b796aa91033d5787857dd16177fa175ea9 \
-                 size    175556313
+    checksums    rmd160  e28e9b40c674ddddbac5d07815bf88d60cebe732 \
+                 sha256  b075a8d60b7d63a5fff5533bd67a2c2b18bd661d7d4942e7fed22398baecef64 \
+                 size    175600777
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 17.0.4.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?