### PR TITLE
textproc/qpdf: update to 11.0.0

### DIFF
--- a/textproc/qpdf/Portfile
+++ b/textproc/qpdf/Portfile
@@ -2,12 +2,13 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           conflicts_build 1.0
 
-github.setup        qpdf qpdf 10.6.3 release-qpdf-
-revision            0
-checksums           rmd160  b65a8f4870035f655864128e47a7c068f03c2a41 \
-                    sha256  e8fc23b2a584ea68c963a897515d3eb3129186741dd19d13c86d31fa33493811 \
-                    size    18573584
+github.setup        qpdf qpdf 11.0.0 v
+checksums           rmd160  4d37f8ae55027f1441a863a9324afd17d21ad6ef \
+                    sha256  8d99e98893f68f52ca3b579770e7e6f4c96612084d6a0e7e05854a6d631b8fe6 \
+                    size    18452218
 
 categories          textproc pdf
 license             Apache-2
@@ -26,6 +27,16 @@ depends_lib         path:include/turbojpeg.h:libjpeg-turbo \
                     port:zlib
 
 compiler.cxx_standard   2014
+cmake.build_type        Release
+configure.args          -DUSE_IMPLICIT_CRYPTO=0 \
+                        -DREQUIRE_CRYPTO_NATIVE=1 \
+                        -DREQUIRE_CRYPTO_GNUTLS=0 \
+                        -DREQUIRE_CRYPTO_OPENSSL=0
+
+# qPDF-11 builds with CMake which will use allready-installed
+# headers if they are available, unfortunately. So you cannot
+# simply `port update` if qPDF-10 is installed, sadly.
+conflicts_build ${name}
 
 platform darwin 8 {
     depends_build-append \
@@ -33,16 +44,16 @@ platform darwin 8 {
     build.cmd           gmake
 }
 
-variant gnutls conflicts openssl description {Build against gnutls} {
-    depends_lib-append  path:lib/pkgconfig/gnutls.pc:gnutls
-    configure.args      --disable-crypto-openssl \
-                        --enable-crypto-gnutls
+variant gnutls description {Build against gnutls} {
+    depends_lib-append      path:lib/pkgconfig/gnutls.pc:gnutls
+    configure.args-delete   -DREQUIRE_CRYPTO_GNUTLS=0
+    configure.args-append   -DREQUIRE_CRYPTO_GNUTLS=1
 }
 
-variant openssl conflicts gnutls description {Build against openssl} {
-    depends_lib-append  port:openssl
-    configure.args      --disable-crypto-gnutls \
-                        --enable-crypto-openssl
+variant openssl description {Build against openssl} {
+    depends_lib-append      port:openssl
+    configure.args-delete   -DREQUIRE_CRYPTO_OPENSSL=0
+    configure.args-append   -DREQUIRE_CRYPTO_OPENSSL=1
 }
 
 if {![variant_isset openssl]} {


### PR DESCRIPTION
* update to 11.0.0
* use the new crypto provider settings
* unfortunately now conflicts_build with itself

Signed-off-by: Andrew Fernandes <andrew@fernandes.org>
