### PR TITLE
mysql5-lib_mysqludf_preg: remove obsolete port

### DIFF
--- a/databases/mysql55-lib_mysqludf_preg/Portfile
+++ b/databases/mysql55-lib_mysqludf_preg/Portfile
@@ -31,11 +31,6 @@ foreach mysql.extension.port ${mysql.extension.ports} {
         }
     }
 }
-subport mysql5-lib_mysqludf_preg {
-
-    replaced_by     mysql51-lib_mysqludf_preg
-    PortGroup       obsolete 1.0
-}
 
 categories          databases lang
 maintainers         nomaintainer


### PR DESCRIPTION
Obsolete since cb83830ef0ce over 8 years ago

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?