### PR TITLE
pinentry: update to 1.2.0

### DIFF
--- a/security/pinentry/Portfile
+++ b/security/pinentry/Portfile
@@ -3,8 +3,8 @@
 PortSystem                  1.0
 
 name                        pinentry
-version                     1.1.0
-revision                    1
+version                     1.2.0
+revision                    0
 categories                  security
 license                     GPL-2+
 maintainers                 {ionic @Ionic} openmaintainer
@@ -19,13 +19,15 @@ long_description            This is a collection of simple PIN or passphrase ent
 
 use_bzip2                   yes
 
-checksums                   rmd160  33b1f9ae44172a0bba37ad4b7d264822e040fe9e \
-                            sha256  68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570 \
-                            size    467702
+checksums                   rmd160  5e9a49b52d9b2c1a1e25f63d200e2e1701a080b1 \
+                            sha256  10072045a3e043d0581f91cd5676fcac7ffee957a16636adedaa4f583a616470 \
+                            size    498390
 
 configure.args              --with-libiconv-prefix=${prefix} \
                             --with-ncurses-include-dir=${prefix}/include/ncurses \
                             --enable-pinentry-curses \
+                            --enable-pinentry-emacs \
+                            --enable-pinentry-tty \
                             --disable-pinentry-gtk2 \
                             --disable-pinentry-gnome3 \
                             --disable-libsecret \
@@ -76,6 +78,7 @@ variant gnome3 description {Enable GNOME3/gtk3-based pinentry tool} {
 
 variant qt4 conflicts qt5 description {Enable qt4-based pinentry tool} {
     PortGroup               qt4 1.0
+
     configure.args-delete   --disable-pinentry-qt
     configure.args-append   --enable-pinentry-qt \
                             --enable-fallback-curses


### PR DESCRIPTION
#### Description

Update to 1.2.0 and enable the TTY and Emacs version of Pinentry. I didn't make separate variants because these two versions do not require additional dependencies and weigh 185 KB. See https://trac.macports.org/ticket/63713

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
