### PR TITLE
glib2: Fix build with pre-C++11 compilers

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -59,6 +59,7 @@ patchfiles-append           patch-meson-build-broken_poll.diff
 platform darwin {
     if {${os.major} < 11} {
         patchfiles-append   patch-gio_gcredentialsprivate.h.diff \
+                            patch-gio_gcredentials.c.diff \
                             patch-gio_gsocket.h.diff
     }
 }

--- a/devel/glib2/files/patch-gio_gcredentials.c.diff
+++ b/devel/glib2/files/patch-gio_gcredentials.c.diff
@@ -1,0 +1,14 @@
+glib_typeof relies on C++11, so we need to fall back to regular typeof
+(supported by GCC and Clang) to build with older compilers.
+
+--- gio/gcredentials.c.orig	2022-08-20 08:42:34.000000000 -0400
++++ gio/gcredentials.c	2022-08-20 08:46:40.000000000 -0400
+@@ -225,7 +225,7 @@
+ {
+   GString *ret;
+ #if G_CREDENTIALS_USE_APPLE_XUCRED
+-  glib_typeof (credentials->native.cr_ngroups) i;
++  typeof (credentials->native.cr_ngroups) i;
+ #endif
+ 
+   g_return_val_if_fail (G_IS_CREDENTIALS (credentials), NULL);


### PR DESCRIPTION
#### Description

`glib_typeof` relies on C++11 which isn't available on ancient systems. So, fall back to regular `typeof`.

The patch should be safe everywhere, but I've chosen to add it to the 10.6 and earlier patch list so it's unobtrusive.

Tested through install.

Fixes: https://trac.macports.org/ticket/65663

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
