### PR TITLE
istioctl: update to 1.15.0

### DIFF
--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -5,10 +5,10 @@ PortGroup           golang 1.0
 
 name                istioctl
 
-go.setup            github.com/istio/istio 1.0.2
+go.setup            github.com/istio/istio 1.15.0
 categories          sysutils
 platforms           darwin
-supported_archs     x86_64
+supported_archs     x86_64 arm64
 license             Apache-2
 
 maintainers         {vmware.com:nnikolay @nickolaev} openmaintainer
@@ -24,17 +24,38 @@ long_description    Istio is an open, platform-independent service mesh designed
                     The port deploys the istioctl command line utility, \
                     used to create, list, modify, and delete configuration \
                     resources in a deployed Istio system.
+livecheck.url       ${github.homepage}/releases
 
 go.package          istio.io/istio
 
-checksums           rmd160  b6c61241b682a1b7f5676de60f3a4387bc057967 \
-                    sha256  12dc01cff8ebb335a08c62c9da95f9c71364d9dfab9c0c0baa5245f17202b057 \
-                    size    18824606
+checksums           rmd160  0f2cc3563d0b1215478f7038230d190295b63868 \
+                    sha256  7ff4877c0f2553e9a07255c8eab0cea7e2adeb4b038cd38066676eac82ac5293 \
+                    size    4851486
 
 build.cmd           make
 build.target        ${name}
-build.env-append    TAG=${version}
+
+# Allow deps to fetched at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
+build.env-append    TAG=${version} \
+                    VERSION=${version} \
+                    BUILD_WITH_CONTAINER=0 \
+                    IGNORE_DIRTY_TREE=1 \
+                    TARGET_OUT=${workpath}/out
 
 destroot {
-    xinstall ${workpath}/out/${goos}_${goarch}/release/${name} ${destroot}${prefix}/bin/
+    set bin_path ${destroot}${prefix}/bin/${name}
+    xinstall ${workpath}/out/${name} ${bin_path}
+
+    set bash_completion ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0755 -d ${bash_completion}
+    exec ${bin_path} completion bash > ${bash_completion}/${name}
+
+    set zsh_completion ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0755 -d ${zsh_completion}
+    exec ${bin_path} completion zsh > ${zsh_completion}/_${name}
+
+    set fish_completion ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0755 -d ${fish_completion}
+    exec ${bin_path} completion fish > ${fish_completion}/${name}.fish
 }


### PR DESCRIPTION
#### Description
- Update to 1.15.0
- Add arm64 support
- Install shell completion scripts

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
