### PR TITLE
dnscontrol: use GitHub releases for livecheck

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -20,6 +20,7 @@ long_description    DNSControl is a system for maintaining DNS zones. It has   \
                     BIND zone files ever. It runs anywhere Go runs (Linux,     \
                     macOS, Windows). The provider model is extensible, so more \
                     providers can be added.
+livecheck.url       ${github.homepage}/releases
 
 categories          sysutils
 license             MIT


### PR DESCRIPTION
#### Description

Use the GitHub releases page instead of the tags page for the livecheck of the `dnscontrol` port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
