### PR TITLE
opencv4-devel: Turn on QUIRC support

### DIFF
--- a/graphics/opencv4-devel/Portfile
+++ b/graphics/opencv4-devel/Portfile
@@ -57,7 +57,7 @@ if {${os.major} > 12} {
 
 if {${opencv_latest}} {
     github.setup    opencv opencv 4.6.0
-    revision        2
+    revision        3
     epoch           1
 
     checksums-append \
@@ -71,7 +71,7 @@ if {${opencv_latest}} {
     livecheck.regex {/archive/([0-9.]+)[a-z]?\.[tz]}
 } else {
     github.setup    opencv opencv 4.5.0
-    revision        8
+    revision        9
 
     checksums-append \
                     ${distname}${extract.suffix} \
@@ -139,6 +139,7 @@ depends_lib-append  \
                     port:libpng \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:openjpeg \
+                    port:libquirc \
                     port:tiff \
                     port:webp \
                     port:openexr \
@@ -283,6 +284,7 @@ configure.args-append \
                     -DWITH_IMGCODEC_PFM:BOOL=ON \
                     -DWITH_QUIRC:BOOL=OFF \
                     \
+                    -DHAVE_QUIRC:BOOL=ON \
                     -DHAVE_COCOA:BOOL=ON \
                     \
                     -DBUILD_opencv_aruco:BOOL=ON \


### PR DESCRIPTION
### Description

* Enable QUIRC support
* Depends on PR: https://github.com/macports/macports-ports/pull/15994

### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

### Tested on
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?