### PR TITLE
pkgconfig: use bootstrap toolchain before 10.7

### DIFF
--- a/devel/pkgconfig/Portfile
+++ b/devel/pkgconfig/Portfile
@@ -35,9 +35,23 @@ patchfiles          patch-glib-configure.diff \
 
 set docdir          ${prefix}/share/doc/${name}
 
-# Also needed by later clangs.
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    clang_dependency.extra_versions 3.7
+
+# the first macOS which can build it on system toolchain is 10.7
+# here a shortcut for platfoms where clang-11-bootstrap is available and can be used
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${build_arch} ni [list ppc ppc64]} {
+    configure.compiler.add_deps \
+                    no
+
+    depends_build-append \
+                    port:clang-11-bootstrap
+    depends_skip_archcheck-append \
+                    clang-11-bootstrap
+    configure.cc    ${prefix}/libexec/clang-11-bootstrap/bin/clang
+    configure.cxx   ${prefix}/libexec/clang-11-bootstrap/bin/clang++
+
+    configure.env-append \
+                    AR=${prefix}/libexec/clang-11-bootstrap/bin/llvm-ar \
+                    RANLIB=${prefix}/libexec/clang-11-bootstrap/bin/llvm-ranlib
 }
 
 conflicts_build     libuuid


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->