### PR TITLE
python38+: apply patch-threadid-older-systems universally

### DIFF
--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -34,10 +34,11 @@ patchfiles          patch-setup.py.diff \
                     patch-configure-xcode4bug.diff \
                     sysconfig.py.patch
 
+# work around no copyfile and/or pthread_threadid_np on older systems
+patchfiles-append   patch-threadid-older-systems.diff
+
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append  patch-no-copyfile-on-Tiger.diff
 }
 
 depends_build       port:pkgconfig

--- a/lang/python311-devel/Portfile
+++ b/lang/python311-devel/Portfile
@@ -35,10 +35,11 @@ patchfiles          patch-setup.py.diff \
                     sysconfig.py.patch \
                     static_assert.patch
 
+# work around no copyfile and/or pthread_threadid_np on older systems
+patchfiles-append   patch-threadid-older-systems.diff
+
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append  patch-no-copyfile-on-Tiger.diff
 }
 
 depends_build       port:pkgconfig

--- a/lang/python38/Portfile
+++ b/lang/python38/Portfile
@@ -41,10 +41,11 @@ patchfiles          patch-setup.py.diff \
                     sysconfig.py.diff \
                     distutils_spawn.py.patch
 
+# work around no copyfile and/or pthread_threadid_np on older systems
+patchfiles-append   patch-threadid-older-systems.diff
+
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append  patch-no-copyfile-on-Tiger.diff
 }
 
 depends_build       port:pkgconfig

--- a/lang/python39/Portfile
+++ b/lang/python39/Portfile
@@ -35,10 +35,11 @@ patchfiles          patch-setup.py.diff \
                     patch-configure-xcode4bug.diff \
                     sysconfig.py.diff
 
+# work around no copyfile and/or pthread_threadid_np on older systems
+patchfiles-append   patch-threadid-older-systems.diff
+
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append  patch-no-copyfile-on-Tiger.diff
 }
 
 depends_build       port:pkgconfig


### PR DESCRIPTION
#### Description

Current condition for applying the patch leaves Rosetta builds broken. Example:
```
Undefined symbols:
  "_pthread_threadid_np", referenced from:
      _PyThread_get_thread_native_id in libpython3.8.a(thread.o)
ld: symbol(s) not found
collect2: ld returned 1 exit status
make: *** [Python.framework/Versions/3.8/Python] Error 1
```
As I remember, @ryandesign suggested applying the patch universally, since it does not hurt. (Of course, alternatively it is possible to apply it for either <11 or <10 + Rosetta.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
