### PR TITLE
iTerm2: fix livecheck

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -49,7 +49,8 @@ long_description    \
 
 homepage            https://iterm2.com/
 
-github.livecheck.regex {(\d+(?:\.\d+)*)}
+livecheck.url       https://raw.githubusercontent.com/gnachman/iterm2-website/master/source/appcasts/final_modern.xml
+livecheck.regex     {sparkle:version="([\d\.]+)"}
 
 post-patch {
     # patch the python script out since it does not set the correct version and may cause trouble


### PR DESCRIPTION
#### Description

Update the URL and regex for the livecheck of the iTerm2 port. 

Automatic nightly tags on the GitHub repo were causing the actual latest version not to appear on the default livecheck page. The new URL uses a feed from the iTerm2 website instead.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
