### PR TITLE
openjdk7-zulu: update to 7.56.0.11

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -88,10 +88,10 @@ subport openjdk7-zulu {
     # https://www.azul.com/downloads/?version=java-7-lts&os=macos&package=jdk
     supported_archs  x86_64
 
-    version      7.54.0.13
+    version      7.56.0.11
     revision     0
 
-    set openjdk_version 7.0.342
+    set openjdk_version 7.0.352
 
     description  Azul Zulu Community OpenJDK 7 (Long Term Support)
     long_description ${long_description_zulu}
@@ -99,9 +99,9 @@ subport openjdk7-zulu {
     master_sites https://cdn.azul.com/zulu/bin/
 
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  5b7a9a2a6c08501a6585df46389d8438b1df23d7 \
-                 sha256  dcc720d6fe21f4c73d41e3276c032396f4e0a91f51b0fcf2b6530a3daa93c61d \
-                 size    68525632
+    checksums    rmd160  93c147af147dde9d6325338569a3ef2230faebc9 \
+                 sha256  31909aa6233289f8f1d015586825587e95658ef59b632665e1e49fc33a2cdf06 \
+                 size    68532201
 
     worksrcdir   ${distname}/zulu-7.jdk
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 7.56.0.11.

###### Tested on

macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?