### PR TITLE
OpenCoarrays: update to 2.10.0, fix the build, add variants

### DIFF
--- a/science/OpenCoarrays/Portfile
+++ b/science/OpenCoarrays/Portfile
@@ -1,15 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 
-github.setup        sourceryinstitute OpenCoarrays 2.9.2
+github.setup        sourceryinstitute OpenCoarrays 2.10.0
 github.tarball_from releases
-revision            1
+revision            0
 categories          science parallel devel
-platforms           darwin
 license             BSD
 maintainers         nomaintainer
 
@@ -18,35 +17,54 @@ long_description    OpenCoarrays is an open-source software project \
                     that produces an application binary interface (ABI) \
                     to support coarrays and other Fortran 2018 parallel \
                     programming features for gfortran in the GNU Compiler \
-                    Collection (GCC).  Gfortran has used OpenCoarrays \
+                    Collection (GCC). Gfortran has used OpenCoarrays \
                     since the GCC 5.1.0 release.
 homepage            http://www.opencoarrays.org
 
 mpi.setup           require require_fortran \
                     -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 \
                     -clang -fortran
+
 universal_variant   no
 
-checksums           rmd160  d0cf1f270b5d17b239825b8720dcacba1d6b6057 \
-                    sha256  6c200ca49808c75b0a2dfa984304643613b6bc77cc0044bee093f9afe03698f7 \
-                    size    324933
+checksums           rmd160  3e94a9fe478d60e027730e596ffe1c384de5da77 \
+                    sha256  c08717aea6ed5c68057f80957188a621b9862ad0e1460470e7ec82cdd84ae798 \
+                    size    329486
 
-#patchfiles          tests-compiler.patch
-
-cmake.out_of_source yes
+patchfiles          patch-isnan.diff
 
 post-patch {
-    reinplace "s|mpicc|${prefix}/bin/mpicc-${mpi.name}|g" \
+    reinplace "s|mpicc|${prefix}/bin/${mpi.cc}|g" \
         src/tests/unit/simple/CMakeLists.txt
 }
 
 # Required to run the test phase.
 pre-configure {
     configure.args-append \
-        -DMPIEXEC=${prefix}/bin/${mpi.exec} \
-        -DMPI_C_COMPILER=${prefix}/bin/mpicc-${mpi.name} \
-        -DMPI_Fortran_COMPILER=${prefix}/bin/mpif90-${mpi.name}
+        -DMPIEXEC_EXECUTABLE=${prefix}/bin/${mpi.exec} \
+        -DMPI_C_COMPILER=${prefix}/bin/${mpi.cc} \
+        -DMPI_Fortran_COMPILER=${prefix}/bin/${mpi.f90}
+}
+
+configure.args-append \
+        -DMPI_C_COMPILE_OPTIONS="-lpthread" \
+        -DMPI_Fortran_COMPILE_OPTIONS="-lpthread"
+
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append \
+        -latomic
+}
+
+variant events description {enable support for the Fortran 2015 events feature} {
+    configure.args-append \
+        -DCOMPILER_SUPPORTS_ATOMICS:BOOL=ON
+}
+
+# Do not make this default: known to trigger some bugs on Intel, broken on PPC.
+variant ULFM description {enable experimental ULFM support} {
+    configure.args-append \
+        -DCAF_ENABLE_FAILED_IMAGES:BOOL=ON
 }
 
 test.run            yes
-test.target         test
+test.target         check

--- a/science/OpenCoarrays/files/patch-isnan.diff
+++ b/science/OpenCoarrays/files/patch-isnan.diff
@@ -1,0 +1,76 @@
+--- src/tests/CMakeLists.txt.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/CMakeLists.txt	2022-09-11 01:15:32.000000000 +0700
+@@ -15,6 +15,10 @@
+     )
+ endif()
+ 
++if (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64")
++  add_compile_definitions(DARWIN_PPC)
++endif()
++
+ set( directory_list
+  utilities
+  integration
+
+# Changing extension from f90 to F90 is intended. See: https://stackoverflow.com/questions/31649691/stringify-macro-with-gnu-gfortran
+--- src/tests/integration/pde_solvers/coarrayHeatSimplified/CMakeLists.txt.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayHeatSimplified/CMakeLists.txt	2022-09-11 02:03:18.000000000 +0700
+@@ -4,7 +4,7 @@
+ add_dependencies(local_field caf_mpi_static)
+ add_dependencies(global_field local_field caf_mpi_static)
+ add_executable(co_heat
+-  main.f90
++  main.F90
+   $<TARGET_OBJECTS:local_field>
+   $<TARGET_OBJECTS:global_field>
+ )
+
+--- src/tests/integration/pde_solvers/coarrayHeatSimplified/main.F90.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayHeatSimplified/main.F90	2022-09-11 01:29:09.000000000 +0700
+@@ -26,7 +26,10 @@
+ !
+ 
+ program main
++#ifndef DARWIN_PPC
+   use IEEE_arithmetic, only : IEEE_is_NaN
++#endif
++  
+   use global_field_module, only : global_field
+   implicit none
+   type(global_field) :: T,laplacian_T,T_half
+@@ -44,7 +47,11 @@
+   block 
+     real, allocatable :: residual(:)
+     residual = laplacian_T%state()
++#ifdef DARWIN_PPC
++    if ( any(residual>tolerance) .or. any(isNaN(residual)) .or. any(residual<0) ) error stop "Test failed."
++#else
+     if ( any(residual>tolerance) .or. any(IEEE_is_NaN(residual)) .or. any(residual<0) ) error stop "Test failed."
++#endif
+   end block
+   if (this_image()==1) print *,"Test passed."
+ end program
+
+--- src/tests/integration/pde_solvers/coarrayBurgers/main.F90.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayBurgers/main.F90	2022-09-11 01:28:08.000000000 +0700
+@@ -1,6 +1,8 @@
+ program main
+   use iso_fortran_env, only : real64,int64,compiler_version,compiler_options
++#ifndef DARWIN_PPC
+   use ieee_arithmetic, only : ieee_is_nan
++#endif
+   use global_field_module, only : global_field,initial_condition
+   use ForTrilinos_assertion_utility, only : assert,error_message
+   implicit none
+@@ -39,7 +41,11 @@
+ contains
+   subroutine test(burgers_solution)
+     type(global_field), intent(in) :: burgers_solution
++#ifdef DARWIN_PPC
++    call assert(.not.any(isnan(u%state())),error_message("Test failed: u is not a number."))
++#else
+     call assert(.not.any(ieee_is_nan(u%state())),error_message("Test failed: u is not a number."))
++#endif
+     call assert(sinusoid(u),error_message("Test failed: improper shape."))
+   end subroutine
+ 


### PR DESCRIPTION
#### Description

Intel builds fixed, checks pass.

PPC builds fine, but on Rosetta tests freeze (issue reported on some configurations of FreeBSD). Basic functionality appears okay.

Upstream being astonishingly unhelpful: https://github.com/sourceryinstitute/OpenCoarrays/issues/768

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
