### PR TITLE
dnscontrol: update to 3.19.0

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/StackExchange/dnscontrol 3.18.1 v
+go.setup            github.com/StackExchange/dnscontrol 3.19.0 v
 
-checksums           rmd160  d718f8be18ec2d14d721b69e39964363dfe59ea8 \
-                    sha256  cfb0e74331ab27d43adc68f99f2ddb384c2d718869dd66a9b39c93351d73b620 \
-                    size    2296781
+checksums           rmd160  e8af1d319e05625defd19688530e57afd111d4c0 \
+                    sha256  7ba3f8a2f75dcf2097ca83f9065fa0b8c313e34c8c2169c778f4793febdda2cf \
+                    size    2394859
 
 homepage            https://stackexchange.github.io/dnscontrol/
 description         Synchronize your DNS to multiple providers from a simple DSL
@@ -29,7 +29,10 @@ maintainers         {@ajhall} \
 # Allow deps to fetched at build time
 build.env-delete    GO111MODULE=off GOPROXY=off
 
-build.args-append   -ldflags \"-s -w\"
+build.args-append   -ldflags \"-s -w \
+                                -X main.Version=${version} \
+                                -X main.SHA=MacPorts \
+                            \"
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Update to dnscontrol 3.19.0, which no longer hard-codes a version number into its source code. Instead, set version info at build time.

```bash
$ dnscontrol version
dnscontrol 3.19.0 (MacPorts)
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
