### PR TITLE
unalz:  Bugfixes and security updates to version 0.65

### DIFF
--- a/archivers/unalz/Files/1000-Makefile.diff
+++ b/archivers/unalz/Files/1000-Makefile.diff
@@ -1,0 +1,58 @@
+--- Makefile.orig	2009-01-19 20:42:59.000000000 -0500
++++ Makefile	2022-07-29 10:50:29.000000000 -0400
+@@ -1,9 +1,10 @@
+-CPP = g++
+-CC  = gcc
+-OBJ = main.o UnAlz.o UnAlzUtils.o UnAlzBz2decompress.o UnAlzBzip2.o UnAlzbzlib.o zlib/adler32.o zlib/crc32.o zlib/infback.o zlib/inffast.o zlib/inflate.o zlib/inftrees.o zlib/zutil.o bzip2/blocksort.o bzip2/compress.o bzip2/crctable.o bzip2/huffman.o bzip2/randtable.o
+-BIN = unalz
+-LDFLAGS = 
+-CFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 
++CXX := clang++
++CC  := clang
++OBJ := main.o UnAlz.o UnAlzUtils.o UnAlzBz2decompress.o UnAlzBzip2.o UnAlzbzlib.o zlib/adler32.o zlib/crc32.o zlib/infback.o zlib/inffast.o zlib/inflate.o zlib/inftrees.o zlib/zutil.o bzip2/blocksort.o bzip2/compress.o bzip2/crctable.o bzip2/huffman.o bzip2/randtable.o
++BIN := unalz
++LDFLAGS += 
++CFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
++CXXFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 
+ 
+ all:
+ 	@echo ""
+@@ -12,7 +13,8 @@
+ 	@echo ""
+ 	@echo "TARGET_SYSTEM is one of"
+ 	@echo ""
+-	@echo " posix-utf8        : POSIX with utf8 filesystem(Most of modern OS, e.g. OSX/Ubuntu)"
++	@echo " posix-utf8        : POSIX with utf8 filesystem(Most of modern OS, e.g. OSX/Ubuntu)"
++
+ 	@echo " posix             : POSIX system (FreeBSD/linux/OSX/sparc/Win32)"
+ 	@echo " linux-utf8        : LINUX with utf8 filesystem(without -liconv option)"
+ 	@echo " posix-noiconv     : POSIX without libiconv (Windows(MINGW32,CYGWIN) or EUC-KR file system)"
+@@ -22,20 +24,20 @@
+ 	@echo ""
+ 
+ posix: unalz
+-	$(CPP) -c UnAlz.cpp -c UnAlzUtils.cpp -c main.cpp -D_UNALZ_ICONV $(CFLAGS) 
+-	$(CPP) $(OBJ) $(LDFLAGS) -liconv -o $(BIN) 
++	$(CXX) -c UnAlz.cpp -c UnAlzUtils.cpp -c main.cpp -D_UNALZ_ICONV $(CXXFLAGS) 
++	$(CXX) $(OBJ) $(LDFLAGS) $(CXXFLAGS) -liconv -o $(BIN) 
+ 
+ posix-utf8: unalz
+-	$(CPP) -c UnAlz.cpp -c UnAlzUtils.cpp -c main.cpp -D_UNALZ_ICONV -D_UNALZ_UTF8 $(CFLAGS)
+-	$(CPP) $(OBJ) $(LDFLAGS) -liconv -o $(BIN)
++	$(CXX) -c UnAlz.cpp -c UnAlzUtils.cpp -c main.cpp -D_UNALZ_ICONV -D_UNALZ_UTF8 $(CXXFLAGS)
++	$(CXX) $(OBJ) $(LDFLAGS) $(CXXFLAGS) -liconv -o $(BIN)
+ 
+ posix-noiconv: unalz
+-	$(CPP) -c UnAlz.cpp -c UnAlzUtils.cpp -c main.cpp $(CFLAGS)
+-	$(CPP) $(OBJ) $(LDFLAGS) -o $(BIN)
++	$(CXX) -c UnAlz.cpp -c UnAlzUtils.cpp -c main.cpp $(CXXFLAGS)
++	$(CXX) $(OBJ) $(LDFLAGS) $(CXXFLAGS) -o $(BIN)
+ 
+ linux-utf8: unalz
+-	$(CPP) -c UnAlz.cpp -c UnAlzUtils.cpp -c main.cpp -D_UNALZ_ICONV -D_UNALZ_UTF8 $(CFLAGS)
+-	$(CPP) $(OBJ) $(LDFLAGS) -o $(BIN)
++	$(CXX) -c UnAlz.cpp -c UnAlzUtils.cpp -c main.cpp -D_UNALZ_ICONV -D_UNALZ_UTF8 $(CXXFLAGS)
++	$(CXX) $(OBJ) $(LDFLAGS) $(CXXFLAGS) -o $(BIN)
+ 
+ install:
+ 	cp unalz /usr/local/bin/

--- a/archivers/unalz/Files/1001-libz-linkage.diff
+++ b/archivers/unalz/Files/1001-libz-linkage.diff
@@ -1,0 +1,24 @@
+--- Makefile.rev1	2022-07-29 10:50:29.000000000 -0400
++++ Makefile	2022-07-29 11:13:10.000000000 -0400
+@@ -1,8 +1,8 @@
+ CXX := clang++
+ CC  := clang
+-OBJ := main.o UnAlz.o UnAlzUtils.o UnAlzBz2decompress.o UnAlzBzip2.o UnAlzbzlib.o zlib/adler32.o zlib/crc32.o zlib/infback.o zlib/inffast.o zlib/inflate.o zlib/inftrees.o zlib/zutil.o bzip2/blocksort.o bzip2/compress.o bzip2/crctable.o bzip2/huffman.o bzip2/randtable.o
++OBJ := main.o UnAlz.o UnAlzUtils.o UnAlzBz2decompress.o UnAlzBzip2.o UnAlzbzlib.o bzip2/blocksort.o bzip2/compress.o bzip2/crctable.o bzip2/huffman.o bzip2/randtable.o
+ BIN := unalz
+-LDFLAGS += 
++LDFLAGS += -lz
+ CFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ CXXFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 
+ 
+--- UnAlzBzip2.cpp.orig	2007-04-12 08:04:56.000000000 -0400
++++ UnAlzBzip2.cpp	2022-07-29 11:17:40.000000000 -0400
+@@ -10,7 +10,7 @@
+ ////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+ //#include "stdafx.h"
+-#include "zlib/zlib.h"
++#include <zlib.h>
+ #include "bzip2/bzlib.h"
+ #include "bzip2/bzlib_private.h"
+ #include "UnAlz.h"

--- a/archivers/unalz/Files/1002-libbz2-linkage.diff
+++ b/archivers/unalz/Files/1002-libbz2-linkage.diff
@@ -1,0 +1,38 @@
+--- Makefile.rev2	2022-07-29 11:13:10.000000000 -0400
++++ Makefile	2022-07-29 11:26:03.000000000 -0400
+@@ -1,8 +1,8 @@
+ CXX := clang++
+ CC  := clang
+-OBJ := main.o UnAlz.o UnAlzUtils.o UnAlzBz2decompress.o UnAlzBzip2.o UnAlzbzlib.o bzip2/blocksort.o bzip2/compress.o bzip2/crctable.o bzip2/huffman.o bzip2/randtable.o
++OBJ := main.o UnAlz.o UnAlzUtils.o UnAlzBz2decompress.o UnAlzBzip2.o
+ BIN := unalz
+-LDFLAGS += -lz
++LDFLAGS += -lz -lbz2
+ CFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ CXXFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 
+ 
+--- UnAlzBzip2.cpp.rev1	2022-07-29 11:17:40.000000000 -0400
++++ UnAlzBzip2.cpp	2022-07-29 11:32:37.000000000 -0400
+@@ -11,10 +11,20 @@
+ 
+ //#include "stdafx.h"
+ #include <zlib.h>
+-#include "bzip2/bzlib.h"
+-#include "bzip2/bzlib_private.h"
++#include <bzlib.h>
+ #include "UnAlz.h"
+ 
++// from bzlib_private.h of bzip2
++typedef char            Char;
++typedef unsigned char   Bool;
++typedef unsigned char   UChar;
++typedef int             Int32;
++typedef unsigned int    UInt32;
++typedef short           Int16;
++typedef unsigned short  UInt16;
++
++#define True  ((Bool)1)
++#define False ((Bool)0)
+ 
+ typedef struct {
+   CUnAlz*    handle;

--- a/archivers/unalz/Files/1003-zlib-1.2.7-build.diff
+++ b/archivers/unalz/Files/1003-zlib-1.2.7-build.diff
@@ -1,0 +1,11 @@
+--- UnAlz.cpp.orig	2009-04-01 02:00:27.000000000 -0400
++++ UnAlz.cpp	2022-07-29 11:47:04.000000000 -0400
+@@ -1907,7 +1907,7 @@
+ ////////////////////////////////////////////////////////////////////////////////////////////////////
+ UINT32 CUnAlz::CRC32(UINT32 l, BYTE c)
+ {
+-	const unsigned long *CRC_TABLE = get_crc_table();
++	const z_crc_t *CRC_TABLE = get_crc_table();
+ 	return CRC_TABLE[(l ^ c) & 0xff] ^ (l >> 8);
+ }
+ 

--- a/archivers/unalz/Files/1004-pipe-mode-fixes.diff
+++ b/archivers/unalz/Files/1004-pipe-mode-fixes.diff
@@ -1,0 +1,11 @@
+--- UnAlz.cpp.rev1	2022-07-29 11:47:04.000000000 -0400
++++ UnAlz.cpp	2022-07-29 12:03:49.000000000 -0400
+@@ -794,7 +794,7 @@
+ 	if(m_pFuncCallBack) m_pFuncCallBack(m_posCur->fileName, 0,m_posCur->uncompressedSize,m_pCallbackParam, NULL);
+ 
+ 	ret = ExtractTo(&dest);
+-	if(dest.fp!=NULL)
++	if(!m_bPipeMode && dest.fp!=NULL)
+ 	{
+ 		fclose(dest.fp);
+ 		// file time setting - from unalz_wcx_01i.zip

--- a/archivers/unalz/Files/1005-filename-length-check.diff
+++ b/archivers/unalz/Files/1005-filename-length-check.diff
@@ -1,0 +1,14 @@
+--- UnAlz.cpp.rev2	2022-07-29 12:03:49.000000000 -0400
++++ UnAlz.cpp	2022-07-29 12:10:15.000000000 -0400
+@@ -431,6 +431,11 @@
+     zipHeader.uncompressedSize      =   unalz_le64toh(zipHeader.uncompressedSize); 
+ 
+ 	// FILE NAME
++	if(zipHeader.head.fileNameLength<=0)
++	{
++			m_nErr = ERR_INVALID_FILENAME_LENGTH;
++			return FALSE;
++	}		
+ 	zipHeader.fileName = (char*)malloc(zipHeader.head.fileNameLength+sizeof(char));
+ 	if(zipHeader.fileName==NULL)
+ 	{

--- a/archivers/unalz/Files/1006-fix-offset-overflow.diff
+++ b/archivers/unalz/Files/1006-fix-offset-overflow.diff
@@ -1,0 +1,15 @@
+--- UnAlz.cpp.rev3	2022-07-29 12:10:15.000000000 -0400
++++ UnAlz.cpp	2022-07-29 12:17:07.000000000 -0400
+@@ -1634,7 +1634,11 @@
+ 
+ 	while(dwRemain)
+ 	{
+-		dwRead = (UINT32)min(dwRemain, (m_files[m_nCurFile].nFileSize-m_nCurFilePos-m_files[m_nCurFile].nMultivolTailSize));
++		INT64 remain = m_files[m_nCurFile].nFileSize - m_nCurFilePos - m_files[m_nCurFile].nMultivolTailSize;
++		if (remain <= 0) {
++			m_bIsEOF = TRUE; return FALSE;
++		}
++		dwRead = (UINT32)min(dwRemain, remain);
+ 		if(dwRead==0) {
+ 			m_bIsEOF = TRUE;return FALSE;
+ 		}

--- a/archivers/unalz/Portfile
+++ b/archivers/unalz/Portfile
@@ -1,49 +1,72 @@
-PortSystem      1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			unalz
-version         0.65
-categories		archivers
-platforms		darwin
-maintainers		nomaintainer
-description		unarchiver for the AlZip format
+PortSystem          1.0
+PortGroup           makefile 1.0
 
-long_description	Unalz is a BSD-licensed unarchiver for AlZip format which \
-				requires proprietary and win32-only software but widely used \
-				in Korea.
+name                unalz
+version             0.65
+revision            1
+categories          archivers
+platforms           darwin
+license             zlib
+maintainers         bawi.org:minskim \
+                    {hotmail.com:amtor @RobK88} \
+                    openmaintainer
 
-homepage		http://www.kipple.pe.kr/win/unalz/
-master_sites	${homepage}
-extract.suffix	.tgz
+description         unarchiver for the AlZip format
 
-depends_lib     port:libiconv
+long_description    Unalz is an unarchiver for the AlZip format which \
+                    is widely used in Korea.  The ALZ file format is a proprietary \
+                    file compression and archiving format designed to overcome \
+                    the file size limitations of the ZIP file format. \
+                    If you want to create .alz archives, \
+                    you will need to use the proprietary ALZip software which only \
+                    runs in Windows.
 
-checksums       md5 e4db2c4e3c8f6f5ee414b68bc55288e5 \
-                sha1 98a64f799892f7adfffd4635bd19826fe8f18b26 \
-                rmd160 bb55aee26e12c8bf0e4422b11feffa5c88844771
+homepage            http://kippler.com/win/unalz/
+master_sites        ${homepage}
 
-worksrcdir		unalz
+extract.suffix      .tgz
 
+depends_lib         port:libiconv \
+                    port:zlib \
+                    port:bzip2
+
+checksums           md5 e4db2c4e3c8f6f5ee414b68bc55288e5 \
+                    rmd160 bb55aee26e12c8bf0e4422b11feffa5c88844771 \
+                    sha256 4c26699eb7545072de2ef7de79b4fff1f01c4db09cebff2d8d50ec03d5d74db0 \
+                    size 137985
+
+patchfiles          1000-Makefile.diff \
+                    1001-libz-linkage.diff \
+                    1002-libbz2-linkage.diff \
+                    1003-zlib-1.2.7-build.diff \
+                    1004-pipe-mode-fixes.diff \
+                    1005-filename-length-check.diff \
+                    1006-fix-offset-overflow.diff \
+                    1007-Remove-CXXFLAGS-from-linking.diff
+
+#
+# Remove this post-patch if you want to take advantage of the potential speed increase
+# offered by using the "register" keyword in the C++ program.
+# Unfortunately, the "register" keyword is only available in older compilers.
+# The "register" keyword was deprecated in the C++17 language standard.
+#
 post-patch {
-    reinplace "s|/usr/local|\$(DESTDIR)${prefix}|" ${worksrcpath}/Makefile
+    reinplace -locale C "s|register ||" ${worksrcpath}/UnAlz.cpp
 }
 
-# Note: CPP in the Makefile is the C++ compiler, not preprocessor
-configure {
-    reinplace -E "/^CFLAGS/s|\$|${configure.cflags} [get_canonical_archflags cc]\\\nCPPFLAGS=${configure.cxxflags} [get_canonical_archflags cxx]|" ${worksrcpath}/Makefile
-    reinplace -E "/^LDFLAGS/s|\$|${configure.ldflags} [get_canonical_archflags ld]|" ${worksrcpath}/Makefile
+configure.ldflags-append    "-stdlib=${configure.cxx_stdlib}"
+
+build.target        posix-utf8
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/unalz ${destroot}${prefix}/bin
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 ${worksrcpath}/readme.txt ${destroot}${prefix}/share/doc/${name}
 }
 
-build.args       CPP="${configure.cxx}" \
-	             CXX="${configure.cxx}" \
-	             CC="${configure.cc}"
-build.target	posix-utf8
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)
 
-post-destroot {
-    set docdir ${prefix}/share/doc/${name}
-    xinstall -d ${destroot}${docdir}
-    xinstall -m 0644 ${worksrcpath}/readme.txt ${destroot}${docdir}
-}
-
-livecheck.type  regex
-livecheck.url   ${homepage}
-livecheck.regex ${name}-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
#### Description
* Revives abandoned port
* Fixes Fails to Build From Source (FTBFS) on modern compilers
* Use Macports zlib instead of the internal old version of zlib
* Use Macports libbz2 instead of the internal old version of libbz2
* Fixes type error caused by introduction of z_crc_t type in zlib
* Corrects pipe mode.  Don't do close() or utime() in pipe mode
* Checks if the filename length field is invalid
* Fixes file offset overflow on incomplete files
* Adds the license to the Portfile
* Updates the long description in the Portfile
* Adds two new library dependencies - zlib and bzip2
* Updates the developer's homepage in the Portfile
* Removes unnecessary statements from Portfile
* Adds revision number to the Portfile

CLOSES:  https://trac.macports.org/ticket/60014
CLOSES:  https://trac.macports.org/ticket/65561

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5 11G63 i386
Xcode 4.6.3 4H1503 / Command Line Tools 4.6.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
