### PR TITLE
bitwarden-cli: update to 2022.9.0

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                bitwarden-cli
-version             2022.8.0
+version             2022.9.0
 revision            0
 
 npm.rootname        @bitwarden/cli
@@ -19,6 +19,6 @@ description         Bitwarden password manager CLI
 long_description    CLI implementation of the Bitwarden password manager.
 homepage            https://bitwarden.com
 
-checksums           rmd160  6aa857e7a2144b0feb8ef27f8a9f5307ba6a8674 \
-                    sha256  6a9f6f2be0c8ed08ee7a35aefb15b31889a4dac83bf49ba95e67542ba682e153 \
-                    size    584974
+checksums           rmd160  e17af948ff200d0cf41c878add0135fe28eae16f \
+                    sha256  66df0a2f1dc842863d6342ff386018e204c08e721edf667ed78651aa822ec26c \
+                    size    587164


### PR DESCRIPTION
#### Description

Created with [seaport](https://seaport.rtfd.io/), the modern MacPorts portfile updater.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?