### PR TITLE
qt(53|55|56|57|58|59|511|513)-qtimageformats: fix build

### DIFF
--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -1585,6 +1585,12 @@ foreach {module module_info} [array get modules] {
                     depends_lib-append  port:${name}-qttools
                 }
             }
+
+            # special case
+            if { ${module} eq "qtimageformats" } {
+                # https://trac.macports.org/ticket/65821
+                patchfiles-append patch-qtimageformats-qjp2handler.cpp.diff
+            }
         }
     }
 

--- a/aqua/qt511/files/patch-qtimageformats-qjp2handler.cpp.diff
+++ b/aqua/qt511/files/patch-qtimageformats-qjp2handler.cpp.diff
@@ -1,0 +1,34 @@
+From 704868db61be1542c2d9e2b75ead00c45c56cc36 Mon Sep 17 00:00:00 2001
+From: "Evgeniy A. Dushistov" <dushistov@mail.ru>
+Date: Sat, 15 Aug 2020 15:09:08 +0300
+Subject: [PATCH] fix build on Arch Linux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp:844:41:
+error: no declaration of «pow»
+  844 |     const double jasperRate = minRate + pow((double(quality) / double(maxQuality)), 2) * maxRate;
+
+Pick-to: 5.15
+Change-Id: I085996c2db2251903b2a3e52e6e648831637c8f9
+Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
+---
+ src/plugins/imageformats/jp2/qjp2handler.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 4311d26..05c7bc1 100644
+--- src/plugins/imageformats/jp2/qjp2handler.cpp.orig
++++ src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -45,6 +45,7 @@
+ #include "qcolor.h"
+ 
+ #include <jasper/jasper.h>
++#include <math.h> // for pow
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+GitLab
+

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -1620,6 +1620,12 @@ foreach {module module_info} [array get modules] {
                     depends_lib-append  port:${name}-qttools
                 }
             }
+
+            # special case
+            if { ${module} eq "qtimageformats" } {
+                # https://trac.macports.org/ticket/65821
+                patchfiles-append patch-qtimageformats-qjp2handler.cpp.diff
+            }
         }
     }
 

--- a/aqua/qt513/files/patch-qtimageformats-qjp2handler.cpp.diff
+++ b/aqua/qt513/files/patch-qtimageformats-qjp2handler.cpp.diff
@@ -1,0 +1,34 @@
+From 704868db61be1542c2d9e2b75ead00c45c56cc36 Mon Sep 17 00:00:00 2001
+From: "Evgeniy A. Dushistov" <dushistov@mail.ru>
+Date: Sat, 15 Aug 2020 15:09:08 +0300
+Subject: [PATCH] fix build on Arch Linux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp:844:41:
+error: no declaration of «pow»
+  844 |     const double jasperRate = minRate + pow((double(quality) / double(maxQuality)), 2) * maxRate;
+
+Pick-to: 5.15
+Change-Id: I085996c2db2251903b2a3e52e6e648831637c8f9
+Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
+---
+ src/plugins/imageformats/jp2/qjp2handler.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 4311d26..05c7bc1 100644
+--- src/plugins/imageformats/jp2/qjp2handler.cpp.orig
++++ src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -45,6 +45,7 @@
+ #include "qcolor.h"
+ 
+ #include <jasper/jasper.h>
++#include <math.h> // for pow
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+GitLab
+

--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -1404,6 +1404,12 @@ foreach {module module_info} [array get modules] {
                     move ${worksrcpath}/src/3rdparty/javascriptcore/VERSION ${worksrcpath}/src/3rdparty/javascriptcore/VERSION.txt
                 }
             }
+
+            # special case
+            if { ${module} eq "qtimageformats" } {
+                # https://trac.macports.org/ticket/65821
+                patchfiles-append patch-qtimageformats-qjp2handler.cpp.diff
+            }
         }
     }
 

--- a/aqua/qt53/files/patch-qtimageformats-qjp2handler.cpp.diff
+++ b/aqua/qt53/files/patch-qtimageformats-qjp2handler.cpp.diff
@@ -1,0 +1,34 @@
+From 704868db61be1542c2d9e2b75ead00c45c56cc36 Mon Sep 17 00:00:00 2001
+From: "Evgeniy A. Dushistov" <dushistov@mail.ru>
+Date: Sat, 15 Aug 2020 15:09:08 +0300
+Subject: [PATCH] fix build on Arch Linux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp:844:41:
+error: no declaration of «pow»
+  844 |     const double jasperRate = minRate + pow((double(quality) / double(maxQuality)), 2) * maxRate;
+
+Pick-to: 5.15
+Change-Id: I085996c2db2251903b2a3e52e6e648831637c8f9
+Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
+---
+ src/plugins/imageformats/jp2/qjp2handler.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 4311d26..05c7bc1 100644
+--- src/plugins/imageformats/jp2/qjp2handler.cpp.orig
++++ src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -50,6 +50,7 @@
+ #define JAS_WIN_MSVC_BUILD
+ #endif
+ #include <jasper/jasper.h>
++#include <math.h> // for pow
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+GitLab
+

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -1466,6 +1466,12 @@ foreach {module module_info} [array get modules] {
                 #   error: cannot initialize a variable of type 'CALayer *' with an rvalue of type 'NSInteger' (aka 'long')
                 patchfiles-append patch-qtmultimedia-avfvideowindowcontrol.mm.diff
             }
+
+            # special case
+            if { ${module} eq "qtimageformats" } {
+                # https://trac.macports.org/ticket/65821
+                patchfiles-append patch-qtimageformats-qjp2handler.cpp.diff
+            }
         }
     }
 

--- a/aqua/qt55/files/patch-qtimageformats-qjp2handler.cpp.diff
+++ b/aqua/qt55/files/patch-qtimageformats-qjp2handler.cpp.diff
@@ -1,0 +1,34 @@
+From 704868db61be1542c2d9e2b75ead00c45c56cc36 Mon Sep 17 00:00:00 2001
+From: "Evgeniy A. Dushistov" <dushistov@mail.ru>
+Date: Sat, 15 Aug 2020 15:09:08 +0300
+Subject: [PATCH] fix build on Arch Linux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp:844:41:
+error: no declaration of «pow»
+  844 |     const double jasperRate = minRate + pow((double(quality) / double(maxQuality)), 2) * maxRate;
+
+Pick-to: 5.15
+Change-Id: I085996c2db2251903b2a3e52e6e648831637c8f9
+Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
+---
+ src/plugins/imageformats/jp2/qjp2handler.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 4311d26..05c7bc1 100644
+--- src/plugins/imageformats/jp2/qjp2handler.cpp.orig
++++ src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -45,6 +45,7 @@
+ #include "qcolor.h"
+ 
+ #include <jasper/jasper.h>
++#include <math.h> // for pow
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+GitLab
+

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -1501,6 +1501,12 @@ foreach {module module_info} [array get modules] {
                 # dependents of qtwebengine
                 supported_archs x86_64
             }
+
+            # special case
+            if { ${module} eq "qtimageformats" } {
+                # https://trac.macports.org/ticket/65821
+                patchfiles-append patch-qtimageformats-qjp2handler.cpp.diff
+            }
         }
     }
 

--- a/aqua/qt56/files/patch-qtimageformats-qjp2handler.cpp.diff
+++ b/aqua/qt56/files/patch-qtimageformats-qjp2handler.cpp.diff
@@ -1,0 +1,34 @@
+From 704868db61be1542c2d9e2b75ead00c45c56cc36 Mon Sep 17 00:00:00 2001
+From: "Evgeniy A. Dushistov" <dushistov@mail.ru>
+Date: Sat, 15 Aug 2020 15:09:08 +0300
+Subject: [PATCH] fix build on Arch Linux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp:844:41:
+error: no declaration of «pow»
+  844 |     const double jasperRate = minRate + pow((double(quality) / double(maxQuality)), 2) * maxRate;
+
+Pick-to: 5.15
+Change-Id: I085996c2db2251903b2a3e52e6e648831637c8f9
+Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
+---
+ src/plugins/imageformats/jp2/qjp2handler.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 4311d26..05c7bc1 100644
+--- src/plugins/imageformats/jp2/qjp2handler.cpp.orig
++++ src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -45,6 +45,7 @@
+ #include "qcolor.h"
+ 
+ #include <jasper/jasper.h>
++#include <math.h> // for pow
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+GitLab
+

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -1577,6 +1577,12 @@ foreach {module module_info} [array get modules] {
                 # dependents of qtwebengine
                 supported_archs x86_64
             }
+
+            # special case
+            if { ${module} eq "qtimageformats" } {
+                # https://trac.macports.org/ticket/65821
+                patchfiles-append patch-qtimageformats-qjp2handler.cpp.diff
+            }
         }
     }
 

--- a/aqua/qt57/files/patch-qtimageformats-qjp2handler.cpp.diff
+++ b/aqua/qt57/files/patch-qtimageformats-qjp2handler.cpp.diff
@@ -1,0 +1,34 @@
+From 704868db61be1542c2d9e2b75ead00c45c56cc36 Mon Sep 17 00:00:00 2001
+From: "Evgeniy A. Dushistov" <dushistov@mail.ru>
+Date: Sat, 15 Aug 2020 15:09:08 +0300
+Subject: [PATCH] fix build on Arch Linux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp:844:41:
+error: no declaration of «pow»
+  844 |     const double jasperRate = minRate + pow((double(quality) / double(maxQuality)), 2) * maxRate;
+
+Pick-to: 5.15
+Change-Id: I085996c2db2251903b2a3e52e6e648831637c8f9
+Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
+---
+ src/plugins/imageformats/jp2/qjp2handler.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 4311d26..05c7bc1 100644
+--- src/plugins/imageformats/jp2/qjp2handler.cpp.orig
++++ src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -45,6 +45,7 @@
+ #include "qcolor.h"
+ 
+ #include <jasper/jasper.h>
++#include <math.h> // for pow
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+GitLab
+

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -1580,6 +1580,12 @@ foreach {module module_info} [array get modules] {
                 # dependents of qtwebengine
                 supported_archs x86_64
             }
+
+            # special case
+            if { ${module} eq "qtimageformats" } {
+                # https://trac.macports.org/ticket/65821
+                patchfiles-append patch-qtimageformats-qjp2handler.cpp.diff
+            }
         }
     }
 

--- a/aqua/qt58/files/patch-qtimageformats-qjp2handler.cpp.diff
+++ b/aqua/qt58/files/patch-qtimageformats-qjp2handler.cpp.diff
@@ -1,0 +1,34 @@
+From 704868db61be1542c2d9e2b75ead00c45c56cc36 Mon Sep 17 00:00:00 2001
+From: "Evgeniy A. Dushistov" <dushistov@mail.ru>
+Date: Sat, 15 Aug 2020 15:09:08 +0300
+Subject: [PATCH] fix build on Arch Linux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp:844:41:
+error: no declaration of «pow»
+  844 |     const double jasperRate = minRate + pow((double(quality) / double(maxQuality)), 2) * maxRate;
+
+Pick-to: 5.15
+Change-Id: I085996c2db2251903b2a3e52e6e648831637c8f9
+Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
+---
+ src/plugins/imageformats/jp2/qjp2handler.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 4311d26..05c7bc1 100644
+--- src/plugins/imageformats/jp2/qjp2handler.cpp.orig
++++ src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -45,6 +45,7 @@
+ #include "qcolor.h"
+ 
+ #include <jasper/jasper.h>
++#include <math.h> // for pow
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+GitLab
+

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -1572,6 +1572,12 @@ foreach {module module_info} [array get modules] {
             }
 
             # special case
+            if { ${module} eq "qtimageformats" } {
+                # https://trac.macports.org/ticket/65821
+                patchfiles-append patch-qtimageformats-qjp2handler.cpp.diff
+            }
+
+            # special case
             if { ${module} eq "qtwebkit-examples" ||
                  ${module} eq "qtwebview"         ||
                  ${module} eq "qtnetworkauth" } {

--- a/aqua/qt59/files/patch-qtimageformats-qjp2handler.cpp.diff
+++ b/aqua/qt59/files/patch-qtimageformats-qjp2handler.cpp.diff
@@ -1,0 +1,34 @@
+From 704868db61be1542c2d9e2b75ead00c45c56cc36 Mon Sep 17 00:00:00 2001
+From: "Evgeniy A. Dushistov" <dushistov@mail.ru>
+Date: Sat, 15 Aug 2020 15:09:08 +0300
+Subject: [PATCH] fix build on Arch Linux
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qtimageformats/src/plugins/imageformats/jp2/qjp2handler.cpp:844:41:
+error: no declaration of «pow»
+  844 |     const double jasperRate = minRate + pow((double(quality) / double(maxQuality)), 2) * maxRate;
+
+Pick-to: 5.15
+Change-Id: I085996c2db2251903b2a3e52e6e648831637c8f9
+Reviewed-by: Shawn Rutledge <shawn.rutledge@qt.io>
+---
+ src/plugins/imageformats/jp2/qjp2handler.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 4311d26..05c7bc1 100644
+--- src/plugins/imageformats/jp2/qjp2handler.cpp.orig
++++ src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -45,6 +45,7 @@
+ #include "qcolor.h"
+ 
+ #include <jasper/jasper.h>
++#include <math.h> // for pow
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65821

[skip ci]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
qt513-qtimageformats successfully built on:
macOS 12.5.1
Xcode  13.4

For others, only the patch phase is tested.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
