### PR TITLE
glfw: disable docs on PPC, fixes Rosetta build

### DIFF
--- a/graphics/glfw/Portfile
+++ b/graphics/glfw/Portfile
@@ -125,16 +125,24 @@ configure.args-append \
     -DBUILD_SHARED_LIBS=on \
     -DGLFW_BUILD_EXAMPLES=off \
     -DGLFW_BUILD_TESTS=off \
-    -DGLFW_CMAKE_CONFIG_PATH=share
+    -DGLFW_CMAKE_CONFIG_PATH=share \
+    -DBUILD_BUILD_DOCS=off
 
 # remove top-level library path, such that internal libraries are used
 # instead of any already-installed ones.
 
 configure.ldflags-delete -L${prefix}/lib
 
-variant docs description {build documentation} {}
+variant docs description {build documentation} {
+    # Default value is ON
+    configure.args-delete -DBUILD_BUILD_DOCS=off
+}
 
-default_variants    +docs
+if {${build_arch} ni [list ppc ppc64]} {
+    # Doxygen fails on PPC with Bus error due to malloc issues.
+    # See: https://github.com/iains/darwin-toolchains-start-here/discussions/20
+    default_variants    +docs
+}
 
 if {[variant_isset docs]} {
     depends_build-append  path:bin/doxygen:doxygen

--- a/graphics/glfw/Portfile
+++ b/graphics/glfw/Portfile
@@ -27,8 +27,9 @@ if {${os.platform} eq "darwin" && ${os.major} == 10} {
     # Mac OS X 10.6: use the latest commit supporting this OS version
     github.setup    glfw glfw a94a84b507b0d6d11e8a3f257cb21f4bd6553516
     version         3.1.2-20151024
-    checksums       rmd160 1c07a75a88f272653ca246aa1212a208a83ecb30 \
-                    sha256 ff4745264f92b740c50ecc90370f102c86c439f2b6108f1495bd60c87e5d6a83
+    checksums       rmd160  1c07a75a88f272653ca246aa1212a208a83ecb30 \
+                    sha256  ff4745264f92b740c50ecc90370f102c86c439f2b6108f1495bd60c87e5d6a83 \
+                    size    366040
     revision        0
 
     # bump the epoch because I moved the version from 20151012 to 3.1.2
@@ -53,6 +54,7 @@ if {${os.platform} eq "darwin" && ${os.major} == 10} {
     compiler.c_standard   2011
     # <stdatomic.h> support was introduced in Xcode 7.0
     PortGroup compiler_blacklist_versions 1.0
+
     compiler.blacklist-append {clang < 700}
 
     compiler.cxx_standard 2011


### PR DESCRIPTION
#### Description

1. Fixes the logic of `+docs` variant.
2. Disables `+docs` for PPC, where Doxygen fails with Bus error: https://trac.macports.org/ticket/64533

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
