### PR TITLE
spidermonkey185: fix building on modern macOS

### DIFF
--- a/lang/spidermonkey185/Portfile
+++ b/lang/spidermonkey185/Portfile
@@ -20,7 +20,8 @@ master_sites        http://ftp.mozilla.org/pub/mozilla.org/js/ \
                     ftp://ftp.mozilla.org/pub/mozilla.org/js/older-packages/
 distname            js[strsed ${js_version} {g/\.//}]-${version}
 checksums           rmd160  23e6ddc81d5b63e015aecc1a104b2d3d3ced5005 \
-                    sha256  5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687
+                    sha256  5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687 \
+                    size    6164605
 
 depends_lib         port:nspr \
                     port:readline
@@ -37,6 +38,19 @@ configure.args      --enable-readline \
 
 test.run            yes
 test.target         check
+
+if {${os.platform} eq "darwin" && (${os.major} < 11 || ${os.major} > 20)} {
+    depends_build-append \
+                    port:python27
+    license_noconflict \
+                    python27
+    configure.python \
+                    ${prefix}/bin/python2.7
+}
+
+post-patch {
+    reinplace "s|asm volatile|asm|g" ${worksrcpath}/methodjit/MethodJIT.cpp
+}
 
 post-destroot {
     # The script name is not versioned so it would conflict with other


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->