### PR TITLE
openjdk18-sap: update to 18.0.2

### DIFF
--- a/java/openjdk18-sap/Portfile
+++ b/java/openjdk18-sap/Portfile
@@ -13,7 +13,7 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-version      18.0.1.1
+version      18.0.2
 revision     0
 
 description  SapMachine 18
@@ -23,14 +23,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  da7505a2042fbf4c97ed21cdad4d620c05389b03 \
-                 sha256  ade1cfa9e3a42919283d50c233b8e9b27aa52534a270dae32ae896f25ae015a3 \
-                 size    180168248
+    checksums    rmd160  8cb2ed749e48338e52e59fbc324f721f6bfb5a0f \
+                 sha256  6f3ae5267896de1fc887b455157c26eac9c6d32c64aa6aee94b0bc2c61253b14 \
+                 size    181289049
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  3c1e0b251b821bee1d3dd97555ea0ad2b00be669 \
-                 sha256  9884a10021da33ac9147627ede7d5514ef55ad4ead55d886a0b7454494930f03 \
-                 size    178492116
+    checksums    rmd160  b643cb712e0e815cee5274d6ce8a3cd34ed50936 \
+                 sha256  75a7e28b1fcfa4366dec5810265b7b8f7844d53e87005176feb797d4173456ab \
+                 size    179132289
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 18.0.2.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?