### PR TITLE
llvm/clang/flang/mlir/lldb-devel: update and repair broken build

### DIFF
--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -24,17 +24,17 @@ maintainers             {jeremyhu @jeremyhu} {jonesc @cjones051073} openmaintain
 # for devel
 PortGroup github        1.0
 
-set llvm-commit         4334cbd49b69ea036e7c9551c6177cd29b02c312
-set date                20220708
+set llvm-commit         02b3a358926e7bbcac9226cbecbfc3067c2ad61b
+set date                20220731
 set llvm_version        devel
-set clang_exe_version   15
+set clang_exe_version   16
 github.setup            llvm llvm-project ${llvm-commit}
 version                 ${date}-[string range ${llvm-commit} 0 7]
 default_variants-append +assertions
 
-checksums               rmd160  2218a34325d070d8400f219cb5ac6f818c4b3b69 \
-                        sha256  c5c5fb436bb2b917b2f815b7dd6e0d225383a655a9964374bbc3871bf68802bc \
-                        size    165259661
+checksums               rmd160  b50e946f229079aae0e3e3fe59f6bbaf51ff5daa \
+                        sha256  3b352c23468299e671e3223bd219af8a800f529394ed7fd8767c524223e48a8b \
+                        size    166265364
 
 # For release
 #set llvm_version        14

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -337,6 +337,10 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         -DDARWIN_PREFER_PUBLIC_SDK=ON      \
         -DLLVM_BUILD_RUNTIME=ON
 
+    # the orc submodule is not building at present - can't find c_api.h
+    # https://trac.macports.org/ticket/65578
+    configure.args-append -DCOMPILER_RT_BUILD_ORC=OFF
+
     if {${os.platform} eq "darwin" && ${os.major} <= 18} {
         # on systems that might build i386, we need atomic builtins
         # https://trac.macports.org/ticket/58712

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -460,11 +460,6 @@ post-destroot {
         ln -s LLVMPolly.so ${destroot}${sub_prefix}/lib/LLVMPolly.dylib
     }
 
-    if {${subport} eq "flang-${llvm_version}"} {
-        # fix errant permissions on the flang binary
-        system "chmod 755 ${destroot}${sub_prefix}/bin/flang"
-    }
-
     if {${subport} eq "clang-${llvm_version}"} {
         # fix the cmake scripts to point to the versioned files
         reinplace "s|/bin/clang-${clang_exe_version}|/bin/clang|g" \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.4 21F79 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

```% port -v installed | grep devel
  clang-devel @20220731-02b3a358_0+analyzer+libstdcxx (active) requested_variants='' platform='darwin 21' archs='x86_64' date='2022-07-31T15:29:01-0700'
  flang-devel @20220731-02b3a358_0 (active) requested_variants='' platform='darwin 21' archs='x86_64' date='2022-07-31T22:42:13-0700'
  lldb-devel @20220731-02b3a358_0 (active) requested_variants='' platform='darwin 21' archs='x86_64' date='2022-07-31T23:25:17-0700'
  llvm-devel @20220731-02b3a358_0 (active) requested_variants='' platform='darwin 21' archs='x86_64' date='2022-07-31T12:42:28-0700'
  mlir-devel @20220731-02b3a358_0 (active) requested_variants='' platform='darwin 21' archs='x86_64' date='2022-07-31T17:11:45-0700'
```

[ci skip]