### PR TITLE
llvm-3.4: unbreak build on Rosetta

### DIFF
--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -263,6 +263,11 @@ platform darwin {
         macosx_deployment_target 10.9
     }
 
+    # Rosetta builds Sample project for x86 and linkage fails
+    if {${os.major} == 10 && ${build_arch} eq "ppc"} {
+        patchfiles-append patch-rosetta.diff
+    }
+
     if {${os.major} < 10} {
         post-patch {
             reinplace "/TARGETS_TO_BUILD=/s/R600//" ${worksrcpath}/configure

--- a/lang/llvm-3.4/files/patch-rosetta.diff
+++ b/lang/llvm-3.4/files/patch-rosetta.diff
@@ -1,0 +1,13 @@
+--- a/projects/Makefile	2013-06-24 15:21:35.000000000 +0800
++++ b/projects/Makefile	2022-10-12 14:12:14.000000000 +0800
+@@ -23,9 +23,7 @@
+ # DragonEgg may be checked out here but doesn't (yet) build directly.
+ DIRS := $(filter-out dragonegg,$(DIRS))
+ 
+-# Sparc cannot link shared libraries (libtool problem?)
+-ifeq ($(ARCH), Sparc)
++# Sample project does not respect arch flags during compilation, Rosetta builds for x86 and and linkage fails.
+ DIRS := $(filter-out sample, $(DIRS))
+-endif
+ 
+ include $(PROJ_SRC_ROOT)/Makefile.rules


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/64498

#### Description

Sample project does not use arch flags and does not pass those even when they are explicitly added either in Makefile or in portfile. So on Rosetta objects are built for x86, and linkage fails.
Sample is optional anyway and excluded on Sparc. Just exclude it for Rosetta case.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
