### PR TITLE
m68k-palm-elf-gcc: new port

### DIFF
--- a/cross/m68k-palm-elf-binutils/Portfile
+++ b/cross/m68k-palm-elf-binutils/Portfile
@@ -1,0 +1,11 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           crossbinutils 1.0
+
+crossbinutils.setup m68k-palm-elf 2.37
+revision            0
+
+maintainers         {@nkorth nkorth.com:nkorth} openmaintainer
+
+configure.args-append --disable-werror

--- a/cross/m68k-palm-elf-gcc/Portfile
+++ b/cross/m68k-palm-elf-gcc/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       crossgcc 1.0
+
+crossgcc.setup  m68k-palm-elf 9.1.0-palm2
+crossgcc.languages c
+revision        0
+maintainers     {@nkorth nkorth.com:nkorth} openmaintainer
+
+master_sites    http://mirrors.nkorth.com/srcpkgs/gcc/
+checksums       rmd160  575d265a975ecbd1055c6d47fcfe778752b2f462 \
+                sha256  53685f64e5abb21adb3ce43b2c748d01b2750b8ca55c9c385f66614ffd9748e8 \
+                size    79885216
+
+# override crossgcc default...
+use_bzip2       no
+use_xz          yes
+# ...which requires resetting these too
+distfiles       gcc-${version}${extract.suffix}
+set extract.only ${distfiles}
+
+# palm specific config
+configure.args-delete --enable-multilib
+configure.args-append --disable-multilib --with-arch=m68k --with-cpu=m68000


### PR DESCRIPTION
#### Description

This is [the other half of][2] a toolchain for building Palm OS apps. It consists of the Retro68 fork of gcc 9.1.0, with a few patches from [dmitrygr][3].

The master site is my own website, even though I didn't write the code. It doesn't have a homepage other than [this reddit post][1], which has a google drive link for the source package. Instead of trying to get macports to download the source from google drive (which also includes a lot of unnecessary code left over from Retro68), I took only the gcc source and put it into a new archive.

[1]: https://old.reddit.com/r/Palm/comments/p81m58/announce_new_gcc_or_palmos_again/
[2]: https://github.com/macports/macports-ports/pull/15788
[3]: http://palmpowerups.com/index.php

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.4 21F79 x86_64
Command Line Tools 13.0.0.0.1.1627064638

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
