### PR TITLE
xar: Don't overlink to libxml2's dependencies

### DIFF
--- a/archivers/xar/Portfile
+++ b/archivers/xar/Portfile
@@ -8,7 +8,7 @@ PortGroup           openssl 1.0
 set apple_version   487.100.1
 github.setup        apple-oss-distributions xar ${apple_version} xar-
 version             1.8.0.${apple_version}
-revision            1
+revision            2
 
 categories          archivers sysutils
 license             BSD
@@ -29,7 +29,6 @@ depends_build       port:pkgconfig \
 
 depends_lib         port:bzip2 \
                     port:libxml2 \
-                    path:lib/pkgconfig/icu-uc.pc:icu \
                     port:zlib
 
 # from Debian: restore *ssl support, etc
@@ -56,6 +55,9 @@ patchfiles-append   patch-src-xar_internal.h.diff
 
 # see: https://trac.macports.org/ticket/65128
 patchfiles-append   patch-lib-filetree.c.diff
+
+# see: https://trac.macports.org/ticket/65839
+patchfiles-append   dont-overlink-to-libxml2.patch
 
 post-patch {
     copy -force ${prefix}/share/automake-1.16/config.guess ${worksrcpath}

--- a/archivers/xar/files/dont-overlink-to-libxml2.patch
+++ b/archivers/xar/files/dont-overlink-to-libxml2.patch
@@ -1,0 +1,11 @@
+--- configure.ac.orig	2022-05-03 23:39:20.000000000 -0500
++++ configure.ac	2022-09-14 22:39:09.000000000 -0500
+@@ -306,7 +306,7 @@
+   AC_MSG_RESULT([${LIBXML2_MAJOR}.${LIBXML2_MINOR}.${LIBXML2_BRANCH}])
+   have_libxml2="1"
+   CPPFLAGS="${CPPFLAGS} `${XML2_CONFIG} --cflags`"
+-  LIBS="${LIBS} `${XML2_CONFIG} --libs`"
++  LIBS="${LIBS} `${XML2_CONFIG} --libs --dynamic`"
+ else
+   AC_MSG_RESULT([no])
+   have_libxml2="0"


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/65839

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H1824 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
