### PR TITLE
openjdk8-corretto: update to 8.342.07.1

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -112,7 +112,7 @@ subport openjdk8-corretto {
     # https://github.com/corretto/corretto-8/releases
     supported_archs  x86_64 arm64
 
-    version     8.332.08.1
+    version     8.342.07.1
     revision    0
 
     description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -122,14 +122,14 @@ subport openjdk8-corretto {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     amazon-corretto-${version}-macosx-x64
-        checksums    rmd160  4d61d171dccf47712455d3b4e3976a56de7ac665 \
-                     sha256  6a6e9a6d2592c3705ef736256486133e0c7f4adf8cbd90e8c95f2bda460c01ed \
-                     size    118754955
+        checksums    rmd160  9a761ae56d8ba432964e4e2600434c3d0d6ad8ad \
+                     sha256  88cfadc52d6ee487e8865bfcfb0ec658ae1aa4d6657ac5ac1aaad00a0ea7db84 \
+                     size    118783948
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     amazon-corretto-${version}-macosx-aarch64
-        checksums    rmd160  cb801bae9d5b436a6ffe014d4827e2a78aece294 \
-                     sha256  0801bcdf8bb85032a450ac78ffadcf9cfc0d1218c5cdf8a25e3ad1b31200a21e \
-                     size    102882291
+        checksums    rmd160  5c401881ae8ce69a6c666ba399ff129be8a48293 \
+                     sha256  528500f87dd2cd524bdf3c0b63ec20307932347951442faabd4c7d3a9555061d \
+                     size    104195573
     }
 
     worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.342.07.1.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?