### PR TITLE
google-cloud-sdk: update to 400.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             399.0.0
+version             400.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  45a8149d40d54559095477ab72c791ef97f664b5 \
-                    sha256  709cbf8cdc4c027213291543b4ff4bfbfc55659909a30410bf3b59bb8e58e23f \
-                    size    108757285
+    checksums       rmd160  2cf5a09645a8b826cb128c78b640f6ac904c22f2 \
+                    sha256  f23e4a4d652864f4d6f6c5ed6f27922bacdf30388ef8c8cda722b515009e18f3 \
+                    size    108947625
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ce91b866950e551c2251f03ffa0454e5e6c5f911 \
-                    sha256  8f73f3723dbee24e6154baedfea3e488a1983c1114a54e2c4170061a64a66324 \
-                    size    106764459
+    checksums       rmd160  9bfa53ec4ab24b19972ef453078f4c122e7a006f \
+                    sha256  bc1b88fbb0fbe221568dcc81f51ee629cbf1f6f98c6c587487be8060c2e55e2a \
+                    size    96388422
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  99eedaf2f66a49a2a1cf8c7013d58364dc7a9dc2 \
-                    sha256  50c9566e49b24dd4ef2101ddfb1925feb9f9be38df9904c9fed27e731fd48adc \
-                    size    105322375
+    checksums       rmd160  c593ac3cdfba32cec06929cf034cf3670cf574c1 \
+                    sha256  727c8cdb5a9b07ba27626d3427733dd5f4fedc54e4d0cdbf19f6379ff7e09d9a \
+                    size    95001564
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 400.0.0.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?