### PR TITLE
openjdk-distributions: move openjdk8-corretto to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -15,9 +15,6 @@ universal_variant no
 version          1.0
 revision         0
 
-set long_description_corretto \
-   "No-cost, multiplatform, production-ready distribution of OpenJDK."
-
 set long_description_temurin \
     "Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes."
 
@@ -70,33 +67,6 @@ subport openjdk7-zulu {
     version      7.56.0.11
     revision     1
     replaced_by  openjdk8-zulu
-}
-
-subport openjdk8-corretto {
-    # https://github.com/corretto/corretto-8/releases
-    supported_archs  x86_64 arm64
-
-    version     8.342.07.3
-    revision    0
-
-    description  Amazon Corretto OpenJDK 8 (Long Term Support)
-    long_description ${long_description_corretto}
-
-    master_sites https://corretto.aws/downloads/resources/${version}/
-
-    if {${configure.build_arch} eq "x86_64"} {
-        distname     amazon-corretto-${version}-macosx-x64
-        checksums    rmd160  966b129d1ae0255d7d9cbfd202c2f9511af048e1 \
-                     sha256  ab4db316b4c5bb886355bbe192a71a5328e43609631477857a1992ca80975fcf \
-                     size    118790575
-    } elseif {${configure.build_arch} eq "arm64"} {
-        distname     amazon-corretto-${version}-macosx-aarch64
-        checksums    rmd160  192cf91d72d450cbaf229e5e0981365e40a4b5b8 \
-                     sha256  cb29f72976f9e9be525c8ec58edc8bfc20a24f3ec13c5c7259cf1ded3a921eeb \
-                     size    104196362
-    }
-
-    worksrcdir   amazon-corretto-8.jdk
 }
 
 # Remove after 2022-10-19
@@ -171,8 +141,6 @@ if {[string match *-graalvm ${subport}]} {
     homepage     https://www.graalvm.org
 } elseif {[string match *-temurin ${subport}]} {
     homepage     https://adoptium.net
-} elseif {[string match *-corretto ${subport}]} {
-    homepage     https://aws.amazon.com/corretto/
 }
 
 livecheck.type  none

--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -1,0 +1,99 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk8-corretto
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://github.com/corretto/corretto-8/releases
+supported_archs  x86_64 arm64
+
+version      8.342.07.3
+revision     0
+
+description  Amazon Corretto OpenJDK 8 (Long Term Support)
+long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
+
+master_sites https://corretto.aws/downloads/resources/${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     amazon-corretto-${version}-macosx-x64
+    checksums    rmd160  966b129d1ae0255d7d9cbfd202c2f9511af048e1 \
+                 sha256  ab4db316b4c5bb886355bbe192a71a5328e43609631477857a1992ca80975fcf \
+                 size    118790575
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     amazon-corretto-${version}-macosx-aarch64
+    checksums    rmd160  192cf91d72d450cbaf229e5e0981365e40a4b5b8 \
+                 sha256  cb29f72976f9e9be525c8ec58edc8bfc20a24f3ec13c5c7259cf1ded3a921eeb \
+                 size    104196362
+}
+
+worksrcdir   amazon-corretto-8.jdk
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # See https://github.com/corretto/corretto-8/blob/release-8.342.07.3/CHANGELOG.md
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
+        return -code error
+    }
+}
+
+homepage     https://aws.amazon.com/corretto/
+
+livecheck.type      regex
+livecheck.url       https://github.com/corretto/corretto-8/releases
+livecheck.regex     amazon-corretto-(8\.\[0-9\.\]+)-macosx-.*\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk8-corretto` to its own portfile. I plan to do this for all `openjdk*` subports for simpler maintainability. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?