### PR TITLE
gitlab-runner: don't use hardcoded REVISION and BRANCH in ld_flags

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            gitlab.com/gitlab-org/gitlab-runner 15.3.0 v
-revision            0
+revision            1
 
 homepage            https://docs.gitlab.com/runner/
 
@@ -29,18 +29,24 @@ checksums           rmd160  9f61ee71f3578a182ef17751ae458a1371ab521d \
 # Allow Go to fetch deps at build time
 build.env-delete    GO111MODULE=off GOPROXY=off
 
-# Reproduce the "build_simple" target from the upstream Makefile
-# Lookup REVISION from https://gitlab.com/gitlab-org/gitlab-runner/-/releases/v${version}
-set go_ldflags     " \
-    -X ${go.package}/common.NAME=${go.package} \
-    -X ${go.package}/common.VERSION=${version} \
-    -X ${go.package}/common.REVISION=32fc1585 \
-    -X ${go.package}/common.BUILT=unknown \
-    -X ${go.package}/common.BRANCH=15-2-stable \
-    -s -w "
+pre-build {
+    # Reproduce the "runner-bin-host" target from the upstream Makefile
+    # Lookup REVISION from https://gitlab.com/gitlab-org/gitlab-runner/-/releases/v${version}
+    set release_info [exec curl -s "https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-runner/releases/v${version}"]
+    regexp {"short_id"\s*:\s*"(.{8})"} ${release_info}     matched short_id
+    regexp {^(\d+)\.(\d+)\.}           ${version}          matched major minor
 
-build.args\
-    -ldflags \"${go_ldflags}\" -o out/binaries/${name} ${go.package}
+    set go_ldflags     " \
+        -X ${go.package}/common.NAME=${go.package} \
+        -X ${go.package}/common.VERSION=${version} \
+        -X ${go.package}/common.REVISION=${short_id} \
+        -X ${go.package}/common.BUILT=unknown \
+        -X ${go.package}/common.BRANCH=${major}-${minor}-stable \
+        -s -w "
+
+    build.args\
+        -ldflags \"${go_ldflags}\" -o out/binaries/${name} ${go.package}
+}
 
 destroot {
     xinstall -m 0755 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
