### PR TITLE
spring-boot-cli: update to 2.7.3

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.7.2
+version         2.7.3
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  619acfd508d1c8ef6b729c26135778620fca7d14 \
-                sha256  b09f83d177d93e8e4ad5f9baccb0e38582d45e92a6abe5b2d505972cfae26577 \
-                size    14319288
+checksums       rmd160  387ab3068a4c3c38e198526133c7cd7f35d1f76e \
+                sha256  48e4cb4895189d392dfc65ab2f333e22a062cf54e49120a8a0cb331d6ca17013 \
+                size    14324541
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.7.3.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?