### PR TITLE
flux: New port (version 0.31.5)

### DIFF
--- a/sysutils/flux/Portfile
+++ b/sysutils/flux/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               golang 1.0
+
+go.setup                github.com/fluxcd/flux2 0.31.5 v
+name                    flux
+
+checksums               rmd160  79c85a30fc055d752a66b76e556814adcef1d315 \
+                        sha256  b78745876389b8cde5b7b3c84a9ce6f4ad8b89475d89b1b8fe501ee692a4efb4 \
+                        size    387637
+
+homepage                https://fluxcd.io/
+description             Flux CLI
+long_description        Flux is a tool for keeping Kubernetes clusters in sync \
+                        with sources of configuration (like Git repositories), \
+                        and automating updates to configuration when there is  \
+                        new code to deploy.
+
+categories              sysutils
+license                 Apache-2
+maintainers             {@ajhall} \
+                        openmaintainer
+
+depends_build-append    port:kustomize port:realpath
+
+# Allow deps to fetched at build time
+build.env-delete        GO111MODULE=off GOPROXY=off
+
+build.env-append        VERSION=${version}
+build.cmd               make
+build.target            build
+
+destroot {
+    set bin_path ${destroot}${prefix}/bin/${name}
+    xinstall -m 0755 ${worksrcpath}/bin/${name} ${bin_path}
+
+    set bash_completion ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0755 -d ${bash_completion}
+    exec ${bin_path} completion bash > ${bash_completion}/${name}
+
+    set zsh_completion ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0755 -d ${zsh_completion}
+    exec ${bin_path} completion zsh > ${zsh_completion}/_${name}
+
+    set fish_completion ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0755 -d ${fish_completion}
+    exec ${bin_path} completion fish > ${fish_completion}/${name}.fish
+}


### PR DESCRIPTION
#### Description
flux: New port (version 0.31.5)
https://github.com/fluxcd/flux2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
