### PR TITLE
openjdk18-temurin: update x86_64 to 18.0.2

### DIFF
--- a/java/openjdk18-temurin/Portfile
+++ b/java/openjdk18-temurin/Portfile
@@ -14,13 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=18
 supported_archs  x86_64 arm64
 
-if {${configure.build_arch} eq "x86_64"} {
-    version      18.0.1
-    set build    10
-} elseif {${configure.build_arch} eq "arm64"} {
-    version      18.0.2
-    set build    9
-}
+version      18.0.2
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 18
@@ -30,9 +25,9 @@ master_sites https://github.com/adoptium/temurin18-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK18U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  05b2257658a2fa6c18484a2bd526811b717c470e \
-                 sha256  fedb5e61de3ecd1e128fbb0378b2467498cbe731366fb089b2a495cbb7e34e73 \
-                 size    188268875
+    checksums    rmd160  f25877b67494e354faf7e78439d9125ad9db6b7c \
+                 sha256  f96196e9eddad09544733af46d33ac5d5a44178316248e0b907c7f6cd4955bcb \
+                 size    188282767
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK18U-jdk_aarch64_mac_hotspot_${version}_${build}
     checksums    rmd160  809c522d4ba10e190b57315560c645a46cd046d2 \


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 18.0.2 for x86_64 (arm64 was already previously available and updated).

###### Tested on

macOS 12.5 21G72 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?