### PR TITLE
maven3: set fallback to openjdk17

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -40,7 +40,7 @@ checksums       rmd160  84143def64b5a426cdc0b1c6d2a43367a474817f \
                 size    8676320
 
 java.version    1.7+
-java.fallback   openjdk11
+java.fallback   openjdk17
 
 depends_run     port:maven_select
 


### PR DESCRIPTION
#### Description

Fall back to installing the latest Long Term Support release of Java if no Java is installed yet.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?