### PR TITLE
fluidsynth: update to 2.2.8, revbump known dependents

### DIFF
--- a/audio/qsynth/Portfile
+++ b/audio/qsynth/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 
 name                qsynth
 version             0.5.7
-revision            1
+revision            2
 maintainers         {gmail.com:rjvbertin @RJVB} {mojca @mojca} openmaintainer
 categories          audio
 platforms           darwin

--- a/emulators/scummvm/Portfile
+++ b/emulators/scummvm/Portfile
@@ -18,7 +18,7 @@ homepage            https://www.scummvm.org
 
 if {${subport} eq ${name}} {
     github.setup        scummvm scummvm 2.5.0 v
-    revision            0
+    revision            1
     checksums           sha256  b47ee4b195828d2c358e38a4088eda49886dc37a04f1cc17b981345a59e0d623 \
                         rmd160  a4fa5b99f483d27e7c132fd5c553aa88030c627e \
                         size    130095472
@@ -43,7 +43,7 @@ if {${subport} eq ${name}} {
 subport ${name}-devel {
     github.setup        scummvm scummvm b8132baa943f3a9c82886ea074a34140aa2557f5
     version             20211011
-    revision            0
+    revision            1
     checksums           rmd160  ff96dad1308e4184a4965eeaec35cd592bc65aa6 \
                         sha256  96cd2135dcdb0ffe4de802181f14faa821f5868ce1c0bff4e869f1488a18e9de \
                         size    151853236

--- a/games/qtads/Portfile
+++ b/games/qtads/Portfile
@@ -8,7 +8,7 @@ PortGroup           qmake5 1.0
 use_xcode           yes
 
 github.setup        realnc qtads 3.3.0 v
-revision            0
+revision            1
 github.tarball_from releases
 
 categories          games

--- a/gnome/gstreamer1-gst-plugins-bad/Portfile
+++ b/gnome/gstreamer1-gst-plugins-bad/Portfile
@@ -11,7 +11,7 @@ name                gstreamer1-gst-plugins-bad
 set my_name         gst-plugins-bad
 # please only commit stable updates (even numbered releases)
 version             1.16.2
-revision            4
+revision            5
 description         A set of plug-ins for GStreamer that need more quality.
 long_description    GStreamer Bad Plug-ins is a set of plug-ins that aren't up to par compared \
                     to the rest. They might be close to being good quality, but they're missing \

--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
@@ -68,7 +68,7 @@ supported_archs         x86_64
 ##
 if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     version             2.2.8
-    revision            12
+    revision            13
     license             GPL-2+
 
     platforms           darwin
@@ -89,7 +89,6 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
                         port:bzip2 \
                         port:faad2 \
                         port:flac \
-                        port:fluidsynth \
                         port:fontconfig \
                         port:freetype \
                         port:fribidi \
@@ -256,7 +255,7 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
                         --enable-dca --enable-png --disable-quicktime --enable-twolame \
                         --enable-speex --enable-theora --enable-x264 --enable-x265 --enable-postproc \
                         --disable-gst-decode --enable-avcodec --enable-avformat --enable-swscale \
-                        --enable-fluidsynth --enable-schroedinger --enable-vpx
+                        --disable-fluidsynth --enable-schroedinger --enable-vpx
 
     # Video Plugins. We do our best to deactivate X11 and disable its auto-detection by
     # claiming the headers and libs are somewhere they're not.

--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -6,7 +6,7 @@ name                audacious-plugins
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
 version             3.10.1
-revision            2
+revision            3
 
 # FIXME: probably more licenses involved here...
 license             BSD GPL-2+

--- a/multimedia/fluidsynth/Portfile
+++ b/multimedia/fluidsynth/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 # Warning: fluidsynth 2.2.0 breaks API (not just ABI as claimed) and causes some dependent ports
 # such as QTads 3.0.0 not to compile. Verify that dependents are updated to work with fluidsynth 2.2+
 # before updating fluidsynth to that version. See https://github.com/FluidSynth/fluidsynth/releases/tag/v2.2.0
-github.setup        FluidSynth fluidsynth 2.1.9 v
+github.setup        FluidSynth fluidsynth 2.2.8 v
 categories          multimedia audio
 maintainers         {gmail.com:rjvbertin @RJVB} {mojca @mojca} openmaintainer
 license             LGPL
@@ -22,9 +22,9 @@ platforms           darwin
 
 homepage            http://www.fluidsynth.org/
 
-checksums           rmd160  c5a51617ce7a82033dbe5908ce7b2fabf3e5d1c3 \
-                    sha256  dca6ce2e1eff22d32f40d55470c079c8fc8999a6e5628bf85f8cb2183f827934 \
-                    size    1369736
+checksums           rmd160  6b58e02c6e36a4ae9fdd81c5f35f3190cb24ae2c \
+                    sha256  a7b012d30f7c3f9272b548dcb5fddacd4fe1f54034d47b574e4b1f6d967d82bc \
+                    size    1751702
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
@@ -41,10 +41,6 @@ depends_lib         port:flac \
                     port:readline
 
 depends_run-append  port:generaluser-soundfont
-
-# Remove with fluidsynth 2.2.3 or later
-# https://trac.macports.org/ticket/63230
-patchfiles-append   patch-pre-snow-leopard.diff
 
 # https://trac.macports.org/ticket/36962
 platform darwin 8 {

--- a/multimedia/lmms/Portfile
+++ b/multimedia/lmms/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           qt4 1.0
 
 github.setup        LMMS lmms 1.1.3 v
-revision            1
+revision            2
 categories          multimedia
 maintainers         ryandesign openmaintainer
 license             GPL-2+

--- a/print/denemo/Portfile
+++ b/print/denemo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                denemo
 version             2.6.0
-revision            0
+revision            1
 checksums           rmd160  27af270ad5f80485565d0f4d95d99625d770768b \
                     sha256  4be5970c69847f97f1f876275c9744e5034e7c983b12a1045fb20c236494b55d \
                     size    17620623


### PR DESCRIPTION
#### Description

This closes Trac ticket [#63501](https://trac.macports.org/ticket/63501). This update to fluidsynth introduces
API and ABI breakage, compilation of all ports except audacious, lmms,
and VLC2 succeeded in local building (with trace mode) using this
version of fluidsynth. Here is a summary of changes to dependents.

* audacious-plugins
  - revbump
  Note: audacious-core fails compilation due to missing the
  dependency gdk-x11-2.0. This does not appear available on MacPorts.
  Moreover, the port maintainer states in Trac ticket #63501 to not
  treat compilation issues "as a blocker" for updating fluidsynth.

* denemo
  - revbump
  Note: this port successfully compiles when building locally, refer
  to GitHub ticket #14510

* gstreamer1-gst-plugins-bad
  - revbump

* libVLC2
  - see VLC2 below

* lmms
  - revbump
  Note: this port fails to compile due to encountering the issue
  described in Trac ticket [#58009](https://trac.macports.org/ticket/58009); this is NOT related to fluidsynth.

* scummvm
  - revbump

* scummvm-devel
  - revbump

* qsynth
  - revbump

* qtads
  - revbump

* VLC2
  - fix modeline for Emacs
  - revbump
  - remove fluidsynth dependency
  - disable fluidsynth in configuration
  Note: this port fails to compile locally, but the issue is NOT
  related to fluidsynth.

As a final note, apply this commit AFTER the pull request in GitHub
ticket #15565 is accepted. I decided to not revbump dosbox-x because
local testing suggests compatibility with fluidsyndth 2.2.8, and I do
not want to introduce a merge conflict when dosbox-x is updated.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
