### PR TITLE
openjdk18: update to 18.0.2.1

### DIFF
--- a/java/openjdk18/Portfile
+++ b/java/openjdk18/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk18
 # https://github.com/openjdk/jdk18u/tags
-version             18.0.2
-set build 9
+version             18.0.2.1
+set build 1
 revision            0
 categories          java devel
 platforms           darwin
@@ -19,9 +19,9 @@ homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk18u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  73a4bde8c6e02da4106e2d5c25cdf25e914022cc \
-                    sha256  ccef9f46af500031330d308dc412d1cab415f2c9e0d06b742e709947158f3079 \
-                    size    105494921
+checksums           rmd160  e309f6e16dea9c38b62f3277af94dd02aeb0e8da \
+                    sha256  7d026848a48e8777d3242bab2adf30122f0acda88abbd3f92636f8793eaf3455 \
+                    size    105492402
 
 depends_lib         port:freetype
 depends_build       port:openjdk18-bootstrap \
@@ -147,3 +147,6 @@ If you want to make ${name} the default JDK, add this to shell profile:
 export JAVA_HOME=${pathb}/Contents/Home
 "
     
+livecheck.type      regex
+livecheck.url       https://github.com/openjdk/jdk18u/tags
+livecheck.regex     jdk-(18\.\[0-9\.\]+)-ga


### PR DESCRIPTION
#### Description

Update to OpenJDK 18.0.2.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?