### PR TITLE
dnscontrol: update to 3.18.1

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/StackExchange/dnscontrol 3.18.0 v
+go.setup            github.com/StackExchange/dnscontrol 3.18.1 v
 
-checksums           rmd160  dfe7374f28331d2a96c45e2dd866cd596c94588b \
-                    sha256  baa62cf19eda2da6f689c30f775096ef5870ef09128a5fc9b5c02fb9771bb209 \
-                    size    2292850
+checksums           rmd160  d718f8be18ec2d14d721b69e39964363dfe59ea8 \
+                    sha256  cfb0e74331ab27d43adc68f99f2ddb384c2d718869dd66a9b39c93351d73b620 \
+                    size    2296781
 
 homepage            https://stackexchange.github.io/dnscontrol/
 description         Synchronize your DNS to multiple providers from a simple DSL


### PR DESCRIPTION
#### Description
dnscontrol: update to 3.18.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
