### PR TITLE
lighttpd: update to lighttpd-1.4.66

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -4,11 +4,11 @@ PortSystem                  1.0
 PortGroup                   legacysupport 1.0
 
 name                        lighttpd
-version                     1.4.65
+version                     1.4.66
 revision                    0
-checksums                   rmd160  8c601ddcc073a2b5b7a735d0cd6f72e05f594db1 \
-                            sha256  bf0fa68a629fbc404023a912b377e70049331d6797bcbb4b3e8df4c3b42328be \
-                            size    1033568
+checksums                   rmd160  c17cd736be60da4ff377a212d4a8f39c68b650ce \
+                            sha256  47ac6e60271aa0196e65472d02d019556dc7c6d09df3b65df2c1ab6866348e3b \
+                            size    1039520
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  www

--- a/www/lighttpd/files/patch-conf.diff
+++ b/www/lighttpd/files/patch-conf.diff
@@ -1,15 +1,3 @@
---- doc/config/conf.d/auth.conf.orig	2020-12-17 03:11:11.000000000 -0600
-+++ doc/config/conf.d/auth.conf	2020-12-18 01:16:22.000000000 -0600
-@@ -11,7 +11,7 @@
- 
- #server.modules += ( "mod_authn_file" )
- #auth.backend                 = "plain"
--#auth.backend.plain.userfile  = "/etc/lighttpd/lighttpd.user"
-+#auth.backend.plain.userfile  = conf_dir + "/lighttpd.user"
- 
- #server.modules += ( "mod_authn_ldap" )
- #auth.backend               = "ldap"
-
 --- doc/config/conf.d/cgi.conf.orig	2010-07-11 12:01:32.000000000 -0500
 +++ doc/config/conf.d/cgi.conf	2010-10-17 05:19:33.000000000 -0500
 @@ -12,11 +12,11 @@
@@ -58,18 +46,9 @@
  ##
  ## webserver chrooted to /srv/www/
  ## php running outside the chroot
-@@ -125,7 +125,7 @@
- #  )))
- #
- #server.chroot = "/srv/www"
--#server.document-root = "/servers/wwww.example.org/htdocs/"
-+#server.document-root = "/servers/www.example.org/htdocs/"
- #
- 
- ##
 --- doc/config/conf.d/rrdtool.conf.orig	2010-07-11 12:01:32.000000000 -0500
 +++ doc/config/conf.d/rrdtool.conf	2010-10-17 05:07:35.000000000 -0500
-@@ -10,12 +10,12 @@
+@@ -10,7 +10,7 @@
  ##
  ## Path to the rrdtool binary.
  ##
@@ -78,12 +57,6 @@
  
  ##
  ## Path to the rrdtool database. You can override this in conditionals.
- ##
--rrdtool.db-name            = "/var/lib/lighttpd/lighttpd.rrd"
-+rrdtool.db-name            = home_dir + "/lighttpd.rrd"
- 
- ##
- #######################################################################
 --- doc/config/lighttpd.conf.orig	2022-06-07 22:05:16.000000000 -0500
 +++ doc/config/lighttpd.conf	2022-06-08 13:51:38.000000000 -0500
 @@ -13,11 +13,11 @@
@@ -112,12 +85,3 @@
  
  ##
  ## Base directory for sockets.
-@@ -388,7 +388,7 @@
- ## Format: <errorfile-prefix><status-code>.html
- ## -> ..../status-404.html for 'File not found'
- ##
--#server.errorfile-prefix    = "/srv/www/htdocs/errors/status-"
-+#server.errorfile-prefix    = server.document-root + /errors/status-"
- 
- ##
- ## mimetype mapping


### PR DESCRIPTION
#### Description

lighttpd: update to lighttpd-1.4.66

* update to lighttpd-1.4.66
* remove patch hunks incorporated upstream

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
