### PR TITLE
py-ldap: update to 3.4.2

### DIFF
--- a/python/py-ldap/Portfile
+++ b/python/py-ldap/Portfile
@@ -4,11 +4,13 @@ PortSystem      1.0
 PortGroup       python 1.0
 
 name            py-ldap
-version         3.2.0
-revision        1
+python.rootname python-ldap
+version         3.4.2
+revision        0
+
 license         PSF
-platforms       darwin
-maintainers     nomaintainer
+maintainers     {mascguy @mascguy} openmaintainer
+
 description     object-oriented api for python to access LDAP directory servers
 long_description \
                 python-ldap provides an object-oriented API to access \
@@ -17,25 +19,45 @@ long_description \
                 Additionally the package contains modules for other \
                 LDAP-related stuff (e.g. processing LDIF, LDAPURLs, \
                 LDAPv3 schema, etc.).
-
 homepage        http://www.python-ldap.org/
-python.rootname python-ldap
-checksums       rmd160 846bf38cb166f478f2cf401f889ad7ecd39b05c5 \
-                sha256 7d1c4b15375a533564aad3d3deade789221e450052b21ebb9720fb822eccdb8e \
-                size   367645
 
-python.versions 27 36 37
+checksums       rmd160  094d82b4e4dc80d7a11083254197cfc16b84832e \
+                sha256  b16470a0983aaf09a00ffb8f40b69a2446f3d0be639a229256bce381fcb268f7 \
+                size    378058
+
+python.versions 27 37 38 39 310
 
 if {$subport ne $name} {
-    depends_build-append \
+    if {${python.version} == 27} {
+        version   3.2.0
+        revision  2
+
+        checksums rmd160 846bf38cb166f478f2cf401f889ad7ecd39b05c5 \
+                  sha256 7d1c4b15375a533564aad3d3deade789221e450052b21ebb9720fb822eccdb8e \
+                  size   367645
+
+        depends_build-append \
                 port:py${python.version}-setuptools
+    } else {
+        python.pep517 yes
+    }
+
     depends_lib-append \
-                path:lib/libldap.dylib:openldap
+                path:lib/libldap.dylib:openldap \
+                port:py${python.version}-asn1 \
+                port:py${python.version}-asn1-modules
 
     post-destroot {
-        xinstall -d -m 755 ${destroot}${prefix}/share/doc/${subport}
+        set doc_dir ${destroot}${prefix}/share/doc/${subport}
+        xinstall -d ${doc_dir}
         xinstall -m 644 -W ${worksrcpath} CHANGES INSTALL LICENCE README TODO \
-            ${destroot}${prefix}/share/doc/${subport}
+            ${doc_dir}
+    }
+
+    if {${python.version} > 27} {
+        test.run        yes
+        # Location of openldap daemon (slapd)
+        test.env-append SBIN=${prefix}/libexec
     }
 
     livecheck.type  none


### PR DESCRIPTION
### Description

* Update `py-ldap` to 3.4.2, for Python 3.x
* Add subports for Python 3.8, 3.9, and 3.10
* Drop subport for Python 3.6
* Fallback to previous release (3.2.0), for Python 2.7

### Tested on
macOS 10.15
Xcode 12.0 / Command Line Tools 12.0

### Verification <!-- (delete not applicable items) -->
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
