### PR TITLE
clang-11-bootstrap: fix build on macOS 10.5

### DIFF
--- a/lang/clang-11-bootstrap/Portfile
+++ b/lang/clang-11-bootstrap/Portfile
@@ -8,7 +8,7 @@ PortGroup           muniversal 1.0
 name                clang-11-bootstrap
 
 version             11.1.0
-revision            0
+revision            1
 epoch               0
 
 platforms           darwin
@@ -45,8 +45,8 @@ depends_build-append \
 depends_skip_archcheck-append \
                     python27-bootstrap
 
-# clang is linked against gcc's libstdc++.6.dylib and libgcc_s.1.1.dylib
-depends_lib-append  port:gcc10-bootstrap
+depends_build-append \
+                    port:gcc10-bootstrap
 
 # Use cmake-bootstrap
 depends_build-replace \
@@ -91,7 +91,9 @@ patchfiles          0002-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.pa
                     5002-patch-toolchains-darwin-add-back-pre-10.6-link-libs.diff \
                     patch-clang-fix-include-next-sysroot-cpp-headers.diff \
                     Fix-build-issues-pre-Lion-due-to-missing-a-strnlen.patch \
-                    fix-build-clang-by-gcc10.diff
+                    fix-build-clang-by-gcc10.diff \
+                    llvm-objdump-help-macho.diff \
+                    fix-build-with-old-xar.diff
 
 # sterilize MacPorts build environment; we want nothing picked up from MP prefix
 compiler.cpath
@@ -143,6 +145,10 @@ configure.pre_args-delete \
 
 configure.pre_args-delete \
                     -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
+
+# prevent it from linking against gcc's libstdc++.6.dylib and libgcc_s.1.1.dylib
+configure.ldflags-append \
+                    -static-libstdc++ -static-libgcc
 
 platform darwin {
     if {${os.major} == 14} {
@@ -207,8 +213,15 @@ configure.args-append \
                     -DLLVM_INCLUDE_GO_TESTS=OFF \
                     -DLLVM_INCLUDE_TESTS=OFF \
                     -DLLVM_INCLUDE_UTILS=OFF \
-                    -DLLVM_TARGETS_TO_BUILD="AArch64\;X86" \
                     -DPYTHON_EXECUTABLE=${prefix}/libexec/python27-bootstrap/bin/python2.7
+
+if {${build_arch} eq "arm64"} {
+    configure.args-append \
+                    -DLLVM_TARGETS_TO_BUILD="AArch64\;X86"
+} else {
+    configure.args-append \
+                    -DLLVM_TARGETS_TO_BUILD=X86
+}
 
 if {${configure.sdkroot} ne ""} {
     configure.args-append \

--- a/lang/clang-11-bootstrap/files/Fix-build-issues-pre-Lion-due-to-missing-a-strnlen.patch
+++ b/lang/clang-11-bootstrap/files/Fix-build-issues-pre-Lion-due-to-missing-a-strnlen.patch
@@ -224,3 +224,78 @@ index 49347431b9..bfd6e56be2 100644
  /// HashHMapKey - This is the 'well known' hash function required by the file
  /// format, used to look up keys in the hash table.  The hash table uses simple
  /// linear probing based on this function.
+diff --git a/lld/lib/ReaderWriter/MachO/MachONormalizedFileBinaryUtils.h b/lld/lib/ReaderWriter/MachO/MachONormalizedFileBinaryUtils.h
+index aeb04ef4508a..844f6d71102f 100644
+--- a/projects/lld/lib/ReaderWriter/MachO/MachONormalizedFileBinaryUtils.h
++++ b/projects/lld/lib/ReaderWriter/MachO/MachONormalizedFileBinaryUtils.h
+@@ -21,6 +21,20 @@
+ #include "llvm/Support/LEB128.h"
+ #include <system_error>
+ 
++#ifdef __APPLE__
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++static size_t strnlen(const char *s, size_t maxlen) {
++  size_t l = 0;
++  while (l < maxlen && *s) {
++    l++;
++    s++;
++  }
++  return l;
++}
++#endif
++#endif
++
+ namespace lld {
+ namespace mach_o {
+ namespace normalized {
+diff --git a/lld/MachO/ExportTrie.cpp b/lld/MachO/ExportTrie.cpp
+index 7cc81bcfd5f1..cafac8aae97d 100644
+--- a/projects/lld/MachO/ExportTrie.cpp
++++ b/projects/lld/MachO/ExportTrie.cpp
+@@ -43,6 +43,20 @@
+ #include "llvm/BinaryFormat/MachO.h"
+ #include "llvm/Support/LEB128.h"
+ 
++#ifdef __APPLE__
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++static size_t strnlen(const char *s, size_t maxlen) {
++  size_t l = 0;
++  while (l < maxlen && *s) {
++    l++;
++    s++;
++  }
++  return l;
++}
++#endif
++#endif
++
+ using namespace llvm;
+ using namespace llvm::MachO;
+ using namespace lld;
+diff --git a/lld/MachO/InputFiles.cpp b/lld/MachO/InputFiles.cpp
+index 46fe82f98822..5912e90d6a40 100644
+--- a/projects/lld/MachO/InputFiles.cpp
++++ b/projects/lld/MachO/InputFiles.cpp
+@@ -58,6 +58,20 @@
+ #include "llvm/Support/MemoryBuffer.h"
+ #include "llvm/Support/Path.h"
+ 
++#ifdef __APPLE__
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++static size_t strnlen(const char *s, size_t maxlen) {
++  size_t l = 0;
++  while (l < maxlen && *s) {
++    l++;
++    s++;
++  }
++  return l;
++}
++#endif
++#endif
++
+ using namespace llvm;
+ using namespace llvm::MachO;
+ using namespace llvm::support::endian;

--- a/lang/clang-11-bootstrap/files/fix-build-with-old-xar.diff
+++ b/lang/clang-11-bootstrap/files/fix-build-with-old-xar.diff
@@ -1,0 +1,24 @@
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -179,7 +179,7 @@ if (LLVM_ENABLE_ZLIB STREQUAL "FORCE_ON" AND NOT HAVE_LIBZ)
+   message(FATAL_ERROR "Failed to configure zlib")
+ endif()
+ 
+-check_library_exists(xar xar_open "" HAVE_LIBXAR)
++check_library_exists(xar xar_extract_tobuffersz "" HAVE_LIBXAR)
+ if(HAVE_LIBXAR)
+   set(XAR_LIB xar)
+ endif()
+diff --git a/llvm/include/llvm/Config/config.h.cmake b/llvm/include/llvm/Config/config.h.cmake
+index 9a682481ccaf..eefd95a8f3e1 100644
+--- a/include/llvm/Config/config.h.cmake
++++ b/include/llvm/Config/config.h.cmake
+@@ -211,7 +211,7 @@
+ /* Define if the setupterm() function is supported this platform. */
+ #cmakedefine HAVE_TERMINFO ${HAVE_TERMINFO}
+ 
+-/* Define if the xar_open() function is supported this platform. */
++/* Define if the xar_extract_tobuffersz() function is supported this platform. */
+ #cmakedefine HAVE_LIBXAR ${HAVE_LIBXAR}
+ 
+ /* Define to 1 if you have the <termios.h> header file. */

--- a/lang/clang-11-bootstrap/files/llvm-objdump-help-macho.diff
+++ b/lang/clang-11-bootstrap/files/llvm-objdump-help-macho.diff
@@ -1,0 +1,136 @@
+Based on https://reviews.llvm.org/D92310
+diff --git a/llvm/tools/llvm-objdump/MachODump.cpp b/llvm/tools/llvm-objdump/MachODump.cpp
+index c1d330bae133d..b3ec20f97c97b 100644
+--- a/tools/llvm-objdump/MachODump.cpp
++++ b/tools/llvm-objdump/MachODump.cpp
+@@ -107,70 +107,70 @@ static cl::opt<bool> NoLeadingHeaders("no-leading-headers",
+ 
+ cl::opt<bool> objdump::UniversalHeaders(
+     "universal-headers",
+-    cl::desc("Print Mach-O universal headers (requires -macho)"),
++    cl::desc("Print Mach-O universal headers (requires --macho)"),
+     cl::cat(MachOCat));
+ 
+ static cl::opt<bool> ArchiveMemberOffsets(
+     "archive-member-offsets",
+     cl::desc("Print the offset to each archive member for Mach-O archives "
+-             "(requires -macho and -archive-headers)"),
++             "(requires --macho and --archive-headers)"),
+     cl::cat(MachOCat));
+ 
+ cl::opt<bool> objdump::IndirectSymbols(
+     "indirect-symbols",
+     cl::desc(
+-        "Print indirect symbol table for Mach-O objects (requires -macho)"),
++        "Print indirect symbol table for Mach-O objects (requires --macho)"),
+     cl::cat(MachOCat));
+ 
+ cl::opt<bool> objdump::DataInCode(
+     "data-in-code",
+     cl::desc(
+-        "Print the data in code table for Mach-O objects (requires -macho)"),
++        "Print the data in code table for Mach-O objects (requires --macho)"),
+     cl::cat(MachOCat));
+ 
+ cl::opt<bool>
+     objdump::LinkOptHints("link-opt-hints",
+                           cl::desc("Print the linker optimization hints for "
+-                                   "Mach-O objects (requires -macho)"),
++                                   "Mach-O objects (requires --macho)"),
+                           cl::cat(MachOCat));
+ 
+ cl::opt<bool>
+     objdump::InfoPlist("info-plist",
+                        cl::desc("Print the info plist section as strings for "
+-                                "Mach-O objects (requires -macho)"),
++                                "Mach-O objects (requires --macho)"),
+                        cl::cat(MachOCat));
+ 
+ cl::opt<bool>
+     objdump::DylibsUsed("dylibs-used",
+                         cl::desc("Print the shared libraries used for linked "
+-                                 "Mach-O files (requires -macho)"),
++                                 "Mach-O files (requires --macho)"),
+                         cl::cat(MachOCat));
+ 
+ cl::opt<bool> objdump::DylibId("dylib-id",
+                                cl::desc("Print the shared library's id for the "
+-                                        "dylib Mach-O file (requires -macho)"),
++                                        "dylib Mach-O file (requires --macho)"),
+                                cl::cat(MachOCat));
+ 
+ static cl::opt<bool>
+     NonVerbose("non-verbose",
+                cl::desc("Print the info for Mach-O objects in non-verbose or "
+-                        "numeric form (requires -macho)"),
++                        "numeric form (requires --macho)"),
+                cl::cat(MachOCat));
+ 
+ cl::opt<bool>
+     objdump::ObjcMetaData("objc-meta-data",
+                           cl::desc("Print the Objective-C runtime meta data "
+-                                   "for Mach-O files (requires -macho)"),
++                                   "for Mach-O files (requires --macho)"),
+                           cl::cat(MachOCat));
+ 
+ static cl::opt<std::string> DisSymName(
+     "dis-symname",
+-    cl::desc("disassemble just this symbol's instructions (requires -macho)"),
++    cl::desc("disassemble just this symbol's instructions (requires --macho)"),
+     cl::cat(MachOCat));
+ 
+ static cl::opt<bool> NoSymbolicOperands(
+     "no-symbolic-operands",
+-    cl::desc("do not symbolic operands when disassembling (requires -macho)"),
++    cl::desc("do not symbolic operands when disassembling (requires --macho)"),
+     cl::cat(MachOCat));
+ 
+ static cl::list<std::string>
+diff --git a/llvm/tools/llvm-objdump/llvm-objdump.cpp b/llvm/tools/llvm-objdump/llvm-objdump.cpp
+index bb33d254370e6..96e936ec4e8f7 100644
+--- a/tools/llvm-objdump/llvm-objdump.cpp
++++ b/tools/llvm-objdump/llvm-objdump.cpp
+@@ -101,7 +101,7 @@ static cl::alias AllHeadersShort("x", cl::desc("Alias for --all-headers"),
+ static cl::opt<std::string>
+     ArchName("arch-name",
+              cl::desc("Target arch to disassemble for, "
+-                      "see -version for available targets"),
++                      "see --version for available targets"),
+              cl::cat(ObjdumpCat));
+ 
+ cl::opt<bool>
+@@ -274,7 +274,7 @@ static cl::alias PrivateHeadersShort("p",
+ cl::list<std::string>
+     objdump::FilterSections("section",
+                             cl::desc("Operate on the specified sections only. "
+-                                     "With -macho dump segment,section"),
++                                     "With --macho dump segment,section"),
+                             cl::cat(ObjdumpCat));
+ static cl::alias FilterSectionsj("j", cl::desc("Alias for --section"),
+                                  cl::NotHidden, cl::Grouping, cl::Prefix,
+@@ -303,7 +303,7 @@ static cl::opt<bool> PrintSource(
+     cl::desc(
+         "Display source inlined with disassembly. Implies disassemble object"),
+     cl::cat(ObjdumpCat));
+-static cl::alias PrintSourceShort("S", cl::desc("Alias for -source"),
++static cl::alias PrintSourceShort("S", cl::desc("Alias for --source"),
+                                   cl::NotHidden, cl::Grouping,
+                                   cl::aliasopt(PrintSource));
+ 
+@@ -335,11 +335,11 @@ static cl::alias DynamicSymbolTableShort("T",
+                                          cl::NotHidden, cl::Grouping,
+                                          cl::aliasopt(DynamicSymbolTable));
+ 
+-cl::opt<std::string> objdump::TripleName(
+-    "triple",
+-    cl::desc(
+-        "Target triple to disassemble for, see -version for available targets"),
+-    cl::cat(ObjdumpCat));
++cl::opt<std::string>
++    objdump::TripleName("triple",
++                        cl::desc("Target triple to disassemble for, see "
++                                 "--version for available targets"),
++                        cl::cat(ObjdumpCat));
+ 
+ cl::opt<bool> objdump::UnwindInfo("unwind-info",
+                                   cl::desc("Display unwind information"),


### PR DESCRIPTION
#### Description

It removes runtime dependency from gcc10-bootstrap, and backports patch which allows to use this ports for cctools.

It is the first PR in series which allows to bootstrap ld64-latest on macOS 10.5 as simple as:
```
macos-leopard:~ catap$ sudo port installed
The following ports are currently installed:
  clang-11-bootstrap @11.1.0_1+emulated_tls (active)
  gcc10-bootstrap @10.3.0_5+universal (active)
macos-leopard:~ catap$ sudo port install ld64
--->  Computing dependencies for ld64
The following dependencies will be installed: 
 cctools-bootstrap
 cmake-bootstrap
 ld64-latest
 legacy-support
 libblocksruntime
 libcxx
 libmacho-headers
 libtapi
 libunwind-headers
 python27-bootstrap
 xz-bootstrap
Continue? [Y/n]:
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->