### PR TITLE
glib2-upstream: disable tests on Rosetta

### DIFF
--- a/devel/glib2-upstream/Portfile
+++ b/devel/glib2-upstream/Portfile
@@ -161,6 +161,11 @@ post-destroot {
 
 platform darwin {
     configure.args-append   -Ddtrace=false
+    
+    # some tests fail to build on 10.6.8 Rosetta: https://trac.macports.org/ticket/65517
+    if {${os.major} == 10 && ${build_arch} eq "ppc"} {
+        configure.args-append   -Dtests=false
+    }
 }
 
 platform darwin 8 {


### PR DESCRIPTION
#### Description

Some tests fail to build on 10.6.8 Rosetta, so disable those: https://trac.macports.org/ticket/65517
In fact I had that fix long back, but somehow it got lost on the way to the port: https://github.com/macports/macports-ports/commit/7ffa0be646e8d1b28ceb038c2bc9961fd9a48fbf

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

P. S. `lint --nitpick` gives two warnings, but those are unrelated to my PR:
```
10:~ svacchanda$ port lint --nitpick glib2-upstream
--->  Verifying Portfile for glib2-upstream
Warning: Patchfile patch-gio_gcredentialsprivate.h does not follow the source patch naming policy "*.diff" or "*.patch"
Warning: Patchfile patch-gio_gsocket.h does not follow the source patch naming policy "*.diff" or "*.patch"
--->  0 errors and 2 warnings found.
```