### PR TITLE
openjdk15-zulu: update to 15.42.15

### DIFF
--- a/java/openjdk15-zulu/Portfile
+++ b/java/openjdk15-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-15-mts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      15.40.19
+version      15.42.15
 revision     0
 
-set openjdk_version 15.0.7
+set openjdk_version 15.0.8
 
 description  Azul Zulu Community OpenJDK 15 (Medium Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  53fb2586e539eb30bc7758d4ed17d3063eb04bbf \
-                 sha256  37c679f4c637306dcda7b2bcc26d99d6c2aec41578b812644f2502bb996ffdc1 \
-                 size    202520858
+    checksums    rmd160  f2feceac9bd43ae295b4761b63f485590dc8fc54 \
+                 sha256  3b2dfc8bc0d329649256666d169bb40547d43a227c4c086a125ada408aa5e1df \
+                 size    202593508
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  c478b8c8b73fda666b75909fb4106ea03d794415 \
-                 sha256  84f5a9d1705621cf7502e070872e154b0dab7e36f02146031cbf9435e3af7199 \
-                 size    176817125
+    checksums    rmd160  2c9e57204767fe803d0a58b7ab0476acef04e5dd \
+                 sha256  9005ee1f3c5bbfb46ddd1d6920a1ea5be918650cefddb749604ec929b7a3f9d1 \
+                 size    176884021
 }
 
 worksrcdir   ${distname}/zulu-15.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 15.42.15.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?