### PR TITLE
graphene: use Leopard patch for Rosetta case too

### DIFF
--- a/graphics/graphene/Portfile
+++ b/graphics/graphene/Portfile
@@ -36,8 +36,11 @@ post-patch {
 
 # 10.5 or less has no special memalign but doesn't absolutely need it
 # as the fallthrough to malloc returns aligned memory. Passes all tests.
-if {${os.platform} eq "darwin" && ${os.major} < 10 } {
-    patchfiles-append patch-graphene-leopard.diff
+# Patch is needed for Rosetta as well.
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        patchfiles-append patch-graphene-leopard.diff
+    }
 }
 
 compiler.c_standard 1999


### PR DESCRIPTION
#### Description

Update to 1.10.8. Fix the build on Rosetta.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. Leopard patch must be applied for 10.6.x Rosetta too, otherwise build fails:
```
[15/22] /usr/bin/gcc-4.2 -Isrc/libgraphene-1.0.0.dylib.p -Isrc -I../ebassi-graphene-9fd2bef/src -Iinclude -I../ebassi-graphene-9fd2bef/include -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include -Wall -Winvalid-pch -std=c99 -O2 -g -D_GNU_SOURCE -pipe -Os -arch ppc -fvisibility=hidden -ffast-math -fstrict-aliasing -Wpointer-arith -Wstrict-prototypes -Wnested-externs -Wold-style-definition -Wunused -Wmissing-noreturn -Wmissing-format-attribute -Wcast-align -Werror=float-equal -Werror=redundant-decls -Werror=missing-prototypes -Werror=missing-declarations -Werror=format=2 -Werror=shadow -Werror=implicit -Werror=init-self -Werror=main -Werror=missing-braces -Werror=return-type -Werror=write-strings -Werror=undef -DGRAPHENE_ENABLE_DEBUG -DGRAPHENE_COMPILATION -MD -MQ src/libgraphene-1.0.0.dylib.p/graphene-gobject.c.o -MF src/libgraphene-1.0.0.dylib.p/graphene-gobject.c.o.d -o src/libgraphene-1.0.0.dylib.p/graphene-gobject.c.o -c ../ebassi-graphene-9fd2bef/src/graphene-gobject.c
FAILED: src/libgraphene-1.0.0.dylib.p/graphene-gobject.c.o
```
