### PR TITLE
libheif: disable aom for Rosetta case

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -15,7 +15,6 @@ license                     LGPL-3+
 maintainers                 {mcalhoun @MarcusCalhoun-Lopez} {mascguy @mascguy} openmaintainer
 description                 a ISO/IEC 23008-12:2017 HEIF file format decoder and encoder
 long_description            ${name} is {*}${description}.
-platforms                   darwin
 
 github.tarball_from         releases
 
@@ -39,15 +38,17 @@ variant tests description {Enable tests} {
     test.run                yes
 }
 
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
-    # TODO: Disable rav1e on 10.6, due to issues with cargo-c; re-enable once fixed
-    # See: https://trac.macports.org/ticket/65434
-    depends_lib-delete      port:rav1e
-    configure.args-append   --disable-rav1e
-}
-
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    # https://trac.macports.org/ticket/62619
-    depends_lib-delete      port:aom
-    configure.args-append   --disable-aom
+platform darwin {
+    if {${os.major} < 11} {
+        # TODO: Disable rav1e on 10.6, due to issues with cargo-c; re-enable once fixed
+        # See: https://trac.macports.org/ticket/65434
+        depends_lib-delete      port:rav1e
+        configure.args-append   --disable-rav1e
+    }
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        # https://trac.macports.org/ticket/62619
+        # aom does not build on 10.6 Rosetta too
+        depends_lib-delete      port:aom
+        configure.args-append   --disable-aom
+    }
 }


### PR DESCRIPTION
#### Description

`aom` does not build for PPC, so it should be disabled for 10.6.x Rosetta too.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
