### PR TITLE
openjdk11-corretto: update to 11.0.16.8.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-11/releases
 supported_archs  x86_64 arm64
 
-version      11.0.15.9.1
+version      11.0.16.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -24,24 +24,24 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  752d92e2e87d3feda836e7c7afa39982ea6b24f3 \
-                 sha256  36afb7f091cd9b986a50c3f878f167c59eae615f004b2cb1c5c394f9f2fc215a \
-                 size    187526579
+    checksums    rmd160  5db184b8b171b05d352b8ae5b3ef6c3a3e0c659c \
+                 sha256  d64d2925c443b07eb43dbb5851f4fb3e3899d244b3ba9b4b3ff71e865a91d505 \
+                 size    187542305
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  d1980a49d5539b892a6ed09f7d100501da1c7d80 \
-                 sha256  939f0cc40f4dd749647e352ea2759fbf73c8c59662476ca237113abf9eed0710 \
-                 size    185394420
+    checksums    rmd160  8e26ca410c96ba175134efc8182972a42d7a0235 \
+                 sha256  5038f6e2fd69f8efe8ea43f04edbd571b7b4fb1b6a8956c739e2e8f64799f6b4 \
+                 size    185895207
 }
 
 worksrcdir   amazon-corretto-11.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 17} {
-    # See https://github.com/corretto/corretto-11/blob/release-11.0.15.9.1/CHANGELOG.md
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # See https://github.com/corretto/corretto-11/blob/release-11.0.16.8.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.13 High Sierra or later."
+        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
         return -code error
     }
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.16.8.1.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?