### PR TITLE
josm: update to 18531

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18513
+version             18531
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  f60a887dbd56ce2dec194460cbf84c44147d69fa \
-                    sha256  33c655dc55d9247a9a7a03ca4278d090c60c5add815222b333c4e2b7836ab54e \
-                    size    77882710
+checksums           rmd160  5577eea21e2f088f7b704cd2c0736a8f5a7f2987 \
+                    sha256  95d713b9a714531b2cb09a89f1c4636cff935a5c5075c36d55b8fc7250cd106c \
+                    size    77895149
 
 extract.mkdir       yes
 
@@ -32,3 +32,7 @@ build {}
 destroot {
     copy ${worksrcpath}/JOSM.app ${destroot}${applications_dir}
 }
+
+livecheck.type          regex
+livecheck.url           https://josm.openstreetmap.de/download/macosx/
+livecheck.regex         {josm-macos-(\d+)-java17\.zip}


### PR DESCRIPTION
#### Description
[2022-08-02: Stable release 18531](https://josm.openstreetmap.de/wiki/Changelog#stable-release-22.07)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
