### PR TITLE
gcc10-bootstrap: fix build on Tiger PPC and on Rosetta

### DIFF
--- a/lang/gcc10-bootstrap/Portfile
+++ b/lang/gcc10-bootstrap/Portfile
@@ -212,6 +212,9 @@ set merger_host(x86_64) x86_64-apple-${os.platform}${os.major}
 foreach {arch target} [array get merger_host] {
     lappend merger_configure_args(${arch}) --build=${target}
     lappend merger_configure_args(${arch}) --target=${target}
+
+    lappend merger_configure_env(${arch}) BUILD_ARCH=${arch}
+    lappend merger_build_env(${arch}) BUILD_ARCH=${arch}
 }
 
 if {${universal_possible} && [variant_isset universal]} {
@@ -240,6 +243,27 @@ if {${universal_possible} && [variant_isset universal]} {
                     --build=$merger_host(${build_arch}) \
                     --target=$merger_host(${build_arch}) \
                     --enable-targets=$merger_host(${build_arch})
+}
+
+# GMP enforces host and target as none-bla-bla that may leads to
+# GMP_NUMB_BITS and sizeof(mp_limb_t) are not consistent.
+#
+# See: https://trac.macports.org/ticket/65498
+pre-configure {
+    file mkdir ${workpath}/bins
+
+    set gcc [open "${workpath}/bins/gcc" w 0755]
+    puts ${gcc} "#!/bin/sh"
+    puts ${gcc} "${configure.cc} -arch $\{BUILD_ARCH:-${build_arch}\} \"\$@\""
+    close ${gcc}
+
+    set gxx [open "${workpath}/bins/g++" w 0755]
+    puts ${gxx} "#!/bin/sh"
+    puts ${gxx} "${configure.cxx} -arch $\{BUILD_ARCH:-${build_arch}\} \"\$@\""
+    close ${gxx}
+
+    configure.cc    ${workpath}/bins/gcc
+    configure.cxx   ${workpath}/bins/g++
 }
 
 build.dir           ${configure.dir}

--- a/lang/gcc10-bootstrap/Portfile
+++ b/lang/gcc10-bootstrap/Portfile
@@ -110,6 +110,9 @@ patchfiles-append patch-build-i686.diff
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
 patchfiles-append patch-xcode12-fix.diff
 
+# Backport additional patches for support darwin8
+patchfiles-append patch-darwin8.diff
+
 # Skip bootstrap comparison entirely
 post-patch {
     reinplace {s|^do-compare =|do-compare = /usr/bin/true|g} \

--- a/lang/gcc10-bootstrap/files/patch-darwin8.diff
+++ b/lang/gcc10-bootstrap/files/patch-darwin8.diff
@@ -1,0 +1,40 @@
+commit be0a1a32207595c0b6dc952f48630f1b077d7aeb
+Author: Iain Sandoe <iain@sandoe.co.uk>
+Date:   Fri Mar 4 12:34:15 2022 +0000
+
+    Darwin, libgcc: Fix build errors on powerpc-darwin8.
+    
+    PowerPC Darwin8 is the last version to use an unwind frame fallback routine.
+    This had been omitted from the new shared EH library, along with one more
+    header dependency that only fires there.
+    
+    Signed-off-by: Iain Sandoe <iain@sandoe.co.uk>
+    
+    libgcc/ChangeLog:
+    
+            * config/rs6000/t-darwin-ehs: Add darwin-fallback.o.
+            * config/t-darwin-ehs: Add dependency on unwind.h.
+    
+    (cherry picked from commit c18ddb05b0391a397f8882fc6a12a1bab7e0df52)
+
+diff --git libgcc/config/rs6000/t-darwin-ehs libgcc/config/rs6000/t-darwin-ehs
+index 42f521411af..581344e862a 100644
+--- libgcc/config/rs6000/t-darwin-ehs
++++ libgcc/config/rs6000/t-darwin-ehs
+@@ -1,3 +1,3 @@
+-# We need the save_world code for the EH library.
++# We need the save_world and anu unwind fallback code for the EH library.
+ 
+-LIBEHSOBJS += darwin-world_s.o
++LIBEHSOBJS += darwin-world_s.o darwin-fallback.o
+diff --git libgcc/config/t-darwin-ehs libgcc/config/t-darwin-ehs
+index 95275023dac..df46f8a6529 100644
+--- libgcc/config/t-darwin-ehs
++++ libgcc/config/t-darwin-ehs
+@@ -3,5 +3,5 @@
+ 
+ LIBEHSOBJS = unwind-dw2_s.o unwind-dw2-fde-darwin_s.o unwind-c_s.o
+ 
+-unwind-dw2_s.o: gthr-default.h md-unwind-support.h
++unwind-dw2_s.o: gthr-default.h md-unwind-support.h unwind.h
+ $(LIBEHSOBJS): libgcc_tm.h


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/65498 and https://trac.macports.org/ticket/65692


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

as `port -s install gcc10-bootstrap -universal build_arch=ppc universal_archs= cxx_stdlib=libstdc++` on:

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

as `port -s install gcc10-bootstrap` on:

macOS 12.4 21F79 arm64
Xcode 13.1 13A1030d

Also Ken confirmed that patch for Tiger works on his Tiger at https://trac.macports.org/ticket/65692 ;)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->