### PR TITLE
openjdk18-corretto: update to 18.0.2.9.1

### DIFF
--- a/java/openjdk18-corretto/Portfile
+++ b/java/openjdk18-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-18/releases
-version      18.0.1.10.1
+version      18.0.2.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK 18 (Short Term Support)
@@ -24,24 +24,24 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  83f208e0801e0c266dd6e2bb18caec8c5b709c94 \
-                 sha256  fcefcb33a9d5b5b1be666a6eb8316243c6d960bd2dc8eb3cc84f0fed6509c1d3 \
-                 size    188679093
+    checksums    rmd160  5ef552ab018e6b21c4968cd3ce66b83a7e4c0dcf \
+                 sha256  980812dd365666b0eccf698011ea29ee5b47712b74d03e874b93fda422b35284 \
+                 size    188837045
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  7fd5f55feccf55c40e9799f794dc67217547f03b \
-                 sha256  16efc9b728af72a3375e47dd73e4fb4ed0c0e6d8006e3aeaa98bdcd87dcac1d7 \
-                 size    186534095
+    checksums    rmd160  8e40dd5346da0368d9cf82441ca7e3ae068f66cc \
+                 sha256  a2a25da58e280e762397ab5bf815833690ab0f9d9531da97c471a57428c479b2 \
+                 size    187052634
 }
 
 worksrcdir   amazon-corretto-18.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 17} {
-    # See https://github.com/corretto/corretto-18/blob/release-18.0.1.10.1/CHANGELOG.md
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # See https://github.com/corretto/corretto-18/blob/release-18.0.2.9.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.13 High Sierra or later."
+        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
         return -code error
     }
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 18.0.2.9.1.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?