### PR TITLE
dnscontrol: New port (version 3.17.0)

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/StackExchange/dnscontrol 3.17.0 v
+
+checksums           rmd160  d3db682a9b741c54c3c07d1c72499e85a3d3286d \
+                    sha256  6a0b73973db57b22e50dd7350b3889dc7d9054a8205d0bd6fcf4650aaeb7f36b \
+                    size    1997040
+
+homepage            https://stackexchange.github.io/dnscontrol/
+description         Synchronize your DNS to multiple providers from a simple DSL
+long_description    DNSControl is a system for maintaining DNS zones. It has   \
+                    two parts: a domain specific language (DSL) for describing \
+                    DNS zones plus software that processes the DSL and pushes  \
+                    the resulting zones to DNS providers such as Route53,      \
+                    Cloudflare, and Gandi. It can send the same DNS records to \
+                    multiple providers. It even generates the most beautiful   \
+                    BIND zone files ever. It runs anywhere Go runs (Linux,     \
+                    macOS, Windows). The provider model is extensible, so more \
+                    providers can be added.
+
+categories          sysutils
+license             MIT
+maintainers         {@ajhall} \
+                    openmaintainer
+
+# Allow deps to fetched at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+build.args-append   -ldflags \"-s -w\"
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
dnscontrol: New port (version 3.17.0)
https://github.com/StackExchange/dnscontrol

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
