### PR TITLE
nanorc: New port (version 2020.10.10)

### DIFF
--- a/editors/nanorc/Portfile
+++ b/editors/nanorc/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        scopatz nanorc 2020.10.10
+
+checksums           rmd160  907c5f9cac9a3c8bafdf8ec8f60d6c4028a0b880 \
+                    sha256  33a90657defa32ca7b1e91e0a67b67a4a63751973f7e70c1c638746162c1b3ea \
+                    size    77966
+
+description         Improved Nano Syntax Highlighting Files
+long_description    Installs nanorc files that have improved definitions of syntax highlighting for various languages.
+categories          editors
+license             GPL-3.0
+maintainers         nomaintainer
+
+use_configure       no
+build               {}
+
+destroot {
+    xinstall -m 0755 -d ${destroot}${prefix}/share/nanorc/
+    xinstall -m 0644 {*}[glob ${worksrcpath}/*.nanorc] ${destroot}${prefix}/share/nanorc
+}
+
+notes "
+Configure Nano to use the new highlight files by adding this line to your ~/.nanorc:
+    include \"${prefix}/share/nanorc/*.nanorc\"
+"


### PR DESCRIPTION
#### Description
nanorc: New port (version 2020.10.10)
https://github.com/scopatz/nanorc

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?