### PR TITLE
pugixml: add cxx 2011 standard

### DIFF
--- a/textproc/pugixml/Portfile
+++ b/textproc/pugixml/Portfile
@@ -21,4 +21,6 @@ description         C++ Library for XML processing
 long_description    C++ library for creating and manipulating XML DOMs. Features: \
                     efficient parsing of XML, XPath 1.0 support, full Unicode support.
 
+compiler.cxx_standard 2011
+
 configure.args-append -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
#### Description

The build fails with `gcc-4.2` with:
```
CMake Error in CMakeLists.txt:
  Target "pugixml-shared" requires the language dialect "CXX11" (with
  compiler extensions).  But the current compiler "GNU" does not support
  this, or CMake does not know the flags to enable it.
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
