### PR TITLE
gopass,gopass-jsonapi: update to 1.14.5

### DIFF
--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.14.3 v
+go.setup            github.com/gopasspw/gopass-jsonapi 1.14.5 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,17 +14,11 @@ long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  15d534dacf13db43e3a0355c374020c38d848168 \
-                        sha256  c7759f962b21aed16cd47d90f329ca446554e82a61546b9582aa5824f5ee7e9a \
-                        size    28967
+                        rmd160  7672f92c7eddb22c72db85433f0a59a6244b7aa2 \
+                        sha256  d1a87c56e06bc2ac79edaf2321ccb2512f436f26b629a4d7b790f65ada396ca9 \
+                        size    30961
 
-go.vendors          rsc.io/qr \
-                        repo    github.com/rsc/qr \
-                        lock    v0.2.0 \
-                        rmd160  f642fe01c13937615e5a975e6a1932f8dc25359a \
-                        sha256  1d69d5a13366a84a1484abdec5affd7f5781016469f4b43b1a26f5fa5c93497b \
-                        size    18816 \
-                    gotest.tools \
+go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
                         lock    v3.0.2 \
                         rmd160  ccc2d160fcdb27d0e8461506d0c38e27487c8bd7 \
@@ -41,30 +35,30 @@ go.vendors          rsc.io/qr \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    065cf7ba2467 \
-                        rmd160  95091f7614b24ca8ac93c8ea13e65ae54b45a366 \
-                        sha256  6c9130ff4c06205225c64668521b77b93658b384014df1e635f30d17633ec30f \
-                        size    14981 \
+                        lock    a9ba230a4035 \
+                        rmd160  2011606ab7a7f34f3deffe211d32ef2c89ebb195 \
+                        sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
+                        size    14845 \
                     golang.org/x/sys \
-                        lock    175b2fd9d664 \
-                        rmd160  babb07e01c60fc729853fc06b19e23a176ef4756 \
-                        sha256  02c9a4f95009a49ed23ba2fb9026aac4b7c6713d6e52282515cfbaddd96056fa \
-                        size    1305845 \
+                        lock    d48e67d00261 \
+                        rmd160  7c6b2b1d4cbda8f8abe93d350965b14dddbb709f \
+                        sha256  a1ea3659428d2c5e8d46933616a058360bccbda10b92ea6908d5435703626cc3 \
+                        size    1358000 \
                     golang.org/x/net \
-                        lock    263ec571b305 \
-                        rmd160  44d64e5c0fee97412b8efd557bcd63bcf8e811b6 \
-                        sha256  a26b89d8ae72495fef04584dff52fb0ca649b39fcf9890a08ee7d472577ba052 \
-                        size    1228295 \
+                        lock    83b083e8dc8b \
+                        rmd160  b07e74f0cce4986e46838bb8194adcc00eeca0d0 \
+                        sha256  555d8cd580927a2a3ac8376d231990200e1615db2ad2f65f3c53f440b5590649 \
+                        size    1226262 \
                     golang.org/x/exp \
-                        lock    b0d781184e0d \
-                        rmd160  228a7cd5c3f0d388d5badded570beee09db60c70 \
-                        sha256  e4d4f78921ce99106a52675d75497f76468895bf227d17e3a4e47f78d361aa17 \
-                        size    1556422 \
+                        lock    334a2380cb91 \
+                        rmd160  59c6c5964fab55dca79a3e46976e46ae5d1afcde \
+                        sha256  4e4e681bb6ec75ab45c48144e6cd8c38e6380e419f46cbed84322e643a9a8ad2 \
+                        size    1556584 \
                     golang.org/x/crypto \
-                        lock    05595931fe9d \
-                        rmd160  44b3bff302fe3a679525f5976c210588402572e1 \
-                        sha256  8d3cffb4319b5f3cf4c06199fd0340ee57a49012c2d523a876c8b88c208e4043 \
-                        size    1631395 \
+                        lock    c86fa9a7ed90 \
+                        rmd160  d10541162293e950d1c79f5b0cff231d0158b53c \
+                        sha256  d97beb5e040b73b1997e0c9b34e1fa78bbbca789f17cfdfb52e3d25c880112bb \
+                        size    1631830 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -73,45 +67,60 @@ go.vendors          rsc.io/qr \
                         size    15600 \
                     go.uber.org/atomic \
                         repo    github.com/uber-go/atomic \
-                        lock    v1.9.0 \
-                        rmd160  7705959c7053aa8e405560f5ffef3fbca414ee69 \
-                        sha256  8baccde94a6ecaea185ef40b9bdecbd3dd8d8df7cbc50c89856b58c5cd897e40 \
-                        size    21353 \
+                        lock    v1.10.0 \
+                        rmd160  3b3e329c78468d0b4711b28f323069a1d6afbeec \
+                        sha256  c03c44af9133c1c06829842b6db2a1bff49818d1cb96c709d65301651f4bc390 \
+                        size    23092 \
                     github.com/xrash/smetrics \
                         lock    039620a65673 \
                         rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.10.3 \
-                        rmd160  c28d3228d49f0446ccde697a5b9b4d233e60b79b \
-                        sha256  160c91ae1e2cd109ff43be7539959c0f74e9daf9f5dccbe45e96c7518b7f40b4 \
-                        size    3457370 \
+                        lock    v2.11.2 \
+                        rmd160  b65ff408aad32c5356d37200299f93331f691d7a \
+                        sha256  077760f0233fd4ef796805f117be37fe4f494991558e8a6810339367752b496d \
+                        size    3459130 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
                         sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
                         size    11986 \
                     github.com/stretchr/testify \
-                        lock    v1.7.4 \
-                        rmd160  ead1da73ad69fb87be0d40619888ecf9650d3438 \
-                        sha256  cf31480faa1c3c0dbfa44395257108884a107f5225f1cd6b8d91e23e5564dccc \
-                        size    94328 \
+                        lock    v1.8.0 \
+                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
+                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
+                        size    97622 \
+                    github.com/skip2/go-qrcode \
+                        lock    da1b6568686e \
+                        rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
+                        sha256  28f73bbd2c7f78308c9189c5c8abb2a329b3e02f11dec7a54254c457630ad581 \
+                        size    36689 \
+                    github.com/schollz/closestmatch \
+                        lock    1fbe626be92e \
+                        rmd160  0c09dba0d527a6046585125a6fb2a93bc08c635c \
+                        sha256  52174a0c7551cbaeb0253dd9a00506e285877fe2cb464c6c79dcf65ed02f7ec9 \
+                        size    623995 \
                     github.com/russross/blackfriday \
                         lock    v2.1.0 \
                         rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
                         sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
                         size    92950 \
                     github.com/rs/zerolog \
-                        lock    v1.27.0 \
-                        rmd160  434d8ba6beae7657617c2116cb48a358b9cd03ed \
-                        sha256  bae5e650804d95ae57b5729483fc81b30f9deb188474d8598b08c3d0ad5f2a49 \
-                        size    165154 \
+                        lock    v1.28.0 \
+                        rmd160  4b23fe27020af1b1b3de36eba648c42ff8af3fee \
+                        sha256  cf98c2e0609d78d49b8c0896583115cb29c3c2c2fd16976795adf248704a549d \
+                        size    166068 \
                     github.com/rogpeppe/go-internal \
                         lock    86f73c517451 \
                         rmd160  12ae7289b3b9f3f0339d1ffe90bfefdd28944914 \
                         sha256  243fd03669a7f2563d066de31a537dc3e99fb3180fcf36f1b492f84e3c8dbd76 \
                         size    131803 \
+                    github.com/pquerna/otp \
+                        lock    c62dc589378a \
+                        rmd160  b95abaf61d798b40eb4c4305f99ebb09f07f57d2 \
+                        sha256  5d5dea17234e378773448f455188ad5614947e35963108028d4f66a533e99a98 \
+                        size    14210 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -142,16 +151,26 @@ go.vendors          rsc.io/qr \
                         rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
                         sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
                         size    3366 \
+                    github.com/mattn/go-tty \
+                        lock    v0.0.4 \
+                        rmd160  aeef24ae0b469f8a83cd43f40843ba3dc58f057d \
+                        sha256  a9ee7c2dc5fcaf640eb3be20fbeab1cebd6fc56a160296c815d1129a0ff0091f \
+                        size    7735 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.14 \
-                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
-                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
-                        size    4705 \
+                        lock    v0.0.16 \
+                        rmd160  dcdf01553caa079315f2293c109de17fc72f0c6b \
+                        sha256  391d25a98e2cc92a2ed5c6abd07cde1053411706bb24e5843562931e6085ab46 \
+                        size    4693 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.12 \
-                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
-                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
-                        size    9805 \
+                        lock    v0.1.13 \
+                        rmd160  c9e8ab9d0773c0984f36235e3c9f8c033552ac1a \
+                        sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
+                        size    9778 \
+                    github.com/martinhoefling/goxkcdpwgen \
+                        lock    v0.1.1 \
+                        rmd160  56164d6a8b2620f53897f85abe3ff7659e0aa0c5 \
+                        sha256  0ee21438461014724b2a3afe08e6db51649748ff23f7f90705b2617d80e568a6 \
+                        size    89925 \
                     github.com/kr/text \
                         lock    v0.2.0 \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
@@ -167,6 +186,11 @@ go.vendors          rsc.io/qr \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
                         sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
                         size    4335 \
+                    github.com/jsimonetti/pwscheme \
+                        lock    4d9895f5db73 \
+                        rmd160  0485fd6bd45cb7670f2d87b00e951e73bba7c19b \
+                        sha256  abf5851434a001a0c50e05aaf9ce0014472f70c887a1d31f49ced68be3293f4c \
+                        size    4284 \
                     github.com/hashicorp/golang-lru \
                         lock    v0.5.4 \
                         rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
@@ -183,10 +207,10 @@ go.vendors          rsc.io/qr \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.3 \
-                        rmd160  7779654513c630544f675e2bffcd0e0941cefd0f \
-                        sha256  7b5b3fc0271a777f6145d57cb5fc3e2829c2a2b8c5d0cbbb3e4413f20e0f75a0 \
-                        size    2252787 \
+                        lock    v1.14.5 \
+                        rmd160  d036a28a4208482935a6eed4613ee2d00bb8f51f \
+                        sha256  a1867548523b437c359bdf580c2f6b6b6cb096f02895991bd7a3260a3944d732 \
+                        size    2247354 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -207,11 +231,6 @@ go.vendors          rsc.io/qr \
                         rmd160  ed853462703f04ce365bb17b8c88a92994aa5006 \
                         sha256  4b107f6d26db03f8a36ae38f7b017399ed56571cdbf7b7ebc7bff0006c7dffb5 \
                         size    69263 \
-                    github.com/gokyle/twofactor \
-                        lock    v1.0.1 \
-                        rmd160  639cb3e1e214c43cd212bbec6faae070a2acbc4c \
-                        sha256  c69fa4f30d2f7a1f8a1781a2bffd4009bd90a69d6a33806b33bdfe73863db258 \
-                        size    22514 \
                     github.com/godbus/dbus \
                         lock    8a1682060722 \
                         rmd160  90cbb8302b7c386e2685633781ec52c8e3f0424f \
@@ -237,11 +256,31 @@ go.vendors          rsc.io/qr \
                         rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
                         sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
                         size    64382 \
+                    github.com/cloudflare/circl \
+                        lock    v1.2.0 \
+                        rmd160  57ecd1876b3db3338e04ee26399ba504d67e15af \
+                        sha256  2d9d0e87698fceae275c06f5641c4dacf1e505217a981a21bac72438d0972ab7 \
+                        size    4702712 \
+                    github.com/chzyer/readline \
+                        lock    v1.5.1 \
+                        rmd160  cea52b55bd592a89cb49da082f5f0f3b6e8ad48a \
+                        sha256  9e5d6daaf4e6fa8d924e82ddec8b1fcfec42f4b1385aa8448b09816478c55c84 \
+                        size    37579 \
+                    github.com/cenkalti/backoff \
+                        lock    v2.2.1 \
+                        rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
+                        sha256  4f6a3d7d9fdc5e02522faed8e96539476f646ab64983633a92ea1b71e18bca4f \
+                        size    8633 \
                     github.com/caspr-io/yamlpath \
                         lock    502e8d113a9b \
                         rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
                         sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
                         size    6334 \
+                    github.com/boombuler/barcode \
+                        lock    v1.0.1 \
+                        rmd160  fe7247722491a03f56b9a41ae144ab05487f29fc \
+                        sha256  bd623e3ea8d79f74464b9ee4f16808545842b0e2c06b07e9b96e2dc5df80e40f \
+                        size    62985 \
                     github.com/blang/semver \
                         lock    v4.0.0 \
                         rmd160  ab0e0d974dcbc784840d4bcc76584242436c51fa \
@@ -253,10 +292,10 @@ go.vendors          rsc.io/qr \
                         sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
                         size    5023 \
                     github.com/ProtonMail/go-crypto \
-                        lock    5afb4c282135 \
-                        rmd160  fb2955998045f47e5e9b424d5dfaa136ea29c0cb \
-                        sha256  618b6dcff5b7c3f449249040c800b4e747fa7c9a8fda666754413a65f9d109f5 \
-                        size    313579 \
+                        lock    4b6e5c587895 \
+                        rmd160  d4b9fbd23c062647ad52781906cb8a7bf94fee3d \
+                        sha256  83ff491e152d6c47a8a8c7813a782581c4782f94c8b2573a47ada6b08449d917 \
+                        size    329665 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
                         lock    v1.0.0 \

--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.14.4 v
+go.setup            github.com/gopasspw/gopass 1.14.5 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  8566a58fcf8202f9e4f82b08b4b3bf203fed2043 \
-                        sha256  5fd5a5ed06550ce6fee68da27651e5f4a54c134f2ca628a20d7782c3a51cba7d \
-                        size    2246382
+                        rmd160  d036a28a4208482935a6eed4613ee2d00bb8f51f \
+                        sha256  a1867548523b437c359bdf580c2f6b6b6cb096f02895991bd7a3260a3944d732 \
+                        size    2247354
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -60,30 +60,30 @@ go.vendors          rsc.io/qr \
                         sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
                         size    14845 \
                     golang.org/x/sys \
-                        lock    a90be440212d \
-                        rmd160  2b0c87a7ffa68a316ea1b7297dbacad6beda835b \
-                        sha256  56e6382df78be406f82d3ba0bb67e6759b2b6aee1f94479854763de0efdeb6e0 \
-                        size    1338183 \
+                        lock    d48e67d00261 \
+                        rmd160  7c6b2b1d4cbda8f8abe93d350965b14dddbb709f \
+                        sha256  a1ea3659428d2c5e8d46933616a058360bccbda10b92ea6908d5435703626cc3 \
+                        size    1358000 \
                     golang.org/x/oauth2 \
-                        lock    128564f6959c \
-                        rmd160  8ba67f426f4a2adc0536dddbaf7b692b27ad290e \
-                        sha256  7c422f154a4d4375297f3cf816581c645afa12fed7374c4dbe1b8c436ffcef73 \
-                        size    104302 \
+                        lock    0ebed06d0094 \
+                        rmd160  d5ca62eacb7896cadd2c4a6c21ad6d02bb5907af \
+                        sha256  afb3425944ed285844ac7c73da2d1ff904aacb90366bfa35ebd10474b17fdc00 \
+                        size    104311 \
                     golang.org/x/net \
-                        lock    c7608f3a8462 \
-                        rmd160  a144498876520ce80806b3d8e1a34fbfb4a6ec88 \
-                        sha256  c12009532d8ba989663861bd67b1829827ff97198a84a316be9fd48c1db417ee \
-                        size    1225991 \
+                        lock    83b083e8dc8b \
+                        rmd160  b07e74f0cce4986e46838bb8194adcc00eeca0d0 \
+                        sha256  555d8cd580927a2a3ac8376d231990200e1615db2ad2f65f3c53f440b5590649 \
+                        size    1226262 \
                     golang.org/x/exp \
-                        lock    a9213eeb770e \
-                        rmd160  22493ca7d5ce3968edbd955efc45c7611ec37477 \
-                        sha256  03cfb2ecf601c4f7d13cbc41b80e781e896f07349ae8cd710947c300c816e2ad \
-                        size    1556302 \
+                        lock    334a2380cb91 \
+                        rmd160  59c6c5964fab55dca79a3e46976e46ae5d1afcde \
+                        sha256  4e4e681bb6ec75ab45c48144e6cd8c38e6380e419f46cbed84322e643a9a8ad2 \
+                        size    1556584 \
                     golang.org/x/crypto \
-                        lock    630584e8d5aa \
-                        rmd160  592a8bc8bab62d399ebd992b3f0a8d2f1d9ff603 \
-                        sha256  41bb49305186ca7a143b4044dc7ad0b85400f213a9ca6a5bb25e5048757430c2 \
-                        size    1631200 \
+                        lock    c86fa9a7ed90 \
+                        rmd160  d10541162293e950d1c79f5b0cff231d0158b53c \
+                        sha256  d97beb5e040b73b1997e0c9b34e1fa78bbbca789f17cfdfb52e3d25c880112bb \
+                        size    1631830 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -92,20 +92,20 @@ go.vendors          rsc.io/qr \
                         size    15600 \
                     go.uber.org/atomic \
                         repo    github.com/uber-go/atomic \
-                        lock    v1.9.0 \
-                        rmd160  7705959c7053aa8e405560f5ffef3fbca414ee69 \
-                        sha256  8baccde94a6ecaea185ef40b9bdecbd3dd8d8df7cbc50c89856b58c5cd897e40 \
-                        size    21353 \
+                        lock    v1.10.0 \
+                        rmd160  3b3e329c78468d0b4711b28f323069a1d6afbeec \
+                        sha256  c03c44af9133c1c06829842b6db2a1bff49818d1cb96c709d65301651f4bc390 \
+                        size    23092 \
                     github.com/xrash/smetrics \
                         lock    039620a65673 \
                         rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.11.1 \
-                        rmd160  d9b1f12257a14b0a92f0c9a63e1f978271b98dfd \
-                        sha256  3432d50bb442045bdcb32828924e7e3b9789afcfc751c2f524674eca1f164668 \
-                        size    3458866 \
+                        lock    v2.11.2 \
+                        rmd160  b65ff408aad32c5356d37200299f93331f691d7a \
+                        sha256  077760f0233fd4ef796805f117be37fe4f494991558e8a6810339367752b496d \
+                        size    3459130 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -132,20 +132,20 @@ go.vendors          rsc.io/qr \
                         sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
                         size    92950 \
                     github.com/rs/zerolog \
-                        lock    v1.27.0 \
-                        rmd160  434d8ba6beae7657617c2116cb48a358b9cd03ed \
-                        sha256  bae5e650804d95ae57b5729483fc81b30f9deb188474d8598b08c3d0ad5f2a49 \
-                        size    165154 \
+                        lock    v1.28.0 \
+                        rmd160  4b23fe27020af1b1b3de36eba648c42ff8af3fee \
+                        sha256  cf98c2e0609d78d49b8c0896583115cb29c3c2c2fd16976795adf248704a549d \
+                        size    166068 \
                     github.com/rogpeppe/go-internal \
                         lock    86f73c517451 \
                         rmd160  12ae7289b3b9f3f0339d1ffe90bfefdd28944914 \
                         sha256  243fd03669a7f2563d066de31a537dc3e99fb3180fcf36f1b492f84e3c8dbd76 \
                         size    131803 \
                     github.com/pquerna/otp \
-                        lock    v1.3.0 \
-                        rmd160  432b55c015662b3ecd02f8cb720f5bd907866629 \
-                        sha256  ab0d0bd272ea8b4749b1d73f15eadb77d78f404cc7ce0d221aad90e137881de5 \
-                        size    14039 \
+                        lock    c62dc589378a \
+                        rmd160  b95abaf61d798b40eb4c4305f99ebb09f07f57d2 \
+                        sha256  5d5dea17234e378773448f455188ad5614947e35963108028d4f66a533e99a98 \
+                        size    14210 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -182,15 +182,15 @@ go.vendors          rsc.io/qr \
                         sha256  a9ee7c2dc5fcaf640eb3be20fbeab1cebd6fc56a160296c815d1129a0ff0091f \
                         size    7735 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.14 \
-                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
-                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
-                        size    4705 \
+                        lock    v0.0.16 \
+                        rmd160  dcdf01553caa079315f2293c109de17fc72f0c6b \
+                        sha256  391d25a98e2cc92a2ed5c6abd07cde1053411706bb24e5843562931e6085ab46 \
+                        size    4693 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.12 \
-                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
-                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
-                        size    9805 \
+                        lock    v0.1.13 \
+                        rmd160  c9e8ab9d0773c0984f36235e3c9f8c033552ac1a \
+                        sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
+                        size    9778 \
                     github.com/martinhoefling/goxkcdpwgen \
                         lock    v0.1.1 \
                         rmd160  56164d6a8b2620f53897f85abe3ff7659e0aa0c5 \
@@ -317,7 +317,7 @@ go.vendors          rsc.io/qr \
                         sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
                         size    6334 \
                     github.com/boombuler/barcode \
-                        lock    6c824513bacc \
+                        lock    v1.0.1 \
                         rmd160  fe7247722491a03f56b9a41ae144ab05487f29fc \
                         sha256  bd623e3ea8d79f74464b9ee4f16808545842b0e2c06b07e9b96e2dc5df80e40f \
                         size    62985 \
@@ -332,10 +332,10 @@ go.vendors          rsc.io/qr \
                         sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
                         size    5023 \
                     github.com/ProtonMail/go-crypto \
-                        lock    d6ffb7692adf \
-                        rmd160  2e04279d46f5a58364b86f2f3b5982f225af3da4 \
-                        sha256  8e680b5baeb07b1b9b03d076e2e44fa5c2f6ad186689757fbef9784e6dd2e5b0 \
-                        size    314580 \
+                        lock    4b6e5c587895 \
+                        rmd160  d4b9fbd23c062647ad52781906cb8a7bf94fee3d \
+                        sha256  83ff491e152d6c47a8a8c7813a782581c4782f94c8b2573a47ada6b08449d917 \
+                        size    329665 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
                         lock    v1.0.0 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.14.5)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
