### PR TITLE
openjdk18-oracle: update to 18.0.2.1

### DIFF
--- a/java/openjdk18-oracle/Portfile
+++ b/java/openjdk18-oracle/Portfile
@@ -14,31 +14,33 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/18/
-version      18.0.2
+version      18.0.2.1
 revision     0
 
 description  Oracle OpenJDK 18
 long_description Open-source Oracle build of OpenJDK 18, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/f6ad4b4450fd4d298113270ec84f30ee/9/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/db379da656dc47308e138f21b33976fa/1/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  3640b73832af50142b67db2ce8a05685444d7796 \
-                 sha256  528aaf1ea27f9a3052bd88a0af877c63e87d517214c1ee91807c9590a77f1a75 \
-                 size    185437991
+    checksums    rmd160  e051eacb45fac420b9b8eb80f047c165233c1add \
+                 sha256  604ba4b3ccb594973a3a73779a367363c53dd91e5a9de743f4fbfae89798f93a \
+                 size    185436355
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  496f942a03dce2b74f713390b978c24d46b853af \
-                 sha256  1da591d9ab49c348d5a424975ae44ea940edf1c3b3b4456d0a3020758829799e \
-                 size    183269809
+    checksums    rmd160  b6c8724094398842b3a63d2b4f969c29c406260d \
+                 sha256  c05aec589f55517b8bedd01463deeba80f666da3fb193be024490c9d293097a8 \
+                 size    183270307
 }
 
 worksrcdir   jdk-${version}.jdk
 
 homepage     https://jdk.java.net/18/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://jdk.java.net/18/
+livecheck.regex     OpenJDK JDK (18\.\[0-9\.\]+)
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 18.0.2.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?