### PR TITLE
cctools: fix build on macOS 10.5

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -46,6 +46,7 @@ patchfiles              cctools-829-lto.patch \
                         cctools-949-build-with-SDKs-older-than-1012.diff \
                         cctools-949-nm-allow-no-lto-support.diff \
                         cctools-949-write_object-fix.diff \
+                        cctools-949-missed-stdio.diff \
                         cctools-949-lipo-segalign-log2fix.diff
 
 # lipo-segalign-log2fix https://trac.macports.org/ticket/63164

--- a/devel/cctools/files/cctools-949-missed-stdio.diff
+++ b/devel/cctools/files/cctools-949-missed-stdio.diff
@@ -1,0 +1,10 @@
+--- misc/PruneTrie.cpp.orig	2022-08-05 23:06:44.000000000 +0200
++++ misc/PruneTrie.cpp	2022-08-05 23:07:04.000000000 +0200
+@@ -22,6 +22,7 @@
+  * @APPLE_LICENSE_HEADER_END@
+  */
+ #include <vector>
++#include <stdio.h>
+ 
+ #include "MachOFileAbstraction.hpp"
+ #include "MachOTrie.hpp"


### PR DESCRIPTION
#### Description

Here extracted useful patch from https://github.com/macports/macports-ports/pull/15653

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->