### PR TITLE
Update to tomcat-native-1.2.35

### DIFF
--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                tomcat-native
-version             1.2.33
+version             1.2.35
 revision            0
 categories          java www
 maintainers         {thebishops.org:matt @mattbishop} openmaintainer
@@ -18,9 +18,9 @@ long_description    This port provides access to native apr and other \
 homepage            https://tomcat.apache.org/
 master_sites        apache:tomcat/tomcat-connectors/native/${version}/source/
 
-checksums           rmd160  92af26ba1d24818b998eb6393886e7a72063fef4 \
-                    sha256  7540cff954774b3f8d8f7480f92f1c206a48f25440a62186b196c5930b45fea1 \
-                    size    430359
+checksums           rmd160  bb60848b76178dcb90a7408110fb1f5b702aed5c \
+                    sha256  24613b7a75c7b00aa1837526758d32c3c3ccf2782e6eb634a900b6ed3f4697ff \
+                    size    436593
 
 distname            ${name}-${version}-src
 worksrcdir          ${distname}/native


### PR DESCRIPTION
#### Description

Update to tomcat-native-1.2.35

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
