### PR TITLE
openjdk8-zulu: update to 8.64.0.19

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
-version      8.64.0.15
+version      8.64.0.19
 revision     0
 
-set openjdk_version 8.0.342
+set openjdk_version 8.0.345
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  550b4e3aefd4a7172395b9b1169cbadfeb813a1f \
-                 sha256  b5b2d962230b0dae56198f76e5c6fa70646ac74b31c0ac63fd665a6227a48f05 \
-                 size    108133841
+    checksums    rmd160  952c27457b74f77ecfedbd5a8478ae8e475cceb2 \
+                 sha256  5ff596d9af2e82eeaa2012c0bb96f0e208f0a7c2bdb7bc44153997fa46274f59 \
+                 size    108138728
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  88e257afd7d20acbdf186ef5f081aeb7ddefdaec \
-                 sha256  98e0d98622109d25a32df81e263d4b953c6f2d74863890acd876c8ad8423a774 \
-                 size    106022063
+    checksums    rmd160  96124aaa14093705d117c477ac204282dbaae64d \
+                 sha256  b7516f10489f9e787d330a478bfa2efdf7b9cb3c0186832b2c010557c5b2ba5f \
+                 size    106047013
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 8.64.0.19.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?