### PR TITLE
xrootd: fix build with gcc

### DIFF
--- a/science/xrootd/Portfile
+++ b/science/xrootd/Portfile
@@ -20,7 +20,6 @@ description         Generic suite for fast, low-latency and scalable data access
 long_description    {*}${description}
 
 license             LGPL-3+
-platforms           darwin
 
 homepage            http://xrootd.org/
 
@@ -35,12 +34,14 @@ depends_lib-append  port:curl \
                     path:lib/libuuid.dylib:ossp-uuid \
                     port:zlib
 
+patchfiles-append   patch-byteswap.diff
+
 default_variants    +ssl +readline +kerberos
 
 cmake.out_of_source yes
 
 # Force a compatible compiler
-compiler.blacklist-append *gcc* {clang < 900} {macports-clang-3.[0-9]} {macports-clang-[4-5].0}
+compiler.blacklist-append *gcc-4.* {clang < 900} {macports-clang-3.[0-9]} {macports-clang-[4-5].0}
 # Blacklist Xcode clang on 10.12
 # error: template argument for template template parameter must be a class template or type alias template
 compiler.blacklist-append {clang < 1000}

--- a/science/xrootd/files/patch-byteswap.diff
+++ b/science/xrootd/files/patch-byteswap.diff
@@ -1,0 +1,22 @@
+--- src/XrdOssCsi/XrdOssCsiTagstoreFile.hh.orig	2022-06-09 17:56:41.000000000 +0800
++++ src/XrdOssCsi/XrdOssCsiTagstoreFile.hh	2022-08-21 21:15:49.000000000 +0800
+@@ -37,7 +37,19 @@
+ 
+ #include <memory>
+ #include <mutex>
++
++#if defined(__GLIBC__) || defined(__BIONIC__) || defined(__CYGWIN__)
+ #include <byteswap.h>
++#elif defined(__APPLE__)
++// Make sure that byte swap functions are not already defined.
++#if !defined(bswap_16)
++// Mac OS X / Darwin features
++#include <libkern/OSByteOrder.h>
++#define bswap_16(x) OSSwapInt16(x)
++#define bswap_32(x) OSSwapInt32(x)
++#define bswap_64(x) OSSwapInt64(x)
++#endif
++#endif
+ 
+ class XrdOssCsiTagstoreFile : public XrdOssCsiTagstore
+ {


### PR DESCRIPTION
#### Description

The PR:
1. Replaces blacklist of `*gcc*` with `*gcc-4.*`, to allow using new GCC. (Do we actually need those at all, given portfile has `compiler.cxx_standard  2014`? Maybe do away with blacklists altogether?)
2. Fixes an error with `byteswap.h` missing on MacOS. (To be honest I wonder how Clang does not err out on that – FWIU that header is missing on all version of MacOS or at least on majority of them.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
