### PR TITLE
gource: update to 0.53

### DIFF
--- a/devel/gource/Portfile
+++ b/devel/gource/Portfile
@@ -4,11 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           boost 1.0
 
-github.setup        acaudwell Gource 0.50 gource-
+github.setup        acaudwell Gource 0.53 gource-
 name                gource
-revision            3
+revision            0
 categories          devel
-platforms           darwin
 license             GPL-3+
 maintainers         nomaintainer
 
@@ -22,9 +21,9 @@ homepage            http://gource.io/
 github.tarball_from releases
 distname            gource-${version}
 
-checksums           rmd160  5f619a703ea307a233af814a48c3b70a121a1b9f \
-                    sha256  5d3412d2d6ceb44ab0bd359fd8537d532dfca336006eab8a6466bc2b71c1dba3 \
-                    size    882693
+checksums           rmd160  23800dafd2d3c45450c219463d1d74ed47d72506 \
+                    sha256  3d5f64c1c6812f644c320cbc9a9858df97bc6036fc1e5f603ca46b15b8dd7237 \
+                    size    900932
 
 depends_build       port:glm \
                     port:pkgconfig
@@ -32,12 +31,18 @@ depends_build       port:glm \
 depends_lib         port:ftgl \
                     port:libsdl2 \
                     port:libsdl2_image \
-                    port:pcre \
+                    port:pcre2 \
                     port:libpng \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:glew \
-                    port:freetype
+                    port:freetype \
+                    port:tinyxml
+
+post-patch {
+    file delete -force ${worksrcpath}/src/tinyxml
+}
 
 compiler.cxx_standard   2011
 
-configure.args      --with-boost=[boost::install_area]
+configure.args      --with-boost=[boost::install_area] \
+                    --with-tinyxml


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/acaudwell/Gource/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
