### PR TITLE
libzzip: fix build with gcc-4.2

### DIFF
--- a/archivers/libzzip/Portfile
+++ b/archivers/libzzip/Portfile
@@ -7,7 +7,6 @@ PortGroup           github 1.0
 github.setup        gdraheim zziplib 0.13.72 v
 name                libzzip
 categories          archivers devel
-platforms           darwin
 license             LGPL
 maintainers         {@mojca mojca} openmaintainer
 description         library providing read access on ZIP-archives
@@ -36,7 +35,8 @@ depends_test-append port:unzip \
 
 patch.pre_args      -p1
 patchfiles          fixed-tests.patch \
-                    fixed-macports-zip-unzip.patch
+                    fixed-macports-zip-unzip.patch \
+                    patch-gcc42.diff
 
 # this build links its own library, so => Disable RPATH
 # See: https://github.com/gdraheim/zziplib/issues/121

--- a/archivers/libzzip/files/patch-gcc42.diff
+++ b/archivers/libzzip/files/patch-gcc42.diff
@@ -1,0 +1,31 @@
+--- a/zzip/CMakeLists.txt	2021-01-05 06:05:08.000000000 +0700
++++ b/zzip/CMakeLists.txt	2022-09-01 01:51:15.000000000 +0700
+@@ -11,6 +11,7 @@
+ include ( TestBigEndian )
+ include ( GNUInstallDirs )
+ include ( JoinPaths )
++include ( CheckCompilerFlag )
+ 
+ # options ###########################################################
+ option(BUILD_SHARED_LIBS "Build a shared library" ON)
+@@ -103,6 +104,7 @@
+ find_package ( ZLIB REQUIRED )
+ 
+ if(UNIX)
++CHECK_COMPILER_FLAG(C "-Warray-bounds" HAS_WARRAY_BOUNDS)
+     add_definitions(
+         -Wpointer-arith
+         -Wsign-compare
+@@ -110,8 +112,12 @@
+         # -Wdeclaration-after-statement
+         -Werror-implicit-function-declaration
+         -Wstrict-aliasing
++    )
++  if(HAS_WARRAY_BOUNDS)
++    add_definitions(
+         -Warray-bounds
+     )
++  endif()
+ endif()
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
#### Description

`gcc-4.2` does not accept `-Warray-bounds` flag. Fixed.

PR to upstream: https://github.com/gdraheim/zziplib/pull/139

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
