### PR TITLE
qt511-qtconnectivity: fix for recent compilers

### DIFF
--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -1333,6 +1333,11 @@ foreach {module module_info} [array get modules] {
             ###############################################################################
 
             # special case
+            if { ${module} eq "qtconnectivity" } {
+                patchfiles-append patch-qtconnectivity_qtbug_76847.diff
+            }
+
+            # special case
             if { ${module} eq "qtdoc" } {
                 build.target    docs
                 destroot.target install_docs

--- a/aqua/qt511/files/patch-qtconnectivity_qtbug_76847.diff
+++ b/aqua/qt511/files/patch-qtconnectivity_qtbug_76847.diff
@@ -1,0 +1,295 @@
+From 8110fdd4c6d80d05934768fa808a4cb187212fe0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andr=C3=A9=20Klitzing?= <aklitzing@gmail.com>
+Date: Fri, 19 Jul 2019 11:06:59 +0200
+Subject: [PATCH] Core/IO/Bluetooth - fix ambiguous conversions for macOS
+
+This is a sibling of QTBUG-76847 on macOS instead of iOS.
+
+Change-Id: I3df6e28d65b9835f5f54e92d462d23423c48d835
+Reviewed-by: Timur Pocheptsov <timur.pocheptsov@qt.io>
+---
+ .../qbluetoothdevicediscoveryagent_osx.mm     |  6 ++---
+ src/bluetooth/qbluetoothlocaldevice_osx.mm    |  2 +-
+ src/bluetooth/qbluetoothserver_osx.mm         |  6 ++---
+ src/bluetooth/qbluetoothserviceinfo_osx.mm    |  2 +-
+ src/bluetooth/qbluetoothsocket_osx.mm         | 26 +++++++++----------
+ src/bluetooth/qbluetoothtransferreply_osx.mm  | 10 +++----
+ 6 files changed, 26 insertions(+), 26 deletions(-)
+
+diff --git a/src/bluetooth/qbluetoothdevicediscoveryagent_osx.mm b/src/bluetooth/qbluetoothdevicediscoveryagent_osx.mm
+index 4657da82..bdc3c85e 100644
+--- src/bluetooth/qbluetoothdevicediscoveryagent_osx.mm
++++ src/bluetooth/qbluetoothdevicediscoveryagent_osx.mm
+@@ -181,7 +181,7 @@ QBluetoothDeviceDiscoveryAgentPrivate::QBluetoothDeviceDiscoveryAgentPrivate(con
+ 
+ QBluetoothDeviceDiscoveryAgentPrivate::~QBluetoothDeviceDiscoveryAgentPrivate()
+ {
+-    if (inquiryLE && agentState != NonActive) {
++    if (inquiryLE.data() && agentState != NonActive) {
+         // We want the LE scan to stop as soon as possible.
+         if (dispatch_queue_t leQueue = OSXBluetooth::qt_LE_queue()) {
+             // Local variable to be retained ...
+@@ -195,7 +195,7 @@ QBluetoothDeviceDiscoveryAgentPrivate::~QBluetoothDeviceDiscoveryAgentPrivate()
+ 
+ bool QBluetoothDeviceDiscoveryAgentPrivate::isValid() const
+ {
+-    return hostController && [hostController powerState] == kBluetoothHCIPowerStateON;
++    return hostController.data() && [hostController powerState] == kBluetoothHCIPowerStateON;
+ }
+ 
+ bool QBluetoothDeviceDiscoveryAgentPrivate::isActive() const
+@@ -292,7 +292,7 @@ void QBluetoothDeviceDiscoveryAgentPrivate::startLE()
+ 
+     // Check queue and create scanner:
+     inquiryLE.reset([[LEDeviceInquiryObjC alloc] initWithNotifier:notifier.data()]);
+-    if (inquiryLE)
++    if (inquiryLE.data())
+         notifier.take(); // Whatever happens next, inquiryLE is already the owner ...
+ 
+     dispatch_queue_t leQueue(qt_LE_queue());
+diff --git a/src/bluetooth/qbluetoothlocaldevice_osx.mm b/src/bluetooth/qbluetoothlocaldevice_osx.mm
+index 52b7bba8..e7dd9906 100644
+--- src/bluetooth/qbluetoothlocaldevice_osx.mm
++++ src/bluetooth/qbluetoothlocaldevice_osx.mm
+@@ -149,7 +149,7 @@ QBluetoothLocalDevicePrivate::QBluetoothLocalDevicePrivate(QBluetoothLocalDevice
+ 
+ bool QBluetoothLocalDevicePrivate::isValid() const
+ {
+-    return hostController;
++    return hostController.data();
+ }
+ 
+ void QBluetoothLocalDevicePrivate::requestPairing(const QBluetoothAddress &address, Pairing pairing)
+diff --git a/src/bluetooth/qbluetoothserver_osx.mm b/src/bluetooth/qbluetoothserver_osx.mm
+index eefaf4da..5d3b8fc4 100644
+--- src/bluetooth/qbluetoothserver_osx.mm
++++ src/bluetooth/qbluetoothserver_osx.mm
+@@ -142,7 +142,7 @@ void QBluetoothServerPrivate::stopListener()
+ 
+ void QBluetoothServerPrivate::openNotify(IOBluetoothRFCOMMChannel *channel)
+ {
+-    Q_ASSERT_X(listener, Q_FUNC_INFO, "invalid listener (nil)");
++    Q_ASSERT_X(listener.data(), Q_FUNC_INFO, "invalid listener (nil)");
+     Q_ASSERT_X(channel, Q_FUNC_INFO, "invalid channel (nil)");
+     Q_ASSERT_X(q_ptr, Q_FUNC_INFO, "invalid q_ptr (null)");
+ 
+@@ -154,7 +154,7 @@ void QBluetoothServerPrivate::openNotify(IOBluetoothRFCOMMChannel *channel)
+ 
+ void QBluetoothServerPrivate::openNotify(IOBluetoothL2CAPChannel *channel)
+ {
+-    Q_ASSERT_X(listener, Q_FUNC_INFO, "invalid listener (nil)");
++    Q_ASSERT_X(listener.data(), Q_FUNC_INFO, "invalid listener (nil)");
+     Q_ASSERT_X(channel, Q_FUNC_INFO, "invalid channel (nil)");
+     Q_ASSERT_X(q_ptr, Q_FUNC_INFO, "invalid q_ptr (null)");
+ 
+@@ -293,7 +293,7 @@ bool QBluetoothServer::listen(const QBluetoothAddress &address, quint16 port)
+ 
+     OSXBluetooth::qt_test_iobluetooth_runloop();
+ 
+-    if (d_ptr->listener) {
++    if (d_ptr->listener.data()) {
+         qCWarning(QT_BT_OSX) << "already in listen mode, close server first";
+         return false;
+     }
+diff --git a/src/bluetooth/qbluetoothserviceinfo_osx.mm b/src/bluetooth/qbluetoothserviceinfo_osx.mm
+index 34de4695..7ce4c645 100644
+--- src/bluetooth/qbluetoothserviceinfo_osx.mm
++++ src/bluetooth/qbluetoothserviceinfo_osx.mm
+@@ -152,7 +152,7 @@ bool QBluetoothServiceInfoPrivate::unregisterService()
+     if (!registered)
+         return false;
+ 
+-    Q_ASSERT_X(serviceRecord, Q_FUNC_INFO, "service registered, but serviceRecord is nil");
++    Q_ASSERT_X(serviceRecord.data(), Q_FUNC_INFO, "service registered, but serviceRecord is nil");
+ 
+     [serviceRecord removeServiceRecord];
+     serviceRecord.reset(nil);
+diff --git a/src/bluetooth/qbluetoothsocket_osx.mm b/src/bluetooth/qbluetoothsocket_osx.mm
+index 7f630146..2a856092 100644
+--- src/bluetooth/qbluetoothsocket_osx.mm
++++ src/bluetooth/qbluetoothsocket_osx.mm
+@@ -103,13 +103,13 @@ void QBluetoothSocketPrivate::connectToService(const QBluetoothAddress &address,
+ 
+     if (socketType == QBluetoothServiceInfo::RfcommProtocol) {
+         rfcommChannel.reset([[ObjCRFCOMMChannel alloc] initWithDelegate:this]);
+-        if (rfcommChannel)
++        if (rfcommChannel.data())
+             status = [rfcommChannel connectAsyncToDevice:address withChannelID:port];
+         else
+             status = kIOReturnNoMemory;
+     } else if (socketType == QBluetoothServiceInfo::L2capProtocol) {
+         l2capChannel.reset([[ObjCL2CAPChannel alloc] initWithDelegate:this]);
+-        if (l2capChannel)
++        if (l2capChannel.data())
+             status = [l2capChannel connectAsyncToDevice:address withPSM:port];
+         else
+             status = kIOReturnNoMemory;
+@@ -183,10 +183,10 @@ QString QBluetoothSocketPrivate::peerName() const
+ 
+     NSString *nsName = nil;
+     if (socketType == QBluetoothServiceInfo::RfcommProtocol) {
+-        if (rfcommChannel)
++        if (rfcommChannel.data())
+             nsName = [rfcommChannel peerName];
+     } else if (socketType == QBluetoothServiceInfo::L2capProtocol) {
+-        if (l2capChannel)
++        if (l2capChannel.data())
+             nsName = [l2capChannel peerName];
+     }
+ 
+@@ -200,10 +200,10 @@ QBluetoothAddress QBluetoothSocketPrivate::peerAddress() const
+ {
+     BluetoothDeviceAddress addr = {};
+     if (socketType == QBluetoothServiceInfo::RfcommProtocol) {
+-        if (rfcommChannel)
++        if (rfcommChannel.data())
+             addr = [rfcommChannel peerAddress];
+     } else if (socketType == QBluetoothServiceInfo::L2capProtocol) {
+-        if (l2capChannel)
++        if (l2capChannel.data())
+             addr = [l2capChannel peerAddress];
+     }
+ 
+@@ -213,10 +213,10 @@ QBluetoothAddress QBluetoothSocketPrivate::peerAddress() const
+ quint16 QBluetoothSocketPrivate::peerPort() const
+ {
+     if (socketType == QBluetoothServiceInfo::RfcommProtocol) {
+-        if (rfcommChannel)
++        if (rfcommChannel.data())
+             return [rfcommChannel getChannelID];
+     } else if (socketType == QBluetoothServiceInfo::L2capProtocol) {
+-        if (l2capChannel)
++        if (l2capChannel.data())
+             return [l2capChannel getPSM];
+     }
+ 
+@@ -233,7 +233,7 @@ void QBluetoothSocketPrivate::_q_writeNotify()
+     Q_ASSERT_X(socketType == QBluetoothServiceInfo::L2capProtocol
+                || socketType == QBluetoothServiceInfo::RfcommProtocol,
+                Q_FUNC_INFO, "invalid socket type");
+-    Q_ASSERT_X(l2capChannel || rfcommChannel, Q_FUNC_INFO,
++    Q_ASSERT_X(l2capChannel.data() || rfcommChannel.data(), Q_FUNC_INFO,
+                "invalid socket (no open channel)");
+     Q_ASSERT_X(q_ptr, Q_FUNC_INFO, "invalid q_ptr (null)");
+ 
+@@ -277,13 +277,13 @@ bool QBluetoothSocketPrivate::setChannel(IOBluetoothRFCOMMChannel *channel)
+ 
+     openMode = QIODevice::ReadWrite;
+     rfcommChannel.reset([[ObjCRFCOMMChannel alloc] initWithDelegate:this channel:channel]);
+-    if (rfcommChannel) {// We do not handle errors, up to an external user.
++    if (rfcommChannel.data()) {// We do not handle errors, up to an external user.
+         q_ptr->setOpenMode(QIODevice::ReadWrite);
+         state = QBluetoothSocket::ConnectedState;
+         socketType = QBluetoothServiceInfo::RfcommProtocol;
+     }
+ 
+-    return rfcommChannel;
++    return rfcommChannel.data();
+ }
+ 
+ bool QBluetoothSocketPrivate::setChannel(IOBluetoothL2CAPChannel *channel)
+@@ -301,13 +301,13 @@ bool QBluetoothSocketPrivate::setChannel(IOBluetoothL2CAPChannel *channel)
+ 
+     openMode = QIODevice::ReadWrite;
+     l2capChannel.reset([[ObjCL2CAPChannel alloc] initWithDelegate:this channel:channel]);
+-    if (l2capChannel) {// We do not handle errors, up to an external user.
++    if (l2capChannel.data()) {// We do not handle errors, up to an external user.
+         q_ptr->setOpenMode(QIODevice::ReadWrite);
+         state = QBluetoothSocket::ConnectedState;
+         socketType = QBluetoothServiceInfo::L2capProtocol;
+     }
+ 
+-    return l2capChannel;
++    return l2capChannel.data();
+ }
+ 
+ 
+diff --git a/src/bluetooth/qbluetoothtransferreply_osx.mm b/src/bluetooth/qbluetoothtransferreply_osx.mm
+index 65c8f82d..40a747f8 100644
+--- src/bluetooth/qbluetoothtransferreply_osx.mm
++++ src/bluetooth/qbluetoothtransferreply_osx.mm
+@@ -136,13 +136,13 @@ QBluetoothTransferReplyOSXPrivate::~QBluetoothTransferReplyOSXPrivate()
+     // The OBEX session will be closed then. If
+     // somehow IOBluetooth/OBEX still has a reference to our
+     // session, it will not call any of delegate's callbacks.
+-    if (session)
++    if (session.data())
+         [session closeSession];
+ }
+ 
+ bool QBluetoothTransferReplyOSXPrivate::isActive() const
+ {
+-    return agent || (session && [session hasActiveRequest]);
++    return agent.data() || (session.data() && [session hasActiveRequest]);
+ }
+ 
+ bool QBluetoothTransferReplyOSXPrivate::startOPP(const QBluetoothAddress &device)
+@@ -218,7 +218,7 @@ void QBluetoothTransferReplyOSXPrivate::sendConnect(const QBluetoothAddress &dev
+ void QBluetoothTransferReplyOSXPrivate::sendPut()
+ {
+     Q_ASSERT_X(inputStream, Q_FUNC_INFO, "invalid input stream (null)");
+-    Q_ASSERT_X(session, Q_FUNC_INFO, "invalid OBEX session (nil)");
++    Q_ASSERT_X(session.data(), Q_FUNC_INFO, "invalid OBEX session (nil)");
+     Q_ASSERT_X([session isConnected], Q_FUNC_INFO, "not connected");
+     Q_ASSERT_X(![session hasActiveRequest], Q_FUNC_INFO,
+                "session already has an active request");
+@@ -268,7 +268,7 @@ void QBluetoothTransferReplyOSXPrivate::OBEXConnectError(OBEXError errorCode, OB
+     Q_UNUSED(errorCode)
+     Q_UNUSED(response)
+ 
+-    if (session) {
++    if (session.data()) {
+         setReplyError(QBluetoothTransferReply::SessionError,
+                       QCoreApplication::translate(TRANSFER_REPLY, TR_CONNECT_FAILED));
+     } else {
+@@ -283,7 +283,7 @@ void QBluetoothTransferReplyOSXPrivate::OBEXConnectError(OBEXError errorCode, OB
+ void QBluetoothTransferReplyOSXPrivate::OBEXConnectSuccess()
+ {
+     // Now that OBEX connect succeeded, we can send an OBEX put request.
+-    if (!session) {
++    if (!session.data()) {
+         // We're still in OBEXConnect(), it'll take care of next steps.
+         return;
+     }
+--- src/bluetooth/osx/osxbtledeviceinquiry.mm-orig	2020-01-25 06:17:56.000000000 -0600
++++ src/bluetooth/osx/osxbtledeviceinquiry.mm	2020-01-25 06:18:01.000000000 -0600
+@@ -129,7 +129,7 @@
+ 
+ - (void)dealloc
+ {
+-    if (manager) {
++    if (manager.data()) {
+         [manager setDelegate:nil];
+         if (internalState == InquiryActive)
+             [manager stopScan];
+--- src/bluetooth/osx/osxbtperipheralmanager.mm.orig
++++ src/bluetooth/osx/osxbtperipheralmanager.mm
+@@ -313,7 +313,7 @@
+ - (void)startAdvertising
+ {
+     state = PeripheralState::waitingForPowerOn;
+-    if (manager)
++    if (manager.data())
+         [manager setDelegate:nil];
+     manager.reset([[CBPeripheralManager alloc] initWithDelegate:self
+                    queue:OSXBluetooth::qt_LE_queue()]);
+@@ -378,7 +378,7 @@
+ 
+ - (void) addServicesToPeripheral
+ {
+-    Q_ASSERT(manager);
++    Q_ASSERT(manager.data());
+ 
+     if (nextServiceToAdd < services.size())
+         [manager addService:services[nextServiceToAdd++]];
+--- src/bluetooth/qlowenergycontroller_osx.mm.orig
++++ src/bluetooth/qlowenergycontroller_osx.mm
+@@ -202,7 +202,7 @@
+ #ifdef Q_OS_TVOS
+     return centralManager;
+ #else
+-    return centralManager || peripheralManager;
++    return centralManager.data() || peripheralManager.data();
+ #endif
+ }
+ 


### PR DESCRIPTION
See: https://trac.macports.org/ticket/60889

[skip ci]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.5.1
Xcode 13.4
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
