### PR TITLE
openjdk17-temurin: update to 17.0.4

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.3
-set build    7
+version      17.0.4
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  2ab1be7abe66d2f1fcdc75853098981bf2debb50 \
-                 sha256  a5db5927760d2864316354d98ff18d18bec2e72bfac59cd25a416ed67fa84594 \
-                 size    187277835
+    checksums    rmd160  a2ec77af68f96f0b75abdb16c86607a9cf4e68aa \
+                 sha256  2a04025a8b974ba69025a498f3327270bdbee4d6c24cf69f603091f6ad60694b \
+                 size    186916566
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  cbd5b0f0707f7a3e8f037525c9c767c2f927f3a2 \
-                 sha256  ff42be4d7a348d0d7aee07749e4daec9f427dcc7eb46b343f8131e8f3906c05b \
-                 size    177467402
+    checksums    rmd160  806ce0917e1bb4b3407eedf82b701d9099ef9a06 \
+                 sha256  19fffac89c4b8c0b4da32cae2cbd864ad9e71875aa3ab69f3a5900b6b2e16e7b \
+                 size    177119187
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.4.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?