### PR TITLE
cdo: update to 2.0.6

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -4,19 +4,19 @@ PortSystem                  1.0
 PortGroup                   mpi 1.0
 
 name                        cdo
-version                     2.0.5
-revision                    1
+version                     2.0.6
+revision                    0
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
 license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/26823
+master_sites                https://code.mpimet.mpg.de/attachments/download/27276
 
-checksums           rmd160  c2b6c60cba15c37dca3c4573d6734abbb0c74d96 \
-                    sha256  edeebbf1c3b1a1f0c642dae6bc8c7624e0c54babe461064dc5c7daca4a5b0dce \
-                    size    11791780
+checksums           rmd160  a1046c666449a2c465eb8af3b6be0d2b42fc95e0 \
+                    sha256  ef120dea9032b1be80a4cfa201958c3b910107205beb6674195675f1ee8ed402 \
+                    size    11981469
 
 long_description \
     CDO is a collection of command line Operators               \
@@ -39,7 +39,8 @@ depends_lib                 port:netcdf \
                             port:proj8 \
                             port:fftw-3
 
-patchfiles                  patch-skip-nc4-test.diff
+patchfiles                  patch-skip-nc4-test.diff \
+                            patch-cdo-2.0.6-missing-include.diff
 
 configure.args              --with-netcdf=${prefix} \
                             --disable-dependency-tracking \

--- a/science/cdo/files/patch-cdo-2.0.6-missing-include.diff
+++ b/science/cdo/files/patch-cdo-2.0.6-missing-include.diff
@@ -1,0 +1,13 @@
+# Patch needed for cdo version 2.0.6. Should be fixed in next version.
+# See: https://code.mpimet.mpg.de/boards/2/topics/13186?r=13240#message-13240
+# 
+--- src/cdo_fft.cc.orig	2022-07-11 14:51:10.000000000 +0200
++++ src/cdo_fft.cc	2022-09-13 15:56:27.000000000 +0200
+@@ -1,6 +1,7 @@
+ // This source code is copied from PINGO version 1.5
+ 
+ #include <cmath>
++#include <algorithm>
+ 
+ namespace cdo
+ {


### PR DESCRIPTION
#### Description

Update to upstream version 2.0.6.
This required an additional patch (patch-cdo-2.0.6-missing-include.diff) as the maintainers confirmed that an include line was missing in src/cdo_fft.cc
See: https://code.mpimet.mpg.de/boards/2/topics/13186?r=13240#message-13240

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 x86_64
Command Line Tools 13.4.0.0.1.1651278267


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
