### PR TITLE
openjdk11-temurin: update arm64 to 11.0.16.1

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,8 +14,13 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.16
-set build    8
+if {${configure.build_arch} eq "x86_64"} {
+    version      11.0.16
+    set build    8
+} elseif {${configure.build_arch} eq "arm64"} {
+    version      11.0.16.1
+    set build    1
+}
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -30,9 +35,9 @@ if {${configure.build_arch} eq "x86_64"} {
                  size    186325803
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  24a0a9df20c14e24edc8d661b5b21b21585cba37 \
-                 sha256  abf9365c07797133874e18bc5da86a42833ceee71986addb59877f5efd23739c \
-                 size    185078783
+    checksums    rmd160  b36984a0b0dfbad9ee75d194a9ac382ecae1e4e0 \
+                 sha256  1953f06702d45eb54bae3ccf453b57c33de827015f5623a2dfc16e1c83e6b0a1 \
+                 size    185088495
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.16.1 for ARM64.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?