### PR TITLE
rclone: add mount variant

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/rclone/rclone 1.59.1 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://rclone.org
 
@@ -40,10 +40,20 @@ build.pre_args-append \
         -X github.com/rclone/rclone/fs.Version=${github.tag_prefix}${version} \
     \"
 
+set pre_args_tags -tags=noselfupdate
+
 if {${os.platform} eq "darwin"} {
-    build.pre_args-append   -tags=noselfupdate,darwin
-} else {
-    build.pre_args-append   -tags=noselfupdate
+    set pre_args_tags $pre_args_tags,darwin
+}
+
+if {[variant_isset mount]} {
+    set pre_args_tags $pre_args_tags,cmount
+}
+
+build.pre_args-append $pre_args_tags
+
+variant mount description {Compile with mount command, requires macFUSE} {
+    depends_run-append port:macfuse
 }
 
 destroot {


### PR DESCRIPTION
#### Description

rclone by default doesn't compile with the mount command on macOS, because it needs macFUSE to work. This PR adds a variant, mount, that enables it.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
