### PR TITLE
stagit: new port

### DIFF
--- a/www/stagit/Portfile
+++ b/www/stagit/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+
+name                stagit
+version             1.2
+revision            0
+license             MIT
+
+categories          www
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+description         static git page generator
+long_description    {*}${description}
+
+homepage            https://git.codemadness.org/${name}/
+
+master_sites        https://codemadness.org/releases/${name}/
+
+checksums           rmd160  9a194bc284756443352d1b2c34cf6d2782df36fa \
+                    sha256  5659bd8ba7e1417edd40f7b7781a8ea26939ab6aa513409023835f04875921c5 \
+                    size    19818
+
+depends_lib-append  port:libgit2
+
+makefile.override   CC PREFIX
+
+livecheck.type      regex
+livecheck.url       [lindex ${master_sites} 0]
+livecheck.regex     href=\"stagit-(.*)\\.tar\\.gz\"


### PR DESCRIPTION
#### Description
[**stagit**](https://codemadness.org/git/stagit/file/README.html) - static git page generator.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
