### PR TITLE
google-cloud-sdk: update to 401.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             400.0.0
+version             401.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  2cf5a09645a8b826cb128c78b640f6ac904c22f2 \
-                    sha256  f23e4a4d652864f4d6f6c5ed6f27922bacdf30388ef8c8cda722b515009e18f3 \
-                    size    108947625
+    checksums       rmd160  555747db2562e59904bfa4bf07532d70d2ea9c63 \
+                    sha256  c0c2566b925d65df816d120ffddec5a1a35f5292c7a0202f4cfc5d4f29c404b1 \
+                    size    109073502
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  9bfa53ec4ab24b19972ef453078f4c122e7a006f \
-                    sha256  bc1b88fbb0fbe221568dcc81f51ee629cbf1f6f98c6c587487be8060c2e55e2a \
-                    size    96388422
+    checksums       rmd160  7347ad86167e93dfff6b5796b9f4c446ba6f22e8 \
+                    sha256  8bdeea7ec803681b465ee46e790f4f9b96e6dda69c8975860446fd94d22245d6 \
+                    size    96517122
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c593ac3cdfba32cec06929cf034cf3670cf574c1 \
-                    sha256  727c8cdb5a9b07ba27626d3427733dd5f4fedc54e4d0cdbf19f6379ff7e09d9a \
-                    size    95001564
+    checksums       rmd160  d920314181ee9fb20eff7fd8354553c00fe1359a \
+                    sha256  c1223af0ccee98259450f2dfe61341463254b14416c96fadc98e75b2ac0eb995 \
+                    size    95127745
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 401.0.0.

###### Tested on

macOS 12.5.1 21G83 arm64
Xcode 13.4 13F17a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?