### PR TITLE
abseil: fix build for old systems

### DIFF
--- a/devel/abseil/Portfile
+++ b/devel/abseil/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+# MAP_ANONYMOUS
+legacysupport.newest_darwin_requires_legacy 14
 
 github.setup        abseil abseil-cpp 20220623.1
 name                abseil
@@ -18,22 +22,19 @@ long_description    Abseil is an open-source collection of C++ library \
                     Google's own C++ code base, has been extensively \
                     tested and used in production.
 
-if {${os.major} < 11} {
-
-    # NB this port builds with < darwin 11 if libcxx is installed
-    # with the emulated_tls variant to enable thread_local_storage
-
-    # https://abseil.io/docs/cpp/platforms/platforms
-    known_fail      yes
-    pre-fetch {
-        ui_error "${name} @${version} requires macOS 10.7 or later."
-        return -code error "incompatible OS X version"
-    }
-}
-
 checksums           rmd160  23e5de419df48b87661f55e2c2867a1d508793fc \
                     sha256  65d5a14a8e5745c15cdd4052b1d72f0d8e57d4b771441dead39479b1f786965c \
                     size    1957478
+
+platform darwin {
+    if {${build_arch} in [list ppc ppc64]} {
+        patchfiles-append patch-darwin-ppc.diff
+    }
+    if {[string match *gcc* ${configure.compiler}]} {
+        configure.ldflags-append \
+                    -latomic
+    }
+}
 
 # ignore pre releases
 github.livecheck.regex  {([0-9.]+)}

--- a/devel/abseil/files/patch-darwin-ppc.diff
+++ b/devel/abseil/files/patch-darwin-ppc.diff
@@ -1,0 +1,136 @@
+--- absl/copts/AbseilConfigureCopts.cmake.orig	2022-09-03 07:16:44.000000000 +0700
++++ absl/copts/AbseilConfigureCopts.cmake	2022-09-03 07:21:50.000000000 +0700
+@@ -52,13 +52,13 @@
+   if(ABSL_RANDOM_RANDEN_COPTS AND NOT ABSL_RANDOM_RANDEN_COPTS_WARNING)
+     list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Wno-unused-command-line-argument")
+   endif()
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
++elseif(CMAKE_OSX_ARCHITECTURES MATCHES "x86_64|amd64|AMD64")
+   if (MSVC)
+     set(ABSL_RANDOM_RANDEN_COPTS "${ABSL_RANDOM_HWAES_MSVC_X64_FLAGS}")
+   else()
+     set(ABSL_RANDOM_RANDEN_COPTS "${ABSL_RANDOM_HWAES_X64_FLAGS}")
+   endif()
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*|aarch64")
++elseif(CMAKE_OSX_ARCHITECTURES MATCHES "arm.*|aarch64")
+   if (CMAKE_SIZEOF_VOID_P STREQUAL "8")
+     set(ABSL_RANDOM_RANDEN_COPTS "${ABSL_RANDOM_HWAES_ARM64_FLAGS}")
+   elseif(CMAKE_SIZEOF_VOID_P STREQUAL "4")
+@@ -66,6 +66,8 @@
+   else()
+     message(WARNING "Value of CMAKE_SIZEOF_VOID_P (${CMAKE_SIZEOF_VOID_P}) is not supported.")
+   endif()
++elseif(CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64")
++  set(ABSL_RANDOM_RANDEN_COPTS "${ABSL_RANDOM_HWAES_PPC_FLAGS}")
+ else()
+   message(WARNING "Value of CMAKE_SYSTEM_PROCESSOR (${CMAKE_SYSTEM_PROCESSOR}) is unknown and cannot be used to set ABSL_RANDOM_RANDEN_COPTS")
+   set(ABSL_RANDOM_RANDEN_COPTS "")
+
+--- absl/copts/copts.py.orig	2022-09-01 00:15:21.000000000 +0700
++++ absl/copts/copts.py	2022-09-03 06:17:38.000000000 +0700
+@@ -162,5 +162,6 @@
+         "-maes",
+         "-msse4.1",
+     ],
++    "ABSL_RANDOM_HWAES_PPC_FLAGS": [],
+     "ABSL_RANDOM_HWAES_MSVC_X64_FLAGS": [],
+ }
+
+--- absl/copts/configure_copts.bzl.orig	2022-06-23 22:22:47.000000000 +0400
++++ absl/copts/configure_copts.bzl	2022-07-22 20:56:32.000000000 +0400
+@@ -45,7 +45,7 @@
+ ABSL_RANDOM_RANDEN_COPTS = select({
+     # APPLE
+     ":cpu_darwin_x86_64": ABSL_RANDOM_HWAES_X64_FLAGS,
+-    ":cpu_darwin": ABSL_RANDOM_HWAES_X64_FLAGS,
++    ":cpu_darwin_ppc": ABSL_RANDOM_HWAES_PPC_FLAGS,
+     ":cpu_x64_windows_msvc": ABSL_RANDOM_HWAES_MSVC_X64_FLAGS,
+     ":cpu_x64_windows": ABSL_RANDOM_HWAES_MSVC_X64_FLAGS,
+     ":cpu_k8": ABSL_RANDOM_HWAES_X64_FLAGS,
+@@ -68,7 +68,7 @@
+         "ppc",
+         "k8",
+         "darwin_x86_64",
+-        "darwin",
++        "darwin_ppc",
+         "x64_windows_msvc",
+         "x64_windows",
+         "aarch64",
+
+--- absl/random/internal/randen_detect.cc.orig	2022-09-01 00:15:21.000000000 +0700
++++ absl/random/internal/randen_detect.cc	2022-09-03 07:03:35.000000000 +0700
+@@ -39,6 +39,8 @@
+ #elif defined(__linux__) && defined(ABSL_HAVE_GETAUXVAL)
+ #define ABSL_INTERNAL_USE_LINUX_GETAUXVAL
+ #define ABSL_INTERNAL_USE_GETAUXVAL
++#elif defined(__APPLE__) && defined(ABSL_ARCH_PPC)
++#define ABSL_INTERNAL_USE_PPC_CPUINFO
+ #endif
+ #endif
+ 
+@@ -56,6 +58,11 @@
+ #endif
+ #endif  // ABSL_INTERNAL_USE_X86_CPUID
+ 
++#if defined(ABSL_INTERNAL_USE_PPC_CPUINFO)
++#include <mach/mach.h>
++#include <mach/machine.h>
++#endif // ABSL_INTERNAL_USE_PPC_CPUINFO
++
+ // On linux, just use the c-library getauxval call.
+ #if defined(ABSL_INTERNAL_USE_LINUX_GETAUXVAL)
+ 
+--- absl/random/internal/platform.h.orig	2022-09-01 00:15:21.000000000 +0700
++++ absl/random/internal/platform.h	2022-09-03 06:56:21.000000000 +0700
+@@ -67,8 +67,8 @@
+ #define ABSL_ARCH_AARCH64
+ #elif defined(__arm__) || defined(__ARMEL__) || defined(_M_ARM)
+ #define ABSL_ARCH_ARM
+-#elif defined(__powerpc64__) || defined(__PPC64__) || defined(__powerpc__) || \
+-    defined(__ppc__) || defined(__PPC__)
++#elif defined(__powerpc64__) || defined(__PPC64__) || defined(__ppc64__) || \
++     defined(__powerpc__) || defined(__PPC__) || defined(__ppc__)
+ #define ABSL_ARCH_PPC
+ #else
+ // Unsupported architecture.
+@@ -105,9 +105,11 @@
+ 
+ #elif defined(ABSL_ARCH_PPC)
+ 
++#if defined(__APPLE__)
++#undef ABSL_HAVE_ACCELERATED_AES
++#define ABSL_HAVE_ACCELERATED_AES 0
+ // Rely on VSX and CRYPTO extensions for vcipher on PowerPC.
+-#if (defined(__VEC__) || defined(__ALTIVEC__)) && defined(__VSX__) && \
+-    defined(__CRYPTO__)
++#elif (defined(__VEC__) || defined(__ALTIVEC__)) && defined(__VSX__) && defined(__CRYPTO__)
+ #undef ABSL_HAVE_ACCELERATED_AES
+ #define ABSL_HAVE_ACCELERATED_AES 1
+ #endif
+@@ -151,6 +153,10 @@
+ // (This captures a lot of Android configurations.)
+ #undef ABSL_RANDOM_INTERNAL_AES_DISPATCH
+ #define ABSL_RANDOM_INTERNAL_AES_DISPATCH 1
++#elif defined(__APPLE__) && defined(ABSL_ARCH_PPC)
++// Darwin PPC
++#undef ABSL_RANDOM_INTERNAL_AES_DISPATCH
++#define ABSL_RANDOM_INTERNAL_AES_DISPATCH 0
+ #endif
+ 
+ // NaCl does not allow dispatch.
+
+--- absl/debugging/internal/examine_stack.cc.orig	2022-06-23 22:22:47.000000000 +0400
++++ absl/debugging/internal/examine_stack.cc	2022-07-23 19:11:23.000000000 +0400
+@@ -223,6 +232,12 @@
+ #else
+     return reinterpret_cast<void*>(signal_ucontext->uc_mcontext->ss.rip);
+ #endif
++#elif defined(__ppc__) || defined(__ppc64__)
++#if __DARWIN_UNIX03
++    return reinterpret_cast<void*>(signal_ucontext->uc_mcontext->__ss.__srr0);
++#else
++    return reinterpret_cast<void*>(signal_ucontext->uc_mcontext->ss.srr0);
++#endif
+ #endif
+   }
+ #elif defined(__akaros__)


### PR DESCRIPTION
#### Description

Preliminary fix for old systems. If anyone can test the build on PPC natively, please update me.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

P. S. On Rosetta the build succeeds with an extra patch, but at the moment it is ugly: https://github.com/abseil/abseil-cpp/issues/1227

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
