### PR TITLE
igraph: update to 0.10

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           linear_algebra 1.0
 
-github.setup        igraph igraph 0.9.10
+github.setup        igraph igraph 0.10.0
 revision            0
 github.tarball_from releases
 
@@ -21,12 +21,11 @@ platforms           darwin
 depends_lib         port:arpack \
                     port:glpk \
                     port:gmp \
-                    port:libxml2 \
-                    port:SuiteSparse_CXSparse
+                    port:libxml2
 
-checksums           rmd160  8b9b06cf948bd58bc88a06813a9f6460bf947b99 \
-                    sha256  3e10eb2e0588bf6a2e1e730fb1a685f7591cbe589326f4ac1f5bb45b36664dbe \
-                    size    3964468
+checksums           rmd160  5c6899ec508fca8f9cfebeed376d3774e0bdaba4 \
+                    sha256  62e3c9e51ac5b0f1871142aac23956f3a6a337fee980bf5474bd4ac3d76e1a68 \
+                    size    4116609
 
 test.run            yes
 test.target         check
@@ -49,11 +48,10 @@ configure.args-append   -DUSE_CCACHE=OFF \
                         -DIGRAPH_GRAPHML_SUPPORT=ON \
                         -DIGRAPH_USE_INTERNAL_ARPACK=OFF \
                         -DIGRAPH_USE_INTERNAL_BLAS=OFF \
-                        -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF \
                         -DIGRAPH_USE_INTERNAL_GLPK=OFF \
                         -DIGRAPH_USE_INTERNAL_GMP=OFF \
                         -DIGRAPH_USE_INTERNAL_LAPACK=OFF \
-                        -DIGRAPH_USE_INTERNAL_PRPACK=ON \
+                        -DIGRAPH_USE_INTERNAL_PLFIT=ON \
                         -DIGRAPH_OPENMP_SUPPORT=OFF
 
 pre-configure {

--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-igraph
 python.rootname     igraph
 python.pep517       yes
-version             0.9.11
+version             0.10.0
 revision            0
 categories-append   math science
 platforms           darwin
@@ -24,9 +24,9 @@ long_description    Python interface to the igraph library for network analysis 
 
 homepage            https://igraph.org/python/
 
-checksums           rmd160  db5c29e1d1aeb99a72ec63878bd0aa152919bfbd \
-                    sha256  52eeaf5c015e297d979fefc53038fbaaf5fff4fb5f5022dce43f3ddc78210515 \
-                    size    3728842
+checksums           rmd160  22c34de1551d5ad5e868f58eda8afaffd401a95a \
+                    sha256  4a106d06753a0dc17f30e4e2fb7260fba8d1bd2f6d3a56934573e624bc0a7146 \
+                    size    3956854
 
 variant external_igraph description {Use external igraph library} { }
 
@@ -52,8 +52,7 @@ if {${name} ne ${subport}} {
         depends_lib-append      port:arpack \
                                 port:glpk \
                                 port:gmp \
-                                port:libxml2 \
-                                port:SuiteSparse_CXSparse
+                                port:libxml2
 
         depends_build-append    path:bin/cmake:cmake
 
@@ -65,7 +64,6 @@ if {${name} ne ${subport}} {
             -DIGRAPH_GRAPHML_SUPPORT=ON
             -DIGRAPH_USE_INTERNAL_ARPACK=OFF
             -DIGRAPH_USE_INTERNAL_BLAS=OFF
-            -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF
             -DIGRAPH_USE_INTERNAL_GLPK=OFF
             -DIGRAPH_USE_INTERNAL_GMP=OFF
             -DIGRAPH_USE_INTERNAL_LAPACK=OFF
@@ -79,7 +77,8 @@ if {${name} ne ${subport}} {
 
     # python-igraph optionally makes use of these, and some tests depend on them.
     # If they are not installed, the corresponding tests will simply be skipped.
-    depends_test-append     port:py${python.version}-networkx \
+    depends_test-append     port:py${python.version}-matplotlib \
+                            port:py${python.version}-networkx \
                             port:py${python.version}-numpy \
                             port:py${python.version}-pandas \
                             port:py${python.version}-scipy
@@ -89,7 +88,6 @@ if {${name} ne ${subport}} {
     }
 
     test.run                yes
-    test.cmd                python${python.branch} -m unittest
     test.target
 
     livecheck.type          none


### PR DESCRIPTION
#### Description

Update both `igraph` and `py-igraph` to 0.10.

The two are submitted together because the `+external_igraph` variant of `py-igraph` depends on `igraph`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
