### PR TITLE
mysql56, mysql57: workaround for newer compilers

### DIFF
--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -63,6 +63,9 @@ if {$subport eq $name} {
     # Avoid implicitly declaring select()
     patchfiles-append   patch-include-sys-select-h.diff
 
+    # Workaround https://bugs.mysql.com/bug.php?id=100217
+    patchfiles-append   patch-innodb_engine-fcommon.diff
+
     checksums           rmd160  c6c43b04fc34fb9ceb55eb6f5be9ce4ea3bff56d \
                         sha256  262ccaf2930fca1f33787505dd125a7a04844f40d3421289a51974b5935d9abc \
                         size    32411131

--- a/databases/mysql56/files/patch-innodb_engine-fcommon.diff
+++ b/databases/mysql56/files/patch-innodb_engine-fcommon.diff
@@ -1,0 +1,12 @@
+Workaround for https://bugs.mysql.com/bug.php?id=100217
+--- a/plugin/innodb_memcached/innodb_memcache/CMakeLists.txt
++++ b/plugin/innodb_memcached/innodb_memcache/CMakeLists.txt
+@@ -38,7 +38,7 @@
+ STRING(REGEX REPLACE "-Wdeclaration-after-statement" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+ ENDIF(CMAKE_C_FLAGS MATCHES "-Werror")
+ 
+-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_SHARED_LIBRARY_C_FLAGS} -std=gnu99")
++SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_SHARED_LIBRARY_C_FLAGS} -std=gnu99 -fcommon")
+ 
+ SET(MCD__UTILITITY_SOURCES
+ 		util-src/config_parser.c

--- a/databases/mysql57/Portfile
+++ b/databases/mysql57/Portfile
@@ -74,6 +74,7 @@ if {$subport eq $name} {
     patch.pre_args  -p1
     patchfiles      patch-cmake-install_layout.cmake.diff \
                     patch-configure.cmake.diff \
+                    patch-innodb_engine-fcommon.diff \
                     patch-innodb_memcached-daemon_memcached-include-memcached-util.h.diff \
                     patch-lockpool.diff \
                     patch-cmake-fix-test-env.diff

--- a/databases/mysql57/files/patch-innodb_engine-fcommon.diff
+++ b/databases/mysql57/files/patch-innodb_engine-fcommon.diff
@@ -1,0 +1,12 @@
+Workaround for https://bugs.mysql.com/bug.php?id=100217
+--- a/plugin/innodb_memcached/innodb_memcache/CMakeLists.txt
++++ b/plugin/innodb_memcached/innodb_memcache/CMakeLists.txt
+@@ -41,7 +41,7 @@
+ # Set extra flags for the C compiler
+ IF(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+   SET(CMAKE_C_FLAGS
+-    "${CMAKE_C_FLAGS} ${CMAKE_SHARED_LIBRARY_C_FLAGS} -std=gnu99")
++    "${CMAKE_C_FLAGS} ${CMAKE_SHARED_LIBRARY_C_FLAGS} -std=gnu99 -fcommon")
+ ENDIF()
+ 
+ SET(MCD__UTILITITY_SOURCES


### PR DESCRIPTION
#### Description
Avoid build failures with LLVM Clang 11 and later (as currently seen on 10.6/10.7 builders for mysql57).
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1
MacPorts LLVM Clang 14

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
