### PR TITLE
openjdk17-microsoft: update to 17.0.4.1

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -14,9 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-set build 7
-
-version      17.0.4
+version      17.0.4.1
+set build    1
 revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
@@ -27,21 +26,23 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  41f63463aa387f265bcd2390f57ba81f3e913bce \
-                 sha256  7ecf431271eebeb76d64855ccced20645c86a5e4ec6c0642d895f22f6f11a0ea \
-                 size    187265182
+    checksums    rmd160  a9886b101c1153d899dcc5b1f2eb868d3a124095 \
+                 sha256  da2352bf73f26a2dbda4de187962163f809c43391fd672c0252308033cc1179d \
+                 size    187255412
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  64a07133909e7a7edb691918974cb95f0cecfa7f \
-                 sha256  fc74037baacb3e628a090cb2ec45c756f461e6cf6f716c78f7104644f0e75436 \
-                 size    177478330
+    checksums    rmd160  39c237acd197d0198ac4845a11a900afa3a7953f \
+                 sha256  29d9c48640818eb041a9a4cbf01ef48684f1fe4a591585b1631186693a131431 \
+                 size    177474164
 }
 
 worksrcdir   jdk-${version}+${build}
 
 homepage     https://www.microsoft.com/openjdk
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://docs.microsoft.com/en-us/java/openjdk/download
+livecheck.regex     microsoft-jdk-(17\.\[0-9\.\]+)-macOS-.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.4.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?