### PR TITLE
libgit2-glib: Update to 1.0.0

### DIFF
--- a/gnome/libgit2-glib/Portfile
+++ b/gnome/libgit2-glib/Portfile
@@ -1,15 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           meson 1.0
+PortGroup           gitlab 1.0
+PortGroup           meson  1.0
 
-# upgrade to version 1.0.0+ requires glib2 >= 2.68
+# Upgrade to version 1.0.0.1+ requires glib2 >= 2.68. Currently MacPorts using
+# glib 2.66.8, which is missing g_time_zone_new_identifier() and
+# g_string_replace().
+# See https://gitlab.gnome.org/GNOME/libgit2-glib/-/issues/76
 
-name                libgit2-glib
-version             0.99.0.1
-revision            5
+gitlab.instance     https://gitlab.gnome.org
+gitlab.setup        GNOME libgit2-glib 1.0.0 v
+revision            0
 license             LGPL-2+
-set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Glib wrapper library around the libgit2 git access library.
 long_description    ${description}
 
@@ -17,13 +20,10 @@ maintainers         {devans @dbevans} openmaintainer
 categories          gnome devel
 platforms           darwin
 homepage            https://gitlab.gnome.org/GNOME/libgit2-glib
-master_sites        gnome:sources/${name}/${branch}/
 
-use_xz              yes
-
-checksums           rmd160  5bff8601649b3e53e2305b9f4125cf185196920f \
-                    sha256  e05a75c444d9c8d5991afc4a5a64cd97d731ce21aeb7c1c651ade1a3b465b9de \
-                    size    140996
+checksums           rmd160  b9e53704b305f3af97d08196da3bdcae037ea9b1 \
+                    sha256  c4a60dcbb43362c2dffb6ee1b02f9c9d8b2aae57ba350fdda1baf8cf0bd49479 \
+                    size    135378
 
 depends_build       port:pkgconfig \
                     port:gtk-doc
@@ -35,6 +35,13 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:bin/vala:vala
 
 compiler.c_standard 2011
+
+# error: implicit declaration of function "'g_string_replace'" is invalid in C99.
+# g_string_replace() is available since glib 2.68
+#
+# 'translate_windows_paths' it's fix for Windows.
+configure.post_args-append \
+                    -Dtranslate_windows_paths=false
 
 # patch meson.build to correctly find our configured python and its installation path
 # minor rework to use meson python() module rather than deprecated python3().

--- a/gnome/libgit2-glib/files/patch-meson-find-mp-python3.diff
+++ b/gnome/libgit2-glib/files/patch-meson-find-mp-python3.diff
@@ -1,6 +1,6 @@
---- meson.build.orig	2020-02-26 02:23:03.000000000 -0800
-+++ meson.build	2020-08-21 19:48:51.000000000 -0700
-@@ -157,7 +157,7 @@
+--- meson.build.Orig	2022-07-31 21:41:49.000000000 +0300
++++ meson.build	2022-07-31 21:42:00.887088726 +0300
+@@ -159,7 +159,7 @@
  # Check for python
  enable_python = get_option('python')
  if enable_python


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/libgit2-glib/-/issues/76

Use GitLab PG because in Gnome mirrors, version 1.0.0 is missing,
only 1.0.0.1.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
