### PR TITLE
openjdk17-microsoft: update to 17.0.4

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -16,7 +16,7 @@ supported_archs  x86_64 arm64
 
 set build 7
 
-version      17.0.3
+version      17.0.4
 revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
@@ -27,14 +27,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  7d8b26bbd28d14f0ff65c8178b0246a679380858 \
-                 sha256  17e2e0fe8ac0745850a1537b7c111178ad57a912bddeafaf6f82548c8c7cc1be \
-                 size    187304425
+    checksums    rmd160  41f63463aa387f265bcd2390f57ba81f3e913bce \
+                 sha256  7ecf431271eebeb76d64855ccced20645c86a5e4ec6c0642d895f22f6f11a0ea \
+                 size    187265182
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  c88e507c3b79167fe30639ae51fc87edf6f61888 \
-                 sha256  3695ee9c60925fc370b34e5f9954bc1834ad55e321e8b0b622ac51c12f8fdb38 \
-                 size    177743370
+    checksums    rmd160  64a07133909e7a7edb691918974cb95f0cecfa7f \
+                 sha256  fc74037baacb3e628a090cb2ec45c756f461e6cf6f716c78f7104644f0e75436 \
+                 size    177478330
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.4.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?