### PR TITLE
openjdk17-corretto: update to 17.0.4.9.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.4.8.1
+version      17.0.4.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  b22c66ee913935f4c153cda188b481abcbe1caa3 \
-                 sha256  b2714d48df8d3d8f22fdfb88af548a11603b2c792f1c0c163f6fd39e555a342a \
-                 size    187773572
+    checksums    rmd160  efc182053540746766c5261e7d2e47227a789fd2 \
+                 sha256  fd0f4005ec2e77b0ec6dff01ad9107daa317b96640c73b0198e0f55966d1dbb9 \
+                 size    187796293
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  39d293da52ee850bf54b7274bcde64bdac2b6168 \
-                 sha256  6b7b85dcf4937777a32aed8f62af886b9e50804e238633871289b2b3bb7f53a3 \
-                 size    185883964
+    checksums    rmd160  d40d89c8455433cb1ededfb643b511b87005ef25 \
+                 sha256  304d6c1d5aa497e720bd04d6cd5f8310e6a8262bf4a688616de10eefb7c9ea52 \
+                 size    185913116
 }
 
 worksrcdir   amazon-corretto-17.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-17/blob/release-17.0.4.8.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-17/blob/release-17.0.4.9.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.4.9.1.

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?