### PR TITLE
openjdk-distributions: move openjdk8-temurin to its own Portfile

### DIFF
--- a/java/openjdk-distributions/Portfile
+++ b/java/openjdk-distributions/Portfile
@@ -15,16 +15,6 @@ universal_variant no
 version          1.0
 revision         0
 
-set long_description_temurin \
-    "Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes."
-
-set long_description_graalvm \
-    "GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
-    JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++."
-
-# Dummy default values
-set build          0
-
 set obsoleted_ports {
     openjdk
     openjdk7-zulu
@@ -76,27 +66,6 @@ subport openjdk8-graalvm {
     replaced_by  openjdk11-graalvm
 }
 
-subport openjdk8-temurin {
-    # https://adoptium.net/temurin/releases/
-    supported_archs  x86_64
-
-    version      8u345
-    revision     0
-
-    set build    01
-
-    description  Eclipse Temurin, based on OpenJDK 8
-    long_description ${long_description_temurin}
-
-    master_sites https://github.com/adoptium/temurin8-binaries/releases/download/jdk${version}-b${build}/
-    distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
-    worksrcdir   jdk${version}-b${build}
-
-    checksums    rmd160  ecf6e0243ac503ebe5903f7e3b137c593077697c \
-                 sha256  3eeba0e76101b9f5e8eb9eb14ad991293cf0cc064df35f6a89882b603630f0c8 \
-                 size    107934646
-}
-
 # Remove after 2022-09-14
 subport openjdk16 {
     version      16.0.2
@@ -124,72 +93,3 @@ subport openjdk16-zulu {
     revision     1
     replaced_by  openjdk17-zulu
 }
-
-if {${os.platform} eq "darwin"} {
-    # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-    if {[string match *-temurin ${subport}] && ${os.major} < 16} {
-        # See https://adoptium.net/supported_platforms.html
-        known_fail yes
-        pre-fetch {
-            ui_error "${name} ${version} is only supported on Mac OS X 10.12 Sierra or later."
-            return -code error
-        }
-    }
-}
-
-if {[string match *-graalvm ${subport}]} {
-    homepage     https://www.graalvm.org
-} elseif {[string match *-temurin ${subport}]} {
-    homepage     https://adoptium.net
-}
-
-livecheck.type  none
-
-use_configure    no
-build {}
-
-if {!(${subport} in ${obsoleted_ports}) && ![info exists meta]} {
-    if {![string match *-temurin ${subport}]} {
-        variant BundledApp \
-            description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-        variant JNI \
-            description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-    }
-
-    variant Applets \
-        description { Advertise the JVM capability "Applets".} {}
-
-    variant WebStart \
-        description { Advertise the JVM capability "WebStart".} {}
-
-    patch {
-        foreach var { Applets BundledApp JNI WebStart } {
-            if {[variant_isset ${var}]} {
-                reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-            }
-        }
-    }
-
-    test.run    yes
-    test.cmd    Contents/Home/bin/java
-    test.target
-    test.args   -version
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-    destroot.violate_mtree yes
-
-    set target /Library/Java/JavaVirtualMachines/${subport}
-    set destroot_target ${destroot}${target}
-
-    destroot {
-        xinstall -m 755 -d ${destroot_target}
-        copy ${worksrcpath}/Contents ${destroot_target}
-    }
-
-    notes "
-    If you have more than one JDK installed you can make ${subport} the default
-    by adding the following line to your shell profile:
-        export JAVA_HOME=${target}/Contents/Home
-    "
-}    

--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -1,0 +1,86 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk8-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/
+supported_archs  x86_64
+
+version      8u345
+set build    01
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK 8
+long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin8-binaries/releases/download/jdk${version}-b${build}/
+distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
+worksrcdir   jdk${version}-b${build}
+
+checksums    rmd160  ecf6e0243ac503ebe5903f7e3b137c593077697c \
+             sha256  3eeba0e76101b9f5e8eb9eb14ad991293cf0cc064df35f6a89882b603630f0c8 \
+             size    107934646
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # See https://adoptium.net/supported_platforms.html
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://adoptium.net
+
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin8-binaries/releases
+livecheck.regex     OpenJDK8U-jdk_x64_mac_hotspot_(8u\[0-9\]+)b\[0-9\]+\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

Move `openjdk8-temurin` to its own portfile. The end goal is to get rid of `openjdk-distributions` completely.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?