### PR TITLE
asdf: New port (version 0.10.2)

### DIFF
--- a/sysutils/asdf/Portfile
+++ b/sysutils/asdf/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        asdf-vm asdf 0.10.2 v
+categories          sysutils devel
+license             MIT
+
+maintainers         {@ajhall} \
+                    openmaintainer
+
+description         Extendable version manager with support for Ruby, Node.js, \
+                    Elixir, Erlang & more
+long_description    ${name} is a CLI tool that can manage multiple language \
+                    runtime versions on a per-project basis.
+homepage            https://asdf-vm.com/
+
+checksums           rmd160  e2914679c43265b47a08d214a3c2a93bdea16e86 \
+                    sha256  de6bce49804f991b3594b9614b4bd14291421dbdd6586c4239d5aa472887222e \
+                    size    192384
+
+use_configure       no
+build               {}
+
+depends_run         bin:curl:curl \
+                    bin:git:git
+
+destroot {
+    xinstall -d -m 0755 ${destroot}${prefix}/share/${name}
+    copy {*}[glob ${worksrcpath}/*] ${destroot}${prefix}/share/${name}
+    touch ${destroot}${prefix}/share/${name}/asdf_updates_disabled
+
+    set asdf_share_dir ${prefix}/share/${name}
+
+    # Bash completions
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    ln -s ${asdf_share_dir}/completions/${name}.bash \
+         ${destroot}${prefix}/share/bash-completion/completions/${name}
+
+    # Zsh completions
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    ln -s ${asdf_share_dir}/completions/_${name} \
+        ${destroot}${prefix}/share/zsh/site-functions/_${name}
+
+    # Fish completions
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    ln -s ${asdf_share_dir}/completions/${name}.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/${name}.fish
+}
+
+notes "
+Activate asdf by adding it to your shell profile.
+
+Zsh or Bash: Add the following line to ~/.zshrc or ~/.bashrc
+    . ${prefix}/share/${name}/asdf.sh
+
+Fish: Add the following line to ~/.config/fish/config.fish
+    source ${prefix}/share/${name}/asdf.fish
+"


### PR DESCRIPTION
#### Description
New port for asdf version manager.
https://asdf-vm.com/

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
