### PR TITLE
GPXSee: update to 11.4

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 11.3
+github.setup        tumic0 GPXSee 11.4
 revision            0
 
-checksums           rmd160  5d72356273aeef8592ff2bd70e947726968058fb \
-                    sha256  8c000fa168670fe5fa555f92d9dc33c21306e464f92400383081695627763fb8 \
-                    size    5323173
+checksums           rmd160  a418af38f682ca3822f1f51b1224e762871098f8 \
+                    sha256  cb35e10b4feeaf7f78c7fbafb1e66e1a6091b1a9cb1c1bf74207a1c7505d2604 \
+                    size    5332433
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
