### PR TITLE
dnscontrol: update to 3.18.0

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/StackExchange/dnscontrol 3.17.0 v
+go.setup            github.com/StackExchange/dnscontrol 3.18.0 v
 
-checksums           rmd160  d3db682a9b741c54c3c07d1c72499e85a3d3286d \
-                    sha256  6a0b73973db57b22e50dd7350b3889dc7d9054a8205d0bd6fcf4650aaeb7f36b \
-                    size    1997040
+checksums           rmd160  dfe7374f28331d2a96c45e2dd866cd596c94588b \
+                    sha256  baa62cf19eda2da6f689c30f775096ef5870ef09128a5fc9b5c02fb9771bb209 \
+                    size    2292850
 
 homepage            https://stackexchange.github.io/dnscontrol/
 description         Synchronize your DNS to multiple providers from a simple DSL


### PR DESCRIPTION
#### Description
dnscontrol: update to 3.18.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?