### PR TITLE
google-cloud-sdk: update to 394.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             393.0.0
+version             394.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  9b927ef004fdc2d44554dcad7ebe7ac5c9c939e2 \
-                    sha256  929f8cb60732160f6ec5e94b2911b86eed1fe4b7e20320cc4a7f29a1fd3f562d \
-                    size    108016103
+    checksums       rmd160  16cde47390174c6833bf03648c9234a8bd7695a3 \
+                    sha256  787fdb40dad00a5dbe45ab4b7242c50f309bb7e0349abad7242582b1535c54a3 \
+                    size    108100993
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  611f2f264d9238d7e6cf0d5cec05382cee5b4642 \
-                    sha256  e814b48b8d0ad26f8173fb93dec1f382b8395cd4ce09149b41dcf697bfb1177e \
-                    size    104768464
+    checksums       rmd160  3f2a425edaa85ee222e47e776b4cb046588a4699 \
+                    sha256  0311884b3f6acf17a2184a80be088d8f027ad79b25ffe2d5f16fb5e6a8e78d6e \
+                    size    104852852
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f8fdb05d6ee59a528cecda4632310975dac83073 \
-                    sha256  a6477ecec26be8675503133752bbe163ffcc2e262c31ec30b08ea7add4feb5a4 \
-                    size    103373140
+    checksums       rmd160  afc3b823a331989b0a844217340c1a6edfad5a2b \
+                    sha256  e358c7d1b411c968d122e2b455a2133d15029aa5339ab4e6e8bc871d6ea50330 \
+                    size    103454814
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 394.0.0.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?