### PR TITLE
openjdk18-zulu: update to 18.32.11

### DIFF
--- a/java/openjdk18-zulu/Portfile
+++ b/java/openjdk18-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-18-sts&os=macos&package=jdk
-version      18.30.11
+version      18.32.11
 revision     0
 
-set openjdk_version 18.0.1
+set openjdk_version 18.0.2
 
 description  Azul Zulu Community OpenJDK 18 (Short Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  cab34d40201820d9bc04a213f51144df4a4e3e70 \
-                 sha256  c7215afec89b7fd5773cba86db6b6c048021b6c15451fa3292fab859de6146f4 \
-                 size    194031312
+    checksums    rmd160  ca70a601901756073c36f92ea5c828f725c47a06 \
+                 sha256  c3bc470a7727ff0c0d5fac5c8b96d36706db2c7d534ea22cbf471b83c8d73768 \
+                 size    194017744
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  27b550d1e1ba29c8b4439214a0a3c7b85dc3b4ba \
-                 sha256  ad25d692b0a085d4c3b8c707bf715fd32c54161632059132a435a03134455705 \
-                 size    191920037
+    checksums    rmd160  396702790f30eca813c60da82e49c585b82b2864 \
+                 sha256  c97810273b1de0293df9e726c2fc0230678ccb0c2bd2f72a4766435d3e5d9b91 \
+                 size    191924823
 }
 
 worksrcdir   ${distname}/zulu-18.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 18.32.11.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?