### PR TITLE
openjdk17-openj9: update to 17.0.4

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      17.0.3
+version      17.0.4
 revision     0
 
-set build    7
-set openj9_version 0.32.0
+set build    8
+set openj9_version 0.33.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  60056a13b8e1b82d6e892a410d9902aac0f8ab17 \
-                 sha256  b4439c09ee0916a328f8aa8e4bd98e45b3621bbb3e2ecc59b81f98fa2ec7704a \
-                 size    208108149
+    checksums    rmd160  77c206691f73d594a074fea444896fc7352322af \
+                 sha256  a935f20564e347a9292955c04eb57e51efdb1853ae7f0b4fe759b22c9fe248be \
+                 size    209040959
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  6b81cbede0f3116a9c73f8db3a76084da6a5ffa2 \
-                 sha256  14d7a9f8aed106bdf964882fe693073ee73dffa06fe3878ce57a8c0e5737364b \
-                 size    184852257
+    checksums    rmd160  aa2b62c4e835a229182cb18e10a6b7545af36181 \
+                 sha256  bf22628b54115dff9939b94751531544ab735b7cbbc8d6ddfe83d1b04df3a532 \
+                 size    202269399
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.4.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?