### PR TITLE
openjdk11-graalvm: update to 22.2.0

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.1.0
+version      22.2.0
 revision     0
 
 description  GraalVM Community Edition based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java11-darwin-amd64-${version}
-    checksums    rmd160  6c4afee0143d6cf4373fa8faf36a6e3eeb4bce22 \
-                 sha256  c4c9df94ca47b83b582758b87d39042732ba0193fc63f1ab93f6818005a1fe6b \
-                 size    435795441
+    checksums    rmd160  152b654b107058bb1e9a4b561210ed28f960d1d7 \
+                 sha256  3c6aca6faefa9e1f73de45fc56cc07d6f7864f63ce0b95148002dadb8f78cd86 \
+                 size    253271371
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-ce-java11-darwin-aarch64-${version}
-    checksums    rmd160  5e834b8bc8ea1150e1f8f95bdc623a81d904fddc \
-                 sha256  06bc19a0b1e93aa3df5e15c08e97f8cef624cb6070eeae40a69a51ec7fd41152 \
-                 size    404445467
+    checksums    rmd160  99b80b02754a9ea7cd5bc5165150069272ffe656 \
+                 sha256  ee513cec2ef7b34ae6fbb8a3015c227ab2a24bfb2771c16152f15a1846df01f4 \
+                 size    248090327
 }
 
 worksrcdir   graalvm-ce-java11-${version}


### PR DESCRIPTION
#### Description

Update to GraalVM 22.2.0.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?