### PR TITLE
libcxx: fix build on macOS 10.5

### DIFF
--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -10,7 +10,7 @@ revision                5
 categories              lang
 platforms               darwin
 license                 MIT NCSA
-maintainers             {jeremyhu @jeremyhu}
+maintainers             {jeremyhu @jeremyhu} {@catap korins.ky:kirill}
 description             libc++ is a new implementation of the C++ standard library with support for C++11 and portions of C++14.
 long_description        ${description} \
                         Because objects cannot be passed between different versions of the C++ runtime, this port must \
@@ -24,18 +24,11 @@ homepage                https://libcxx.llvm.org/
 master_sites            https://releases.llvm.org/${version}/
 dist_subdir             llvm
 
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${configure.cxx_stdlib} eq "libc++"} {
-    # Bootstrap problem, libcxx is indirectly used by the normal xz port.
-    depends_extract     port:xz-bootstrap
-    depends_skip_archcheck-append   xz-bootstrap
-    extract.suffix      .tar.xz
-    extract.cmd         ${prefix}/libexec/xz-bootstrap/bin/xz
-    # And having the stdlib set to libc++ on 10.6 causes a
-    # macports-clang compiler to be selected.
-    configure.cxx_stdlib
-} else {
-    use_xz              yes
-}
+depends_extract         port:xz-bootstrap
+depends_skip_archcheck-append\
+                        xz-bootstrap
+extract.suffix          .tar.xz
+extract.cmd             ${prefix}/libexec/xz-bootstrap/bin/xz
 
 set libcxxabi_distname  libcxxabi-${version}.src
 set libcxx_distname     libcxx-${version}.src
@@ -168,6 +161,13 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
             foreach header [glob ${workpath}/libcxx-${version}.src/include/*] {
                 reinplace "s|Availability.h|AvailabilityMacros.h|g" ${header}
             }
+        }
+
+        if {${os.major} < 10} {
+            # debug symbols produced by clang-11-bootstrap cause a Bus error inside ld on Leopard
+            reinplace "s|-c -g|-c|g" \
+                ${libcxx_worksrcpath}/lib/buildit \
+                ${libcxxabi_worksrcpath}/lib/buildit
         }
     }
 


### PR DESCRIPTION
#### Description

It also always use xz-bootstrap

It is the second PR in series which allows to bootstrap ld64-latest on macOS 10.5 as simple as:
```
macos-leopard:~ catap$ sudo port installed
The following ports are currently installed:
  clang-11-bootstrap @11.1.0_1+emulated_tls (active)
  gcc10-bootstrap @10.3.0_5+universal (active)
macos-leopard:~ catap$ sudo port install ld64
--->  Computing dependencies for ld64
The following dependencies will be installed: 
 cctools-bootstrap
 cmake-bootstrap
 ld64-latest
 legacy-support
 libblocksruntime
 libcxx
 libmacho-headers
 libtapi
 libunwind-headers
 python27-bootstrap
 xz-bootstrap
Continue? [Y/n]:
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->