### PR TITLE
llvm-5.0: fix the build on old systems with newer GCC, enable PPC

### DIFF
--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -370,6 +370,12 @@ platform darwin {
 
         # https://llvm.org/bugs/show_bug.cgi?id=25680
         configure.cxxflags-append -U__STRICT_ANSI__
+        
+        # Wrong type in OrcRemoteTargetClient.h
+        # error: could not convert 'Src->((llvm::orc::remote::OrcRemoteTargetClient<ChannelT>*)this)->callB<llvm::orc::remote::OrcRemoteTargetRPCAPI::ReadMem>(Size)'
+        # from 'Expected<vector<unsigned char,allocator<unsigned char>>>' to 'Expected<vector<char,allocator<char>>>'
+        # Patch borrows from llvm-7.1: https://github.com/iains/LLVM-7-branch/blob/7.1.1-Darwin-WIP/llvm/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
+        patchfiles-append patch-include-orc.diff
     }
 
     # https://llvm.org/bugs/show_bug.cgi?id=25674

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -17,7 +17,6 @@ set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
 categories              lang
-platforms               darwin
 license                 NCSA
 maintainers             {jeremyhu @jeremyhu}
 
@@ -314,16 +313,17 @@ if {${os.platform} eq "darwin" && ${os.major} >= 11} {
 configure.args-append   -DPYTHON_EXECUTABLE=${pythonfullpath}
 
 platform darwin {
+    # libcxx is untested on PPC
+    if {${build_arch} ni [list ppc ppc64]} {
+        configure.cxx_stdlib libc++
+        depends_lib-append port:libcxx
 
-    configure.cxx_stdlib libc++
-    depends_lib-append port:libcxx
-    supported_archs i386 x86_64
-
-    pre-fetch {
-        if {${os.major} < 11} {
-            if {![file exists /usr/lib/libc++.dylib]} {
-                ui_error "$name requires a C++11 runtime, which your configuration does not allow"
-                error "unsupported configuration"
+        pre-fetch {
+            if {${os.major} < 11} {
+                if {![file exists /usr/lib/libc++.dylib]} {
+                    ui_error "$name requires a C++11 runtime, which your configuration does not allow"
+                    error "unsupported configuration"
+                }
             }
         }
     }

--- a/lang/llvm-5.0/files/patch-include-orc.diff
+++ b/lang/llvm-5.0/files/patch-include-orc.diff
@@ -1,0 +1,15 @@
+# Existing code fails to build on PPC:
+# error: could not convert 'Src->((llvm::orc::remote::OrcRemoteTargetClient<ChannelT>*)this)->callB<llvm::orc::remote::OrcRemoteTargetRPCAPI::ReadMem>(Size)' from 'Expected<vector<unsigned char,allocator<unsigned char>>>' to 'Expected<vector<char,allocator<char>>>'
+# Fix from: https://github.com/iains/LLVM-7-branch/blob/7.1.1-Darwin-WIP/llvm/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
+
+--- include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h.orig	2022-08-07 10:10:02.000000000 +0545
++++ include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h	2022-08-07 09:48:41.000000000 +0545
+@@ -713,7 +713,7 @@
+ 
+   uint32_t getTrampolineSize() const { return RemoteTrampolineSize; }
+ 
+-  Expected<std::vector<char>> readMem(char *Dst, JITTargetAddress Src,
++  Expected<std::vector<uint8_t>> readMem(char *Dst, JITTargetAddress Src,
+                                       uint64_t Size) {
+     // Check for an 'out-of-band' error, e.g. from an MM destructor.
+     if (ExistingError)


### PR DESCRIPTION
#### Description

PR enables building `llvm-5.0` on older systems (10.5.x and 10.6.x) with newer GCC compilers (tested with `gcc11` and `gcc12`) and for PPC.

First commit fixes a type in OrcRemoteTargetClient.h due to which the build fails on =<10.6 with:
```
error: could not convert 'Src->((llvm::orc::remote::OrcRemoteTargetClient<ChannelT>*)this)->callB<llvm::orc::remote::OrcRemoteTargetRPCAPI::ReadMem>(Size)' from 'Expected<vector<unsigned char,allocator<unsigned char>>>' to 'Expected<vector<char,allocator<char>>>'
```
The fix borrows from `llvm-7.1`. I have restricted the patch to <11.

Second commit allows PPC build. While it is known that `llvm` on PPC is not fully functional, there is no reason to prohibit building it, at least for testing and potentially fixing it. It also makes portfile logic consistent: current portfile has some ppc-specific settings, while another chunk of code restricts it to x86_64 and i386.

What _does_ work and is tested reasonably well is using `llvm-5.0` with `ld64`: I have rebuilt `ld64-97` with `+llvm5` on Leopard, SL PPC and SL Rosetta. It works at least as good as with `llvm34` (potentially better).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@catap From this PR it should build on 10.6.8 Rosetta, at least with newer `gcc` (`gcc11` and `gcc12` confirmed to work).
```
10:files svacchanda$ sw_vers
ProductName:	Mac OS X Server
ProductVersion:	10.6.8
BuildVersion:	10K549
10:files svacchanda$ port -v installed llvm-5.0
The following ports are currently installed:
  llvm-5.0 @5.0.2_4+polly (active) requested_variants='+polly' platform='darwin 10' archs='ppc' date='2022-08-07T10:35:01+0545'
```
