### PR TITLE
py-mistune: update to 2.0.4

### DIFF
--- a/python/py-mistune/Portfile
+++ b/python/py-mistune/Portfile
@@ -4,16 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-mistune
-version             0.8.4
+version             2.0.4
 revision            0
-epoch               1
 
 categories-append   devel textproc
 supported_archs     noarch
 license             BSD
 
 python.versions     27 37 38 39 310
-python.pep517       no
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -22,13 +20,16 @@ long_description    {*}${description}
 
 homepage            https://github.com/lepture/mistune
 
-checksums           rmd160  b63b71998bac291a54fc94f11700aa806bccb92d \
-                    sha256  59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e \
-                    size    58322
+checksums           rmd160  e01823be07a372d852a2215e4178a967ae9ccfcc \
+                    sha256  9ee0a66053e2267aba772c71e06891fa8f1af6d4b01d5e84e267b4570d4d9808 \
+                    size    75977
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
+    if {${python.version} == 27} {
+        depends_build-append port:py${python.version}-setuptools
+    } else {
+        python.pep517       yes
+    }
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
Update to 2.0.4. This will not break spyder again (see https://trac.macports.org/ticket/64935) if `py-nbconvert` is also updated to latest upstream version (7.0.0). This update would make `py-mistune-devel` obsolete.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
