### PR TITLE
tig: update to 2.5.7

### DIFF
--- a/devel/tig/Portfile
+++ b/devel/tig/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonas tig 2.5.6 tig-
+github.setup        jonas tig 2.5.7 tig-
 github.tarball_from releases
-checksums           rmd160  3d3d2b3c45785f3f7041db0c5cc103db6ec17ebd \
-                    sha256  50bb5f33369b50b77748115c730c52b13e79b2de49cba7167bb634eb683d965f \
-                    size    1176006
+checksums           rmd160  95c70d5df106401a2fb77e3ee98ff3dd9928ea4e \
+                    sha256  dbc7bac86b29098adaa005a76161e200f0734dda36de9f6bd35a861c7c29ca76 \
+                    size    1176146
 
 categories          devel
 maintainers         {cal @neverpanic} \


### PR DESCRIPTION
#### Description

Created with [seaport](https://seaport.rtfd.io/), the modern MacPorts portfile updater.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?