### PR TITLE
qt5-qtwebengine: fallback to nodejs16 on macOS 10.13

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1720,15 +1720,8 @@ foreach {module module_info} [array get modules] {
 
                 # build requires Node.js as of 5.15.3
                 # nodejs12 (which chromium 87 uses by default) or later are known to work
-                if { ${os.platform} eq "darwin" && ${os.major} >= 18 } {
-                    # prefer latest LTS Node.js as fallback
-                    depends_build-append path:bin/node:nodejs16
-                } else {
-                    # nodejs16 (latest LTS) currently does not build on macOS 10.13
-                    # see https://trac.macports.org/ticket/64130
-                    # use nodejs14 (previous LTS) as fallback
-                    depends_build-append path:bin/node:nodejs14
-                }
+                # prefer latest LTS Node.js as fallback
+                depends_build-append path:bin/node:nodejs16
 
                 # UsingTheRightCompiler (https://trac.macports.org/wiki/UsingTheRightCompiler)
                 build.env-append      CXX=${configure.cxx}


### PR DESCRIPTION
[skip ci]

#### Description
nodejs16 has built successfully on macOS 10.13 since being updated to 16.14 back in February.
I am aware nodejs18 will be the newest LTS version, I will see if it works if I update qt5-qtwebengine in the future.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
