### PR TITLE
jsmin: update to 20191031

### DIFF
--- a/lang/jsmin/Portfile
+++ b/lang/jsmin/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        douglascrockford JSMin 20120415
+github.setup        douglascrockford JSMin 430bfe68dc0823d8c0f92c08d426e517cbc8de5e
 name                jsmin
+version             20191031
 categories          lang
 maintainers         sergiokas.com:dev openmaintainer
-platforms           darwin
 license             MIT
 
 description         JavaScript minifier tool
@@ -15,8 +15,10 @@ description         JavaScript minifier tool
 long_description    Douglas Crockford's original JavaScript minifier tool
 
 homepage            http://www.crockford.com/javascript/jsmin.html
-fetch.type          git
-git.branch          5ca277ea452beae1c25db3bc0ef5c81309a3daf4
+
+checksums           rmd160  fa16ff9fe5edfd7803cf238967609c8de16ebfc2 \
+                    sha256  314261fac2c97f27dba687c80785804be5dd33bd27a470c5faa150fcff9a3abe \
+                    size    4408
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Just an update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
