### PR TITLE
MoarVM, nqp, rakudo: update to 2022.07

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -9,10 +9,9 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                MoarVM
-version             2022.04
+version             2022.07
 revision            0
 categories          lang devel
-platforms           darwin
 license             Artistic-2 MIT BSD ISC public-domain
 maintainers         {mojca @mojca} openmaintainer
 description         A virtual machine for NQP And Rakudo
@@ -23,9 +22,9 @@ long_description    MoarVM is a modern virtual machine built for the Rakudo \
 homepage            https://moarvm.org/
 master_sites        https://moarvm.org/releases/
 
-checksums           rmd160  542658d58bcb490f20b0a15d68ce9c89d3fd2a53 \
-                    sha256  ae06f50ba5562721a4e5eb6457e2fea2d07eda63e2abaa8c939c9daf70774804 \
-                    size    14867431
+checksums           rmd160  cc576d02ba8b3eea4a7e8af79758b93de153b76d \
+                    sha256  337ef04d16f826f99465c653b92006028fe220be68d3dcfd0729612f4f6b5b46 \
+                    size    14867536
 
 depends_build       port:perl5 \
                     port:pkgconfig

--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -42,6 +42,13 @@ patchfiles          patch-Configure.diff \
 # https://trac.macports.org/ticket/53950
 compiler.blacklist  cc gcc-* apple-gcc-* llvm-gcc-*
 
+platform darwin 10 {
+    if {${build_arch} eq "ppc"} {
+        # Clang is broken on PPC, but Rosetta tries using it
+        compiler.blacklist-append *clang*
+    }
+}
+
 configure.cmd       ${prefix}/bin/perl Configure.pl
 configure.args      --cc=${configure.cc} \
                     --has-dyncall \
@@ -59,11 +66,6 @@ platform darwin 8 {
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     configure.args-append \
                     --no-mimalloc
-}
-
-if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
-    # Clang is broken on PPC, but Rosetta tries using it
-    compiler.blacklist-append *clang*
 }
 
 # https://github.com/MoarVM/MoarVM/issues/414

--- a/lang/nqp/Portfile
+++ b/lang/nqp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Raku nqp 2022.04
+github.setup        Raku nqp 2022.07
 revision            0
 description         A lightweight Perl-6 like language for virtual machines
 long_description    This is "Not Quite Perl" -- a lightweight Perl 6-like \
@@ -17,13 +17,12 @@ long_description    This is "Not Quite Perl" -- a lightweight Perl 6-like \
 maintainers         {mojca @mojca} openmaintainer
 categories          lang devel
 license             Artistic-2
-platforms           darwin
 
 github.tarball_from releases
 
-checksums           rmd160  74ff31649a656fcbc7ba55c48a18104627e32a24 \
-                    sha256  556d458e25d3c0464af9f04ea3e92bbde10046066b329188a88663943bd4e79c \
-                    size    5222049
+checksums           rmd160  d674949da07cabd2d4c1eb2e14f8153b54a5b7ab \
+                    sha256  58081c106d672a5406018fd69912c8d485fd12bf225951325c50c929a8232268 \
+                    size    5222066
 
 depends_build       port:perl5
 

--- a/lang/rakudo/Portfile
+++ b/lang/rakudo/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rakudo rakudo 2022.04
+github.setup        rakudo rakudo 2022.07
 revision            0
 description         Raku compiler
 long_description    Rakudo is a compiler for the Raku language \
@@ -13,16 +13,14 @@ long_description    Rakudo is a compiler for the Raku language \
 maintainers         {mojca @mojca} openmaintainer
 categories          lang perl
 license             Artistic-2
-platforms           darwin
 homepage            https://rakudo.org/
 # master_sites      https://rakudo.org/downloads/rakudo/
 
-github.tarball_from \
-                    releases
+github.tarball_from releases
 
-checksums           rmd160  a4598208cc794544a2621898f5752865a65d9f02 \
-                    sha256  7e13a8cc927efbe86b8ff7b19155a60a6f6e2b6e2952bd690dcacef2d02a1c74 \
-                    size    6004940
+checksums           rmd160  446426d206f3dbd636a9ddbc147f0194cb26bd1b \
+                    sha256  7a3bc9d654e1d2792a055b4faf116ef36d141f6b6adde7aa70317705f26090ad \
+                    size    6018342
 
 depends_build       port:perl5
 


### PR DESCRIPTION
#### Description

Updates to `rakudo` and friends.

I changed the fix for Rosetta, it has to be above configure.args, otherwise it is ignored, and Rosetta still tries to use `clang` (for `ppc`), which fails.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
