### PR TITLE
lazydocker: update to 0.18.1

### DIFF
--- a/devel/lazydocker/Portfile
+++ b/devel/lazydocker/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazydocker 0.12 v
+go.setup            github.com/jesseduffield/lazydocker 0.18.1 v
 
-checksums           rmd160  965c2701b11f29e8cfb302f2b634566d072ef3a2 \
-                    sha256  dd43d4fce273b700093e7ba6dfac4d948ae9bfe041464b4443f29dc6fcac7413 \
-                    size    12046982
+checksums           rmd160  517878832b17f1248331e3262c428bc5e8fb8c07 \
+                    sha256  a7a1e2c934457c90e39af956688e849cacdbab17df2eb537eb346a57fedc056d \
+                    size    12641076
 
 categories          devel
 platforms           darwin
@@ -19,7 +19,7 @@ description         The lazy way to manage everything docker
 long_description    A simple terminal UI for both docker and docker-compose, written in Go with the gocui library
 
 set time [clock format [clock seconds] -format %Y%m%dT%H%M%S]
-build.args-append   -ldflags=\"-X 'main.Version=v${version}' -X 'main.BuildDate=${time}'\" -o ./lazydocker ./
+build.args-append   -ldflags=\"-X 'main.version=v${version}' -X 'main.date=${time}' -X 'main.commit=unknown' -X 'main.buildSource=MacPorts'\" -o ./lazydocker ./
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Update to 0.18.1, supply up-to-date ldflags

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Xcode 13.4.1 13F100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
