### PR TITLE
mesa, libepoxy: add EGL support, fix mesa 19.0.8 for 10.6

### DIFF
--- a/graphics/libepoxy/Portfile
+++ b/graphics/libepoxy/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           meson 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        anholt libepoxy 1.5.10
-revision            0
+revision            1
 license             MIT permissive
 categories          graphics
 maintainers         nomaintainer
-platforms           darwin
 
 description         Epoxy is a library for handling OpenGL function \
                     pointer management for you
@@ -43,6 +43,27 @@ patchfiles          prefix.patch \
 #   in /opt/local/lib/libgdk-3.0.dylib
 configure.args-append \
                     -Dglx=yes
+
+if {${os.platform} eq "darwin" && ${os.major} > 9} {
+    PortGroup       legacysupport 1.1
+
+    # strndup
+    legacysupport.newest_darwin_requires_legacy 10
+
+    compiler.blacklist-append \
+                    *gcc-4.* {clang < 400}
+
+    # enable EGL, needed for gtk4
+    configure.args-append \
+                    -Degl=yes
+
+    # https://github.com/anholt/libepoxy/issues/278
+    configure.cppflags-append \
+                    -D_DARWIN_C_SOURCE
+
+    patchfiles-replace \
+                    prefix.patch patch-egl.diff
+}
 
 # https://trac.macports.org/ticket/64468
 platform darwin 8 {

--- a/graphics/libepoxy/files/patch-egl.diff
+++ b/graphics/libepoxy/files/patch-egl.diff
@@ -1,0 +1,24 @@
+--- src/dispatch_common.h.orig	2022-02-17 19:56:12.000000000 +0700
++++ src/dispatch_common.h	2022-09-01 21:11:53.000000000 +0700
+@@ -28,7 +28,7 @@
+ #define PLATFORM_HAS_GLX ENABLE_GLX
+ #define PLATFORM_HAS_WGL 1
+ #elif defined(__APPLE__)
+-#define PLATFORM_HAS_EGL 0 
++#define PLATFORM_HAS_EGL ENABLE_EGL
+ #define PLATFORM_HAS_GLX ENABLE_GLX
+ #define PLATFORM_HAS_WGL 0
+ #elif defined(ANDROID)
+
+--- src/dispatch_common.c.orig	2022-02-17 19:56:12.000000000 +0700
++++ src/dispatch_common.c	2022-09-01 21:11:35.000000000 +0700
+@@ -174,7 +174,8 @@
+ #include "dispatch_common.h"
+ 
+ #if defined(__APPLE__)
+-#define GLX_LIB "/opt/X11/lib/libGL.1.dylib"
++#define GLX_LIB "@PREFIX@/lib/libGL.1.dylib"
++#define EGL_LIB "@PREFIX@/lib/libEGL.1.dylib"
+ #define OPENGL_LIB "/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL"
+ #define GLES1_LIB "libGLESv1_CM.so"
+ #define GLES2_LIB "libGLESv2.so"

--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -5,12 +5,13 @@ PortGroup           compiler_blacklist_versions 1.0
 
 # May need clock_gettime()
 PortGroup           legacysupport 1.0
+
 legacysupport.newest_darwin_requires_legacy 15
 
 name                mesa
 epoch               1
 version             19.0.8
-revision            1
+revision            2
 categories          x11 graphics
 maintainers         {jeremyhu @jeremyhu} openmaintainer
 license             MIT
@@ -78,9 +79,9 @@ configure.env-append \
 compiler.blacklist gcc-3.3 gcc-4.0 gcc-4.2 llvm-gcc-4.2 {clang < 800}
 
 platform darwin {
-    if {${os.major} < 11} {
+    if {${os.major} < 10} {
 
-        # versions > 17 do not presently compile on systems prior to 10.7
+        # versions > 17 do not presently compile on systems prior to 10.6
         version             17.1.6
         revision            2
         checksums           sha1    2acc201e24ea67c5231074d6746a42a747228ed6 \
@@ -97,6 +98,12 @@ platform darwin {
             mesa17-0002-glext.h-Add-missing-include-of-stddef.h-for-ptrdiff_.patch \
             mesa17-0003-applegl-Provide-requirements-of-_SET_DrawBuffers.patch \
             mesa17-0004-mesa-Deal-with-size-differences-between-GLuint-and-G.patch
+
+        if {[string match *gcc* ${configure.compiler}]} {
+        # Older gcc fail to do -Werror=missing-prototypes correctly
+        # https://trac.macports.org/ticket/46827
+            patchfiles-append no-missing-prototypes-error.patch
+        }
 
         # https://bugs.freedesktop.org/show_bug.cgi?id=89088
         configure.env-append INDENT=cat
@@ -138,12 +145,6 @@ platform darwin {
     }
 }
 
-if {[string match *gcc* ${configure.compiler}]} {
-    # Older gcc fail to do -Werror=missing-prototypes correctly
-    # https://trac.macports.org/ticket/46827
-    patchfiles-append no-missing-prototypes-error.patch
-}
-
 configure.cppflags-delete -I${prefix}/include
 
 variant python27 description {Use python 2.7} {
@@ -162,6 +163,17 @@ variant osmesa description {enable OSMesa library} {
     configure.args-append --enable-osmesa
 }
 default_variants-append +osmesa
+
+variant egl description {enable EGL support} {
+    patchfiles-append patch-pthread_condattr_setclock.diff
+
+    configure.args-delete --disable-egl
+    configure.args-append --enable-egl
+}
+
+if {!(${os.platform} eq "darwin" && ${os.major} < 10)} {
+    default_variants-append +egl
+}
 
 #variant openvg description {enable support for OpenVG API} {
 #    configure.args-delete --disable-egl --disable-openvg

--- a/x11/mesa/files/patch-pthread_condattr_setclock.diff
+++ b/x11/mesa/files/patch-pthread_condattr_setclock.diff
@@ -1,0 +1,18 @@
+--- a/src/egl/drivers/dri2/egl_dri2.c	2019-06-27 03:14:08.000000000 +0700
++++ b/src/egl/drivers/dri2/egl_dri2.c	2022-09-01 20:21:19.000000000 +0700
+@@ -3003,6 +3003,7 @@
+          return NULL;
+       }
+ 
++   #if !defined(__APPLE__) // no pthread_condattr_setclock on MacOS
+       /* change clock attribute to CLOCK_MONOTONIC */
+       ret = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+ 
+@@ -3011,6 +3012,7 @@
+          free(dri2_sync);
+          return NULL;
+       }
++   #endif
+ 
+       ret = pthread_cond_init(&dri2_sync->cond, &attr);
+ 


### PR DESCRIPTION
#### Description

This PR:
1. Adds EGL support to `mesa` and `libepoxy`: needed for `gtk4`.
2. Allows `mesa` 19.0.8 to be built on 10.6.
3. Fixes the patch error: https://trac.macports.org/ticket/65750
4. Adds needed fixes for old systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
