### PR TITLE
openjdk17-sap: update to 17.0.4.1

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.4
+version      17.0.4.1
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,20 +24,22 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  004623d35e2dcf27bed87ee57d43a01387539954 \
-                 sha256  78dba5e09788d0e88f45d00fbab37b85c17af22bae7f404f6bae0252ba0b14d9 \
-                 size    179970289
+    checksums    rmd160  96b9e64f7849b609ad1dc80c418173cf36509e39 \
+                 sha256  9650dfe7f85edf28bf01f5d1243e60c2b351e4434e6f0207664534af8e220f1c \
+                 size    179970596
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  08424961d82fb7566531892392e7c3e34dd19fb8 \
-                 sha256  e5bb306387a87af2140ece8d4100f8ff1610266ce1417c11e05ca887b38f6480 \
-                 size    177731278
+    checksums    rmd160  1b5a315e6a8ddb93c60802cba2496656b44c55e4 \
+                 sha256  0f77e79f2314243c736170f90527418f8dcad404e3a8b7c991052f1d6f53d9f6 \
+                 size    177743026
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 
 homepage     https://sapmachine.io
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/SAP/SapMachine/releases
+livecheck.regex     sapmachine-jdk-(17\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.4.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?