### PR TITLE
py-pkgutil_resolve_name: submission

### DIFF
--- a/python/py-jsonschema/Portfile
+++ b/python/py-jsonschema/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-jsonschema
 version             4.9.1
-revision            0
+revision            1
 categories-append   devel
 license             MIT
 supported_archs     noarch
@@ -55,7 +55,8 @@ if {${name} ne ${subport}} {
             depends_lib-append  port:py${python.version}-typing_extensions
         }
         if {${python.version} < 39} {
-            depends_lib-append  port:py${python.version}-importlib-resources
+            depends_lib-append  port:py${python.version}-importlib-resources \
+                                port:py${python.version}-pkgutil_resolve_name
         }
     }
 

--- a/python/py-pkgutil_resolve_name/Portfile
+++ b/python/py-pkgutil_resolve_name/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pkgutil_resolve_name
+version             1.3.10
+revision            0
+categories-append   devel
+license             MIT
+supported_archs     noarch
+
+python.versions     37 38
+python.pep517       yes
+python.pep517_backend flit
+
+maintainers         nomaintainer
+
+description         A backport of Python 3.9’s pkgutil.resolve_name.
+long_description    {*}${description}
+
+homepage            https://github.com/graingert/pkgutil-resolve-name
+
+checksums           rmd160  d63e02f9beb87d70e1f9c95076176233eac639cd \
+                    sha256  357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174 \
+                    size    5054
+
+if {${name} ne ${subport}} {
+    post-patch {
+        reinplace "s|flit_core >=2,<3|flit_core >=2|g" pyproject.toml
+    }
+}


### PR DESCRIPTION
#### Description

Submitting `py-pkgutil_resolve_name`, which is needed by `py-jsonschema` on Python <= 3.8 (see https://trac.macports.org/ticket/65687). Reviews and corrections welcome.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
