### PR TITLE
mesa: avoid apple-gcc on old system

### DIFF
--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -69,13 +69,8 @@ configure.env-append \
 configure.env-append \
     INDENT=${prefix}/bin/gindent
 
-# This project is affected by a bug in Apple's gcc driver driver that I fixed in the apple-gcc42 port.
-# Use that or clang.
-# clang-700.1.81 (Xcode 7.2.1) fails at:
-#     disk_cache.c:637:7: error: cannot compile this atomic library call yet
-#           p_atomic_add(cache->size, - (uint64_t)sb.st_blocks * 512);
-#           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-compiler.blacklist gcc-3.3 gcc-4.0 gcc-4.2 llvm-gcc-4.2 {clang < 800}
+# Avoid Apple's gcc on old systems
+compiler.blacklist *gcc-3.* *gcc-4.* {clang < 800}
 
 platform darwin {
     if {${os.major} < 11} {


### PR DESCRIPTION
#### Description

Why? MacPorts has much never compilers which is available on old system this days.

`apple-gcc42` for example fails as:
```
leopard:~ catap$ sudo port install --unrequested apple-gcc42           
--->  Computing dependencies for apple-gcc42
--->  Fetching archive for apple-gcc42
--->  Attempting to fetch apple-gcc42-5666.3_16+universal.darwin_9.i386-x86_64.tbz2 from http://packages.macports.org/apple-gcc42
--->  Attempting to fetch apple-gcc42-5666.3_16+universal.darwin_9.i386-x86_64.tbz2 from http://fra.de.packages.macports.org/apple-gcc42
--->  Attempting to fetch apple-gcc42-5666.3_16+universal.darwin_9.i386-x86_64.tbz2 from http://nue.de.packages.macports.org/apple-gcc42
--->  Fetching distfiles for apple-gcc42
--->  Verifying checksums for apple-gcc42
--->  Extracting apple-gcc42
--->  Applying patches to apple-gcc42
Warning: reinplace /^PPC_SYSROOT=/ s:=.*$:=/Developer/SDKs/MacOSX10.5.sdk: didn't change anything in /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_apple-gcc42/apple-gcc42/work/gcc-5666.3/build_gcc
--->  Configuring apple-gcc42
--->  Building apple-gcc42
Error: Failed to build apple-gcc42: command execution failed
Error: See /opt/local/var/macports/logs/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_apple-gcc42/apple-gcc42/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets if you believe there is a bug.
Error: Processing of port apple-gcc42 failed
leopard:~ catap$ sudo port clean apple-gcc42
--->  Cleaning apple-gcc42
leopard:~ catap$ sudo port install --unrequested apple-gcc42 -universal
--->  Computing dependencies for apple-gcc42
--->  Fetching archive for apple-gcc42
--->  Attempting to fetch apple-gcc42-5666.3_16.darwin_9.i386.tbz2 from http://packages.macports.org/apple-gcc42
--->  Attempting to fetch apple-gcc42-5666.3_16.darwin_9.i386.tbz2 from http://fra.de.packages.macports.org/apple-gcc42
--->  Attempting to fetch apple-gcc42-5666.3_16.darwin_9.i386.tbz2 from http://nue.de.packages.macports.org/apple-gcc42
--->  Fetching distfiles for apple-gcc42
--->  Verifying checksums for apple-gcc42
--->  Extracting apple-gcc42
--->  Applying patches to apple-gcc42
Warning: reinplace /^PPC_SYSROOT=/ s:=.*$:=/Developer/SDKs/MacOSX10.5.sdk: didn't change anything in /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_apple-gcc42/apple-gcc42/work/gcc-5666.3/build_gcc
--->  Configuring apple-gcc42
--->  Building apple-gcc42
Error: Failed to build apple-gcc42: command execution failed
Error: See /opt/local/var/macports/logs/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_apple-gcc42/apple-gcc42/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets if you believe there is a bug.
Error: Processing of port apple-gcc42 failed
leopard:~ catap$ 
```
with error:
```
:info:build ld: warning: could not create compact unwind for __Unwind_RaiseException: non-standard register 0 being saved in prolog
:info:build ld: warning: could not create compact unwind for __Unwind_Resume_or_Rethrow: non-standard register 0 being saved in prolog
:info:build ld: warning: could not create compact unwind for __Unwind_Resume: non-standard register 0 being saved in prolog
:info:build ld: warning: could not create compact unwind for __Unwind_ForcedUnwind: non-standard register 0 being saved in prolog
:info:build ld: illegal text-relocation to _uw_update_context_1 in libgcc/./unwind-dw2_s.o from anon in libgcc/./unwind-dw2_s.o for architecture i386
:info:build collect2: ld returned 1 exit status
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->