### PR TITLE
erlang: do not use *gcc-4.*

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -77,7 +77,7 @@ depends_lib         port:ncurses
 # Erlang seems to have an on-again/off-again relationship with Clang.
 # As of Xcode 4.2, it's off again.
 # GCC 4.2 also fails: https://trac.macports.org/ticket/52507
-compiler.blacklist  {clang < 300} gcc-4.2
+compiler.blacklist  {clang < 300} *gcc-4.*
 
 post-destroot   {
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_html_${version}${extract.suffix}]"


### PR DESCRIPTION
#### Description

Existing compliler.blacklist leads to `llvm-gcc-4.2` being picked on 10.6: https://trac.macports.org/ticket/52507
This is a wrong choice when the build is for `ppc` (such as Rosetta case): to begin with, Rosetta starts building for Intel, but even when that is fixed (adding `--build=`), build still fails.

PR adds:
```
platform darwin 10 powerpc {
    compiler.blacklist-append *gcc-4.*
}
```
No other systems are affected.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Rosetta
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
