### PR TITLE
ocaml-ocamlnet: update to 4.1.9, fix build, enable on PPC

### DIFF
--- a/ocaml/ocaml-ocamlnet/Portfile
+++ b/ocaml/ocaml-ocamlnet/Portfile
@@ -1,8 +1,14 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
+PortGroup           legacysupport 1.1
+
+# O_CLOEXEC
+legacysupport.newest_darwin_requires_legacy 10
 
 name                ocaml-ocamlnet
-version             4.0.3
-revision            2
+version             4.1.9
+revision            0
 categories          ocaml devel
 maintainers         nomaintainer
 license             {BSD GPL-2 LGPL-2}
@@ -15,15 +21,15 @@ long_description    Internet protocols (http, cgi, email etc.) and helper \
                     programming.
 
 homepage            http://projects.camlcity.org/projects/ocamlnet.html
-platforms           darwin
 master_sites        http://download.camlcity.org/download/
 
 distname            ocamlnet-${version}
 
-checksums           rmd160  66a814b7167de880f2dcaaf8ff9c1f1fd3600a49 \
-                    sha256  d3b030715fe2c5f395ff9c08f0a8d3baa8830161300ba29e5aa8fabb92b182c1
+checksums           rmd160  e5518628bf13195b8ac45088bf78c21ae24d084c \
+                    sha256  f98ed19979848f1949b1b001e30ac132b254d0f4a705150c6dcf9094bbec9cee \
+                    size    4628747
 
-depends_lib         port:ocaml \
+depends_lib-append  port:ocaml \
                     port:ocaml-findlib \
                     port:ocaml-pcre
 
@@ -37,9 +43,15 @@ post-patch {
 }
 
 configure.pre_args
-configure.args      -enable-pcre
+configure.args-append \
+                    -enable-pcre
 
-build.target        all opt
+if {${build_arch} in [list ppc ppc64]} {
+    build.target    all
+} else {
+    build.target    all opt
+}
+
 use_parallel_build  no
 
 pre-destroot {

--- a/ocaml/ocaml-pcre/Portfile
+++ b/ocaml/ocaml-pcre/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 PortGroup           ocaml 1.1
 
 name                ocaml-pcre
 version             7.1.5
-revision            2
+revision            3
 categories          ocaml devel
 maintainers         nomaintainer
 license             LGPL-2.1
@@ -16,7 +16,6 @@ long_description    This OCaml-library interfaces the PCRE (Perl-compatibility r
                     or splitting text should become much easier with this library.
 
 homepage            https://mmottl.github.io/pcre-ocaml/
-platforms           darwin
 master_sites        https://github.com/mmottl/pcre-ocaml/releases/download/v${version}/
 
 checksums           rmd160  d4e6b89a92753465352f1a42e1ba90dcdca90eff \


### PR DESCRIPTION
#### Description

Update, fix building on PPC which currently can only use `ocamlc`.

The existing version of the port is broken across the board: https://ports.macports.org/port/ocaml-ocamlnet/details/
Hopefully this one builds if not for all systems, then at least for some.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
