### PR TITLE
netcdf: do not use gcc-4.2 and Xcode 3.2.6 clang

### DIFF
--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -6,6 +6,7 @@ PortGroup                   github 1.0
 PortGroup                   cmake 1.0
 PortGroup                   muniversal 1.0
 PortGroup                   legacysupport 1.1
+PortGroup                   compiler_blacklist_versions 1.0
 
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
@@ -15,7 +16,6 @@ revision                    0
 epoch                       3
 name                        netcdf
 maintainers                 {takeshi @tenomoto} openmaintainer
-platforms                   darwin
 categories                  science
 license                     Permissive
 
@@ -42,6 +42,9 @@ configure.args-append       -DENABLE_NETCDF_4=OFF \
                             -DENABLE_DAP=OFF \
                             -DENABLE_CDF5=OFF \
                             -DCMAKE_PREFIX_PATH=${worksrcpath}/cmake/modules
+
+# https://trac.macports.org/ticket/65672
+compiler.blacklist-append   *gcc-4.* {clang < 400}
 
 test.run                    yes
 test.target                 test


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65672

#### Description

Blacklist `*gcc-4.*` and archaic Xcode clang.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
