### PR TITLE
jdk18: update to 18.0.2

### DIFF
--- a/java/jdk18/Portfile
+++ b/java/jdk18/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk18-mac
-version      18.0.1.1
+version      18.0.2
 revision     0
 
 description  Oracle Java SE Development Kit 18
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/18/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  6d2ef8078d83071789cc0cc2304072cb53c2eb68 \
-                 sha256  32b228166cc176ced7dd699a082e3d520c3ddd499bc138118a045d7279c4042c \
-                 size    178751801
+    checksums    rmd160  46e4068a93540d6c21661a3f8e8a4743b23d3bed \
+                 sha256  4001e1fc158796b1ac5803c285eda87e769dd10a3729c6c60b9a94e333ba83bb \
+                 size    178759977
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  3d6805ecbbb2828d65ff87039939bb0a84529734 \
-                 sha256  5bde851b4b666b8d16119f988eb96a83e36de7b4db40f76cf0b39fbe8388eccf \
-                 size    176605563
+    checksums    rmd160  cc070dc3c1b81744a7de821eb197c164b157bc3d \
+                 sha256  0128c6a429000da265637840fe1c22c61fa6abb510275389e4687ba639d46567 \
+                 size    176601156
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 18.0.2.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?