### PR TITLE
nhc98: fixing build on >10.6

### DIFF
--- a/lang/nhc98/Portfile
+++ b/lang/nhc98/Portfile
@@ -6,7 +6,7 @@ name            nhc98
 version         1.22
 revision        0
 categories      lang
-maintainers     nomaintainer
+maintainers     {@barracuda156 gmail.com:vital.had} openmaintainer
 supported_archs ppc i386
 license         {LGPL BSD}
 description     The nhc98 Haskell Compiler

--- a/lang/nhc98/Portfile
+++ b/lang/nhc98/Portfile
@@ -1,32 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
 
-PortSystem  1.0
+PortSystem      1.0
 
-name        nhc98
-version     1.22
-revision    0
-categories  lang
-maintainers nomaintainer
+name            nhc98
+version         1.22
+revision        0
+categories      lang
+maintainers     nomaintainer
 supported_archs ppc i386
-license     {LGPL BSD}
-description The nhc98 Haskell Compiler
+license         {LGPL BSD}
+description     The nhc98 Haskell Compiler
 long_description \
-    nhc98 is a small, easy to install, standards-compliant \
-    compiler for Haskell 98, the lazy functional \
-    programming language. It is very portable, and aims \
-    to produce small executables that run in small amounts \
-    of memory. It produces medium-fast code, and compilation \
-    is itself quite fast. It also comes with extensive tool \
-    support for automatic compilation, foreign language \
-    interfacing, heap and time profiling, tracing \
-    and debugging. Some of its advanced kinds of heap \
-    profiles are not found in any other Haskell compiler.
+                nhc98 is a small, easy to install, standards-compliant \
+                compiler for Haskell 98, the lazy functional \
+                programming language. It is very portable, and aims \
+                to produce small executables that run in small amounts \
+                of memory. It produces medium-fast code, and compilation \
+                is itself quite fast. It also comes with extensive tool \
+                support for automatic compilation, foreign language \
+                interfacing, heap and time profiling, tracing \
+                and debugging. Some of its advanced kinds of heap \
+                profiles are not found in any other Haskell compiler.
 
-homepage http://www.haskell.org/${name}
-master_sites \
-    http://www.cs.york.ac.uk/fp/${name} \
-    ftp://ftp.cs.york.ac.uk/pub/haskell/${name} \
-    https://www.haskell.org/nhc98/
+homepage        http://www.haskell.org/${name}
+master_sites    http://www.cs.york.ac.uk/fp/${name} \
+                ftp://ftp.cs.york.ac.uk/pub/haskell/${name} \
+                https://www.haskell.org/nhc98/
 
 distfiles ${name}src-${version}${extract.suffix}
 
@@ -46,7 +45,7 @@ build.cmd       ${prefix}/bin/gmake
 compiler.blacklist  *clang*
 
 # Donʼt build in parallel, seriously
-use_parallel_build no
+use_parallel_build  no
 
 patchfiles      patch-ppc.diff patch-modern-gcc.diff patch-tests.diff
 

--- a/lang/nhc98/Portfile
+++ b/lang/nhc98/Portfile
@@ -44,6 +44,34 @@ build.cmd       ${prefix}/bin/gmake
 # Supported compilers are gcc, ghc and hbc
 compiler.blacklist  *clang*
 
+platform darwin {
+    if {${os.major} > 10 && ${os.major} < 19} {
+        # nhc98 currently builds for 32 bit
+        # See: /nhc98-1.22/configure
+        # ppc is supported through 10.6, i386 is supported through 10.14
+        build_arch  i386
+    }
+
+    if {${os.major} > 18} {
+        known_fail  yes
+        pre-fetch {
+            ui_error "${name} requires MacOS 10.14 or earlier"
+            return -code error "incompatible OS version"
+        }
+    }
+
+    if {${os.major} > 10 && ${os.major} < 16} {
+        # Newer gcc fails to build it
+        # apple-gcc-4.2 builds through 10.11
+        depends_build-append    port:apple-gcc42
+        configure.compiler      apple-gcc-4.2
+    }
+
+    if {${os.major} > 15} {
+        depends_build-append    port:ghc-bootstrap
+    }
+}
+
 # Donʼt build in parallel, seriously
 use_parallel_build  no
 
@@ -54,6 +82,13 @@ configure.args  --buildwith=gcc \
                 --docdir=${prefix}/share/doc/${name} \
                 --mandir=${prefix}/share/man/man1 \
                 --heap=8M
+
+if {${os.platform} eq "darwin" && ${os.major} >= 16} {
+    configure.args-replace \
+                --buildwith=gcc --buildwith=ghc
+    configure.args-append \
+                --ghcdir=${prefix}/share/ghc-bootstrap
+}
 
 post-patch {
     reinplace "s|-\$(CC)|-\gcc|g" ${worksrcpath}/Makefile


### PR DESCRIPTION
#### Description

An initial attempt to fix build on later systems.
Port remains restricted to 32-bit OSs, since that is exactly what its configure script has.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
