### PR TITLE
openjdk17-corretto: update to 17.0.4.8.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.3.6.1
+version      17.0.4.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -24,24 +24,24 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  f044c2766aaba6a5c8422b434755322c7f550dff \
-                 sha256  8d5390c8af8063d0f584eb0dcd9d0a85e685ee76de3ffaacc19fab1b5c658669 \
-                 size    188083065
+    checksums    rmd160  1a5015ed0299b0f478da055c48733c980b35a1ca \
+                 sha256  798db2f96f981686d522446597055d15dd333fa2280cdd4404a5349e1b2503ce \
+                 size    187775418
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  927b93f0350596c6af87271248e91febdb2bfe18 \
-                 sha256  27e5a2969a6abf3b7f390e0e63d8e622a353d31a289898fcfd808dd605f9a6ba \
-                 size    185932597
+    checksums    rmd160  d8c702e6c750d313d06cd73c00b5f7e96d45113a \
+                 sha256  f08123ba018ee54c4d937153c95637b1d4da48694e660d0639d590b53de0aa72 \
+                 size    185883977
 }
 
 worksrcdir   amazon-corretto-17.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 17} {
-    # See https://github.com/corretto/corretto-17/blob/release-17.0.3.6.1/CHANGELOG.md
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # See https://github.com/corretto/corretto-17/blob/release-17.0.4.8.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.13 High Sierra or later."
+        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
         return -code error
     }
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.4.8.1.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?