### PR TITLE
libfilezilla: update to 0.32.0, fix build for old systems

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -1,17 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 
 # AT_SYMLINK_NOFOLLOW
 legacysupport.newest_darwin_requires_legacy 13
 
+# 0.32.0 is the last version supporting old gnutls.
+# 0.33.0+ require gnutls 3.7.0+, which is currently in gnutls-devel port.
+# Update libfilezilla once gnutls port is updated. 0.38.1 confirmed to build fine.
 name                libfilezilla
-version             0.25.0
+version             0.32.0
 revision            0
 
 categories          devel
-platforms           darwin
 maintainers         {@lhaeger gmx.net:lothar.haeger} openmaintainer
 license             GPL-2+
 
@@ -24,27 +26,48 @@ long_description    Small and modern C++ library, offering some basic \
 homepage            https://lib.filezilla-project.org/
 master_sites        https://download.filezilla-project.org/libfilezilla/
 
-checksums           rmd160  880b3fd782670669a88038cc919eb4337f0c8fbb \
-                    sha256  3bf6feb5246ed3d11b72d74b485d1989724be0884568cd456195e7624f9c7b2a \
-                    size    562726
+checksums           rmd160  8e9b05833261bb362c27ba45f2c1c6bf21aca368 \
+                    sha256  60c912bff2867a36d97ea2bca01a06e293d42445795cedd43f5164a92e585b0f \
+                    size    591199
 
-configure.env-append \
-                    DX_PERL=/usr/bin/perl
+patchfiles-append   patch-util.diff
 
-depends_build       port:cppunit \
+depends_build-append \
+                    path:bin/perl:perl5 \
                     port:gettext \
-                    port:pkgconfig \
-                    bin:perl:perl5
+                    port:pkgconfig
 
-depends_lib         port:libiconv \
-                    port:nettle \
-                    path:lib/pkgconfig/gnutls.pc:gnutls
+depends_lib-append  path:lib/pkgconfig/gnutls.pc:gnutls \
+                    port:gmp \
+                    port:libiconv \
+                    port:nettle
+
+depends_test-append port:cppunit
 
 use_bzip2           yes
 
 compiler.cxx_standard   2017
 # libfilezilla uses thread_local, which is not supported in Xcode < 8
 compiler.thread_local_storage   yes
+
+configure.env-append \
+                    DX_PERL=${prefix}/bin/perl
+
+configure.args-append \
+                    --disable-doxygen-doc
+
+platform darwin {
+    if {${os.major} < 11} {
+        # process.cpp: error: invalid conversion from 'uint32_t*' {aka 'unsigned int*'} to 'UInt32*' {aka 'long unsigned int*'} [-fpermissive]
+        configure.cxxflags-append \
+                    -fpermissive
+    }
+}
+
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append \
+                    -latomic
+}
 
 test.run            yes
 test.dir            ${worksrcpath}/tests

--- a/devel/libfilezilla/files/patch-util.diff
+++ b/devel/libfilezilla/files/patch-util.diff
@@ -1,0 +1,14 @@
+# random.h: error: 'u_int' has not been declared
+
+--- lib/util.cpp.orig	2021-09-14 20:31:27.000000000 +0800
++++ lib/util.cpp	2022-03-25 01:56:45.000000000 +0800
+@@ -18,6 +18,9 @@
+ 	#endif
+ 	#if HAVE_GETENTROPY
+ 		#ifdef __APPLE__
++			#ifndef u_int
++			#define u_int unsigned int
++			#endif
+ 			#include <Availability.h>
+ 			#include <sys/random.h>
+ 		#endif


### PR DESCRIPTION
#### Description

Long due update to the port.
Should also fix it for older systems too: 10.6.8 confirmed to build (Leopard pending, cannot check atm).
Existing version is broken for 10.6: https://ports.macports.org/port/libfilezilla/details/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
