### PR TITLE
multiple ports: add email to maintainer line

### DIFF
--- a/multimedia/DeaDBeeF/Portfile
+++ b/multimedia/DeaDBeeF/Portfile
@@ -9,7 +9,7 @@ name                DeaDBeeF
 categories          multimedia
 platforms           macosx
 
-maintainers         {@ajhall} \
+maintainers         {ajhall.us:macports @ajhall} \
                     openmaintainer
 description         ${name} is a modular cross-platform audio player
 long_description    {*}${description}. It plays a variety of audio formats,    \

--- a/sysutils/asdf/Portfile
+++ b/sysutils/asdf/Portfile
@@ -7,7 +7,7 @@ github.setup        asdf-vm asdf 0.10.2 v
 categories          sysutils devel
 license             MIT
 
-maintainers         {@ajhall} \
+maintainers         {ajhall.us:macports @ajhall} \
                     openmaintainer
 
 description         Extendable version manager with support for Ruby, Node.js, \

--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -24,7 +24,7 @@ livecheck.url       ${github.homepage}/releases
 
 categories          sysutils
 license             MIT
-maintainers         {@ajhall} \
+maintainers         {ajhall.us:macports @ajhall} \
                     openmaintainer
 
 # Allow deps to be fetched at build time

--- a/sysutils/flux/Portfile
+++ b/sysutils/flux/Portfile
@@ -19,7 +19,7 @@ long_description        Flux is a tool for keeping Kubernetes clusters in sync \
 
 categories              sysutils
 license                 Apache-2
-maintainers             {@ajhall} \
+maintainers             {ajhall.us:macports @ajhall} \
                         openmaintainer
 
 depends_build-append    port:kustomize port:realpath


### PR DESCRIPTION
#### Description
Add an email address to the ports I maintain instead of just a GitHub username. (Didn't realize the buildbot needed more info than just the GitHub handle)

###### Type(s)
N/A

###### Tested on
N/A

###### Verification <!-- (delete not applicable items) -->
N/A