### PR TITLE
krew: add installation instructions

### DIFF
--- a/sysutils/krew/Portfile
+++ b/sysutils/krew/Portfile
@@ -49,3 +49,11 @@ destroot {
     xinstall -d ${destroot}${krew_doc_dir}
     copy {*}[glob ${worksrcpath}/docs/*] ${destroot}${krew_doc_dir}/
 }
+
+notes "
+To initialize ${name} as a kubectl plugin, run:
+
+    ${name} install krew
+
+Then add the \$HOME/.krew/bin directory to your PATH environment variable.
+"


### PR DESCRIPTION
#### Description
I installed `krew` and had to look up the [setup guide](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) to get it working as a `kubectl` plugin.

This change adds a note to help with initial setup.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
