### PR TITLE
openjdk8: add livecheck

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -179,3 +179,6 @@ If you want to make the JRE installed by the ${name} the default JRE, add this t
 export JAVA_HOME=${jre_path}/Contents/Home
 "
     
+livecheck.type      regex
+livecheck.url       https://github.com/openjdk/jdk8u/tags
+livecheck.regex     jdk(8u\[0-9\]+)-ga


### PR DESCRIPTION
#### Description

Add livecheck for OpenJDK 8.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?