### PR TITLE
openjdk8-temurin: update to 8u345

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -148,10 +148,10 @@ subport openjdk8-temurin {
     # https://adoptium.net/temurin/releases/
     supported_archs  x86_64
 
-    version      8u332
+    version      8u345
     revision     0
 
-    set build    09
+    set build    01
 
     description  Eclipse Temurin, based on OpenJDK 8
     long_description ${long_description_temurin}
@@ -160,9 +160,9 @@ subport openjdk8-temurin {
     distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  20fa5b11b34ee833b62cca7d9d7d6f76b9047759 \
-                 sha256  a75e8182bb8e77a02c7b4d9f93120c64c1988e2c415b3646d4f4496544e87291 \
-                 size    107924497
+    checksums    rmd160  ecf6e0243ac503ebe5903f7e3b137c593077697c \
+                 sha256  3eeba0e76101b9f5e8eb9eb14ad991293cf0cc064df35f6a89882b603630f0c8 \
+                 size    107934646
 }
 
 # Remove after 2022-09-14


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u345.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?