### PR TITLE
httpie: update to 3.2.1

### DIFF
--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        httpie httpie 3.1.0
+github.setup        httpie httpie 3.2.1
 
 maintainers         nomaintainer
 categories          net
@@ -26,13 +26,15 @@ variant python310 conflicts python37 python38 python39 description "Use Python 3
 
 if {[variant_isset python37]} {
     python.default_version 37
+    depends_lib-append port:py${python.version}-typing_extensions
+} elseif {[variant_isset python38]} {
+    python.default_version 38
+    depends_lib-append port:py${python.version}-typing_extensions
 } elseif {[variant_isset python39]} {
     python.default_version 39
-} elseif {[variant_isset python310]} {
-    python.default_version 310
 } else {
-    default_variants +python38
-    python.default_version 38
+    default_variants +python310
+    python.default_version 310
 }
 
 depends_lib-append  port:py${python.version}-requests \
@@ -41,10 +43,17 @@ depends_lib-append  port:py${python.version}-requests \
                     port:py${python.version}-socks \
                     port:py${python.version}-charset-normalizer \
                     port:py${python.version}-defusedxml \
-                    port:py${python.version}-multidict
+                    port:py${python.version}-multidict \
+                    port:py${python.version}-rich \
+                    port:py${python.version}-pip
 
-checksums           rmd160  cd93e40be405dc303adeb65957d5d000dbdf3a19 \
-                    sha256  0debb527b90acd2641c0b6474bec1cb6e4dc0d9a46b2c0c47c73ef05043ef4c0 \
-                    size    1189673
+checksums           rmd160  1aadb0db6311783ed8311a8d2a7c1b0494e4b46c \
+                    sha256  889c9f411fc95e4352f0495021c087ddcc6b381154d453f6424d55f0e5c23315 \
+                    size    1276567
 
 python.link_binaries_suffix
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0444 {*}[glob ${worksrcpath}/extras/man/*.1] ${destroot}${prefix}/share/man/man1
+}


### PR DESCRIPTION
#### Description

- Update httpie to 3.2.1
- Change default variant to python310
- Add new dependency on py-rich
- Add missing dependencies on py-pip and py-typing_extensions (only for older Python versions)
- Install man pages

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
