### PR TITLE
openjdk11-openj9: update to 11.0.16

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.15
+version      11.0.16
 revision     0
 
-set build    10
-set openj9_version 0.32.0
+set build    8
+set openj9_version 0.33.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  2d8d7a2633be194c0975642e9b3ef070c9f55a97 \
-                 sha256  53d18ed227d02ebc73344255a07b6331aa7d990abfd12fce1396376afcfd17cc \
-                 size    203564021
+    checksums    rmd160  3b407dad625ad56c02e8170182f01aa260272959 \
+                 sha256  8638735d2cae3efff212f898728685380355bb0a298076e9e46244d0bf3d4a64 \
+                 size    204217112
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  5c09b0cd81b4466b320a7c997c9ba2eaf67933f6 \
-                 sha256  f71a81f3496ad5cda9bb1f2f23dbb47360202dedca126cf8e92437b3f017d11e \
-                 size    180597648
+    checksums    rmd160  0d3ed07ae0ef6dcb1a31ae3eaa5f775853033794 \
+                 sha256  9881b292142a129f6f5c6b21608b090f8f94625052b4f7d0ce5bd982c054ca2e \
+                 size    198390114
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.16.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?