### PR TITLE
binutils: disable silent rules, fix typo in comment

### DIFF
--- a/devel/binutils/Portfile
+++ b/devel/binutils/Portfile
@@ -29,13 +29,14 @@ patchfiles          dynamic_lookup-11.patch
 
 configure.args      --infodir='${prefix}/share/info' \
                     --mandir='${prefix}/share/man' \
+                    --disable-silent-rules \
                     --disable-werror \
                     --program-prefix=g \
                     --enable-shared \
                     --enable-install-libbfd
 
 # The Makefile runs configure again in subdirectories.
-# It correcty passes along most configure variables (CFLAGS, LDFLAGS, ...),
+# It correctly passes along most configure variables (CFLAGS, LDFLAGS, ...),
 #    but seems to neglect CPPFLAGS.
 build.env-append    CPPFLAGS=-I${prefix}/include
 


### PR DESCRIPTION
#### Description
Maybe there are other binutils ports to disable silent rules for…

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7
Command Line Tools 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
  Only verified up to destroot.
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
