### PR TITLE
ffcall: fix Rosetta build

### DIFF
--- a/devel/ffcall/Portfile
+++ b/devel/ffcall/Portfile
@@ -13,7 +13,6 @@ long_description    ffcall is a collection of four libraries which can \
                     be used to build foreign function call interfaces \
                     in embedded interpreters.
 homepage            https://www.gnu.org/software/libffcall/
-platforms           darwin
 distname            libffcall-${version}
 checksums           rmd160  b5f5b9c3447eb67cb4c827ac993035e81aa8ee93 \
                     sha256  8ef69921dbdc06bc5bb90513622637a7b83a71f31f5ba377be9d8fd8f57912c2 \
@@ -28,6 +27,13 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 # configure accepts --infodir, although there is no info pages (yet?).
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info
+
+# https://trac.macports.org/ticket/65736
+platform darwin 10 powerpc {
+    configure.args-append \
+                    --build=powerpc-apple-darwin${os.major} \
+                    CC="${configure.cc} [get_canonical_archflags cc]"
+}
 
 use_parallel_build  no
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65736

#### Description

Fixes otherwise failing build on Rosetta. Passing arch flags is necessary, Macports does not handle it correctly here (see the ticket).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
