### PR TITLE
gitweb: update to 0.3.5

### DIFF
--- a/devel/gitweb/Portfile
+++ b/devel/gitweb/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 PortGroup           openssl 1.0
 
-github.setup        yoannfleurydev gitweb 0.3.3 v
-revision            3
+github.setup        yoannfleurydev gitweb 0.3.5 v
+revision            0
 
 description         Open the current remote git repository in your browser
 
@@ -20,15 +20,13 @@ license             Apache-2
 installs_libs       no
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6def2576a27d639726ff3da4d5cfe1726acb2288 \
-                    sha256  484b1c56973e06c2ad7b33ccdaafa8ef6fba236681c7f8cd04027738b5335cd3 \
-                    size    5907311
+                    rmd160  c1239b3c9fff15a5f15e489b2adc4bc26c6ddbba \
+                    sha256  65414eeefc7bb7b7970799cdfd2156d8393deb0707674670c47c95e6d3364c96 \
+                    size    5908538
 
 # Not yet ready for openssl 3
 # https://trac.macports.org/ticket/63959
 openssl.branch      1.1
-
-depends_build-append port:pkgconfig
 
 depends_lib-append  port:libgit2
 
@@ -41,41 +39,56 @@ destroot {
 }
 
 cargo.crates \
+    addr2line                       0.16.0  3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
     aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
-    anyhow                          1.0.44  61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1 \
+    anyhow                          1.0.56  4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    backtrace                       0.3.61  e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01 \
     bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    cc                              1.0.61  ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d \
+    cc                              1.0.72  22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
     clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
-    flexi_logger                    0.19.4  35627d78fcea84d52181369fe48fcfce56a2a18e29443dba23d4c24b650fb107 \
+    color-eyre                      0.5.11  1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7 \
+    color-spantrace                  0.1.6  b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1 \
+    eyre                             0.6.5  221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b \
+    flexi_logger                    0.22.3  969940c39bc718475391e53a3a59b0157e64929c80cf83ad5dde5f770ecdc423 \
     form_urlencoded                  1.0.1  5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
-    git-url-parse                    0.3.1  ad6e3b1adb6fd23071df9ec0d5042636daff11333e8bcd7ed3d1dd7ad4f964a9 \
-    git2                           0.13.22  9c1cbbfc9a1996c6af82c2b4caf828d2c653af4fcdbb0e5674cc966eee5a4197 \
+    gimli                           0.25.0  f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7 \
+    git-url-parse                    0.4.0  4b223a4c4957b1b46e7bd24cb361bef01dbedff634463e57dfb1b1863dff704c \
+    git2                            0.14.1  6e7d3b96ec1fcaa8431cf04a4f1ef5caafe58d5cf7bcc31f09c1626adddb0ffe \
     glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
     heck                             0.3.1  20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
     hermit-abi                      0.1.17  5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8 \
     idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
+    indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
+    itoa                             1.0.1  1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35 \
     jobserver                       0.1.21  5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                            0.2.79  2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743 \
-    libgit2-sys              0.12.23+1.2.0  29730a445bae719db3107078b46808cc45a5b7a6bae3f31272923af969453356 \
+    libc                           0.2.107  fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219 \
+    libgit2-sys                   0.13.1+1.4.2  43e598aa7a4faedf1ea1b4608f582b06f0f40211eec551b7ef36019ae3f62def \
     libssh2-sys                     0.2.19  ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056 \
     libz-sys                         1.1.2  602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655 \
     log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
     memchr                           2.4.0  b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc \
-    num-integer                     0.1.43  8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b \
-    num-traits                      0.2.12  ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611 \
-    open                             2.0.1  b46b233de7d83bc167fe43ae2dda3b5b84e80e09cceba581e4decb958a4896bf \
+    miniz_oxide                      0.4.4  a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b \
+    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
+    num-traits                      0.2.14  9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290 \
+    num_threads                      0.1.3  97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15 \
+    object                          0.26.0  c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386 \
+    once_cell                        1.8.0  692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56 \
+    open                             2.1.1  9213e7b66aa06a7722828ee2980c1adff22a3922b582baaa1e62e30ca2a6c018 \
     openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
     openssl-sys                     0.9.58  a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
+    owo-colors                       1.3.0  2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55 \
     pathdiff                         0.2.0  877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34 \
     percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pin-project-lite                 0.2.7  8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443 \
     pkg-config                      0.3.18  d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33 \
     proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
@@ -83,18 +96,27 @@ cargo.crates \
     quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
     regex                            1.5.3  ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b \
     regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
+    rustc-demangle                  0.1.21  7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342 \
     rustversion                      1.0.5  61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088 \
+    sharded-slab                     0.1.4  900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    structopt                       0.3.23  bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa \
-    structopt-derive                0.4.16  134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba \
-    strum                           0.20.0  7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c \
-    strum_macros                    0.20.1  ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149 \
+    structopt                       0.3.26  0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10 \
+    structopt-derive                0.4.18  dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0 \
+    strum                           0.22.0  f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e \
+    strum_macros                    0.22.0  339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb \
     syn                             1.0.48  cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-    thiserror                       1.0.29  602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88 \
-    thiserror-impl                  1.0.29  bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c \
-    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
+    thiserror                       1.0.30  854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417 \
+    thiserror-impl                  1.0.30  aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b \
+    thread_local                     1.1.3  8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd \
+    time                             0.3.7  004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d \
+    time-macros                      0.2.3  25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6 \
     tinyvec                          0.3.4  238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117 \
+    tracing                         0.1.29  375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105 \
+    tracing-attributes              0.1.18  f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e \
+    tracing-core                    0.1.21  1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4 \
+    tracing-error                    0.1.2  b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24 \
+    tracing-subscriber              0.2.25  0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71 \
     unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
     unicode-normalization           0.1.13  6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977 \
     unicode-segmentation             1.6.0  e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0 \
@@ -104,7 +126,6 @@ cargo.crates \
     vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
     version_check                    0.9.2  b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed \
-    wasi     0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f


### PR DESCRIPTION
#### Description
gitweb: update to 0.3.5

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
