### PR TITLE
google-cloud-sdk: update to 399.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             398.0.0
+version             399.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  9178e7969b7f1f8c86ab8497ee9512aa161d0c35 \
-                    sha256  de0d924e296dd4a1cf2b84d86c90ea974f59d75a960e9b3dcf830a29a7404bee \
-                    size    108687066
+    checksums       rmd160  45a8149d40d54559095477ab72c791ef97f664b5 \
+                    sha256  709cbf8cdc4c027213291543b4ff4bfbfc55659909a30410bf3b59bb8e58e23f \
+                    size    108757285
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  cc828cfe6a9a10decbab77fc3331dfd95ece3dca \
-                    sha256  7eeed24f2060995a9e70cc4dfa578e2c2143a51545e2d995b0f9f62c846acb89 \
-                    size    106697456
+    checksums       rmd160  ce91b866950e551c2251f03ffa0454e5e6c5f911 \
+                    sha256  8f73f3723dbee24e6154baedfea3e488a1983c1114a54e2c4170061a64a66324 \
+                    size    106764459
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  a7f73e848097a2a09497059abf01f20c0831ac0c \
-                    sha256  62864574e5f1dd6f010a6a393edd02a9a31dce5cd06f0242cdda76e0268a0c4d \
-                    size    105254904
+    checksums       rmd160  99eedaf2f66a49a2a1cf8c7013d58364dc7a9dc2 \
+                    sha256  50c9566e49b24dd4ef2101ddfb1925feb9f9be38df9904c9fed27e731fd48adc \
+                    size    105322375
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -46,15 +46,17 @@ python.default_version 37
 
 post-patch {
     # Default to the MacPorts Python binary
-    reinplace "s|CLOUDSDK_PYTHON=\$(order_python .*|CLOUDSDK_PYTHON=${python.bin}|" ${worksrcpath}/bin/bq
-    reinplace "s|CLOUDSDK_PYTHON=\$(order_python .*|CLOUDSDK_PYTHON=${python.bin}|" ${worksrcpath}/bin/docker-credential-gcloud
-    reinplace "s|CLOUDSDK_PYTHON=\$(order_python .*|CLOUDSDK_PYTHON=${python.bin}|" ${worksrcpath}/bin/git-credential-gcloud.sh
-    reinplace "s|CLOUDSDK_PYTHON=\$(order_python .*|CLOUDSDK_PYTHON=${python.bin}|" ${worksrcpath}/bin/gcloud
-    reinplace "s|CLOUDSDK_PYTHON=\$(order_python .*|CLOUDSDK_PYTHON=${python.bin}|" ${worksrcpath}/bin/gsutil
-    reinplace "s|CLOUDSDK_PYTHON=\$(order_python .*|CLOUDSDK_PYTHON=${python.bin}|" ${worksrcpath}/bin/java_dev_appserver.sh
+    reinplace "s|CLOUDSDK_PYTHON=\$(order_python .*|CLOUDSDK_PYTHON=${python.bin}|" \
+        ${worksrcpath}/bin/bq \
+        ${worksrcpath}/bin/docker-credential-gcloud \
+        ${worksrcpath}/bin/git-credential-gcloud.sh \
+        ${worksrcpath}/bin/gcloud \
+        ${worksrcpath}/bin/gsutil \
+        ${worksrcpath}/bin/java_dev_appserver.sh
 
-    reinplace "s|^#!/usr/bin/env python$|#!${python.bin}|" ${worksrcpath}/bin/dev_appserver.py
-    reinplace "s|^#!/usr/bin/env python$|#!${python.bin}|" ${worksrcpath}/bin/endpointscfg.py
+    reinplace "s|^#!/usr/bin/env python$|#!${python.bin}|" \
+        ${worksrcpath}/bin/dev_appserver.py \
+        ${worksrcpath}/bin/endpointscfg.py
 
     # Disable updater
     reinplace "s|\"disable_updater\": false|\"disable_updater\": true|" ${worksrcpath}/lib/googlecloudsdk/core/config.json


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 399.0.0, compact `reinplace` commands.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?