### PR TITLE
py-lxml: fix build for PPC

### DIFF
--- a/python/py-lxml/Portfile
+++ b/python/py-lxml/Portfile
@@ -30,6 +30,13 @@ python.versions     27 35 36 37 38 39 310
 # https://trac.macports.org/ticket/56666
 patchfiles-append   patch-setupinfo-remove-xcrun-call.diff
 
+platform darwin powerpc {
+    # gcc-4.x do not support "-Wno-unused-result": https://trac.macports.org/ticket/65179
+    # On 10.6.8 Rosetta clang is used when *gcc-4* is blacklisted, which also fails for ppc.
+    # Therefore both are to be blacklisted: https://trac.macports.org/ticket/65043#comment:1
+    compiler.blacklist-append *clang* *gcc-4*
+}
+
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

`py-lxml` fails to build for PPC due to this: https://trac.macports.org/ticket/65179
On Rosetta also a linking error happens: https://trac.macports.org/ticket/65043#comment:1
This PR addresses both issues. Only `darwin powerpc` is affected, therefore no change to revision.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
