### PR TITLE
postgresql12: version bump to 12.12

### DIFF
--- a/databases/postgresql12-doc/Portfile
+++ b/databases/postgresql12-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql12-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc \
     postgresql13-doc
-version             12.11
+version             12.12
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -22,9 +22,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql12
 
-checksums           rmd160  f2f024b92771a88b394b04bbe8a09626eafc175b \
-                    sha256  1026248a5fd2beeaf43e4c7236ac817e56d58b681a335856465dfbc75b3e8302 \
-                    size    21086745
+checksums           rmd160  97003e54c9737fac0d3df995ebb37519f57456e2 \
+                    sha256  34b3f1c69408e22068c0c71b1827691f1c89153b0ad576c1a44f8920a858039c \
+                    size    21089064
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql12-server/Portfile
+++ b/databases/postgresql12-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql12-server
-version             12.11
+version             12.12
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql12/Portfile
+++ b/databases/postgresql12/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql12
-version             12.11
+version             12.12
 revision            0
 
 categories          databases
@@ -27,9 +27,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  f2f024b92771a88b394b04bbe8a09626eafc175b \
-                    sha256  1026248a5fd2beeaf43e4c7236ac817e56d58b681a335856465dfbc75b3e8302 \
-                    size    21086745
+checksums           rmd160  97003e54c9737fac0d3df995ebb37519f57456e2 \
+                    sha256  34b3f1c69408e22068c0c71b1827691f1c89153b0ad576c1a44f8920a858039c \
+                    size    21089064
 
 use_bzip2           yes
 


### PR DESCRIPTION
#### Description

Upate to 12.12

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix: https://www.postgresql.org/about/news/postgresql-145-138-1212-1117-1022-and-15-beta-3-released-2496/

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
