### PR TITLE
cgrc: new port, version 0.3.2

### DIFF
--- a/textproc/cgrc/Portfile
+++ b/textproc/cgrc/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           qt6 1.0
+
+fetch.type          git
+github.setup        carlonluca cgrc 0.3.2 v
+revision            0
+license             GPL-3
+categories          textproc
+maintainers         {@carlonluca gmail.com:carlon.luca} openmaintainer
+description         Configurable terminal text formatter
+long_description    cgrc formats text from stdin according to custom configuration files \
+                    and outputs the result with ANSI escape codes to stdout. Configuration \
+                    files includes a set of regular expressions with the related format \
+                    to be used to the match and the captures.
+cmake.install_rpath-append \
+                    ${qt_dir}/lib
+compiler.cxx_standard \
+                    2017
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}


### PR DESCRIPTION
#### Description

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?