### PR TITLE
tix: prefer upstream approach in patch

### DIFF
--- a/x11/tix/files/patch-generic-tixGrSort.c.diff
+++ b/x11/tix/files/patch-generic-tixGrSort.c.diff
@@ -1,18 +1,22 @@
- generic/tixGrSort.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
-diff --git a/generic/tixGrSort.c b/generic/tixGrSort.c
-index 7dee30f..26ec054 100644
 --- generic/tixGrSort.c
 +++ generic/tixGrSort.c
-@@ -447,8 +447,8 @@ SortCompareProc(first, second)
+@@ -426,6 +426,7 @@ SortCompareProc(first, second)
+     } else {
+ 	int oldLength;
+ 	char *end;
++	const char *result;
+ 
+ 	/*
+ 	 * Generate and evaluate a command to determine which string comes
+@@ -447,8 +448,9 @@ SortCompareProc(first, second)
  	 * Parse the result of the command.
  	 */
  
 -	order = strtol(sortInterp->result, &end, 0);
 -	if ((end == sortInterp->result) || (*end != 0)) {
-+	order = strtol(Tcl_GetStringResult(sortInterp), &end, 0);
-+	if ((end == Tcl_GetStringResult(sortInterp)) || (*end != 0)) {
++	result = Tcl_GetStringResult(sortInterp);
++	order = strtol(result, &end, 0);
++	if ((end == result) || (*end != 0)) {
  	    Tcl_ResetResult(sortInterp);
  	    Tcl_AppendResult(sortInterp,
  		    "comparison command returned non-numeric result",


### PR DESCRIPTION
#### Description
This is the approach used in upstream CVS change history since the last release. The approach MacPorts used is equivalent; no rebuilding is required.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
