### PR TITLE
openjdk7-zulu: obsolete

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -29,18 +29,13 @@ set long_description_graalvm \
     "GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++."
 
-set long_description_zulu \
-    "Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
-    specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
-    verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
-    respective Java SE version."
-
 # Dummy default values
 set build          0
 set openj9_version 0
 
 set obsoleted_ports {
     openjdk
+    openjdk7-zulu
     openjdk8-graalvm
     openjdk8-openj9-large-heap
     openjdk11-openj9-large-heap
@@ -84,28 +79,11 @@ if {${subport} eq ${name}} {
     }
 }
 
+# Remove after 2023-01-23
 subport openjdk7-zulu {
-    # https://www.azul.com/downloads/?version=java-7-lts&os=macos&package=jdk
-    supported_archs  x86_64
-
     version      7.56.0.11
-    revision     0
-
-    set openjdk_version 7.0.352
-
-    description  Azul Zulu Community OpenJDK 7 (Long Term Support)
-    long_description ${long_description_zulu}
-
-    master_sites https://cdn.azul.com/zulu/bin/
-
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  93c147af147dde9d6325338569a3ef2230faebc9 \
-                 sha256  31909aa6233289f8f1d015586825587e95658ef59b632665e1e49fc33a2cdf06 \
-                 size    68532201
-
-    worksrcdir   ${distname}/zulu-7.jdk
-
-    configure.cxx_stdlib libstdc++
+    revision     1
+    replaced_by  openjdk8-zulu
 }
 
 subport openjdk8-corretto {
@@ -231,20 +209,11 @@ if {${os.platform} eq "darwin"} {
             ui_error "${name} ${version} is only supported on Mac OS X 10.12 Sierra or later."
             return -code error
         }
-    } elseif {[string match *-zulu ${subport}] && ${os.major} < 18} {
-        # See https://www.azul.com/downloads/?os=macos&package=jdk
-        known_fail yes
-        pre-fetch {
-            ui_error "${name} ${version} is only supported on Mac OS X 10.14 Mojave or later."
-            return -code error
-        }
     }
 }
 
 if {[string match *-graalvm ${subport}]} {
     homepage     https://www.graalvm.org
-} elseif {[string match *-zulu ${subport}]} {
-    homepage     https://www.azul.com/downloads/
 } elseif {[string match *-temurin ${subport}]} {
     homepage     https://adoptium.net
 } elseif {[string match *-corretto ${subport}]} {
@@ -293,11 +262,6 @@ if {!(${subport} in ${obsoleted_ports}) && ![info exists meta]} {
     destroot {
         xinstall -m 755 -d ${destroot_target}
         copy ${worksrcpath}/Contents ${destroot_target}
-
-        if {${subport} eq "openjdk7-zulu"} {
-            # MacPorts reports this file as broken
-            delete ${destroot_target}/Contents/Home/jre/lib/xawt/libmawt.dylib
-        }
     }
 
     notes "


### PR DESCRIPTION
#### Description

Obsolete Azul Zulu 7, because [support ended](https://www.azul.com/products/azul-support-roadmap/). Replace with Azul Zulu 8.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?