### PR TITLE
libopus: fix build on Rosetta

### DIFF
--- a/audio/libopus/Portfile
+++ b/audio/libopus/Portfile
@@ -36,6 +36,15 @@ depends_build   port:pkgconfig
 
 configure.args  --disable-silent-rules
 
+platform darwin 10 {
+    # See: https://trac.macports.org/ticket/64611
+    if {${build_arch} eq "ppc"} {
+        compiler.blacklist-append *gcc-4.* *clang*
+        configure.args-append   --build=powerpc-apple-darwin${os.major} \
+                                --disable-doc
+    }
+}
+
 livecheck.type  regex
 livecheck.url   ${master_sites}
 livecheck.regex opus-(\[\\d.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

The PR fixes build on 10.6.x Rosetta and closes my own ticket: https://trac.macports.org/ticket/64611
Only 10.6 when `${build_arch} eq "ppc"` is affected.

(P. S. Only Rosetta requires this fix. 10.6 PPC (10A190) does not need it, but it won’t break anything either.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
