### PR TITLE
json2tsv: new port

### DIFF
--- a/textproc/json2tsv/Portfile
+++ b/textproc/json2tsv/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+
+name                json2tsv
+version             1.0
+revision            0
+license             MIT
+
+categories          textproc
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+description         JSON to TSV converter
+long_description    {*}${description}
+
+homepage            https://codemadness.org/json2tsv.html
+
+master_sites        https://codemadness.org/releases/${name}/
+
+checksums           rmd160  8c27844d009f343d2aa82139a5de7edab8df1a5c \
+                    sha256  04e6a60d6b33603a8a19d28e94038b63b17d49c65a0495cd761cf7f22616de9b \
+                    size    8551
+
+makefile.override   PREFIX
+
+livecheck.type      regex
+livecheck.url       [lindex ${master_sites} 0]
+livecheck.regex     href=\"json2tsv-(.*)\\.tar\\.gz\"


### PR DESCRIPTION
#### Description
[**json2tsv**](https://codemadness.org/json2tsv.html): a JSON to TSV converter.

[![Packaging status](https://repology.org/badge/tiny-repos/json2tsv.svg)](https://repology.org/project/json2tsv/versions)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
