### PR TITLE
poac: use legacysupport.use_mp_libcxx on Mojave and older

### DIFF
--- a/sysutils/poac/Portfile
+++ b/sysutils/poac/Portfile
@@ -5,7 +5,12 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
 PortGroup           openssl 1.0
+PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
+
+# On <10.15 built-in libc++ has no support for std::filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx                 yes
 
 github.setup        poacpm poac 0.3.10
 categories          sysutils
@@ -21,6 +26,10 @@ long_description    Poac is a package manager for C++ like Cargo \
 checksums           rmd160  13108a1b06d9c9cf7d4da27d49b121d255467d62 \
                     sha256  8d7b13d2a4421e1ca1b3d6208aff67583d99b86194b92bd3be0bf8b61610a8b0 \
                     size    149703
+
+# Do not allow CMake to use system Git on older systems
+depends_fetch-append \
+                    port:git
 
 depends_lib-append  port:libarchive \
                     port:libfmt \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
