### PR TITLE
jdk17: update to 17.0.4.1

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.4
+version      17.0.4.1
 revision     0
 
 description  Oracle Java SE Development Kit 17
@@ -26,21 +26,23 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  126a6e3a657c1a5bd803d31758d85c056d6c46d4 \
-                 sha256  d39ee8290d65c53db4919733d1c6c8c7a6f1641569087f2c619f631ac95c63d6 \
-                 size    178252857
+    checksums    rmd160  4ae7cf5ad074e752b1a1ca6aa81628ca044ab473 \
+                 sha256  1419160aa761fbe25431a20bd8ea8483704668700f1d3eb8774745f7263560b9 \
+                 size    178265322
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  e28e9b40c674ddddbac5d07815bf88d60cebe732 \
-                 sha256  b075a8d60b7d63a5fff5533bd67a2c2b18bd661d7d4942e7fed22398baecef64 \
-                 size    175600777
+    checksums    rmd160  59107acfe786aac0543b721b9a19aa2a340de3d1 \
+                 sha256  2712f7d169f989bf34e6879c0822be7a37906f4f927b8763ac8e719d39cd853f \
+                 size    175604899
 }
 
 worksrcdir   jdk-${version}.jdk
 
 homepage     https://www.oracle.com/java/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://www.oracle.com/java/technologies/downloads/
+livecheck.regex     Java SE Development Kit (17\.\[0-9\.\]+)
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Oracle JDK 17.0.4.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?