### PR TITLE
openjdk17-openj9: update to 17.0.4.1

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      17.0.4
+version      17.0.4.1
 revision     0
 
-set build    8
-set openj9_version 0.33.0
+set build    1
+set openj9_version 0.33.1
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,21 +28,23 @@ master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  77c206691f73d594a074fea444896fc7352322af \
-                 sha256  a935f20564e347a9292955c04eb57e51efdb1853ae7f0b4fe759b22c9fe248be \
-                 size    209040959
+    checksums    rmd160  0ace9d4d0ae0772c0518c3bd9b429f6edc1e9d1b \
+                 sha256  7de428bd9637081126ffe945bd178367015da32ef03903feb183efad6158d88b \
+                 size    209034425
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  aa2b62c4e835a229182cb18e10a6b7545af36181 \
-                 sha256  bf22628b54115dff9939b94751531544ab735b7cbbc8d6ddfe83d1b04df3a532 \
-                 size    202269399
+    checksums    rmd160  1b60da1879940004ee3f6c0b26b9bc836b6c3c3e \
+                 sha256  50e4c324e7ffcf18c2e3ea7b1bfa870672203dab3fe61520c09fb2bdbe81f2c0 \
+                 size    202255954
 }
 
 worksrcdir   jdk-${version}+${build}
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/ibmruntimes/semeru17-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(17\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.4.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?