### PR TITLE
clang-11-bootstrap: fix build on 10.6 i386

### DIFF
--- a/lang/clang-11-bootstrap/Portfile
+++ b/lang/clang-11-bootstrap/Portfile
@@ -342,7 +342,7 @@ post-patch {
     }
 }
 
-if {${universal_possible} && [variant_isset universal]} {
+if {[variant_exists universal] && [variant_isset universal]} {
     foreach arch ${universal_archs_supported} {
         lappend merger_configure_env(${arch}) BUILD_ARCH=${arch}
         lappend merger_build_env(${arch}) BUILD_ARCH=${arch}


### PR DESCRIPTION
#### Description

The fix is tricky. `muniversal` PG adds `universal` variant only when it can be used. When it can be used, it picks settings from `merger_configure_args`.

So, I simple add settings into `merger_configure_args` when `universal` variant is existed and was requested.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
