### PR TITLE
dnscontrol: update to 3.20.0

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/StackExchange/dnscontrol 3.19.0 v
+go.setup            github.com/StackExchange/dnscontrol 3.20.0 v
 
-checksums           rmd160  e8af1d319e05625defd19688530e57afd111d4c0 \
-                    sha256  7ba3f8a2f75dcf2097ca83f9065fa0b8c313e34c8c2169c778f4793febdda2cf \
-                    size    2394859
+checksums           rmd160  a6cea0b57eeb7e8fc86faf320f0d5cb3385a26e1 \
+                    sha256  cd4cdbad7e3709f70c600fdfc8b1b0a49579dcd527af1560ebb1133d91a515d3 \
+                    size    2395297
 
 homepage            https://stackexchange.github.io/dnscontrol/
 description         Synchronize your DNS to multiple providers from a simple DSL
@@ -27,7 +27,7 @@ license             MIT
 maintainers         {@ajhall} \
                     openmaintainer
 
-# Allow deps to fetched at build time
+# Allow deps to be fetched at build time
 build.env-delete    GO111MODULE=off GOPROXY=off
 
 build.args-append   -ldflags \"-s -w \


### PR DESCRIPTION
#### Description
dnscontrol: update to 3.20.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
