### PR TITLE
swig: remove dependency on swig3

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            swig
 version         4.0.2
-revision        3
+revision        4
 checksums       rmd160 1a995ebc0ff1a11d9d1002357673e655f6a0d2b2 \
                 sha256 d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc \
                 size   8097014
@@ -88,7 +88,6 @@ foreach lang [lsort [array names bindings]] {
         configure.args-append   --with-${arg}
         destroot.args           lib-languages=\"${arg_name}\"
         swig.lang               $arg_name
-        depends_lib-append      port:swig3-${lang}
     "
     if {${swig.lang} != $arg_name} {
         configure.args-append --without-${arg_name}
@@ -259,10 +258,6 @@ subport swig-ruby {
 
 if {${swig.lang} eq ""} {
     depends_lib     port:pcre
-
-    # REMOVE next revision/version bump
-    # used to force the binary renaming
-    depends_lib-append port:swig3
 
     set docdir      ${prefix}/share/doc/${name}-${version}
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/61120
Closes: https://trac.macports.org/ticket/61857

###### Type(s)

- [x] bugfix

###### Tested on
macOS 12.5 21G72 x86_64
Xcode 13.4.1 13F100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?