### PR TITLE
mrustc: update to 20220904

### DIFF
--- a/lang/mrustc/Portfile
+++ b/lang/mrustc/Portfile
@@ -5,14 +5,14 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        thepowersgang mrustc bf313192a66e783daa262b64378af99c25cfb3b9
+github.setup        thepowersgang mrustc a04f166ea5762037895738d88d144803e2e433f5
 
 set rust_version    1.54.0
 set rust_version_major [join [lrange [split ${rust_version} .-] 0 1] .]
 set rust_version_major_underscore [join [lrange [split ${rust_version} .-] 0 1] _]
 
 # subport mrustc-rust has its own versioning
-version             ${rust_version_major}-20220830
+version             ${rust_version_major}-20220904
 revision            0
 epoch               1
 
@@ -30,9 +30,9 @@ master_sites-append https://static.rust-lang.org/dist/:rust
 distfiles-append    rustc-${rust_version}-src.tar.gz:rust
 
 checksums           mrustc-${github.version}.tar.gz \
-                    rmd160  77521687f5db2ba7b2ee0283be2c739c019ece4d \
-                    sha256  b4d622e89ecb55929b219026d66ea7e1ef34ace921298b56baa18163dcde6bd2 \
-                    size    1189530 \
+                    rmd160  d608075c56b6aa8175b25016ff0e64190f5e94cd \
+                    sha256  4d25c6e55d8b1c05a87a408a9edbdd5ec8416f40be660619442e12e0d23356af \
+                    size    1189691 \
                     rustc-${rust_version}-src.tar.gz \
                     rmd160  be2de16e2deaf91aee723e631a36f6de52636ddd \
                     sha256  ac8511633e9b5a65ad030a1a2e5bdaa841fdfe3132f2baaa52cc04e71c6c6976 \
@@ -96,13 +96,17 @@ patchfiles          0001-Introduced-support-of-MACPORTS_LEGACY_SUPPORT_.patch \
                     0004-libssh2-sys-use-src-instead-.git-as-vendored-indicat.patch \
                     0005-libgit2-sys-recovered-LIBGIT2_SYS_USE_PKG_CONFIG.patch
 
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    patchfiles-append \
+                    0006-macOS-10.7-Switch-to-OpenSSL.patch
+}
+
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     PortGroup       active_variants 1.1
 
     patchfiles-append \
-                    0006-macOS-10.6-enforce-emulated-TLS-via-LLVM-Clang.patch \
-                    0007-macOS-10.6-Fix-pthread_cond_destroy.patch \
-                    0008-macOS-10.6-Switch-to-OpenSSL.patch
+                    0007-macOS-10.6-enforce-emulated-TLS-via-LLVM-Clang.patch \
+                    0008-macOS-10.6-Fix-pthread_cond_destroy.patch
 
     set libemutls ${workpath}/libemutls
     set libemutls_a ${libemutls}/libemutls.a

--- a/lang/mrustc/Portfile
+++ b/lang/mrustc/Portfile
@@ -47,9 +47,8 @@ compiler.cxx_standard 2014
 compiler.c_standard 2011
 compiler.thread_local_storage yes
 
-# GCC can't be used as a run-time compiler, see
-# https://github.com/thepowersgang/mrustc/issues/214
-compiler.blacklist *gcc*
+# Officially tested with GCC 5.4+
+compiler.blacklist *gcc-3.* *gcc-4.*
 
 # See https://github.com/thepowersgang/mrustc/issues/255
 compiler.blacklist-append {clang < 1300} {macports-clang-3.[0-9]} macports-clang-4.0
@@ -61,12 +60,19 @@ if { [string match macports-clang-* ${configure.compiler}] } {
     depends_run-append \
                     port:[string map {"macports-" ""} ${configure.compiler}]
 }
+if { [string match macports-gcc-* ${configure.compiler}] } {
+    depends_run-append \
+                   port:[string map {"macports-gcc-" "gcc"} ${configure.compiler}]
 
-# Uncomment the lines below and delete the line above when GCC support is fixed
-# if { [string match macports-gcc-* ${configure.compiler}] } {
-#   depends_run-append \
-#                    port:[string map {"macports-gcc-" "gcc"} ${configure.compiler}]
-# }
+    # GCC is required to be linked with libatomic
+    # See: https://github.com/thepowersgang/mrustc/issues/214
+    # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358
+    post-patch {
+        set script [open "${worksrcpath}/script-overrides/stable-${rust_version}-macos/build_libc.txt" a]
+        puts ${script} "cargo:rustc-link-lib=atomic"
+        close ${script}
+    }
+}
 
 post-extract {
     # prevent it from re-download sources

--- a/lang/mrustc/files/0001-Introduced-support-of-MACPORTS_LEGACY_SUPPORT_.patch
+++ b/lang/mrustc/files/0001-Introduced-support-of-MACPORTS_LEGACY_SUPPORT_.patch
@@ -1,7 +1,7 @@
 From 59461f577c356f685ff398bb9d8b5128dbb9fedd Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Tue, 8 Feb 2022 04:07:30 +0100
-Subject: [PATCH 1/8] Introduced support of `MACPORTS_LEGACY_SUPPORT_*`
+Subject: [PATCH] Introduced support of `MACPORTS_LEGACY_SUPPORT_*`
 
 MacPorts defines `MACPORTS_LEGACY_SUPPORT_ENABLED` with value `1` when
 port should link against LegacySupport.
@@ -42,5 +42,5 @@ index a14ac63c7a..f481ffd176 100644
      let target = env::var("TARGET").expect("TARGET was not set");
      if target.contains("freebsd") {
 -- 
-2.37.1
+2.37.2
 

--- a/lang/mrustc/files/0002-curl-sys-never-try-to-link-with-lib-darwin.patch
+++ b/lang/mrustc/files/0002-curl-sys-never-try-to-link-with-lib-darwin.patch
@@ -1,7 +1,7 @@
 From 21bedbb14739809ba4ec247f22632ee3cca64c55 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 9 Feb 2022 05:47:47 +0100
-Subject: [PATCH 2/8] `curl-sys`: never try to link with `/lib/darwin`
+Subject: [PATCH] `curl-sys`: never try to link with `/lib/darwin`
 
 `clang --print-search-dirs` may return `libraries: =` that leads to
 `/lib/darwin` which may leads to attempt to find `clang_rt.osx` inside
@@ -26,5 +26,5 @@ index 64df41e995..3213c66b33 100644
      }
  
 -- 
-2.37.1
+2.37.2
 

--- a/lang/mrustc/files/0003-libgit2-sys-use-src-instead-.git-as-vendored-indicat.patch
+++ b/lang/mrustc/files/0003-libgit2-sys-use-src-instead-.git-as-vendored-indicat.patch
@@ -1,8 +1,7 @@
 From 1e6d35d907ead0504a634082d5971b41dae67b7c Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Mon, 7 Feb 2022 01:37:13 +0100
-Subject: [PATCH 3/8] `libgit2-sys`: use `src` instead `.git` as vendored
- indicator
+Subject: [PATCH] `libgit2-sys`: use `src` instead `.git` as vendored indicator
 
 When someone vendored `libgit2-sys` he may exclude `.git` folder.
 
@@ -32,5 +31,5 @@ index 76aa687cf6..9ea69e171c 100644
              .args(&["submodule", "update", "--init", "libgit2"])
              .status();
 -- 
-2.37.1
+2.37.2
 

--- a/lang/mrustc/files/0004-libssh2-sys-use-src-instead-.git-as-vendored-indicat.patch
+++ b/lang/mrustc/files/0004-libssh2-sys-use-src-instead-.git-as-vendored-indicat.patch
@@ -1,8 +1,7 @@
 From d06c3e59c01b9c15d35464f02d163d1ef07abe8f Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Thu, 10 Feb 2022 00:53:41 +0100
-Subject: [PATCH 4/8] `libssh2-sys`: use `src` instead `.git` as vendored
- indicator
+Subject: [PATCH] `libssh2-sys`: use `src` instead `.git` as vendored indicator
 
 When someone vendored `libssh-sys` he may exclude `.git` folder.
 
@@ -26,5 +25,5 @@ index 215014864b..235bc16cd7 100644
              .args(&["submodule", "update", "--init"])
              .status();
 -- 
-2.37.1
+2.37.2
 

--- a/lang/mrustc/files/0005-libgit2-sys-recovered-LIBGIT2_SYS_USE_PKG_CONFIG.patch
+++ b/lang/mrustc/files/0005-libgit2-sys-recovered-LIBGIT2_SYS_USE_PKG_CONFIG.patch
@@ -1,7 +1,7 @@
 From e16148f9bab7a71032bbf245c8fc1dcafa2efd62 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Thu, 10 Feb 2022 02:07:33 +0100
-Subject: [PATCH 5/8] `libgit2-sys`: recovered `LIBGIT2_SYS_USE_PKG_CONFIG`
+Subject: [PATCH] `libgit2-sys`: recovered `LIBGIT2_SYS_USE_PKG_CONFIG`
 
 ---
  vendor/libgit2-sys/build.rs | 2 +-
@@ -21,5 +21,5 @@ index 9ea69e171c..e30a09b44a 100644
          if let Ok(lib) = cfg.atleast_version("1.1.0").probe("libgit2") {
              for include in &lib.include_paths {
 -- 
-2.37.1
+2.37.2
 

--- a/lang/mrustc/files/0006-macOS-10.7-Switch-to-OpenSSL.patch
+++ b/lang/mrustc/files/0006-macOS-10.7-Switch-to-OpenSSL.patch
@@ -1,9 +1,9 @@
-From 1713faf9ef2750e690e134f0cb51796b87f7b50f Mon Sep 17 00:00:00 2001
+From 91a823edc714105c8900632147cebfc176ca003d Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
-Date: Sat, 5 Feb 2022 23:21:39 +0100
-Subject: [PATCH 8/8] macOS 10.6: Switch to OpenSSL
+Date: Sat, 3 Sep 2022 19:06:22 +0200
+Subject: [PATCH] macOS 10.7: Switch to OpenSSL
 
-macOS before 10.7 requires to use OpenSSL because a lot of things is
+macOS before 10.8 requires to use OpenSSL because a lot of things is
 simple missed.
 ---
  vendor/crypto-hash/Cargo.toml | 4 ++--
@@ -73,5 +73,5 @@ index e30a09b44a..a5af5eec64 100644
              features.push_str("#define GIT_OPENSSL 1\n");
              if let Some(path) = env::var_os("DEP_OPENSSL_INCLUDE") {
 -- 
-2.37.1
+2.37.2
 

--- a/lang/mrustc/files/0007-macOS-10.6-enforce-emulated-TLS-via-LLVM-Clang.patch
+++ b/lang/mrustc/files/0007-macOS-10.6-enforce-emulated-TLS-via-LLVM-Clang.patch
@@ -1,7 +1,7 @@
-From 9dc1c672f413a45c2db040afd2a875e4edf83872 Mon Sep 17 00:00:00 2001
+From e6284ce2c30fb0bfde60468d3a46d8d44953fc8e Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Sat, 23 Jul 2022 14:09:34 +0200
-Subject: [PATCH 6/8] macOS 10.6: enforce emulated TLS via LLVM/Clang
+Subject: [PATCH] macOS 10.6: enforce emulated TLS via LLVM/Clang
 
 ---
  Cargo.lock                                    |  1 +
@@ -435,5 +435,5 @@ index f1bd8ff237..137da31496 100644
          target_option_val!(forces_embed_bitcode);
          target_option_val!(bitcode_llvm_cmdline);
 -- 
-2.37.1
+2.37.2
 

--- a/lang/mrustc/files/0008-macOS-10.6-Fix-pthread_cond_destroy.patch
+++ b/lang/mrustc/files/0008-macOS-10.6-Fix-pthread_cond_destroy.patch
@@ -1,7 +1,7 @@
-From f201284935125d2e12666b56530fbc8be5010de4 Mon Sep 17 00:00:00 2001
+From ac26fb414f4a2c84da35c793a80560c0b63682b2 Mon Sep 17 00:00:00 2001
 From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Thu, 17 Feb 2022 15:12:11 +0100
-Subject: [PATCH 7/8] macOS 10.6: Fix `pthread_cond_destroy`
+Subject: [PATCH] macOS 10.6: Fix `pthread_cond_destroy`
 
 macOS 10.7 returns `EINVAL` for `pthread_cond_destroy()`.
 ---
@@ -30,5 +30,5 @@ index e38f91af9f..c03c22b2cf 100644
          let r = libc::pthread_cond_destroy(self.inner.get());
          // On DragonFly pthread_cond_destroy() returns EINVAL if called on
 -- 
-2.37.1
+2.37.2
 


### PR DESCRIPTION
#### Description

Update includes fix for 10.14.

It also includes a small patch reorganization that fixed build on 10.7.

And as bonus I've also fixed support of GCC as compiler for mrustc :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

and as `port -s install mrustc mrustc-rust configure.compiler=macports-gcc-12` on

macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->