### PR TITLE
libsrtp, libsrtp1: update to 2.4.2 and 1.6.0, fix libsrtp1 build

### DIFF
--- a/net/libsrtp/Portfile
+++ b/net/libsrtp/Portfile
@@ -1,44 +1,43 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           openssl 1.0
 PortGroup           muniversal 1.0
+PortGroup           github 1.0
 
-name                libsrtp
-version             2.1.0
-revision            2
+github.setup        cisco libsrtp 2.4.2 v
+revision            0
 categories          net devel
 maintainers         {db.org:aeh @alfredh} openmaintainer
 description         Secure Real-time Transport Protocol (SRTP)
 long_description    The libSRTP library is an open-source implementation of \
                     the Secure Real-time Transport Protocol (SRTP).
 homepage            https://github.com/cisco/libsrtp
-platforms           darwin
-master_sites        https://github.com/cisco/libsrtp/archive/
 license             BSD
 
-checksums           rmd160  436b1167489562ac7e3360136182ce4e28078ceb \
-                    sha256  0302442ed97d34a77abf84617b657e77674bdd8e789d649f1cac0c5f0d0cf5ee
+checksums           rmd160  f02155cb6deb598abfd4a2d759e2ec9aac277f16 \
+                    sha256  1e217993dc12fe4b53768654755102adb172da2b96ba7df77bcd93f11722eb37 \
+                    size    631812
 
-depends_build-append  port:pkgconfig
-depends_lib-append                 \
-    path:lib/libssl.dylib:openssl  \
-    port:zlib                      \
-    port:libpcap
+depends_build-append    port:pkgconfig
+depends_lib-append      port:zlib \
+                        port:libpcap
 
-configure.args-append \
-    --enable-openssl
-
-livecheck.url       https://github.com/cisco/libsrtp/releases
-livecheck.regex     {/v(\d+(?:\.\d+)*)}
+configure.args-append   --enable-openssl
 
 subport libsrtp1 {
-    version             1.5.4
-    revision            2
+    github.setup        cisco libsrtp 1.6.0 v
+    revision            0
 
-    checksums           rmd160  9a02b2644839147dd794d368cede6cf7f23d75e4 \
-                        sha256  56a7b521c25134f48faff26b0b1e3d4378a14986a2d3d7bc6fefb48987304ff0
+    # The subport is not compatible with 1.1 API, fails with error: field ‘ctx’ has incomplete type
+    # Related info: https://github.com/dun/munge/commit/d913c154425217f89b827e86686b777c9b3d0cf4
+    openssl.branch      1.0
 
-    livecheck.regex     {/v(1(?:\.\d+)*)}
+    checksums           rmd160  50230cfced7e8ec66b525881f167b81a66e59da3 \
+                        sha256  3132460eecb32c4fb87b8addba51eccda65acbb391229e4fff319725e562ae83 \
+                        size    1648893
+
+    platform powerpc {
+        configure.args-append   CPU_RISC=1
+    }
 }
-
-distfiles           v${version}${extract.suffix}


### PR DESCRIPTION
#### Description

Update of both to current versions.

`libsrtp1` subport is broken across the board: https://ports.macports.org/port/libsrtp1/details/
Fix the build: use `openssl` PG due to API incompatibility with 1.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
