### PR TITLE
qt55-qtsvg, qt56-qtsvg, qt57-qtsvg, qt58-qtsvg: unset `known_fail`

### DIFF
--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -15,10 +15,10 @@ homepage            https://www.qt.io
 
 version             5.5.1
 
+# Requires xcodebuild
+# https://trac.macports.org/ticket/59312
 # https://trac.macports.org/ticket/63154
-if { ${xcodeversion} ne "none" } {
-    use_xcode       yes
-}
+use_xcode           yes
 
 set just_want_qt5_variables yes
 PortGroup qt5 1.0
@@ -774,9 +774,6 @@ foreach {module module_info} [array get modules] {
             # see https://trac.macports.org/ticket/59434
             patchfiles-append patch-qtbase-icu_test.diff
 
-            # see https://trac.macports.org/ticket/59312
-            use_xcode yes
-
             #-----------------------------------------------------------------------------
             # qtbase is used for:
             #    1) building qtbase
@@ -1432,19 +1429,6 @@ foreach {module module_info} [array get modules] {
                 # see https://trac.macports.org/ticket/59321
                 post-extract {
                     move ${worksrcpath}/src/3rdparty/javascriptcore/VERSION ${worksrcpath}/src/3rdparty/javascriptcore/VERSION.txt
-                }
-            }
-
-            # special case
-            if {${module} eq "qtsvg" && ${os.platform} eq "darwin" && ${os.major} >= 19} {
-                # Project ERROR: Xcode not set up properly.
-                known_fail  yes
-                depends_lib
-                depends_build
-                depends_extract
-                pre-fetch {
-                    ui_error "${subport} does not build on macOS 10.15 or later"
-                    return -code error "incompatible OS version"
                 }
             }
         }

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -15,10 +15,10 @@ homepage            https://www.qt.io
 
 version             5.6.3
 
+# Requires xcodebuild
+# https://trac.macports.org/ticket/59312
 # https://trac.macports.org/ticket/63154
-if { ${xcodeversion} ne "none" } {
-    use_xcode       yes
-}
+use_xcode           yes
 
 set just_want_qt5_variables yes
 PortGroup qt5 1.0
@@ -819,9 +819,6 @@ foreach {module module_info} [array get modules] {
             # see https://trac.macports.org/ticket/59434
             patchfiles-append patch-qtbase-icu_test.diff
 
-            # see https://trac.macports.org/ticket/59312
-            use_xcode yes
-
             #-----------------------------------------------------------------------------
             # qtbase is used for:
             #    1) building qtbase
@@ -1474,19 +1471,6 @@ foreach {module module_info} [array get modules] {
             if { ${module} eq "qtwebview" } {
                 # dependents of qtwebengine
                 supported_archs x86_64
-            }
-
-            # special case
-            if {${module} eq "qtsvg" && ${os.platform} eq "darwin" && ${os.major} >= 19} {
-                # Project ERROR: Xcode not set up properly.
-                known_fail  yes
-                depends_lib
-                depends_build
-                depends_extract
-                pre-fetch {
-                    ui_error "${subport} does not build on macOS 10.15 or later"
-                    return -code error "incompatible OS version"
-                }
             }
         }
     }

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -15,10 +15,10 @@ homepage            https://www.qt.io
 
 version             5.7.1
 
+# Requires xcodebuild
+# https://trac.macports.org/ticket/59312
 # https://trac.macports.org/ticket/63154
-if { ${xcodeversion} ne "none" } {
-    use_xcode       yes
-}
+use_xcode           yes
 
 set just_want_qt5_variables yes
 PortGroup qt5 1.0
@@ -889,9 +889,6 @@ foreach {module module_info} [array get modules] {
             # see https://trac.macports.org/ticket/59434
             patchfiles-append patch-qtbase-icu_test.diff
 
-            # see https://trac.macports.org/ticket/59312
-            use_xcode yes
-
             #-----------------------------------------------------------------------------
             # qtbase is used for:
             #    1) building qtbase
@@ -1551,19 +1548,6 @@ foreach {module module_info} [array get modules] {
             if { ${module} eq "qtwebview" } {
                 # dependents of qtwebengine
                 supported_archs x86_64
-            }
-
-            # special case
-            if {${module} eq "qtsvg" && ${os.platform} eq "darwin" && ${os.major} >= 19} {
-                # Project ERROR: Could not resolve SDK Path for 'macosx'
-                known_fail  yes
-                depends_lib
-                depends_build
-                depends_extract
-                pre-fetch {
-                    ui_error "${subport} does not build on macOS 10.15 or later"
-                    return -code error "incompatible OS version"
-                }
             }
         }
     }

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -15,10 +15,10 @@ homepage            https://www.qt.io
 
 version             5.8.0
 
+# Requires xcodebuild
+# https://trac.macports.org/ticket/59312
 # https://trac.macports.org/ticket/63154
-if { ${xcodeversion} ne "none" } {
-    use_xcode       yes
-}
+use_xcode           yes
 
 set just_want_qt5_variables yes
 PortGroup qt5 1.0
@@ -892,9 +892,6 @@ foreach {module module_info} [array get modules] {
                     mkspecs/features/mac/rez.prf
             }
 
-            # see https://trac.macports.org/ticket/59312
-            use_xcode yes
-
             #-----------------------------------------------------------------------------
             # qtbase is used for:
             #    1) building qtbase
@@ -1565,20 +1562,6 @@ foreach {module module_info} [array get modules] {
                  ${module} eq "qtnetworkauth" } {
                 # dependents of qtwebengine
                 supported_archs x86_64
-            }
-
-            # special case
-            if {${module} eq "qtsvg" && ${os.platform} eq "darwin" && ${os.major} >= 19} {
-                # Project ERROR: Could not resolve SDK Path for 'macosx'
-                # https://trac.macports.org/ticket/62190
-                known_fail  yes
-                depends_lib
-                depends_build
-                depends_extract
-                pre-fetch {
-                    ui_error "${subport} does not build on macOS 10.15 or later, see https://trac.macports.org/ticket/62190"
-                    return -code error "incompatible OS version"
-                }
             }
         }
     }


### PR DESCRIPTION
No longer needed as of c06efd1cc95aSee: https://trac.macports.org/ticket/62190

Clean up `use_xcode yes` usage

[skip ci]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5 21G72 x86_64
Xcode 14.0 14A5270f

Note: I have not tested any dependents that have been blocked by qtsvg not building.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried ~~a full install with `sudo port -vst install`~~ `sudo port -vst build`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
