### PR TITLE
openjdk11-corretto: fix checksums

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -24,14 +24,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  5db184b8b171b05d352b8ae5b3ef6c3a3e0c659c \
-                 sha256  d64d2925c443b07eb43dbb5851f4fb3e3899d244b3ba9b4b3ff71e865a91d505 \
-                 size    187542305
+    checksums    rmd160  3373016e65ff52774c75f387f950ae9d9e928400 \
+                 sha256  6c466e90639c0ea30291eb6bba71b7af88343b07b007ff0c6a56ae9c0ec24686 \
+                 size    187541047
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  8e26ca410c96ba175134efc8182972a42d7a0235 \
-                 sha256  5038f6e2fd69f8efe8ea43f04edbd571b7b4fb1b6a8956c739e2e8f64799f6b4 \
-                 size    185895207
+    checksums    rmd160  b866a58efdb50ef795df0eadbc563324f52458e7 \
+                 sha256  830932a49619a605972b19672e6c20340a0d471b40cce40cbe46df330275cafb \
+                 size    185896173
 }
 
 worksrcdir   amazon-corretto-11.jdk


### PR DESCRIPTION
#### Description

Fix checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?