### PR TITLE
qt6-qtdeclarative: relocate special case

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -909,6 +909,13 @@ foreach {module module_info} [array get modules] {
             destroot.destdir
             destroot.env-append DESTDIR=${destroot}
 
+            # special case (needs to go before compiler options are read from)
+            if { ${module} eq "qtdeclarative" } {
+                PortGroup compiler_blacklist_versions 1.0
+                # Xcode 10.3 compiler segfaults
+                compiler.blacklist-append {clang < 1100}
+            }
+
             # Set CMake variables (similar to what cmake portgroup does)
             # to allow using ccache and controlling compiler selection
             configure.post_args --
@@ -1017,12 +1024,6 @@ foreach {module module_info} [array get modules] {
             # Special Cases
             ###############################################################################
             
-            # special case
-            if { ${module} eq "qtdeclarative" } {
-                PortGroup compiler_blacklist_versions 1.0
-                # Xcode 10.3 compiler segfaults
-                compiler.blacklist-append {clang < 1100}
-            }
         }
     }
 }


### PR DESCRIPTION
`compiler.blacklist` must be set before `configure.cc`, etc. are read from

[skip ci]


#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5
Xcode clang 14 beta 3
Verified by changing `compiler.blacklist-append {clang < 1100}` to `compiler.blacklist-append {clang < 1500}` and building qt6-qtdeclarative.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
