### PR TITLE
josm: update to 18543

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18531
+version             18543
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  5577eea21e2f088f7b704cd2c0736a8f5a7f2987 \
-                    sha256  95d713b9a714531b2cb09a89f1c4636cff935a5c5075c36d55b8fc7250cd106c \
-                    size    77895149
+checksums           rmd160  bd61d7bace36dc0981ff458ae90aea08c9d763d7 \
+                    sha256  a46567f8d81f4a5c98713d010938fe36d6deeddd25e8b2527838bdc6f7b42b88 \
+                    size    77902486
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2022-08-30: Stable release 18543](https://josm.openstreetmap.de/wiki/Changelog#stable-release-22.08)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
