### PR TITLE
openjdk11-zulu: update to 11.58.15

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.56.19
+version      11.58.15
 revision     0
 
-set openjdk_version 11.0.15
+set openjdk_version 11.0.16
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  012f063dd25db637f7ed45d3919c1b3627e9f35d \
-                 sha256  2614e5c5de8e989d4d81759de4c333aa5b867b17ab9ee78754309ba65c7f6f55 \
-                 size    193550721
+    checksums    rmd160  40263711dc20caaf3875a824929b993ad195c966 \
+                 sha256  a5d1f39e1d54ca015d8640813de80cdb43a247f99ad40ef1cfa09318bd9525d8 \
+                 size    193630992
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  8a0f7adca8377f7ace5f5cf05e00fdc90d6d1349 \
-                 sha256  6bb0d2c6e8a29dcd9c577bbb2986352ba12481a9549ac2c0bcfd00ed60e538d2 \
-                 size    191059414
+    checksums    rmd160  d8aa9518baf8c227107cd26335ebca2fb397b351 \
+                 sha256  cb71a8ad38755f881a692098ca02378183a7a9c5093d7e6ad98ca5e7bc74b937 \
+                 size    191793488
 }
 
 worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.58.15.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?