### PR TITLE
openjdk8-openj9: update to 8u345

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -124,11 +124,11 @@ subport openjdk8-openj9 {
     # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
     supported_archs  x86_64
 
-    version      8u332
+    version      8u345
     revision     0
 
-    set build    09
-    set openj9_version 0.32.0
+    set build    01
+    set openj9_version 0.33.0
 
     homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
@@ -139,9 +139,9 @@ subport openjdk8-openj9 {
     distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  2311bc6a6bc259adee9c7bba01f0133ce2846f21 \
-                 sha256  f4b1ec4b1ba3eb318642ddcbb0c02d67e6edfc9e37a7c3bfb13630e4806942e2 \
-                 size    128972742
+    checksums    rmd160  1a4b825178e0268db47bace8b690596ad5e80efa \
+                 sha256  c69086950c006b17484a70ef7bc85e92d121be15e69e282e1446fd238d42b6b4 \
+                 size    129519233
 }
 
 subport openjdk8-temurin {


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8u345.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?