### PR TITLE
openjdk11-sap: update to 11.0.16

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -12,9 +12,9 @@ license          GPL-2 NoMirror
 universal_variant no
 
 # https://sap.github.io/SapMachine/latest/11
-supported_archs  x86_64
+supported_archs  x86_64 arm64
 
-version      11.0.15.0.1
+version      11.0.16
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -22,10 +22,17 @@ long_description Sap builds of OpenJDK for everyone who wish to use OpenJDK to r
 
 master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
 
-distname     sapmachine-jdk-${version}_osx-x64_bin
-checksums    rmd160  c5cb8d973381ee35aaab6f11367c1f41bfa7e5af \
-             sha256  7744b3632fba1c6e8339b9fb74c46728f8109c07070df49d898799832a934abd \
-             size    186905770
+if {${configure.build_arch} eq "x86_64"} {
+    distname     sapmachine-jdk-${version}_macos-x64_bin
+    checksums    rmd160  efebc3815fe14f95960f757d2ba3ad8b609315f9 \
+                 sha256  183837bb7407fc0dca48cdfbe6af08b8ed85d1805fa223b05b8e61e2597d2652 \
+                 size    186898404
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     sapmachine-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  e829babbf693042155e36474b0836e3498d1b363 \
+                 sha256  828d2906526b560cdea086deac7025cadc0cefef80e06d3f65d9688c04efb160 \
+                 size    185061175
+}
 
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.16.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?