### PR TITLE
qt6: various build fixes

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -176,7 +176,7 @@ array set modules {
             5aeb841a5665f79672a302569754ea7d541c69102c551707e43489e797213c71
             29764804
         }
-        "port:ninja port:python39"
+        "port:python310"
         ""
         "qtbase qtsvg qtimageformats"
         {"Qt QML" "Qt Quick" "Qt Quick Layouts" "Qt Quick Widgets"}
@@ -191,7 +191,7 @@ array set modules {
             df61dc1a517988bfa123117c78a7dbeda859cbb6d9cbd080ce60058277bca3df
             1845284
         }
-        "port:ninja"
+        ""
         "path:lib/pkgconfig/jasper.pc:jasper port:libmng port:tiff port:webp"
         "qtbase"
         {"Qt Image Formats"}
@@ -296,7 +296,7 @@ array set modules {
             86e27e005c2421052ca90e619c8d13f1bd19c6bf1a7b84dd4e0f7855fc884fd7
             1717684
         }
-        "port:ninja"
+        ""
         ""
         "qtbase"
         {"Qt SVG"}
@@ -311,7 +311,7 @@ array set modules {
             5a856d3d3d5fe6e15dc3f1af707a0ef1df2e687850403fc94af635edb9312bfb
             8668512
         }
-        "port:ninja"
+        ""
         "port:clang-${llvm_version}"
         "qtbase qtdeclarative"
         {"Qt Designer" "Qt Help" "Qt UI Tools"}
@@ -326,7 +326,7 @@ array set modules {
             3f680b520da585697fc725697a52c7d2074a6a728f6830366b491a6f8b9183c7
             1444712
         }
-        "port:ninja"
+        ""
         ""
         "qttools"
         {"translation files"}
@@ -555,6 +555,7 @@ foreach {module module_info} [array get modules] {
 
             # use ninja for the build/installation
             build.cmd               "ninja"
+            build.post_args-append  -v
             destroot.target         install
             # ninja needs the DESTDIR argument in the environment
             destroot.destdir
@@ -752,6 +753,25 @@ foreach {module module_info} [array get modules] {
             # use -Os instead of -O2
             configure.args-append -optimize-size
 
+            # Set CMake variables (similar to what cmake portgroup does)
+            # to allow using ccache and controlling compiler selection
+            configure.post_args-append \
+                -- \
+                -DCMAKE_C_COMPILER=${configure.cc} \
+                -DCMAKE_CXX_COMPILER=${configure.cxx} \
+                -DCMAKE_OBJC_COMPILER=${configure.objc} \
+                -DCMAKE_OBJCXX_COMPILER=${configure.objcxx}
+            if {[option configure.ccache]} {
+                # Do not use `configure.args-append -ccache`
+                # or `configure.post_args-append -DQT_USE_CCACHE=1`
+                # since that affects installed files.
+                configure.post_args-append \
+                    -DCMAKE_C_COMPILER_LAUNCHER=${prefix}/bin/ccache \
+                    -DCMAKE_CXX_COMPILER_LAUNCHER=${prefix}/bin/ccache \
+                    -DCMAKE_OBJC_COMPILER_LAUNCHER=${prefix}/bin/ccache \
+                    -DCMAKE_OBJCXX_COMPILER_LAUNCHER=${prefix}/bin/ccache
+            }
+
             configure.args-append \
                 -no-testcocoon    \
                 -force-pkg-config
@@ -886,13 +906,27 @@ foreach {module module_info} [array get modules] {
             configure.dir                ${workpath}/build
 
             # Qt suggests using Ninja to build
+            depends_build-append         port:ninja
             build.cmd                    ninja
+            build.post_args-append       -v
             build.dir                    ${workpath}/build
 
             destroot.target install
             # ninja needs the DESTDIR argument in the environment
             destroot.destdir
             destroot.env-append DESTDIR=${destroot}
+
+            # Set CMake variables (similar to what cmake portgroup does)
+            # to allow using ccache and controlling compiler selection
+            configure.post_args-append \
+                -- \
+                -DCMAKE_C_COMPILER=${configure.cc} \
+                -DCMAKE_CXX_COMPILER=${configure.cxx} \
+                -DCMAKE_OBJC_COMPILER=${configure.objc} \
+                -DCMAKE_OBJCXX_COMPILER=${configure.objcxx}
+            if {[option configure.ccache]} {
+                configure.post_args-append -DQT_USE_CCACHE=1
+            }
 
             # determine which variants are to be turned off
             set request_examples true
@@ -1154,9 +1188,9 @@ if { [info exists depends_lib] } {
 }
 
 foreach deps ${depends_check} {
-    if { [string first ":python39" ${deps}] >= 0 } {
-        # If Qt components use Python, ensure that MacPorts python39 is used
-        set python_framework ${frameworks_dir}/Python.framework/Versions/3.9
+    if { [string first ":python310" ${deps}] >= 0 } {
+        # If Qt components use Python, ensure that MacPorts python310 is used
+        set python_framework ${frameworks_dir}/Python.framework/Versions/3.10
     }
 }
 if { ${python_framework} ne "" } {


### PR DESCRIPTION
- Allow compiler selection
- Allow using ccache
- Run ninja verbosely
- Set ninja build dependency for modules
- qtdeclarative: Migrate to Python 3.10

[skip ci]

Fixes: https://trac.macports.org/ticket/65500

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5 21G72 x86_64
Command Line Tools 14.0.0.0.1.1656675061


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -vst destroot`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
