### PR TITLE
py-xattr: update to 0.9.9

### DIFF
--- a/python/py-xattr/Portfile
+++ b/python/py-xattr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xattr
-version             0.9.7
+version             0.9.9
 license             {MIT PSF}
 platforms           darwin linux
 maintainers         {danchr @danchr} openmaintainer
@@ -18,13 +18,13 @@ long_description    xattr is a Python wrapper for Darwin, Linux, and FreeBSD \
                     Darwin 8.0 and later. This corresponds to Mac OS X 10.4 \
                     (Tiger) and later.
 
-homepage            http://undefined.org/python/#xattr
+homepage            https://undefined.org/python/#xattr
 
-checksums           rmd160  48424e7c2812dd341b1e09bc9b8278f1a2bf2529 \
-                    sha256  b0bbca828e04ef2d484a6522ae7b3a7ccad5e43fa1c6f54d78e24bb870f49d44 \
-                    size    13389
+checksums           rmd160  3e73463efdb7d7abecd9e098f0bf61a9bf4ce3e8 \
+                    sha256  09cb7e1efb3aa1b4991d6be4eb25b73dc518b4fe894f0915f5b0dcede972f346 \
+                    size    15508
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Tested with some use of the xattr CLI it installs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
