### PR TITLE
MacVim: added arm64 to supported_archs

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 set vim_version     9.0
 set snapshot        173
 github.setup        macvim-dev macvim ${snapshot} snapshot-
-revision            0
+revision            1
 name                MacVim
 version             ${vim_version}.snapshot${snapshot}
 categories          editors
@@ -35,7 +35,7 @@ depends_lib         port:ncurses \
 
 # MacVim does not build for arch i386
 # https://trac.macports.org/ticket/54666
-supported_archs     x86_64
+supported_archs     arm64 x86_64
 
 patchfiles          patch-remove-updater.diff \
                     patch-remove-Homebrew-python.diff \


### PR DESCRIPTION
#### Description

MacVim: added arm64 to supported_archs. MacVim supports arm64 since [Snapshot 170](https://github.com/macvim-dev/macvim/releases/tag/snapshot-170).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
