### PR TITLE
openjdk18-zulu: add livecheck

### DIFF
--- a/java/openjdk18-zulu/Portfile
+++ b/java/openjdk18-zulu/Portfile
@@ -53,7 +53,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
 
 homepage     https://www.azul.com/downloads/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://cdn.azul.com/zulu/bin/
+livecheck.regex     zulu(18\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Add livecheck for Azul Zulu OpenJDK 18.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?