### PR TITLE
openjdk11-temurin: update to 11.0.16

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.15
-set build    10
+version      11.0.16
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  5d66fe3d953619e7a6ca326110654344f1883773 \
-                 sha256  ebd8b9553a7b4514599bc0566e108915ce7dc95d29d49a9b10b8afe4ab7cc9db \
-                 size    186328533
+    checksums    rmd160  05d08b2b8756f032d44df0d8456301e94edf877d \
+                 sha256  8e9bd7669f5c59c60404cebf25c086e04623677e0f827ce85e3ecdbfb0581c3a \
+                 size    186325803
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  30bef82b1a4c70621f64e42b00824e563b6e7f30 \
-                 sha256  e84143a6c633a26aeefcb1fd5ad8dfb9e952cfec2a1af5c9d9b69f2390990dac \
-                 size    184840725
+    checksums    rmd160  24a0a9df20c14e24edc8d661b5b21b21585cba37 \
+                 sha256  abf9365c07797133874e18bc5da86a42833ceee71986addb59877f5efd23739c \
+                 size    185078783
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.16.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?