### PR TITLE
optpp: update to 20181125, fix config

### DIFF
--- a/math/optpp/Portfile
+++ b/math/optpp/Portfile
@@ -1,40 +1,44 @@
-PortSystem 1.0
-PortGroup  mpi 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name		optpp
-version		2.4
-revision        1
-categories	math
-platforms	darwin
-maintainers	nomaintainer
-license     LGPL
-description	C++ library for non-linear optimization
-long_description	\
-	OPT++ is a C++ library for non-linear optimization.
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           mpi 1.0
 
-homepage	https://software.sandia.gov/opt++/
-distname	optpp-${version}
-master_sites	${homepage}/downloads/
-checksums   md5     7bd39f389c19ef16c3f62bc6ffa06234 \
-            sha1    089fb515f2f2e8632d603f2d1306d39aa355e9f0 \
-            rmd160  1f554c4702dedc24150f198e1a1df35ad1bf9a19
+github.setup        openturns optpp e9e83df1dfbf1a14754dec9078d356480cf5f42d
+version             20181125
+revision            0
+categories          math
+maintainers         nomaintainer
+license             LGPL
+description         C++ library for non-linear optimization
+long_description    OPT++ is a C++ library for non-linear optimization.
 
-compilers.choose cc cxx
+homepage            https://github.com/openturns/optpp
+checksums           rmd160  78e8e3367519c4b7a77e8cf2bac27590203f8518 \
+                    sha256  e8644bd93a4de9183d9d68e0cec00f8ced10a9b273d8927e19f49b04b12992d2 \
+                    size    1248217
+
+compilers.choose    cc cxx
 mpi.setup
 
-patchfiles patch-acx_blas.m4.diff
-use_autoconf yes
-configure.ldflags	"-framework vecLib"
-configure.args --includedir=${prefix}/include/OPT++ --with-blas
+patchfiles-append   patch-acx_blas.m4.diff
+
+use_autoreconf      yes
+
+configure.args-append \
+                    --includedir=${prefix}/include/OPT++ \
+                    --with-blas
+
+configure.ldflags-append \
+                    "-framework Accelerate"
 
 pre-configure {
     if {[mpi_variant_isset]} {
-        configure.args-append --enable-mpi
-        configure.env-append MPICC=${mpi.cc} \
-                             MPICXX=${prefix}/lib/openmpi/bin/mpic++
+        configure.args-append \
+                    --enable-mpi
+        configure.env-append \
+                    MPICC=${prefix}/bin/${mpi.cc} \
+                    MPICXX=${prefix}/bin/${mpi.cxx} \
+                    MPI_RUN_COMMAND=${prefix}/bin/${mpi.exec}
     }
 }
-
-livecheck.type  regex
-livecheck.url   ${master_sites}
-livecheck.regex ${name}-(\[0-9.\]+)\\.tar\\.gz


### PR DESCRIPTION
#### Description

Currently the port is broken completely: https://ports.macports.org/port/optpp/details/
This PR attempts to fix it.
Confirmed to build with `gcc-4.2` without `mpi`, confirmed to build with `+mpich` using gcc12 + mpich 4.0.2.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
