### PR TITLE
micronaut: update to 3.6.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.6.1 v
+github.setup    micronaut-projects micronaut-starter 3.6.2 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  1424c89d2e1b730b512933ee31f3464f60b9cbec \
-                sha256  55aa7e07197c0173b95524963662e4233eb0f5a9166d52cbdcbd8f2ffd0b212e \
-                size    19796219
+checksums       rmd160  8cea6ce9579d4175cfda2a387640d95b286ca0ab \
+                sha256  1122cd6394faa84a39904122250ed14ae97ee89939f93d245077e47af6b911a9 \
+                size    19807711
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.6.2.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?