### PR TITLE
happy: native build with bootstrapped cabal

### DIFF
--- a/devel/happy/Portfile
+++ b/devel/happy/Portfile
@@ -1,11 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           haskell_stack 1.0
 
 name                happy
 version             1.20.0
-revision            0
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -24,39 +23,57 @@ checksums           rmd160  6132dd3496fc22363d09dc7e307d93f779bfdc3e \
                     sha256  3b1d3a8f93a2723b554d9f07b2cd136be1a7b2fcab1855b12b7aab5cbac8868c \
                     size    184515
 
-# relative paths to ${prefix}
-set happy_datadir   share/${name}
+variant stack \
+    description {Use stack to build.} {}
 
-post-extract {
-    xinstall -m 0755 -d \
-        "[option haskell_stack.stack_root]" \
-        ${destroot}${prefix}/${happy_datadir}
+if { [variant_isset "stack"] } {
+    PortGroup       haskell_stack 1.0
 
-    # Fix for cabal data-files hardcoded path in binary
-    # See:
-    # https://github.com/commercialhaskell/stack/issues/848
-    # https://github.com/commercialhaskell/stack/issues/4857
-    # https://github.com/haskell/cabal/issues/462
-    # https://github.com/haskell/cabal/issues/3586
-    xinstall -m 0644 -W ${worksrcpath} \
-        ${filespath}/Paths_NAME.hs ./src/Paths_${name}.hs
+    # relative paths to ${prefix}
+    set happy_datadir   share/${name}
 
-    reinplace "s|@PREFIX@|${prefix}|g" \
-        ${worksrcpath}/src/Paths_${name}.hs
-    reinplace "s|@NAME@|${name}|g" \
-        ${worksrcpath}/src/Paths_${name}.hs
-    reinplace -E "s|(Version\[\[:space:\]\]+)\\\[\[\[:digit:\]\]+(,\[\[:digit:\]\]+){1,4}\\\]|\\1\[[join [split ${version} .] ,]\]|" \
-        ${worksrcpath}/src/Paths_${name}.hs
-}
+    post-extract {
+        xinstall -m 0755 -d \
+            "[option haskell_stack.stack_root]" \
+            ${destroot}${prefix}/${happy_datadir}
 
-post-destroot {
-    # install cabal data-files
-    fs-traverse f ${worksrcpath}/.stack-work {
-        if { [file isdirectory ${f}]
-            && [file tail ${f}] eq "${name}-${version}" } {
-            set stack_happy_datadir ${f}
-            xinstall -m 0644 {*}[glob ${stack_happy_datadir}/*] \
-                ${destroot}${prefix}/${happy_datadir}
+        # Fix for cabal data-files hardcoded path in binary
+        # See:
+        # https://github.com/commercialhaskell/stack/issues/848
+        # https://github.com/commercialhaskell/stack/issues/4857
+        # https://github.com/haskell/cabal/issues/462
+        # https://github.com/haskell/cabal/issues/3586
+        xinstall -m 0644 -W ${worksrcpath} \
+            ${filespath}/Paths_NAME.hs ./src/Paths_${name}.hs
+
+        reinplace "s|@PREFIX@|${prefix}|g" \
+            ${worksrcpath}/src/Paths_${name}.hs
+        reinplace "s|@NAME@|${name}|g" \
+            ${worksrcpath}/src/Paths_${name}.hs
+        reinplace -E "s|(Version\[\[:space:\]\]+)\\\[\[\[:digit:\]\]+(,\[\[:digit:\]\]+){1,4}\\\]|\\1\[[join [split ${version} .] ,]\]|" \
+            ${worksrcpath}/src/Paths_${name}.hs
+    }
+
+    post-destroot {
+        # install cabal data-files
+        fs-traverse f ${worksrcpath}/.stack-work {
+            if { [file isdirectory ${f}]
+                 && [file tail ${f}] eq "${name}-${version}" } {
+                set stack_happy_datadir ${f}
+                xinstall -m 0644 {*}[glob ${stack_happy_datadir}/*] \
+                    ${destroot}${prefix}/${happy_datadir}
+            }
         }
     }
+} else {
+    PortGroup       haskell_cabal 1.0
+
+    variant haskell_cabal_use_prebuilt \
+        description {Use prebuilt cabal and ghc. This is a necessary\
+            default variant because happy is used to bootstrap ghc\
+            and ghc is used to bootstrap cabal.} {
+        haskell_cabal.use_prebuilt  yes
+    }
+    default_variants-append \
+                    +haskell_cabal_use_prebuilt
 }


### PR DESCRIPTION
#### Description
This depends upon #15770.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
