### PR TITLE
hscolour: native build with bootstrapped cabal

### DIFF
--- a/devel/hscolour/Portfile
+++ b/devel/hscolour/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           haskell_stack 1.0
 
 name                hscolour
 version             1.24.4
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -24,3 +24,21 @@ master_sites        https://hackage.haskell.org/package/${name}-${version}
 checksums           rmd160  385831baaead9b6dd1d37bcf45a61c53160b3405 \
                     sha256  243332b082294117f37b2c2c68079fa61af68b36223b3fc07594f245e0e5321d \
                     size    28729
+
+variant stack \
+    description {Use stack to build.} {}
+
+if { [variant_isset "stack"] } {
+    PortGroup       haskell_stack 1.0
+} else {
+    PortGroup       haskell_cabal 1.0
+
+    variant haskell_cabal_use_prebuilt \
+        description {Use prebuilt cabal and ghc. This is a necessary\
+            default variant because HsColour is used to bootstrap ghc\
+            and ghc is used to bootstrap cabal.} {
+        haskell_cabal.use_prebuilt  yes
+    }
+    default_variants-append \
+                    +haskell_cabal_use_prebuilt
+}


### PR DESCRIPTION
#### Description
This depends upon #15770.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
