### PR TITLE
hevea: update to 2.36, allow build on PPC

### DIFF
--- a/lang/coq/Portfile
+++ b/lang/coq/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        coq coq 8.13.2 V
-revision            0
+revision            1
 platforms           darwin
 categories          lang math
 license             LGPL-2.1

--- a/textproc/bibtex2html/Portfile
+++ b/textproc/bibtex2html/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                bibtex2html
 version             1.99
+revision            1
 categories          textproc www
 platforms           darwin
 license             GPL-2

--- a/textproc/hevea/Portfile
+++ b/textproc/hevea/Portfile
@@ -1,29 +1,29 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem      1.0
+PortSystem          1.0
+PortGroup           github 1.0
 
-PortGroup       github 1.0
-github.setup    maranget hevea 2.36 v
-categories      textproc www tex
-maintainers     {pmetzger @pmetzger} openmaintainer
-license         {QPL LGPL}
-description     HEVEA is a quite complete and fast LATEX to HTML translator.
-long_description HEVEA is a LaTeX to HTML translator.\
-                The input language is a fairly complete subset\
-                of LaTeX2e (old LaTeX style is also accepted) and\
-                the output language is HTML that is (hopefully)\
-                correct with respect to version 4.0 (transitional)
+github.setup        maranget hevea 2.36 v
+categories          textproc www tex
+maintainers         {pmetzger @pmetzger} openmaintainer
+license             {QPL LGPL}
+description         HEVEA is a quite complete and fast LATEX to HTML translator.
+long_description    HEVEA is a LaTeX to HTML translator. \
+                    The input language is a fairly complete subset \
+                    of LaTeX2e (old LaTeX style is also accepted) and \
+                    the output language is HTML that is (hopefully) \
+                    correct with respect to version 4.0 (transitional)
 
-homepage        http://hevea.inria.fr/
+homepage            https://hevea.inria.fr/
 
 checksums           rmd160  86a6c3556521312afc3e8eb8e12261e6bfa7c768 \
                     sha256  e46e53b80da79309e61014ec43dd6cd3572230f979fa8dc539d311d94ff34fdf \
                     size    1218008
 
-patchfiles      patch-Makefile.diff
+patchfiles          patch-Makefile.diff
 
-depends_build   port:ocaml \
-                port:ocaml-ocamlbuild
+depends_build       port:ocaml \
+                    port:ocaml-ocamlbuild
 
 universal_variant   no
 installs_libs       no

--- a/textproc/hevea/Portfile
+++ b/textproc/hevea/Portfile
@@ -3,9 +3,8 @@
 PortSystem      1.0
 
 PortGroup       github 1.0
-github.setup    maranget hevea 2.32 v
+github.setup    maranget hevea 2.36 v
 categories      textproc www tex
-platforms       darwin
 maintainers     {pmetzger @pmetzger} openmaintainer
 license         {QPL LGPL}
 description     HEVEA is a quite complete and fast LATEX to HTML translator.
@@ -17,9 +16,9 @@ long_description HEVEA is a LaTeX to HTML translator.\
 
 homepage        http://hevea.inria.fr/
 
-checksums           rmd160  b9a0da12e94b199e6e0c10a5e6693cdcc49a2428 \
-                    sha256  b06929e0a4a5a0e750144966a9932a4e9f344d974d5bb5706cae6ce66eadb916 \
-                    size    1202366
+checksums           rmd160  86a6c3556521312afc3e8eb8e12261e6bfa7c768 \
+                    sha256  e46e53b80da79309e61014ec43dd6cd3572230f979fa8dc539d311d94ff34fdf \
+                    size    1218008
 
 patchfiles      patch-Makefile.diff
 
@@ -34,4 +33,10 @@ configure {
     reinplace "s|^LIBDIR=.*|LIBDIR=${prefix}/share/${name}|" ${worksrcpath}/Makefile
     reinplace "s|^LATEXLIBDIR=.*|LATEXLIBDIR=${prefix}/share/${name}|" ${worksrcpath}/Makefile
     reinplace "s|^DESTDIR=.*|DESTDIR=${destroot}|" ${worksrcpath}/Makefile
+}
+
+# Keep this until we fix OCaml native compiler for PPC
+if {${build_arch} in [list ppc ppc64]} {
+    build.target    byte
+    destroot.cmd    ./install.sh byte
 }


### PR DESCRIPTION
#### Description

Update to current version. Use `byte` target for PPC until `ocamlopt` is fixed for it.
Fix lint warning, improve alignments, use https for homepage.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
