### PR TITLE
openjdk18-oracle: update to 18.0.2

### DIFF
--- a/java/openjdk18-oracle/Portfile
+++ b/java/openjdk18-oracle/Portfile
@@ -14,25 +14,24 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/18/
-version      18.0.1.1
-set build    2
+version      18.0.2
 revision     0
 
 description  Oracle OpenJDK 18
 long_description Open-source Oracle build of OpenJDK 18, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/65ae32619e2f40f3a9af3af1851d6e19/${build}/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/f6ad4b4450fd4d298113270ec84f30ee/9/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  1e796dbda1ddcb4680760e51410e59d923c858ff \
-                 sha256  f02d17ec5a387555f8489abc352d973b6c10364409b597046025938e2266d72a \
-                 size    185423668
+    checksums    rmd160  3640b73832af50142b67db2ce8a05685444d7796 \
+                 sha256  528aaf1ea27f9a3052bd88a0af877c63e87d517214c1ee91807c9590a77f1a75 \
+                 size    185437991
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  cb5a455f5094adbca4ff97c12589dbb05ccf6764 \
-                 sha256  29773ad68063bdad7fbaeb762cd873d3f243e86de380d3ac5335cdb929371fb5 \
-                 size    183267676
+    checksums    rmd160  496f942a03dce2b74f713390b978c24d46b853af \
+                 sha256  1da591d9ab49c348d5a424975ae44ea940edf1c3b3b4456d0a3020758829799e \
+                 size    183269809
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 18.0.2.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?