### PR TITLE
openjdk11-temurin: add arm64 support

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -12,7 +12,7 @@ license          GPL-2 NoMirror
 universal_variant no
 
 # https://adoptium.net/temurin/releases/
-supported_archs  x86_64
+supported_archs  x86_64 arm64
 
 version      11.0.15
 set build    10
@@ -23,11 +23,17 @@ long_description Eclipse Temurin provides secure, TCK-tested and compliant, prod
 
 master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${version}%2B${build}/
 
-distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-
-checksums    rmd160  5d66fe3d953619e7a6ca326110654344f1883773 \
-             sha256  ebd8b9553a7b4514599bc0566e108915ce7dc95d29d49a9b10b8afe4ab7cc9db \
-             size    186328533
+if {${configure.build_arch} eq "x86_64"} {
+    distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  5d66fe3d953619e7a6ca326110654344f1883773 \
+                 sha256  ebd8b9553a7b4514599bc0566e108915ce7dc95d29d49a9b10b8afe4ab7cc9db \
+                 size    186328533
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  30bef82b1a4c70621f64e42b00824e563b6e7f30 \
+                 sha256  e84143a6c633a26aeefcb1fd5ad8dfb9e952cfec2a1af5c9d9b69f2390990dac \
+                 size    184840725
+}
 
 worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

Add arm64 support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?