### PR TITLE
google-cloud-sdk: update to 397.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             396.0.0
+version             397.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  da2dad98aacb879f8ab40d72f7e13c1e87bc6120 \
-                    sha256  7a282fec457570e8af5291f1398908b792f3ec97156f880d4cc68f4774d335a7 \
-                    size    108562096
+    checksums       rmd160  481220036d967aa516ebca0592ac6fc7d769baa8 \
+                    sha256  278a0e00c6945516c8b28986cd97844888274dddc007d83dc10d997593f49d38 \
+                    size    108640837
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  2dc0960d24a8c8baffc2375ae7441d95796eea6e \
-                    sha256  e9962039a34f9436e42d516f68b778b271f02aea68514dcaef7d595679aa91a6 \
-                    size    106569346
+    checksums       rmd160  6d1c9ca42225f72004a82962ad6dfc0bb6d8db16 \
+                    sha256  fa96fce1c9ab1054ba7b4b6d5aaeb2694fa951b6d8bfe262beb32bb28e7a3e46 \
+                    size    106639892
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e0fcf09a2ce970cf8c6fb6226e73789323d38059 \
-                    sha256  5f3a0c6aab30901d9ec407332c3012c8076321e495efa6d37808942f40986e7f \
-                    size    105131133
+    checksums       rmd160  16e31d96d8327ad58eeb2279a31e72eff364f281 \
+                    sha256  ff346c9fde207381565f70962176b1b1ceafbb288b83ab0d01166e5daf03e642 \
+                    size    105205277
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 397.0.0.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?