### PR TITLE
tippecanoe: update to 2.6.0

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -6,18 +6,17 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            mapbox tippecanoe 1.36.0
+github.setup            felt tippecanoe 2.6.0
 revision                0
 categories              gis
 license                 BSD
-maintainers             {@sikmir gmail.com:sikmir} openmaintainer
-platforms               darwin
+maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Build vector tilesets from large collections of GeoJSON features
-long_description        ${description}
+long_description        {*}${description}
 
-checksums               rmd160  685878a57d9170d9bdb86e8253a6faa126419b0d \
-                        sha256  274ef274808ed847d3612e8906fbaf16d0b17516b9d7b3b342389f8c0a659d2e \
-                        size    16240869
+checksums               rmd160  2c2e10de56195772a416b7334fc463c50824d02b \
+                        sha256  dc598907d707cf088b5a29fe04b255ff81920f3e6863f3144481383c50774fd7 \
+                        size    17318392
 
 depends_lib-append      port:sqlite3 \
                         port:zlib
@@ -25,3 +24,5 @@ depends_lib-append      port:sqlite3 \
 destroot.args-append    PREFIX=${destroot}${prefix}
 
 compiler.blacklist-append {clang < 500}
+
+test.run                yes


### PR DESCRIPTION
#### Description
From [README](https://github.com/felt/tippecanoe/blob/main/README.md):
> This intends to be an actively maintained fork of [tippecanoe](https://github.com/mapbox/tippecanoe) originally developed by [Erica Fischer](https://github.com/e-n-f) at Mapbox. Version 2.0.0 is equivalent to [1.36.0](https://github.com/mapbox/tippecanoe/tree/1.36.0) in the original repository. Thank you Mapbox and Erica for an incredible tool!

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
