### PR TITLE
gtk4: add system blockers

### DIFF
--- a/gnome/gtk4/Portfile
+++ b/gnome/gtk4/Portfile
@@ -15,7 +15,7 @@ set my_name         gtk4
 set gname           gtk
 
 version             4.6.7
-revision            0
+revision            1
 
 categories          gnome
 platforms           darwin
@@ -130,6 +130,18 @@ variant quartz conflicts x11 {
         configure.objcxxflags-prepend   -isystem ${filespath}/old_appkit_compat
     }
 
+    if {${os.platform} eq "darwin" && ${os.major} < 15} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
+            ui_error "${name} is not supported on this os version at present."
+            return -code error {unsupported platform}
+        }
+    }
+
 }
 
 variant x11 conflicts quartz {
@@ -142,16 +154,29 @@ variant x11 conflicts quartz {
                              port:xorg-libXinerama
 
     configure.args-append   -Dx11-backend=true -Dmacos-backend=false
+
+    # the x11 variant needs EGL support added to mesa and libepoxy
+    # and even then the performance is well below the quartz variant
+    # so keep it disabled until it can be fixed
+
+    if {${os.platform} eq "darwin"} {
+        depends_build
+        depends_lib
+        depends_run
+        archive_sites
+        known_fail yes
+        pre-fetch {
+            ui_error "${name} is not supported with the +x11 variant at present."
+            ui_error "Please use the +quartz variant instead"
+            return -code error {unsupported platform}
+        }
+    }
 }
 
-#if {![variant_isset quartz]} {
-# the x11 variant needs EGL support added to mesa and libepoxy
-# and even then the performance is well below the quartz variant
-#    default_variants +x11
-#}
-
-if {![variant_isset x11]} {
-    default_variants +quartz
+if {![variant_isset quartz]} {
+    # it is somewhat illogical to default to a variant that cannot build, however
+    # this matches the rest of macports and will tweak users to build as +quartz manually
+    default_variants +x11
 }
 
 variant tests description "build tests" {


### PR DESCRIPTION
block +quartz on darwin < 15
block +x11 on all systems

change default to x11 to match macports
this presently gives a message to users to install with +quartz

revbump to enforce new defaults