### PR TITLE
aerc: update to 0.12.0

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                aerc
-version             0.11.0
+version             0.12.0
 revision            0
 categories          mail
 license             MIT
@@ -19,9 +19,9 @@ master_sites        https://git.sr.ht/~rjarry/aerc/archive/
 distname            ${version}
 worksrcdir          ${name}-${distname}
 
-checksums           rmd160  59eb97688d7f533382abd184e4a31bd6c6f43fa2 \
-                    sha256  3d8f3a2800946fce070e3eb02122e77c427a61c670a06337539b3e7f09e57861 \
-                    size    230891
+checksums           rmd160  7f8e08802dfa22459a1ed4fd8e23aa79b040e859 \
+                    sha256  402b48367b87338188036e713b3a421e228199accfa5fdb551f5efa21edb23be \
+                    size    293215
 
 depends_build       port:go \
                     port:scdoc


### PR DESCRIPTION
#### Description
[Changelog](https://git.sr.ht/~rjarry/aerc/refs/0.12.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
