### PR TITLE
wezterm: also link wezterm-gui so `wezterm ssh` can run

### DIFF
--- a/aqua/wezterm/Portfile
+++ b/aqua/wezterm/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 
 github.setup        wez wezterm 20220807-113146-c2fee766
-revision            0
+revision            1
 
 homepage            https://wezfurlong.org/wezterm
 
@@ -61,5 +61,8 @@ destroot {
     delete  ${destroot}${applications_dir}/${wz_zip_name}.zip
 
     ln -s ${applications_dir}/WezTerm.app/Contents/MacOS/wezterm \
+        ${destroot}${prefix}/bin/
+
+    ln -s ${applications_dir}/WezTerm.app/Contents/MacOS/wezterm-gui \
         ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description

[`wezterm ssh`](https://wezfurlong.org/wezterm/ssh.html) needs `wezterm-gui` to work. See https://github.com/wez/wezterm/issues/2457.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
