### PR TITLE
jpegoptim: update to 1.4.7

### DIFF
--- a/graphics/jpegoptim/Portfile
+++ b/graphics/jpegoptim/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                jpegoptim
-version             1.4.6
+github.setup        tjko jpegoptim 1.4.7 v
+github.tarball_from archive
 revision            0
 categories          graphics
-platforms           darwin
 license             GPL-2+
 maintainers         casa-z.org:jingoro
 
@@ -17,10 +17,9 @@ long_description    Provides lossless optimization (based on optimizing \
                     on setting maximum quality factor.
 
 homepage            https://www.kokkonen.net/tjko/projects.html
-master_sites        https://www.kokkonen.net/tjko/src/
 
-checksums           rmd160  3047a5e5cf3a8ca7966e97b3feb49e5e292feaf6 \
-                    sha256  88b1eb64c2a33a2f013f068df8b0331f42c019267401ae3fa28e3277403a5ab7 \
-                    size 99004
+checksums           rmd160  887d3f6fd8abc6f70c68c21452d0728a39c1ebef \
+                    sha256  c52616f2fb8d481315871680f9943b0f58c553d1e0c49a6bd4691a3e66d7e6de \
+                    size    109026
 
 depends_lib         path:include/turbojpeg.h:libjpeg-turbo


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/tjko/jpegoptim/releases/tag/v1.4.7)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
