### PR TITLE
bison: fix build on Rosetta

### DIFF
--- a/devel/bison/Portfile
+++ b/devel/bison/Portfile
@@ -13,7 +13,6 @@ if {${subport} eq "bison"} {
     revision        0
 }
 categories          devel
-platforms           darwin
 if {${subport} eq "bison-runtime"} {
     supported_archs noarch
 }
@@ -71,6 +70,15 @@ configure.args      --disable-silent-rules \
                     ac_cv_prog_HAVE_JRE_IN_PATH= \
                     ac_cv_prog_HAVE_JVIEW_IN_PATH= \
                     ac_cv_prog_VALGRIND=
+
+# Fix for Rosetta: https://trac.macports.org/ticket/64486
+platform darwin 10 {
+    if {${build_arch} eq "ppc"} {
+        configure.args-append \
+            --build=powerpc-apple-darwin${os.major} \
+            CC="${configure.cc} -arch ppc"
+    }
+}
 
 if {${subport} eq "bison-runtime"} {
     build.dir       ${worksrcpath}/runtime-po


### PR DESCRIPTION
#### Description

Fixes build on Rosetta, no other systems affected. Closes my own ticket: https://trac.macports.org/ticket/64486
@mascguy Unlike other cases, just specifying `--build=` is insufficient, since for w/e reason Intel version of compiler is pulled and destroot fails, but at least we got rid of unnecessary manual settings.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
