### PR TITLE
libproxy: update to 0.4.18

### DIFF
--- a/net/libproxy/Portfile
+++ b/net/libproxy/Portfile
@@ -64,6 +64,9 @@ configure.args-append \
 # Fix an issue with clang-900 (Xcode 9) using the Sierra SDK, <rdar://problem/31263056>
 configure.cppflags-append -D_DARWIN_C_SOURCE=1
 
+# Set standard via cxx flags, as cmake.set_cxx_flags is not working properly
+configure.cxxflags-append -std=c++11
+
 variant python27 conflicts python38 python36 python37 python39 description {Build Bindings for Python 2.7} {
     set python_prefix ${frameworks_dir}/Python.framework/Versions/2.7
     depends_lib-append port:python27

--- a/net/libproxy/Portfile
+++ b/net/libproxy/Portfile
@@ -4,12 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        libproxy libproxy 0.4.17
+github.setup        libproxy libproxy 0.4.18
 revision            0
 epoch               1
 categories          net
 maintainers         {devans @dbevans} openmaintainer
-platforms           darwin
 license             LGPL-2.1+
 homepage            https://libproxy.github.io/libproxy
 
@@ -19,9 +18,9 @@ long_description    Libproxy exists to answer the question: Given a \
                     network resource, how do I reach it? It handles all \
                     the details, enabling you to get back to programming.
 
-checksums           rmd160  4440c0024eaf3b958eba049d0b180a872bb84045 \
-                    sha256  1a40d344d61eee9d962cbdcf9b382255a63ed5a15c487384cf94174503dfffdb \
-                    size    95576
+checksums           rmd160  18680c62196d6b1765864ac8d8cfb0da19e96fb3 \
+                    sha256  712f5965b57dc329fd5700f906d9943dbdc379e547e31dc8b11c77332a652d52 \
+                    size    98063
 
 patchfiles          patch-libproxy-cmake.diff \
                     patch-libproxy-test-CMakeLists.txt.diff \

--- a/net/libproxy/Portfile
+++ b/net/libproxy/Portfile
@@ -14,29 +14,29 @@ homepage            https://libproxy.github.io/libproxy
 
 description         A library that provides automatic proxy configuration management.
 
-long_description    Libproxy exists to answer the question: Given a \
-                    network resource, how do I reach it? It handles all \
+long_description    Libproxy exists to answer the question: Given \
+                    a network resource, how do I reach it? It handles all \
                     the details, enabling you to get back to programming.
 
 checksums           rmd160  18680c62196d6b1765864ac8d8cfb0da19e96fb3 \
                     sha256  712f5965b57dc329fd5700f906d9943dbdc379e547e31dc8b11c77332a652d52 \
                     size    98063
 
-patchfiles          patch-libproxy-cmake.diff \
-                    patch-libproxy-test-CMakeLists.txt.diff \
-                    patch-bindings-perl-src-CMakeLists.txt.diff
+patchfiles-append   patch-bindings-perl-src-CMakeLists.txt.diff \
+                    patch-libproxy-cmake.diff \
+                    patch-libproxy-test-CMakeLists.txt.diff
 
 depends_build-append \
                     port:pkgconfig
 
-depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    path:bin/vala:vala
+depends_lib-append  path:bin/vala:vala \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2
 
 # https://trac.macports.org/ticket/63267
 compiler.cxx_standard 2011
 
-# webkit and mozjs pacrunners disabled by default due to the
-# following issues
+# webkit and mozjs pacrunners disabled by default
+# due to the following issues:
 #
 # webkit pacrunner circular dependency problem
 # webkit-gtk -> libsoup -> libproxy -> webkit-gtk (#26261)


### PR DESCRIPTION
#### Description

There are no changes to the code.
First commit updates the port to current version. Second makes a few minor non-functional improvements to portfile (adds -append, sorts dependencies alphabetically).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
