### PR TITLE
vim, MacVim: Update to 9.0.0065

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -7,10 +7,10 @@ PortGroup           compiler_blacklist_versions 1.0
 # The vim port should always follow the patch level used in the MacVim port. This
 # is because they both share the same set of configuration files and ensures
 # that the user's configuration files will always work with both.
-set vim_version     8.2
-set snapshot        171
+set vim_version     9.0
+set snapshot        173
 github.setup        macvim-dev macvim ${snapshot} snapshot-
-revision            2
+revision            0
 name                MacVim
 version             ${vim_version}.snapshot${snapshot}
 categories          editors
@@ -25,9 +25,9 @@ long_description \
 
 homepage            https://macvim-dev.github.io/macvim/
 
-checksums           rmd160  884dc22e50e9ecf5acd8754d046674849b478e97 \
-                    sha256  51ee54b7c3b2dd5ec6d9856117ca12e90dd7694f06c8d40ca2830f375a6f8f76 \
-                    size    22966978
+checksums           rmd160  88e64d4c6c5352a998f92a759b2a64118f93f844 \
+                    sha256  edf8cb0cd4215281374af95585830721d7200020a081e213ecaf92c19710381a \
+                    size    24213601
 
 depends_lib         port:ncurses \
                     port:gettext \
@@ -77,7 +77,7 @@ configure.args      --enable-gui=macvim \
 build.args          XCODEFLAGS="CACHE_ROOT=${workpath}/caches"
 
 if {[vercmp ${xcodeversion} 12.0] >= 0} {
-    build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target} ARCHS=${configure.build_arch}"
+    build.args    XCODEFLAGS="-scheme MacVim -configuration Release -derivedDataPath ${workpath}/.home/DerivedData CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target} ARCHS=${configure.build_arch}"
 } elseif {[vercmp ${xcodeversion} 10.0] >= 0} {
     build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}"
 }

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -6,8 +6,8 @@ PortGroup           github 1.0
 # The vim port should always follow the patch level used in the MacVim port. This
 # is because they both share the same set of configuration files and ensures
 # that the user's configuration files will always work with both.
-set vim_version     8.2
-set vim_patchlevel  4324
+set vim_version     9.0
+set vim_patchlevel  0065
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v
 revision            0
 
@@ -23,9 +23,9 @@ long_description    Vim is an advanced text editor that seeks to provide the\
 
 homepage            https://www.vim.org/
 
-checksums           rmd160  ca008ee7734fd1753bbc7e91a2d498a5177ae642 \
-                    sha256  a2b842f258fda87446504df911c27fa4ea54084e5112722d419a8b63b2bd8027 \
-                    size    15981311
+checksums           rmd160  1ae829aec84c7101c2713d9712c060f32e55cac6 \
+                    sha256  0e2b58f34ea6faee10f06bfefb163cc4d27a6f1b69e068d581c4e224b850acb3 \
+                    size    16704943
 
 depends_lib         port:ncurses \
                     port:gettext \


### PR DESCRIPTION
#### Description

vim: Update to 9.0.0065
MacVim: Update to release 173 (Vim 9.0.0065)

Had to add -derivedDataPath to the xcode flags, because otherwise Xcode wanted to write to /opt/local/var/macports/home/Library/Xcode/DerivedData. Setting that flag also required setting -scheme, and without -configuration Release only the Debug build would be run.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
