### PR TITLE
ghidra: use pg java; cleanup

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -1,52 +1,59 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           app 1.0
 PortGroup           github 1.0
+PortGroup           java 1.0
+PortGroup           app 1.0
 
 github.setup        NationalSecurityAgency ghidra 10.1.1 Ghidra_ _build
 set filedate        20211221
-revision            0
+revision            1
 checksums           rmd160  fa62c4dcf356b27ce9a1f6ad5b41b623171b87b1 \
                     sha256  d4ee61ed669cec7e20748462f57f011b84b1e8777b327704f1646c0d47a5a0e8 \
                     size    348978464
 
-homepage            https://ghidra-sre.org/
-github.tarball_from releases
-use_zip             yes
-distname            ${name}_${version}_PUBLIC_${filedate}
-
+supported_archs     noarch
 categories          devel
+license             Apache
 maintainers         {1e0.co.uk:dev @hexagonal-sun} openmaintainer
 description         A software reverse engineering (SRE) suite of tools developed by NSA's \
                     Research Directorate in support of the Cybersecurity mission
 long_description    ${description}
-license             Apache
-platforms           darwin
+homepage            https://ghidra-sre.org/
 
-depends_lib-append  port:openjdk11-zulu
+github.tarball_from releases
+use_zip             yes
+distname            ${name}_${version}_PUBLIC_${filedate}
+
+java.version        11+
+java.fallback       openjdk11
+
 use_configure       no
 universal_variant   no
-
 build {}
 
-set javadest        "${prefix}/share/java/${name}-${version}"
+set javadest        ${prefix}/share/java/${name}-${version}
+set ghidra_copy_list \
+[list \
+    Extensions \
+    GPL \
+    Ghidra \
+    LICENSE \
+    docs \
+    ghidraRun \
+    licenses \
+    server \
+    support \
+]
+
 destroot {
-    file mkdir "${destroot}${javadest}"
-    file copy "${worksrcpath}/Extensions" "${destroot}${javadest}/"
-    file copy "${worksrcpath}/GPL" "${destroot}${javadest}/"
-    file copy "${worksrcpath}/Ghidra" "${destroot}${javadest}/"
-    file copy "${worksrcpath}/LICENSE" "${destroot}${javadest}/"
-    file copy "${worksrcpath}/docs" "${destroot}${javadest}/"
-    file copy "${worksrcpath}/ghidraRun" "${destroot}${javadest}/"
-    file copy "${worksrcpath}/licenses" "${destroot}${javadest}/"
-    file copy "${worksrcpath}/server" "${destroot}${javadest}/"
-    file copy "${worksrcpath}/support" "${destroot}${javadest}/"
+    xinstall -d ${destroot}${javadest}
+    foreach item ${ghidra_copy_list} {
+        copy ${worksrcpath}/${item} ${destroot}${javadest}/
+    }
 }
 
 # app settings
-app.create yes
-app.name GHIDRA
-app.executable "${javadest}/ghidraRun"
-app.icon "support/ghidra.ico"
-app.retina yes
+app.executable      ${javadest}/ghidraRun
+app.icon            ${worksrcpath}/support/ghidra.ico
+app.retina          yes


### PR DESCRIPTION
### Description

* Use pg `java`, to eliminate hard-coded dependency on JDK distribution.
* General cleanup, eliminating both superfluous things (for pg `app`), as well as reducing copy-pasta for copying logic.