### PR TITLE
openssh: disable apple keychain on Rosetta

### DIFF
--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -8,7 +8,6 @@ name                openssh
 version             9.0p1
 revision            6
 categories          net
-platforms           darwin
 maintainers         nomaintainer
 license             BSD
 installs_libs       no
@@ -113,8 +112,10 @@ if {${name} eq ${subport}} {
     use_parallel_build  yes
 
     platform macosx {
-        if {${os.major} < 10} {
+        if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
             # See: https://trac.macports.org/ticket/60385
+            # clang does not work for ppc on 10.6.8 Rosetta
+            # See also: https://trac.macports.org/ticket/65613
             configure.args-delete   --with-keychain=apple
         } elseif {${os.major} <= 11} {
             # clang is required to build the new Apple Keychain integration due


### PR DESCRIPTION
#### Description

Portfile says Apple keychain integration requires `clang`, but it is broken for PPC. Therefore disable keychain, like it is already done for Leopard.
This also removes dependency on `clang-11` port (which, again, cannot build for PPC): https://trac.macports.org/ticket/65613

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
