### PR TITLE
openjdk18-openj9: update to 18.0.2.1

### DIFF
--- a/java/openjdk18-openj9/Portfile
+++ b/java/openjdk18-openj9/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 version      18.0.2
-revision     0
+revision     1
 
 set build    9
-set openj9_version 0.33.0
+set openj9_version 0.33.1
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 18
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,21 +28,23 @@ master_sites https://github.com/ibmruntimes/semeru18-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  6f744cf87b47ea3a297478eb1ee6cdcad1708813 \
-                 sha256  08387494d81de88831a0d4c15c4a1b99be3397c2ec97a4216a5919077457bb52 \
-                 size    210567465
+    checksums    rmd160  1ab42085fd2bef56416b5177e9e75ebff11a69cc \
+                 sha256  a7ecbcfc57304d28637ab490330da33f55255200d7310ba217e255cbacd321e6 \
+                 size    210549227
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  5c1108f83455fb782b039c20ce2345211d71ec0a \
-                 sha256  69abcd5542b3befb4c766674742fb0ad16b9d9a9541fa3cae0d9673217e6f888 \
-                 size    203771879
+    checksums    rmd160  60972530b6f9ccaf963bdf6115462b9ef06deb42 \
+                 sha256  0330df7979f28e17d193b97c190d7be524888247671206eff467144133d8e115 \
+                 size    203764949
 }
 
 worksrcdir   jdk-${version}+${build}
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/ibmruntimes/semeru18-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(18\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 18.0.2.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?