### PR TITLE
py-poppler-qt5: use_xcode when py-pyqt5 uses it

### DIFF
--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -27,7 +27,7 @@ checksums           md5     83a1c785aa3d0a0b0e82a7805492eabb \
                     sha256  add766db2c04026a6087f38f2044e66c8b053c81002f3753d8059713497d022d \
                     size    28235
 
-python.versions     27 35 36 37 38 39 310
+python.versions     37 38 39 310
 
 compiler.cxx_standard   2011
 
@@ -36,43 +36,30 @@ if {${name} ne ${subport}} {
         use_xcode   yes
     }
 
-    if {${python.version} eq 27} {
-        PortGroup       qt5 1.0
+    PortGroup       qmake5 1.0
 
-        depends_lib-append \
-                        port:py${python.version}-sip4
+    patchfiles      patch-types.sip.diff \
+                    patch-fix-py36.diff
 
-        patchfiles      patch-fix-qt-dirs.diff
+    depends_build-append \
+                    port:py${python.version}-pyqt-builder
 
-        post-patch {
-            reinplace "s|%%QMAKE%%|${qt_qmake_cmd}|g" ${worksrcpath}/setup.py
-        }
-    } else {
-        PortGroup       qmake5 1.0
+    depends_lib-append \
+                    path:${python.prefix}/bin/sip-build:py${python.version}-sip
 
-        patchfiles      patch-types.sip.diff \
-                        patch-fix-py36.diff
+    build.cmd       sip-build-${python.branch}
+    build.args-append \
+                    --qmake ${qt_qmake_cmd} \
+                    --verbose
+    build.target
 
-        depends_build-append \
-                        port:py${python.version}-pyqt-builder
-
-        depends_lib-append \
-                        path:${python.prefix}/bin/sip-build:py${python.version}-sip
-
-        build.cmd       sip-build-${python.branch}
-        build.args-append \
-                        --qmake ${qt_qmake_cmd} \
-                        --verbose
-        build.target
-
-        pre-destroot {
-            reinplace "s|sip-distinfo|sip-distinfo-${python.branch}|g" \
-                ${build.dir}/build/Makefile
-        }
-
-        destroot.cmd    make
-        destroot.dir    ${build.dir}/build
+    pre-destroot {
+        reinplace "s|sip-distinfo|sip-distinfo-${python.branch}|g" \
+            ${build.dir}/build/Makefile
     }
+
+    destroot.cmd    make
+    destroot.dir    ${build.dir}/build
 
     depends_build-append \
                     port:py${python.version}-setuptools

--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -32,6 +32,10 @@ python.versions     27 35 36 37 38 39 310
 compiler.cxx_standard   2011
 
 if {${name} ne ${subport}} {
+    if { ${os.platform} eq "darwin" && (( ${os.major} >= 15 && ${os.major} <= 16 ) || ${os.major} >= 20 ) } {
+        use_xcode   yes
+    }
+
     if {${python.version} eq 27} {
         PortGroup       qt5 1.0
 

--- a/python/py-poppler-qt5/files/patch-fix-qt-dirs.diff
+++ b/python/py-poppler-qt5/files/patch-fix-qt-dirs.diff
@@ -1,9 +1,0 @@
---- setup.py
-+++ setup.py
-@@ -138,5 +138,5 @@ class build_ext(build_ext_base):
-         build_ext_base.initialize_options(self)
-         self.poppler_version = None
--        self.qmake_bin = 'qmake'
-+        self.qmake_bin = '%%QMAKE%%'
-         self.qt_include_dir = None
-         self.pyqt_sip_dir = None


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/65600

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61
(actually not tested on my system)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
