### PR TITLE
mysql57: allow newer libtool from PATH

### DIFF
--- a/databases/mysql57/Portfile
+++ b/databases/mysql57/Portfile
@@ -88,6 +88,10 @@ if {$subport eq $name} {
         reinplace "s|@PREFIX@|${prefix}|g" \
             ${cmake.build_dir}/macports/macports-default.cnf \
             ${cmake.build_dir}/macports/my.cnf
+
+        # don't force /usr/bin/libtool -- allow cctools' version to be used
+        reinplace "s|/usr/bin/libtool|libtool|g" \
+            ${worksrcpath}/cmake/merge_archives.cmake.in
     }
 
 


### PR DESCRIPTION
Based on approach in mysql56 (and previously in mysql8)

Fixes: https://trac.macports.org/ticket/59073

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5 21G72 x86_64
Command Line Tools 14.0.0.0.1.1656675061

I have not personally tested this change on the affected platform (10.6 x86-64), but others in the ticket have confirmed that an equivalent or identical change works (allows the build to proceed at least until the error described by https://trac.macports.org/ticket/64250).

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
