### PR TITLE
groovy: set fallback to openjdk17

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -50,7 +50,7 @@ worksrcdir      ${name}-${version}
 use_configure   no
 
 java.version    1.8+
-java.fallback   openjdk8
+java.fallback   openjdk17
 
 build {}
 


### PR DESCRIPTION
#### Description

Change fallback Java to `openjdk17`, because that is the latest Long Term Support release and `openjdk8` is not available on arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?