### PR TITLE
folly: update to 2022.08.08.00, add fixes for gcc and older OS

### DIFF
--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -11,11 +11,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 19
 legacysupport.use_mp_libcxx                 yes
 
-github.setup        facebook folly 2022.06.06.00 v
-revision            3
-checksums           rmd160  b651b4493de3c8609517a03986c3245cde8f563d \
-                    sha256  ea082ca1c858d64331765a11c26de886e60cd644b413f12c65ffbea9221a7a2b \
-                    size    3638240
+github.setup        facebook folly 2022.08.08.00 v
+revision            0
+checksums           rmd160  aaaf802ce3318fb2a666201779d8d254a53e6dec \
+                    sha256  a8915c7191f36d5529a49b89c3fe6847db840e5e28a9456149352c0238a5776d \
+                    size    3684846
 
 categories          devel
 license             Apache-2

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -9,7 +9,11 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.1
 
 legacysupport.newest_darwin_requires_legacy 19
-legacysupport.use_mp_libcxx                 yes
+
+if {[string match *clang* ${configure.compiler}]} {
+    # Don’t use libcxx with gcc.
+    legacysupport.use_mp_libcxx yes
+}
 
 github.setup        facebook folly 2022.08.08.00 v
 revision            0
@@ -39,16 +43,6 @@ github.tarball_from releases
 distname            ${name}-v${version}
 extract.mkdir       yes
 
-platform darwin {
-    if {${os.major} < 16} {
-        known_fail      yes
-        pre-fetch {
-            ui_error "${subport} requires macOS 10.12 or later"
-            return -code error "incompatible macOS version"
-        }
-    }
-}
-
 set port_libfmt     libfmt9
 cmake.module_path-append \
                     ${prefix}/lib/${port_libfmt}/cmake
@@ -70,6 +64,16 @@ depends_lib-append  port:bzip2 \
 
 cmake.generator     Ninja
 
+patchfiles          patch-cmakelists.diff
+
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    patchfiles-append patch-older-systems.diff
+}
+
+if {${build_arch} in [list ppc ppc64]} {
+    patchfiles-append patch-darwin-ppc.diff
+}
+
 configure.args-append -DBUILD_SHARED_LIBS=ON -DFOLLY_USE_JEMALLOC=0
 
 compiler.cxx_standard   2017
@@ -84,13 +88,26 @@ platform darwin {
     # https://github.com/facebook/folly/issues/864
     if {${os.major} <= 16} {
         configure.args-append     -DCOMPILER_HAS_F_ALIGNED_NEW=OFF
-        configure.cxxflags-append -fno-aligned-allocation
+        # gcc does not recognize -fno-aligned-allocation
+        if {[string match *clang* ${configure.compiler}]} {
+            configure.cxxflags-append \
+                                  -fno-aligned-allocation
+        }
+    }
+    # https://kumasento.github.io/2020-06-12-glog-gflags-and-c-abi/
+    if {${os.major} < 16} {
+        configure.cxxflags-append -D_GLIBCXX_USE_CXX11_ABI=0
     }
     # Support for TCP fast-open was only added to macOS 10.11+
     if {${os.major} < 15} {
         configure.cxxflags-append -DFOLLY_ALLOW_TFO=0
     }
-    configure.cxxflags-append -DFOLLY_MOBILE=0
+    if {[string match *gcc* ${configure.compiler}]} {
+        # ___atomic_fetch_sub_8, ___atomic_load_8, ___atomic_exchange_8, ___atomic_store_8, ___atomic_compare_exchange_8, ___atomic_fetch_add_8
+        configure.ldflags-append  -latomic
+        # https://github.com/macports/macports-ports/pull/15689#issuecomment-1212969969
+        configure.ldflags-append  -L${prefix}/lib -lgflags
+    }
 }
 
 variant jemalloc description {Use je_malloc} {
@@ -101,5 +118,14 @@ variant jemalloc description {Use je_malloc} {
 }
 
 variant native description {Build with best native support for local CPU capabilities} {
-    configure.cxxflags-append -march=native
+    if {${build_arch} ni [list ppc ppc64]} {
+        # This flag is unsupported for PPC:
+        configure.cxxflags-append -march=native
+    }
+    if {${build_arch} eq "ppc"} {
+        configure.cxxflags-append -mtune=G4
+    }
+    if {${build_arch} eq "ppc64"} {
+        configure.cxxflags-append -mtune=G5
+    }
 }

--- a/devel/folly/files/patch-cmakelists.diff
+++ b/devel/folly/files/patch-cmakelists.diff
@@ -1,0 +1,32 @@
+--- CMakeLists.txt.orig.txt	2022-07-30 03:08:35.000000000 +0545
++++ CMakeLists.txt	2022-08-11 21:23:56.000000000 +0545
+@@ -230,6 +230,16 @@
+ endif()
+ 
+ # base64 SIMD files compilation
++
++if (APPLE AND CMAKE_OSX_ARCHITECTURES STREQUAL "ppc")
++  message(
++    STATUS
++    "PowerPC Big Endian has a limited support, "
++    "skipping building Base64SWAR of base64"
++  )
++  list(REMOVE_ITEM files ${FOLLY_DIR}/detail/base64_detail/Base64SWAR.cpp)
++endif()
++
+ if (${IS_X86_64_ARCH})
+   message(
+     STATUS
+
+
+--- CMake/folly-deps.cmake.orig	2022-08-12 00:46:34.000000000 +0545
++++ CMake/folly-deps.cmake	2022-08-12 00:33:29.000000000 +0545
+@@ -247,7 +247,7 @@
+   FOLLY_STDLIB_LIBCPP
+ )
+ 
+-if (APPLE)
++if (APPLE AND NOT(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+   list (APPEND CMAKE_REQUIRED_LIBRARIES c++abi)
+   list (APPEND FOLLY_LINK_LIBRARIES c++abi)
+ endif ()

--- a/devel/folly/files/patch-darwin-ppc.diff
+++ b/devel/folly/files/patch-darwin-ppc.diff
@@ -1,0 +1,79 @@
+--- folly/Portability.h.orig	2022-07-30 03:08:35.000000000 +0545
++++ folly/Portability.h	2022-08-10 23:12:09.000000000 +0545
+@@ -103,12 +103,18 @@
+ #define FOLLY_AARCH64 0
+ #endif
+ 
+-#if defined(__powerpc64__)
++#if defined(__powerpc64__) || defined(__ppc64__)
+ #define FOLLY_PPC64 1
+ #else
+ #define FOLLY_PPC64 0
+ #endif
+ 
++#if defined(__ppc__)
++#define FOLLY_PPC 1
++#else
++#define FOLLY_PPC 0
++#endif
++
+ #if defined(__s390x__)
+ #define FOLLY_S390X 1
+ #else
+@@ -120,6 +126,7 @@
+ constexpr bool kIsArchAmd64 = FOLLY_X64 == 1;
+ constexpr bool kIsArchAArch64 = FOLLY_AARCH64 == 1;
+ constexpr bool kIsArchPPC64 = FOLLY_PPC64 == 1;
++constexpr bool kIsArchPPC = FOLLY_PPC == 1;
+ constexpr bool kIsArchS390X = FOLLY_S390X == 1;
+ } // namespace folly
+ 
+@@ -318,6 +325,9 @@
+ #else
+ constexpr auto kIsLittleEndian = true;
+ #endif
++#elif defined(__APPLE__) && defined(__POWERPC__)
++// Darwin ppc/ppc64
++constexpr auto kIsLittleEndian = false;
+ #else
+ constexpr auto kIsLittleEndian = __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__;
+ #endif
+
+
+# https://github.com/mr-c/misc/wiki/pause-techniques-on-many-architectures
+--- folly/portability/Asm.h.orig	2022-07-30 03:08:35.000000000 +0545
++++ folly/portability/Asm.h	2022-08-10 23:07:57.000000000 +0545
+@@ -41,8 +41,10 @@
+   asm volatile("pause");
+ #elif FOLLY_AARCH64 || (defined(__arm__) && !(__ARM_ARCH < 7))
+   asm volatile("yield");
+-#elif FOLLY_PPC64
++#elif FOLLY_PPC64 && !(defined(__APPLE__))
+   asm volatile("or 27,27,27");
++#elif (FOLLY_PPC || FOLLY_PPC64) && defined(__APPLE__)
++  __asm__ volatile ("or r27,r27,r27" ::: "memory");
+ #endif
+ }
+ } // namespace folly
+
+
+# https://github.com/facebook/folly/issues/1834
+--- folly/detail/base64_detail/Base64Api.cpp.orig	2022-08-14 12:11:09.000000000 +0700
++++ folly/detail/base64_detail/Base64Api.cpp	2022-08-14 12:19:29.000000000 +0700
+@@ -31,10 +31,16 @@
+         base64URLDecodeSWAR};
+   }
+ #endif
++#if defined(__POWERPC__) // PowerPC BE
++  return {
++      base64EncodeScalar,
++      base64URLEncode};
++#else // Everything but PowerPC BE
+   return {
+       base64EncodeScalar,
+       base64URLEncodeScalar,
+       base64DecodeSWAR,
+       base64URLDecodeSWAR};
++#endif
+ }
+ } // namespace folly::detail::base64_detail

--- a/devel/folly/files/patch-older-systems.diff
+++ b/devel/folly/files/patch-older-systems.diff
@@ -1,0 +1,158 @@
+# https://github.com/macports/macports-ports/pull/15689#issuecomment-1211163024
+# https://github.com/facebook/folly/issues/1833
+--- folly/File.cpp.orig	2022-07-30 03:08:35.000000000 +0545
++++ folly/File.cpp	2022-08-11 19:15:42.000000000 +0545
+@@ -120,8 +120,10 @@
+     int fd;
+ #ifdef _WIN32
+     fd = ::dup(fd_);
+-#else
++#elseif defined(F_DUPFD_CLOEXEC)
+     fd = ::fcntl(fd_, F_DUPFD_CLOEXEC, 0);
++#else
++    fd = ::dup(fd_);
+ #endif
+     checkUnixError(fd, "dup() failed");
+ 
+
+# TASK_INFO: https://github.com/bear-metal/tunemygc/commit/9652a759ab4eba7caa7a333383ebd7461e3040cf
+# Can CLOCK_PROCESS_CPUTIME_ID and CLOCK_THREAD_CPUTIME_ID be borrowed?
+# https://opensource.apple.com/source/Libc/Libc-1158.50.2/gen/clock_gettime.c.auto.html
+--- folly/portability/Time.cpp.orig	2022-07-30 03:08:35.000000000 +0545
++++ folly/portability/Time.cpp	2022-08-12 00:53:36.000000000 +0545
+@@ -37,11 +37,13 @@
+ #if !FOLLY_HAVE_CLOCK_GETTIME || FOLLY_FORCE_CLOCK_GETTIME_DEFINITION
+ #if __MACH__
+ #include <errno.h>
++#include <sys/types.h>
+ #include <mach/mach_init.h> // @manual
+ #include <mach/mach_port.h> // @manual
+ #include <mach/mach_time.h> // @manual
+ #include <mach/mach_types.h> // @manual
+ #include <mach/task.h> // @manual
++#include <mach/task_info.h> // for MacOS <= Lion
+ #include <mach/thread_act.h> // @manual
+ #include <mach/vm_map.h> // @manual
+ 
+@@ -64,6 +66,7 @@
+   }
+ 
+   // Get CPU usage for terminated threads.
++#ifdef MACH_TASK_BASIC_INFO
+   mach_task_basic_info task_basic_info;
+   mach_msg_type_number_t task_basic_info_count = MACH_TASK_BASIC_INFO_COUNT;
+   kern_result = task_info(
+@@ -74,6 +77,18 @@
+   if (UNLIKELY(kern_result != KERN_SUCCESS)) {
+     return -1;
+   }
++#else
++  task_basic_info task_basic_info;
++  mach_msg_type_number_t task_basic_info_count = TASK_BASIC_INFO_COUNT;
++  kern_result = task_info(
++      mach_task_self(),
++      TASK_BASIC_INFO,
++      (thread_info_t)&task_basic_info,
++      &task_basic_info_count);
++  if (UNLIKELY(kern_result != KERN_SUCCESS)) {
++    return -1;
++  }
++#endif
+ 
+   auto cputime = time_value_to_ns(thread_times_info.user_time) +
+       time_value_to_ns(thread_times_info.system_time) +
+@@ -99,6 +114,7 @@
+   return 0;
+ }
+ 
++#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 101100
+ FOLLY_ATTR_WEAK int clock_gettime(clockid_t clk_id, struct timespec* ts) {
+   switch (folly::to_underlying(clk_id)) {
+     case CLOCK_REALTIME: {
+@@ -120,6 +136,7 @@
+       return -1;
+   }
+ }
++#endif
+ 
+ int clock_getres(clockid_t clk_id, struct timespec* ts) {
+   if (clk_id != CLOCK_MONOTONIC) {
+@@ -190,6 +207,7 @@
+       res->tv_nsec = time_t(perSec * kNsPerSec);
+       return 0;
+     }
++#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 101100
+     case CLOCK_PROCESS_CPUTIME_ID:
+     case CLOCK_THREAD_CPUTIME_ID: {
+       DWORD adj, timeIncrement;
+@@ -198,12 +216,11 @@
+         errno = EINVAL;
+         return -1;
+       }
+-
+       res->tv_sec = 0;
+       res->tv_nsec = long(timeIncrement * 100);
+       return 0;
+     }
+-
++#endif
+     default:
+       errno = EINVAL;
+       return -1;
+@@ -236,6 +253,7 @@
+       duration_to_ts(now, tp);
+       return 0;
+     }
++#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 101100
+     case CLOCK_PROCESS_CPUTIME_ID: {
+       if (!GetProcessTimes(
+               GetCurrentProcess(),
+@@ -268,7 +286,7 @@
+           filetimeToUnsignedNanos(kernalTime) +
+               filetimeToUnsignedNanos(userTime));
+     }
+-
++#endif
+     default:
+       errno = EINVAL;
+       return -1;
+
+
+--- folly/system/ThreadId.cpp.orig	2022-07-30 03:08:35.000000000 +0545
++++ folly/system/ThreadId.cpp	2022-08-12 00:37:48.000000000 +0545
+@@ -40,9 +40,18 @@
+ 
+ uint64_t getOSThreadIDSlow() {
+ #if __APPLE__
+-  uint64_t tid;
+-  pthread_threadid_np(nullptr, &tid);
+-  return tid;
++    #if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
++         uint64_t tid;
++         tid = pthread_mach_thread_np(pthread_self());
++     #elif MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++             uint64_t tid;
++             tid = pthread_mach_thread_np(pthread_self());
++         }
++     #else
++        uint64_t tid;
++        pthread_threadid_np(nullptr, &tid);
++        return tid;
++     #endif
+ #elif defined(_WIN32)
+   return uint64_t(GetCurrentThreadId());
+ #elif defined(__FreeBSD__)
+
+
+--- folly/net/TcpInfoTypes.h.orig	2022-08-06 08:35:42.000000000 +0700
++++ folly/net/TcpInfoTypes.h	2022-08-14 19:19:26.000000000 +0700
+@@ -179,7 +179,7 @@
+   __u32 tcpi_total_retrans;
+ };
+ 
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003
+ #define FOLLY_HAVE_TCP_INFO 1
+ using tcp_info = ::tcp_connection_info;
+ const int tcp_info_sock_opt = TCP_CONNECTION_INFO;
+


### PR DESCRIPTION
#### Description

This PR:
1. Updates the port to 2022.08.08.00.
2. Adds fixes for building with GCC and corrects portfile to that end.
3. Fixes the build for PPC and possibly older Intel.
4. _TCP provisionally fixed: no more excluding files from the build._

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
