### PR TITLE
phantomjs-qt-qtwebkit: fix bild with bison-3.8.2

### DIFF
--- a/aqua/phantomjs-qt/Portfile
+++ b/aqua/phantomjs-qt/Portfile
@@ -680,6 +680,9 @@ foreach {module module_info} [array get modules] {
                 #https://codereview.qt-project.org/#/c/139970/
                 patchfiles-append patch-ssl.diff
 
+                # support for bison-3.8.2
+                patchfiles-append patch-bison-382.diff
+
                 # qtwebkit uses
                 #    glx
                 #    libXcomposite

--- a/aqua/phantomjs-qt/files/patch-bison-382.diff
+++ b/aqua/phantomjs-qt/files/patch-bison-382.diff
@@ -1,0 +1,110 @@
+bison-3.8.2 created .hpp header for .cpp source. Here I've removed ton of old hacks,
+that prevents it to build :)
+
+diff --git Source/WebCore/DerivedSources.pri Source/WebCore/DerivedSources.pri
+index 57a6b0f70..abcb76062 100644
+--- Source/WebCore/DerivedSources.pri
++++ Source/WebCore/DerivedSources.pri
+@@ -987,7 +987,7 @@ GENERATORS += pluginsresources
+ # GENERATOR 11: XPATH grammar
+ xpathbison.output = ${QMAKE_FILE_BASE}.cpp
+ xpathbison.input = XPATHBISON
+-xpathbison.commands = bison -d -p xpathyy ${QMAKE_FILE_NAME} -o ${QMAKE_FUNC_FILE_OUT_PATH}/${QMAKE_FILE_BASE}.tab.c && $(MOVE) ${QMAKE_FUNC_FILE_OUT_PATH}$${QMAKE_DIR_SEP}${QMAKE_FILE_BASE}.tab.c ${QMAKE_FUNC_FILE_OUT_PATH}$${QMAKE_DIR_SEP}${QMAKE_FILE_BASE}.cpp && $(MOVE) ${QMAKE_FUNC_FILE_OUT_PATH}$${QMAKE_DIR_SEP}${QMAKE_FILE_BASE}.tab.h ${QMAKE_FUNC_FILE_OUT_PATH}$${QMAKE_DIR_SEP}${QMAKE_FILE_BASE}.h
++xpathbison.commands = bison -d -p xpathyy ${QMAKE_FILE_NAME} -o ${QMAKE_FUNC_FILE_OUT_PATH}/${QMAKE_FILE_BASE}.cpp
+ xpathbison.depends = ${QMAKE_FILE_NAME}
+ GENERATORS += xpathbison
+ 
+diff --git Source/WebCore/GNUmakefile.am Source/WebCore/GNUmakefile.am
+index acf4c63ae..79b25a4de 100644
+--- Source/WebCore/GNUmakefile.am
++++ Source/WebCore/GNUmakefile.am
+@@ -139,7 +139,7 @@ webcoregtk_cppflags += \
+ endif # END TARGET_WIN32
+ 
+ # XPath grammar
+-$(GENSOURCES_WEBCORE)/XPathGrammar.h: $(GENSOURCES_WEBCORE)/XPathGrammar.cpp
++$(GENSOURCES_WEBCORE)/XPathGrammar.hpp: $(GENSOURCES_WEBCORE)/XPathGrammar.cpp
+ $(GENSOURCES_WEBCORE)/XPathGrammar.cpp: $(WebCore)/xml/XPathGrammar.y
+ 	$(AM_V_GEN)
+ 	$(AM_V_at)perl $(WebCore)/css/makegrammar.pl --outputDir $(GENSOURCES_WEBCORE) --bison "$(BISON)" --symbolsPrefix xpathyy $<
+@@ -251,7 +251,7 @@ DerivedSources/WebCore/HTMLEntityTable.cpp: $(WebCore)/html/parser/HTMLEntityNam
+ 
+ # CSS grammar
+ 
+-DerivedSources/WebCore/CSSGrammar.h: $(GENSOURCES_WEBCORE)/CSSGrammar.cpp
++DerivedSources/WebCore/CSSGrammar.hpp: $(GENSOURCES_WEBCORE)/CSSGrammar.cpp
+ DerivedSources/WebCore/CSSGrammar.cpp: $(WebCore)/css/CSSGrammar.y.in
+ 	$(AM_V_GEN)
+ 	$(AM_V_at)perl -I $(WebCore)/bindings/scripts $(WebCore)/css/makegrammar.pl --extraDefines "$(feature_defines)" --outputDir $(GENSOURCES_WEBCORE) --bison "$(BISON)" --symbolsPrefix cssyy $<
+diff --git Source/WebCore/GNUmakefile.list.am Source/WebCore/GNUmakefile.list.am
+index 71d664515..3eee5b359 100644
+--- Source/WebCore/GNUmakefile.list.am
++++ Source/WebCore/GNUmakefile.list.am
+@@ -1,6 +1,6 @@
+ webcore_built_sources += \
+ 	DerivedSources/WebCore/CSSGrammar.cpp \
+-	DerivedSources/WebCore/CSSGrammar.h \
++	DerivedSources/WebCore/CSSGrammar.hpp \
+ 	DerivedSources/WebCore/CSSPropertyNames.h \
+ 	DerivedSources/WebCore/CSSPropertyNames.cpp \
+ 	DerivedSources/WebCore/CSSValueKeywords.h \
+@@ -900,7 +900,7 @@ webcore_built_sources += \
+ 	DerivedSources/WebCore/XMLViewerCSS.h \
+ 	DerivedSources/WebCore/XMLViewerJS.h \
+ 	DerivedSources/WebCore/XPathGrammar.cpp \
+-	DerivedSources/WebCore/XPathGrammar.h
++	DerivedSources/WebCore/XPathGrammar.hpp
+ 
+ platform_built_sources += \
+ 	DerivedSources/Platform/ColorData.cpp \
+diff --git Source/WebCore/css/CSSParser.cpp Source/WebCore/css/CSSParser.cpp
+index 54fd5e238..257664188 100644
+--- Source/WebCore/css/CSSParser.cpp
++++ Source/WebCore/css/CSSParser.cpp
+@@ -9722,7 +9722,7 @@ bool CSSParser::parseCalculation(CSSParserValue* value, CalculationPermittedValu
+ 
+ #define END_TOKEN 0
+ 
+-#include "CSSGrammar.h"
++#include "CSSGrammar.hpp"
+ 
+ enum CharacterType {
+     // Types for the main switch.
+diff --git Source/WebCore/css/makegrammar.pl Source/WebCore/css/makegrammar.pl
+index 4e0452ed8..e7f09f58f 100644
+--- Source/WebCore/css/makegrammar.pl
++++ Source/WebCore/css/makegrammar.pl
+@@ -89,7 +89,3 @@ close HPP;
+ 
+ print HEADER "#endif\n";
+ close HEADER;
+-
+-unlink("$fileBase.cpp.h");
+-unlink("$fileBase.hpp");
+-
+diff --git Source/WebCore/css/maketokenizer Source/WebCore/css/maketokenizer
+index d2a786f75..ec8f0abf6 100644
+--- Source/WebCore/css/maketokenizer
++++ Source/WebCore/css/maketokenizer
+@@ -44,7 +44,7 @@ END
+ {
+ print<<END
+ 
+-#include "CSSGrammar.h"
++#include "CSSGrammar.hpp"
+ 
+ #define INITIAL 0
+ #define mediaquery 1
+diff --git Source/WebCore/xml/XPathParser.cpp Source/WebCore/xml/XPathParser.cpp
+index 749180dbe..ce4484330 100644
+--- Source/WebCore/xml/XPathParser.cpp
++++ Source/WebCore/xml/XPathParser.cpp
+@@ -43,7 +43,7 @@ using namespace Unicode;
+ using namespace XPath;
+ 
+ extern int xpathyyparse(WebCore::XPath::Parser*);
+-#include "XPathGrammar.h"
++#include "XPathGrammar.hpp"
+ 
+ Parser* Parser::currentParser = 0;
+ 


### PR DESCRIPTION
#### Description

phantomjs-qt-qtwebkit can't be built since bison was update :(

This PR is required for https://github.com/macports/macports-ports/pull/15987

Anyway, it is unrelated to update ICU => keep it as dedicated PR.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->