### PR TITLE
openjdk11: update to 11.0.16.1

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 name                openjdk11
 # https://github.com/openjdk/jdk11u/tags
 # remove 'jdk-' from the latest tag without '-ga' that has commit that corresponds to the latest tag with '-ga'
-version             11.0.16
-set build 8
+version             11.0.16.1
+set build 1
 revision            0
 categories          java devel
 platforms           darwin
@@ -20,9 +20,9 @@ homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  070b09234c15f5ed3da23d85152781ce87d06ce4 \
-                    sha256  58acafa79830b550eed738b9c9590d3a19c44d776f9be634e0f7e1c5a57cb1b9 \
-                    size    123145634
+checksums           rmd160  22919c59d4f3561b7e42cbb35c13e7ca91701620 \
+                    sha256  72eae6ec11a0f04dbe2a18d314cbc8cd0aa64da8dd4709f0aea3d5c0a536e931 \
+                    size    123137897
 
 depends_lib         port:freetype
 depends_build       port:autoconf \
@@ -157,4 +157,8 @@ notes "
 If you want to make ${name} the default JDK, add this to shell profile:
 export JAVA_HOME=${pathb}/Contents/Home
 "
-    
+
+livecheck.type      regex
+livecheck.url       https://github.com/openjdk/jdk11u/tags
+livecheck.regex     jdk-(\[0-9.\]+)-ga
+


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.16.1 and add livecheck.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?