### PR TITLE
nodejs18: use MacPorts' newly upgraded ICU 71.1

### DIFF
--- a/devel/nodejs18/Portfile
+++ b/devel/nodejs18/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs18
 version                 18.9.0
-revision                1
+revision                2
 
 categories              devel net
 platforms               darwin
@@ -43,11 +43,9 @@ depends_build-append    port:pkgconfig
 set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
-depends_lib-append      port:python${py_ver_nodot} \
+depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
+                        port:python${py_ver_nodot} \
                         port:zlib
-
-# TODO: when icu is upgraded to v68.x, use MacPorts'.
-#depends_lib-append             path:lib/pkgconfig/icu-uc.pc:icu
 
 # error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
 set min_darwin 13
@@ -96,15 +94,14 @@ post-patch {
 pre-configure {
     # Copy zlib headers here because we do not want to prepend the entire
     # ${prefix}/include to the include path (the build will then attempt to use
-    # ICU 67 headers)
+    # ICU headers)
     file mkdir ${workpath}/zlib-inc
     file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
         ${workpath}/zlib-inc/
 }
 
 configure.args-append   --without-npm
-# TODO: when icu is upgraded to v68.x, use MacPorts'.
-# configure.args-append   --with-intl=system-icu
+configure.args-append   --with-intl=system-icu
 configure.args-append   --shared-zlib
 configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
 configure.args-append   --shared-zlib-libpath=${prefix}/lib


### PR DESCRIPTION
#### Description

Switch to using the system's ICU. A nice reduction in size of the binary. Before:

```
$ ls -l /opt/local/bin/node                                          
-rwxr-xr-x 1 root admin 83973832 Sep 12 02:25 /opt/local/bin/node
$ /usr/bin/otool -L /opt/local/bin/node                              
/opt/local/bin/node:                                                            
        /opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)                                                                       
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1775.118.101)             
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.100.5)                                                                    
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 905.6.0)
```

After:

```
$ ls -l /opt/local/bin/node                                          
-rwxr-xr-x 1 root admin 47788464 Sep 12 03:36 /opt/local/bin/node
$ /usr/bin/otool -L /opt/local/bin/node                              
/opt/local/bin/node:                                                            
        /opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)                                                                       
        /opt/local/lib/libicui18n.71.dylib (compatibility version 71.0.0, current version 71.1.0)                                                               
        /opt/local/lib/libicuuc.71.dylib (compatibility version 71.0.0, current version 71.1.0)                                                                 
        /opt/local/lib/libicudata.71.dylib (compatibility version 71.0.0, current version 71.1.0)                                                               
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1775.118.101)             
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.100.5)                                                                    
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 905.6.0)
```

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.6.8 20G730 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
