### PR TITLE
just: update to 1.3.0

### DIFF
--- a/sysutils/just/Portfile
+++ b/sysutils/just/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        casey just 1.1.3
+github.setup        casey just 1.3.0
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ maintainers         {@casey rodarmor.com:casey} \
                     openmaintainer
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160 463bd46d0ba7c5a3381bfba8a927fc036f2abe1c \
-                    sha256 571f35b2b08d0e0617028854a8c2781b822544c58b8a081f4fc795a779c80878 \
-                    size   545356
+                    rmd160 68e3ffed8a59b804cd48ee6f0075349599bb657e \
+                    sha256 0214a95b7a46c6a812d3257a976114a6971892bc2129ebc87ee3094a329d71e6 \
+                    size   623232
 
 destroot {
     xinstall -m 0755 \
@@ -61,60 +61,70 @@ cargo.crates \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    block-buffer                    0.10.2  0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324 \
     bstr                            0.2.17  ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223 \
-    camino                           1.0.7  6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23 \
+    camino                           1.0.9  869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
+    cpufeatures                      0.2.2  59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b \
     cradle                           0.2.2  7096122c1023d53de7298f322590170540ad3eba46bbc2750b495f098c27c09a \
+    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     ctor                            0.1.22  f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c \
     ctrlc                            3.2.2  b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865 \
     derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
-    diff                            0.1.12  0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499 \
+    diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
+    digest                          0.10.3  f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506 \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     dotenv                          0.15.0  77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f \
     edit-distance                    2.1.0  bbbaaaf38131deb9ca518a274a45bfdb8771f139517b073b16c2d3d32ae5037b \
-    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
+    either                           1.7.0  3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be \
     env_logger                       0.9.0  0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3 \
     executable-path                  1.0.0  3ebc5a6d89e3c90b84e8f33c8737933dda8f1c106b5415900b38b9d433841478 \
-    fastrand                         1.7.0  c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf \
+    fastrand                         1.8.0  a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499 \
+    generic-array                   0.14.5  fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803 \
+    getopts                         0.2.21  14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5 \
+    getrandom                        0.2.7  4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6 \
     heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
     heck                             0.4.0  2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9 \
     hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
     humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
     instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
-    itoa                             1.0.1  1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35 \
+    itoa                             1.0.2  112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lexiclean                        0.0.1  441225017b106b9f902e97947a6d31e44ebcf274b91bdbfb51e5c477fcd468e5 \
-    libc                           0.2.125  5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b \
-    linked-hash-map                  0.5.4  7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3 \
+    libc                           0.2.126  349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836 \
+    linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     log                             0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
     memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
-    nix                             0.24.1  8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9 \
+    nix                             0.24.2  195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc \
     output_vt100                     0.1.3  628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66 \
     pretty_assertions                1.2.1  c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563 \
     proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
-    proc-macro2                     1.0.37  ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1 \
-    quote                           1.0.18  a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1 \
-    redox_syscall                   0.2.13  62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42 \
-    regex                            1.5.5  1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286 \
+    proc-macro2                     1.0.41  cdcc2916cde080c1876ff40292a396541241fe0072ef928cd76582e9ea5d60d2 \
+    pulldown-cmark                   0.9.1  34f197a544b0c9ab3ae46c359a7ec9cbbb5c7bf97054266fecb7ead794a181d6 \
+    pulldown-cmark-to-cmark         10.0.2  c1353ac408192fa925228d3e60ff746167d03f4f7e54835d78ef79e08225d913 \
+    quote                           1.0.20  3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804 \
+    redox_syscall                   0.2.15  534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a \
+    regex                            1.6.0  4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
-    regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
+    regex-syntax                    0.6.27  a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244 \
     remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
-    rustversion                      1.0.6  f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f \
-    ryu                              1.0.9  73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f \
-    serde                          1.0.137  61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1 \
-    serde_derive                   1.0.137  1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be \
-    serde_json                      1.0.81  9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c \
+    rustversion                      1.0.8  24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8 \
+    ryu                             1.0.10  f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695 \
+    serde                          1.0.140  fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03 \
+    serde_derive                   1.0.140  6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da \
+    serde_json                      1.0.82  82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7 \
+    sha2                            0.10.2  55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676 \
     similar                          2.1.0  2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3 \
     snafu                            0.7.1  5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2 \
     snafu-derive                     0.7.1  410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     structopt                       0.3.26  0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10 \
     structopt-derive                0.4.18  dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0 \
-    strum                           0.24.0  e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8 \
-    strum_macros                    0.24.0  6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef \
-    syn                             1.0.92  7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52 \
+    strum                           0.24.1  063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f \
+    strum_macros                    0.24.2  4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b \
+    syn                             1.0.98  c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd \
     target                           2.0.0  ba852e71502340e2eaf2fa51f9b3ec6aa25750da1aa65771491c69d67789b05c \
     tempfile                         3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
     temptree                         0.2.0  8fda94d8251b40088cb769576f436da19ac1d1ae792c97d0afe1cadc890c8630 \
@@ -122,11 +132,15 @@ cargo.crates \
     termcolor                        1.1.3  bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
     typed-arena                      2.0.1  0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae \
+    typenum                         1.15.0  dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987 \
+    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
+    unicode-ident                    1.0.2  15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7 \
     unicode-segmentation             1.9.0  7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99 \
     unicode-width                    0.1.9  3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973 \
-    unicode-xid                      0.2.3  957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04 \
+    uuid                             1.1.2  dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
     version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
     which                            4.2.5  5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \


### PR DESCRIPTION
#### Description
just: update to 1.3.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
