### PR TITLE
google-cloud-sdk: update to 395.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             394.0.0
+version             395.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  16cde47390174c6833bf03648c9234a8bd7695a3 \
-                    sha256  787fdb40dad00a5dbe45ab4b7242c50f309bb7e0349abad7242582b1535c54a3 \
-                    size    108100993
+    checksums       rmd160  1154f5676487c1345048f12ca1dc9ee086d46f37 \
+                    sha256  a2567c4af442662baafa007c03a17f060e6fd1071983d91170c0753c6b82c02a \
+                    size    108263395
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3f2a425edaa85ee222e47e776b4cb046588a4699 \
-                    sha256  0311884b3f6acf17a2184a80be088d8f027ad79b25ffe2d5f16fb5e6a8e78d6e \
-                    size    104852852
+    checksums       rmd160  241a6208655261275a735a150155770032381c8c \
+                    sha256  6ed8434db8f492c188d02d1ebb3eb378d92ce23e0f571853a1954d8d3c0a2ef0 \
+                    size    105022050
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  afc3b823a331989b0a844217340c1a6edfad5a2b \
-                    sha256  e358c7d1b411c968d122e2b455a2133d15029aa5339ab4e6e8bc871d6ea50330 \
-                    size    103454814
+    checksums       rmd160  6ff92f8f4c74c3111357018583517be141a8cba0 \
+                    sha256  ee62501adcbda9f5d159f032272df5399ba6d6b8f7c9f8a9e21fe18ecbfff195 \
+                    size    103622836
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 395.0.0.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?