### PR TITLE
google-cloud-sdk: update to 402.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             401.0.0
+version             402.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  555747db2562e59904bfa4bf07532d70d2ea9c63 \
-                    sha256  c0c2566b925d65df816d120ffddec5a1a35f5292c7a0202f4cfc5d4f29c404b1 \
-                    size    109073502
+    checksums       rmd160  e356209d08b6f499e0fa309853195665a82adabc \
+                    sha256  943470764f8426fe97132a6f82a1559c786c009f939532dcac71e8466341d1fb \
+                    size    109172516
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  7347ad86167e93dfff6b5796b9f4c446ba6f22e8 \
-                    sha256  8bdeea7ec803681b465ee46e790f4f9b96e6dda69c8975860446fd94d22245d6 \
-                    size    96517122
+    checksums       rmd160  672ca2aa768f3207a24d8f907ec1e48d832b1340 \
+                    sha256  b8a9758e9689216e1a300bd8c25ca8b0a310cd8111aa366382846187cd2fc168 \
+                    size    96613044
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d920314181ee9fb20eff7fd8354553c00fe1359a \
-                    sha256  c1223af0ccee98259450f2dfe61341463254b14416c96fadc98e75b2ac0eb995 \
-                    size    95127745
+    checksums       rmd160  c6fcc743629147749be0e0addee885475c76a14f \
+                    sha256  d06707dcd8cfdcc9d833662a5d78ceca76e4cabba3195fee11eac52aba2cc0cc \
+                    size    95228264
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 402.0.0.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?