### PR TITLE
sparsehash: do not build arch-dependent libtcmalloc test

### DIFF
--- a/devel/sparsehash/Portfile
+++ b/devel/sparsehash/Portfile
@@ -30,18 +30,16 @@ post-patch {
     reinplace "s|@VERSION@|${version}|g" ${worksrcpath}/configure.ac
 }
 
-# While the port installs only headers, it builds tests in the process.
-# Using noarch setting breaks the build: https://github.com/macports/macports-ports/pull/15768
-installs_libs       no
-
 use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh
 autoreconf.args
 depends_build-append \
                     port:autoconf \
                     port:automake \
-                    port:gperftools \
                     port:libtool
+
+# This is a header-only library.
+supported_archs     noarch
 
 # Setting compiler.cxx_standard (to any value) is necessary so that MacPorts
 # sets configure.cxx_stdlib, which the port needs in order to build for the
@@ -49,5 +47,9 @@ depends_build-append \
 # requires, so I'll just guess.
 compiler.cxx_standard 1998
 
-test.run
+# https://github.com/macports/macports-ports/pull/15768
+configure.args-append \
+                    ac_cv_header_google_malloc_extension_h=no
+
+test.run            yes
 test.target         check

--- a/devel/sparsehash/Portfile
+++ b/devel/sparsehash/Portfile
@@ -17,7 +17,6 @@ long_description    {*}${description}. 2 bits/entry overhead! The SparseHash \
                     characteristics. It's easy to replace hash_map by \
                     sparse_hash_map or dense_hash_map in C++ code.
 
-platforms           darwin
 license             BSD
 
 checksums           rmd160  8156dead55d2cf8fc3af2cd0017d494397ee812f \
@@ -31,16 +30,24 @@ post-patch {
     reinplace "s|@VERSION@|${version}|g" ${worksrcpath}/configure.ac
 }
 
+# While the port installs only headers, it builds tests in the process.
+# Using noarch setting breaks the build: https://github.com/macports/macports-ports/pull/15768
+installs_libs       no
+
 use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh
 autoreconf.args
-depends_build-append port:autoconf port:automake port:libtool
-
-# This is a header-only library.
-supported_archs     noarch
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:gperftools \
+                    port:libtool
 
 # Setting compiler.cxx_standard (to any value) is necessary so that MacPorts
 # sets configure.cxx_stdlib, which the port needs in order to build for the
 # right stdlib. I don't know what version of the C++ standard this port
 # requires, so I'll just guess.
 compiler.cxx_standard 1998
+
+test.run
+test.target         check


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65685

#### Description

Add arch flags, fixes Rosetta build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
