### PR TITLE
gobject-introspection: fix build on Rosetta

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -77,7 +77,16 @@ configure.args      -Ddoctool=enabled \
 # when building this project. Identical logic already exists
 # in the gobject_introspection PortGroup, so dependent projects
 # should not require modification.
-build.env-append    CC=${configure.cc}
+#
+# 10.6.8 Rosetta requires a specific solution: https://github.com/mesonbuild/meson/issues/10351
+
+platform darwin {
+    if {${os.major} == 10 && ${build_arch} eq "ppc"} {
+        build.env-append    CC=${developer_dir}/usr/bin/powerpc-apple-darwin10-gcc-4.2.1
+    } else {
+        build.env-append    CC=${configure.cc}
+    }
+}
 
 platform darwin 8 {
     # Tiger does not support RPATHs at this time


### PR DESCRIPTION
#### Description

This PR only affects builds for `ppc` on 10.6.x. It fixes a failure on Rosetta: https://github.com/mesonbuild/meson/issues/10351

(In fact, _only_ Rosetta needs this change, while 10.6 PPC (10A190) does not.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
