### PR TITLE
openjdk8: update to 8u345

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -9,8 +9,8 @@ name                openjdk8
 # Tags: https://github.com/openjdk/jdk8u/tags
 # remove 'jdk' from the latest tag without '-ga' that has commit that corresponds to the latest tag with '-ga'
 set major 8
-set update 342
-set build 07
+set update 345
+set build 01
 version             ${major}u${update}
 revision            0
 categories          java devel
@@ -18,16 +18,16 @@ platforms           darwin
 supported_archs     ppc x86_64
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
-description         Openjdk 8
-long_description    JDK 8 and JRE 8 builds of Openjdk, the Open-Source implementation \
+description         OpenJDK 8
+long_description    JDK 8 and JRE 8 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk8u/archive/refs/tags/
 distname            jdk${major}u${update}-b${build}
 
-checksums           rmd160  69e2ae70dfb693e1ee6ad25ca62adaf875983ba9 \
-                    sha256  0cb35a90c794c8ed527f8ca287d76441ca5e4dd09ecd77005c8cdcafd18b9b92 \
-                    size    88180770
+checksums           rmd160  a5f2ee5ee3db4b42b5640c3364a026523a0af8c7 \
+                    sha256  0b7cd73c6ad6c07cbcdd4b37559b8a49a5d43be2c8e2b922c41d4761108779c4 \
+                    size    88179096
 
 patchfiles          patch-openjdk8-xcode.diff
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 8u345. Closes https://trac.macports.org/ticket/65588.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?