### PR TITLE
py-hatch-fancy-pypi-readme: submission

### DIFF
--- a/python/py-hatch-fancy-pypi-readme/Portfile
+++ b/python/py-hatch-fancy-pypi-readme/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-hatch-fancy-pypi-readme
+version             22.3.0
+revision            0
+categories-append   devel
+license             MIT
+supported_archs     noarch
+
+python.versions     37 38 39 310
+python.pep517       yes
+python.pep517_backend hatch
+
+maintainers         nomaintainer
+
+description         a Hatch metadata plugin for projects' PyPI landing page
+long_description    {*}${description}
+
+homepage            https://github.com/hynek/hatch-fancy-pypi-readme
+distname            hatch_fancy_pypi_readme-${version}
+
+checksums           rmd160  715d9e3a3300cb6c9f04d7c4b45479aa13410631 \
+                    sha256  7d4651f8f07825931c92873cb51137214a938badb7a759b85c1d95bf74f86efa \
+                    size    22301
+
+if {${name} ne ${subport}} {
+     depends_lib-append port:py${python.version}-tomli
+    if {${python.version} < 38} {
+         depends_lib-append port:py${python.version}-typing_extensions
+    }
+}


### PR DESCRIPTION
#### Description
Submitting `py-hatch-fancy-pypi-readme` which is needed by e.g. the latest upstream version of `py-jsonschema` (4.14.0).

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
