### PR TITLE
DeaDBeeF: New port (version 1.9.1)

### DIFF
--- a/multimedia/DeaDBeeF/Portfile
+++ b/multimedia/DeaDBeeF/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           xcode 1.0
+PortGroup           github 1.0
+
+github.setup        DeaDBeeF-Player deadbeef 1.9.1
+name                DeaDBeeF
+categories          multimedia
+platforms           macosx
+
+maintainers         {@ajhall} \
+                    openmaintainer
+description         ${name} is a modular cross-platform audio player
+long_description    {*}${description}. It plays a variety of audio formats,    \
+                    converts between them, lets you customize the UI in almost \
+                    any way you want, and use many additional plugins which    \
+                    can extend it even more.\n\nNOTE: The macOS version has    \
+                    not been officially released, and has many unresolved      \
+                    issues and unimplemented features.
+
+homepage            http://deadbeef.sf.net/
+license             zlib LGPL-2.1 GPL-2
+
+fetch.type          git
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+xcode.configuration     Release
+xcode.target            DeaDBeeF
+xcode.project           osx/deadbeef.xcodeproj
+xcode.build.settings    GCC_TREAT_WARNINGS_AS_ERRORS=NO
+
+destroot {
+    copy \
+        [glob ${worksrcpath}/osx/build/Release/DeaDBeeF.app] \
+        ${destroot}${applications_dir}/
+}


### PR DESCRIPTION
#### Description
New port for DeaDBeeF audio player.

Closes: https://trac.macports.org/ticket/63206

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
