### PR TITLE
py-undetected-chromedriver: Bugfix run dependency, clean up tests

### DIFF
--- a/python/py-undetected-chromedriver/Portfile
+++ b/python/py-undetected-chromedriver/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-undetected-chromedriver
 version             3.1.5.post4
+revision            1
 categories-append   python www
 maintainers         nomaintainer
 license             GPL-3
@@ -27,14 +28,11 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:python${python.version} \
                     port:py${python.version}-requests \
-                    port:py${python.version}-setuptools \
-                    port:py${python.version}-websockets
+                    port:py${python.version}-setuptools
 
     depends_lib-append \
-                    port:py${python.version}-selenium
-
-    depends_test-append \
-                    port:py${python.version}-pytest
+                    port:py${python.version}-selenium \
+                    port:py${python.version}-websockets
 
     post-patch {
         fs-traverse f ${worksrcpath}/undetected_chromedriver {
@@ -47,8 +45,6 @@ if {${name} ne ${subport}} {
     }
 
     test.run        yes
-    test.env-append PYTHONPATH=${worksrcpath}/build/lib
-    test.cmd        py.test-${python.branch}
     test.target     tests/v2/test_uc.py
 }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
