### PR TITLE
openjdk11-sap: update to 11.0.16.1

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.16
+version      11.0.16.1
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  efebc3815fe14f95960f757d2ba3ad8b609315f9 \
-                 sha256  183837bb7407fc0dca48cdfbe6af08b8ed85d1805fa223b05b8e61e2597d2652 \
-                 size    186898404
+    checksums    rmd160  02fd47852bf6185914d980bbc9c9d33ea2ea6cc1 \
+                 sha256  1d6d0b4f8f8fd32b559102ab4fe7e571ed3eee3848877d055ce4d475448ad9a3 \
+                 size    186897220
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  e829babbf693042155e36474b0836e3498d1b363 \
-                 sha256  828d2906526b560cdea086deac7025cadc0cefef80e06d3f65d9688c04efb160 \
-                 size    185061175
+    checksums    rmd160  9ef2448cdbaa98c055783f0f2e41b300578af5c4 \
+                 sha256  e3d8d11afd3766c300b02f5c4b4158041807ef2b6dba63d3de7320f9ce5a4826 \
+                 size    185066000
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk
@@ -85,3 +85,7 @@ by adding the following line to your shell profile:
 
     export JAVA_HOME=${target}/Contents/Home
 "
+
+livecheck.type      regex
+livecheck.url       https://github.com/SAP/SapMachine/releases
+livecheck.regex     sapmachine-jdk-(11\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.16.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?