### PR TITLE
Add `+spice` variant to qemu, and fix build for `spice-server`

### DIFF
--- a/devel/spice-protocol/Portfile
+++ b/devel/spice-protocol/Portfile
@@ -10,14 +10,14 @@ checksums           rmd160  5a59b1347e4d0b2a54d0b9083e10e1b80341de08 \
                     sha256  f986e5bc2a1598532c4897f889afb0df9257ac21c160c083703ae7c8de99487a \
                     size    22224
 
-maintainers         nomaintainer
 categories          devel
-platforms           darwin
 license             BSD
+maintainers         nomaintainer
+supported_archs     noarch
+
 description         Remote virtual machine protocol
 long_description    {*}${description}
-
 homepage            https://www.spice-space.org
+
 master_sites        ${homepage}/download/releases/
 use_xz              yes
-supported_archs     noarch

--- a/devel/spice-server/Portfile
+++ b/devel/spice-server/Portfile
@@ -5,7 +5,7 @@ PortGroup           meson 1.0
 
 name                spice-server
 version             0.14.3
-revision            2
+revision            3
 
 categories          devel
 license             BSD
@@ -22,7 +22,7 @@ checksums           rmd160  fe99d8d0db4b275b1d19dc9a7231144133c5bfa0 \
                     sha256  551d4be4a07667cf0543f3c895beb6da8a93ef5a9829f2ae47817be5e616a114 \
                     size    1504304
 
-set py_ver_nodot    38
+set py_ver_nodot    310
 
 patchfiles-append \
                     meson-build.diff \

--- a/devel/spice-server/Portfile
+++ b/devel/spice-server/Portfile
@@ -27,11 +27,11 @@ patchfiles          meson-build.diff \
                     pthread-setname-args.diff \
                     no-msg-nosignal.diff \
                     no-tools.diff \
-                    no-tests.diff
+                    no-tests.diff \
+                    fix-py-module-search.diff
 
 configure.args-append \
-    -Dsasl=false \
-    -Dtests=no
+    -Dsasl=false
 
 depends_build-append \
     port:pkgconfig \

--- a/devel/spice-server/Portfile
+++ b/devel/spice-server/Portfile
@@ -6,23 +6,26 @@ PortGroup           meson 1.0
 name                spice-server
 version             0.14.3
 revision            2
-maintainers         nomaintainer
+
 categories          devel
-platforms           darwin
 license             BSD
+maintainers         nomaintainer
+
 description         Remote virtual machine server
 long_description    {*}${description}
-
 homepage            https://www.spice-space.org/
-master_sites        https://www.spice-space.org/download/releases/
 
+master_sites        https://www.spice-space.org/download/releases/
 use_bzip2           yes
 
 checksums           rmd160  fe99d8d0db4b275b1d19dc9a7231144133c5bfa0 \
                     sha256  551d4be4a07667cf0543f3c895beb6da8a93ef5a9829f2ae47817be5e616a114 \
                     size    1504304
 
-patchfiles          meson-build.diff \
+set py_ver_nodot    38
+
+patchfiles-append \
+                    meson-build.diff \
                     no-werror.diff \
                     pthread-setname-args.diff \
                     no-msg-nosignal.diff \
@@ -35,7 +38,9 @@ configure.args-append \
 
 depends_build-append \
     port:pkgconfig \
-    port:python38 port:py38-six port:py38-parsing
+    port:python${py_ver_nodot} \
+    port:py${py_ver_nodot}-six \
+    port:py${py_ver_nodot}-parsing
 
 depends_lib-append \
     port:lz4 \

--- a/devel/spice-server/files/fix-py-module-search.diff
+++ b/devel/spice-server/files/fix-py-module-search.diff
@@ -1,0 +1,12 @@
+--- subprojects/spice-common/meson.build        2022-08-14 21:05:58.000000000 +0900
++++ subprojects/spice-common/meson.build.new    2022-08-14 21:14:04.000000000 +0900
+@@ -136,7 +136,7 @@
+ if get_option('python-checks')
+   foreach module : ['six', 'pyparsing']
+     message('Checking for python module @0@'.format(module))
+-    cmd = run_command(python, '-m', module)
++    cmd = run_command(python, '-c', 'import @0@'.format(module))
+     if cmd.returncode() != 0
+       error('Python module @0@ not found'.format(module))
+     endif
+

--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
 version                 7.1.0
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -229,6 +229,14 @@ variant vnc description {Support VNC server} {
                             port:cyrus-sasl2 \
                             path:include/turbojpeg.h:libjpeg-turbo \
                             port:libpng
+}
+
+variant spice description {Support Spice server} {
+    configure.args-replace  --disable-spice --enable-spice
+    configure.args-append   --enable-gnutls
+    depends_lib-append      path:lib/pkgconfig/gnutls.pc:gnutls \
+                            port:spice-server \
+                            port:spice-protocol
 }
 
 variant vde description {Support VDE networking} {


### PR DESCRIPTION
#### Description

First contribution here.

Qemu port had no option to enable spice support. When I tried enabling it simply, I have found out that `spice-server` port was failing to build as well.

This PR does;
* Add `+spice` variant to qemu, requiring `spice-protocol` and `spice-server` ports
* Fix build for `spice-server` port

Any additional test, check, guidance is welcome :pray:

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested~~ WIP! STILL TESTING on

macOS 12.5 21G72 x86_64
Xcode 13.3.1 13E500a

Python 3.10

###### Test TODO / Issues

* [x] Compiles and installs fine
* [x] Libvirt invocation ( reportedly working, [tested by](https://github.com/macports/macports-ports/pull/15723#issuecomment-1215676878) @brad-x )
* [x] Direct qemu invocation ( reportedly working, [tested by](https://github.com/macports/macports-ports/pull/15723#issuecomment-1215676878) @brad-x )
* [ ] Python 3.8 / 3.10 issue
  * I have 3.10 installed as well, but even though I set 3.8 as default, the build scripts used python3.10 for some reason.. had to install python packages for that version as well)
  * ~~(It is probably just fine)~~
    * [CI says it isn't fine](https://github.com/macports/macports-ports/pull/15723#issuecomment-1226704058)
* [ ] ~~Consider testing & including `spice-protocol` and `spice-server` version updates as well~~
  * It is apparently working fine with current versions, version updates could be left for another PR I guess?

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] ~~squashed and [minimized your commits](https://guide.macports.org/#project.github)?~~ probably not necessary, no non-significant commits.
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files? => almost

[skip notification]