### PR TITLE
courier-unicode: update to 2.2.4

### DIFF
--- a/devel/courier-unicode/Portfile
+++ b/devel/courier-unicode/Portfile
@@ -3,10 +3,10 @@
 PortSystem 1.0
 
 name                    courier-unicode
-version                 2.1
-checksums               rmd160  6d8dbb7de4793e2df9bca7ce5da97a226d41c2f5 \
-                        sha256  684cba7fe722b084ae1ffb0a7f71999756409d5ad4c84bce0efeb8887943ea21 \
-                        size    447917
+version                 2.2.4
+checksums               rmd160  40f942239fe868ca0e6768f3d5a807d260ed0a12 \
+                        sha256  0198e6aeb2170fc129a17631e23fc70da4de9cf6c91d70ba836e65b8b4da2ea5 \
+                        size    594513
 
 categories              devel mail
 license                 GPL-3
@@ -24,6 +24,7 @@ depends_lib-append      port:libiconv
 patchfiles              patch-courier-unicode.h.in-add-missing-includes.diff
 
 compiler.cxx_standard   2011
+configure.cxxflags-append -std=c++11
 
 # Limit the length of the minor and patch version components to avoid picking
 # up development versions (that contain a YYYYMMDD timestamp).


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update to latest version 2.2.4.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F45 x86_64
Xcode 4.5.2 4G2008a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
