### PR TITLE
py-clang/ctypeslib2: 310 versions & fixes

### DIFF
--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -5,11 +5,11 @@ PortGroup               python 1.0
 
 # meta-version; bump whenever underlying variants are updated. Needed to
 # support portindex (variants can't have different versions.)
-version                 7
+version                 8
 # Needed for change to meta-versioning
 epoch                   1
 name                    py-clang
-python.versions         37 38 39
+python.versions         37 38 39 310
 license                 NCSA
 maintainers             {eborisch @eborisch} \
                         openmaintainer
@@ -22,7 +22,7 @@ supported_archs         noarch
 
 livecheck.url           https://api.github.com/repos/llvm/llvm-project/git/refs/tags
 # Update this to the most recent clang supported
-livecheck.version       13.0.0
+livecheck.version       14.0.6
 livecheck.regex         {llvmorg-([\d.]+)\"}
 
 if {${name} ne ${subport}} {
@@ -34,9 +34,9 @@ if {${name} ne ${subport}} {
      cfe-3.7.1.src.tar.xz \
       rmd160  185b0f75970bc50682766a21794440578db87b5d \
       sha256  56e2164c7c2a1772d5ed2a3e57485ff73ff06c97dff12edbeea1acc4412b0674 \
-     clang-12.0.1.src.tar.xz \
-      rmd160  662d890fe81218fbf79c25540eb09c7664bc5b8a \
-      sha256  6e912133bcf56e9cfe6a346fa7e5c52c2cde3e4e48b7a6cc6fcc7c75047da45f \
+     clang-14.0.6.src.tar.xz \
+      rmd160  0e08ef630f183fd654247aeeb10d8fafee5e0814 \
+      sha256  2b5847b6a63118b9efe5c85548363c81ffe096b66c3b3675e953e26342ae4031 \
      clang-13.0.0.src.tar.xz \
       rmd160  41d60ff0bfa3dbd9e4f04461db1750c2d9f50ac2 \
       sha256  5d611cbb06cfb6626be46eb2f23d003b2b80f40182898daa54b1c4e8b5b9e17e
@@ -44,8 +44,8 @@ if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
 
     # Keeping 37 around for old systems; otherwise two latest releases.
-    set clanglist       {37    12     13}
-    set clangvlist      {3.7.1 12.0.1 13.0.0}
+    set clanglist       {37    14     13}
+    set clangvlist      {3.7.1 14.0.6 13.0.0}
 
     foreach cvnum $clanglist {
         # Explictly use (and depend on) the libclang we select during install
@@ -89,17 +89,17 @@ if {${name} ne ${subport}} {
     test.target         -m unittest discover -v
 
     if {![variant_isset clang37] &&
-        ![variant_isset clang12] &&
-        ![variant_isset clang13]} {
-        default_variants +clang13
+        ![variant_isset clang13] &&
+        ![variant_isset clang14]} {
+        default_variants +clang14
     }
 
     pre-extract {
         # Will never hit this when installing from packages, which is OK, as
         # they will have the default variant set above.
         if {![variant_isset clang37] &&
-            ![variant_isset clang12] &&
-            ![variant_isset clang13]} {
+            ![variant_isset clang13] &&
+            ![variant_isset clang14]} {
             ui_error "At least one of the clangNN variants must be active."
             return -code error "Unsupported (no) variants selected."
         }

--- a/python/py-ctypeslib2/Portfile
+++ b/python/py-ctypeslib2/Portfile
@@ -7,8 +7,8 @@ PortGroup               github 1.0
 github.setup            trolldbois ctypeslib 2.3.2
 name                    py-ctypeslib2
 revision                1
-python.versions         37 38 39
-python.default_version  39
+python.versions         37 38 39 310
+python.default_version  310
 platforms               darwin
 license                 MIT
 maintainers             {eborisch @eborisch} \
@@ -32,6 +32,11 @@ if {${name} ne ${subport}} {
 
     # Use the libclang that is provided by pyXX-clang (via its +clangY variant)
     patchfiles              init_py.patch
+
+    post-extract {
+        # Latest tomli rejects "True"
+        reinplace s/True/true/g pyproject.toml
+    }
 
     post-destroot {
         set DOCDIR ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
Maintainer update.

Fixes (in py-ctypeslib2) build with latest tomli; don't need to rebuild already installed versions.