### PR TITLE
google-cloud-sdk: update to 396.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             395.0.0
+version             396.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1154f5676487c1345048f12ca1dc9ee086d46f37 \
-                    sha256  a2567c4af442662baafa007c03a17f060e6fd1071983d91170c0753c6b82c02a \
-                    size    108263395
+    checksums       rmd160  da2dad98aacb879f8ab40d72f7e13c1e87bc6120 \
+                    sha256  7a282fec457570e8af5291f1398908b792f3ec97156f880d4cc68f4774d335a7 \
+                    size    108562096
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  241a6208655261275a735a150155770032381c8c \
-                    sha256  6ed8434db8f492c188d02d1ebb3eb378d92ce23e0f571853a1954d8d3c0a2ef0 \
-                    size    105022050
+    checksums       rmd160  2dc0960d24a8c8baffc2375ae7441d95796eea6e \
+                    sha256  e9962039a34f9436e42d516f68b778b271f02aea68514dcaef7d595679aa91a6 \
+                    size    106569346
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  6ff92f8f4c74c3111357018583517be141a8cba0 \
-                    sha256  ee62501adcbda9f5d159f032272df5399ba6d6b8f7c9f8a9e21fe18ecbfff195 \
-                    size    103622836
+    checksums       rmd160  e0fcf09a2ce970cf8c6fb6226e73789323d38059 \
+                    sha256  5f3a0c6aab30901d9ec407332c3012c8076321e495efa6d37808942f40986e7f \
+                    size    105131133
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 396.0.0.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?