### PR TITLE
mpd: Fix compilation on below macOS12

### DIFF
--- a/audio/mpd/Portfile
+++ b/audio/mpd/Portfile
@@ -26,17 +26,6 @@ long_description    Music Player Daemon (MPD) allows remote access for playing m
     console junkie, like frontend options, or restart X often.
 homepage            https://www.musicpd.org/
 
-platform darwin {
-    if {${os.major} < 21} {
-        version     0.23.7
-        revision    2
-
-        checksums   rmd160  81749eef69fa544a88607f539519e3169dc152fe \
-                    sha256  960dcbac717c388f5dcc4fd945e3af19a476f2b15f367e9653d4c7a948768211 \
-                    size    771992
-    }
-}
-
 set branch          [join [lrange [split ${version} .] 0 1] .]
 master_sites        https://www.musicpd.org/download/${name}/${branch}/
 use_xz              yes
@@ -147,6 +136,14 @@ configure.args \
 
 configure.cflags-append -I${prefix}/include
 
+# Wrap the macOS12 functions, may be added into legacy-support see PR49
+if {${os.major} < 21} {
+    configure.cflags-prepend        -isystem ${filespath}/wrappers
+    configure.cxxflags-prepend      -isystem ${filespath}/wrappers
+    configure.objcflags-prepend     -isystem ${filespath}/wrappers
+    configure.objcxxflags-prepend   -isystem ${filespath}/wrappers
+}
+
 variant ffmpeg description {Support for myriad formats (including ALAC) via FFmpeg} {
     depends_lib-append path:lib/libavcodec.dylib:ffmpeg
     configure.args-replace -Dffmpeg=disabled -Dffmpeg=enabled
@@ -251,6 +248,9 @@ destroot.env-append {*}${configure.env}
 
 # requires support for C++17.
 compiler.cxx_standard   2017
+
+# Won't compile with anything below Xcode12
+compiler.blacklist-append {clang < 1200}
 
 if {${os.platform} eq "darwin" && ${os.major} > 8} {
     set mpduser       _mpd

--- a/audio/mpd/files/wrappers/AudioToolBox/AudioToolbox.h
+++ b/audio/mpd/files/wrappers/AudioToolBox/AudioToolbox.h
@@ -1,0 +1,23 @@
+
+/*
+ * Copyright (c) 2022
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#if (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050 && MAC_OS_X_VERSION_MAX_ALLOWED < 120000)
+#define kAudioHardwareServiceDeviceProperty_VirtualMainVolume kAudioHardwareServiceDeviceProperty_VirtualMasterVolume
+#define kAudioHardwareServiceDeviceProperty_VirtualMainBalance kAudioHardwareServiceDeviceProperty_VirtualMasterBalance
+#endif
+
+#include_next <AudioToolbox/AudioToolbox.h>

--- a/audio/mpd/files/wrappers/CoreAudio/CoreAudio.h
+++ b/audio/mpd/files/wrappers/CoreAudio/CoreAudio.h
@@ -1,0 +1,22 @@
+
+/*
+ * Copyright (c) 2022
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 120000
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
+
+#include_next <CoreAudio/CoreAudio.h>


### PR DESCRIPTION
Wrap the relevant macOS12 API calls to the prior names, also blacklist anything below Xcode12 as anything lower is know to fail.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6.7 20G630 arm64
Xcode 13.2.1 13C100

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505
_Using MacOSX10.13.SDK_

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
