### PR TITLE
openjdk17: update to 17.0.4.1

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk17
 # https://github.com/openjdk/jdk17u/tags
-version             17.0.4
-set build 8
+version             17.0.4.1
+set build 1
 revision            0
 categories          java devel
 platforms           darwin
@@ -19,9 +19,9 @@ homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  d0a70d2e3cf7fa70ef9e5a2ac2551e0b605fb595 \
-                    sha256  b10b80aa96ac43c75163c1888bb42b66e1eeaecb02412d30de5369df7337ac8f \
-                    size    104904275
+checksums           rmd160  c7de36c4dee6cd8006eb8d30539df0ae1028d319 \
+                    sha256  2164a1e2a426c0353b80817f83ee85f16f7fc9ce47bc0ff5024e491616a1cd24 \
+                    size    104892822
 
 depends_lib         port:freetype
 depends_build       port:autoconf \
@@ -147,3 +147,6 @@ If you want to make ${name} the default JDK, add this to shell profile:
 export JAVA_HOME=${pathb}/Contents/Home
 "
     
+livecheck.type      regex
+livecheck.url       https://github.com/openjdk/jdk17u/tags
+livecheck.regex     jdk-(17\.\[0-9.\]+)-ga


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.4.1 and add livecheck.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?