### PR TITLE
openjdk17-zulu: update to 17.36.17

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.36.13
+version      17.36.17
 revision     0
 
-set openjdk_version 17.0.4
+set openjdk_version 17.0.4.1
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  3ff6471469d2180a6a625facc09d01eec7c50980 \
-                 sha256  272414ef009d68b1b2d951b32595e0eb1a311722d000218b832d82f037209352 \
-                 size    193513867
+    checksums    rmd160  c9d70a65bec54e0d5a23a279aad6f9bcf95acb8f \
+                 sha256  a078284cc127155f9d72c85649a13405288ec690a5908b8a039b93357a01149d \
+                 size    193484983
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  77ac5516053a14a15eb1c4e409bcabfe61fd4a07 \
-                 sha256  a8a5dcdc4561b48d25fa251244962d0980ce7231eef0728abdf6d1efd7ea77ec \
-                 size    191329853
+    checksums    rmd160  88fe4ac0c25917cd46146e4e643067c4208c313e \
+                 sha256  47e27e38ed09279d826e14cae4b5bf91dd93c3efc2a1d1a20235b8df74964f34 \
+                 size    191313750
 }
 
 worksrcdir   ${distname}/zulu-17.jdk
@@ -53,7 +53,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
 
 homepage     https://www.azul.com/downloads/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://cdn.azul.com/zulu/bin/
+livecheck.regex     zulu(17\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 17.36.17, add livecheck.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?