### PR TITLE
x265: fix Rosetta and ppc64 builds

### DIFF
--- a/multimedia/x265/Portfile
+++ b/multimedia/x265/Portfile
@@ -20,7 +20,6 @@ checksums           rmd160  e614c4a03134a67e79efe8d3dd64d54c3990b99a \
                     size    1530200
 
 categories          multimedia
-platforms           darwin
 license             GPL-2+
 maintainers         nomaintainer
 
@@ -39,12 +38,22 @@ worksrcdir          ${name}-${version}/source
 # allow overriding system processor detection
 patchfiles          patch-cmakelists-override-processor.diff
 
+# Altivec uses instructions unsupported on Darwin: https://trac.macports.org/ticket/64781
+patchfiles-append   patch-ppc.diff
+
 depends_build-append port:gmake
 
 compiler.blacklist-append *llvm-gcc-4.2
 
 # https://trac.macports.org/ticket/59246
 xcode_workaround.fixed_xcode_version 11.2
+
+platform darwin 10 {
+    # Rosetta build has to override CMAKE_SYSTEM_PROCESSOR: https://trac.macports.org/ticket/64528
+    if {${build_arch} eq "ppc"} {
+        configure.args-append -DOVERRIDE_SYSTEM_PROCESSOR="ppc"
+    }
+}
 
 if {${universal_possible} && [variant_isset universal] && ![variant_isset highdepth]} {
 

--- a/multimedia/x265/files/patch-ppc.diff
+++ b/multimedia/x265/files/patch-ppc.diff
@@ -1,0 +1,20 @@
+--- CMakeLists.txt.orig	2020-05-29 23:24:35.000000000 +0545
++++ CMakeLists.txt	2022-08-04 01:19:02.000000000 +0545
+@@ -43,7 +43,7 @@
+ set(ARM_ALIASES armv6l armv7l aarch64)
+ list(FIND X86_ALIASES "${SYSPROC}" X86MATCH)
+ list(FIND ARM_ALIASES "${SYSPROC}" ARMMATCH)
+-set(POWER_ALIASES ppc64 ppc64le)
++set(POWER_ALIASES ppc ppc64 ppc64le)
+ list(FIND POWER_ALIASES "${SYSPROC}" POWERMATCH)
+ if("${SYSPROC}" STREQUAL "" OR X86MATCH GREATER "-1")
+     set(X86 1)
+@@ -469,7 +469,7 @@
+     endif(WINXP_SUPPORT)
+ endif()
+ 
+-if(POWER)
++if(POWER AND NOT APPLE)
+     # IBM Power8
+     option(ENABLE_ALTIVEC "Enable ALTIVEC profiling instrumentation" ON)
+     if(ENABLE_ALTIVEC)


### PR DESCRIPTION
#### Description

This PR solves two problems:
1. On Rosetta we have to override CMAKE_SYSTEM_PROCESSOR, otherwise x86 flags are used and build fails: https://trac.macports.org/ticket/64528
2. Altivec implementation uses instructions from later ISA than supported on Darwin: https://trac.macports.org/ticket/64781

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. Opened PR with upstream: https://github.com/videolan/x265/pull/11