### PR TITLE
vtk: repair +qt5 variant for v9.1

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -15,7 +15,7 @@ compiler.blacklist-append {clang < 900}
 
 name                vtk
 version             9.1.0
-revision            0
+revision            1
 categories          graphics devel
 platforms           darwin
 license             BSD
@@ -69,12 +69,9 @@ configure.args-append \
                     ../${distname}/ \
                     -DCMAKE_BUILD_TYPE=Release \
                     -DBUILD_SHARED_LIBS=ON \
-                    -DBUILD_EXAMPLES:BOOL=OFF \
+                    -DVTK_BUILD_EXAMPLES:BOOL=OFF \
                     -DVTK_WRAP_PYTHON:BOOL=OFF \
                     -DVTK_WRAP_JAVA:BOOL=OFF \
-                    -DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON \
-                    -DVTK_USE_SYSTEM_LIBPROJ:BOOL=OFF \
-                    -DVTK_USE_SYSTEM_DIY2:BOOL=OFF \
                     -DVTK_USE_COCOA:BOOL=ON
 
 # As proposed at #46890
@@ -94,8 +91,12 @@ variant qt5 description {Add Qt5 support.} {
 
     configure.args-append \
                         -DQT_QMAKE_EXECUTABLE:PATH=${qt_qmake_cmd} \
-                        -DVTK_Group_Qt:BOOL=ON \
-                        -DVTK_BUILD_QT_DESIGNER_PLUGIN=OFF
+                        -DQMLPLUGINDUMP_EXECUTABLE:PATH=${qt_bins_dir}/qmlplugindump \
+                        -DVTK_QT_VERSION=5 \
+                        -DVTK_GROUP_ENABLE_Qt:STRING=YES \
+                        -DVTK_MODULE_ENABLE_VTK_GUISupportQt=YES \
+                        -DVTK_MODULE_ENABLE_VTK_RenderingQt=YES \
+                        -DVTK_MODULE_ENABLE_VTK_ViewsQt=YES
 }
 
 # Supported pythons


### PR DESCRIPTION
#### Description

After the recent revbump to VTK 9.1, the +qt5 variant builds successfully but the resultant libraries don't have qt5 functionality enabled. This is due to some changes in the cmake setup, which this PR addresses. With these changes the +qt5 variant works as expected for me.

Fixes: https://trac.macports.org/ticket/65127

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 arm64
Xcode 14.0 14A5270f

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
