### PR TITLE
Gildas: update to 202209a

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1
 
 name                gildas
-version             202207c
+version             202209a
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 supported_archs     arm64 x86_64
 set my_machine      [if {[string match *arm* ${os.arch}]} {list arm64} {list x86_64}]
@@ -32,9 +32,9 @@ master_sites        https://www.iram.fr/~gildas/dist/ \
 distname            ${name}-src-${my_version}
 use_xz              yes
 
-checksums           rmd160  e00f9ec41687d0314101e54c8449e1fe18ffeb8b \
-                    sha256  8d4e62a3f6a1533badb097e6e7d07b5e8ff2f4b79edd5ad4dfc700ffa3a6aa78 \
-                    size    44506864
+checksums           rmd160  14641704ac16b1c1c0b3c64ae499c74160eafb96 \
+                    sha256  e0ccf107522cda7a170d9457fc8d0099091bd4e94eeb9c2a015cab24b79d7df5 \
+                    size    45008860
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \


### PR DESCRIPTION
#### Description

Update to GILDAS version sep22a

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.4 21F79 x86_64

macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
