### PR TITLE
openjdk17-zulu: update to 17.36.13

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.34.19
+version      17.36.13
 revision     0
 
-set openjdk_version 17.0.3
+set openjdk_version 17.0.4
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  dbd49be4c782dd63f278dbcefd8727e40175f012 \
-                 sha256  a889b2c550b6cb6421c6e559c1a98a3f2a38ebe9feef2b48157a582347bac367 \
-                 size    193484877
+    checksums    rmd160  3ff6471469d2180a6a625facc09d01eec7c50980 \
+                 sha256  272414ef009d68b1b2d951b32595e0eb1a311722d000218b832d82f037209352 \
+                 size    193513867
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  b77bb3eba4f53e6d4adad02ab0059787ffd1ec83 \
-                 sha256  79a457f106bf32aafd261a4748471fd10f5ce2a9aa2cc816a91864104c008dff \
-                 size    190867581
+    checksums    rmd160  77ac5516053a14a15eb1c4e409bcabfe61fd4a07 \
+                 sha256  a8a5dcdc4561b48d25fa251244962d0980ce7231eef0728abdf6d1efd7ea77ec \
+                 size    191329853
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.36.13.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?