### PR TITLE
terraform-docs: Update to 0.16.0

### DIFF
--- a/devel/terraform-docs/Portfile
+++ b/devel/terraform-docs/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/terraform-docs/terraform-docs 0.12.1 v
+go.setup            github.com/terraform-docs/terraform-docs 0.16.0 v
 revision            0
 
 description         Generate Terraform modules documentation in various formats.
@@ -18,9 +18,9 @@ license             MIT
 maintainers         @asobrien \
                     openmaintainer
 
-checksums           rmd160  908dd9095c5c1f05898d93eb7d546ab00c165039 \
-                    sha256  800c8b651f68b9511e7f45b4f31742962596edd48751cc7a93b8f2da5ebad517 \
-                    size    153242
+checksums           rmd160  343825c82e4e3b8b10ea8b857be72dc23b7350ce \
+                    sha256  ce8d4f893eb28e97d081059c03a20b876fb14a0f8c444989a2b7cb0fbab0a2c9 \
+                    size    188552
 
 build.cmd           make
 build.target        build
@@ -41,4 +41,3 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
 destroot {
     xinstall -m 0755 {*}[glob ${worksrcpath}/bin/${os.platform}-*/${name}] ${destroot}${prefix}/bin/
 }
-


### PR DESCRIPTION
#### Description
terraform-docs: Update to version 0.16.0

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?