### PR TITLE
Select python ports: blacklist old compilers for subports py39, py310 due to unsupported flag

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                py-Pillow
 version             9.2.0
@@ -61,6 +62,12 @@ if {${name} ne ${subport}} {
                         port:webp \
                         port:openjpeg \
                         port:freetype
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
 
     post-patch {
         reinplace "s|@prefix@|${prefix}|g" ${worksrcpath}/setup.py

--- a/python/py-bcrypt/Portfile
+++ b/python/py-bcrypt/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                py-bcrypt
 version             3.2.2
@@ -38,6 +39,12 @@ if {${name} ne ${subport}} {
         depends_build-append \
                             port:py${python.version}-setuptools
         depends_lib-append  port:py${python.version}-six
+    }
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
     }
 
     livecheck.type      none

--- a/python/py-brotli/Portfile
+++ b/python/py-brotli/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 # keep this in sync with port brotli
 github.setup        google brotli 1.0.9 v
@@ -32,6 +33,12 @@ if {$subport ne $name} {
     depends_build-append port:py${python.version}-setuptools
 
     patchfiles      CXXFLAGS.patch
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
 
     test.run yes
 }

--- a/python/py-cffi/Portfile
+++ b/python/py-cffi/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           compiler_wrapper 1.0
 
 name                py-cffi
@@ -29,8 +30,9 @@ checksums           rmd160  9cc1d96670ad9df27e3be8dc3132e439347542ea \
 if {${name} ne ${subport}} {
     patchfiles-append   patch-setup.py.diff
 
-    # ticket 61804
-    compiler.blacklist-append *gcc-3.* *gcc-4.*
+    # https://trac.macports.org/ticket/61804
+    # https://trac.macports.org/ticket/65179
+    compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
 
     depends_build-append \
                         port:py${python.version}-setuptools

--- a/python/py-cryptography/Portfile
+++ b/python/py-cryptography/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        pyca cryptography 37.0.2
 name                py-${github.project}
 revision            1
 categories-append   devel
-platforms           darwin
 license             BSD
 
 python.versions     27 36 37 38 39 310
@@ -38,6 +38,12 @@ if {${name} ne ${subport}
 
     depends_lib-append \
                     port:py${python.version}-cffi
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
 
     # legacy support
     if {${python.version} eq 27

--- a/python/py-curl/Portfile
+++ b/python/py-curl/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                py-curl
 python.rootname     pycurl
@@ -37,6 +38,12 @@ if {${name} ne ${subport}} {
 
     depends_lib-append  port:curl \
                         path:lib/libssl.dylib:openssl
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
 
     pre-build {
         system -W ${build.dir} "${python.bin} setup.py docstrings"

--- a/python/py-cython/Portfile
+++ b/python/py-cython/Portfile
@@ -48,7 +48,8 @@ if {${name} ne ${subport}} {
                             size    2060265
     } else {
         # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
-        compiler.blacklist-append *gcc-3.* *gcc-4.*
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
     }
 
     if {${python.version} < 37} {

--- a/python/py-gdbm/Portfile
+++ b/python/py-gdbm/Portfile
@@ -1,7 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem      1.0
+PortGroup       python 1.0
+PortGroup       compiler_blacklist_versions 1.0
 
 name			py-gdbm
 version			2.4.6
@@ -14,7 +15,7 @@ long_description	${description}
 
 homepage		https://docs.python.org/2/library/gdbm.html
 
-python.versions 26 27 32 33 34 35 36 37 38 39
+python.versions 26 27 32 33 34 35 36 37 38 39 310
 
 set setup_py "setup.py"
 set extract_files "Modules/gdbmmodule.c"
@@ -161,7 +162,6 @@ subport py310-gdbm {
     livecheck.regex {Python (3\.10\.[0-9]+)}
 }
 
-
 distname		Python-${version}
 master_sites	https://www.python.org/ftp/python/${version}/
 
@@ -169,6 +169,12 @@ livecheck.type	none
 
 if {${name} ne ${subport}} {
     depends_lib-append	port:gdbm
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
 
     dist_subdir		python${python.version}
 

--- a/python/py-libxml2/Portfile
+++ b/python/py-libxml2/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 # Please keep the version of the libxml2 and py-libxml2 ports the same.
 name                py-libxml2
@@ -33,6 +34,12 @@ python.versions     27 37 38 39 310
 if {${name} ne ${subport}} {
     depends_lib-append  \
                     port:libxml2
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
 
     worksrcdir      ${worksrcdir}/python
 

--- a/python/py-lxml/Portfile
+++ b/python/py-lxml/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                py-lxml
 version             4.8.0
@@ -38,6 +39,12 @@ if {${name} ne ${subport}} {
                     port:zlib \
                     port:libxml2 \
                     port:libxslt
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]

--- a/python/py-setproctitle/Portfile
+++ b/python/py-setproctitle/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                py-setproctitle
 version             1.2.2
@@ -24,4 +25,17 @@ checksums           rmd160  502e9b7ec141d29faa959db8a07330f51acafc9f \
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
+    
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
+
+    if {${build_arch} in [list ppc ppc64]} {
+        # This is a hack; otherwise on Rosetta it fails with: Cannot install clang-11 for the arch 'powerpc' because
+        # its dependency python310 does not build for the required arch by default and does not have a universal variant.
+        # But no clang works on PPC presently.
+        compiler.whitelist macports-gcc-12 macports-gcc-11 macports-gcc-10 macports-gcc-7 macports-gcc-6
+    }
 }

--- a/python/py-tkinter/Portfile
+++ b/python/py-tkinter/Portfile
@@ -1,7 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem      1.0
+PortGroup       python 1.0
+PortGroup       compiler_blacklist_versions 1.0
 
 name            py-tkinter
 version         2.4.6
@@ -15,7 +16,7 @@ long_description \
 
 homepage        https://docs.python.org/library/tkinter.html
 
-python.versions 26 27 32 33 34 35 36 37 38 39
+python.versions 26 27 32 33 34 35 36 37 38 39 310
 
 set extract_files "Modules/_tkinter.c Modules/tkappinit.c"
 set module_name Tkinter
@@ -156,6 +157,12 @@ distname        Python-${version}
 
 if {${name} ne ${subport}} {
     depends_lib-append port:tk
+
+    if {${python.version} in [list 39 310]} {
+        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+        # https://trac.macports.org/ticket/65179
+        compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 421}
+    }
 
     dist_subdir python${python.version}
 


### PR DESCRIPTION
#### Description

Let us finally fix existing disaster with broken Python subports on <10.7 due to unsupported flag `-Wno-unused-result`.
We have a precedent: https://github.com/macports/macports-ports/commit/0476e42f1442d300d34fa25a75516efe27a17ea0
See also: https://trac.macports.org/ticket/65179

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
