### PR TITLE
openjdk11-temurin: update x86_64 to 11.0.16.1

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,13 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-if {${configure.build_arch} eq "x86_64"} {
-    version      11.0.16
-    set build    8
-} elseif {${configure.build_arch} eq "arm64"} {
-    version      11.0.16.1
-    set build    1
-}
+version      11.0.16.1
+set build    1
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -30,9 +25,9 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  05d08b2b8756f032d44df0d8456301e94edf877d \
-                 sha256  8e9bd7669f5c59c60404cebf25c086e04623677e0f827ce85e3ecdbfb0581c3a \
-                 size    186325803
+    checksums    rmd160  efbc5bea3b4279b2112c940ed07488f596c42477 \
+                 sha256  723548e36e0b3e0a5a2f36a38b22ea825d3004e26054a0e254854adc57045352 \
+                 size    186335152
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
     checksums    rmd160  b36984a0b0dfbad9ee75d194a9ac382ecae1e4e0 \
@@ -54,7 +49,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
 
 homepage     https://adoptium.net
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin11-binaries/releases
+livecheck.regex     OpenJDK11U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin x86_64 11.0.16.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?