### PR TITLE
glfw: add v3.2.1 as fallback for 10.7-10.8

### DIFF
--- a/graphics/glfw/Portfile
+++ b/graphics/glfw/Portfile
@@ -44,9 +44,24 @@ if {${os.platform} eq "darwin" && ${os.major} == 10} {
 
     patchfiles-append patch-CMakeLists.txt.legacy.diff
 
+} elseif {${os.platform} eq "darwin" && (${os.major} == 11 || ${os.major} == 12) } {
+
+    # Mac OS X 10.7-8: use the latest commit supporting this OS version
+    github.setup    glfw glfw 3.2.1
+    checksums       rmd160  5fb5988736a0a2812426907ab8d64b94eeacc010 \
+                    sha256  34bc25f8111501eec35a52fd39fa50336a0c2e812d4a14454c7c946458ab015c \
+                    size    472539
+
+    long_description ${description}. This version of GLFW is the latest to provide support for \
+        Mac OS X 10.7 and 10.8, and it will not be updated. It is provided in the \
+        hope that it allows ports depending on GLFW to build on these older Mac OS X installs.
+
+    patchfiles      patch-CMakeLists.txt.321.1.diff \
+                    patch-CMakeLists.txt.321.2.diff
+
 } else {
 
-    # Mac OS X 10.7 and newer: release and devel
+    # Mac OS X 10.9 and newer: release and devel
 
     # requires c11 support as of 82ca58da (20190305) for
     # <stdatomic.h>; 3.3 was released shortly after this change, so

--- a/graphics/glfw/files/patch-CMakeLists.txt.321.1.diff
+++ b/graphics/glfw/files/patch-CMakeLists.txt.321.1.diff
@@ -1,0 +1,37 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -356,7 +356,11 @@
+ #--------------------------------------------------------------------
+ include(CMakePackageConfigHelpers)
+ 
+-set(GLFW_CONFIG_PATH "lib${LIB_SUFFIX}/cmake/glfw3")
++if (NOT GLFW_CMAKE_CONFIG_PATH)
++  set(GLFW_CMAKE_CONFIG_PATH "lib${LIB_SUFFIX}")
++endif()
++
++set(GLFW_CONFIG_PATH "${GLFW_CMAKE_CONFIG_PATH}/cmake/glfw3")
+ 
+ configure_package_config_file(src/glfw3Config.cmake.in
+                               src/glfw3Config.cmake
+@@ -386,6 +390,9 @@
+ 
+ if (DOXYGEN_FOUND AND GLFW_BUILD_DOCS)
+     add_subdirectory(docs)
++    if (NOT GLFW_DOCS_PATH)
++        set(GLFW_DOCS_PATH "share/doc/glfw3/")
++    endif()
+ endif()
+ 
+ #--------------------------------------------------------------------
+@@ -406,6 +413,11 @@
+     install(FILES "${GLFW_BINARY_DIR}/src/glfw3.pc"
+             DESTINATION "lib${LIB_SUFFIX}/pkgconfig")
+ 
++    if (DOXYGEN_FOUND AND GLFW_BUILD_DOCS)
++        install(FILES "${GLFW_BINARY_DIR}/docs/html"
++            DESTINATION "${GLFW_DOCS_PATH}")
++    endif()
++
+     # Only generate this target if no higher-level project already has
+     if (NOT TARGET uninstall)
+         configure_file(cmake_uninstall.cmake.in

--- a/graphics/glfw/files/patch-CMakeLists.txt.321.2.diff
+++ b/graphics/glfw/files/patch-CMakeLists.txt.321.2.diff
@@ -1,0 +1,15 @@
+--- src/CMakeLists.txt.orig
++++ src/CMakeLists.txt
+@@ -96,9 +96,10 @@
+     elseif (APPLE)
+         # Add -fno-common to work around a bug in Apple's GCC
+         target_compile_options(glfw PRIVATE "-fno-common")
+-
+-        set_target_properties(glfw PROPERTIES
++	if (NOT CMAKE_INSTALL_NAME_DIR)
++            set_target_properties(glfw PROPERTIES
+                               INSTALL_NAME_DIR "lib${LIB_SUFFIX}")
++	endif()
+     elseif (UNIX)
+         # Hide symbols not explicitly tagged for export from the shared library
+         target_compile_options(glfw PRIVATE "-fvisibility=hidden")


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/65506

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7
Xcode 4.6.3 / 4H1503

patches from git history 20190214 prior to 3.3 update
installed, library names and links verified
not actually tested (is there a way)?

I believe from the build history this is also the last version that built on 10.8