### PR TITLE
openjdk18-temurin: update arm64 to 18.0.2

### DIFF
--- a/java/openjdk18-temurin/Portfile
+++ b/java/openjdk18-temurin/Portfile
@@ -11,11 +11,16 @@ license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
 universal_variant no
 
-# https://adoptium.net/temurin/releases/
+# https://adoptium.net/temurin/releases/?version=18
 supported_archs  x86_64 arm64
 
-version      18.0.1
-set build    10
+if {${configure.build_arch} eq "x86_64"} {
+    version      18.0.1
+    set build    10
+} elseif {${configure.build_arch} eq "arm64"} {
+    version      18.0.2
+    set build    9
+}
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 18
@@ -30,9 +35,9 @@ if {${configure.build_arch} eq "x86_64"} {
                  size    188268875
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK18U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  594cbf51b7f63c6df2589a3aa9ced3e93f983d27 \
-                 sha256  4f459195df89e52bbadfb5b7ab8a95030b08fcd84b7e0017eceed00f05ec0458 \
-                 size    178818976
+    checksums    rmd160  809c522d4ba10e190b57315560c645a46cd046d2 \
+                 sha256  d84ec85a9e6b5e22f6bac7e96cc764f5369da393ab233149bfbcbacf1e7de9b7 \
+                 size    178826838
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin arm64 18.0.2. (x86_64 18.0.2 is not available yet.)

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?