### PR TITLE
google-glog: fix build on old systems using gcc

### DIFF
--- a/devel/gflags/Portfile
+++ b/devel/gflags/Portfile
@@ -39,4 +39,13 @@ platform darwin 10 powerpc {
 configure.args-append \
         -DBUILD_SHARED_LIBS=ON \
         -DBUILD_STATIC_LIBS=ON \
+        -DGFLAGS_BUILD_gflags_LIB=ON \
         -DREGISTER_INSTALL_PREFIX=OFF
+
+platform darwin {
+    # Needed to support building dependents. See: https://kumasento.github.io/2020-06-12-glog-gflags-and-c-abi/
+    if {${os.major} < 16} {
+        configure.args-append \
+                    -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"
+    }
+}

--- a/devel/gflags/Portfile
+++ b/devel/gflags/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        gflags gflags 2.2.2 v
-revision            0
+revision            1
 
 categories          devel
 maintainers         nomaintainer
@@ -17,12 +17,24 @@ long_description    The gflags package contains a library that implements comman
                     the ability to define flags in the source file in which \
                     they're used.
 
-platforms           darwin
 license             BSD
 
 checksums           rmd160  9748753d2cf4d581cd0881bd5f5c1e3dac365896 \
                     sha256  660b2cd42849d720f8b403c4e78b6e16bdd05c9af33c0fdd19860c96d7b695c0 \
                     size    98723
+
+# While gflags builds fine with gcc-4.2, its dependent google-glog does not.
+# However they both should be built by the same compiler, otherwise google-glog build fails.
+# https://trac.macports.org/ticket/65645
+compiler.blacklist-append \
+                    *gcc-4.2 *gcc-4.3 *gcc-4.4 *gcc-4.5
+
+# Rosetta ignores blacklist and still tries to use llvm-g++-4.2.
+# Prioritize newer gcc; list versions that are realistically used and confirmed to build and work.
+platform darwin 10 powerpc {
+    compiler.whitelist \
+                    macports-gcc-12 macports-gcc-11 macports-gcc-10 macports-gcc-7 macports-gcc-6
+}
 
 configure.args-append \
         -DBUILD_SHARED_LIBS=ON \

--- a/devel/google-glog/Portfile
+++ b/devel/google-glog/Portfile
@@ -20,7 +20,6 @@ long_description    The glog library implements application-level logging. \
                     This library provides logging APIs based on C++-style \
                     streams and various helper macros.
 
-platforms           darwin
 license             BSD
 
 # See: https://github.com/google/glog/pull/239
@@ -30,10 +29,33 @@ patchfiles-append   patch-pkg_file.diff
 legacysupport.newest_darwin_requires_legacy \
                     15
 
+compiler.cxx_standard \
+                    1998
+
+# https://trac.macports.org/ticket/65645
+# #pragma GCC diagnostic inside functions available from gcc-4.6.
+compiler.blacklist-append \
+                    *gcc-4.2 *gcc-4.3 *gcc-4.4 *gcc-4.5
+
+# Rosetta ignores blacklist and still tries to use llvm-g++-4.2.
+# Prioritize newer gcc; list versions that are realistically used and confirmed to build and work.
+platform darwin 10 powerpc {
+    compiler.whitelist \
+                    macports-gcc-12 macports-gcc-11 macports-gcc-10 macports-gcc-7 macports-gcc-6
+}
+
 configure.args-append \
                     -DWITH_GFLAGS=OFF \
                     -DBUILD_SHARED_LIBS=ON \
                     -DWITH_GTEST=OFF
+
+# Undefined symbols:
+# "___atomic_load_8", referenced from: _main in logging_unittest.cc.o
+# "___atomic_store_8", referenced from: _main in logging_unittest.cc.o
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append \
+                    -latomic
+}
 
 variant gflags description {Includes gflags command line control of logging} {
     configure.args-replace \

--- a/devel/google-glog/Portfile
+++ b/devel/google-glog/Portfile
@@ -7,7 +7,7 @@ PortGroup           cmake 1.1
 
 name                google-glog
 github.setup        google glog 0.6.0 v
-revision            0
+revision            1
 checksums           rmd160  f59cdbebd81c3c8881e3775ccec9336968648387 \
                     sha256  8eb8a80e63839beb9587bbd7deb95ba263bc112f55db9042c6cd8c77f69a2a1f \
                     size    193314
@@ -48,6 +48,14 @@ configure.args-append \
                     -DWITH_GFLAGS=OFF \
                     -DBUILD_SHARED_LIBS=ON \
                     -DWITH_GTEST=OFF
+
+platform darwin {
+    # Needed to support building dependents. See: https://kumasento.github.io/2020-06-12-glog-gflags-and-c-abi/
+    if {${os.major} < 16} {
+        configure.args-append \
+                    -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"
+    }
+}
 
 # Undefined symbols:
 # "___atomic_load_8", referenced from: _main in logging_unittest.cc.o


### PR DESCRIPTION
#### Description

Changes concern older systems <10 plus 10.6 PPC/Rosetta. Newer MacOS that use Clang aren’t affected.
For `google-glog` port:
1. GCC earlier than `gcc-4.6` are blacklisted, because they do not support `#pragma GCC diagnostic` inside functions.
2. For Rosetta case, whitelist of GCC versions is added, because it ignores blacklist and still tries to use `llvm-g++-4.2`, which fails (blacklisting it explicitly fails to work).
3. When GCC is used as a compiler, `-latomic` ld flag is added, otherwise build fails on undefined atomics symbols.
4. Finally, identical compiler choice settings (not relevant for Clang-using systems) are added to `gflags` port, because while `gflags` itself does build fine with `gcc-4.2`, `google-glog` build then fails with undefined symbols `__GLOBAL__sub_I_logging.cc in logging.cc.o` and ` __GLOBAL__sub_I_vlog_is_on.cc in vlog_is_on.cc.o`. Apparently identical compiler is to be used. Similar issue: https://github.com/gflags/gflags/issues/203
Once `gflags` is built with the same compiler as used for `google-glog`, the latter builds fine too.
```
10:~ svacchanda$ port -v installed gflags
The following ports are currently installed:
  gflags @2.2.2_0 (active) requested_variants='' platform='darwin 10' archs='ppc' date='2022-08-10T00:26:32+0545'
10:~ svacchanda$ port -v installed google-glog
The following ports are currently installed:
  google-glog @0.6.0_0+gflags (active) requested_variants='' platform='darwin 10' archs='ppc' date='2022-08-10T00:49:00+0545'
```
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
