### PR TITLE
legacysupport: do not use_mp_libcxx if we’re not building against libc++

### DIFF
--- a/_resources/port1.0/group/legacysupport-1.1.tcl
+++ b/_resources/port1.0/group/legacysupport-1.1.tcl
@@ -154,6 +154,7 @@ set ls_cache_cppflags [list]
 proc legacysupport::add_legacysupport {} {
     global prefix os.platform os.major
     global ls_cache_incpath ls_cache_ldflags ls_cache_cppflags
+    global configure.cxx_stdlib
 
     if { ${os.platform} eq "darwin" && ${os.major} <= [option legacysupport.newest_darwin_requires_legacy] } {
 
@@ -175,7 +176,7 @@ proc legacysupport::add_legacysupport {} {
         set ls_cache_cppflags "[legacysupport::get_cpp_flags]"
 
         # Flags for using MP libcxx
-        if { [option legacysupport.use_mp_libcxx] } {
+        if { [option legacysupport.use_mp_libcxx] && ${configure.cxx_stdlib} eq "libc++" } {
             legacysupport::add_once depends_lib append port:macports-libcxx
             append ls_cache_incpath  " ${prefix}/include/libcxx/v1"
             append ls_cache_ldflags  " -L${prefix}/lib/libcxx"


### PR DESCRIPTION
#### Description

@mascguy As suggested by @catap – better solve this issue via PG rather than individual ports: https://github.com/macports/macports-ports/commit/3133dc494488dfe355af65b37419800aba5f1e98#commitcomment-83625195

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
