### PR TITLE
curl: switch to xz-bootstrap

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -37,7 +37,12 @@ homepage                        https://curl.se
 master_sites                    ${homepage}/download/:curl \
                                 https://curl.askapache.com/:curl
 
-use_xz                          yes
+# use xz-bootstrap to extract that to make dependency tree short
+depends_extract                 port:xz-bootstrap
+depends_skip_archcheck-append   xz-bootstrap
+extract.suffix                  .tar.xz
+extract.cmd                     ${prefix}/libexec/xz-bootstrap/bin/xz
+
 set curl_distfile               ${distfiles}
 distfiles                       ${curl_distfile}:curl
 checksums-prepend               ${curl_distfile}


### PR DESCRIPTION
#### Description

A lot of ports are depend on curl. Old system which requires xz port to unpack it builds a few clangs. Let me cut it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->