### PR TITLE
istioctl: update livecheck

### DIFF
--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -25,7 +25,9 @@ long_description    Istio is an open, platform-independent service mesh designed
                     The port deploys the istioctl command line utility, \
                     used to create, list, modify, and delete configuration \
                     resources in a deployed Istio system.
-livecheck.url       ${github.homepage}/releases
+
+github.livecheck.regex \
+                    {([0-9.]+)}
 
 go.package          istio.io/istio
 


### PR DESCRIPTION
#### Description
Switch the `istioctl` livecheck back to the default GitHub tag page and exclude tags with a suffix.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
