### PR TITLE
openjdk8-graalvm: fix replacement port

### DIFF
--- a/java/openjdk8-graalvm/Portfile
+++ b/java/openjdk8-graalvm/Portfile
@@ -6,6 +6,6 @@ PortGroup   obsolete 1.0
 
 name        openjdk8-graalvm
 categories  java devel
-replaced_by openjdk8-zulu
+replaced_by openjdk11-graalvm
 version     21.0.0.2
 revision    2


### PR DESCRIPTION
#### Description

Fix incorrect replacement port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?