### PR TITLE
leiningen: use codeberg for master_sites, update version to 2.9.10

### DIFF
--- a/devel/leiningen/Portfile
+++ b/devel/leiningen/Portfile
@@ -2,10 +2,9 @@
 
 PortSystem          1.0
 PortGroup           java 1.0
-# *sigh* can't seem to get the git portgroup to have additional distfiles, so do everything manually
 
 name                leiningen
-version             2.9.8
+version             2.9.10
 categories          devel java
 maintainers         {easieste @easye} openmaintainer
 platforms           darwin
@@ -17,9 +16,12 @@ long_description    {*}${description}
 
 homepage            https://leiningen.org
 
+# Codeberg attachments use UUIDs for non-source archives
+set uuid 60dddfb3-74f1-4177-945a-a4ccfe8f7d88
+
 master_sites \
-    https://github.com/technomancy/leiningen/archive/:source \
-    https://github.com/technomancy/leiningen/releases/download/${version}/:standalone
+    https://codeberg.org/leiningen/leiningen/archive/:source \
+    https://codeberg.org/attachments/${uuid}?dummy=:standalone
 
 distfiles           \
     ${version}.tar.gz:source \
@@ -27,13 +29,13 @@ distfiles           \
 
 checksums           \
     ${version}.tar.gz \
-                    rmd160  11dcbc678c383b9dff071a2152afccf3d1a89606 \
-                    sha256  be299cbd70693213c6887f931327fb9df3bd54930a521d0fc88bea04d55c5cd4 \
-                    size    924543 \
+                    rmd160  4d4e0a11f6316fb6169a7914bcbbf92f079264b7 \
+                    sha256  abc47643ff10c5bcafec32d1c2f704e005d3781a316223dd4db370e4c0646f47 \
+                    size    969381 \
     leiningen-${version}-standalone.jar \
-                    rmd160  26a078d5dffb7e1acf4d8eac98ceaf56df8a0164 \
-                    sha256  2a0e9114e0d623c748a9ade5d72b54128b31b5ddb13f51b04c533f104bb0c48d \
-                    size    12834369
+                    rmd160  6085b1836d587f2671c9cde335f6c558e83f8605 \
+                    sha256  9d02547e1b80b65e7ae64a710840cf3ac288a7da2eddc0ea21581b98671de94c \
+                    size    13201118
 
 java.version    1.8+
 


### PR DESCRIPTION
#### Description
* closes https://trac.macports.org/ticket/65647
* use codeberg in master_sites
* update version to 2.9.10
* remove outdated comment that applies to the GitHub portgroup

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
