### PR TITLE
pam-u2f: update to 1.2.1, fix build on 10.6

### DIFF
--- a/security/pam-u2f/Portfile
+++ b/security/pam-u2f/Portfile
@@ -1,12 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
+
+# O_CLOEXEC
+legacysupport.newest_darwin_requires_legacy 10
 
 name                pam-u2f
-version             1.1.0
+version             1.2.1
 revision            0
 categories          security
-platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
 license             BSD
 
@@ -21,12 +25,16 @@ homepage            https://developers.yubico.com/pam-u2f/
 master_sites        https://developers.yubico.com/pam-u2f/Releases/
 distname            pam_u2f-${version}
 
-checksums           rmd160  7c919073f9898a5e189448b901e99d301ed46618 \
-                    sha256  0dc3bf96ebb69c6e398b5f8991493b37a8ce1af792948af71e694f695d5edc05 \
-                    size    415677
+checksums           rmd160  8f371b537c3d4a8f4bbf9854f0ecfb1b644bcd9d \
+                    sha256  70e741bca197b64b4fbe8dd1f6d57ce2b8ad58ca786352c525f3f2d44125894c \
+                    size    450747
 
 depends_build       port:asciidoc port:autoconf port:automake port:gengetopt port:libtool port:pkgconfig
 depends_lib         port:libfido2
+
+# cc1: error: unrecognized command line option "-Wno-sign-conversion"
+compiler.blacklist-append \
+                    *gcc-4.* {clang < 421}
 
 configure.args      --with-pam-dir=${prefix}/lib/pam
 


### PR DESCRIPTION
#### Description

Update to 1.2.1, fix the build for older systems (10.6.8 confirmed).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
