### PR TITLE
nektarpp: update to 5.2.0

### DIFF
--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -7,7 +7,7 @@ PortGroup               gitlab 1.0
 PortGroup               boost 1.0
 
 gitlab.instance         https://gitlab.nektar.info
-gitlab.setup            nektar nektar 5.0.3 v
+gitlab.setup            nektar nektar 5.2.0 v
 
 boost.version           1.71
 
@@ -35,10 +35,10 @@ distfiles               ${main_distfile}:main \
                         tetgen-1.5.zip:thirdparty \
                         triangle-1.6.zip:thirdparty
 
-checksums               nektar-5.0.3.tar.bz2 \
-                        rmd160  352e69fb1d7fc56c59ea344c3772f6b03e5e57e7 \
-                        sha256  2786525ec46884c726c1ab3518846b639b1995d761b66031b7e3d55441c6364f \
-                        size    51949715 \
+checksums               nektar-5.2.0.tar.bz2 \
+                        rmd160  3d7fa153c316cd00fd50d9ab5c22f0c79cd89379 \
+                        sha256  42be94624cd049be4a2d62b89033504f1bfd5e8cda005c3705581b1be7ca63b1 \
+                        size    58312042 \
                         tetgen-1.5.zip \
                         rmd160  d8785f4ca6b26608ec9423f7574a0e736380370a \
                         sha256  52207793198746de14abcb30a0aeed617d7348ff37544e7d7e65aaaa76d7fa70 \
@@ -53,7 +53,8 @@ checksums               nektar-5.0.3.tar.bz2 \
 extract.only            ${main_distfile}
 
 patchfiles              no-homebrew.patch \
-                        fusion-copy-constructor.patch
+                        fusion-copy-constructor.patch \
+                        opencascade.patch
 
 compiler.cxx_standard   2011
 cmake.build_type        Release
@@ -65,6 +66,7 @@ depends_lib-append      port:arpack \
                         port:opencascade \
                         port:scotch \
                         port:tinyxml \
+                        port:vtk \
                         port:zlib
 
 # Don't build demos and tests by default.
@@ -79,7 +81,8 @@ configure.args-append   -DNEKTAR_BUILD_DEMOS=OFF \
                         -DNEKTAR_USE_ARPACK=ON \
                         -DNEKTAR_USE_FFTW=ON \
                         -DNEKTAR_USE_MESHGEN=ON \
-                        -DNEKTAR_USE_SCOTCH=ON
+                        -DNEKTAR_USE_SCOTCH=ON \
+                        -DNEKTAR_USE_VTK=ON
 
 variant petsc description {
     Enable PETSc support for linear algebra solvers.
@@ -124,7 +127,7 @@ post-extract {
     }
 }
 
-set pythons_suffixes    {37 38 39}
+set pythons_suffixes    {37 38 39 310}
 
 set pythons_ports       {}
 foreach s ${pythons_suffixes} {
@@ -133,7 +136,7 @@ foreach s ${pythons_suffixes} {
 
 foreach s ${pythons_suffixes} {
     set p python${s}
-    set v [string index ${s} 0].[string index ${s} 1]
+    set v [string index ${s} 0].[string range ${s} 1 2]
     set pe ${prefix}/bin/python${v}
     set i [lsearch -exact ${pythons_ports} ${p}]
     set c [lreplace ${pythons_ports} ${i} ${i}]
@@ -154,5 +157,6 @@ foreach s ${pythons_suffixes} {
 
         require_active_variants boost       ${p}
         require_active_variants boost-numpy ${p}
+        require_active_variants vtk         ${p}
     "
 }

--- a/science/nektarpp/files/opencascade.patch
+++ b/science/nektarpp/files/opencascade.patch
@@ -1,0 +1,12 @@
+Remove missing OpenCASCADE header file which is not available
+in newer versions.
+--- library/NekMesh/CADSystem/OCE/OpenCascade.h.orig
++++ library/NekMesh/CADSystem/OCE/OpenCascade.h
+@@ -60,7 +60,6 @@
+ #include <BRep_Tool.hxx>
+ #include <GCPnts_AbscissaPoint.hxx>
+ #include <GProp_GProps.hxx>
+-#include <GeomAdaptor_HSurface.hxx>
+ #include <GeomLProp_CLProps.hxx>
+ #include <GeomLProp_SLProps.hxx>
+ #include <ShapeAnalysis_Curve.hxx>


### PR DESCRIPTION
#### Description

Updates Nektar++ to 5.2.0. Adds Python 3.10 variant & dependency on VTK.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
