### PR TITLE
openjdk8-corretto: update to 8.342.07.3

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -112,7 +112,7 @@ subport openjdk8-corretto {
     # https://github.com/corretto/corretto-8/releases
     supported_archs  x86_64 arm64
 
-    version     8.342.07.1
+    version     8.342.07.3
     revision    0
 
     description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -122,14 +122,14 @@ subport openjdk8-corretto {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     amazon-corretto-${version}-macosx-x64
-        checksums    rmd160  9a761ae56d8ba432964e4e2600434c3d0d6ad8ad \
-                     sha256  88cfadc52d6ee487e8865bfcfb0ec658ae1aa4d6657ac5ac1aaad00a0ea7db84 \
-                     size    118783948
+        checksums    rmd160  966b129d1ae0255d7d9cbfd202c2f9511af048e1 \
+                     sha256  ab4db316b4c5bb886355bbe192a71a5328e43609631477857a1992ca80975fcf \
+                     size    118790575
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     amazon-corretto-${version}-macosx-aarch64
-        checksums    rmd160  5c401881ae8ce69a6c666ba399ff129be8a48293 \
-                     sha256  528500f87dd2cd524bdf3c0b63ec20307932347951442faabd4c7d3a9555061d \
-                     size    104195573
+        checksums    rmd160  192cf91d72d450cbaf229e5e0981365e40a4b5b8 \
+                     sha256  cb29f72976f9e9be525c8ec58edc8bfc20a24f3ec13c5c7259cf1ded3a921eeb \
+                     size    104196362
     }
 
     worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.342.07.3.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?