### PR TITLE
broot: remove xorg-libxcb dependency

### DIFF
--- a/sysutils/broot/Portfile
+++ b/sysutils/broot/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        Canop broot 1.14.2 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://dystroy.org/broot
 
@@ -30,7 +30,6 @@ checksums           ${distname}${extract.suffix} \
                     size    10043403
 
 depends_lib-append  port:libgit2 \
-                    port:xorg-libxcb \
                     port:zlib
 
 destroot {


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65661

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port destroot`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
