### PR TITLE
libffi: fix build on Rosetta

### DIFF
--- a/devel/libffi/Portfile
+++ b/devel/libffi/Portfile
@@ -8,7 +8,6 @@ github.setup        libffi libffi 3.4.2 v
 revision            2
 github.tarball_from releases
 categories          devel
-platforms           darwin
 license             MIT
 maintainers         nomaintainer
 
@@ -40,6 +39,13 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Doesn't actually use C++, and having the stdlib set to libc++
     # on 10.6 causes a macports-clang compiler to be chosen.
     configure.cxx_stdlib
+}
+
+# Fix for Rosetta: https://trac.macports.org/ticket/64485
+platform darwin {
+    if {${os.major} == 10 && ${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
 }
 
 # Older versions of cctools have a history of being problematic with complex


### PR DESCRIPTION
#### Description

Fix for Rosetta, closes my own ticket: https://trac.macports.org/ticket/64485
No other systems affected.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
