### PR TITLE
clang-11-bootstrap: backport support of `using_if_exists`

### DIFF
--- a/lang/clang-11-bootstrap/Portfile
+++ b/lang/clang-11-bootstrap/Portfile
@@ -8,7 +8,7 @@ PortGroup           muniversal 1.0
 name                clang-11-bootstrap
 
 version             11.1.0
-revision            2
+revision            3
 epoch               0
 
 platforms           darwin
@@ -96,7 +96,9 @@ patchfiles          0001-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.pa
                     0026-clang-support-macports-libstdcxx.patch \
                     0027-compiler-rt-fix-building-by-GCC.patch \
                     0028-compiler-rt-allow-to-define-required-archs.patch \
-                    0029-compiler-rt-atomic-which-can-be-compiled-by-GCC.patch
+                    0029-compiler-rt-atomic-which-can-be-compiled-by-GCC.patch \
+                    0035-clang-Implement-the-using_if_exists-attribute.patch \
+                    0036-clang-Parse-Add-parsing-support-for-C-attributes-on-.patch
 
 # sterilize MacPorts build environment; we want nothing picked up from MP prefix
 compiler.cpath

--- a/lang/clang-11-bootstrap/files/0001-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.patch
+++ b/lang/clang-11-bootstrap/files/0001-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.patch
@@ -1,8 +1,8 @@
 From 3998ef54ce5a2d63be2a5763170a98d464d59762 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Sun, 18 Jan 2015 11:18:13 -0800
-Subject: [PATCH 01/34] Define EXC_MASK_CRASH and MACH_EXCEPTION_CODES if
- they're not defined in the SDK
+Subject: [PATCH] Define EXC_MASK_CRASH and MACH_EXCEPTION_CODES if they're not
+ defined in the SDK
 
 The 10.4 SDK does not define these macros
 

--- a/lang/clang-11-bootstrap/files/0002-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch
+++ b/lang/clang-11-bootstrap/files/0002-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch
@@ -1,8 +1,8 @@
 From 9cf659947ce441ab497be344ede8025f0f347bd2 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Sat, 17 Jan 2015 16:41:30 -0800
-Subject: [PATCH 02/34] MacPorts Only: Don't embed the deployment target in the
- asm when using -fno-integrated-as
+Subject: [PATCH] MacPorts Only: Don't embed the deployment target in the asm
+ when using -fno-integrated-as
 
 http://llvm.org/bugs/show_bug.cgi?id=21636
 

--- a/lang/clang-11-bootstrap/files/0003-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch
+++ b/lang/clang-11-bootstrap/files/0003-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch
@@ -1,8 +1,7 @@
 From d55a5be574088cf71a7707797e70dbf8b7ec6180 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Tue, 20 Dec 2016 12:41:21 -0800
-Subject: [PATCH 03/34] Fix build issues pre-Lion due to missing a strnlen
- definition
+Subject: [PATCH] Fix build issues pre-Lion due to missing a strnlen definition
 
 https://trac.macports.org/ticket/51520
 https://llvm.org/bugs/show_bug.cgi?id=27714

--- a/lang/clang-11-bootstrap/files/0004-Fix-build-issues-pre-Lion-due-to-missing-a-memmem-de.patch
+++ b/lang/clang-11-bootstrap/files/0004-Fix-build-issues-pre-Lion-due-to-missing-a-memmem-de.patch
@@ -1,8 +1,7 @@
 From a509cabf15ac7d231c902aa850499e144dc57eff Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 16:07:55 +0200
-Subject: [PATCH 04/34] Fix build issues pre-Lion due to missing a memmem
- definition
+Subject: [PATCH] Fix build issues pre-Lion due to missing a memmem definition
 
 ---
  compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp | 34 ++++++++++++++++++++++

--- a/lang/clang-11-bootstrap/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/clang-11-bootstrap/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -1,8 +1,7 @@
 From cf34a554b5fb5d3909d82bcf8d540d7c0cd434f9 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Wed, 27 Dec 2017 23:05:43 -0800
-Subject: [PATCH 05/34] Threading: Only call pthread_setname_np() on
- SnowLeopard+
+Subject: [PATCH] Threading: Only call pthread_setname_np() on SnowLeopard+
 
 Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 ---

--- a/lang/clang-11-bootstrap/files/0006-Only-call-setpriority-PRIO_DARWIN_THREAD-0-PRIO_DARW.patch
+++ b/lang/clang-11-bootstrap/files/0006-Only-call-setpriority-PRIO_DARWIN_THREAD-0-PRIO_DARW.patch
@@ -1,8 +1,8 @@
 From f789d7d5a40bcd20d344a9a805afdaa1a82a7454 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Thu, 4 Jul 2019 13:23:19 -0700
-Subject: [PATCH 06/34] Only call setpriority(PRIO_DARWIN_THREAD, 0,
- PRIO_DARWIN_BG) if it is available
+Subject: [PATCH] Only call setpriority(PRIO_DARWIN_THREAD, 0, PRIO_DARWIN_BG)
+ if it is available
 
 Tiger and earlier versions of darwin do not support this.
 

--- a/lang/clang-11-bootstrap/files/0007-dsymutil-fix-build-on-Leopard.patch
+++ b/lang/clang-11-bootstrap/files/0007-dsymutil-fix-build-on-Leopard.patch
@@ -1,7 +1,7 @@
 From 44255c29f72697e7b5fb2c0d4df8305f4d9544b4 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 13:45:22 +0200
-Subject: [PATCH 07/34] dsymutil: fix build on Leopard
+Subject: [PATCH] dsymutil: fix build on Leopard
 
 - alias `CFPropertyListCreateWithStream` to `CFPropertyListCreateFromStream`
 - add a workable definition for `uuid_string_t`

--- a/lang/clang-11-bootstrap/files/0008-lib-Support-Unix-Path.inc-define-COPYFILE_CLONE-if-n.patch
+++ b/lang/clang-11-bootstrap/files/0008-lib-Support-Unix-Path.inc-define-COPYFILE_CLONE-if-n.patch
@@ -1,8 +1,7 @@
 From b89fadcc31b6524f7b11af24e9feef5b9844c04c Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 13:49:38 +0200
-Subject: [PATCH 08/34] lib/Support/Unix/Path.inc: define COPYFILE_CLONE if
- needed
+Subject: [PATCH] lib/Support/Unix/Path.inc: define COPYFILE_CLONE if needed
 
 ---
  llvm/lib/Support/Unix/Path.inc | 3 +++

--- a/lang/clang-11-bootstrap/files/0009-MacPorts-Only-Fix-name-of-scan-view-executable-insid.patch
+++ b/lang/clang-11-bootstrap/files/0009-MacPorts-Only-Fix-name-of-scan-view-executable-insid.patch
@@ -1,7 +1,7 @@
 From 1bb478c260682b6597f7b7f84ce529ef2e7be4e3 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Sat, 17 Jan 2015 17:55:27 -0800
-Subject: [PATCH 09/34] MacPorts Only: Fix name of scan-view executable inside
+Subject: [PATCH] MacPorts Only: Fix name of scan-view executable inside
  scan-build
 
 http://trac.macports.org/ticket/35006

--- a/lang/clang-11-bootstrap/files/0010-default-to-libcxx-on-all-systems.patch
+++ b/lang/clang-11-bootstrap/files/0010-default-to-libcxx-on-all-systems.patch
@@ -1,7 +1,7 @@
 From 7d6818a3bb0c1f61bc8a0acab944ddb4549a9bfd Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Thu, 18 Aug 2022 02:07:11 +0200
-Subject: [PATCH 10/34] default to libcxx on all systems
+Subject: [PATCH] default to libcxx on all systems
 
 ---
  clang/lib/Driver/ToolChains/Darwin.cpp | 4 ++--

--- a/lang/clang-11-bootstrap/files/0011-Default-to-fragile-ObjC-runtime-when-targeting-darwi.patch
+++ b/lang/clang-11-bootstrap/files/0011-Default-to-fragile-ObjC-runtime-when-targeting-darwi.patch
@@ -1,8 +1,7 @@
 From aaf6221d782afa8de9235678f10f95e8552c64ff Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Tue, 20 Jan 2015 00:09:16 -0800
-Subject: [PATCH 11/34] Default to fragile ObjC runtime when targeting
- darwin/ppc
+Subject: [PATCH] Default to fragile ObjC runtime when targeting darwin/ppc
 
 Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 ---

--- a/lang/clang-11-bootstrap/files/0012-Fixup-libstdc-header-search-paths-for-older-versions.patch
+++ b/lang/clang-11-bootstrap/files/0012-Fixup-libstdc-header-search-paths-for-older-versions.patch
@@ -1,8 +1,8 @@
 From a48d51f49e3186bebb143921580c1277ffe54114 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Mon, 31 Oct 2016 15:06:36 -0700
-Subject: [PATCH 12/34] Fixup libstdc++ header search paths for older versions
- of Mac OS X
+Subject: [PATCH] Fixup libstdc++ header search paths for older versions of Mac
+ OS X
 
 The subpaths were removed in Lion.  Leopard and Snow Leopard had darwin8
 symlinks for compatibility.

--- a/lang/clang-11-bootstrap/files/0013-Fix-float.h-to-work-on-Snow-Leopard-and-earlier.patch
+++ b/lang/clang-11-bootstrap/files/0013-Fix-float.h-to-work-on-Snow-Leopard-and-earlier.patch
@@ -1,7 +1,7 @@
 From c1a2bd1699317f16c833616863ccb2888a36084e Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Thu, 20 Jul 2017 17:15:35 -0700
-Subject: [PATCH 13/34] Fix float.h to work on Snow Leopard and earlier
+Subject: [PATCH] Fix float.h to work on Snow Leopard and earlier
 
 https://bugs.llvm.org/show_bug.cgi?id=31504
 https://trac.macports.org/ticket/54135

--- a/lang/clang-11-bootstrap/files/0014-compiler-rt-add-some-defs-missing-in-older-SDKs.patch
+++ b/lang/clang-11-bootstrap/files/0014-compiler-rt-add-some-defs-missing-in-older-SDKs.patch
@@ -1,7 +1,7 @@
 From 6e5a41acb0ffc95f3a5756e4dfe25bc189a22389 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 13:57:02 +0200
-Subject: [PATCH 14/34] compiler-rt: add some defs missing in older SDKs
+Subject: [PATCH] compiler-rt: add some defs missing in older SDKs
 
 ---
  compiler-rt/lib/fuzzer/FuzzerUtilDarwin.cpp        | 8 ++++++++

--- a/lang/clang-11-bootstrap/files/0015-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch
+++ b/lang/clang-11-bootstrap/files/0015-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch
@@ -1,8 +1,8 @@
 From b4c19d923fa1fcff5c08d5bdd211997a1e4ba9a7 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 14:03:50 +0200
-Subject: [PATCH 15/34] 10.5 and less: compiler-rt work around no libdispatch
- before 10.6
+Subject: [PATCH] 10.5 and less: compiler-rt work around no libdispatch before
+ 10.6
 
 ---
  compiler-rt/lib/builtins/os_version_check.c | 13 ++++++++++++-

--- a/lang/clang-11-bootstrap/files/0016-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/clang-11-bootstrap/files/0016-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -1,8 +1,8 @@
 From fd4de49747f1528eb72b2b73319bcab5d4298c9a Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Sat, 17 Jan 2015 16:26:20 -0800
-Subject: [PATCH 16/34] Fix missing long long math prototypes when using the
- Snow Leopard SDK
+Subject: [PATCH] Fix missing long long math prototypes when using the Snow
+ Leopard SDK
 
 Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 ---

--- a/lang/clang-11-bootstrap/files/0017-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch
+++ b/lang/clang-11-bootstrap/files/0017-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch
@@ -1,8 +1,8 @@
 From 884ca9bc09df5859489abba1741fdb7d16cd4c7a Mon Sep 17 00:00:00 2001
 From: David Fang <fang@csl.cornell.edu>
 Date: Wed, 15 Jan 2014 21:27:34 -0800
-Subject: [PATCH 17/34] implement atomic<> using mutex/lock_guard for 64b ops
- on 32b PPC not pretty, not fast, but passes atomic tests
+Subject: [PATCH] implement atomic<> using mutex/lock_guard for 64b ops on 32b
+ PPC not pretty, not fast, but passes atomic tests
 
 ---
  libcxx/include/__atomic_locked | 240 +++++++++++++++++++++++++++++++++

--- a/lang/clang-11-bootstrap/files/0018-libcxx-src-chrono.cpp-fix-build-by-older-SDKs.patch
+++ b/lang/clang-11-bootstrap/files/0018-libcxx-src-chrono.cpp-fix-build-by-older-SDKs.patch
@@ -1,7 +1,7 @@
 From 242d08207030270d0f3a6bf96c0d6835173bd2b1 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 14:09:22 +0200
-Subject: [PATCH 18/34] libcxx/src/chrono.cpp: fix build by older SDKs
+Subject: [PATCH] libcxx/src/chrono.cpp: fix build by older SDKs
 
 See: https://github.com/llvm/llvm-project/commit/babd3aefc9193b44ad0620a2cfd63ebb6ad7e952
 ---

--- a/lang/clang-11-bootstrap/files/0019-compiler-rt-allow-build-before-10.7.patch
+++ b/lang/clang-11-bootstrap/files/0019-compiler-rt-allow-build-before-10.7.patch
@@ -1,7 +1,7 @@
 From afe4131b6374bd5ff72a831faa58340945b6aa0a Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 14:11:06 +0200
-Subject: [PATCH 19/34] compiler-rt: allow build before 10.7
+Subject: [PATCH] compiler-rt: allow build before 10.7
 
 ---
  compiler-rt/cmake/config-ix.cmake | 3 ---

--- a/lang/clang-11-bootstrap/files/0020-compiler-rt-added-CMAKE_OSX_DEPLOYMENT_TARGET-fallba.patch
+++ b/lang/clang-11-bootstrap/files/0020-compiler-rt-added-CMAKE_OSX_DEPLOYMENT_TARGET-fallba.patch
@@ -1,7 +1,7 @@
 From 0691517ced61dc1789b8efbee301f46756f7cecb Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 14:13:11 +0200
-Subject: [PATCH 20/34] compiler-rt: added CMAKE_OSX_DEPLOYMENT_TARGET fallback
+Subject: [PATCH] compiler-rt: added CMAKE_OSX_DEPLOYMENT_TARGET fallback
 
 ---
  .../cmake/Modules/CompilerRTDarwinUtils.cmake      | 14 +++++---------

--- a/lang/clang-11-bootstrap/files/0021-add-back-runtime-libraries-used-on-10.4-and-10.5.patch
+++ b/lang/clang-11-bootstrap/files/0021-add-back-runtime-libraries-used-on-10.4-and-10.5.patch
@@ -1,7 +1,7 @@
 From ba3d665b91d33f808ffd39e9ee4675b72e564526 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 14:14:50 +0200
-Subject: [PATCH 21/34] add back runtime libraries used on 10.4 and 10.5
+Subject: [PATCH] add back runtime libraries used on 10.4 and 10.5
 
 removed in https://github.com/llvm/llvm-project/commit/3434ade2b7ca351b61522f7da4b55070d811b83f
 

--- a/lang/clang-11-bootstrap/files/0022-Don-t-look-into-sysroot-for-C-headers-if-they-are-fo.patch
+++ b/lang/clang-11-bootstrap/files/0022-Don-t-look-into-sysroot-for-C-headers-if-they-are-fo.patch
@@ -1,8 +1,8 @@
 From b4e43cb5b9fc3ea342a37a27e3af78393575cc72 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 14:17:11 +0200
-Subject: [PATCH 22/34] Don't look into <sysroot> for C++ headers if they are
- found alongside the toolchain
+Subject: [PATCH] Don't look into <sysroot> for C++ headers if they are found
+ alongside the toolchain
 
 Currently, Clang looks for libc++ headers alongside the installation
 directory of Clang, and it also adds a search path for headers in the

--- a/lang/clang-11-bootstrap/files/0023-disable-DirectoryWatcher-when-builds-by-GCC.patch
+++ b/lang/clang-11-bootstrap/files/0023-disable-DirectoryWatcher-when-builds-by-GCC.patch
@@ -1,7 +1,7 @@
 From 74dda39256362d98a74fefeddfea344b9d34b681 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 15:11:27 +0200
-Subject: [PATCH 23/34] disable DirectoryWatcher when builds by GCC
+Subject: [PATCH] disable DirectoryWatcher when builds by GCC
 
 ---
  clang/lib/DirectoryWatcher/CMakeLists.txt | 2 +-

--- a/lang/clang-11-bootstrap/files/0024-Use-for-long-options-in-help-text.patch
+++ b/lang/clang-11-bootstrap/files/0024-Use-for-long-options-in-help-text.patch
@@ -1,7 +1,7 @@
 From 453bcd6038730cf1da7d9b988574513cadb99cf1 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 15:14:31 +0200
-Subject: [PATCH 24/34] Use "--" for long options in --help text
+Subject: [PATCH] Use "--" for long options in --help text
 
 See: https://reviews.llvm.org/D92310
 ---

--- a/lang/clang-11-bootstrap/files/0025-compatibility-with-xar-on-macOS-10.5.patch
+++ b/lang/clang-11-bootstrap/files/0025-compatibility-with-xar-on-macOS-10.5.patch
@@ -1,7 +1,7 @@
 From 5deccc8875fb46daeba4b674f187ed81f93005da Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 15:22:09 +0200
-Subject: [PATCH 25/34] compatibility with xar on macOS 10.5
+Subject: [PATCH] compatibility with xar on macOS 10.5
 
 macOS 10.5 uses very old xar which has `xar_open` but misses
 `xar_extract_tobuffersz`, update the check for `check_library_exists`.

--- a/lang/clang-11-bootstrap/files/0026-clang-support-macports-libstdcxx.patch
+++ b/lang/clang-11-bootstrap/files/0026-clang-support-macports-libstdcxx.patch
@@ -1,7 +1,7 @@
 From 250ee3cf3ee96307c494b62e93b93b9b63ec4db2 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Thu, 18 Aug 2022 02:31:25 +0200
-Subject: [PATCH 26/34] [clang] support macports-libstdcxx
+Subject: [PATCH] [clang] support macports-libstdcxx
 
 ---
  clang/include/clang/Driver/ToolChain.h  |  1 +

--- a/lang/clang-11-bootstrap/files/0027-compiler-rt-fix-building-by-GCC.patch
+++ b/lang/clang-11-bootstrap/files/0027-compiler-rt-fix-building-by-GCC.patch
@@ -1,7 +1,7 @@
 From 1cd1b67b0ba87471304b046649316d466c5364bc Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 16:08:45 +0200
-Subject: [PATCH 27/34] [compiler-rt] fix building by GCC
+Subject: [PATCH] [compiler-rt] fix building by GCC
 
 ---
  compiler-rt/cmake/config-ix.cmake | 15 ++++++++++-----

--- a/lang/clang-11-bootstrap/files/0028-compiler-rt-allow-to-define-required-archs.patch
+++ b/lang/clang-11-bootstrap/files/0028-compiler-rt-allow-to-define-required-archs.patch
@@ -1,7 +1,7 @@
 From 60cd288acdf48e3cd3f19eccf776e8fe23fcc04f Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 16:09:26 +0200
-Subject: [PATCH 28/34] [compiler-rt] allow to define required archs
+Subject: [PATCH] [compiler-rt] allow to define required archs
 
 ---
  compiler-rt/cmake/builtin-config-ix.cmake | 18 ++++++++++--------

--- a/lang/clang-11-bootstrap/files/0029-compiler-rt-atomic-which-can-be-compiled-by-GCC.patch
+++ b/lang/clang-11-bootstrap/files/0029-compiler-rt-atomic-which-can-be-compiled-by-GCC.patch
@@ -1,7 +1,7 @@
 From ac23587c43ba957f530de1c4b2214ea1aaae39d6 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Thu, 18 Aug 2022 00:14:22 +0200
-Subject: [PATCH 29/34] [compiler-rt] atomic which can be compiled by GCC
+Subject: [PATCH] [compiler-rt] atomic which can be compiled by GCC
 
 ---
  compiler-rt/lib/builtins/atomic.c             | 109 ++++++++++++++++++

--- a/lang/clang-11-bootstrap/files/0030-fix-building-on-10.10-by-GCC-10.patch
+++ b/lang/clang-11-bootstrap/files/0030-fix-building-on-10.10-by-GCC-10.patch
@@ -1,7 +1,7 @@
 From 7bcddfb1ac8f9786f02b0313304e0c595f369b22 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 15:23:05 +0200
-Subject: [PATCH 30/34] fix building on 10.10 by GCC 10
+Subject: [PATCH] fix building on 10.10 by GCC 10
 
 macOS 10.10 Yosemite defines `dispatch_block_t` on the way that it can
 be compiled by gcc 10; redefine in properly.

--- a/lang/clang-11-bootstrap/files/0031-fix-build-of-shared-libc-.dylib-on-10.7.patch
+++ b/lang/clang-11-bootstrap/files/0031-fix-build-of-shared-libc-.dylib-on-10.7.patch
@@ -1,7 +1,7 @@
 From 2619c3115f82a504540780ff29d5c932007d7ac3 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 15:27:16 +0200
-Subject: [PATCH 31/34] fix build of shared libc++.dylib on < 10.7
+Subject: [PATCH] fix build of shared libc++.dylib on < 10.7
 
 reexported_symbols_list is not accepted on < 10.7
 but reexport_library is, and that is what was used previously

--- a/lang/clang-11-bootstrap/files/0032-disable-Apple-libc-Availability-tests.patch
+++ b/lang/clang-11-bootstrap/files/0032-disable-Apple-libc-Availability-tests.patch
@@ -1,7 +1,7 @@
 From 2bcfad170970fa3d0b668c0d904f9767e115cdfe Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 15:27:50 +0200
-Subject: [PATCH 32/34] disable Apple libc++ Availability tests
+Subject: [PATCH] disable Apple libc++ Availability tests
 
 if we are using MacPort's installed libc++
 then Apple's availablilty tests for libcxx by OS version

--- a/lang/clang-11-bootstrap/files/0033-Leopard-Default-to-fno-blocks.patch
+++ b/lang/clang-11-bootstrap/files/0033-Leopard-Default-to-fno-blocks.patch
@@ -1,7 +1,7 @@
 From ce1e4345f85cffe8a7a3359c6fa2ba711e88e0dc Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Wed, 7 Jan 2015 03:42:15 -0800
-Subject: [PATCH 33/34] Leopard: Default to -fno-blocks
+Subject: [PATCH] Leopard: Default to -fno-blocks
 
 Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 ---

--- a/lang/clang-11-bootstrap/files/0034-Support-emulated-TLS-before-10.7.patch
+++ b/lang/clang-11-bootstrap/files/0034-Support-emulated-TLS-before-10.7.patch
@@ -1,7 +1,7 @@
 From 1c2e45c471d804f4bd53d833239bdeb7d9992668 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 17 Aug 2022 15:30:28 +0200
-Subject: [PATCH 34/34] Support emulated TLS before 10.7
+Subject: [PATCH] Support emulated TLS before 10.7
 
 ---
  clang/lib/Basic/Targets/OSTargets.h | 2 +-

--- a/lang/clang-11-bootstrap/files/0035-clang-Implement-the-using_if_exists-attribute.patch
+++ b/lang/clang-11-bootstrap/files/0035-clang-Implement-the-using_if_exists-attribute.patch
@@ -1,0 +1,922 @@
+From 7f47b12289d44de089feb7fcb80c9412b3138ec5 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Tue, 30 Aug 2022 14:34:44 +0200
+Subject: [PATCH] [clang] Implement the using_if_exists attribute
+
+Backport from https://reviews.llvm.org/D90188
+---
+ clang/include/clang/AST/DeclCXX.h             |  22 ++
+ clang/include/clang/AST/RecursiveASTVisitor.h |   2 +
+ clang/include/clang/Basic/Attr.td             |   8 +
+ clang/include/clang/Basic/AttrDocs.td         |  25 ++
+ clang/include/clang/Basic/DeclNodes.td        |   1 +
+ .../clang/Basic/DiagnosticSemaKinds.td        |   6 +
+ clang/include/clang/Sema/Sema.h               |  13 +-
+ .../include/clang/Serialization/ASTBitCodes.h |   3 +
+ clang/lib/AST/DeclBase.cpp                    |   3 +
+ clang/lib/AST/DeclCXX.cpp                     |  19 ++
+ clang/lib/CodeGen/CGDecl.cpp                  |   1 +
+ clang/lib/Sema/SemaDecl.cpp                   |  23 +-
+ clang/lib/Sema/SemaDeclAttr.cpp               |   4 +
+ clang/lib/Sema/SemaDeclCXX.cpp                |  47 +++-
+ clang/lib/Sema/SemaExpr.cpp                   |  16 +-
+ .../lib/Sema/SemaTemplateInstantiateDecl.cpp  |  24 +-
+ clang/lib/Sema/TreeTransform.h                |   6 +-
+ clang/lib/Serialization/ASTCommon.cpp         |   1 +
+ clang/lib/Serialization/ASTReaderDecl.cpp     |   9 +
+ clang/lib/Serialization/ASTWriterDecl.cpp     |   7 +
+ clang/test/Parser/using-if-exists-attr.cpp    |  27 +++
+ clang/test/SemaCXX/attr-deprecated.cpp        |  12 +
+ clang/test/SemaCXX/using-if-exists.cpp        | 226 ++++++++++++++++++
+ clang/tools/libclang/CIndex.cpp               |   1 +
+ 24 files changed, 480 insertions(+), 26 deletions(-)
+ create mode 100644 clang/test/Parser/using-if-exists-attr.cpp
+ create mode 100644 clang/test/SemaCXX/using-if-exists.cpp
+
+diff --git a/clang/include/clang/AST/DeclCXX.h b/clang/include/clang/AST/DeclCXX.h
+index 2b8d7e879a0a..266c6c1d3f51 100644
+--- a/clang/include/clang/AST/DeclCXX.h
++++ b/clang/include/clang/AST/DeclCXX.h
+@@ -3788,6 +3788,28 @@ public:
+   static bool classofKind(Kind K) { return K == UnresolvedUsingTypename; }
+ };
+ 
++/// This node is generated when a using-declaration that was annotated with
++/// __attribute__((using_if_exists)) failed to resolve to a known declaration.
++/// In that case, Sema builds a UsingShadowDecl whose target is an instance of
++/// this declaration, adding it to the current scope. Referring to this
++/// declaration in any way is an error.
++class UnresolvedUsingIfExistsDecl final : public NamedDecl {
++  UnresolvedUsingIfExistsDecl(DeclContext *DC, SourceLocation Loc,
++                              DeclarationName Name);
++
++  void anchor() override;
++
++public:
++  static UnresolvedUsingIfExistsDecl *Create(ASTContext &Ctx, DeclContext *DC,
++                                             SourceLocation Loc,
++                                             DeclarationName Name);
++  static UnresolvedUsingIfExistsDecl *CreateDeserialized(ASTContext &Ctx,
++                                                         unsigned ID);
++
++  static bool classof(const Decl *D) { return classofKind(D->getKind()); }
++  static bool classofKind(Kind K) { return K == Decl::UnresolvedUsingIfExists; }
++};
++
+ /// Represents a C++11 static_assert declaration.
+ class StaticAssertDecl : public Decl {
+   llvm::PointerIntPair<Expr *, 1, bool> AssertExprAndFailed;
+diff --git a/clang/include/clang/AST/RecursiveASTVisitor.h b/clang/include/clang/AST/RecursiveASTVisitor.h
+index 3dcfc9fee629..2c04eae7c03e 100644
+--- a/clang/include/clang/AST/RecursiveASTVisitor.h
++++ b/clang/include/clang/AST/RecursiveASTVisitor.h
+@@ -1816,6 +1816,8 @@ DEF_TRAVERSE_DECL(UnresolvedUsingTypenameDecl, {
+   // source.
+ })
+ 
++DEF_TRAVERSE_DECL(UnresolvedUsingIfExistsDecl, {})
++
+ DEF_TRAVERSE_DECL(EnumDecl, {
+   TRY_TO(TraverseDeclTemplateParameterLists(D));
+ 
+diff --git a/clang/include/clang/Basic/Attr.td b/clang/include/clang/Basic/Attr.td
+index 60eaee7839e2..1bc86e43b6e6 100644
+--- a/clang/include/clang/Basic/Attr.td
++++ b/clang/include/clang/Basic/Attr.td
+@@ -3421,6 +3421,14 @@ def NoBuiltin : Attr {
+   let Documentation = [NoBuiltinDocs];
+ }
+ 
++def UsingIfExists : InheritableAttr {
++  let Spellings = [Clang<"using_if_exists", 0>];
++  let Subjects = SubjectList<[Using,
++                              UnresolvedUsingTypename,
++                              UnresolvedUsingValue], ErrorDiag>;
++  let Documentation = [UsingIfExistsDocs];
++}
++
+ // FIXME: This attribute is not inheritable, it will not be propagated to
+ // redecls. [[clang::lifetimebound]] has the same problems. This should be
+ // fixed in TableGen (by probably adding a new inheritable flag).
+diff --git a/clang/include/clang/Basic/AttrDocs.td b/clang/include/clang/Basic/AttrDocs.td
+index 833127ed44eb..46929ce49599 100644
+--- a/clang/include/clang/Basic/AttrDocs.td
++++ b/clang/include/clang/Basic/AttrDocs.td
+@@ -4820,6 +4820,31 @@ once.
+   }];
+ }
+ 
++def UsingIfExistsDocs : Documentation {
++  let Category = DocCatDecl;
++  let Content = [{
++The ``using_if_exists`` attribute applies to a using-declaration. It allows
++programmers to import a declaration that potentially does not exist, instead
++deferring any errors to the point of use. For instance:
++
++.. code-block:: c++
++
++  namespace empty_namespace {};
++  __attribute__((using_if_exists))
++  using empty_namespace::does_not_exist; // no error!
++
++  does_not_exist x; // error: use of unresolved 'using_if_exists'
++
++The C++ spelling of the attribte (`[[clang::using_if_exists]]`) is also
++supported as a clang extension, since ISO C++ doesn't support attributes in this
++position. If the entity referred to by the using-declaration is found by name
++lookup, the attribute has no effect. This attribute is useful for libraries
++(primarily, libc++) that wish to redeclare a set of declarations in another
++namespace, when the availability of those declarations is difficult or
++impossible to detect at compile time with the preprocessor.
++  }];
++}
++
+ def HandleDocs : DocumentationCategory<"Handle Attributes"> {
+   let Content = [{
+ Handles are a way to identify resources like files, sockets, and processes.
+diff --git a/clang/include/clang/Basic/DeclNodes.td b/clang/include/clang/Basic/DeclNodes.td
+index 866988ee3f01..c7d3f513b7d5 100644
+--- a/clang/include/clang/Basic/DeclNodes.td
++++ b/clang/include/clang/Basic/DeclNodes.td
+@@ -74,6 +74,7 @@ def Named : DeclNode<Decl, "named declarations", 1>;
+   def UsingPack : DeclNode<Named>;
+   def UsingShadow : DeclNode<Named>;
+     def ConstructorUsingShadow : DeclNode<UsingShadow>;
++  def UnresolvedUsingIfExists : DeclNode<Named>;
+   def ObjCMethod : DeclNode<Named, "Objective-C methods">, DeclContext;
+   def ObjCContainer : DeclNode<Named, "Objective-C containers", 1>, DeclContext;
+     def ObjCCategory : DeclNode<ObjCContainer>;
+diff --git a/clang/include/clang/Basic/DiagnosticSemaKinds.td b/clang/include/clang/Basic/DiagnosticSemaKinds.td
+index 941f2cafc372..0581296ac802 100644
+--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
++++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
+@@ -548,6 +548,12 @@ def err_using_decl_conflict_reverse : Error<
+ def note_using_decl : Note<"%select{|previous }0using declaration">;
+ def err_using_decl_redeclaration_expansion : Error<
+   "using declaration pack expansion at block scope produces multiple values">;
++def err_use_of_empty_using_if_exists : Error<
++  "reference to unresolved using declaration">;
++def note_empty_using_if_exists_here : Note<
++  "using declaration annotated with 'using_if_exists' here">;
++def err_using_if_exists_on_ctor : Error<
++  "'using_if_exists' attribute cannot be applied to an inheriting constructor">;
+ 
+ def warn_access_decl_deprecated : Warning<
+   "access declarations are deprecated; use using declarations instead">,
+diff --git a/clang/include/clang/Sema/Sema.h b/clang/include/clang/Sema/Sema.h
+index 16a7084f6b08..89d7730d2420 100644
+--- a/clang/include/clang/Sema/Sema.h
++++ b/clang/include/clang/Sema/Sema.h
+@@ -5399,11 +5399,14 @@ public:
+                                const DeclarationNameInfo &NameInfo,
+                                SourceLocation NameLoc);
+ 
+-  NamedDecl *BuildUsingDeclaration(
+-      Scope *S, AccessSpecifier AS, SourceLocation UsingLoc,
+-      bool HasTypenameKeyword, SourceLocation TypenameLoc, CXXScopeSpec &SS,
+-      DeclarationNameInfo NameInfo, SourceLocation EllipsisLoc,
+-      const ParsedAttributesView &AttrList, bool IsInstantiation);
++  NamedDecl *BuildUsingDeclaration(Scope *S, AccessSpecifier AS,
++                                   SourceLocation UsingLoc,
++                                   bool HasTypenameKeyword,
++                                   SourceLocation TypenameLoc, CXXScopeSpec &SS,
++                                   DeclarationNameInfo NameInfo,
++                                   SourceLocation EllipsisLoc,
++                                   const ParsedAttributesView &AttrList,
++                                   bool IsInstantiation, bool IsUsingIfExists);
+   NamedDecl *BuildUsingPackDecl(NamedDecl *InstantiatedFrom,
+                                 ArrayRef<NamedDecl *> Expansions);
+ 
+diff --git a/clang/include/clang/Serialization/ASTBitCodes.h b/clang/include/clang/Serialization/ASTBitCodes.h
+index c6f9f1d1a08f..737023e7d1dc 100644
+--- a/clang/include/clang/Serialization/ASTBitCodes.h
++++ b/clang/include/clang/Serialization/ASTBitCodes.h
+@@ -1423,6 +1423,9 @@ public:
+       /// \brief A ConceptDecl record.
+       DECL_CONCEPT,
+ 
++      /// An UnresolvedUsingIfExistsDecl record.
++      DECL_UNRESOLVED_USING_IF_EXISTS,
++
+       /// \brief A StaticAssertDecl record.
+       DECL_STATIC_ASSERT,
+ 
+diff --git a/clang/lib/AST/DeclBase.cpp b/clang/lib/AST/DeclBase.cpp
+index f4314d0bd961..7e5ace6c111b 100644
+--- a/clang/lib/AST/DeclBase.cpp
++++ b/clang/lib/AST/DeclBase.cpp
+@@ -812,6 +812,9 @@ unsigned Decl::getIdentifierNamespaceForKind(Kind DeclKind) {
+     case TypeAliasTemplate:
+       return IDNS_Ordinary | IDNS_Tag | IDNS_Type;
+ 
++    case UnresolvedUsingIfExists:
++      return IDNS_Type | IDNS_Ordinary;
++
+     case OMPDeclareReduction:
+       return IDNS_OMPReduction;
+ 
+diff --git a/clang/lib/AST/DeclCXX.cpp b/clang/lib/AST/DeclCXX.cpp
+index 6f1fd2f14ede..e7fa4849063f 100644
+--- a/clang/lib/AST/DeclCXX.cpp
++++ b/clang/lib/AST/DeclCXX.cpp
+@@ -3085,6 +3085,25 @@ UnresolvedUsingTypenameDecl::CreateDeserialized(ASTContext &C, unsigned ID) {
+       SourceLocation(), nullptr, SourceLocation());
+ }
+ 
++UnresolvedUsingIfExistsDecl *
++UnresolvedUsingIfExistsDecl::Create(ASTContext &Ctx, DeclContext *DC,
++                                    SourceLocation Loc, DeclarationName Name) {
++  return new (Ctx, DC) UnresolvedUsingIfExistsDecl(DC, Loc, Name);
++}
++
++UnresolvedUsingIfExistsDecl *
++UnresolvedUsingIfExistsDecl::CreateDeserialized(ASTContext &Ctx, unsigned ID) {
++  return new (Ctx, ID)
++      UnresolvedUsingIfExistsDecl(nullptr, SourceLocation(), DeclarationName());
++}
++
++UnresolvedUsingIfExistsDecl::UnresolvedUsingIfExistsDecl(DeclContext *DC,
++                                                         SourceLocation Loc,
++                                                         DeclarationName Name)
++    : NamedDecl(Decl::UnresolvedUsingIfExists, DC, Loc, Name) {}
++
++void UnresolvedUsingIfExistsDecl::anchor() {}
++
+ void StaticAssertDecl::anchor() {}
+ 
+ StaticAssertDecl *StaticAssertDecl::Create(ASTContext &C, DeclContext *DC,
+diff --git a/clang/lib/CodeGen/CGDecl.cpp b/clang/lib/CodeGen/CGDecl.cpp
+index 1729c7ed3c31..d149756c3f48 100644
+--- a/clang/lib/CodeGen/CGDecl.cpp
++++ b/clang/lib/CodeGen/CGDecl.cpp
+@@ -99,6 +99,7 @@ void CodeGenFunction::EmitDecl(const Decl &D) {
+   case Decl::ConstructorUsingShadow:
+   case Decl::ObjCTypeParam:
+   case Decl::Binding:
++  case Decl::UnresolvedUsingIfExists:
+     llvm_unreachable("Declaration should not be in declstmts!");
+   case Decl::Function:  // void X();
+   case Decl::Record:    // struct/union/class X;
+diff --git a/clang/lib/Sema/SemaDecl.cpp b/clang/lib/Sema/SemaDecl.cpp
+index 5b0417fa8859..1de95feb0f25 100644
+--- a/clang/lib/Sema/SemaDecl.cpp
++++ b/clang/lib/Sema/SemaDecl.cpp
+@@ -434,12 +434,14 @@ ParsedType Sema::getTypeName(const IdentifierInfo &II, SourceLocation NameLoc,
+     // Look to see if we have a type anywhere in the list of results.
+     for (LookupResult::iterator Res = Result.begin(), ResEnd = Result.end();
+          Res != ResEnd; ++Res) {
+-      if (isa<TypeDecl>(*Res) || isa<ObjCInterfaceDecl>(*Res) ||
+-          (AllowDeducedTemplate && getAsTypeTemplateDecl(*Res))) {
++      NamedDecl *RealRes = (*Res)->getUnderlyingDecl();
++      if (isa<TypeDecl, ObjCInterfaceDecl, UnresolvedUsingIfExistsDecl>(
++              RealRes) ||
++          (AllowDeducedTemplate && getAsTypeTemplateDecl(RealRes))) {
+         if (!IIDecl ||
+-            (*Res)->getLocation().getRawEncoding() <
+-              IIDecl->getLocation().getRawEncoding())
+-          IIDecl = *Res;
++            // Make the selection of the recovery decl deterministic.
++            RealRes->getLocation() < IIDecl->getLocation())
++          IIDecl = RealRes;
+       }
+     }
+ 
+@@ -488,6 +490,10 @@ ParsedType Sema::getTypeName(const IdentifierInfo &II, SourceLocation NameLoc,
+     (void)DiagnoseUseOfDecl(IDecl, NameLoc);
+     if (!HasTrailingDot)
+       T = Context.getObjCInterfaceType(IDecl);
++  } else if (auto *UD = dyn_cast<UnresolvedUsingIfExistsDecl>(IIDecl)) {
++    (void)DiagnoseUseOfDecl(UD, NameLoc);
++    // Recover with 'int'
++    T = Context.IntTy;
+   } else if (AllowDeducedTemplate) {
+     if (auto *TD = getAsTypeTemplateDecl(IIDecl))
+       T = Context.getDeducedTemplateSpecializationType(TemplateName(TD),
+@@ -504,7 +510,7 @@ ParsedType Sema::getTypeName(const IdentifierInfo &II, SourceLocation NameLoc,
+   // constructor or destructor name (in such a case, the scope specifier
+   // will be attached to the enclosing Expr or Decl node).
+   if (SS && SS->isNotEmpty() && !IsCtorOrDtorName &&
+-      !isa<ObjCInterfaceDecl>(IIDecl)) {
++      !isa<ObjCInterfaceDecl, UnresolvedUsingIfExistsDecl>(IIDecl)) {
+     if (WantNontrivialTypeSourceInfo) {
+       // Construct a type with type-source information.
+       TypeLocBuilder Builder;
+@@ -1163,6 +1169,11 @@ Corrected:
+     return NameClassification::Concept(
+         TemplateName(cast<TemplateDecl>(FirstDecl)));
+ 
++  if (auto *EmptyD = dyn_cast<UnresolvedUsingIfExistsDecl>(FirstDecl)) {
++    (void)DiagnoseUseOfDecl(EmptyD, NameLoc);
++    return NameClassification::Error();
++  }
++
+   // We can have a type template here if we're classifying a template argument.
+   if (isa<TemplateDecl>(FirstDecl) && !isa<FunctionTemplateDecl>(FirstDecl) &&
+       !isa<VarTemplateDecl>(FirstDecl))
+diff --git a/clang/lib/Sema/SemaDeclAttr.cpp b/clang/lib/Sema/SemaDeclAttr.cpp
+index a9a2a19b4797..3cff1937e221 100644
+--- a/clang/lib/Sema/SemaDeclAttr.cpp
++++ b/clang/lib/Sema/SemaDeclAttr.cpp
+@@ -7450,6 +7450,10 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
+   case ParsedAttr::AT_UseHandle:
+     handleHandleAttr<UseHandleAttr>(S, D, AL);
+     break;
++
++  case ParsedAttr::AT_UsingIfExists:
++    handleSimpleAttribute<UsingIfExistsAttr>(S, D, AL);
++    break;
+   }
+ }
+ 
+diff --git a/clang/lib/Sema/SemaDeclCXX.cpp b/clang/lib/Sema/SemaDeclCXX.cpp
+index 22bf35dbd0cb..710fe3bce6ef 100644
+--- a/clang/lib/Sema/SemaDeclCXX.cpp
++++ b/clang/lib/Sema/SemaDeclCXX.cpp
+@@ -11495,10 +11495,11 @@ Decl *Sema::ActOnUsingDeclaration(Scope *S, AccessSpecifier AS,
+     }
+   }
+ 
+-  NamedDecl *UD =
+-      BuildUsingDeclaration(S, AS, UsingLoc, TypenameLoc.isValid(), TypenameLoc,
+-                            SS, TargetNameInfo, EllipsisLoc, AttrList,
+-                            /*IsInstantiation*/false);
++  NamedDecl *UD = BuildUsingDeclaration(
++      S, AS, UsingLoc, TypenameLoc.isValid(), TypenameLoc, SS, TargetNameInfo,
++      EllipsisLoc, AttrList,
++      /*IsInstantiation=*/false,
++      AttrList.hasAttribute(ParsedAttr::AT_UsingIfExists));
+   if (UD)
+     PushOnScopeChains(UD, S, /*AddToContext*/ false);
+ 
+@@ -11518,6 +11519,12 @@ IsEquivalentForUsingDecl(ASTContext &Context, NamedDecl *D1, NamedDecl *D2) {
+       return Context.hasSameType(TD1->getUnderlyingType(),
+                                  TD2->getUnderlyingType());
+ 
++  // Two using_if_exists using-declarations are equivalent if both are
++  // unresolved.
++  if (isa<UnresolvedUsingIfExistsDecl>(D1) &&
++      isa<UnresolvedUsingIfExistsDecl>(D2))
++    return true;
++
+   return false;
+ }
+ 
+@@ -11628,6 +11635,20 @@ bool Sema::CheckUsingShadowDecl(UsingDecl *Using, NamedDecl *Orig,
+   if (FoundEquivalentDecl)
+     return false;
+ 
++  // Always emit a diagnostic for a mismatch between an unresolved
++  // using_if_exists and a resolved using declaration in either direction.
++  if (isa<UnresolvedUsingIfExistsDecl>(Target) !=
++      (isa_and_nonnull<UnresolvedUsingIfExistsDecl>(NonTag))) {
++    if (!NonTag && !Tag)
++      return false;
++    Diag(Using->getLocation(), diag::err_using_decl_conflict);
++    Diag(Target->getLocation(), diag::note_using_decl_target);
++    Diag((NonTag ? NonTag : Tag)->getLocation(),
++         diag::note_using_decl_conflict);
++    Using->setInvalidDecl();
++    return true;
++  }
++
+   if (FunctionDecl *FD = Target->getAsFunction()) {
+     NamedDecl *OldDecl = nullptr;
+     switch (CheckOverload(nullptr, FD, Previous, OldDecl,
+@@ -11892,7 +11913,8 @@ NamedDecl *Sema::BuildUsingDeclaration(
+     Scope *S, AccessSpecifier AS, SourceLocation UsingLoc,
+     bool HasTypenameKeyword, SourceLocation TypenameLoc, CXXScopeSpec &SS,
+     DeclarationNameInfo NameInfo, SourceLocation EllipsisLoc,
+-    const ParsedAttributesView &AttrList, bool IsInstantiation) {
++    const ParsedAttributesView &AttrList, bool IsInstantiation,
++    bool IsUsingIfExists) {
+   assert(!SS.isInvalid() && "Invalid CXXScopeSpec.");
+   SourceLocation IdentLoc = NameInfo.getLoc();
+   assert(IdentLoc.isValid() && "Invalid TargetName location.");
+@@ -11961,6 +11983,13 @@ NamedDecl *Sema::BuildUsingDeclaration(
+                               IdentLoc))
+     return nullptr;
+ 
++  // 'using_if_exists' doesn't make sense on an inherited constructor.
++  if (IsUsingIfExists && UsingName.getName().getNameKind() ==
++                             DeclarationName::CXXConstructorName) {
++    Diag(UsingLoc, diag::err_using_if_exists_on_ctor);
++    return nullptr;
++  }
++
+   DeclContext *LookupContext = computeDeclContext(SS);
+   NamedDecl *D;
+   NestedNameSpecifierLoc QualifierLoc = SS.getWithLocInContext(Context);
+@@ -12015,6 +12044,11 @@ NamedDecl *Sema::BuildUsingDeclaration(
+ 
+   LookupQualifiedName(R, LookupContext);
+ 
++  if (R.empty() && IsUsingIfExists)
++    R.addDecl(UnresolvedUsingIfExistsDecl::Create(Context, CurContext, UsingLoc,
++                                                  UsingName.getName()),
++              AS_public);
++
+   // Try to correct typos if possible. If constructor name lookup finds no
+   // results, that means the named class has no explicit constructors, and we
+   // suppressed declaring implicit ones (probably because it's dependent or
+@@ -12089,7 +12123,8 @@ NamedDecl *Sema::BuildUsingDeclaration(
+ 
+   if (HasTypenameKeyword) {
+     // If we asked for a typename and got a non-type decl, error out.
+-    if (!R.getAsSingle<TypeDecl>()) {
++    if (!R.getAsSingle<TypeDecl>() &&
++        !R.getAsSingle<UnresolvedUsingIfExistsDecl>()) {
+       Diag(IdentLoc, diag::err_using_typename_non_type);
+       for (LookupResult::iterator I = R.begin(), E = R.end(); I != E; ++I)
+         Diag((*I)->getUnderlyingDecl()->getLocation(),
+diff --git a/clang/lib/Sema/SemaExpr.cpp b/clang/lib/Sema/SemaExpr.cpp
+index d301e6c732ab..807e5e33dd45 100644
+--- a/clang/lib/Sema/SemaExpr.cpp
++++ b/clang/lib/Sema/SemaExpr.cpp
+@@ -82,6 +82,9 @@ bool Sema::CanUseDecl(NamedDecl *D, bool TreatUnavailableAsInvalid) {
+       cast<Decl>(CurContext)->getAvailability() != AR_Unavailable)
+     return false;
+ 
++  if (isa<UnresolvedUsingIfExistsDecl>(D))
++    return false;
++
+   return true;
+ }
+ 
+@@ -348,6 +351,12 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
+     return true;
+   }
+ 
++  if (const auto *EmptyD = dyn_cast<UnresolvedUsingIfExistsDecl>(D)) {
++    Diag(Loc, diag::err_use_of_empty_using_if_exists);
++    Diag(EmptyD->getLocation(), diag::note_empty_using_if_exists_here);
++    return true;
++  }
++
+   DiagnoseAvailabilityOfDecl(D, Locs, UnknownObjCClass, ObjCPropertyAccess,
+                              AvoidPartialAvailabilityChecks, ClassReceiver);
+ 
+@@ -3123,8 +3132,7 @@ ExprResult Sema::BuildDeclarationNameExpr(
+   }
+ 
+   // Make sure that we're referring to a value.
+-  ValueDecl *VD = dyn_cast<ValueDecl>(D);
+-  if (!VD) {
++  if (!isa<ValueDecl, UnresolvedUsingIfExistsDecl>(D)) {
+     Diag(Loc, diag::err_ref_non_value)
+       << D << SS.getRange();
+     Diag(D->getLocation(), diag::note_declared_at);
+@@ -3135,9 +3143,11 @@ ExprResult Sema::BuildDeclarationNameExpr(
+   // this check when we're going to perform argument-dependent lookup
+   // on this function name, because this might not be the function
+   // that overload resolution actually selects.
+-  if (DiagnoseUseOfDecl(VD, Loc))
++  if (DiagnoseUseOfDecl(D, Loc))
+     return ExprError();
+ 
++  auto *VD = cast<ValueDecl>(D);
++
+   // Only create DeclRefExpr's for valid Decl's.
+   if (VD->isInvalidDecl() && !AcceptInvalidDecl)
+     return ExprError();
+diff --git a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+index 7e6efe6105bf..248b8293eb41 100644
+--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
++++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+@@ -3000,9 +3000,15 @@ Decl *TemplateDeclInstantiator::VisitUsingDecl(UsingDecl *D) {
+       if (auto *BaseShadow = CUSD->getNominatedBaseClassShadowDecl())
+         OldTarget = BaseShadow;
+ 
+-    NamedDecl *InstTarget =
+-        cast_or_null<NamedDecl>(SemaRef.FindInstantiatedDecl(
+-            Shadow->getLocation(), OldTarget, TemplateArgs));
++    NamedDecl *InstTarget = nullptr;
++    if (auto *EmptyD =
++            dyn_cast<UnresolvedUsingIfExistsDecl>(Shadow->getTargetDecl())) {
++      InstTarget = UnresolvedUsingIfExistsDecl::Create(
++          SemaRef.Context, Owner, EmptyD->getLocation(), EmptyD->getDeclName());
++    } else {
++      InstTarget = cast_or_null<NamedDecl>(SemaRef.FindInstantiatedDecl(
++          Shadow->getLocation(), OldTarget, TemplateArgs));
++    }
+     if (!InstTarget)
+       return nullptr;
+ 
+@@ -3125,13 +3131,16 @@ Decl *TemplateDeclInstantiator::instantiateUnresolvedUsingDecl(
+   SourceLocation EllipsisLoc =
+       InstantiatingSlice ? SourceLocation() : D->getEllipsisLoc();
+ 
++  bool IsUsingIfExists = D->template hasAttr<UsingIfExistsAttr>();
+   NamedDecl *UD = SemaRef.BuildUsingDeclaration(
+       /*Scope*/ nullptr, D->getAccess(), D->getUsingLoc(),
+       /*HasTypename*/ TD, TypenameLoc, SS, NameInfo, EllipsisLoc,
+       ParsedAttributesView(),
+-      /*IsInstantiation*/ true);
+-  if (UD)
++      /*IsInstantiation*/ true, IsUsingIfExists);
++  if (UD) {
++    SemaRef.InstantiateAttrs(TemplateArgs, D, UD);
+     SemaRef.Context.setInstantiatedFromUsingDecl(UD, D);
++  }
+ 
+   return UD;
+ }
+@@ -3146,6 +3155,11 @@ Decl *TemplateDeclInstantiator::VisitUnresolvedUsingValueDecl(
+   return instantiateUnresolvedUsingDecl(D);
+ }
+ 
++Decl *TemplateDeclInstantiator::VisitUnresolvedUsingIfExistsDecl(
++    UnresolvedUsingIfExistsDecl *D) {
++  llvm_unreachable("referring to unresolved decl out of UsingShadowDecl");
++}
++
+ Decl *TemplateDeclInstantiator::VisitUsingPackDecl(UsingPackDecl *D) {
+   SmallVector<NamedDecl*, 8> Expansions;
+   for (auto *UD : D->expansions()) {
+diff --git a/clang/lib/Sema/TreeTransform.h b/clang/lib/Sema/TreeTransform.h
+index ae0e9f1119b4..091be27e3d17 100644
+--- a/clang/lib/Sema/TreeTransform.h
++++ b/clang/lib/Sema/TreeTransform.h
+@@ -14052,7 +14052,11 @@ QualType TreeTransform<Derived>::RebuildUnresolvedUsingType(SourceLocation Loc,
+ 
+     // A valid resolved using typename decl points to exactly one type decl.
+     assert(++Using->shadow_begin() == Using->shadow_end());
+-    Ty = cast<TypeDecl>((*Using->shadow_begin())->getTargetDecl());
++
++    NamedDecl *Target = Using->shadow_begin()->getTargetDecl();
++    if (SemaRef.DiagnoseUseOfDecl(Target, Loc))
++      return QualType();
++    Ty = cast<TypeDecl>(Target);
+   } else {
+     assert(isa<UnresolvedUsingTypenameDecl>(D) &&
+            "UnresolvedUsingTypenameDecl transformed to non-using decl");
+diff --git a/clang/lib/Serialization/ASTCommon.cpp b/clang/lib/Serialization/ASTCommon.cpp
+index bf583b02f96b..165d96fd4d85 100644
+--- a/clang/lib/Serialization/ASTCommon.cpp
++++ b/clang/lib/Serialization/ASTCommon.cpp
+@@ -416,6 +416,7 @@ bool serialization::isRedeclarableDeclKind(unsigned Kind) {
+   case Decl::Concept:
+   case Decl::LifetimeExtendedTemporary:
+   case Decl::RequiresExprBody:
++  case Decl::UnresolvedUsingIfExists:
+     return false;
+ 
+   // These indirectly derive from Redeclarable<T> but are not actually
+diff --git a/clang/lib/Serialization/ASTReaderDecl.cpp b/clang/lib/Serialization/ASTReaderDecl.cpp
+index c0bf240464f7..c2390403900c 100644
+--- a/clang/lib/Serialization/ASTReaderDecl.cpp
++++ b/clang/lib/Serialization/ASTReaderDecl.cpp
+@@ -325,6 +325,7 @@ namespace clang {
+     void VisitTypedefDecl(TypedefDecl *TD);
+     void VisitTypeAliasDecl(TypeAliasDecl *TD);
+     void VisitUnresolvedUsingTypenameDecl(UnresolvedUsingTypenameDecl *D);
++    void VisitUnresolvedUsingIfExistsDecl(UnresolvedUsingIfExistsDecl *D);
+     RedeclarableResult VisitTagDecl(TagDecl *TD);
+     void VisitEnumDecl(EnumDecl *ED);
+     RedeclarableResult VisitRecordDeclImpl(RecordDecl *RD);
+@@ -1689,6 +1690,11 @@ void ASTDeclReader::VisitUnresolvedUsingTypenameDecl(
+   mergeMergeable(D);
+ }
+ 
++void ASTDeclReader::VisitUnresolvedUsingIfExistsDecl(
++    UnresolvedUsingIfExistsDecl *D) {
++  VisitNamedDecl(D);
++}
++
+ void ASTDeclReader::ReadCXXDefinitionData(
+     struct CXXRecordDecl::DefinitionData &Data, const CXXRecordDecl *D) {
+   #define FIELD(Name, Width, Merge) \
+@@ -3841,6 +3847,9 @@ Decl *ASTReader::ReadDeclRecord(DeclID ID) {
+   case DECL_UNRESOLVED_USING_TYPENAME:
+     D = UnresolvedUsingTypenameDecl::CreateDeserialized(Context, ID);
+     break;
++  case DECL_UNRESOLVED_USING_IF_EXISTS:
++    D = UnresolvedUsingIfExistsDecl::CreateDeserialized(Context, ID);
++    break;
+   case DECL_CXX_RECORD:
+     D = CXXRecordDecl::CreateDeserialized(Context, ID);
+     break;
+diff --git a/clang/lib/Serialization/ASTWriterDecl.cpp b/clang/lib/Serialization/ASTWriterDecl.cpp
+index eecdf89c791a..7b65fdd7eb8d 100644
+--- a/clang/lib/Serialization/ASTWriterDecl.cpp
++++ b/clang/lib/Serialization/ASTWriterDecl.cpp
+@@ -69,6 +69,7 @@ namespace clang {
+     void VisitTypedefDecl(TypedefDecl *D);
+     void VisitTypeAliasDecl(TypeAliasDecl *D);
+     void VisitUnresolvedUsingTypenameDecl(UnresolvedUsingTypenameDecl *D);
++    void VisitUnresolvedUsingIfExistsDecl(UnresolvedUsingIfExistsDecl *D);
+     void VisitTagDecl(TagDecl *D);
+     void VisitEnumDecl(EnumDecl *D);
+     void VisitRecordDecl(RecordDecl *D);
+@@ -1337,6 +1338,12 @@ void ASTDeclWriter::VisitUnresolvedUsingTypenameDecl(
+   Code = serialization::DECL_UNRESOLVED_USING_TYPENAME;
+ }
+ 
++void ASTDeclWriter::VisitUnresolvedUsingIfExistsDecl(
++    UnresolvedUsingIfExistsDecl *D) {
++  VisitNamedDecl(D);
++  Code = serialization::DECL_UNRESOLVED_USING_IF_EXISTS;
++}
++
+ void ASTDeclWriter::VisitCXXRecordDecl(CXXRecordDecl *D) {
+   VisitRecordDecl(D);
+ 
+diff --git a/clang/test/Parser/using-if-exists-attr.cpp b/clang/test/Parser/using-if-exists-attr.cpp
+new file mode 100644
+index 000000000000..ba34b9beb6bc
+--- /dev/null
++++ b/clang/test/Parser/using-if-exists-attr.cpp
+@@ -0,0 +1,27 @@
++// RUN: %clang_cc1 -std=c++20 -fsyntax-only %s -pedantic -verify
++
++#define UIE __attribute__((using_if_exists))
++
++namespace NS {
++typedef int x;
++}
++
++using NS::x __attribute__((using_if_exists));
++
++using NS::x [[clang::using_if_exists]]; // expected-warning{{ISO C++ does not allow an attribute list to appear here}}
++
++[[clang::using_if_exists]] // expected-warning{{ISO C++ does not allow an attribute list to appear here}}
++using NS::not_there,
++    NS::not_there2;
++
++using NS::not_there3,                          // expected-error {{no member named 'not_there3' in namespace 'NS'}}
++    NS::not_there4 [[clang::using_if_exists]]; // expected-warning{{C++ does not allow an attribute list to appear here}}
++
++[[clang::using_if_exists]] using NS::not_there5 [[clang::using_if_exists]]; // expected-warning 2 {{ISO C++ does not allow}}
++
++struct Base {};
++struct Derived : Base {
++  [[clang::using_if_exists]] using Base::x;          // expected-warning {{ISO C++ does not allow an attribute list to appear here}}
++  using Base::y [[clang::using_if_exists]];          // expected-warning {{ISO C++ does not allow an attribute list to appear here}}
++  [[clang::using_if_exists]] using Base::z, Base::q; // expected-warning {{C++ does not allow an attribute list to appear here}}
++};
+diff --git a/clang/test/SemaCXX/attr-deprecated.cpp b/clang/test/SemaCXX/attr-deprecated.cpp
+index 5ba55f0c23b5..5c427ad8fef1 100644
+--- a/clang/test/SemaCXX/attr-deprecated.cpp
++++ b/clang/test/SemaCXX/attr-deprecated.cpp
+@@ -256,3 +256,15 @@ typedef struct TDS {
+ } TDS __attribute__((deprecated)); // expected-note {{'TDS' has been explicitly marked deprecated here}}
+ TDS tds; // expected-warning {{'TDS' is deprecated}}
+ struct TDS tds2; // no warning, attribute only applies to the typedef.
++
++namespace test8 {
++struct A {
++  // expected-note@+1 {{'B' has been explicitly marked deprecated here}}
++  struct __attribute__((deprecated)) B {};
++};
++template <typename T> struct D : T {
++  using typename T::B;
++  B b; // expected-warning {{'B' is deprecated}}
++};
++D<A> da; // expected-note {{in instantiation of template class}}
++} // namespace test8
+diff --git a/clang/test/SemaCXX/using-if-exists.cpp b/clang/test/SemaCXX/using-if-exists.cpp
+new file mode 100644
+index 000000000000..36fbbb171fb9
+--- /dev/null
++++ b/clang/test/SemaCXX/using-if-exists.cpp
+@@ -0,0 +1,226 @@
++// RUN: %clang_cc1 -std=c++20 -fsyntax-only %s -verify
++
++#define UIE __attribute__((using_if_exists))
++
++namespace test_basic {
++namespace NS {}
++
++using NS::x UIE; // expected-note{{using declaration annotated with 'using_if_exists' here}}
++x usex();        // expected-error{{reference to unresolved using declaration}}
++
++using NotNS::x UIE; // expected-error{{use of undeclared identifier 'NotNS'}}
++
++using NS::NotNS::x UIE; // expected-error{{no member named 'NotNS' in namespace 'test_basic::NS'}}
++} // namespace test_basic
++
++namespace test_redecl {
++namespace NS {}
++
++using NS::x UIE;
++using NS::x UIE;
++
++namespace NS1 {}
++namespace NS2 {}
++namespace NS3 {
++int A();     // expected-note{{target of using declaration}}
++struct B {}; // expected-note{{target of using declaration}}
++int C();     // expected-note{{conflicting declaration}}
++struct D {}; // expected-note{{conflicting declaration}}
++} // namespace NS3
++
++using NS1::A UIE;
++using NS2::A UIE; // expected-note{{using declaration annotated with 'using_if_exists' here}} expected-note{{conflicting declaration}}
++using NS3::A UIE; // expected-error{{target of using declaration conflicts with declaration already in scope}}
++int i = A();      // expected-error{{reference to unresolved using declaration}}
++
++using NS1::B UIE;
++using NS2::B UIE; // expected-note{{conflicting declaration}} expected-note{{using declaration annotated with 'using_if_exists' here}}
++using NS3::B UIE; // expected-error{{target of using declaration conflicts with declaration already in scope}}
++B myB;            // expected-error{{reference to unresolved using declaration}}
++
++using NS3::C UIE;
++using NS2::C UIE; // expected-error{{target of using declaration conflicts with declaration already in scope}} expected-note{{target of using declaration}}
++int j = C();
++
++using NS3::D UIE;
++using NS2::D UIE; // expected-error{{target of using declaration conflicts with declaration already in scope}} expected-note{{target of using declaration}}
++D myD;
++} // namespace test_redecl
++
++namespace test_dependent {
++template <class B>
++struct S : B {
++  using B::mf UIE;          // expected-note 3 {{using declaration annotated with 'using_if_exists' here}}
++  using typename B::mt UIE; // expected-note{{using declaration annotated with 'using_if_exists' here}}
++};
++
++struct BaseEmpty {
++};
++struct BaseNonEmpty {
++  void mf();
++  typedef int mt;
++};
++
++template <class Base>
++struct UseCtor : Base {
++  using Base::Base UIE; // expected-error{{'using_if_exists' attribute cannot be applied to an inheriting constructor}}
++};
++struct BaseCtor {};
++
++void f() {
++  S<BaseEmpty> empty;
++  S<BaseNonEmpty> nonempty;
++  empty.mf(); // expected-error {{reference to unresolved using declaration}}
++  nonempty.mf();
++  (&empty)->mf(); // expected-error {{reference to unresolved using declaration}}
++  (&nonempty)->mf();
++
++  S<BaseEmpty>::mt y; // expected-error {{reference to unresolved using declaration}}
++  S<BaseNonEmpty>::mt z;
++
++  S<BaseEmpty>::mf(); // expected-error {{reference to unresolved using declaration}}
++
++  UseCtor<BaseCtor> usector;
++}
++
++template <class B>
++struct Implicit : B {
++  using B::mf UIE;          // expected-note {{using declaration annotated with 'using_if_exists' here}}
++  using typename B::mt UIE; // expected-note 2 {{using declaration annotated with 'using_if_exists' here}}
++
++  void use() {
++    mf(); // expected-error {{reference to unresolved using declaration}}
++    mt x; // expected-error {{reference to unresolved using declaration}}
++  }
++
++  mt alsoUse(); // expected-error {{reference to unresolved using declaration}}
++};
++
++void testImplicit() {
++  Implicit<BaseNonEmpty> nonempty;
++  Implicit<BaseEmpty> empty; // expected-note {{in instantiation}}
++  nonempty.use();
++  empty.use(); // expected-note {{in instantiation}}
++}
++
++template <class>
++struct NonDep : BaseEmpty {
++  using BaseEmpty::x UIE; // expected-note{{using declaration annotated with 'using_if_exists' here}}
++  x y();                  // expected-error{{reference to unresolved using declaration}}
++};
++} // namespace test_dependent
++
++namespace test_using_pack {
++template <class... Ts>
++struct S : Ts... {
++  using typename Ts::x... UIE; // expected-error 2 {{target of using declaration conflicts with declaration already in scope}} expected-note{{conflicting declaration}} expected-note{{target of using declaration}}
++};
++
++struct E1 {};
++struct E2 {};
++S<E1, E2> a;
++
++struct F1 {
++  typedef int x; // expected-note 2 {{conflicting declaration}}
++};
++struct F2 {
++  typedef int x; // expected-note 2 {{target of using declaration}}
++};
++S<F1, F2> b;
++
++S<E1, F2> c; // expected-note{{in instantiation of template class}}
++S<F1, E2> d; // expected-note{{in instantiation of template class}}
++
++template <class... Ts>
++struct S2 : Ts... {
++  using typename Ts::x... UIE; // expected-error 2 {{target of using declaration conflicts with declaration already in scope}} expected-note 3 {{using declaration annotated with 'using_if_exists' here}} expected-note{{conflicting declaration}} expected-note{{target of using declaration}}
++
++  x mem(); // expected-error 3 {{reference to unresolved using declaration}}
++};
++
++S2<E1, E2> e; // expected-note{{in instantiation of template class}}
++S2<F1, F2> f;
++S2<E1, F2> g; // expected-note{{in instantiation of template class}}
++S2<F1, E2> h; // expected-note{{in instantiation of template class}}
++
++template <class... Ts>
++struct S3 : protected Ts... {
++  using Ts::m... UIE; // expected-error{{target of using declaration conflicts with declaration already in scope}} expected-note{{target of using declaration}}
++};
++struct B1 {
++  enum { m }; // expected-note{{conflicting declaration}}
++};
++struct B2 {};
++
++S3<B1, B2> i; // expected-note{{in instantiation of template}}
++S<B2, B1> j;
++
++} // namespace test_using_pack
++
++namespace test_nested {
++namespace NS {}
++
++using NS::x UIE; // expected-note {{using declaration annotated with 'using_if_exists' here}}
++
++namespace NS2 {
++using ::test_nested::x UIE;
++}
++
++NS2::x y; // expected-error {{reference to unresolved using declaration}}
++} // namespace test_nested
++
++namespace test_scope {
++int x; // expected-note{{conflicting declaration}}
++void f() {
++  int x; // expected-note{{conflicting declaration}}
++  {
++    using ::x UIE; // expected-note {{using declaration annotated with 'using_if_exists' here}}
++    (void)x;       // expected-error {{reference to unresolved using declaration}}
++  }
++
++  {
++    using test_scope::x;
++    using ::x UIE; // expected-error{{target of using declaration conflicts with declaration already in scope}} expected-note{{target of using declaration}}
++    (void)x;
++  }
++
++  (void)x;
++
++  using ::x UIE; // expected-error{{target of using declaration conflicts with declaration already in scope}} expected-note{{target of using declaration}}
++  (void)x;
++}
++} // namespace test_scope
++
++namespace test_appertains_to {
++namespace NS {
++typedef int x;
++}
++
++// FIXME: This diagnostics is wrong.
++using alias UIE = NS::x; // expected-error {{'using_if_exists' attribute only applies to named declarations, types, and value declarations}}
++
++template <class>
++using template_alias UIE = NS::x; // expected-error {{'using_if_exists' attribute only applies to named declarations, types, and value declarations}}
++
++void f() UIE; // expected-error {{'using_if_exists' attribute only applies to named declarations, types, and value declarations}}
++
++using namespace NS UIE; // expected-error {{'using_if_exists' attribute only applies to named declarations, types, and value declarations}}
++} // namespace test_appertains_to
++
++typedef int *fake_FILE;
++int fake_printf();
++
++namespace std {
++using ::fake_FILE UIE;
++using ::fake_printf UIE;
++using ::fake_fopen UIE;  // expected-note {{using declaration annotated with 'using_if_exists' here}}
++using ::fake_size_t UIE; // expected-note {{using declaration annotated with 'using_if_exists' here}}
++} // namespace std
++
++int main() {
++  std::fake_FILE file;
++  file = std::fake_fopen(); // expected-error {{reference to unresolved using declaration}} expected-error{{incompatible integer to pointer}}
++  std::fake_size_t size;    // expected-error {{reference to unresolved using declaration}}
++  size = fake_printf();
++  size = std::fake_printf();
++}
+diff --git a/clang/tools/libclang/CIndex.cpp b/clang/tools/libclang/CIndex.cpp
+index 93f9797a965e..e533703e5158 100644
+--- a/clang/tools/libclang/CIndex.cpp
++++ b/clang/tools/libclang/CIndex.cpp
+@@ -6406,6 +6406,7 @@ CXCursor clang_getCursorDefinition(CXCursor C) {
+   case Decl::Concept:
+   case Decl::LifetimeExtendedTemporary:
+   case Decl::RequiresExprBody:
++  case Decl::UnresolvedUsingIfExists:
+     return C;
+ 
+   // Declaration kinds that don't make any sense here, but are
+-- 
+2.37.2
+

--- a/lang/clang-11-bootstrap/files/0036-clang-Parse-Add-parsing-support-for-C-attributes-on-.patch
+++ b/lang/clang-11-bootstrap/files/0036-clang-Parse-Add-parsing-support-for-C-attributes-on-.patch
@@ -1,0 +1,423 @@
+From da46206ab118338f438756e7d3bf2cd87f1badb0 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Tue, 30 Aug 2022 14:35:02 +0200
+Subject: [PATCH] [clang][Parse] Add parsing support for C++ attributes on
+ using-declarations
+
+This is backport of https://reviews.llvm.org/D91630 to clang-11
+---
+ clang/docs/LanguageExtensions.rst             | 14 +++++
+ clang/docs/ReleaseNotes.rst                   |  3 ++
+ .../clang/Basic/DiagnosticParseKinds.td       |  3 ++
+ .../clang/Basic/DiagnosticSemaKinds.td        |  3 ++
+ clang/include/clang/Basic/Features.def        |  1 +
+ clang/include/clang/Parse/Parser.h            |  5 ++
+ clang/lib/Parse/ParseDecl.cpp                 |  7 +++
+ clang/lib/Parse/ParseDeclCXX.cpp              | 54 +++++++++----------
+ clang/lib/Sema/SemaDeclAttr.cpp               | 12 +++++
+ clang/lib/Sema/SemaDeclCXX.cpp                |  6 ++-
+ clang/test/Parser/cxx0x-attributes.cpp        | 15 ++++--
+ .../cxx11-attributes-on-using-declaration.cpp | 42 +++++++++++++++
+ 12 files changed, 131 insertions(+), 34 deletions(-)
+ create mode 100644 clang/test/SemaCXX/cxx11-attributes-on-using-declaration.cpp
+
+diff --git a/clang/docs/LanguageExtensions.rst b/clang/docs/LanguageExtensions.rst
+index 06ecc186c7dc..7408333be64f 100644
+--- a/clang/docs/LanguageExtensions.rst
++++ b/clang/docs/LanguageExtensions.rst
+@@ -619,6 +619,20 @@ Attributes on the ``enum`` declaration do not apply to individual enumerators.
+ 
+ Query for this feature with ``__has_extension(enumerator_attributes)``.
+ 
++C++11 Attributes on using-declarations
++======================================
++
++Clang allows C++-style ``[[]]`` attributes to be written on using-declarations.
++For instance:
++
++.. code-block:: c++
++
++  [[clang::using_if_exists]] using foo::bar;
++  using foo::baz [[clang::using_if_exists]];
++
++You can test for support for this extension with
++``__has_extension(cxx_attributes_on_using_declarations)``.
++
+ 'User-Specified' System Frameworks
+ ==================================
+ 
+diff --git a/clang/docs/ReleaseNotes.rst b/clang/docs/ReleaseNotes.rst
+index 0ccaa7a82121..720e941e3b87 100644
+--- a/clang/docs/ReleaseNotes.rst
++++ b/clang/docs/ReleaseNotes.rst
+@@ -302,6 +302,9 @@ Attribute Changes in Clang
+   `Clang Plugins <ClangPlugins.html#defining-attributes>`_ documentation for
+   details.
+ 
++- Added support for C++11-style ``[[]]`` attributes on using-declarations, as a
++  clang extension.
++
+ Windows Support
+ ---------------
+ 
+diff --git a/clang/include/clang/Basic/DiagnosticParseKinds.td b/clang/include/clang/Basic/DiagnosticParseKinds.td
+index 1038a4119d4c..a89e6067b2b5 100644
+--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
++++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
+@@ -672,6 +672,9 @@ def ext_using_attribute_ns : ExtWarn<
+ def err_using_attribute_ns_conflict : Error<
+   "attribute with scope specifier cannot follow default scope specifier">;
+ def err_attributes_not_allowed : Error<"an attribute list cannot appear here">;
++def ext_cxx11_attr_placement : ExtWarn<
++  "ISO C++ does not allow an attribute list to appear here">,
++  InGroup<DiagGroup<"cxx-attribute-extension">>;
+ def err_attributes_misplaced : Error<"misplaced attributes; expected attributes here">;
+ def err_l_square_l_square_not_attribute : Error<
+   "C++11 only allows consecutive left square brackets when "
+diff --git a/clang/include/clang/Basic/DiagnosticSemaKinds.td b/clang/include/clang/Basic/DiagnosticSemaKinds.td
+index 0581296ac802..2f4511e4110f 100644
+--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
++++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
+@@ -3824,6 +3824,9 @@ def warn_attribute_sentinel_named_arguments : Warning<
+ def warn_attribute_sentinel_not_variadic : Warning<
+   "'sentinel' attribute only supported for variadic %select{functions|blocks}0">,
+   InGroup<IgnoredAttributes>;
++def warn_deprecated_ignored_on_using : Warning<
++  "%0 currently has no effect on a using declaration">,
++  InGroup<IgnoredAttributes>;
+ def err_attribute_sentinel_less_than_zero : Error<
+   "'sentinel' parameter 1 less than zero">;
+ def err_attribute_sentinel_not_zero_or_one : Error<
+diff --git a/clang/include/clang/Basic/Features.def b/clang/include/clang/Basic/Features.def
+index 999bcb7e2e29..7234eceb493e 100644
+--- a/clang/include/clang/Basic/Features.def
++++ b/clang/include/clang/Basic/Features.def
+@@ -255,6 +255,7 @@ EXTENSION(pragma_clang_attribute_external_declaration, true)
+ EXTENSION(gnu_asm, LangOpts.GNUAsm)
+ EXTENSION(gnu_asm_goto_with_outputs, LangOpts.GNUAsm)
+ EXTENSION(matrix_types, LangOpts.MatrixTypes)
++EXTENSION(cxx_attributes_on_using_declarations, LangOpts.CPlusPlus11)
+ 
+ #undef EXTENSION
+ #undef FEATURE
+diff --git a/clang/include/clang/Parse/Parser.h b/clang/include/clang/Parse/Parser.h
+index e809d87b59a0..8a7418389933 100644
+--- a/clang/include/clang/Parse/Parser.h
++++ b/clang/include/clang/Parse/Parser.h
+@@ -2631,6 +2631,10 @@ private:
+   /// locations where attributes are not allowed.
+   void DiagnoseAndSkipCXX11Attributes();
+ 
++  /// Emit warnings for C++11 and C2x attributes that are in a position that
++  /// clang accepts as an extension.
++  void DiagnoseCXX11AttributeExtension(ParsedAttributesWithRange &Attrs);
++
+   /// Parses syntax-generic attribute arguments for attributes which are
+   /// known to the implementation, and adds them to the given ParsedAttributes
+   /// list with the given attribute syntax. Returns the number of arguments
+@@ -2962,6 +2966,7 @@ private:
+                                        const ParsedTemplateInfo &TemplateInfo,
+                                        SourceLocation UsingLoc,
+                                        SourceLocation &DeclEnd,
++                                       ParsedAttributesWithRange &Attrs,
+                                        AccessSpecifier AS = AS_none);
+   Decl *ParseAliasDeclarationAfterDeclarator(
+       const ParsedTemplateInfo &TemplateInfo, SourceLocation UsingLoc,
+diff --git a/clang/lib/Parse/ParseDecl.cpp b/clang/lib/Parse/ParseDecl.cpp
+index c87d240a8206..8967aa74feda 100644
+--- a/clang/lib/Parse/ParseDecl.cpp
++++ b/clang/lib/Parse/ParseDecl.cpp
+@@ -1549,6 +1549,13 @@ void Parser::ProhibitCXX11Attributes(ParsedAttributesWithRange &Attrs,
+   }
+ }
+ 
++void Parser::DiagnoseCXX11AttributeExtension(ParsedAttributesWithRange &Attrs) {
++  for (const ParsedAttr &PA : Attrs) {
++    if (PA.isCXX11Attribute() || PA.isC2xAttribute())
++      Diag(PA.getLoc(), diag::ext_cxx11_attr_placement) << PA << PA.getRange();
++  }
++}
++
+ // Usually, `__attribute__((attrib)) class Foo {} var` means that attribute
+ // applies to var, not the type Foo.
+ // As an exception to the rule, __declspec(align(...)) before the
+diff --git a/clang/lib/Parse/ParseDeclCXX.cpp b/clang/lib/Parse/ParseDeclCXX.cpp
+index ddcbb5615fee..f4b774f7071d 100644
+--- a/clang/lib/Parse/ParseDeclCXX.cpp
++++ b/clang/lib/Parse/ParseDeclCXX.cpp
+@@ -497,11 +497,7 @@ Parser::ParseUsingDirectiveOrDeclaration(DeclaratorContext Context,
+   }
+ 
+   // Otherwise, it must be a using-declaration or an alias-declaration.
+-
+-  // Using declarations can't have attributes.
+-  ProhibitAttributes(attrs);
+-
+-  return ParseUsingDeclaration(Context, TemplateInfo, UsingLoc, DeclEnd,
++  return ParseUsingDeclaration(Context, TemplateInfo, UsingLoc, DeclEnd, attrs,
+                                AS_none);
+ }
+ 
+@@ -628,7 +624,8 @@ bool Parser::ParseUsingDeclarator(DeclaratorContext Context,
+       Context == DeclaratorContext::MemberContext &&
+       Tok.is(tok::identifier) &&
+       (NextToken().is(tok::semi) || NextToken().is(tok::comma) ||
+-       NextToken().is(tok::ellipsis)) &&
++       NextToken().is(tok::ellipsis) || NextToken().is(tok::l_square) ||
++       NextToken().is(tok::kw___attribute)) &&
+       D.SS.isNotEmpty() && LastII == Tok.getIdentifierInfo() &&
+       !D.SS.getScopeRep()->getAsNamespace() &&
+       !D.SS.getScopeRep()->getAsNamespaceAlias()) {
+@@ -671,11 +668,10 @@ bool Parser::ParseUsingDeclarator(DeclaratorContext Context,
+ ///     alias-declaration: C++11 [dcl.dcl]p1
+ ///       'using' identifier attribute-specifier-seq[opt] = type-id ;
+ ///
+-Parser::DeclGroupPtrTy
+-Parser::ParseUsingDeclaration(DeclaratorContext Context,
+-                              const ParsedTemplateInfo &TemplateInfo,
+-                              SourceLocation UsingLoc, SourceLocation &DeclEnd,
+-                              AccessSpecifier AS) {
++Parser::DeclGroupPtrTy Parser::ParseUsingDeclaration(
++    DeclaratorContext Context, const ParsedTemplateInfo &TemplateInfo,
++    SourceLocation UsingLoc, SourceLocation &DeclEnd,
++    ParsedAttributesWithRange &PrefixAttrs, AccessSpecifier AS) {
+   // Check for misplaced attributes before the identifier in an
+   // alias-declaration.
+   ParsedAttributesWithRange MisplacedAttrs(AttrFactory);
+@@ -688,6 +684,17 @@ Parser::ParseUsingDeclaration(DeclaratorContext Context,
+   MaybeParseGNUAttributes(Attrs);
+   MaybeParseCXX11Attributes(Attrs);
+ 
++  // If we had any misplaced attributes from earlier, this is where they
++  // should have been written.
++  if (MisplacedAttrs.Range.isValid()) {
++    Diag(MisplacedAttrs.Range.getBegin(), diag::err_attributes_not_allowed)
++        << FixItHint::CreateInsertionFromRange(
++               Tok.getLocation(),
++               CharSourceRange::getTokenRange(MisplacedAttrs.Range))
++        << FixItHint::CreateRemoval(MisplacedAttrs.Range);
++    Attrs.takeAllFrom(MisplacedAttrs);
++  }
++
+   // Maybe this is an alias-declaration.
+   if (Tok.is(tok::equal)) {
+     if (InvalidDeclarator) {
+@@ -695,16 +702,7 @@ Parser::ParseUsingDeclaration(DeclaratorContext Context,
+       return nullptr;
+     }
+ 
+-    // If we had any misplaced attributes from earlier, this is where they
+-    // should have been written.
+-    if (MisplacedAttrs.Range.isValid()) {
+-      Diag(MisplacedAttrs.Range.getBegin(), diag::err_attributes_not_allowed)
+-        << FixItHint::CreateInsertionFromRange(
+-               Tok.getLocation(),
+-               CharSourceRange::getTokenRange(MisplacedAttrs.Range))
+-        << FixItHint::CreateRemoval(MisplacedAttrs.Range);
+-      Attrs.takeAllFrom(MisplacedAttrs);
+-    }
++    ProhibitAttributes(PrefixAttrs);
+ 
+     Decl *DeclFromDeclSpec = nullptr;
+     Decl *AD = ParseAliasDeclarationAfterDeclarator(
+@@ -712,10 +710,7 @@ Parser::ParseUsingDeclaration(DeclaratorContext Context,
+     return Actions.ConvertDeclToDeclGroup(AD, DeclFromDeclSpec);
+   }
+ 
+-  // C++11 attributes are not allowed on a using-declaration, but GNU ones
+-  // are.
+-  ProhibitAttributes(MisplacedAttrs);
+-  ProhibitAttributes(Attrs);
++  DiagnoseCXX11AttributeExtension(PrefixAttrs);
+ 
+   // Diagnose an attempt to declare a templated using-declaration.
+   // In C++11, alias-declarations can be templates:
+@@ -733,8 +728,11 @@ Parser::ParseUsingDeclaration(DeclaratorContext Context,
+ 
+   SmallVector<Decl *, 8> DeclsInGroup;
+   while (true) {
+-    // Parse (optional) attributes (most likely GNU strong-using extension).
++    // Parse (optional) attributes.
+     MaybeParseGNUAttributes(Attrs);
++    MaybeParseCXX11Attributes(Attrs);
++    DiagnoseCXX11AttributeExtension(Attrs);
++    Attrs.addAll(PrefixAttrs.begin(), PrefixAttrs.end());
+ 
+     if (InvalidDeclarator)
+       SkipUntil(tok::comma, tok::semi, StopBeforeMatch);
+@@ -2578,8 +2576,6 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
+   MaybeParseMicrosoftAttributes(attrs);
+ 
+   if (Tok.is(tok::kw_using)) {
+-    ProhibitAttributes(attrs);
+-
+     // Eat 'using'.
+     SourceLocation UsingLoc = ConsumeToken();
+ 
+@@ -2598,7 +2594,7 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
+     SourceLocation DeclEnd;
+     // Otherwise, it must be a using-declaration or an alias-declaration.
+     return ParseUsingDeclaration(DeclaratorContext::MemberContext, TemplateInfo,
+-                                 UsingLoc, DeclEnd, AS);
++                                 UsingLoc, DeclEnd, attrs, AS);
+   }
+ 
+   // Hold late-parsed attributes so we can attach a Decl to them later.
+diff --git a/clang/lib/Sema/SemaDeclAttr.cpp b/clang/lib/Sema/SemaDeclAttr.cpp
+index 3cff1937e221..92f0c314635b 100644
+--- a/clang/lib/Sema/SemaDeclAttr.cpp
++++ b/clang/lib/Sema/SemaDeclAttr.cpp
+@@ -2416,6 +2416,13 @@ AvailabilityAttr *Sema::mergeAvailabilityAttr(
+ }
+ 
+ static void handleAvailabilityAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
++  if (isa<UsingDecl, UnresolvedUsingTypenameDecl, UnresolvedUsingValueDecl>(
++          D)) {
++    S.Diag(AL.getRange().getBegin(), diag::warn_deprecated_ignored_on_using)
++        << AL;
++    return;
++  }
++
+   if (!checkAttributeNumArgs(S, AL, 1))
+     return;
+   IdentifierLoc *Platform = AL.getArgAsIdent(0);
+@@ -6398,6 +6405,11 @@ static void handleDeprecatedAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+       // namespace.
+       return;
+     }
++  } else if (isa<UsingDecl, UnresolvedUsingTypenameDecl,
++                 UnresolvedUsingValueDecl>(D)) {
++    S.Diag(AL.getRange().getBegin(), diag::warn_deprecated_ignored_on_using)
++        << AL;
++    return;
+   }
+ 
+   // Handle the cases where the attribute has a text message.
+diff --git a/clang/lib/Sema/SemaDeclCXX.cpp b/clang/lib/Sema/SemaDeclCXX.cpp
+index 710fe3bce6ef..119f61a1f2d9 100644
+--- a/clang/lib/Sema/SemaDeclCXX.cpp
++++ b/clang/lib/Sema/SemaDeclCXX.cpp
+@@ -11638,7 +11638,7 @@ bool Sema::CheckUsingShadowDecl(UsingDecl *Using, NamedDecl *Orig,
+   // Always emit a diagnostic for a mismatch between an unresolved
+   // using_if_exists and a resolved using declaration in either direction.
+   if (isa<UnresolvedUsingIfExistsDecl>(Target) !=
+-      (isa_and_nonnull<UnresolvedUsingIfExistsDecl>(NonTag))) {
++      (llvm::isa_and_nonnull<UnresolvedUsingIfExistsDecl>(NonTag))) {
+     if (!NonTag && !Tag)
+       return false;
+     Diag(Using->getLocation(), diag::err_using_decl_conflict);
+@@ -11991,9 +11991,9 @@ NamedDecl *Sema::BuildUsingDeclaration(
+   }
+ 
+   DeclContext *LookupContext = computeDeclContext(SS);
+-  NamedDecl *D;
+   NestedNameSpecifierLoc QualifierLoc = SS.getWithLocInContext(Context);
+   if (!LookupContext || EllipsisLoc.isValid()) {
++    NamedDecl *D;
+     if (HasTypenameKeyword) {
+       // FIXME: not all declaration name kinds are legal here
+       D = UnresolvedUsingTypenameDecl::Create(Context, CurContext,
+@@ -12007,6 +12007,7 @@ NamedDecl *Sema::BuildUsingDeclaration(
+     }
+     D->setAccess(AS);
+     CurContext->addDecl(D);
++    ProcessDeclAttributeList(S, D, AttrList);
+     return D;
+   }
+ 
+@@ -12016,6 +12017,7 @@ NamedDecl *Sema::BuildUsingDeclaration(
+                           UsingName, HasTypenameKeyword);
+     UD->setAccess(AS);
+     CurContext->addDecl(UD);
++    ProcessDeclAttributeList(S, UD, AttrList);
+     UD->setInvalidDecl(Invalid);
+     return UD;
+   };
+diff --git a/clang/test/Parser/cxx0x-attributes.cpp b/clang/test/Parser/cxx0x-attributes.cpp
+index 101e03845b8f..f01fe389a992 100644
+--- a/clang/test/Parser/cxx0x-attributes.cpp
++++ b/clang/test/Parser/cxx0x-attributes.cpp
+@@ -131,12 +131,12 @@ extern "C++" [[]] { } // expected-error {{an attribute list cannot appear here}}
+ [[]] static_assert(true, ""); //expected-error {{an attribute list cannot appear here}}
+ [[]] asm(""); // expected-error {{an attribute list cannot appear here}}
+ 
+-[[]] using ns::i; // expected-error {{an attribute list cannot appear here}}
++[[]] using ns::i;
+ [[unknown]] using namespace ns; // expected-warning {{unknown attribute 'unknown' ignored}}
+ [[noreturn]] using namespace ns; // expected-error {{'noreturn' attribute only applies to functions}}
+ namespace [[]] ns2 {} // expected-warning {{attributes on a namespace declaration are a C++17 extension}}
+ 
+-using [[]] alignas(4) [[]] ns::i; // expected-error {{an attribute list cannot appear here}}
++using[[]] alignas(4)[[]] ns::i;          // expected-error {{an attribute list cannot appear here}} expected-error {{'alignas' attribute only applies to variables, data members and tag types}} expected-warning {{ISO C++}}
+ using [[]] alignas(4) [[]] foobar = int; // expected-error {{an attribute list cannot appear here}} expected-error {{'alignas' attribute only applies to}}
+ 
+ void bad_attributes_in_do_while() {
+@@ -157,7 +157,16 @@ void bad_attributes_in_do_while() {
+ [[]] using T = int; // expected-error {{an attribute list cannot appear here}}
+ using T [[]] = int; // ok
+ template<typename T> using U [[]] = T;
+-using ns::i [[]]; // expected-error {{an attribute list cannot appear here}}
++using ns::i [[]];
++using ns::i [[]], ns::i [[]]; // expected-warning {{use of multiple declarators in a single using declaration is a C++17 extension}}
++struct using_in_struct_base {
++  typedef int i, j, k, l;
++};
++struct using_in_struct : using_in_struct_base {
++  [[]] using using_in_struct_base::i;
++  using using_in_struct_base::j [[]];
++  [[]] using using_in_struct_base::k [[]], using_in_struct_base::l [[]]; // expected-warning {{use of multiple declarators in a single using declaration is a C++17 extension}}
++};
+ using [[]] ns::i; // expected-error {{an attribute list cannot appear here}}
+ using T [[unknown]] = int; // expected-warning {{unknown attribute 'unknown' ignored}}
+ using T [[noreturn]] = int; // expected-error {{'noreturn' attribute only applies to functions}}
+diff --git a/clang/test/SemaCXX/cxx11-attributes-on-using-declaration.cpp b/clang/test/SemaCXX/cxx11-attributes-on-using-declaration.cpp
+new file mode 100644
+index 000000000000..5823ba7bfc2f
+--- /dev/null
++++ b/clang/test/SemaCXX/cxx11-attributes-on-using-declaration.cpp
+@@ -0,0 +1,42 @@
++// RUN: %clang_cc1 -pedantic -triple x86_64-apple-macos11 -std=c++20 -fsyntax-only -verify %s
++
++static_assert(__has_extension(cxx_attributes_on_using_declarations), "");
++
++namespace NS { typedef int x; }
++
++[[clang::annotate("foo")]] using NS::x; // expected-warning{{ISO C++ does not allow an attribute list to appear here}}
++
++
++[[deprecated]] using NS::x;                                    // expected-warning {{'deprecated' currently has no effect on a using declaration}} expected-warning{{ISO C++ does not allow}}
++using NS::x [[deprecated]];                                    // expected-warning {{'deprecated' currently has no effect on a using declaration}} expected-warning{{ISO C++ does not allow}}
++using NS::x __attribute__((deprecated));                       // expected-warning {{'deprecated' currently has no effect on a using declaration}}
++using NS::x __attribute__((availability(macos,introduced=1))); // expected-warning {{'availability' currently has no effect on a using declaration}}
++
++[[clang::availability(macos,introduced=1)]] using NS::x; // expected-warning {{'availability' currently has no effect on a using declaration}} expected-warning{{ISO C++ does not allow}}
++
++// expected-warning@+1 3 {{ISO C++ does not allow an attribute list to appear here}}
++[[clang::annotate("A")]] using NS::x [[clang::annotate("Y")]], NS::x [[clang::annotate("Z")]];
++
++template <class T>
++struct S : T {
++  [[deprecated]] using typename T::x; // expected-warning{{ISO C++ does not allow}} expected-warning {{'deprecated' currently has no effect on a using declaration}}
++  [[deprecated]] using T::y;          // expected-warning{{ISO C++ does not allow}} expected-warning {{'deprecated' currently has no effect on a using declaration}}
++
++  using typename T::z [[deprecated]]; // expected-warning{{ISO C++ does not allow}} expected-warning {{'deprecated' currently has no effect on a using declaration}}
++  using T::a [[deprecated]];          // expected-warning{{ISO C++ does not allow}} expected-warning {{'deprecated' currently has no effect on a using declaration}}
++};
++
++struct Base {};
++
++template <class B>
++struct DepBase1 : B {
++  using B::B [[]];
++
++};
++template <class B>
++struct DepBase2 : B {
++  using B::B __attribute__(());
++};
++
++DepBase1<Base> db1;
++DepBase2<Base> db2;
+-- 
+2.37.2
+


### PR DESCRIPTION
#### Description

Here I've backported the feature that sets up a requirement clang-13+ for building clang-15+.

I've used this code to successfully build `clang-devel` port, and `clang-15.0.0-rc3`.

This code was tested by two compilers:
 - `Apple clang version 13.1.6 (clang-1316.0.21.2.5)`
 - `gcc10-bootstrap`

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?