### PR TITLE
qt5pas: update to 2.2.0-0, fix build

### DIFF
--- a/devel/qt5pas/Portfile
+++ b/devel/qt5pas/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           qmake5 1.0
 
 name                qt5pas
-version             2.0.10-2
+version             2.2.0-0
 revision            0
 categories          devel
-platforms           darwin
 license             GPL-2 LGPL-2
 maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
 description         Pascal wrapper for Qt5
@@ -22,11 +21,13 @@ homepage            https://wiki.freepascal.org/Qt5_Interface
 dist_subdir         lazarus
 master_sites        sourceforge:lazarus
 distname            lazarus-${version}
-checksums           rmd160  1e9c89a34bbdf90bf4010e73424b53be117e8e74 \
-                    sha256  64d5626468dd24a3332b205f3abd0a581ab7de1b060a2d57e21864066cfd43b7 \
-                    size    69626076
+checksums           rmd160  101bd48ae7bae9fdf941d96ea62c4b386085526f \
+                    sha256  b6b5d516511e3dfb34910d7656db068d4bba80f009692500aebbcae79cb12160 \
+                    size    76777421
 
 worksrcdir          lazarus/lcl/interfaces/qt5/cbindings
+
+use_xcode           yes
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/qt5pas


### PR DESCRIPTION
#### Description
Fix build

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
