### PR TITLE
micronaut: update to 3.6.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.5.4 v
+github.setup    micronaut-projects micronaut-starter 3.6.0 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  80027c1ad4e774adf45c29c8c5f0c5466578a6b8 \
-                sha256  cd3b2eabdb4ff00a9f903bf9a2bfa86e7f6ec0a93cdec737c4c352a311caca45 \
-                size    21343625
+checksums       rmd160  db1a3bbf2a1266523fafe93bb9ddbd7b267dff1c \
+                sha256  cbb2226375227a6917f46f10ac26b169362c69518221828b7c27fd9b9e579733 \
+                size    19795765
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.6.0.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?