### PR TITLE
Multiple ports: fix triple for Rosetta case

### DIFF
--- a/audio/libopus/Portfile
+++ b/audio/libopus/Portfile
@@ -36,6 +36,15 @@ depends_build   port:pkgconfig
 
 configure.args  --disable-silent-rules
 
+platform darwin 10 {
+    # See: https://trac.macports.org/ticket/64611
+    if {${build_arch} eq "ppc"} {
+        compiler.blacklist-append *gcc-4.* *clang*
+        configure.args-append   --build=powerpc-apple-darwin${os.major} \
+                                --disable-doc
+    }
+}
+
 livecheck.type  regex
 livecheck.url   ${master_sites}
 livecheck.regex opus-(\[\\d.\]+)${extract.suffix}

--- a/devel/libassuan/Portfile
+++ b/devel/libassuan/Portfile
@@ -5,7 +5,6 @@ PortSystem          1.0
 name                libassuan
 version             2.5.5
 categories          devel
-platforms           darwin
 # strangely enough, only the docs are under GPL3
 license             LGPL-2.1+ GPL-3+
 maintainers         {larryv @larryv} openmaintainer
@@ -30,6 +29,15 @@ patchfiles          yosemite-libtool.patch
 
 # assuan-socket.c:723: error: 'fd_set' undeclared
 patchfiles-append   patch-src-assuan-socket-tiger-needs-sys-select.diff
+
+platform darwin 10 {
+    # Rosetta misdetects the arch and gives a warning of a mismatch:
+    # *** The config script "/opt/local/bin/gpgrt-config --libdir=/opt/local/lib gpg-error" was
+    # *** built for powerpc-apple-darwin10 and thus may not match the used host x86_64-apple-darwin10.8.0.
+    if {${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
 
 test.run            yes
 test.target         check

--- a/devel/libffi/Portfile
+++ b/devel/libffi/Portfile
@@ -8,7 +8,6 @@ github.setup        libffi libffi 3.4.2 v
 revision            2
 github.tarball_from releases
 categories          devel
-platforms           darwin
 license             MIT
 maintainers         nomaintainer
 
@@ -40,6 +39,13 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Doesn't actually use C++, and having the stdlib set to libc++
     # on 10.6 causes a macports-clang compiler to be chosen.
     configure.cxx_stdlib
+}
+
+# Fix for Rosetta: https://trac.macports.org/ticket/64485
+platform darwin {
+    if {${os.major} == 10 && ${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
 }
 
 # Older versions of cctools have a history of being problematic with complex

--- a/devel/libgcrypt/Portfile
+++ b/devel/libgcrypt/Portfile
@@ -36,7 +36,7 @@ configure.args  --disable-asm
 configure.cflags-append "-std=gnu89"
 
 # Some versions of gcc fail to build this for i386 including:
-#     gcc-4.0 from Xcode 3.1.6 (5493) -- Note that gcc-4.0 from Xcode 2.5 (5370) works 
+#     gcc-4.0 from Xcode 3.1.6 (5493) -- Note that gcc-4.0 from Xcode 2.5 (5370) works
 #     gcc-4.2 from Xcode 3.1.6 (5577)
 #     gcc-4.2 from Xcode 3.2.6 (5666.3)
 # rijndael.c: In function 'do_aesni_ctr':

--- a/devel/libgcrypt/Portfile
+++ b/devel/libgcrypt/Portfile
@@ -49,6 +49,13 @@ if {${build_arch} eq "i386" || ([variant_isset universal] && [lsearch ${configur
     compiler.blacklist-append gcc-4.2
 }
 
+platform darwin 10 {
+    # Rosetta misdetects the arch: warning: `-no-install' is ignored for x86_64-apple-darwin10.8.0
+    if {${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
+
 if {[string match "*clang*" ${configure.compiler}]} {
     # libgcrypt-1.5.0 does some ugly stuff with their udiv_qrnnd macro in mpih-div.c
     # error: invalid use of a cast in a inline asm context requiring an l-value: remove the cast

--- a/devel/libgpg-error/Portfile
+++ b/devel/libgpg-error/Portfile
@@ -7,10 +7,10 @@ PortGroup       conflicts_build 1.0
 set using_muniversal_PG false
 if {${os.platform} eq "darwin" && ${os.major} < 18} {
 
-	set using_muniversal_PG true
-	PortGroup muniversal 1.0
+    set using_muniversal_PG true
+    PortGroup muniversal 1.0
 
-	merger_must_run_binaries yes
+    merger_must_run_binaries yes
 }
 
 name            libgpg-error

--- a/devel/libgpg-error/Portfile
+++ b/devel/libgpg-error/Portfile
@@ -48,6 +48,15 @@ platform darwin 8 {
     configure.cppflags-append -D__DARWIN_UNIX03
 }
 
+platform darwin 10 {
+    # Rosetta misdetects the arch, which creates a problem for dependent libgcrypt.
+    # *** The config script "/opt/local/bin/gpgrt-config --libdir=/opt/local/lib gpg-error" was
+    # *** built for x86_64-apple-darwin10.8.0 and thus may not match the used host powerpc-apple-darwin10.
+    if {${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
+
 if {${universal_possible} && [variant_isset universal] && ${using_muniversal_PG}} {
     # muniversal's *.h merger does not handle \-continued lines properly
     patchfiles-append           patch-gen-posix-lock-obj_c.diff

--- a/devel/libksba/Portfile
+++ b/devel/libksba/Portfile
@@ -11,7 +11,6 @@ checksums           rmd160  6f68f478d5c628c86890c387d42ba5c6f209bb8d \
                     size    662120
 
 categories          devel security
-platforms           darwin
 license             GPL-3+
 maintainers         {larryv @larryv} openmaintainer
 
@@ -33,6 +32,15 @@ depends_lib         port:gettext-runtime \
 
 master_sites        gnupg
 use_bzip2           yes
+
+platform darwin 10 {
+    # Rosetta misdetects the arch and gives a warning of a mismatch:
+    # *** The config script "/opt/local/bin/gpgrt-config --libdir=/opt/local/lib gpg-error" was
+    # *** built for powerpc-apple-darwin10 and thus may not match the used host x86_64-apple-darwin10.8.0.
+    if {${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
 
 test.run            yes
 test.target         check

--- a/devel/m4/Portfile
+++ b/devel/m4/Portfile
@@ -9,7 +9,6 @@ categories      devel
 license         GPL-3+
 installs_libs   no
 maintainers     nomaintainer
-platforms       darwin
 description     GNU macro processor
 
 long_description \
@@ -48,6 +47,13 @@ configure.args  --disable-silent-rules \
                 --with-packager-version="revision $revision" \
                 --with-packager-bug-reports=https://trac.macports.org/wiki/Tickets \
                 ac_cv_libsigsegv=no
+
+# Fix for Rosetta: https://trac.macports.org/ticket/64487
+platform darwin {
+    if {${os.major} == 10 && ${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
 
 post-destroot {
     move ${destroot}${prefix}/share/info/m4.info ${destroot}${prefix}/share/info/gm4.info

--- a/devel/nspr/Portfile
+++ b/devel/nspr/Portfile
@@ -44,6 +44,13 @@ platform darwin 9 {
     }
 }
 
+platform darwin 10 {
+    if {${build_arch} eq "ppc"} {
+    # Otherwise Intel flags are used on Rosetta: https://trac.macports.org/ticket/64900
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
+
 if {(!${universal_possible} || ![variant_isset universal]) && ${configure.build_arch} in [list arm64 ppc64 x86_64]} {
     configure.args-append --enable-64bit
 }

--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -77,6 +77,15 @@ post-destroot {
     ln -s ${prefix}/bin/gpg ${destroot}${prefix}/bin/gpg2
 }
 
+platform darwin 10 {
+    # Rosetta misdetects the arch and gives a warning of a mismatch:
+    # *** The config script "/opt/local/bin/gpgrt-config --libdir=/opt/local/lib gpg-error" was
+    # *** built for powerpc-apple-darwin10 and thus may not match the used host x86_64-apple-darwin10.8.0.
+    if {${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
+
 variant pinentry conflicts pinentry_mac description {Handle user input via pinentry.} {
     depends_lib-append      port:pinentry
     configure.args-append   --with-pinentry-pgm=${prefix}/bin/pinentry

--- a/security/pinentry/Portfile
+++ b/security/pinentry/Portfile
@@ -9,7 +9,6 @@ categories                  security
 license                     GPL-2+
 maintainers                 {ionic @Ionic} openmaintainer
 homepage                    https://gnupg.org/software/pinentry/
-platforms                   darwin
 master_sites                gnupg
 
 description                 Passphrase entry dialog utilizing the Assuan protocol
@@ -51,6 +50,15 @@ depends_lib                 port:libiconv \
                             port:ncurses \
                             port:libassuan \
                             port:libgpg-error
+
+platform darwin 10 {
+    # Rosetta misdetects the arch and gives a warning of a mismatch:
+    # *** The config script "/opt/local/bin/gpgrt-config --libdir=/opt/local/lib gpg-error" was
+    # *** built for powerpc-apple-darwin10 and thus may not match the used host x86_64-apple-darwin10.8.0.
+    if {${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
 
 variant gtk2 description {Enable gtk2-based pinentry tool} {
     depends_lib-append      path:lib/pkgconfig/gtk+-2.0.pc:gtk2

--- a/sysutils/grep/Portfile
+++ b/sysutils/grep/Portfile
@@ -48,6 +48,14 @@ depends_build   port:gettext
 depends_lib     port:gettext-runtime \
                 port:pcre
 
+# Fix for Rosetta: https://trac.macports.org/ticket/64497
+platform darwin 10 {
+    if {${build_arch} eq "ppc"} {
+        configure.args-append \
+                --build=powerpc-apple-darwin${os.major}
+    }
+}
+
 pre-test {
     reinplace "s|base64 -d|base64 --decode|g" ${worksrcpath}/tests/pcre-jitstack
 }

--- a/sysutils/groff/Portfile
+++ b/sysutils/groff/Portfile
@@ -7,7 +7,6 @@ name                groff
 version             1.22.4
 revision            6
 categories          sysutils textproc
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-3+
 installs_libs       no
@@ -46,6 +45,13 @@ depends_lib-append  port:ghostscript \
                     port:netpbm \
                     port:uchardet \
                     port:urw-fonts
+
+# Fix for Rosetta: https://trac.macports.org/ticket/64542
+platform darwin 10 {
+    if {${build_arch} eq "ppc"} {
+        configure.args-append --build=powerpc-apple-darwin${os.major}
+    }
+}
 
 post-destroot {
     delete ${destroot}${prefix}/lib/charset.alias


### PR DESCRIPTION
#### Description

Multiple ports misdetect OS arch when built on Rosetta. This causes many ports to fail altogether and leads to warnings of mismatching archs in config with others (dependents of `libgpg-error`). The PR fixes that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
