### PR TITLE
watson: update to 2.1.0 and fix test

### DIFF
--- a/office/watson/Portfile
+++ b/office/watson/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                watson
 python.rootname     td-watson
-version             2.0.1
+version             2.1.0
 revision            0
 
 homepage            http://tailordev.github.io/Watson
@@ -24,15 +24,16 @@ categories          office python
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  cae4d7d3d9f4e1a839fc49d318b9c5183597b3e7 \
-                    sha256  a665775a76fb3ac464153e10991577a38ca938adae2142a24c9d1b1234db95f0 \
-                    size    8895378
+checksums           rmd160  e1c5e0c4f97c519e00e62e1737e5151d29887baf \
+                    sha256  204384dc04653e0dbe8f833243bb833beda3d79b387fe173bfd33faecdd087c8 \
+                    size    8895400
+
+python.default_version  310
 
 test.run            yes
 test.env            PYTHONPATH=${worksrcpath}/build/lib
-test.cmd            ${python.bin} -m watson --version
-
-python.default_version  39
+test.cmd            ${python.bin}
+test.args           -m watson --version
 
 depends_lib-append      port:py${python.version}-arrow              \
                         port:py${python.version}-click              \

--- a/python/py-click-didyoumean/Portfile
+++ b/python/py-click-didyoumean/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-click-didyoumean
-version             0.0.3
+version             0.3.0
 revision            0
 categories-append   devel
 platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     38 39
+python.versions     38 39 310
 
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
@@ -21,9 +21,9 @@ long_description    ${description}
 
 homepage            https://github.com/click-contrib/click-didyoumean
 
-checksums           rmd160  217545f3e2d4d724d721b18b3db24c189f195fa2 \
-                    sha256  112229485c9704ff51362fe34b2d4f0b12fc71cc20f6d2b3afabed4b8bfa6aeb \
-                    size    2562
+checksums           rmd160  46ca7329be003005c378be960858b61ca110ee79 \
+                    sha256  f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035 \
+                    size    2405
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description
The update is required to make watson compatible with py-click>=8: https://github.com/TailorDev/Watson/pull/471

As py-click is already at version 8 in macports, the current version of watson (2.0.1) does not work.

Additionally, fix two issues that made the test fail:
- set python version before using the variable python.bin
- properly set test.args to override the default defined for tests using pytest

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> (no open tickets)
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
