### PR TITLE
ttyd: update to 1.7.1, fix build for <11

### DIFF
--- a/net/ttyd/Portfile
+++ b/net/ttyd/Portfile
@@ -2,16 +2,19 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           cmake 1.0
+PortGroup           cmake 1.1
+PortGroup           legacysupport 1.1
 
-github.setup        tsl0922 ttyd 1.6.3
-revision            1
-checksums           rmd160  924fb4e6f3b7628bf5baa15c1c7ffb6ce230d86f \
-                    sha256  1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9 \
-                    size    500424
+# LegacySupport is needed for strnlen before 10.7
+legacysupport.newest_darwin_requires_legacy 10
+
+github.setup        tsl0922 ttyd 1.7.1
+revision            0
+checksums           rmd160  e462272404e2e580ee77f4d867325f9182f1b81f \
+                    sha256  e1e9993b1320c8623447304ae27031502569a1e37227ec48d4e21dae7db6eb66 \
+                    size    508841
 
 categories          net
-platforms           darwin
 maintainers         nomaintainer
 license             MIT
 
@@ -27,3 +30,11 @@ depends_build-append \
 depends_lib-append  port:json-c \
                     port:libwebsockets \
                     path:lib/libssl.dylib:openssl
+
+# If gcc-4.2 is used, build fails with undefined symbols from libwebsockets
+compiler.blacklist-append *gcc-4.*
+
+platform powerpc {
+    # Without this, Rosetta pulls out Xcode clang
+    compiler.blacklist-append clang
+}


### PR DESCRIPTION
#### Description

Update to the current v. 1.7.1.
Fixes for older systems.

_Note:_ to build this on <11, this is required first: https://github.com/macports/macports-ports/pull/15804 (but this does not affect check buildbots).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
