### PR TITLE
istioctl: fix build by patching init.sh

### DIFF
--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 name                istioctl
+revision            1
 
 go.setup            github.com/istio/istio 1.15.0
 categories          sysutils
@@ -31,6 +32,8 @@ go.package          istio.io/istio
 checksums           rmd160  0f2cc3563d0b1215478f7038230d190295b63868 \
                     sha256  7ff4877c0f2553e9a07255c8eab0cea7e2adeb4b038cd38066676eac82ac5293 \
                     size    4851486
+
+patchfiles          patch-init-script.diff
 
 build.cmd           make
 build.target        ${name}

--- a/sysutils/istioctl/files/patch-init-script.diff
+++ b/sysutils/istioctl/files/patch-init-script.diff
@@ -1,0 +1,37 @@
+# https://github.com/istio/istio/pull/40912
+# Remove an unnecessary reference to a URL that no longer works.
+--- bin/init.sh.orig
++++ bin/init.sh
+@@ -65,14 +65,8 @@ ISTIO_ENVOY_LINUX_RELEASE_PATH="${ISTIO_ENVOY_LINUX_RELEASE_PATH:-${ISTIO_ENVOY_
+ ISTIO_ENVOY_CENTOS_LINUX_RELEASE_NAME="${ISTIO_ENVOY_CENTOS_LINUX_RELEASE_NAME:-envoy-centos-${ISTIO_ENVOY_LINUX_VERSION}}"
+ ISTIO_ENVOY_CENTOS_LINUX_RELEASE_PATH="${ISTIO_ENVOY_CENTOS_LINUX_RELEASE_PATH:-${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_CENTOS_LINUX_RELEASE_NAME}}"
+
+-# Envoy macOS vars.
+-# TODO Change url when official envoy release for macOS is available
+-ISTIO_ENVOY_MACOS_VERSION="${ISTIO_ENVOY_MACOS_VERSION:-1.0.2}"
+-ISTIO_ENVOY_MACOS_RELEASE_URL="${ISTIO_ENVOY_MACOS_RELEASE_URL:-https://github.com/istio/proxy/releases/download/${ISTIO_ENVOY_MACOS_VERSION}/istio-proxy-${ISTIO_ENVOY_MACOS_VERSION}-macos.tar.gz}"
+-# Variables for the extracted debug/release Envoy artifacts.
+-ISTIO_ENVOY_MACOS_RELEASE_DIR="${ISTIO_ENVOY_MACOS_RELEASE_DIR:-${TARGET_OUT}/release}"
+-ISTIO_ENVOY_MACOS_RELEASE_NAME="${ISTIO_ENVOY_MACOS_RELEASE_NAME:-envoy-${ISTIO_ENVOY_MACOS_VERSION}}"
+-ISTIO_ENVOY_MACOS_RELEASE_PATH="${ISTIO_ENVOY_MACOS_RELEASE_PATH:-${ISTIO_ENVOY_MACOS_RELEASE_DIR}/${ISTIO_ENVOY_MACOS_RELEASE_NAME}}"
++# There is no longer an Istio built Envoy binary available for the Mac. Copy the Linux binary as the Mac binary was
++# very old and likely no one was really using it (at least temporarily).
+
+ # Download Envoy debug and release binaries for Linux x86_64. They will be included in the
+ # docker images created by Dockerfile.proxyv2.
+@@ -173,14 +167,7 @@ fi
+ # Download and extract the Envoy linux release binary.
+ download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH" "${SIDECAR}"
+ download_envoy_if_necessary "${ISTIO_ENVOY_CENTOS_RELEASE_URL}" "$ISTIO_ENVOY_CENTOS_LINUX_RELEASE_PATH" "${SIDECAR}-centos"
+-
+-if [[ "$GOOS_LOCAL" == "darwin" ]]; then
+-  # Download and extract the Envoy macOS release binary
+-  download_envoy_if_necessary "${ISTIO_ENVOY_MACOS_RELEASE_URL}" "$ISTIO_ENVOY_MACOS_RELEASE_PATH" "${SIDECAR}"
+-  ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_MACOS_RELEASE_PATH}
+-else
+-  ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH}
+-fi
++ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH}
+
+ # Download WebAssembly plugin files
+ WASM_RELEASE_DIR=${ISTIO_ENVOY_LINUX_RELEASE_DIR}


### PR DESCRIPTION
#### Description
Fix the `istioctl` build by applying https://github.com/istio/istio/pull/40912 from upstream.

The release branch (https://github.com/istio/istio/tree/release-1.15) has been updated, so it shouldn't be necessary to manually patch in the future, but they haven't tagged a new release yet.

Closes: https://trac.macports.org/ticket/65805
Istio bug report: https://github.com/istio/istio/issues/40890

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
