### PR TITLE
openjdk11-corretto: add livecheck

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -48,7 +48,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 19} {
 
 homepage     https://aws.amazon.com/corretto/
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/corretto/corretto-11/releases
+livecheck.regex     amazon-corretto-(11\.\[0-9\.\]+)-macosx-.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Add livecheck for Amazon Corretto 11.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?