### PR TITLE
boost: fix build on Rosetta

### DIFF
--- a/devel/boost169/Portfile
+++ b/devel/boost169/Portfile
@@ -132,9 +132,12 @@ if {[string match *gcc* ${configure.compiler}]} {
 }
 
 # makecontext/swapcontext introduced in 10.6
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    configure.args-append   --without-libraries=context \
-                            --without-libraries=coroutine
+# In 10.6.x Rosetta they do not work: https://trac.macports.org/ticket/64978
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        configure.args-append   --without-libraries=context \
+                                --without-libraries=coroutine
+    }
 }
 
 configure.universal_args

--- a/devel/boost171/Portfile
+++ b/devel/boost171/Portfile
@@ -138,9 +138,12 @@ if {[string match *gcc* ${configure.compiler}]} {
 }
 
 # makecontext/swapcontext introduced in 10.6
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    configure.args-append   --without-libraries=context \
-                            --without-libraries=coroutine
+# In 10.6.x Rosetta they do not work: https://trac.macports.org/ticket/64978
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        configure.args-append   --without-libraries=context \
+                                --without-libraries=coroutine
+    }
 }
 
 configure.universal_args

--- a/devel/boost173/Portfile
+++ b/devel/boost173/Portfile
@@ -131,9 +131,12 @@ if {[string match *gcc* ${configure.compiler}]} {
 }
 
 # makecontext/swapcontext introduced in 10.6
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    configure.args-append   --without-libraries=context \
-                            --without-libraries=coroutine
+# In 10.6.x Rosetta they do not work: https://trac.macports.org/ticket/64978
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        configure.args-append   --without-libraries=context \
+                                --without-libraries=coroutine
+    }
 }
 
 configure.universal_args

--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -166,9 +166,12 @@ if {[string match *gcc* ${configure.compiler}]} {
 }
 
 # makecontext/swapcontext introduced in 10.6
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    configure.args-append   --without-libraries=context \
-                            --without-libraries=coroutine
+# In 10.6.x Rosetta they do not work: https://trac.macports.org/ticket/64978
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        configure.args-append   --without-libraries=context \
+                                --without-libraries=coroutine
+    }
 }
 
 configure.universal_args

--- a/devel/boost177/Portfile
+++ b/devel/boost177/Portfile
@@ -167,9 +167,12 @@ if {[string match *gcc* ${configure.compiler}]} {
 }
 
 # makecontext/swapcontext introduced in 10.6
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    configure.args-append   --without-libraries=context \
-                            --without-libraries=coroutine
+# In 10.6.x Rosetta they do not work: https://trac.macports.org/ticket/64978
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        configure.args-append   --without-libraries=context \
+                                --without-libraries=coroutine
+    }
 }
 
 configure.universal_args

--- a/devel/boost178/Portfile
+++ b/devel/boost178/Portfile
@@ -167,9 +167,12 @@ if {[string match *gcc* ${configure.compiler}]} {
 }
 
 # makecontext/swapcontext introduced in 10.6
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    configure.args-append   --without-libraries=context \
-                            --without-libraries=coroutine
+# In 10.6.x Rosetta they do not work: https://trac.macports.org/ticket/64978
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        configure.args-append   --without-libraries=context \
+                                --without-libraries=coroutine
+    }
 }
 
 configure.universal_args

--- a/devel/boost179/Portfile
+++ b/devel/boost179/Portfile
@@ -167,9 +167,12 @@ if {[string match *gcc* ${configure.compiler}]} {
 }
 
 # makecontext/swapcontext introduced in 10.6
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    configure.args-append   --without-libraries=context \
-                            --without-libraries=coroutine
+# In 10.6.x Rosetta they do not work: https://trac.macports.org/ticket/64978
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        configure.args-append   --without-libraries=context \
+                                --without-libraries=coroutine
+    }
 }
 
 configure.universal_args


### PR DESCRIPTION
#### Description

A fix for the build on 10.6.x Rosetta. Addresses my own ticket: https://trac.macports.org/ticket/64978

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
