### PR TITLE
phantomjs-qt-qtwebkit, qt55-qtwebkit, qt56-qtwebkit: set `known_fail` on 10.7

### DIFF
--- a/aqua/phantomjs-qt/Portfile
+++ b/aqua/phantomjs-qt/Portfile
@@ -657,6 +657,14 @@ foreach {module module_info} [array get modules] {
             # special case
             if { ${module} eq "qtwebkit" } {
 
+                platform darwin 11 {
+                    known_fail yes
+                    pre-fetch {
+                        ui_error "${subport} currently does not build on OS X 10.7, see https://trac.macports.org/ticket/64172"
+                        return -code error "incompatible OS version"
+                    }
+                }
+
                 use_xcode yes
 
                 # from phantomjs build.py

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -1265,6 +1265,14 @@ foreach {module module_info} [array get modules] {
             # special case
             if { ${module} eq "qtwebkit" } {
 
+                platform darwin 11 {
+                    known_fail yes
+                    pre-fetch {
+                        ui_error "${subport} currently does not build on OS X 10.7, see https://trac.macports.org/ticket/64172"
+                        return -code error "incompatible OS version"
+                    }
+                }
+
                 # use MacPorts icu
                 #
                 # qmake uses pkgconfig to look for icu

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -1312,6 +1312,14 @@ foreach {module module_info} [array get modules] {
             # special case
             if { ${module} eq "qtwebkit" } {
 
+                platform darwin 11 {
+                    known_fail yes
+                    pre-fetch {
+                        ui_error "${subport} currently does not build on OS X 10.7, see https://trac.macports.org/ticket/64172"
+                        return -code error "incompatible OS version"
+                    }
+                }
+
                 # use MacPorts icu
                 #
                 # qmake uses pkgconfig to look for icu


### PR DESCRIPTION
See: https://trac.macports.org/ticket/64126
See: https://trac.macports.org/ticket/64172

[skip ci]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
