### PR TITLE
google-cloud-sdk: update to 398.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             397.0.0
+version             398.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  481220036d967aa516ebca0592ac6fc7d769baa8 \
-                    sha256  278a0e00c6945516c8b28986cd97844888274dddc007d83dc10d997593f49d38 \
-                    size    108640837
+    checksums       rmd160  9178e7969b7f1f8c86ab8497ee9512aa161d0c35 \
+                    sha256  de0d924e296dd4a1cf2b84d86c90ea974f59d75a960e9b3dcf830a29a7404bee \
+                    size    108687066
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  6d1c9ca42225f72004a82962ad6dfc0bb6d8db16 \
-                    sha256  fa96fce1c9ab1054ba7b4b6d5aaeb2694fa951b6d8bfe262beb32bb28e7a3e46 \
-                    size    106639892
+    checksums       rmd160  cc828cfe6a9a10decbab77fc3331dfd95ece3dca \
+                    sha256  7eeed24f2060995a9e70cc4dfa578e2c2143a51545e2d995b0f9f62c846acb89 \
+                    size    106697456
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  16e31d96d8327ad58eeb2279a31e72eff364f281 \
-                    sha256  ff346c9fde207381565f70962176b1b1ceafbb288b83ab0d01166e5daf03e642 \
-                    size    105205277
+    checksums       rmd160  a7f73e848097a2a09497059abf01f20c0831ac0c \
+                    sha256  62864574e5f1dd6f010a6a393edd02a9a31dce5cd06f0242cdda76e0268a0c4d \
+                    size    105254904
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 398.0.0.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?