### PR TITLE
openjdk17-corretto: fix checksums

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -24,14 +24,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  1a5015ed0299b0f478da055c48733c980b35a1ca \
-                 sha256  798db2f96f981686d522446597055d15dd333fa2280cdd4404a5349e1b2503ce \
-                 size    187775418
+    checksums    rmd160  b22c66ee913935f4c153cda188b481abcbe1caa3 \
+                 sha256  b2714d48df8d3d8f22fdfb88af548a11603b2c792f1c0c163f6fd39e555a342a \
+                 size    187773572
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  d8c702e6c750d313d06cd73c00b5f7e96d45113a \
-                 sha256  f08123ba018ee54c4d937153c95637b1d4da48694e660d0639d590b53de0aa72 \
-                 size    185883977
+    checksums    rmd160  39d293da52ee850bf54b7274bcde64bdac2b6168 \
+                 sha256  6b7b85dcf4937777a32aed8f62af886b9e50804e238633871289b2b3bb7f53a3 \
+                 size    185883964
 }
 
 worksrcdir   amazon-corretto-17.jdk


### PR DESCRIPTION
#### Description

Fix checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?