### PR TITLE
qt55-qtbase-docs: needs patch-xcrun.diff

### DIFF
--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -692,7 +692,7 @@ foreach {module module_info} [array get modules] {
             # this qt55 patch does not apply on qt53 and does not appear to be needed
             # patchfiles-append patch-machtest.diff
 
-            # see #52200
+            # see https://trac.macports.org/ticket/52200
             # see https://codereview.qt-project.org/#/c/164673/
             patchfiles-append patch-xcrun.diff
 
@@ -1446,6 +1446,11 @@ foreach {module module_info} [array get modules] {
             qt5.debug_variant   no
 
             # special cases
+            if { ${module} eq "qtbase" } {
+                # see https://trac.macports.org/ticket/52200
+                # see https://codereview.qt-project.org/#/c/164673/
+                patchfiles-append patch-xcrun.diff
+            }
             if { ${module} eq "qttools" || ${module} eq "qtbase" } {
                 post-extract {
                     # generated makefiles assume full Qt was built locally
@@ -1562,7 +1567,7 @@ foreach {sql_names sql_info} [array get sql_plugins] {
         # see https://trac.macports.org/ticket/53248
         qt5.top_level ${worksrcpath}
 
-        # see #52200
+        # see https://trac.macports.org/ticket/52200
         # see https://codereview.qt-project.org/#/c/164673/
         patchfiles-append patch-xcrun.diff
     }

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -742,7 +742,7 @@ foreach {module module_info} [array get modules] {
             # When testing, ensure that a universal object file is not inadvertently created.
             patchfiles-append patch-machtest.diff
 
-            # see #52200
+            # see https://trac.macports.org/ticket/52200
             # see https://codereview.qt-project.org/#/c/164673/
             patchfiles-append patch-xcrun.diff
 
@@ -1506,6 +1506,10 @@ foreach {module module_info} [array get modules] {
                     xinstall -d -m 0755 ${worksrcpath}/Source/WebCore/generated
                     touch ${worksrcpath}/Source/WebCore/generated/InspectorBackendCommands.qrc
                 }
+            } elseif { ${module} eq "qtbase" } {
+                # see https://trac.macports.org/ticket/52200
+                # see https://codereview.qt-project.org/#/c/164673/
+                patchfiles-append patch-xcrun.diff
             }
         }
     }
@@ -1592,7 +1596,7 @@ foreach {sql_names sql_info} [array get sql_plugins] {
         # see https://trac.macports.org/ticket/53248
         qt5.top_level ${worksrcpath}
 
-        # see #52200
+        # see https://trac.macports.org/ticket/52200
         # see https://codereview.qt-project.org/#/c/164673/
         patchfiles-append patch-xcrun.diff
     }


### PR DESCRIPTION
Not known if also needed for qt53-qtbase-docs, but apply anyway for consistency
Put URL to ticket in comments
See: https://trac.macports.org/ticket/52200

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Only patch phase is tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
