### PR TITLE
kotlin: set fallback to openjdk17

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  1a1899fdb1f4af50504ec9a374987c8f9e4cc6b8 \
                     size    72957814
 
 java.version        1.8+
-java.fallback       openjdk8
+java.fallback       openjdk17
 
 worksrcdir          kotlinc
 


### PR DESCRIPTION
#### Description

Change fallback Java to `openjdk17`, because that is the latest Long Term Support release and `openjdk8` is not available on arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?