### PR TITLE
openjdk11-zulu: update to 11.58.23

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.58.15
+version      11.58.23
 revision     0
 
-set openjdk_version 11.0.16
+set openjdk_version 11.0.16.1
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  40263711dc20caaf3875a824929b993ad195c966 \
-                 sha256  a5d1f39e1d54ca015d8640813de80cdb43a247f99ad40ef1cfa09318bd9525d8 \
-                 size    193630992
+    checksums    rmd160  deb05210ad6d6253f56a248dd8fc40aa2771de5d \
+                 sha256  7eee35218c02ee660178153ed91c283514f1b5c79ef2e0a90446a61e641d2601 \
+                 size    193695225
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  d8aa9518baf8c227107cd26335ebca2fb397b351 \
-                 sha256  cb71a8ad38755f881a692098ca02378183a7a9c5093d7e6ad98ca5e7bc74b937 \
-                 size    191793488
+    checksums    rmd160  24c4ddc6b5388ffedb1ad40771e808b7b9ab4320 \
+                 sha256  53be67a043aeb6aabdfd2a02764c9374a6cb7056bc0a31114a87cd492d3e90cf \
+                 size    191781689
 }
 
 worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 11.58.23.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?