### PR TITLE
afscompress: enable LZVN/LZFSE support

### DIFF
--- a/sysutils/afscompress/Portfile
+++ b/sysutils/afscompress/Portfile
@@ -5,8 +5,10 @@ PortGroup            cmake 1.1
 PortGroup            github 1.0
 
 github.setup         RJVB afsctool 1.7.2
+set lzfse_version    e634ca58b4821d9f3d560cdc6df5dec02ffc93fd
 
 name                 afscompress
+revision             1
 categories           sysutils
 platforms            darwin
 license              GPL-3
@@ -27,9 +29,17 @@ long_description     AFSC (Apple File System Compression) tool is a utility that
     to specify an arbitrary (though positive :)) number of threads that will \
     compress the specified files in parallel.
 
-checksums            sha256  cc4ca89af59cede79c32722d92bdb805d4cb93a9e9117e8e23b83eda1aa93ca7 \
+master_sites-append  https://github.com/lzfse/lzfse/archive/:lzfse
+distfiles-append     ${lzfse_version}.tar.gz:lzfse
+
+checksums            afsctool-${version}.tar.gz \
+                     sha256  cc4ca89af59cede79c32722d92bdb805d4cb93a9e9117e8e23b83eda1aa93ca7 \
                      rmd160  9237a055a04c83f1203865ac5231680f9e86b288 \
-                     size    111841
+                     size    111841 \
+                     ${lzfse_version}.tar.gz \
+                     sha256  ca98aa6644d44500e3315858daa747ce15bd06d49e3edb12a5458e5525e8ebdb \
+                     rmd160  2a571ba71473d3e46b3e82f2c212d2867a207c63 \
+                     size    50694
 
 depends_build-append port:pkgconfig
 
@@ -43,6 +53,11 @@ pre-fetch {
         ui_error "${name} is only compatible with Mac OS X 10.6 or later; earlier versions lack support for HFS compression."
         return -code error "incompatible Mac OS X version"
     }
+}
+
+post-extract {
+    file delete -force ${worksrcpath}/src/private/lzfse
+    ln -s ${workpath}/lzfse-${lzfse_version} ${worksrcpath}/src/private/lzfse
 }
 
 compiler.cxx_standard  2011


### PR DESCRIPTION
#### Description

Support of this compression algorithms was made via required submodule.

Unfortunately GitHub PG doesn’t support such feature :( So I implemented it by hand.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 x86_64
Xcode 13.4.1 13F100

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?