### PR TITLE
py-awscli2: update to 2.7.26

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.7.22
+github.setup        aws aws-cli 2.7.26
 revision            0
 
 categories          python devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  a14182d841d5885729c66c732d1d485c6bf02909 \
-                    sha256  593b8f739ee6978c3ac4e1dcbe93ae514d6d9da9561e830d3d89a9078f3be61a \
-                    size    11140872
+checksums           rmd160  8cd18eceb89365a7bff4f6faa387f55b180ebe7b \
+                    sha256  7a79b7ea61826f982e53e09b8c9d88b451b7e67b3213a9314caf73b542ee2dc3 \
+                    size    11197069
 
 python.versions     38 39 310
 

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,9 +1,9 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-diff -ru aws-cli-2.7.16-orig/setup.cfg aws-cli-2.7.16/setup.cfg
---- aws-cli-2.7.16-orig/setup.cfg	2022-07-15 12:58:56.000000000 -0400
-+++ aws-cli-2.7.16/setup.cfg	2022-07-15 15:54:50.619473352 -0400
+diff -ru aws-cli-2.7.26-orig/setup.cfg aws-cli-2.7.26/setup.cfg
+--- aws-cli-2.7.26-orig/setup.cfg	2022-08-24 14:34:39.000000000 -0400
++++ aws-cli-2.7.26/setup.cfg	2022-08-24 21:56:22.727217713 -0400
 @@ -29,17 +29,17 @@
  python_requires = >=3.8
  include_package_data = True
@@ -15,7 +15,7 @@ diff -ru aws-cli-2.7.16-orig/setup.cfg aws-cli-2.7.16/setup.cfg
 -    wcwidth<0.2.0
 -    prompt-toolkit>=3.0.24,<3.0.29
 -    distro>=1.5.0,<1.6.0
--    awscrt>=0.12.4,<=0.13.11
+-    awscrt>=0.12.4,<=0.14.0
 -    python-dateutil>=2.1,<3.0.0
 -    jmespath>=0.7.1,<1.1.0
 -    urllib3>=1.25.4,<1.27
@@ -26,7 +26,7 @@ diff -ru aws-cli-2.7.16-orig/setup.cfg aws-cli-2.7.16/setup.cfg
 +    wcwidth
 +    prompt-toolkit
 +    distro
-+    awscrt==0.13.11
++    awscrt==0.14.0
 +    python-dateutil
 +    jmespath
 +    urllib3

--- a/python/py-awscrt/Portfile
+++ b/python/py-awscrt/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-awscrt
 # This is only used by awscli2. Bump when Amazon bumps
 # their pinned version in awscli2's setup.cfg.
-version             0.13.11
+version             0.14.0
 revision            0
 
 categories-append   devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  e20617aa2f818fd16a2538d2ed6672fac5bb51e6 \
-                    sha256  631dc8dd10f9ecdc7a0af9b89a8739ce631b76c1de6223208437db414a2bdfc1 \
-                    size    19921081
+checksums           rmd160  53741306c16670da29fe1811addbc15cb6b876c4 \
+                    sha256  3062d315cb16542fe04dd8239f2e8bc3238ee9045cd5070b915cf2ebbecbaaac \
+                    size    19961152
 
 python.versions     37 38 39 310
 


### PR DESCRIPTION
#### Description

Bumping the version of awscrt as they have relaxed the constraints in awscli.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
