### PR TITLE
qore-openldap-module: update to 1.2.2

### DIFF
--- a/lang/qore-openldap-module/Portfile
+++ b/lang/qore-openldap-module/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cmake 1.1
 
-github.setup        qorelanguage module-openldap 1.2 v
-revision            1
+github.setup        qorelanguage module-openldap 1.2.2 v
+revision            0
 github.tarball_from releases
 
 name                qore-openldap-module
@@ -18,12 +19,11 @@ homepage            http://qore.org
 platforms           darwin
 distname            qore-openldap-module-${github.version}
 
-checksums           rmd160 62488209a6048f1dc2efd1db6f1bbd8e53502eb4 \
-                    sha256 d6d9da06e4b810cce97ea026a241d868ecf4b9e09796e15775df231c9b3534ed \
-                    size 460762
+checksums           rmd160  4dce571c32574105310790ae6e902abfdd93b4c0 \
+                    sha256  1f0a73cea18f83d5cc25121e933264310f229d2868d9995f4b99aea7e723d042 \
+                    size    1332405
 
 depends_lib         port:qore \
                     path:lib/libldap.dylib:openldap
 
-configure.args      --disable-debug
 configure.ldflags-append -Wl,-undefined -Wl,dynamic_lookup


### PR DESCRIPTION
### Description

Update to latest upstream release, 1.2.2. Fixes existing build, which fails to find `openldap` on 10.14 and later.

Fixes: https://trac.macports.org/ticket/65625

### Tested on
macOS 10.15
Xcode 12.0 / Command Line Tools 12.0