### PR TITLE
cgal5: update to 5.5 and add missing dependency to boost

### DIFF
--- a/gis/cgal5/Portfile
+++ b/gis/cgal5/Portfile
@@ -17,7 +17,7 @@ long_description        The goal of the ${description} is to provide easy access
 
 platforms               darwin
 
-github.setup            CGAL cgal 5.4.1 v
+github.setup            CGAL cgal 5.5 v
 revision                0
 conflicts               cgal4
 github.tarball_from     releases
@@ -26,19 +26,19 @@ license                 LGPL-3+ GPL-3+
 categories              gis science
 maintainers             {vince @Veence}
 use_xz                  yes
-# switch to this (and remove worksrcdir) with the next version update
-#distname                CGAL-${version}
+distname                CGAL-${version}
 
 homepage                http://www.cgal.org/
 
-checksums           rmd160  dc23065b0c2827aff91f6cc611ea7c185f0d7e0c \
-                    sha256  4c3dd7ee4d36d237111a4d72b6e14170093271595d5b695148532daa95323d76 \
-                    size    24110884
+checksums           rmd160  6f628b35ac5a55b253f2acbc54aea1bac3e37adf \
+                    sha256  98ac395ca08aacf38b7a8170a822b650aedf10355df41dd0e4bfb238408e08a6 \
+                    size    24156768
+                                        
 
-worksrcdir              CGAL-${version}
 depends_lib-append      port:mpfr \
                         port:zlib \
                         port:gmp \
+                        port:boost \
                         path:include/eigen3/Eigen/Eigen:eigen3
 
 compiler.cxx_standard   2014


### PR DESCRIPTION
#### Description

Update CGAL5 to latest upstream version (5.5). By the way, it seems to me that boost should be listed explicitly in the dependencies of the `cgal5` port (using portgroup `boost` is not enough) for it to be installed when `cgal5` is installed. As suggested in the portfile by the Maintainer, the field `distname` is now used instead of `worksrcdir`.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1922 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
