### PR TITLE
coreutils*: fix build on old macOS

### DIFF
--- a/sysutils/coreutils-devel/Portfile
+++ b/sysutils/coreutils-devel/Portfile
@@ -48,6 +48,9 @@ depends_lib-append \
 compiler.blacklist-append \
                 {clang < 900}
 
+# See: https://trac.macports.org/ticket/62994
+patchfiles      patch-getcwd.m4.diff
+
 configure.args-append \
                 --disable-silent-rules \
                 --program-prefix=g

--- a/sysutils/coreutils-devel/files/patch-getcwd.m4.diff
+++ b/sysutils/coreutils-devel/files/patch-getcwd.m4.diff
@@ -1,0 +1,13 @@
+Backport of https://lists.gnu.org/archive/html/bug-gnulib/2022-09/msg00045.html
+
+--- ./configure
++++ ./configure
+@@ -42907,7 +42907,7 @@
+ 
+   gl_abort_bug=no
+   case "$host_os" in
+-    mingw*)
++    darwin* | mingw*)
+       gl_cv_func_getcwd_path_max=yes
+       ;;
+     *)

--- a/sysutils/coreutils/Portfile
+++ b/sysutils/coreutils/Portfile
@@ -48,6 +48,9 @@ depends_lib-append \
 compiler.blacklist-append \
                 {clang < 900}
 
+# See: https://trac.macports.org/ticket/62994
+patchfiles      patch-getcwd.m4.diff
+
 configure.args-append \
                 --disable-silent-rules \
                 --program-prefix=g

--- a/sysutils/coreutils/files/patch-getcwd.m4.diff
+++ b/sysutils/coreutils/files/patch-getcwd.m4.diff
@@ -1,0 +1,13 @@
+Backport of https://lists.gnu.org/archive/html/bug-gnulib/2022-09/msg00045.html
+
+--- ./configure
++++ ./configure
+@@ -42907,7 +42907,7 @@
+ 
+   gl_abort_bug=no
+   case "$host_os" in
+-    mingw*)
++    darwin* | mingw*)
+       gl_cv_func_getcwd_path_max=yes
+       ;;
+     *)


### PR DESCRIPTION
#### Description

Used patch was backported to upstream of gnulib: https://lists.gnu.org/archive/html/bug-gnulib/2022-09/msg00045.html

See: https://trac.macports.org/ticket/62994

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->