### PR TITLE
openjdk{11,17}-graalvm: add native-image subport

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -86,3 +86,48 @@ by adding the following line to your shell profile:
 
     export JAVA_HOME=${target}/Contents/Home
 "
+
+subport ${name}-native-image {
+    depends_lib        port:${name}
+    description        Native Image component for GraalVM
+    long_description   ${description}
+
+    if {${configure.build_arch} eq "x86_64"} {
+        set jar_file native-image-installable-svm-java11-darwin-amd64-${version}.jar
+        distfiles    ${jar_file}
+        checksums    rmd160  b484f8c9b78afe5230a1c712a2c2e83728994906 \
+                     sha256  de9bf830d000a54934a01149691a9a8d4ef6e33414776abd14f95c65b149c908 \
+                     size    110346461
+    } elseif {${configure.build_arch} eq "arm64"} {
+        set jar_file native-image-installable-svm-java11-darwin-aarch64-${version}.jar
+        distfiles    ${jar_file}
+        checksums    rmd160  30811497def96c32a75940616a98efd4f14870ca \
+                     sha256  aba76d671017f93cdaae5102607d0bc7a1398adc5de8a4b1e308fa366d5983f9 \
+                     size    27717768
+    }
+
+    set java_home ${target}/Contents/Home
+
+    extract {}
+
+    destroot {
+        xinstall -d -m 0755 ${destroot}${prefix}/share/java/${subport}
+        file copy ${distpath}/${jar_file} ${destroot}${prefix}/share/java/${subport}
+    }
+
+    post-activate {
+        # Graal Updater doesn't signal errors if the component is already installed.
+        # Unfortunately, we require root privileges to invoke Graal Updater.
+        system "sudo ${java_home}/bin/gu -L install ${prefix}/share/java/${subport}/${jar_file}"
+    }
+
+    post-deactivate {
+        # This helps prevent breakage if the user removed native-image themselves
+        # and wants to deactivate or uninstall this port.
+        if {[regexp {(?i)native-image} [exec ${java_home}/bin/gu list] match]} {
+            system "sudo ${java_home}/bin/gu remove native-image"
+        }
+    }
+
+    notes "The Native Image component of GraalVM has been installed for you"
+}

--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -86,3 +86,48 @@ by adding the following line to your shell profile:
 
     export JAVA_HOME=${target}/Contents/Home
 "
+
+subport ${name}-native-image {
+    depends_lib        port:${name}
+    description        Native Image component for GraalVM
+    long_description   ${description}
+
+    if {${configure.build_arch} eq "x86_64"} {
+        set jar_file native-image-installable-svm-java17-darwin-amd64-${version}.jar
+        distfiles    ${jar_file}
+        checksums    rmd160  12063d0246ad5ce8e2ec1be96b3a85f15e1251e4 \
+                     sha256  a751d0c0dcdc7e06dd0166d731a482a6937f36a1b69ef62f9e9f443922e85861 \
+                     size    112202934
+    } elseif {${configure.build_arch} eq "arm64"} {
+        set jar_file native-image-installable-svm-java17-darwin-aarch64-${version}.jar
+        distfiles    ${jar_file}
+        checksums    rmd160  6bf4187f13883feeb8178ebc0249243a85f1c5b4 \
+                     sha256  c6584429fe443f5415a7ec0545072b069f2e10bef1dbd6e7cb7fdec6ddb89b62 \
+                     size    29367028
+    }
+
+    set java_home ${target}/Contents/Home
+
+    extract {}
+
+    destroot {
+        xinstall -d -m 0755 ${destroot}${prefix}/share/java/${subport}
+        file copy ${distpath}/${jar_file} ${destroot}${prefix}/share/java/${subport}
+    }
+
+    post-activate {
+        # Graal Updater doesn't signal errors if the component is already installed.
+        # Unfortunately, we require root privileges to invoke Graal Updater.
+        system "sudo ${java_home}/bin/gu -L install ${prefix}/share/java/${subport}/${jar_file}"
+    }
+
+    post-deactivate {
+        # This helps prevent breakage if the user removed native-image themselves
+        # and wants to deactivate or uninstall this port.
+        if {[regexp {(?i)native-image} [exec ${java_home}/bin/gu list] match]} {
+            system "sudo ${java_home}/bin/gu remove native-image"
+        }
+    }
+
+    notes "The Native Image component of GraalVM has been installed for you"
+}


### PR DESCRIPTION
#### Description
This port is part of an effort to bring [clojure-lsp](https://github.com/clojure-lsp/clojure-lsp/) into MacPorts. While it is possible to build clojure-lsp into a standalone JAR file; this is not recommended by upstream, and they plan to remove any JAR releases soon. Rather than make a future clojure-lsp port deviate from upstream releases, I have decided to attempt bringing GraalVM's native-image tool as naturally as possible to MacPorts.

I have been able to install and uninstall each subport locally. I have also successfully invoked `native-image` from the java17 subport to produce a native executable of a Java hello world program.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
