### PR TITLE
gingerblue: add app bundle; add variant debug

### DIFF
--- a/gnome/gingerblue/Portfile
+++ b/gnome/gingerblue/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           debug 1.0
+PortGroup           app 1.0
 
 name                gingerblue
 version             6.2.0
-revision            0
+revision            1
 set branch          [join [lrange [split $version .] 0 1] .]
 
 categories          gnome
@@ -55,3 +57,5 @@ depends_run         port:adwaita-icon-theme \
                     port:gstreamer1-gst-plugins-ugly
 
 patchfiles          no-intltool-perl.patch
+
+app.icon            ${worksrcpath}/data/icons/1024x1024/apps/gingerblue.png


### PR DESCRIPTION
### Description

* Add app launcher, so that users aren't forced to run from cmdline;
* Add variant `debug`

### Tested on
* macOS 10.14
* macOS 10.15