### PR TITLE
centerim: update to 5.0.1

### DIFF
--- a/net/centerim/Portfile
+++ b/net/centerim/Portfile
@@ -2,39 +2,41 @@
 
 PortSystem          1.0
 PortGroup           active_variants 1.1
+PortGroup           cmake 1.1
+PortGroup           github 1.0
 
+github.setup        petrpavlu centerim5 5.0.1 v
 name                centerim
-version             4.22.10
-revision            6
+revision            0
 categories          net
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-2+
 
 description         Console multi-IM client.
 long_description    Console client for ICQ/Yahoo/IRC/LiveJournal.
 
-checksums           sha1    46fbac7a55f33b0d4f42568cca21ed83770650e5 \
-                    rmd160  2514c871388edb98b4a8957f965ccee3450b968f
+checksums           rmd160  843096dc6b654ef269079eafa032f96637d9e064 \
+                    sha256  d4531d56cf58b12373c0665207f048a424fc547428b10b0034d0784b29a8c5cf \
+                    size    272889
 
 homepage            https://www.centerim.org/
-master_sites        ${homepage}download/releases/
 
-depends_build       port:pkgconfig
+depends_build-append \
+                    port:pkgconfig
 
-depends_lib         port:libiconv port:gettext port:ncurses path:lib/libssl.dylib:openssl \
-                    path:include/turbojpeg.h:libjpeg-turbo port:gpgme port:curl
+depends_lib-append  path:include/turbojpeg.h:libjpeg-turbo \
+                    path:lib/libssl.dylib:openssl \
+                    port:curl \
+                    port:gettext \
+                    port:gpgme \
+                    port:libiconv \
+                    port:libpurple \
+                    port:libsigcxx2 \
+                    port:ncurses
 
 require_active_variants curl {ssl}
 
-patchfiles          patch-configure.diff patch-libjabber_jconn.c.diff
-
-configure.args      --with-libiconv-prefix=${prefix} \
-                    --with-libintl-prefix=${prefix} \
-                    --with-ssl --with-openssl=${prefix}/include \
-                    --with-libjpeg --with-gpgme-prefix=${prefix} \
-                    --with-libcurl=${prefix}
-build.type          gnu
+compiler.cxx_standard 2011
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]


### PR DESCRIPTION
#### Description

Update to 5.0.1. Hopefully fixes the build for all systems. See: https://trac.macports.org/ticket/44088

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
