### PR TITLE
openjdk11-microsoft: update to 11.0.16.1

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.16
-set build    8
+version      11.0.16.1
+set build    1
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -26,21 +26,23 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  7ee6562dcbecc078bde1f0bb075b1eb2792550f0 \
-                 sha256  12579c27312e083003dc3595ca477b8e4878c2068c1a173fc3497bc8241730a0 \
-                 size    187093103
+    checksums    rmd160  278b7d8bf8130fa2c00ada843e74a069d16b15b2 \
+                 sha256  ae4da8381f9bd27e7a9f2a01083eb524290d480aed1dc239c477f6f2f525e7b0 \
+                 size    187070226
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  7c7964bf559413ee6464b6009171c2d900565d42 \
-                 sha256  bb44d21ecd07cd7ebd8affe0267389e746101887290b44bf70ea26c393f2b294 \
-                 size    184704311
+    checksums    rmd160  6705543351c5b55963210802f68c3626e2170d49 \
+                 sha256  46912c2f0ba11595b54b1c5cf6e9ef97538729e4ffb26f462fca99615f26c44e \
+                 size    184693905
 }
 
 worksrcdir   jdk-${version}+${build}
 
 homepage     https://www.microsoft.com/openjdk
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://docs.microsoft.com/en-us/java/openjdk/download
+livecheck.regex     microsoft-jdk-(11\.\[0-9\.\]+)-macOS-.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.16.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?