### PR TITLE
qt6: Tcl syntax adjustment, drop mysql57 variant 

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -1084,7 +1084,7 @@ foreach {sql_names sql_info} [array get sql_plugins] {
                 configure.args-append                                              \
                     [subst -D${dbms}_INCLUDE_DIR=\"[lindex ${variant_info} 2]\"]   \
                     [subst -DCMAKE_INCLUDE_PATH=\"[lindex ${variant_info} 2]\"]    \
-                    [subst -D${dbms}_LIBRARY=\"[lindex ${variant_info} 3]/[lindex ${variant_info} 4]"] \
+                    [subst -D${dbms}_LIBRARY=\"[lindex ${variant_info} 3]/[lindex ${variant_info} 4]\"] \
                     [subst -DCMAKE_LIBRARY_PATH=\"[lindex ${variant_info} 3]\"]
             }
         }

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -465,14 +465,6 @@ array set sql_plugins {
             "libmysqlclient.dylib"
             ""
         }
-        {
-            "mysql57"
-            "port:mysql57"
-            "${prefix}/include/mysql57/mysql"
-            "${prefix}/lib/mysql57/mysql"
-            "libmysqlclient_r.dylib"
-            ""
-        }
     }
 }
 


### PR DESCRIPTION
#### Description

The mysql57 variant of qt6-mysql-plugin has never built, because the desired shared library is actually named "libmysqlclient.dylib", not "libmysqlclient_r.dylib". I propose deleting the variant rather than fixing it, because MySQL 5.7 is no longer supported by upstream on macOS (even though it remains supported on other OSes until 2023-10, and MacPorts continues to update it).

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
⚠️ **Suggest merging after** #15427 
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
