### PR TITLE
miniflux: update to 2.0.38

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.37
+go.setup            github.com/miniflux/v2 2.0.38
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  b789b78000a16e9713b2476217f1b7c46802b505 \
-                        sha256  2f8d0b45bf3c3467e53ba08d1c6d9b169a259b8ba733e25037e00f6abf613896 \
-                        size    555483
+                        rmd160  616dce442eafb34404f702b20096b7bc2fb42ac7 \
+                        sha256  91f7c09381e412caabe45792eb84bc75403f1625fd3456f98eaf93be9acb663b \
+                        size    568515
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -38,66 +38,66 @@ go.vendors          mvdan.cc/xurls \
                         size    308121 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.26.0 \
-                        rmd160  6923d4e51b34904c6ba0d2b5f9aa69b8e131b3c3 \
-                        sha256  39c8b81c37f468a07b91f526de0fce90631368eec08c2bdb8fdf958d986a233a \
-                        size    1270531 \
+                        lock    v1.28.1 \
+                        rmd160  b6e8eb6d53889424dd6b451c20ac9b72de99a639 \
+                        sha256  0bf41d25ed04a6a4ac9d9cb33031b50718a64ca76b0e9853dabdade80ee34f3b \
+                        size    1281110 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.6 \
                         rmd160  ee3e5a6d2742607fd310e18634c1268156f39ad4 \
                         sha256  084ba3a248eccd0c7606dc6cff3918326a0adb2e8d30babcbaf6f1c00e1d28f9 \
                         size    333013 \
-                    golang.org/x/xerrors \
-                        lock    5ec99f83aff1 \
-                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
-                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
-                        size    13667 \
                     golang.org/x/text \
-                        lock    v0.3.6 \
-                        rmd160  e3da48fcc60d98e202458228188bf6dac408e309 \
-                        sha256  6b2d69df22b5ba1634bc6730c3f03404db499536a96c48b8016da80ced804450 \
-                        size    8356058 \
+                        lock    v0.3.7 \
+                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
+                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
+                        size    8356115 \
                     golang.org/x/sys \
-                        lock    da31bd327af9 \
-                        rmd160  d8b0df85d70b8cbb71b19b9cc280f0c8f7b855b5 \
-                        sha256  64217c9d7c5d88f4c9ce502dd660576d70fc89ad31c22916ab2616123fa58d02 \
-                        size    1257082 \
+                        lock    bc2c85ada10a \
+                        rmd160  c4b2c26618cd3f02fe04653b3a4fbe6707de5716 \
+                        sha256  b2526b52942c803a1687e16f87942bd0f0701b5d260fbaa35d53231e0a520577 \
+                        size    1303117 \
                     golang.org/x/oauth2 \
-                        lock    f6687ab2804c \
-                        rmd160  4e0869428be254c38f749258d27e213b203b86f1 \
-                        sha256  b7fe336b0f84961c2f652bac01f0fa40e7e0345c2ad64bc5c75bbea3f3911379 \
-                        size    79623 \
+                        lock    ee480838109b \
+                        rmd160  acb364be9c92be7d474ecc77f8b00bc5b3f91647 \
+                        sha256  895bdcba756ffeca30fa286d97f0da2cca2b4e46ffa219c853f8427dad33a6a7 \
+                        size    87815 \
                     golang.org/x/net \
-                        lock    12bc252f5db8 \
-                        rmd160  103c09b86c8fc108f36ae479f64a14dd8ef5f016 \
-                        sha256  36d4043751156a71a051e104685bd53bf2e500fbd14c028a7152fafe25c8b01e \
-                        size    1255149 \
+                        lock    27dd8689420f \
+                        rmd160  d7b9477ec487c7f547c2d6669088f0b77c4ecd3f \
+                        sha256  53a566616d208e83a2ec4a58651a450187a3bef980128571a04b01f6231e162d \
+                        size    1229543 \
                     golang.org/x/crypto \
                         lock    75b288015ac9 \
                         rmd160  d0df189672060fb880ac1bd440bfe94a5fc3e6d9 \
                         sha256  290dc7a301e9ad139c8a5bd91bc0fd9936c60e2d7e7f9361eb3766e8b5947e86 \
                         size    1729939 \
+                    github.com/yuin/goldmark \
+                        lock    v1.4.13 \
+                        rmd160  bb05cad916044abcb54304c02cc88b32e89776ad \
+                        sha256  d5f917488d17192777b40d1951506c5e1395cf3b2013a0ec4018cf3d6dfc890a \
+                        size    257808 \
                     github.com/technoweenie/multipartstreamer \
                         lock    v1.0.1 \
                         rmd160  f1ac41924fe0ca28bf79b5737680452a907b70b4 \
                         sha256  4d7559e4d965a056e8dc4c32f852a23451ad47cd639123bc7a4bf7268ff94861 \
                         size    3248 \
                     github.com/tdewolff/test \
-                        lock    v1.0.6 \
-                        rmd160  356ec42d41a32c7db4f4be7fbe5e136236c88162 \
-                        sha256  521e9c769207c752824fb3f241dcb093f99e33e93c14f52882c07b2c7513dc56 \
-                        size    2835 \
+                        lock    v1.0.7 \
+                        rmd160  2ed22bbdbe37e41a47c72b0723f119aca5b05378 \
+                        sha256  ec3d36b70718e240d985ffb44998ff043680dbaf8800abb8acabd509ad3c06a5 \
+                        size    2949 \
                     github.com/tdewolff/parse \
-                        lock    v2.5.31 \
-                        rmd160  f51ead1f781871324eab0855b45f622122a6f7db \
-                        sha256  e96230011bcf643238bbc319ea887e5391cd084d03ba0a70c74dc10d21e1d946 \
-                        size    102040 \
+                        lock    v2.6.1 \
+                        rmd160  8f9b13ba7c89f77cc69534cb12f2552cf528cdd5 \
+                        sha256  e004304c4dbc8c1be41dcd0a7f7c1c17a106aad6ede0f5ab3c949060df1db0fb \
+                        size    102301 \
                     github.com/tdewolff/minify \
-                        lock    v2.11.5 \
-                        rmd160  2ffe1316d4b050939000f88f8f4499a7ee0aa673 \
-                        sha256  eb25fb0762d1f0684b1abcfd0e073854797c7a9be557eecc5c49a6ee699cb2b1 \
-                        size    7010890 \
+                        lock    v2.12.0 \
+                        rmd160  c389b0d3a9cc107c27540fc4228b221e41d95369 \
+                        sha256  ba9f8cbc33ef8052bbb2737ab6819c2801bd47fe1451f6a57d3207b32142d9e8 \
+                        size    7012567 \
                     github.com/stretchr/testify \
                         lock    v1.6.1 \
                         rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
@@ -109,25 +109,25 @@ go.vendors          mvdan.cc/xurls \
                         sha256  79003ca68407b3b358db8ef8e073dbec1f7aaab3cafd44f21818d6bc0e08c326 \
                         size    22092 \
                     github.com/prometheus/procfs \
-                        lock    v0.7.3 \
-                        rmd160  22af59de47369bf8ac95300e14ef8b1d370712a5 \
-                        sha256  40015c2a7a52b34e6502d2fc17458c30c3ee23f9c2246269d878ab0f96ca3177 \
-                        size    179014 \
+                        lock    v0.8.0 \
+                        rmd160  0cd72a082087a0c3dd922a362316063f79364968 \
+                        sha256  4047304194f7f2cf99f627a1dae661ec0b3037f34aa07cd4d359e82015debc64 \
+                        size    194848 \
                     github.com/prometheus/common \
-                        lock    v0.32.1 \
-                        rmd160  a6acf4fa8fde63b73fdce283bf384bf0ef1beae8 \
-                        sha256  a6f193ddcbff86669bc3b3b88681dc45e456042b8d54bbd318a708c8761d7110 \
-                        size    146608 \
+                        lock    v0.37.0 \
+                        rmd160  4b9ab33f6ebadf18c84de43be89633d0adf967d9 \
+                        sha256  ed4d3dbcb57018812d44094380bb26c0c331ef6d99d4df13b4ed907aa221bc47 \
+                        size    148974 \
                     github.com/prometheus/client_model \
                         lock    v0.2.0 \
                         rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
                         sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
                         size    10985 \
                     github.com/prometheus/client_golang \
-                        lock    v1.12.2 \
-                        rmd160  6e2120fbbdd478bcbab9f1a7f014a2f85797db53 \
-                        sha256  df1e3c29b486c86bde89d01588b30c333265f8110a92c44bef38f21e147d2472 \
-                        size    197136 \
+                        lock    v1.13.0 \
+                        rmd160  4e0a400d5ec02a478288bf851637b98f7fcc04f4 \
+                        sha256  23ec964ec317fdfb5fbe481cf0f41d213befaa1693b804bef86934fb478b649c \
+                        size    218821 \
                     github.com/pquerna/cachecontrol \
                         lock    1555304b9b35 \
                         rmd160  0a0f37cba23e467f89c717d93a37c5b34005b64e \
@@ -159,10 +159,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  b94c995107eaf9f5bcaa0a29629fb6c23bab9ec0606071c09070e143fdf323fa \
                         size    45524 \
                     github.com/google/go-cmp \
-                        lock    v0.5.5 \
-                        rmd160  5caef57da3ce09c102ed270168afa2a5200c2c47 \
-                        sha256  be284023d91976ef03d13cb5670e338c09a0a0da9925d7de457f44e33aebb724 \
-                        size    102365 \
+                        lock    v0.5.8 \
+                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
+                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
+                        size    104650 \
                     github.com/golang/protobuf \
                         lock    v1.5.2 \
                         rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.38)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
