### PR TITLE
wangle: update to 2022.08.08.00, allow build with gcc and on older OS

### DIFF
--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -8,11 +8,11 @@ PortGroup           openssl 1.0
 PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        facebook wangle 2022.06.06.00 v
-revision            3
-checksums           rmd160  165c785187362e0e7845d7b290eefc655893237a \
-                    sha256  76ee18993616690c278187beffd76301934065e21c76a90ff694a86bed6cfbf3 \
-                    size    335082
+github.setup        facebook wangle 2022.08.08.00 v
+revision            0
+checksums           rmd160  60cfe88b01bb5c1ed4b49aa280b0d077c407b355 \
+                    sha256  b0e4f1beda451e3a35547d250531eb40950fe1d376dd6dc0282e21b1709eb4d8 \
+                    size    336226
 
 categories          devel
 license             BSD

--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -27,16 +27,6 @@ github.tarball_from releases
 distname            ${name}-v${version}
 extract.mkdir       yes
 
-platform darwin {
-    if {${os.major} < 16} {
-        known_fail      yes
-        pre-fetch {
-            ui_error "${subport} requires macOS 10.12 or later"
-            return -code error "incompatible macOS version"
-        }
-    }
-}
-
 set port_libfmt     libfmt9
 cmake.module_path-append \
                     ${prefix}/lib/${port_libfmt}/cmake
@@ -53,6 +43,10 @@ depends_lib-append  port:double-conversion \
 
 cmake.source_dir    ${worksrcpath}/${name}
 
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    patchfiles-append patch-tcp.diff
+}
+
 # Fix error: invalid output constraint '=@ccc' in asm
 compiler.blacklist-append \
                     {clang < 1200}
@@ -65,4 +59,19 @@ configure.args-append \
                     -DBUILD_SHARED_LIBS=ON
 
 legacysupport.newest_darwin_requires_legacy 19
-legacysupport.use_mp_libcxx                 yes
+
+if {[string match *clang* ${configure.compiler}]} {
+    # Don’t use libcxx with gcc.
+    legacysupport.use_mp_libcxx yes
+}
+
+platform darwin {
+    # https://kumasento.github.io/2020-06-12-glog-gflags-and-c-abi/
+    if {${os.major} < 16} {
+        configure.cxxflags-append -D_GLIBCXX_USE_CXX11_ABI=0
+    }
+    if {[string match *gcc* ${configure.compiler}]} {
+        # ___atomic_fetch_sub_8, ___atomic_compare_exchange_8, ___atomic_store_8, ___atomic_load_8, ___atomic_fetch_add_8
+        configure.ldflags-append  -latomic
+    }
+}

--- a/devel/wangle/files/patch-tcp.diff
+++ b/devel/wangle/files/patch-tcp.diff
@@ -1,0 +1,75 @@
+--- wangle/acceptor/TransportInfo.h.orig	2022-08-15 00:36:09.000000000 +0700
++++ wangle/acceptor/TransportInfo.h	2022-08-15 00:29:03.000000000 +0700
+@@ -114,11 +114,11 @@
+    */
+   int32_t maxPacingRate{-1};
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003
+   typedef tcp_connection_info tcp_info;
+ #endif
+ 
+-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003)
+   /*
+    * TCP information as fetched from getsockopt(2)
+    */
+@@ -352,7 +352,7 @@
+    */
+   static int64_t readRTT(const folly::AsyncSocket* sock);
+ 
+-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003)
+   /*
+    * perform the getsockopt(2) syscall to fetch TCP info for a given socket
+    */
+
+--- wangle/acceptor/TransportInfo.cpp.orig	2022-08-08 08:24:55.000000000 +0700
++++ wangle/acceptor/TransportInfo.cpp	2022-08-15 00:28:35.000000000 +0700
+@@ -27,12 +27,12 @@
+ namespace wangle {
+ 
+ bool TransportInfo::initWithSocket(const folly::AsyncSocket* sock) {
+-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003)
+   if (!TransportInfo::readTcpInfo(&tcpinfo, sock)) {
+     tcpinfoErrno = errno;
+     return false;
+   }
+-#ifdef __APPLE__
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003
+   rtt = microseconds(tcpinfo.tcpi_srtt * 1000);
+   rtt_var = tcpinfo.tcpi_rttvar * 1000;
+   rto = tcpinfo.tcpi_rto * 1000;
+@@ -127,7 +127,7 @@
+ #endif // defined(__linux__) || defined(__FreeBSD__)
+ 
+ int64_t TransportInfo::readRTT(const folly::AsyncSocket* sock) {
+-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003)
+   tcp_info tcpinfo;
+   if (!TransportInfo::readTcpInfo(&tcpinfo, sock)) {
+     return -1;
+@@ -135,7 +135,7 @@
+ #endif
+ #if defined(__linux__) || defined(__FreeBSD__)
+   return tcpinfo.tcpi_rtt;
+-#elif defined(__APPLE__)
++#elif (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003)
+   return tcpinfo.tcpi_srtt;
+ #else
+   (sock); // unused
+@@ -143,11 +143,11 @@
+ #endif
+ }
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003
+ #define TCP_INFO TCP_CONNECTION_INFO
+ #endif
+ 
+-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101003)
+ bool TransportInfo::readTcpInfo(
+     tcp_info* tcpinfo,
+     const folly::AsyncSocket* sock) {


### PR DESCRIPTION
#### Description

1. Version update.
2. Fixes for gcc and older OS. (If we can fix TCP here rather than disabling unsupported functions, please suggest how.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
