### PR TITLE
rsync: fix build on Rosetta

### DIFF
--- a/net/rsync/Portfile
+++ b/net/rsync/Portfile
@@ -58,6 +58,16 @@ pre-configure {
     system -W ${worksrcpath} "./prepare-source"
 }
 
+# Temporary fix for build on Rosetta, from upstream.
+# Perhaps can be removed with update to 3.2.5.
+# https://github.com/WayneD/rsync/issues/338
+# Also: https://trac.macports.org/ticket/65034
+platform darwin 10 powerpc {
+    post-configure {
+        reinplace "s|#define GETGROUPS_T int|#define GETGROUPS_T gid_t|" ${worksrcpath}/config.h
+    }
+}
+
 test.run           yes
 test.target        check
 


### PR DESCRIPTION
#### Description

Temporary fix for Rosetta, advised by the upstream: https://github.com/WayneD/rsync/issues/338#issuecomment-1201403133
Perhaps will be redundant with the next update (3.2.5).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
