### PR TITLE
gopass: update to 1.14.4

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.14.3 v
+go.setup            github.com/gopasspw/gopass 1.14.4 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  7779654513c630544f675e2bffcd0e0941cefd0f \
-                        sha256  7b5b3fc0271a777f6145d57cb5fc3e2829c2a2b8c5d0cbbb3e4413f20e0f75a0 \
-                        size    2252787
+                        rmd160  8566a58fcf8202f9e4f82b08b4b3bf203fed2043 \
+                        sha256  5fd5a5ed06550ce6fee68da27651e5f4a54c134f2ca628a20d7782c3a51cba7d \
+                        size    2246382
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -44,10 +44,10 @@ go.vendors          rsc.io/qr \
                         size    32368 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.28.0 \
-                        rmd160  076cb79b7651b0fdc12168a43cdc613d111fb371 \
-                        sha256  7efea04ee3dd363a74c04a25473bcc2361d669011086c85a8b04e0c0639ad432 \
-                        size    1280082 \
+                        lock    v1.28.1 \
+                        rmd160  b6e8eb6d53889424dd6b451c20ac9b72de99a639 \
+                        sha256  0bf41d25ed04a6a4ac9d9cb33031b50718a64ca76b0e9853dabdade80ee34f3b \
+                        size    1281110 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.7 \
@@ -55,35 +55,35 @@ go.vendors          rsc.io/qr \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/term \
-                        lock    e5f449aeb171 \
-                        rmd160  815a83a4b9782102c3877cf61ee45ab5f8f89f4f \
-                        sha256  825a85ed3b123e641b82daecec59a33954393371b3f5e59dc90742a9ec46622f \
-                        size    14976 \
+                        lock    a9ba230a4035 \
+                        rmd160  2011606ab7a7f34f3deffe211d32ef2c89ebb195 \
+                        sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
+                        size    14845 \
                     golang.org/x/sys \
-                        lock    bc2c85ada10a \
-                        rmd160  c4b2c26618cd3f02fe04653b3a4fbe6707de5716 \
-                        sha256  b2526b52942c803a1687e16f87942bd0f0701b5d260fbaa35d53231e0a520577 \
-                        size    1303117 \
+                        lock    a90be440212d \
+                        rmd160  2b0c87a7ffa68a316ea1b7297dbacad6beda835b \
+                        sha256  56e6382df78be406f82d3ba0bb67e6759b2b6aee1f94479854763de0efdeb6e0 \
+                        size    1338183 \
                     golang.org/x/oauth2 \
-                        lock    622c5d57e401 \
-                        rmd160  5d8bde1bfad6155205b49cd27929e62bda3e2192 \
-                        sha256  f2540be465954c2f9b9507d6ec0f5a009ed65316a1fe94ad3e39a85a6dfa443e \
-                        size    88483 \
+                        lock    128564f6959c \
+                        rmd160  8ba67f426f4a2adc0536dddbaf7b692b27ad290e \
+                        sha256  7c422f154a4d4375297f3cf816581c645afa12fed7374c4dbe1b8c436ffcef73 \
+                        size    104302 \
                     golang.org/x/net \
-                        lock    1d687d428aca \
-                        rmd160  3b5398a1e78a7dd155c1f2561ce98e19b9a7cbcf \
-                        sha256  7f047e05f77914905c28199e79918f6aa8ac36d09409a6f11681eae22baf3e13 \
-                        size    1228827 \
+                        lock    c7608f3a8462 \
+                        rmd160  a144498876520ce80806b3d8e1a34fbfb4a6ec88 \
+                        sha256  c12009532d8ba989663861bd67b1829827ff97198a84a316be9fd48c1db417ee \
+                        size    1225991 \
                     golang.org/x/exp \
-                        lock    0b5c67f07fdf \
-                        rmd160  6069b3742e7b2a5e0a584e9e2cfce3015a624f47 \
-                        sha256  d67bf520ab8c023637dd665c077daa2766ba9df9998d73c97f59adc6e3201cd3 \
-                        size    1561252 \
+                        lock    a9213eeb770e \
+                        rmd160  22493ca7d5ce3968edbd955efc45c7611ec37477 \
+                        sha256  03cfb2ecf601c4f7d13cbc41b80e781e896f07349ae8cd710947c300c816e2ad \
+                        size    1556302 \
                     golang.org/x/crypto \
-                        lock    6f7dac969898 \
-                        rmd160  61fb52fa2fae9b5d6b2bcc369d94587f99e20409 \
-                        sha256  c1ba5ecc2d113e2490e89b0fb85cc68bd60139ffe3f05238945d279377925255 \
-                        size    1631350 \
+                        lock    630584e8d5aa \
+                        rmd160  592a8bc8bab62d399ebd992b3f0a8d2f1d9ff603 \
+                        sha256  41bb49305186ca7a143b4044dc7ad0b85400f213a9ca6a5bb25e5048757430c2 \
+                        size    1631200 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -102,20 +102,20 @@ go.vendors          rsc.io/qr \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.8.1 \
-                        rmd160  c25f7ac0b784c027c3d8b8381fe94e128021556f \
-                        sha256  4bcb2b794410cf485a18b89689ff41782482733de938a0f72f16c915759b257f \
-                        size    3448050 \
+                        lock    v2.11.1 \
+                        rmd160  d9b1f12257a14b0a92f0c9a63e1f978271b98dfd \
+                        sha256  3432d50bb442045bdcb32828924e7e3b9789afcfc751c2f524674eca1f164668 \
+                        size    3458866 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
                         sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
                         size    11986 \
                     github.com/stretchr/testify \
-                        lock    v1.7.1 \
-                        rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
-                        sha256  27cabaf81344157a188083266cf8ccc19d04c43d9a34b6276b760514b9c880a3 \
-                        size    94020 \
+                        lock    v1.8.0 \
+                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
+                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
+                        size    97622 \
                     github.com/skip2/go-qrcode \
                         lock    da1b6568686e \
                         rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
@@ -132,15 +132,20 @@ go.vendors          rsc.io/qr \
                         sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
                         size    92950 \
                     github.com/rs/zerolog \
-                        lock    v1.26.1 \
-                        rmd160  fa1b98732bdf2fd4dd00ac52f9a9dc08a299ff70 \
-                        sha256  9cf189d730c31839de68fc87a2ce52d393cae5bf9b0144880f922abd68067245 \
-                        size    164666 \
+                        lock    v1.27.0 \
+                        rmd160  434d8ba6beae7657617c2116cb48a358b9cd03ed \
+                        sha256  bae5e650804d95ae57b5729483fc81b30f9deb188474d8598b08c3d0ad5f2a49 \
+                        size    165154 \
                     github.com/rogpeppe/go-internal \
                         lock    86f73c517451 \
                         rmd160  12ae7289b3b9f3f0339d1ffe90bfefdd28944914 \
                         sha256  243fd03669a7f2563d066de31a537dc3e99fb3180fcf36f1b492f84e3c8dbd76 \
                         size    131803 \
+                    github.com/pquerna/otp \
+                        lock    v1.3.0 \
+                        rmd160  432b55c015662b3ecd02f8cb720f5bd907866629 \
+                        sha256  ab0d0bd272ea8b4749b1d73f15eadb77d78f404cc7ce0d221aad90e137881de5 \
+                        size    14039 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -281,21 +286,26 @@ go.vendors          rsc.io/qr \
                         rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
                         sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
                         size    64382 \
-                    github.com/chzyer/test \
-                        lock    061457976a23 \
-                        rmd160  c699e58ffd3ae3512a7c11a24a6bbac536199306 \
-                        sha256  06993bed996297710c90d23bd91edf8331291da98b96bce266874e33bd5cbca9 \
-                        size    4245 \
-                    github.com/chzyer/readline \
-                        lock    v1.5.0 \
-                        rmd160  27e26f8769b8ee2193cfd7b2eabf6ad659e84deb \
-                        sha256  57b4a1d8a77799c32e754a0ed5edb7aafbbd22fe81fd2a293b805bed9e7c62a3 \
-                        size    37300 \
-                    github.com/chzyer/logex \
+                    github.com/cloudflare/circl \
                         lock    v1.2.0 \
-                        rmd160  d8e2d08f0627240e115a603e1cd1e29b1a9c3ecb \
-                        sha256  a3254fe6ae0c63339d3cb8800193d943978d40257f9fdcbf68c88b2ea24698df \
-                        size    5192 \
+                        rmd160  57ecd1876b3db3338e04ee26399ba504d67e15af \
+                        sha256  2d9d0e87698fceae275c06f5641c4dacf1e505217a981a21bac72438d0972ab7 \
+                        size    4702712 \
+                    github.com/chzyer/test \
+                        lock    v1.0.0 \
+                        rmd160  ee8ba7f33ad3ff52b6a991375519772dfafc1750 \
+                        sha256  4d42204ff25e044d1ad8900467e347a55a16f2b560d1e51537d0246955a2a36a \
+                        size    4440 \
+                    github.com/chzyer/readline \
+                        lock    v1.5.1 \
+                        rmd160  cea52b55bd592a89cb49da082f5f0f3b6e8ad48a \
+                        sha256  9e5d6daaf4e6fa8d924e82ddec8b1fcfec42f4b1385aa8448b09816478c55c84 \
+                        size    37579 \
+                    github.com/chzyer/logex \
+                        lock    v1.2.1 \
+                        rmd160  adc2c290bea4076e3cc00dc1400db7819686b73a \
+                        sha256  eea4c37dd6d235809222ab053410c77685903c751f5f796d491115e917c10f47 \
+                        size    5104 \
                     github.com/cenkalti/backoff \
                         lock    v2.2.1 \
                         rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
@@ -306,6 +316,11 @@ go.vendors          rsc.io/qr \
                         rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
                         sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
                         size    6334 \
+                    github.com/boombuler/barcode \
+                        lock    6c824513bacc \
+                        rmd160  fe7247722491a03f56b9a41ae144ab05487f29fc \
+                        sha256  bd623e3ea8d79f74464b9ee4f16808545842b0e2c06b07e9b96e2dc5df80e40f \
+                        size    62985 \
                     github.com/blang/semver \
                         lock    v4.0.0 \
                         rmd160  ab0e0d974dcbc784840d4bcc76584242436c51fa \
@@ -317,10 +332,10 @@ go.vendors          rsc.io/qr \
                         sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
                         size    5023 \
                     github.com/ProtonMail/go-crypto \
-                        lock    88bb52951d5b \
-                        rmd160  a296ce5faf27aa9a1644ba77d74f2306b5e11012 \
-                        sha256  298f607d7869fd0c3a79f0bdde144f7484ae57b0d2da875ee24a92eb8d99d362 \
-                        size    312901 \
+                        lock    d6ffb7692adf \
+                        rmd160  2e04279d46f5a58364b86f2f3b5982f225af3da4 \
+                        sha256  8e680b5baeb07b1b9b03d076e2e44fa5c2f6ad186689757fbef9784e6dd2e5b0 \
+                        size    314580 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
                         lock    v1.0.0 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.14.4)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
