### PR TITLE
openjdk11: update to 11.0.16

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -5,24 +5,24 @@ PortSystem          1.0
 name                openjdk11
 # https://github.com/openjdk/jdk11u/tags
 # remove 'jdk-' from the latest tag without '-ga' that has commit that corresponds to the latest tag with '-ga'
-version             11.0.15
-set build 10
+version             11.0.16
+set build 8
 revision            0
 categories          java devel
 platforms           darwin
 supported_archs     x86_64 arm64
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
-description         Openjdk 11
-long_description    JDK 11 builds of Openjdk, the Open-Source implementation \
+description         OpenJDK 11
+long_description    JDK 11 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  4e54be9b3a7ee2a0c7d8c5596f6b95396d30bb25 \
-                    sha256  a125f0f2e34061ea1509c9f24caec51e6e23411552d6b660a6f60c054853dc63 \
-                    size    122892672
+checksums           rmd160  070b09234c15f5ed3da23d85152781ce87d06ce4 \
+                    sha256  58acafa79830b550eed738b9c9590d3a19c44d776f9be634e0f7e1c5a57cb1b9 \
+                    size    123145634
 
 depends_lib         port:freetype
 depends_build       port:autoconf \


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.16.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?