### PR TITLE
emacs{,-app}-devel: update to 20220728

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -99,14 +99,14 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 }
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
-    set date        2022-07-12
+    set date        2022-07-28
     epoch           5
     version         [string map {- {}} ${date}]
-    revision        1
+    revision        0
 
     fetch.type      git
     git.url         --shallow-since=${date}T00:00:00 https://github.com/emacs-mirror/emacs.git
-    git.branch      4650ea9c25514831d925e5006ea0c3679344333b
+    git.branch      f2465b6b2ff64fe81612b5a02c16a98942c5ca57
 
     # --shallow-since needs a newer version of git than on some older systems
     # So use MacPorts version


### PR DESCRIPTION
#### Description

Update to the latest `master` in which a big improvement for long-line handling has been landed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
