### PR TITLE
clisp: update to 2.50.0

### DIFF
--- a/lang/clisp/Portfile
+++ b/lang/clisp/Portfile
@@ -2,10 +2,12 @@
 
 PortSystem      1.0
 PortGroup       compiler_blacklist_versions 1.0
+PortGroup       gitlab 1.0
 
-name            clisp
-version         2.49.92
-revision        1
+gitlab.setup    gnu-clisp clisp 16b1cd19000ea018ea82a07d08fa3bc5b46ad55b
+version         2.50.0
+
+revision        0
 categories      lang
 maintainers     {easieste @easye} openmaintainer
 platforms       darwin
@@ -24,13 +26,10 @@ long_description        \
   Maxima, ACL2 and many other Common Lisp packages.
 
 homepage        https://www.clisp.org
-master_sites    https://alpha.gnu.org/gnu/clisp/
 
-checksums       md5     edb0e61a66693bfb246d157b75df195a \
-                sha1    7782db3789b12ac3a2f518b47bfbc13088c3ebb8 \
-                rmd160  7dea9e01b52b95b765fd0ea32cf613ecc5ca5b7a \
-                sha256  bd443a94aa9b02da4c4abbcecfc04ffff1919c0a8b0e7e35649b86198cd6bb89 \
-                size    8919616
+checksums       rmd160  95a1293787bfc253e0c8d73197a2a4d8361ad829 \
+                sha256  259592f42620910b6b1c044660136cf1e076e106f56d9bcc77d82fd95692b668 \
+                size    8800864
 
 depends_lib     port:readline   \
                 port:gettext    \


### PR DESCRIPTION
#### Description
This updates the Portfile to pull in from the GNU CLISP GitLab
repository, where current developemnt of GNU CLISP continues. While a
formal release has not been made, Bruno Haible (the maintainer of the
software) has cut out a "clisp-2.50.0" branch for those wanting a
release of GNU CLISP. The commit we use is the HEAD of this branch.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
