### PR TITLE
libssh2: apply pragma patch for gcc versions, not OS

### DIFF
--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -28,9 +28,11 @@ checksums           rmd160  b3af89cc5974dbffbcba0dd80dcd521e6e60b39d \
                     sha256  2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51 \
                     size    965044
 
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    # remove errant pragmas inside functions no supported on older gcc versions
-    patchfiles-append patch-libssh2-pragmas-older-gcc.diff
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+    # Remove errant pragmas inside functions not supported on older gcc versions. Rosetta also needs this patch.
+        patchfiles-append patch-libssh2-pragmas-older-gcc.diff
+    }
 }
 
 depends_lib-append  port:zlib

--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -10,7 +10,6 @@ github.tarball_from releases
 revision            0
 
 categories          devel net
-platforms           darwin
 maintainers         {wohner.eu:normen @Gminfly} openmaintainer
 
 homepage            https://www.libssh2.org/
@@ -28,11 +27,9 @@ checksums           rmd160  b3af89cc5974dbffbcba0dd80dcd521e6e60b39d \
                     sha256  2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51 \
                     size    965044
 
-platform darwin {
-    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
-    # Remove errant pragmas inside functions not supported on older gcc versions. Rosetta also needs this patch.
-        patchfiles-append patch-libssh2-pragmas-older-gcc.diff
-    }
+if {[string match *gcc-4.* ${configure.compiler}]} {
+# Remove errant pragmas inside functions not supported on older gcc versions.
+    patchfiles-append patch-libssh2-pragmas-older-gcc.diff
 }
 
 depends_lib-append  port:zlib


### PR DESCRIPTION
#### Description

Rosetta also needs existing patch, otherwise build fails with:
```
x11.c: In function ‘main’:
x11.c:328: error: #pragma GCC diagnostic not allowed inside functions
x11.c:329: error: #pragma GCC diagnostic not allowed inside functions
x11.c:333: error: #pragma GCC diagnostic not allowed inside functions
make[1]: *** [x11.o] Error 1
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
