### PR TITLE
mingw-w64: Always install mingw-widl

### DIFF
--- a/cross/mingw-w64/Portfile
+++ b/cross/mingw-w64/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        mirror mingw-w64 10.0.0 v
+revision            1
 set mingw_name      w64-mingw32
 
 platforms           darwin
@@ -27,7 +28,7 @@ configure.dir       ${workpath}/build
 build.dir           ${configure.dir}
 post-extract {      file mkdir "${build.dir}" }
 
-# create six subports:
+# create eight subports:
 # - i686-w64-mingw32-headers
 # - i686-w64-mingw32-crt
 # - i686-w64-mingw32-winpthreads
@@ -153,8 +154,10 @@ if {${subport} ne ${name}} {
     PortGroup               stub 1.0
 
     supported_archs         noarch
-    description             "GCC cross-compiler for Windows 64 & 32 bits (meta port)"
+    description             "GCC cross-compiler toolchain for Windows 64 & 32 bits (meta port)"
 
     depends_run             port:i686-${mingw_name}-gcc \
-                            port:x86_64-${mingw_name}-gcc
+                            port:i686-${mingw_name}-widl \
+                            port:x86_64-${mingw_name}-gcc \
+                            port:x86_64-${mingw_name}-widl
 }


### PR DESCRIPTION
#### Description

We really should be treating mingw-widl as an actual part of the mingw toolchain, this has been the case in brew since I’d added widl support to there formula.

This helps avoid needing to constantly add mingw-widl ports while working on other mingw ports.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
