### PR TITLE
proxy-audio-device: Update to version 1.0.6

### DIFF
--- a/audio/proxy-audio-device/Portfile
+++ b/audio/proxy-audio-device/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        briankendall proxy-audio-device 1.0.5 v
+github.setup        briankendall proxy-audio-device 1.0.6 v
+revision            0
 github.tarball_from archive
 categories          audio
 platforms           darwin
@@ -47,6 +48,6 @@ post-deactivate {
     system "sudo launchctl kickstart -kp system/com.apple.audio.coreaudiod"
 }
 
-checksums           rmd160  c9d1ac2ddc66a3b93017d3d57ef355f87002abcd \
-                    sha256  e88756ad9255a9be7a3ffe00bea95a0172cfbbdbcdaefd670be80b56d2780dcf \
-                    size    1741561
+checksums           rmd160  199394d2e9df4ab1ca9b07ddf2b5a625fb395631 \
+                    sha256  4289c311321b9c5f439450185464b9ab5e8582db2a64ada2295f8b8bba79784d \
+                    size    1741755


### PR DESCRIPTION
#### Description

See: https://github.com/briankendall/proxy-audio-device/releases/tag/v1.0.6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
