### PR TITLE
docker: update to 20.10.17

### DIFF
--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/cli 20.10.14 v
+go.setup            github.com/docker/cli 20.10.17 v
 revision            0
 name                docker
 categories          devel
@@ -15,9 +15,9 @@ description         The open-source application container engine
 long_description    Docker is an open source project to pack, ship \
                     and run any application as a lightweight container.
 
-checksums           rmd160  7ee554cf6a576ca6ea986f54f8de3e9b7827f658 \
-                    sha256  4e3751f95ee88dc5a3fb492db3c3c549b1691708860f16d141f6df409898a80e \
-                    size    7509047
+checksums           rmd160  419389ce878b7889fed694d5c77fdf3aa1e6134e \
+                    sha256  29636a5425985d8e311f10622ec1899d52f42d35c5ea0f90d6fe03cb2f8bfb74 \
+                    size    7636772
 
 build.target        github.com/docker/cli/cmd/docker
 


### PR DESCRIPTION
#### Description

Update to Docker CLI 20.10.17.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?