### PR TITLE
openjdk8-openj9: update to 8.0.345.1

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -116,10 +116,10 @@ subport openjdk8-openj9 {
     supported_archs  x86_64
 
     version      8u345
-    revision     0
+    revision     1
 
     set build    01
-    set openj9_version 0.33.0
+    set openj9_version 0.33.1
 
     homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
@@ -130,9 +130,9 @@ subport openjdk8-openj9 {
     distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
 
-    checksums    rmd160  1a4b825178e0268db47bace8b690596ad5e80efa \
-                 sha256  c69086950c006b17484a70ef7bc85e92d121be15e69e282e1446fd238d42b6b4 \
-                 size    129519233
+    checksums    rmd160  372400ffc0ec6e0c444337289eec66cb060265cf \
+                 sha256  332da84b1cc928e32a4d4fc00f0bb1c102e489abe80df24aa7fab59133379359 \
+                 size    129511642
 }
 
 subport openjdk8-temurin {
@@ -211,7 +211,13 @@ if {[string match *-graalvm ${subport}]} {
     homepage     https://aws.amazon.com/corretto/
 }
 
-livecheck.type  none
+if {[string match *-openj9 ${subport}]} {
+    livecheck.type      regex
+    livecheck.url       https://github.com/ibmruntimes/semeru8-binaries/releases/
+    livecheck.regex     ibm-semeru-open-jdk_.*_mac_(8u\[0-9\.\]+).*_openj9-\[0-9\.\]+\.tar\.gz
+} else {
+    livecheck.type  none
+}
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8.0.345.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?