### PR TITLE
clojure: fix livecheck URL

### DIFF
--- a/lang/clojure/Portfile
+++ b/lang/clojure/Portfile
@@ -52,5 +52,5 @@ notes "Install the rlwrap port and invoke `clj` for more a more ergonomic REPL."
 
 # ${homepage} now returns 0 bytes; the only indication of the current version on
 # all of clojure.org is currently the Linux install script instructions.
-livecheck.url       https://clojure.org/guides/getting_started
+livecheck.url       https://clojure.org/guides/install_clojure
 livecheck.regex     {linux-install-(\d+(?:\.\d+)*)\.sh}


### PR DESCRIPTION
#### Description
The content that the livecheck regex matches for is in a new page. This commit allows users to run `port livecheck` again. Since this change does not influence the Clojure installation in any way, I decided to not bump the revision number.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H1519 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
