### PR TITLE
libtapi: fixed build on old macOS

### DIFF
--- a/devel/libtapi/Portfile
+++ b/devel/libtapi/Portfile
@@ -3,7 +3,6 @@
 PortSystem              1.0
 PortGroup               cmake 1.1
 PortGroup               compiler_blacklist_versions 1.0
-PortGroup               clang_dependency 1.0
 PortGroup               github 1.0
 
 github.setup            tpoechtrager apple-libtapi b7b5bdbfda9e8062d405b48da3b811afad98ae76
@@ -49,8 +48,7 @@ configure.args-append -DLLVM_ENABLE_ZLIB=OFF
 # avoid opportunistic linking ncuses
 configure.args-append -DLLVM_ENABLE_TERMINFO=OFF
 
-compiler.cxx_standard   2011
-
+compiler.cxx_standard   2017
 cmake.build_type        Release
 
 # needs support for llvm::Expect, which requires c++17 inline variables (clang 3.9+)
@@ -86,15 +84,27 @@ if {[string match macports-clang-* ${configure.compiler}]} {
     }
 }
 
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
+# on macOS before 10.12 use clang-11-bootstrap
+if {${os.platform} eq "darwin" && ${os.major} < 16 && ${build_arch} ni [list ppc ppc64]} {
 
     # use cmake-bootstrap to minimize dependencies.
     depends_build-replace  path:bin/cmake:cmake port:cmake-bootstrap
     configure.cmd          ${prefix}/libexec/cmake-bootstrap/bin/cmake
 
+    configure.compiler.add_deps no
+
+    depends_build-append   port:clang-11-bootstrap
+    depends_skip_archcheck-append \
+                           clang-11-bootstrap
+
+    configure.cc           ${prefix}/libexec/clang-11-bootstrap/bin/clang
+    configure.cxx          ${prefix}/libexec/clang-11-bootstrap/bin/clang++
+
     configure.cxx_stdlib   libc++
     depends_lib-append     port:libcxx
+}
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Proxy for eliminating the dependency on native TLS
     # http://trac.macports.org/ticket/46887
     configure.args-append -DLLVM_ENABLE_BACKTRACES=OFF

--- a/devel/libtapi/Portfile
+++ b/devel/libtapi/Portfile
@@ -90,6 +90,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 16 && ${build_arch} ni [list ppc
     # use cmake-bootstrap to minimize dependencies.
     depends_build-replace  path:bin/cmake:cmake port:cmake-bootstrap
     configure.cmd          ${prefix}/libexec/cmake-bootstrap/bin/cmake
+    depends_skip_archcheck-append \
+                           cmake-bootstrap
 
     configure.compiler.add_deps no
 
@@ -112,6 +114,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # https://llvm.org/bugs/show_bug.cgi?id=25680
     configure.cxxflags-append -U__STRICT_ANSI__
 }
+
+# Rosetta build may not match cmake arch
+depends_skip_archcheck-append cmake
 
 # add a missing strnlen definition if needed
 patchfiles-append       patch-0006-strnlen.diff


### PR DESCRIPTION
#### Description

`clang_dependency` PG blacklists all clang 5+ and with restriction on Portfile it makes all compilers are blacklisted.

Instead enforce `clang-11-bootstrap` when it is available.

Closes: https://trac.macports.org/ticket/65757

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->