### PR TITLE
py-pyqt5: `use_xcode yes`, `qt5.min_version 5.6`

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -26,6 +26,11 @@ python.versions     35 36 37 38 39 310
 if {${name} ne ${subport}} {
     PortGroup       qmake5 1.0
 
+    # https://trac.macports.org/ticket/65410
+    if { ${os.platform} eq "darwin" && (( ${os.major} >= 15 && ${os.major} <= 16 ) || ${os.major} >= 20 ) } {
+        use_xcode   yes
+    }
+
     patchfiles      patch-project.py.diff
 
     post-patch {
@@ -34,6 +39,7 @@ if {${name} ne ${subport}} {
 
     compiler.cxx_standard 2011
 
+    qt5.min_version 5.6
     qt5.depends_component \
                     qtscript \
                     qt3d \


### PR DESCRIPTION
See: https://trac.macports.org/ticket/65410

[skip ci]

#### Description
`use_xcode yes` only applied for OS versions whose build exhibits the SDK error (with the default Qt version for that OS version): macOS 10.11, 10.12, and 11 and later.

See https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/113721/steps/install-port/logs/stdio for why ≥5.6 is needed:
```
sip-build-3.10: Qt v5.6 or later is required and you seem to be using v5.3.2
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5
Xcode 14 beta 3
Python 3.10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
Build is at least progressing past SDK error…
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
