### PR TITLE
atari800: update to version 5.0.0

### DIFF
--- a/emulators/atari800/Portfile
+++ b/emulators/atari800/Portfile
@@ -3,17 +3,18 @@
 PortSystem                  1.0
 
 name                        atari800
-version                     4.2.0
+version                     5.0.0
 revision                    0
 platforms                   darwin
 categories                  emulators
 license                     GPL-2+
+
 maintainers                 {krischik @krischik} openmaintainer
 description                 Atari 800 emulator
 long_description            Atari800 is an emulator of the classic Atari 800 8bit computer.
 
-set tagversion              ATARI800_4_2_0
-set patchversion            4.2.0
+set tagversion              [string toupper ${name}]_[string map {. _} ${version}]
+set patchversion            ${version}
 
 homepage                    https://atari800.github.io
 master_sites                git:https://github.com/atari800/atari800/releases/download/${tagversion}:prog                                   \
@@ -38,9 +39,9 @@ extract.only                ${prog}                                             
                             ${appbundles}
 
 checksums                   ${prog} \
-                            rmd160  bc8b8c953fe2d1c2907c625beff8427967c74adb \
-                            sha256  55cb5568229c415f1782130afd11df88c03bb6d81fa4aa60a4ac8a2f151f1359 \
-                            size    7047710 \
+                            rmd160  abf550021a903fadeff9061cafe74d1793cd45b6 \
+                            sha256  eaa2df7b76646f1e49d5e564391707e5a4b56d961810cff6bc7c809bfa774605 \
+                            size    1847596 \
                             ${rom1} \
                             rmd160  e3960898223dd4d1b9a9cc5cfb1251bd726ea5a7 \
                             sha256  98ae0ad10413dd6f35ed80f5662dba6d790def70c7829046e52012a03b574b8a \
@@ -50,13 +51,13 @@ checksums                   ${prog} \
                             sha256  2c0cf7e30ae8a486fc03903de4ebb1d7a40f0d9db3bfcb5dd4861e0cf5da67a5 \
                             size    590041 \
                             ${share} \
-                            rmd160  816979a50b93d0fa74e831d3e3b58a3b8c76278f \
-                            sha256  cc023a557d522bb805f90abf517227be57bcdd8ad96fc12477385808f08c1276 \
-                            size    75647 \
+                            rmd160  bede7f4df7fb64549763ef6b1cb40555f2ea6e4e \
+                            sha256  4f2b20c42f1d199adbbb86eb102dc0959ce800a440351319ae9a3b1d526742ae \
+                            size    75646 \
                             ${appbundles} \
-                            rmd160  c48ce36a9e372216cb2b68c1933ddd234fa3cc0d \
-                            sha256  63c6fd17c991a834e10e509dd22182d5a0addf711d7c9d9f01cd99a59715d11c \
-                            size    2520284
+                            rmd160  2a212c652624b13c14f780cb176cac5c0ce9a1dd \
+                            sha256  c341ff8d531138c29556ec7d531651011f291b7af34c027282af9d003d8ba07c \
+                            size    5041480
 
 depends_lib                 port:libsdl                                         \
                             port:libpng                                         \


### PR DESCRIPTION
#### Description

Update to version 5.0.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
