### PR TITLE
openjdk18-temurin: update to 18.0.2.1

### DIFF
--- a/java/openjdk18-temurin/Portfile
+++ b/java/openjdk18-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=18
 supported_archs  x86_64 arm64
 
-version      18.0.2
-set build    9
+version      18.0.2.1
+set build    1
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 18
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin18-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK18U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  f25877b67494e354faf7e78439d9125ad9db6b7c \
-                 sha256  f96196e9eddad09544733af46d33ac5d5a44178316248e0b907c7f6cd4955bcb \
-                 size    188282767
+    checksums    rmd160  6c82404d0c6fd60fda15dc162fab18fd19ffa6a7 \
+                 sha256  2ed916b0c9d197a6bf71b76e84d94125023c2609e0a9b22c64553eff5c9c29c1 \
+                 size    188272216
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK18U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  809c522d4ba10e190b57315560c645a46cd046d2 \
-                 sha256  d84ec85a9e6b5e22f6bac7e96cc764f5369da393ab233149bfbcbacf1e7de9b7 \
-                 size    178826838
+    checksums    rmd160  27b21b956bf47a9107b3864c4503b10ca4b57340 \
+                 sha256  c5ec423f52d8f3aa632941f29fd289f2e31dce5fe6f3abed9b72bd374f54cd41 \
+                 size    178821710
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -49,7 +49,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
 
 homepage     https://adoptium.net
 
-livecheck.type  none
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin18-binaries/releases
+livecheck.regex     OpenJDK18U-jdk_.*_mac_hotspot_(18\.\[0-9\.\]+)_\[0-9\]+.tar.gz
+
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 18.0.2.1, add livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?