### PR TITLE
a60: ensure Rosetta builds for ppc and not x86

### DIFF
--- a/lang/a60/Portfile
+++ b/lang/a60/Portfile
@@ -6,7 +6,6 @@ name                a60
 version             0.23a
 
 categories          lang
-platforms           darwin
 license             GPL-2
 maintainers         nomaintainer
 
@@ -31,6 +30,12 @@ patchfiles          patch-comm.h.diff \
                     patch-Makefile.in.diff
 
 configure.args      --prefix=${destroot}${prefix}
+
+platform darwin 10 powerpc {
+    # Without this Rosetta silently builds x86 binary.
+    configure.args-append \
+                    CC="${configure.cc} -arch ppc"
+}
 
 variant xa60 description {Add xa60 which is a simple X11 front end for a60} {
     depends_lib     port:xorg-libice \


### PR DESCRIPTION
#### Description

This fixes a bug in the build system: on Rosetta arch settings are ignored and x86 binary is silently built with no warnings.
```
--->  Installing a60 @0.23a_0
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_a60/a60/work/destroot" && /usr/bin/tar -cvf - . | /opt/local/bin/lbzip2 -c9 > /opt/local/var/macports/software/a60/a60-0.23a_0.darwin_10.ppc.tbz2 
--->  Activating a60 @0.23a_0
10:~ svacchanda$ file /opt/local/bin/a60
/opt/local/bin/a60: Mach-O 64-bit executable x86_64
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
