### PR TITLE
igraph and py-igraph: fix for older macOS

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -52,7 +52,8 @@ configure.args-append   -DUSE_CCACHE=OFF \
                         -DIGRAPH_USE_INTERNAL_GMP=OFF \
                         -DIGRAPH_USE_INTERNAL_LAPACK=OFF \
                         -DIGRAPH_USE_INTERNAL_PLFIT=ON \
-                        -DIGRAPH_OPENMP_SUPPORT=OFF
+                        -DIGRAPH_OPENMP_SUPPORT=OFF \
+                        -DIGRAPH_WARNINGS_AS_ERRORS=OFF
 
 pre-configure {
     # Link to chosen BLAS/LAPACK

--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -70,6 +70,7 @@ if {${name} ne ${subport}} {
             -DIGRAPH_USE_INTERNAL_PLFIT=ON
             -DIGRAPH_OPENMP_SUPPORT=OFF
             -DBLA_VENDOR=Apple
+            -DIGRAPH_WARNINGS_AS_ERRORS=OFF
         }
 
         build.env-append        IGRAPH_CMAKE_EXTRA_ARGS=[join $extra_cmake_args]


### PR DESCRIPTION
#### Description

Fixes compilation on older macOS, see error here: https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/194208/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
