### PR TITLE
terragrunt: update to 0.38.9

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -19,11 +19,11 @@ set latestVersion       terragrunt-0.38
 
 subport terragrunt-0.38 {
     set dependsOn       1.2
-    set patchNumber     7
+    set patchNumber     9
 
-    checksums           rmd160  e295b0e90a6ec7f7a0a31c8c683fe1621c878b71 \
-                        sha256  19ae411c3206857b655976c8d4b972113be90592dac9f73050449e27ee8aeda3 \
-                        size    2299205
+    checksums           rmd160  293b4ed0252fa62b5b32a4cc6f84a8977f6ea96d \
+                        sha256  978fc09f6b439a3860476f547df4ddedd8fcb45a2a922b7eabc95752f778616b \
+                        size    2306674
 }
 
 subport terragrunt-0.37 {


### PR DESCRIPTION
#### Description
terragrunt: update to 0.38.9

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
