### PR TITLE
swig-python3: remove obsolete subport

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -300,14 +300,3 @@ if {${swig.lang} eq ""} {
         }
     }
 }
-
-# 20200414
-# make it obsolete since Python3 folder
-# doesn't exist and swig has only Python
-subport swig-python3 {
-    PortGroup       obsolete 1.0
-
-    replaced_by     swig-python
-    version         4.0.1
-    revision        2
-}


### PR DESCRIPTION
Replaced by swig-python in 044d67ffcec3

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
