### PR TITLE
terragrunt: update to 0.38.7

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -15,15 +15,78 @@ maintainers         {mjrc.nl:macports @mjrc} openmaintainer
 
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       terragrunt-0.31
+set latestVersion       terragrunt-0.38
+
+subport terragrunt-0.38 {
+    set dependsOn       1.2
+    set patchNumber     7
+
+    checksums           rmd160  e295b0e90a6ec7f7a0a31c8c683fe1621c878b71 \
+                        sha256  19ae411c3206857b655976c8d4b972113be90592dac9f73050449e27ee8aeda3 \
+                        size    2299205
+}
+
+subport terragrunt-0.37 {
+    set dependsOn       1.1
+    set patchNumber     4
+
+    checksums           rmd160  05c2c7f530cf1057c7a1cae0617fffb0ca353c16 \
+                        sha256  b2dc6468535e057cf01b7aa5d6b40c74717e0c3b5501a14bb8bb4420136e0a52 \
+                        size    2292470
+}
+
+subport terragrunt-0.36 {
+    set dependsOn       1.1
+    set patchNumber     12
+
+    checksums           rmd160  83934e8373eda08aa64391031975195bc059ce6c \
+                        sha256  91a6f41056971d231de1b0786ee92019608cda9aa1066fe66119dafd94919024 \
+                        size    2288539
+}
+
+subport terragrunt-0.35 {
+    set dependsOn       1.0
+    set patchNumber     20
+
+    checksums           rmd160  5e29cc8cb9adee6612bd76fb7405027231548cd0 \
+                        sha256  4b3ea8406e2a42e066148a073cba3413be65f2edb0e4e528d033533774aeefa3 \
+                        size    2281426
+}
+
+subport terragrunt-0.34 {
+    set dependsOn       1.0
+    set patchNumber     3
+
+    checksums           rmd160  87f15774fe41a8e2ebe893ce5cfd19dfb813cfc8 \
+                        sha256  8885e91d853d9f2284fa6e11d88160d040130cb547595f2f90ad34a1e9fd115f \
+                        size    2268245
+}
+
+subport terragrunt-0.33 {
+    set dependsOn       1.0
+    set patchNumber     2
+
+    checksums           rmd160  783302b6ca6845d8743e8cf0ad3da071877e4f76 \
+                        sha256  567b61a8f4a739f115e980ee665773584ffe8b01ae306f0dd13b7d0d6c341105 \
+                        size    2264318
+}
+
+subport terragrunt-0.32 {
+    set dependsOn       1.0
+    set patchNumber     6
+
+    checksums           rmd160  20a04e3d928d06565327f37e5bed5117ff7d6031 \
+                        sha256  a58e87b8a99e3adbfdde5807453236dccd1186e1d100e33aa546d3cecea6b985 \
+                        size    2259950
+}
 
 subport terragrunt-0.31 {
     set dependsOn       1.0
-    set patchNumber     0
+    set patchNumber     11
 
-    checksums           rmd160  51c5e1fd2b0dab4d44cf928df0b3c524ccc0a871 \
-                        sha256  bd59d37cce1bceee0aba83d9701a560bc55fd45d3ae4bb546ec5ff8731481def \
-                        size    2214906
+    checksums           rmd160  b18d043e757af99213c4668b57f28f2217b4941f \
+                        sha256  9ebde9edc147121fada2ecdcb90fd21b67592ee13720401835ed7dae3a1bb091 \
+                        size    2246065
 }
 
 subport terragrunt-0.29 {
@@ -33,33 +96,6 @@ subport terragrunt-0.29 {
     checksums           rmd160  26ac8c2618aa7ca869ee45dc8eb55027e2f75159 \
                         sha256  4ee3db5390f93bfe43b49f45a2904d9ebe91179a1d154beb8b43a0a24ba650c3 \
                         size    2232674
-}
-
-subport terragrunt-0.27 {
-    set dependsOn       0.14
-    set patchNumber     0
-
-    checksums           rmd160  22cc7f81c24718c39cf1aaa57266590775bf6dea \
-                        sha256  051eeb79c326bc6ccc734418a15366d9cef9880a1c5fdee0304d818e0ccb8a25 \
-                        size    2184321
-}
-
-subport terragrunt-0.26 {
-    set dependsOn       0.13
-    set patchNumber     7
-
-    checksums           rmd160  d17297226396d511ba7e14cf44cb18a33d76fe51 \
-                        sha256  291246e6ccfd0f1c18712de4f85fc63bcae49bc20fd54330af109daf5d186330 \
-                        size    2178214
-}
-
-subport terragrunt-0.24 {
-    set dependsOn       0.12
-    set patchNumber     4
-
-    checksums           rmd160  5c23e704d7192b4de32c824663598a3466729b7f \
-                        sha256  cc9c56fcbd299f59055b92f1f6258c9ea1610609c1d29a3ca5d32ac93577e335 \
-                        size    2029411
 }
 
 subport terragrunt_select {}
@@ -98,7 +134,7 @@ if {${subport} == ${name}} {
 
     PortGroup           golang 1.0
 
-    supported_archs     x86_64
+    supported_archs     x86_64 arm64
 
     depends_run         port:terragrunt_select port:terraform-${dependsOn}
 


### PR DESCRIPTION
#### Description
* Update Terragrunt to 0.38.7
* Add subports for versions 0.32 through 0.38
* Bump the subport for 0.31 to the latest bugfix release
* Remove subports for 0.24, 0.26, and 0.27, as they no longer build with Go 1.18

It may be possible to get the older versions to build by patching them to use a newer version of https://pkg.go.dev/golang.org/x/sys (the same as in https://github.com/google/go-jsonnet/issues/596). Let me know if you think it's worth the effort.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?