### PR TITLE
openlibm: update to 0.8.1

### DIFF
--- a/math/openlibm/Portfile
+++ b/math/openlibm/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                JuliaMath openlibm 0.7.0 v
+github.setup                JuliaMath openlibm 0.8.1 v
 revision                    0
 categories                  math devel
 license                     MIT ISCL BSD LGPL-2.1+
@@ -14,9 +14,9 @@ long_description            OpenLibm is an effort to have a high quality, portab
 
 homepage                    https://openlibm.org
 
-checksums                   rmd160  e434191f41b5cd051499f6cf9e12bc5d6cd697cd \
-                            sha256  1b1ee5c36b8e5417bf6d718d9c704705553471c2e4863f63beeded6db119bfe6 \
-                            size    366366
+checksums                   rmd160  abf6659a76f333b40a7110b2cbf5197dedfa6109 \
+                            sha256  da7caf8af9d5d206f07b12321f8a47adcd524bdc93efaa83e2ed954467964cbb \
+                            size    368794
 
 supported_archs-delete      ppc64
 


### PR DESCRIPTION
### Description

* Update to latest upstream release, which also includes a fix for ARM builds

Fixes: https://trac.macports.org/ticket/65780

### Tested on

While I don't have an ARM machine, I did test across a wide swath of releases:
* macOS 10.6
* macOS 10.7
* macOS 10.9
* macOS 10.11
* macOS 10.13
* macOS 10.14
* macOS 10.15
* macOS Big Sur
* macOS Monterey