### PR TITLE
haproxy: fix build for older OSs

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -37,6 +37,11 @@ checksums           rmd160  d88ec423262399e4f275320b26b8e2c843048a43 \
 openssl.branch      3
 depends_lib         port:pcre port:zlib
 
+# https://trac.macports.org/ticket/65699
+compiler.thread_local_storage yes
+
+patchfiles-append   patch-older_systems.diff
+
 use_configure       no
 
 # Disable compiler wrapping
@@ -59,13 +64,13 @@ pre-build {
                     USE_ZLIB=1
 }
 
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    build.args-append   USE_TFO=0
+}
+
 variant lua description {Build with Lua support} {
     depends_lib-append  port:lua
     build.args-append   USE_LUA=1
-}
-
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
-    build.args-delete   USE_THREAD=1
 }
 
 destroot.args       DOCDIR=${prefix}/share/doc/${name} \

--- a/net/haproxy/files/patch-older_systems.diff
+++ b/net/haproxy/files/patch-older_systems.diff
@@ -1,0 +1,22 @@
+# https://trac.macports.org/ticket/65699
+--- include/haproxy/compat.h.orig	2022-08-19 23:29:02.000000000 +0800
++++ include/haproxy/compat.h	2022-08-20 23:13:25.000000000 +0800
+@@ -281,13 +281,18 @@
+ 
+ /* macOS has a call similar to malloc_usable_size */
+ #if defined(__APPLE__)
++#include <AvailabilityMacros.h>
+ #include <malloc/malloc.h>
+ #define malloc_usable_size malloc_size
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
+ #define HA_HAVE_MALLOC_ZONE
++#endif
+ #define TCP_KEEPIDLE TCP_KEEPALIVE
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 101003
+ #define TCP_INFO TCP_CONNECTION_INFO
+ #define tcp_info tcp_connection_info
+ #endif
++#endif
+ 
+ /* Max number of file descriptors we send in one sendmsg(). Linux seems to be
+  * able to send 253 fds per sendmsg(), however musl is limited to 252, not sure


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65699

#### Description

PR addresses a lack of support for `tcp_info` and `_malloc_zone_pressure_relief` on older OSs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
