### PR TITLE
dhex: update to 0.69

### DIFF
--- a/editors/dhex/Portfile
+++ b/editors/dhex/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    dhex
-version                 0.68
+version                 0.69
 license                 GPL-2+
 categories              editors
 platforms               darwin
@@ -19,8 +19,9 @@ long_description        DHEX is a more than just another hex editor: It includes
 homepage                http://www.dettus.net
 master_sites            ${homepage}/${name}/
 distname                ${name}_${version}
-checksums               rmd160  0b5e4232a8f9e0a3ae345a9c1486c335ae7038c2 \
-                        sha256  126c34745b48a07448cfe36fe5913d37ec562ad72d3f732b99bd40f761f4da08
+checksums               rmd160  e963140362f661bb415ae0519dcd62192ab4fa70 \
+                        sha256  52730bcd1cf16bd4dae0de42531be9a4057535ec61ca38c0804eb8246ea6c41b \
+                        size    57362
 
 depends_lib-append      port:ncurses
 
@@ -35,3 +36,7 @@ build.env               CXX=${configure.cxx} \
                         PREFIX=${prefix}
 
 destroot.destdir        DESTDIR=${destroot}${prefix}
+
+livecheck.type          regex
+livecheck.regex         "href=\"${name}_(\\d+(?:\\.\\d+)*)"
+livecheck.url           [lindex ${master_sites} 0]

--- a/editors/dhex/files/patch-dhex-makefile.diff
+++ b/editors/dhex/files/patch-dhex-makefile.diff
@@ -1,14 +1,14 @@
---- Makefile.old	2017-12-30 13:06:37.000000000 -0800
-+++ Makefile	2017-12-30 13:06:59.000000000 -0800
+--- Makefile.old	2019-01-19 10:17:28.000000000 -0600
++++ Makefile	2022-07-21 13:01:19.000000000 -0500
 @@ -1,11 +1,11 @@
 -CC=		gcc
 -LDFLAGS=	-L/usr/lib	-L/usr/local/lib  	-L/usr/lib/ncurses	-L/usr/local/lib/ncurses
 -CPPFLAGS=	-I/usr/include	-I/usr/local/include	-I/usr/include/ncurses	-I/usr/local/include/ncurses
--CFLAGS=		-O3 -Wall -std=c99 
+-CFLAGS=		-O3 -Wall #-std=c99 
 +#CC=		gcc
 +#LDFLAGS=	-L/usr/lib	-L/usr/local/lib  	-L/usr/lib/ncurses	-L/usr/local/lib/ncurses
 +#CPPFLAGS=	-I/usr/include	-I/usr/local/include	-I/usr/include/ncurses	-I/usr/local/include/ncurses
-+#CFLAGS=		-O3 -Wall -std=c99 
++#CFLAGS=		-O3 -Wall #-std=c99 
  #CFLAGS+= -ffunction-sections -fdata-sections
  #LDFLAGS+= --gc-sections 
  LIBS=		-lncurses


### PR DESCRIPTION
Fix livecheck

#### Description

From README.txt:
```
0.69: this will be the final release of dhex 0.6x. I fixed a bug which caused
      the terminal to be broken. And added the functionality to start the
      hexcal from the commandline (-x).
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H1922 x86_64
Command Line Tools 12.4.0.0.1.1610135815

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
