### PR TITLE
kustomize: update to 4.5.7

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 4.5.6 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 4.5.7 kustomize/v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  cbe2b9a126db213a1de94fbd29a2da4e7c6f2996 \
-                    sha256  bcc380524bfc3abf2f29d3d723d18f662893a988496eba4a0aabac492347401b \
-                    size    4100697
+checksums           rmd160  b07ec139afd558c2f0073175b1c5eee6f64a39a6 \
+                    sha256  4ca0a8204dc1976af78dfabe3caec1a111ddd4894467ca8b048593d3d52f13d2 \
+                    size    4100566
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 4.5.7.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?