### PR TITLE
openjdk18-corretto: fix checksums

### DIFF
--- a/java/openjdk18-corretto/Portfile
+++ b/java/openjdk18-corretto/Portfile
@@ -24,14 +24,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  5ef552ab018e6b21c4968cd3ce66b83a7e4c0dcf \
-                 sha256  980812dd365666b0eccf698011ea29ee5b47712b74d03e874b93fda422b35284 \
-                 size    188837045
+    checksums    rmd160  e44c83158182621bd5b795996f9cdf90d4b2a281 \
+                 sha256  243313e935abd7c76c2c1f4b541b6cd6e0b7ac8b97e222245bb50249fb18a9d3 \
+                 size    188835751
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  8e40dd5346da0368d9cf82441ca7e3ae068f66cc \
-                 sha256  a2a25da58e280e762397ab5bf815833690ab0f9d9531da97c471a57428c479b2 \
-                 size    187052634
+    checksums    rmd160  ed66d255f047d22eba63debc4b8a3551589bd9cd \
+                 sha256  f003000033a25d0ce8f00adfc1b88935da0d330b0ab5587c520f793869415462 \
+                 size    187052397
 }
 
 worksrcdir   amazon-corretto-18.jdk


### PR DESCRIPTION
#### Description

Fix checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.4 21F79 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?