### PR TITLE
openjdk18-sap: update to 18.0.2.1

### DIFF
--- a/java/openjdk18-sap/Portfile
+++ b/java/openjdk18-sap/Portfile
@@ -13,7 +13,7 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-version      18.0.2
+version      18.0.2.1
 revision     0
 
 description  SapMachine 18
@@ -23,21 +23,23 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  8cb2ed749e48338e52e59fbc324f721f6bfb5a0f \
-                 sha256  6f3ae5267896de1fc887b455157c26eac9c6d32c64aa6aee94b0bc2c61253b14 \
-                 size    181289049
+    checksums    rmd160  23c0c5a4382663ebac61015a24f91d6be5dc9c65 \
+                 sha256  b1a125af11804e90ebb6d4eb1be8336b706cb39a38ffafdbf5906de9dd0cdf86 \
+                 size    181284233
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  b643cb712e0e815cee5274d6ce8a3cd34ed50936 \
-                 sha256  75a7e28b1fcfa4366dec5810265b7b8f7844d53e87005176feb797d4173456ab \
-                 size    179132289
+    checksums    rmd160  6de3a3abeab10c4f57c0c7e3c645e48b76fb95bd \
+                 sha256  3ec5a50c2404c2bbe19e6d9b2beb59763642ad9ab4d800e10ff8ca76c96ccf70 \
+                 size    179140169
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk
 
 homepage     https://sap.github.io/SapMachine/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/SAP/SapMachine/releases
+livecheck.regex     sapmachine-jdk-(18\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to SapMachine 18.0.2.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?