### PR TITLE
kustomize: update to 4.5.6

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.5.5 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.5.6 kustomize/v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  50f28e82ff26d1bace8d8633344abb93202ffb2b \
-                    sha256  70fd536380b7925e345f2fee1681f0a4a19082e480c0e6668d9e724a161ecb2e \
-                    size    4049754
+checksums           rmd160  cbe2b9a126db213a1de94fbd29a2da4e7c6f2996 \
+                    sha256  bcc380524bfc3abf2f29d3d723d18f662893a988496eba4a0aabac492347401b \
+                    size    4100697
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Customise 4.5.6.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?