### PR TITLE
openjdk8-corretto: fix checksums

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -122,14 +122,14 @@ subport openjdk8-corretto {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     amazon-corretto-${version}-macosx-x64
-        checksums    rmd160  9a761ae56d8ba432964e4e2600434c3d0d6ad8ad \
-                     sha256  88cfadc52d6ee487e8865bfcfb0ec658ae1aa4d6657ac5ac1aaad00a0ea7db84 \
-                     size    118783948
+        checksums    rmd160  a3239abb9e63ac8fd246fb6abff6778a1a43a255 \
+                     sha256  030fb6f44439adca2395475a97c12f10907a1b66828b4e47246653538d1fe423 \
+                     size    118784288
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     amazon-corretto-${version}-macosx-aarch64
-        checksums    rmd160  5c401881ae8ce69a6c666ba399ff129be8a48293 \
-                     sha256  528500f87dd2cd524bdf3c0b63ec20307932347951442faabd4c7d3a9555061d \
-                     size    104195573
+        checksums    rmd160  84c7d283bf815ed03620b969a76d53ae98806aaa \
+                     sha256  fba03ac8a2eb78000b2a727d99f56f931d2ebe59497e756123c5d1100d78d32a \
+                     size    104196400
     }
 
     worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Fix checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tested basic functionality of all binary files?