### PR TITLE
openjdk18-zulu: update to 18.32.13

### DIFF
--- a/java/openjdk18-zulu/Portfile
+++ b/java/openjdk18-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-18-sts&os=macos&package=jdk
-version      18.32.11
+version      18.32.13
 revision     0
 
-set openjdk_version 18.0.2
+set openjdk_version 18.0.2.1
 
 description  Azul Zulu Community OpenJDK 18 (Short Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  ca70a601901756073c36f92ea5c828f725c47a06 \
-                 sha256  c3bc470a7727ff0c0d5fac5c8b96d36706db2c7d534ea22cbf471b83c8d73768 \
-                 size    194017744
+    checksums    rmd160  8c74a654326219ffc7ba41302b972a4f128e9405 \
+                 sha256  b873dcc8e83151d4e0ce6215469fdac2dc2f7bdcd2b7ed5364d79fec352ea118 \
+                 size    194044334
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  396702790f30eca813c60da82e49c585b82b2864 \
-                 sha256  c97810273b1de0293df9e726c2fc0230678ccb0c2bd2f72a4766435d3e5d9b91 \
-                 size    191924823
+    checksums    rmd160  2a553dc61f3998ea07db994c0a282a5b381351b0 \
+                 sha256  8c0643831b5632affbe32280c40ebda0e5340bd9d7bca1b93239992ec2b4e223 \
+                 size    191949023
 }
 
 worksrcdir   ${distname}/zulu-18.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 18.32.13 (OpenJDK 18.0.2.1).

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?