### PR TITLE
simg2img-devel: remove obsolete port

### DIFF
--- a/sysutils/simg2img/Portfile
+++ b/sysutils/simg2img/Portfile
@@ -32,19 +32,6 @@ variant universal {}
 
 destroot.args-append    PREFIX=${destroot}${prefix}
 
-# Remove after 2022-06-18
-subport ${name}-devel {
-    PortGroup       obsolete 1.0
-
-    version         20191105
-    revision        1
-    replaced_by     ${name}
-}
-
-if {${subport} eq ${name}} {
-    conflicts       simg2img-devel
-}
-
 compiler.cxx_standard 2017
 
 build.args-append   CC="${configure.cc} [get_canonical_archflags cc]" \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
-

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
