### PR TITLE
py-gmic: use libjpeg-turbo; use gmic-lib

### DIFF
--- a/python/py-gmic/Portfile
+++ b/python/py-gmic/Portfile
@@ -5,10 +5,7 @@ PortGroup           python 1.0
 
 name                py-gmic
 version             2.9.4-alpha1
-revision            5
-
-# py-gmic is broken and no longer actively being developed upstream
-known_fail          yes
+revision            6
 
 # gmic and py-gmic should be the same version
 set gmic_version    2.9.4
@@ -16,27 +13,20 @@ set gmic_version    2.9.4
 categories-append   science
 license             CeCILL
 maintainers         {mps @Schamschula} openmaintainer
+
 description         Python binding for G'MIC - A Full-Featured Open-Source Framework for Image Processing
 long_description    {*}${description}
-platforms           darwin
 homepage            https://gmic.eu
 
-master_sites        https://github.com/myselfhimself/gmic-py/archive/:py-gmic \
-                    https://gmic.eu/files/source/:gmic
+master_sites        https://github.com/myselfhimself/gmic-py/archive/
+distfiles           v${version}${extract.suffix}
 
-distfiles           v${version}${extract.suffix}:py-gmic \
-                    gmic_${gmic_version}${extract.suffix}:gmic
-
-python.versions     37 38 39
+python.versions     38 39 310
 
 checksums           v${version}${extract.suffix} \
                     rmd160  11db37d67af0d451661562a3cae66b4b18a9b0fb \
                     sha256  da38a9afecbc20dfc5dade26c5be94d13514dbc8498aba5f7277107cee26712e \
-                    size    13255511 \
-                    gmic_${gmic_version}${extract.suffix} \
-                    rmd160  f2b8179bd16d7a04b8c47355bb5582c268edb075 \
-                    sha256  790bee48f496765f6b59067dfb10dc34e1eb576caf9a95f30af0d567026eacc7 \
-                    size    7279628
+                    size    13255511
 
 if {${name} ne ${subport}} {
     build.dir       ${workpath}/gmic-py-${version}
@@ -49,10 +39,10 @@ if {${name} ne ${subport}} {
                     port:curl \
                     path:lib/libavcodec.dylib:ffmpeg \
                     port:fftw-3 \
+                    port:gmic-lib \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
                     port:libomp \
-                    path:lib/opencv4/libopencv_core.dylib:opencv4 \
                     port:py${python.version}-numpy \
                     port:py${python.version}-Pillow \
                     port:py${python.version}-psutil \
@@ -64,17 +54,13 @@ if {${name} ne ${subport}} {
                     port:xorg-libsm \
                     port:zlib
 
-    build.env-append \
-                    PKG_CONFIG_PATH=${prefix}/lib/opencv4/pkgconfig
-
     patch.dir       ${build.dir}
-    patchfiles      patch-setup.py.diff
+    patchfiles      patch-setup.py.diff \
+                    patch-gmicpy.h-use-cimg.diff
 
     post-patch {
         reinplace   "s|%PREFIX%|${prefix}|g" ${build.dir}/setup.py
-
-        xinstall    -d ${build.dir}/src/gmic
-        move        ${workpath}/gmic-${gmic_version}/src ${build.dir}/src/gmic
+        move        ${worksrcpath}/VERSION ${worksrcpath}/VERSION.ver
     }
 
     livecheck.type  none

--- a/python/py-gmic/Portfile
+++ b/python/py-gmic/Portfile
@@ -49,7 +49,7 @@ if {${name} ne ${subport}} {
                     port:curl \
                     path:lib/libavcodec.dylib:ffmpeg \
                     port:fftw-3 \
-                    port:jpeg \
+                    path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
                     port:libomp \
                     path:lib/opencv4/libopencv_core.dylib:opencv4 \

--- a/python/py-gmic/files/patch-gmicpy.h-use-cimg.diff
+++ b/python/py-gmic/files/patch-gmicpy.h-use-cimg.diff
@@ -1,0 +1,9 @@
+--- gmicpy.h.orig	2022-10-01 11:37:18.000000000 -0400
++++ gmicpy.h	2022-10-01 11:37:44.000000000 -0400
+@@ -1,3 +1,6 @@
++#include "CImg.h"
++using namespace cimg_library;
++
+ #include "gmic.h"
+ 
+ // Set T be a float if not platform-overridden

--- a/python/py-gmic/files/patch-setup.py.diff
+++ b/python/py-gmic/files/patch-setup.py.diff
@@ -41,3 +41,75 @@
  elif sys.platform == "linux":  # Enable openmp for 32bit & 64bit linuxes
      extra_compile_args += ["-fopenmp"]
      extra_link_args += ["-lgomp"]
+--- setup.py.orig	2022-08-23 11:18:06.529888929 -0400
++++ setup.py	2022-08-23 11:18:31.909018857 -0400
+@@ -9,8 +9,6 @@
+ import pkgconfig
+ 
+ here = path.abspath(path.dirname(__file__))
+-gmic_src_path = path.abspath("src/gmic/src")
+-
+ 
+ # List of non-standard '-l*' compiler parameters
+ extra_link_args = []
+@@ -71,10 +69,10 @@
+     "pthread"
+ ]  # removed core-dumping 'gomp' temporarily (for manylinux builds)
+ 
+-library_dirs = packages["library_dirs"] + [here, gmic_src_path]
++library_dirs = packages["library_dirs"] + [here]
+ if sys.platform == "darwin":
+     library_dirs += ["%PREFIX%/libexec/llvm-9.0/lib"]
+-include_dirs = packages["include_dirs"] + [here, gmic_src_path]
++include_dirs = packages["include_dirs"] + [here]
+ if sys.platform == "darwin":
+     include_dirs += ["%PREFIX%/libexec/llvm-9.0/include"]
+ # Debugging is now set through --global-option --debug and more.
+@@ -118,7 +116,7 @@
+     include_dirs=include_dirs,
+     libraries=libraries,
+     library_dirs=library_dirs,
+-    sources=["gmicpy.cpp", path.join(gmic_src_path, "gmic.cpp")],
++    sources=["gmicpy.cpp"],
+     define_macros=define_macros,
+     extra_compile_args=extra_compile_args,
+     extra_link_args=extra_link_args,
+--- setup.py.orig	2022-10-01 11:22:30.000000000 -0400
++++ setup.py	2022-10-01 11:23:51.000000000 -0400
+@@ -20,6 +20,7 @@
+ # cimg_date and cimg_date are true variables, the value of which is checked in the C/C++ source
+ define_macros = [
+     ("gmic_build", None),
++    ("cimg_OS", '1'),
+     ("cimg_date", '""'),
+     ("cimg_time", '""'),
+     ("gmic_is_parallel", None),
+--- setup.py.orig	2022-10-01 14:25:41.000000000 -0400
++++ setup.py	2022-10-01 14:26:34.000000000 -0400
+@@ -71,11 +71,11 @@
+ ]  # removed core-dumping 'gomp' temporarily (for manylinux builds)
+ 
+ library_dirs = packages["library_dirs"] + [here]
+-if sys.platform == "darwin":
+-    library_dirs += ["%PREFIX%/libexec/llvm-9.0/lib"]
++# if sys.platform == "darwin":
++#     library_dirs += ["%PREFIX%/libexec/llvm-9.0/lib"]
+ include_dirs = packages["include_dirs"] + [here]
+-if sys.platform == "darwin":
+-    include_dirs += ["%PREFIX%/libexec/llvm-9.0/include"]
++# if sys.platform == "darwin":
++#     include_dirs += ["%PREFIX%/libexec/llvm-9.0/include"]
+ # Debugging is now set through --global-option --debug and more.
+ # debugging_args = [
+ #     "-O0",
+--- setup.py.orig	2022-10-01 14:53:30.000000000 -0400
++++ setup.py	2022-10-01 14:53:58.000000000 -0400
+@@ -130,7 +130,7 @@
+ 
+ # Grab the version from the VERSION file, which is also include in MANIFEST.in
+ # Technique highlighted here: https://packaging.python.org/guides/single-sourcing-package-version/
+-with open(path.join(".", "VERSION")) as version_file:
++with open(path.join(".", "VERSION.ver")) as version_file:
+     version = version_file.read().strip()
+ 
+ setup(

--- a/science/gmic/Portfile
+++ b/science/gmic/Portfile
@@ -216,6 +216,7 @@ if {${subport} eq ${name}} {
 
     destroot {
         xinstall -m 0644 ${worksrcpath}/src/gmic.h                      ${destroot}${prefix}/include
+        xinstall -m 0644 ${worksrcpath}/src/CImg.h                      ${destroot}${prefix}/include
         xinstall -m 0644 ${worksrcpath}/src/libgmic.a                   ${destroot}${prefix}/lib
         xinstall -m 0755 ${worksrcpath}/src/libgmic.${soversion}.dylib  ${destroot}${prefix}/lib
         ln       -s      libgmic.${soversion}.dylib                     ${destroot}${prefix}/lib/libgmic.dylib


### PR DESCRIPTION
### Description

* Use path-style dep to `libjpeg-turbo`, rather than `jpeg`. (Based on a search of the ports tree, this is the only straggler with a hard dep on `jpeg`.)
* Use `gmic-lib`, rather than building `gmic` from source.

Fixes: https://trac.macports.org/ticket/65639

### Tested On
* macOS 10.6 thru Monterey
* Currently failing on 10.6, but otherwise looks good.