### PR TITLE
jdk18: update to 18.0.2.1

### DIFF
--- a/java/jdk18/Portfile
+++ b/java/jdk18/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk18-mac
-version      18.0.2
+version      18.0.2.1
 revision     0
 
 description  Oracle Java SE Development Kit 18
@@ -26,21 +26,23 @@ master_sites https://download.oracle.com/java/18/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  46e4068a93540d6c21661a3f8e8a4743b23d3bed \
-                 sha256  4001e1fc158796b1ac5803c285eda87e769dd10a3729c6c60b9a94e333ba83bb \
-                 size    178759977
+    checksums    rmd160  081abed3c2fa1be7aa0bbd17d2cc25865af54b49 \
+                 sha256  4c0bfa05cf27b9bee6586933581204d6757b5939769a7c25e13a52bf07a9b9db \
+                 size    178759371
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  cc070dc3c1b81744a7de821eb197c164b157bc3d \
-                 sha256  0128c6a429000da265637840fe1c22c61fa6abb510275389e4687ba639d46567 \
-                 size    176601156
+    checksums    rmd160  d4c243eb6e25acd03888be1341735ea3d62505a0 \
+                 sha256  ee900a062e0a4b76e9da4f90933ea560c9129b24685f78664a892beeb4f53c64 \
+                 size    176602474
 }
 
 worksrcdir   jdk-${version}.jdk
 
 homepage     https://www.oracle.com/java/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://www.oracle.com/java/technologies/downloads/
+livecheck.regex     Java SE Development Kit (18\.\[0-9\.\]+)
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Oracle JDK 18.0.2.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?