### PR TITLE
openjdk8-zulu: update to 8.64.0.15

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
-version      8.62.0.19
+version      8.64.0.15
 revision     0
 
-set openjdk_version 8.0.332
+set openjdk_version 8.0.342
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  660b8025b0e7c7b548712dba2750ec52533d681e \
-                 sha256  9b2a14112de141bdcef0ee34a57072b3310568b365ca5ecf54724a8100039339 \
-                 size    108062182
+    checksums    rmd160  550b4e3aefd4a7172395b9b1169cbadfeb813a1f \
+                 sha256  b5b2d962230b0dae56198f76e5c6fa70646ac74b31c0ac63fd665a6227a48f05 \
+                 size    108133841
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  76bec864caf7c23762a241c51f77cb459a3aad67 \
-                 sha256  e5c84a46bbd985c3a53358db9c97a6fd4930f92b833c3163a0d1e47dab59768c \
-                 size    105742233
+    checksums    rmd160  88e257afd7d20acbdf186ef5f081aeb7ddefdaec \
+                 sha256  98e0d98622109d25a32df81e263d4b953c6f2d74863890acd876c8ad8423a774 \
+                 size    106022063
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.64.0.15.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?