### PR TITLE
openjdk17-graalvm: update to 22.2.0

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.1.0
+version      22.2.0
 revision     0
 
 description  GraalVM Community Edition based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java17-darwin-amd64-${version}
-    checksums    rmd160  7e932f8907856537c4fd4a9915d14eb035ebd615 \
-                 sha256  b9327fa73531a822d9a27d25980396353869eefbd73fdcef89b4fceb9f529c75 \
-                 size    444981011
+    checksums    rmd160  447cfacab9fdc1357aad3d461658cf147172277c \
+                 sha256  b92b6f5f7f11282f20c8f8b94ea1c16d776cbadd7b254119836a7ace9f513b0d \
+                 size    259574942
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-ce-java17-darwin-aarch64-${version}
-    checksums    rmd160  f13dd6cbc5e41e0d28fd68b8c4091895147fe18b \
-                 sha256  06075cd390bd261721392cd6fd967b1d28c0500d1b5625272ea906038e5cd533 \
-                 size    418107972
+    checksums    rmd160  8fe8a28a14d8885df1a3493466f44f0a78c3e83d \
+                 sha256  cfbeb38cd707a330048ab2140cb185176201c5cb654df752fcb4bd95e899b4ec \
+                 size    256787870
 }
 
 worksrcdir   graalvm-ce-java17-${version}


### PR DESCRIPTION
#### Description

Update to GraalVM 22.2.0.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?