### PR TITLE
qt6: actually allow compiler selection

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -746,13 +746,14 @@ foreach {module module_info} [array get modules] {
             configure.args-append -optimize-size
 
             # Set CMake variables (similar to what cmake portgroup does)
-            # to allow using ccache and controlling compiler selection
+            # to allow using ccache (and possibly compiler selection
+            # if .tbd file support was not an issue; see comment above)
+            configure.post_args --
             configure.post_args-append \
-                -- \
-                -DCMAKE_C_COMPILER=${configure.cc} \
-                -DCMAKE_CXX_COMPILER=${configure.cxx} \
-                -DCMAKE_OBJC_COMPILER=${configure.objc} \
-                -DCMAKE_OBJCXX_COMPILER=${configure.objcxx}
+                -DCMAKE_C_COMPILER=[option configure.cc] \
+                -DCMAKE_CXX_COMPILER=[option configure.cxx] \
+                -DCMAKE_OBJC_COMPILER=[option configure.objc] \
+                -DCMAKE_OBJCXX_COMPILER=[option configure.objcxx]
             if {[option configure.ccache]} {
                 # Do not use `configure.args-append -ccache`
                 # or `configure.post_args-append -DQT_USE_CCACHE=1`
@@ -910,12 +911,12 @@ foreach {module module_info} [array get modules] {
 
             # Set CMake variables (similar to what cmake portgroup does)
             # to allow using ccache and controlling compiler selection
+            configure.post_args --
             configure.post_args-append \
-                -- \
-                -DCMAKE_C_COMPILER=${configure.cc} \
-                -DCMAKE_CXX_COMPILER=${configure.cxx} \
-                -DCMAKE_OBJC_COMPILER=${configure.objc} \
-                -DCMAKE_OBJCXX_COMPILER=${configure.objcxx}
+                -DCMAKE_C_COMPILER=[option configure.cc] \
+                -DCMAKE_CXX_COMPILER=[option configure.cxx] \
+                -DCMAKE_OBJC_COMPILER=[option configure.objc] \
+                -DCMAKE_OBJCXX_COMPILER=[option configure.objcxx]
             if {[option configure.ccache]} {
                 configure.post_args-append -DQT_USE_CCACHE=1
             }


### PR DESCRIPTION
…at least for building modules
(I assume qtbase still requires Xcode clang for .tbd file support)

[skip ci]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5 21G72 x86_64
Xcode 14.0 14A5270f

Actually verified with `sudo port -vst install qt6-qtsvg configure.compiler=clang-mp-14`.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
