### PR TITLE
google-cloud-sdk: fix livecheck

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -168,4 +168,5 @@ variant zsh_completion description {Enable completion support for zsh} {
             source '${prefix}/libexec/google-cloud-sdk/completion.zsh.inc'"
 }
 
-livecheck.url       https://cloud.google.com/sdk/docs/quickstart-macos
+livecheck.url       https://cloud.google.com/sdk/docs/install-sdk
+livecheck.regex     {google-cloud-cli-([\d\.]+)-darwin}


### PR DESCRIPTION
#### Description
Use a new regex and URL for the `google-cloud-sdk` livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
