### PR TITLE
openjdk11-microsoft: update to 11.0.16

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.15
-set build    10
+version      11.0.16
+set build    8
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  b8daf288010149295baa021f1bb177904e0f5952 \
-                 sha256  787b68e250d6aece2c765c49fb00c184ff3e3b87e2bf8320a6b017eece040d78 \
-                 size    186851366
+    checksums    rmd160  7ee6562dcbecc078bde1f0bb075b1eb2792550f0 \
+                 sha256  12579c27312e083003dc3595ca477b8e4878c2068c1a173fc3497bc8241730a0 \
+                 size    187093103
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  3fda055c54284df3d8ae79b2e69636f89eb08112 \
-                 sha256  083c74fa731e0c514b840479c4c5ba52b69b7a0a17fab1b2a9b09b052bb378ac \
-                 size    184482606
+    checksums    rmd160  7c7964bf559413ee6464b6009171c2d900565d42 \
+                 sha256  bb44d21ecd07cd7ebd8affe0267389e746101887290b44bf70ea26c393f2b294 \
+                 size    184704311
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.16.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?