### PR TITLE
openjdk17-temurin: update to 17.0.4.1

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.4
-set build    8
+version      17.0.4.1
+set build    1
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  a2ec77af68f96f0b75abdb16c86607a9cf4e68aa \
-                 sha256  2a04025a8b974ba69025a498f3327270bdbee4d6c24cf69f603091f6ad60694b \
-                 size    186916566
+    checksums    rmd160  fdc1f600ce30da3d736dad16dfad804d2dbc6e63 \
+                 sha256  ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a \
+                 size    186906753
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  806ce0917e1bb4b3407eedf82b701d9099ef9a06 \
-                 sha256  19fffac89c4b8c0b4da32cae2cbd864ad9e71875aa3ab69f3a5900b6b2e16e7b \
-                 size    177119187
+    checksums    rmd160  65e5e9f27671659ad604ea3e7feeb8971de7e4c1 \
+                 sha256  3a976943a9e6a635e68e2b06bd093fc096aad9f5894acda673d3bea0cb3a6f38 \
+                 size    177121101
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -49,7 +49,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
 
 homepage     https://adoptium.net
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin17-binaries/releases
+livecheck.regex     OpenJDK17U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.4.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?