### PR TITLE
armadillo: make openblas variant default on PPC, fixes build

### DIFF
--- a/science/armadillo/Portfile
+++ b/science/armadillo/Portfile
@@ -48,12 +48,20 @@ variant arpack description {compile with ARPACK support} {
 
 variant openblas description {compile with OpenBLAS support} {
     depends_lib-append          path:lib/libopenblas.dylib:OpenBLAS
-    configure.args-append       -DALLOW_BLAS_LAPACK_MACOS=TRUE
+    configure.args-append       -DALLOW_BLAS_LAPACK_MACOS=TRUE \
+                                -DALLOW_OPENBLAS_MACOS=ON
 }
 
 variant superlu description {compile with SuperLU support} {
     depends_lib-append          port:superlu
     configure.args-append       -DARMA_USE_SUPERLU=ON
+}
+
+if {${os.platform} eq "darwin" && ${build_arch} in [list ppc ppc64]} {
+    # Without OpenBLAS the build fails on Leopard and Rosetta with undefined symbols.
+    # https://trac.macports.org/ticket/65292
+    # -DALLOW_OPENBLAS_MACOS=ON is necessary.
+    default_variants            +openblas
 }
 
 # Fix https://trac.macports.org/ticket/59173,


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65292

#### Description

Without OpenBLAS the build fails with undefined symbols.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
