### PR TITLE
qbitorrent ports: license is GPLv2 or later

### DIFF
--- a/net/qBittorrent-qt5/Portfile
+++ b/net/qBittorrent-qt5/Portfile
@@ -11,7 +11,7 @@ name            qBittorrent-qt5
 conflicts       qBittorrent
 maintainers     {i0ntempest @i0ntempest} openmaintainer
 platforms       darwin
-license         {GPL-2 OpenSSLException}
+license         {GPL-2+ OpenSSLException}
 
 description     The qBittorrent project aims to provide an open-source software alternative to µTorrent.
 long_description \

--- a/net/qBittorrent/Portfile
+++ b/net/qBittorrent/Portfile
@@ -13,7 +13,7 @@ conflicts       qBittorrent-qt5
 categories      net
 maintainers     {i0ntempest @i0ntempest} openmaintainer
 platforms       darwin
-license         {GPL-2 OpenSSLException}
+license         {GPL-2+ OpenSSLException}
 
 description     The qBittorrent project aims to provide an open-source software alternative to µTorrent.
 long_description \


### PR DESCRIPTION
#### Description
This is clarified in the COPYING file of recent releases, but was already the case as stated in source code files. See explanation: https://github.com/qbittorrent/qBittorrent/commit/f6336a60562758ce1100ec35b62b8c1e136b03f6
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
