### PR TITLE
GPXSee: update to 11.2

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,15 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 11.1
+github.setup        tumic0 GPXSee 11.2
 revision            0
 
-checksums           rmd160  725d290c1629cd2c782ba7a3f5063944f0189c5a \
-                    sha256  dce4c55c6ed9ee555c3ed5d32fb29ccd6f8163887d33f9740cf9a9d6846d4ecb \
-                    size    5168543
+checksums           rmd160  677007617679c5d5e4821b9daf81f7fd1f62273d \
+                    sha256  721d4d6c41b93c8e25a2cebb089272733cd2d359b7da16bfcd17b928485c8b7b \
+                    size    5319350
 
 categories          gis graphics
-platforms           darwin
 license             GPL-3
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

