### PR TITLE
nss: PPC fixes

### DIFF
--- a/net/nss/Portfile
+++ b/net/nss/Portfile
@@ -39,6 +39,17 @@ if {${configure.build_arch} in [list i386 x86_64]} {
     compiler.blacklist-append *gcc-4.* *gcc-3.*
 }
 
+# VSX and Crypto have to be disabled, since they belong to post-G5 ISA.
+# See: https://bugzilla.mozilla.org/show_bug.cgi?id=1687164
+# gcc-4.2 does not recognize these flags:
+# cc1: error: unrecognized command line option "-mcrypto"
+# cc1: error: unrecognized command line option "-mvsx"
+# Recent gcc does, however build still fails: https://trac.macports.org/ticket/64900
+# Therefore approach is different from Intel case.
+if {${configure.build_arch} in [list ppc ppc64]} {
+    patchfiles-append patch-ppc.diff
+}
+
 # fails with clang-425 https://trac.macports.org/ticket/63245
 compiler.blacklist-append {clang < 426}
 
@@ -113,6 +124,8 @@ configure.cflags-append -std=c99
 
 array set cpu_arch_map [list \
     arm64   aarch64 \
+    ppc     ppc \
+    ppc64   ppc64 \
     i386    x86 \
     x86_64  x86_64]
 

--- a/net/nss/files/patch-ppc.diff
+++ b/net/nss/files/patch-ppc.diff
@@ -1,0 +1,34 @@
+--- nss/coreconf/Darwin.mk.orig	2022-07-21 19:11:57.000000000 +0545
++++ nss/coreconf/Darwin.mk	2022-08-04 15:40:28.000000000 +0545
+@@ -29,16 +29,29 @@
+ CCC             += -arch i386
+ override CPU_ARCH	= x86
+ endif
+-else
++endif
++
+ ifeq (arm,$(CPU_ARCH))
+ # Nothing set for arm currently.
+-else
++endif
++
++ifeq (,$(filter-out ppc ppc64,$(CPU_ARCH)))
+ OS_REL_CFLAGS	= -Dppc
++ifdef USE_64
++CC              += -arch ppc64
++CCC             += -arch ppc64
++else
+ CC              += -arch ppc
+ CCC             += -arch ppc
+ endif
+ endif
+ 
++ifeq (,$(filter-out ppc ppc64,$(CPU_ARCH)))
++ifneq ($(NSS_DISABLE_CRYPTO_VSX),0)
++	NSS_DISABLE_CRYPTO_VSX=1
++endif
++endif
++
+ ifneq (,$(MACOS_SDK_DIR))
+     GCC_VERSION_FULL := $(shell $(CC) -dumpversion)
+     GCC_VERSION_MAJOR := $(shell echo $(GCC_VERSION_FULL) | awk -F. '{ print $$1 }')


### PR DESCRIPTION
#### Description

PPC fixes, which finally resolve a failing build on Rosetta: https://trac.macports.org/ticket/64900

I cannot test `ppc64` now, but from what I understand VSX and Crypto are not supported on G5, since they were introduced in ISA 2.06 and later. See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1687164

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. Initially I wrote a separate condition for Rosetta:
```
platform darwin 10 {
    if {${build_arch} eq "ppc"} {
    # Otherwise -Di386 flag is added and build fails. See nss/coreconf/Darwin.mk
        build.env-append CPU_ARCH=ppc
    }
}
```
But it seems that the code in Portfile was faulty (with missing definitions for `ppc` and `ppc64`), which led to confusion with archs in build system. Once definitions are added, they are used correctly, and Rosetta-specific code becomes redundant. I have verified the build without it, so removed it.
