### PR TITLE
bitwarden-cli: Use npm portgroup

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -1,12 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-
-github.setup        bitwarden cli 1.22.1 v
-revision            0
+PortGroup           npm 1.0
 
 name                bitwarden-cli
+version             1.22.1
+revision            0
+
+npm.rootname        @bitwarden/cli
+distname            cli-${version}
+
 categories          security
 license             GPL-3
 maintainers         {bochtler.io:macports @MarcelBochtler} \
@@ -16,23 +19,6 @@ description         Bitwarden password manager CLI
 long_description    CLI implementation of the Bitwarden password manager.
 homepage            https://bitwarden.com
 
-fetch.type          git
-
-depends_fetch-append \
-                    path:bin/npm:npm6
-
-post-fetch {
-    system -W "${worksrcpath}" "npm run sub:init"
-}
-
-configure {
-    system -W "${worksrcpath}" "npm install"
-}
-
-build {
-    system -W "${worksrcpath}" "npm run dist:mac"
-}
-
-destroot {
-    xinstall -m 755 ${worksrcpath}/dist/macos/bw ${destroot}${prefix}/bin
-}
+checksums           rmd160  52f7f8af25ac9454325cd78fe7e773f876023c5f \
+                    sha256  3bddf569de988fbf5a3c1b433f0df69a329be795b42860d84ebf8ba5cbd67c81 \
+                    size    581932


### PR DESCRIPTION
#### Description

Use the npm portgroup to install bitwarden-cli.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
