### PR TITLE
libwebsockets: fix build on <11

### DIFF
--- a/devel/libwebsockets/Portfile
+++ b/devel/libwebsockets/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           legacysupport 1.1
+
+# LegacySupport is needed for strnlen before 10.7
+legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        warmcat libwebsockets 4.3.2 v
 github.tarball_from archive
@@ -28,6 +32,14 @@ depends_lib-append  path:lib/libssl.dylib:openssl \
                     port:zlib \
                     port:libev \
                     port:libuv
+
+# https://trac.macports.org/ticket/65706
+compiler.blacklist-append *gcc-4.*
+
+platform powerpc {
+    # Without this, Rosetta pulls out Xcode clang
+    compiler.blacklist-append clang
+}
 
 # Set LWS_BUILD_HASH directly. Otherwise, it will require a git repository.
 configure.args-append \


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65706

#### Description

Currently the port is broken on <11: https://ports.macports.org/port/libwebsockets/details/
This PR hopefully fixes it for all affected systems. Confirmed to build on 10.6.8.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
