### PR TITLE
java PG: fix detection of arm

### DIFF
--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -59,7 +59,9 @@ namespace eval java {
             # as required, as currently these are the only ones supporting arm.
             # To be reviewed as support for arm comes for the other versions.
             # Following regex matches openjdk<version> only.
-            if { [option configure.build_arch] eq "arm64" &&
+            # Keep in mind that configure.build_arch isn't available here
+            global os.arch
+            if { ${os.arch} eq "arm" &&
                  [regexp {openjdk(\d{1,2}$)} ${java.fallback}] } {
                 set newjdk ${java.fallback}-zulu
                 ui_debug "Redefining java fallback ${java.fallback} to ${newjdk} for arm compatibility"


### PR DESCRIPTION
#### Description

`${configure.build_arch}` and `[option configure.build_arch]` both return an empty string here.

This lead to using default fallback on clean system which is `openjdkXY` which probably won't be build on arm64.

To fix it I've migrated to `${os.arch}` which is available and which has value `arm` instead of `arm64`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

I've tested it on clean

macOS 12.4 21F79 arm64
Xcode 13.1 13A1030d

by simple installing `scala3.2` port.

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->