### PR TITLE
flux: update to 0.32.0

### DIFF
--- a/sysutils/flux/Portfile
+++ b/sysutils/flux/Portfile
@@ -3,12 +3,12 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/fluxcd/flux2 0.31.5 v
+go.setup                github.com/fluxcd/flux2 0.32.0 v
 name                    flux
 
-checksums               rmd160  79c85a30fc055d752a66b76e556814adcef1d315 \
-                        sha256  b78745876389b8cde5b7b3c84a9ce6f4ad8b89475d89b1b8fe501ee692a4efb4 \
-                        size    387637
+checksums               rmd160  6b4fdf902fd7ff5760296a9a01f9c1dec3c3ee6a \
+                        sha256  38a9ed0be03a6d12308f46e3b795f8defd3a3f7a855ab9ac204cc4cd579d0945 \
+                        size    416234
 
 homepage                https://fluxcd.io/
 description             Flux CLI


### PR DESCRIPTION
#### Description
flux: update to 0.32.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
