### PR TITLE
pilrc: update to 3.2

### DIFF
--- a/palm/pilrc/Portfile
+++ b/palm/pilrc/Portfile
@@ -1,39 +1,34 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			pilrc
-version			3.1
-revision		1
-categories		palm devel
-license			GPL-2+
-maintainers		nomaintainer
-description		Palm OS resource compiler
-long_description	This is a tool that turns a textual description of \
-					Palm OS forms, bitmaps, fonts, and other resources \
-					into a binary form that can be included in an \
-					application or library. The name is derived from \
-					\"PILot Resource Compiler\". This tool is used with \
-					many popular Palm OS development tools, including \
-					prc-tools and CodeWarrior for Palm OS.
-homepage		http://pilrc.sourceforge.net/
-master_sites	sourceforge
-checksums		md5 bbfea963c4e34252f634c6a39a2578b8
-platforms		darwin
+PortSystem      1.0
 
-configure.cmd	unix/configure
-configure.args	--disable-pilrcui
+name            pilrc
+version         3.2
+revision        0
+categories      palm devel
+license         GPL-2+
+maintainers     {@nkorth nkorth.com:nkorth} openmaintainer
+description     Palm OS resource compiler
+long_description    This is a tool that turns a textual description of \
+                    Palm OS forms, bitmaps, fonts, and other resources \
+                    into a binary form that can be included in an \
+                    application or library. The name is derived from \
+                    \"PILot Resource Compiler\". This tool is used with \
+                    many popular Palm OS development tools, including \
+                    prc-tools and CodeWarrior for Palm OS.
+homepage        http://pilrc.sourceforge.net/
+master_sites    sourceforge
+checksums       rmd160  e9dfb96082c7406e269ea99aec4ce2a6029e8afd \
+                sha256  f3d6ea3c77f5d2a00707f4372a212377ab7bd77b3d68c3db7e28a553b235903f \
+                size    259898
+patchfiles      fix-resource-list.diff
 
-variant gtk	{
-	depends_lib		lib:libgtk.1:gtk1
-
-	configure.args-delete	--disable-pilrcui
-	configure.args-append	--enable-pilrcui \
-							--enable-gtktest \
-							--with-gtk-prefix=${prefix}
-}
+configure.cmd   unix/configure
+configure.args  --disable-pilrcui
 
 post-destroot {
-	set docPath ${destroot}${prefix}/share/doc
-	xinstall -d -m 0755 ${docPath}
-	system "cp -R ${worksrcpath}/doc ${docPath}/${name}"
-	system "cp -R ${worksrcpath}/example ${docPath}/${name}/"
+    set docPath ${destroot}${prefix}/share/doc
+    xinstall -d -m 0755 ${docPath}
+    copy ${worksrcpath}/doc ${docPath}/${name}
+    copy ${worksrcpath}/example ${docPath}/${name}/
 }

--- a/palm/pilrc/files/fix-resource-list.diff
+++ b/palm/pilrc/files/fix-resource-list.diff
@@ -1,0 +1,15 @@
+--- ../pilrc-3.2-orig/util.c    2004-07-14 22:38:17.000000000 -0400
++++ util.c    2022-08-19 23:05:24.000000000 -0400
+@@ -73,9 +73,9 @@
+ DEFPL(PLEXRESOURCEDIR)
+ typedef struct RESOURCEDIRENTRY
+ {
+-  int type[4];
+-  int id;
+-  int offset;
++  p_int type[4];
++  p_int id;
++  p_int offset;
+ } RESOURCEDIRENTRY;
+ 
+ #define szRESOURCEDIRENTRY "b4,w,l"


### PR DESCRIPTION
#### Description

- Updated pilrc to 3.2
- Fixed a mac-specific bug which was also present in 3.1 (PRC output was mangled, the default .bin output was ok.)
- Removed gtk variant which depends on gtk1 and which the readme says is broken

I tested this commit on my own PRC project which was failing to build on 3.1; now it builds correctly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.6 20G165 x86_64
Command Line Tools 12.5.1.0.1.1623191612

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
