### PR TITLE
llvm-gcc42: remove unused portgroup

### DIFF
--- a/lang/llvm-gcc42/Portfile
+++ b/lang/llvm-gcc42/Portfile
@@ -1,6 +1,5 @@
 PortSystem 1.0
 PortGroup select 1.0
-PortGroup compiler_blacklist_versions 1.0
 
 name                    llvm-gcc42
 version                 2336.11


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
