### PR TITLE
openjdk18-openj9: update to 18.0.2

### DIFF
--- a/java/openjdk18-openj9/Portfile
+++ b/java/openjdk18-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      18.0.1.1
+version      18.0.2
 revision     0
 
-set build    2
-set openj9_version 0.32.0
+set build    9
+set openj9_version 0.33.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 18
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru18-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  f558c50664ca6956526dc86de154155ba56a75f3 \
-                 sha256  d6f262cb6077af35d18f0405b4133c9cf4014d4909589d8bdf0af0f350be9abc \
-                 size    209566466
+    checksums    rmd160  6f744cf87b47ea3a297478eb1ee6cdcad1708813 \
+                 sha256  08387494d81de88831a0d4c15c4a1b99be3397c2ec97a4216a5919077457bb52 \
+                 size    210567465
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  4db1c989eaf310956dd9764b03be8d2cf4e1b142 \
-                 sha256  38f9b44bcaf1d472720beac31f6b76b29b6a73db8e5631f685eca70787c58200 \
-                 size    186329294
+    checksums    rmd160  5c1108f83455fb782b039c20ce2345211d71ec0a \
+                 sha256  69abcd5542b3befb4c766674742fb0ad16b9d9a9541fa3cae0d9673217e6f888 \
+                 size    203771879
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 18.0.2.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?