### PR TITLE
qscintilla: work around failure to find SDK

### DIFF
--- a/devel/qscintilla/Portfile
+++ b/devel/qscintilla/Portfile
@@ -67,6 +67,13 @@ foreach qt_major {4 5} {
 
             # fixup @rpath in the library's install_name
             patchfiles-append patch-src-qscintilla.pro.diff
+
+            # https://trac.macports.org/ticket/65293
+            if { ${os.platform} eq "darwin" && (( ${os.major} >= 15 && ${os.major} <= 16 ) || ${os.major} >= 20 ) } {
+                use_xcode   yes
+            }
+
+            qt5.min_version 5.6
         }
 
         if {${qt_major} eq 4} {
@@ -97,6 +104,13 @@ foreach qt_major {4 5} {
             PortGroup qmake${qt_major} 1.0
 
             worksrcdir ${worksrcdir}/designer
+
+            # https://trac.macports.org/ticket/65293
+            if { ${os.platform} eq "darwin" && (( ${os.major} >= 15 && ${os.major} <= 16 ) || ${os.major} >= 20 ) } {
+                use_xcode   yes
+            }
+
+            qt5.min_version 5.6
         }
 
         description       Qt Designer plugin for Qt${qt_major} QScintilla
@@ -146,6 +160,13 @@ foreach qt_major {4 5} {
 
                 # the Python bindings below require the latest qscintilla-qt5 version
                 conflicts py36-pyqt5-scintilla py37-pyqt5-scintilla py38-pyqt5-scintilla py39-pyqt5-scintilla
+
+                # https://trac.macports.org/ticket/65293
+                if { ${os.platform} eq "darwin" && (( ${os.major} >= 15 && ${os.major} <= 16 ) || ${os.major} >= 20 ) } {
+                    use_xcode   yes
+                }
+
+                qt5.min_version 5.6
             }
             categories-append   python
             description         Python bindings for Qt${qt_major} QScintilla


### PR DESCRIPTION
#### Description

See https://trac.macports.org/ticket/65293

I only need/use qscintilla-qt5, but according to the Port Health on ports.macports.com (e.g. https://ports.macports.org/port/py37-pyqt5-scintilla/details/) all of the Qt5 subports of this portfile are affected, so I applied the workaround to all of them.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
