### PR TITLE
openjdk-distributions: move openjdk8-openj9 to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -18,10 +18,6 @@ revision         0
 set long_description_corretto \
    "No-cost, multiplatform, production-ready distribution of OpenJDK."
 
-set long_description_ibm_semeru \
-    "The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications built with\
-the OpenJDK class libraries and the Eclipse OpenJ9 JVM."
-
 set long_description_temurin \
     "Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes."
 
@@ -31,7 +27,6 @@ set long_description_graalvm \
 
 # Dummy default values
 set build          0
-set openj9_version 0
 
 set obsoleted_ports {
     openjdk
@@ -111,30 +106,6 @@ subport openjdk8-graalvm {
     replaced_by  openjdk11-graalvm
 }
 
-subport openjdk8-openj9 {
-    # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
-    supported_archs  x86_64
-
-    version      8u345
-    revision     1
-
-    set build    01
-    set openj9_version 0.33.1
-
-    homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
-
-    description  Open Java Development Kit 8 (IBM Semeru) with Eclipse OpenJ9 VM
-    long_description ${long_description_ibm_semeru}
-
-    master_sites https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
-    distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
-    worksrcdir   jdk${version}-b${build}
-
-    checksums    rmd160  372400ffc0ec6e0c444337289eec66cb060265cf \
-                 sha256  332da84b1cc928e32a4d4fc00f0bb1c102e489abe80df24aa7fab59133379359 \
-                 size    129511642
-}
-
 subport openjdk8-temurin {
     # https://adoptium.net/temurin/releases/
     supported_archs  x86_64
@@ -186,14 +157,7 @@ subport openjdk16-zulu {
 
 if {${os.platform} eq "darwin"} {
     # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-    if {[string match *-openj9 ${subport}] && ${os.major} < 14} {
-        # See https://www.ibm.com/support/pages/semeru-runtimes-support
-        known_fail yes
-        pre-fetch {
-            ui_error "${name} ${version} is only supported on Mac OS X 10.10 Yosemite or later."
-            return -code error
-        }
-    } elseif {[string match *-temurin ${subport}] && ${os.major} < 16} {
+    if {[string match *-temurin ${subport}] && ${os.major} < 16} {
         # See https://adoptium.net/supported_platforms.html
         known_fail yes
         pre-fetch {
@@ -211,13 +175,7 @@ if {[string match *-graalvm ${subport}]} {
     homepage     https://aws.amazon.com/corretto/
 }
 
-if {[string match *-openj9 ${subport}]} {
-    livecheck.type      regex
-    livecheck.url       https://github.com/ibmruntimes/semeru8-binaries/releases/
-    livecheck.regex     ibm-semeru-open-jdk_.*_mac_(8u\[0-9\.\]+).*_openj9-\[0-9\.\]+\.tar\.gz
-} else {
-    livecheck.type  none
-}
+livecheck.type  none
 
 use_configure    no
 build {}

--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -1,0 +1,86 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk8-openj9
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
+supported_archs  x86_64
+
+version      8u345
+revision     1
+
+set build    01
+set openj9_version 0.33.1
+
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 8
+long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
+                 built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
+
+master_sites https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+
+distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
+worksrcdir   jdk${version}-b${build}
+
+checksums    rmd160  372400ffc0ec6e0c444337289eec66cb060265cf \
+             sha256  332da84b1cc928e32a4d4fc00f0bb1c102e489abe80df24aa7fab59133379359 \
+             size    129511642
+
+homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
+
+livecheck.type      regex
+livecheck.url       https://github.com/ibmruntimes/semeru8-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(8u\[0-9\.\]+).*_openj9-\[0-9\.\]+\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk8-openj9` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?