### PR TITLE
imlib2: disable building docs on Rosetta

### DIFF
--- a/graphics/imlib2/Portfile
+++ b/graphics/imlib2/Portfile
@@ -66,7 +66,7 @@ post-destroot {
         TODO ${destroot}${docdir}
 }
 
-variant doc {
+variant doc description {Build documentation} {
     depends_lib-append \
                     path:bin/doxygen:doxygen
 
@@ -81,7 +81,11 @@ variant doc {
     }
 }
 
-default_variants    +doc
+if {!(${os.major} == 10 && ${build_arch} eq "ppc")} {
+    # Disable on Rosetta until Doxygen is fixed.
+    # https://trac.macports.org/ticket/65770
+    default_variants    +doc
+}
 
 platform darwin 8 {
     patchfiles-append   patch-imlib2-off_t.diff


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65770

#### Description

Doxygen is broken on Rosetta, so apply default variant `+doc` in all cases except for that one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
