### PR TITLE
openjdk13-zulu: update to 13.50.15

### DIFF
--- a/java/openjdk13-zulu/Portfile
+++ b/java/openjdk13-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      13.48.19
+version      13.50.15
 revision     0
 
-set openjdk_version 13.0.11
+set openjdk_version 13.0.12
 
 description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  78d7bef0a42dd84b71118a7baf78f39b8ce20b82 \
-                 sha256  c47e0a44e19edcc2b1fdd451f7c6a86965ce8936e5df1123fdbfe2899eeb55e9 \
-                 size    200698199
+    checksums    rmd160  e9122cdc8868033bc76d5ffb7dcc068f04282b66 \
+                 sha256  14d1d7c73ae52f13e1d99bef05424b913a38c3a3c0d04164ba1d38b716a3989e \
+                 size    200762576
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  a82d9f92075a99765848feff0405f7587c7526bd \
-                 sha256  77a1a462b4a797de8cda9032bf74924d6c0e095ca1de5a1890f08bf8545eb71a \
-                 size    180015317
+    checksums    rmd160  dbabbedb54d0e8d1294ac67662724c54ba2dbe50 \
+                 sha256  5037095b31842e9d70ffa59c8314bcf10b7d0b3dc9a47d30968722a7a95f1464 \
+                 size    180080915
 }
 
 worksrcdir   ${distname}/zulu-13.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 13.50.15.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?