### PR TITLE
py-nbconvert: update to 7.0.0

### DIFF
--- a/python/py-nbconvert/Portfile
+++ b/python/py-nbconvert/Portfile
@@ -4,13 +4,15 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-nbconvert
-version             6.5.0
+version             7.0.0
 revision            1
 categories-append   textproc
 license             BSD
 supported_archs     noarch
 
 python.versions     37 38 39 310
+python.pep517       yes
+python.pep517_backend hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -19,9 +21,9 @@ long_description    ${description}
 
 homepage            https://jupyter.org/
 
-checksums           rmd160  171648b1f6889ac6a7cad4105e4b2524da6c5803 \
-                    sha256  223e46e27abe8596b8aed54301fadbba433b7ffea8196a68fd7b1ff509eee99d \
-                    size    908377
+checksums           rmd160  4662b28c439e9ff1e06767468233f9455ba96107 \
+                    sha256  fd1e361da30e30e4c5a5ae89f7cae95ca2a4d4407389672473312249a7ba0060 \
+                    size    860724
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
Update to 7.0.0. This PR should be made after #15942 is accepted, since `nbconvert` 7 uses `mistune` >= 2 at runtime.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
