### PR TITLE
clang-11-bootstrap, llvm-*: fix build on macOS 10.5

### DIFF
--- a/lang/clang-11-bootstrap/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/clang-11-bootstrap/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,19 +12,11 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index ed9a9656305..e8f9a13860f 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -14,6 +14,7 @@
- #include "llvm/ADT/Twine.h"
- 
- #if defined(__APPLE__)
-+#include <Availability.h>
- #include <mach/mach_init.h>
- #include <mach/mach_port.h>
- #endif
 @@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-10/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-10/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,19 +12,11 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index ed9a9656305..e8f9a13860f 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -14,6 +14,7 @@
- #include "llvm/ADT/Twine.h"
- 
- #if defined(__APPLE__)
-+#include <Availability.h>
- #include <mach/mach_init.h>
- #include <mach/mach_port.h>
- #endif
 @@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-11/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-11/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,19 +12,11 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index ed9a9656305..e8f9a13860f 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -14,6 +14,7 @@
- #include "llvm/ADT/Twine.h"
- 
- #if defined(__APPLE__)
-+#include <Availability.h>
- #include <mach/mach_init.h>
- #include <mach/mach_port.h>
- #endif
 @@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-5.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-5.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,19 +12,11 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index 267af388ecd..1c8c1b026e3 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -15,6 +15,7 @@
- #include "llvm/ADT/Twine.h"
- 
- #if defined(__APPLE__)
-+#include <Availability.h>
- #include <mach/mach_init.h>
- #include <mach/mach_port.h>
- #endif
 @@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-6.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-6.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,19 +12,11 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index 267af388ecd..1c8c1b026e3 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -15,6 +15,7 @@
- #include "llvm/ADT/Twine.h"
- 
- #if defined(__APPLE__)
-+#include <Availability.h>
- #include <mach/mach_init.h>
- #include <mach/mach_port.h>
- #endif
 @@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-7.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-7.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,19 +12,11 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index 267af388ecd..1c8c1b026e3 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -15,6 +15,7 @@
- #include "llvm/ADT/Twine.h"
- 
- #if defined(__APPLE__)
-+#include <Availability.h>
- #include <mach/mach_init.h>
- #include <mach/mach_port.h>
- #endif
 @@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-8.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-8.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,19 +12,11 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index 267af388ecd..1c8c1b026e3 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -15,6 +15,7 @@
- #include "llvm/ADT/Twine.h"
- 
- #if defined(__APPLE__)
-+#include <Availability.h>
- #include <mach/mach_init.h>
- #include <mach/mach_port.h>
- #endif
 @@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-9.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-9.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -12,19 +12,11 @@ diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Suppor
 index ed9a9656305..e8f9a13860f 100644
 --- llvm_master/lib/Support/Unix/Threading.inc
 +++ macports_master/lib/Support/Unix/Threading.inc
-@@ -14,6 +14,7 @@
- #include "llvm/ADT/Twine.h"
- 
- #if defined(__APPLE__)
-+#include <Availability.h>
- #include <mach/mach_init.h>
- #include <mach/mach_port.h>
- #endif
 @@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif


### PR DESCRIPTION
#### Description

On macOS 10.5 `__MAC_OS_X_VERSION_MAX_ALLOWED` has value `1060`, anyway, llvm uses different macros to detect availability of `pthread_setname_np`.

See: https://trac.macports.org/ticket/37418

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->