### PR TITLE
kops: update to 1.24.1

### DIFF
--- a/devel/kops/Portfile
+++ b/devel/kops/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes/kops 1.23.2 v
+go.setup            github.com/kubernetes/kops 1.24.1 v
 github.tarball_from archive
 revision            0
 go.package          k8s.io/kops
@@ -18,14 +18,19 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  5ab50d96c4dba33c2b15eb87be505e8e407e46b4 \
-                    sha256  adfc507517295fa1c1289528459921abb3e8dad1c7f304f6cd2310382f37c3d0 \
-                    size    30376137
+checksums           rmd160  71f07f966d381f51140819a7c63359cdac066a7f \
+                    sha256  011c01528e5906e6d4ffa4371f9f855b8fe8c635f67a056eaeda0b02f8050e92 \
+                    size    30839565
 
-depends_run         port:kubectl-1.23
+depends_run         port:kubectl-1.24
 
 build.cmd           make
-build.target        all
+
+# This project uses vendored sources, which cannot be used with Go modules
+# and the proxy turned off.
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+build.target        kops
 
 # Do not build on macOS 10.11 and earlier
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
@@ -39,7 +44,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
 
 destroot {
     xinstall -m 0755 \
-        {*}[glob ${worksrcpath}/.build/local/*] ${destroot}${prefix}/bin
+        {*}[glob ${worksrcpath}/.build/dist/${goos}/${goarch}/kops] ${destroot}${prefix}/bin
 }
 
 github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

* update to `kops` 1.24.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5
Xcode 13.4.1 / Command Line Tools x.y.z

###### Verification 

Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
