### PR TITLE
isl: bump to 0.25

### DIFF
--- a/devel/isl/Portfile
+++ b/devel/isl/Portfile
@@ -10,8 +10,8 @@ name                isl
 # (e.g. port file all | sort -u | xargs grep -E ':isl( |$)' | cut -d / -f 13 | sort -u)
 # see https://lists.macports.org/pipermail/macports-dev/2019-May/040678.html
 epoch               4
-version             0.24
-revision            1
+version             0.25
+revision            0
 
 categories          devel math
 platforms           darwin
@@ -38,9 +38,9 @@ depends_lib         port:gmp
 master_sites        sourceforge:libisl
 use_bzip2           yes
 
-checksums           rmd160  b3bf8e1ad50207d4eebecc47cb4cffdac6581a57 \
-                    sha256  fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0 \
-                    size    2261594
+checksums           rmd160  73b9005b8e7fe52eb9500b98ba65450bdfb9f7fb \
+                    sha256  4305c54d4eebc4bf3ce365af85f04984ef5aa97a52e01128445e26da5b1f467a \
+                    size    2304378
 
 configure.args      --disable-silent-rules
 
@@ -58,6 +58,12 @@ if {${subport} eq ${name}} {
 
     # ./include/isl/typed_cpp.h:2132:12: error: no matching conversion for functional-style cast from 'const isl::basic_set' to 'isl::typed::basic_set<>'
     compiler.blacklist {clang < 500}
+
+    if { ${os.platform} eq "darwin" && ${os.version} < 18 } {
+        # cxx17 support on these systems is incomplete when building against libc++
+        patchfiles-append   patch-configure-force-cxx17-to-fail.diff
+    }
+
 }
 
 subport isl14 {

--- a/devel/isl/files/patch-configure-force-cxx17-to-fail.diff
+++ b/devel/isl/files/patch-configure-force-cxx17-to-fail.diff
@@ -1,0 +1,22 @@
+--- configure.orig	2022-07-29 10:01:55.000000000 -0700
++++ configure	2022-07-29 10:02:40.000000000 -0700
+@@ -9283,6 +9285,9 @@
+ 
+ #else
+ 
++// MacPorts
++#error "C++17 support forced off"
++
+ #include <initializer_list>
+ #include <utility>
+ #include <type_traits>
+@@ -10105,6 +10110,9 @@
+ 
+ #else
+ 
++// MacPorts
++#error "C++17 support forced off"
++
+ #include <initializer_list>
+ #include <utility>
+ #include <type_traits>


### PR DESCRIPTION
and disable cxx17 on older darwin systems
the libc++ in these older systems does not
support sufficient c++17 for isl, but the
isl c++17 tests don't dig deeply enough
to find these failures

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

This PR uses a rather blunt method to force the c++17 tests to fail, thereby disabling c++17 on systems where it is not fully supported. Proper tests that fail on macOS systems without full c++17 support would be better than this, but I leave this here as a concept of what might be done in the meantime perhaps.

[isl-0.25-tests-Lion.txt](https://github.com/macports/macports-ports/files/9235674/isl-0.25-tests-Lion.txt)

