### PR TITLE
openjdk11-corretto: update to 11.0.16.8.3

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-11/releases
 supported_archs  x86_64 arm64
 
-version      11.0.16.8.1
+version      11.0.16.8.3
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  3373016e65ff52774c75f387f950ae9d9e928400 \
-                 sha256  6c466e90639c0ea30291eb6bba71b7af88343b07b007ff0c6a56ae9c0ec24686 \
-                 size    187541047
+    checksums    rmd160  4d1bdebdb7a33fa89b14f9bb45b42b187df2019c \
+                 sha256  8d015d4bf405b5027bd88a806a025078a8daa82afbaab06b2ed64c9e638e1e01 \
+                 size    187538389
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  b866a58efdb50ef795df0eadbc563324f52458e7 \
-                 sha256  830932a49619a605972b19672e6c20340a0d471b40cce40cbe46df330275cafb \
-                 size    185896173
+    checksums    rmd160  daac5cba8149eb6e053b9b45f70010f0db544437 \
+                 sha256  b3a85aa264b2c4fc49f70001ccff40b30b9d5e719c57b4ff3d24631d3e6ed4d0 \
+                 size    185912667
 }
 
 worksrcdir   amazon-corretto-11.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-11/blob/release-11.0.16.8.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-11/blob/release-11.0.16.8.3/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.16.8.3.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?