### PR TITLE
openjdk11-openj9: update to 11.0.16.1

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.16
+version      11.0.16.1
 revision     0
 
-set build    8
-set openj9_version 0.33.0
+set build    1
+set openj9_version 0.33.1
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,21 +28,23 @@ master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  3b407dad625ad56c02e8170182f01aa260272959 \
-                 sha256  8638735d2cae3efff212f898728685380355bb0a298076e9e46244d0bf3d4a64 \
-                 size    204217112
+    checksums    rmd160  0a8d11bca008a3c1d4f5ff497232d4043d906d8a \
+                 sha256  a17760f2e2e860650fab0518e3af79cad574576a76d554219663217956dbe267 \
+                 size    204211072
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  0d3ed07ae0ef6dcb1a31ae3eaa5f775853033794 \
-                 sha256  9881b292142a129f6f5c6b21608b090f8f94625052b4f7d0ce5bd982c054ca2e \
-                 size    198390114
+    checksums    rmd160  1744cb4597b047fd9fcd4e4871de6bf4125cdaa6 \
+                 sha256  b04676d83c6362301581cea79ae6a878ea9e00deab32e6f95fb5454dc5b76f62 \
+                 size    198376263
 }
 
 worksrcdir   jdk-${version}+${build}
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/ibmruntimes/semeru11-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(11\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.16.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?