### PR TITLE
vislcg3: update to 1.3.7, drop explicit p5-getopt-long

### DIFF
--- a/textproc/vislcg3/Portfile
+++ b/textproc/vislcg3/Portfile
@@ -5,8 +5,8 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               boost 1.0
 
-github.setup            TinoDidriksen cg3 1.3.0 v
-revision                3
+github.setup            GrammarSoft cg3 1.3.7 v
+revision                0
 github.tarball_from     archive
 
 name                    vislcg3
@@ -33,13 +33,13 @@ long_description        Constraint Grammar (CG) is a methodological paradigm \
 
 homepage                https://visl.sdu.dk/constraint_grammar.html
 
-checksums               rmd160 393f7cb49d40c265a1fcd29c13b999278712ee8d \
-                        sha256 ada9dd9f7cdd47d050f53fb87f5f4d590f899b7e5629e9fff694397a6b2bcd05 \
-                        size   357195
+checksums               rmd160 0cf89156f2a974dded3b324dd18bd3df28768fb4 \
+                        sha256 6d57a1b454511a54f90359774120d15231cdd564ba63cbbbb52e74d6cd6a9166 \
+                        size   367388
 
 boost.depends_type      build
 
-depends_lib-append      port:icu port:p5.28-getopt-long
+depends_lib-append      port:icu port:perl5
 
 compiler.cxx_standard   2017
 test.run                yes


### PR DESCRIPTION
#### Description

Update to upstream version 1.3.7, and remove explicit dependency on `p5-getopt-long` in favour of using perl5's built-in `Getopt::Long`. No specific perl5 version requirement - any current version will do.

See also: https://github.com/macports/macports-ports/pull/15265 which solves the Perl upgrade in a different way.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
