### PR TITLE
Update Xft2 to 2.3.6

### DIFF
--- a/archivers/wimlib/Portfile
+++ b/archivers/wimlib/Portfile
@@ -3,14 +3,13 @@
 PortSystem          1.0
 
 name                wimlib
-version             1.13.5
+version             1.13.6
 revision            0
-checksums           rmd160  dc24dd325157a4542f7572834cfd6345264f0c06 \
-                    sha256  32fcc9e9b144b7cb1db4c86e104ca78283cdc225e13fe82b273660586aefe323 \
-                    size    1045949
+checksums           rmd160  fe563e6874c28e0b929866ed2a81889b0604807c \
+                    sha256  0a0f9c1c0d3a2a76645535aeb0f62e03fc55914ca65f3a4d5599bb8b0260dbd9 \
+                    size    1045088
 
 categories          archivers
-platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             {GPL-3+ LGPL-3+}
 

--- a/archivers/xar/Portfile
+++ b/archivers/xar/Portfile
@@ -8,7 +8,7 @@ PortGroup           openssl 1.0
 set apple_version   487.100.1
 github.setup        apple-oss-distributions xar ${apple_version} xar-
 version             1.8.0.${apple_version}
-revision            1
+revision            2
 
 categories          archivers sysutils
 license             BSD
@@ -29,7 +29,6 @@ depends_build       port:pkgconfig \
 
 depends_lib         port:bzip2 \
                     port:libxml2 \
-                    path:lib/pkgconfig/icu-uc.pc:icu \
                     port:zlib
 
 # from Debian: restore *ssl support, etc
@@ -56,6 +55,9 @@ patchfiles-append   patch-src-xar_internal.h.diff
 
 # see: https://trac.macports.org/ticket/65128
 patchfiles-append   patch-lib-filetree.c.diff
+
+# see: https://trac.macports.org/ticket/65839
+patchfiles-append   dont-overlink-to-libxml2.patch
 
 post-patch {
     copy -force ${prefix}/share/automake-1.16/config.guess ${worksrcpath}

--- a/archivers/xar/files/dont-overlink-to-libxml2.patch
+++ b/archivers/xar/files/dont-overlink-to-libxml2.patch
@@ -1,0 +1,11 @@
+--- configure.ac.orig	2022-05-03 23:39:20.000000000 -0500
++++ configure.ac	2022-09-14 22:39:09.000000000 -0500
+@@ -306,7 +306,7 @@
+   AC_MSG_RESULT([${LIBXML2_MAJOR}.${LIBXML2_MINOR}.${LIBXML2_BRANCH}])
+   have_libxml2="1"
+   CPPFLAGS="${CPPFLAGS} `${XML2_CONFIG} --cflags`"
+-  LIBS="${LIBS} `${XML2_CONFIG} --libs`"
++  LIBS="${LIBS} `${XML2_CONFIG} --libs --dynamic`"
+ else
+   AC_MSG_RESULT([no])
+   have_libxml2="0"

--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -36,11 +36,11 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake c3793b41573ee584e572ea546527b9350f46a05d
-version             20220817-3.24.1-[string range ${gitlab.version} 0 7]
-checksums           rmd160  0e2da65d017561b75fbb221a2bc345cb00dcc286 \
-                    sha256  d0058fcc459f62717f8d47b29de0b39747b9e5024327c584a0d1a240408b4f42 \
-                    size    7957547
+gitlab.setup        cmake   cmake 31f835410efeea50acd43512eb9e5646a26ea177
+version             20220913-3.24.2-[string range ${gitlab.version} 0 7]
+checksums           rmd160  9146a07e43a9595245cc406520213eedd216bbd8 \
+                    sha256  7668de6ff09a64c135805b7a54dd61c497f6e7c769756ed9968038fc22000850 \
+                    size    7953559
 revision            0
 
 # switched from "3.23.0" to "date-ver-hash"

--- a/devel/datree/Portfile
+++ b/devel/datree/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/datreeio/datree 1.6.29
+revision            0
+
+categories          devel
+maintainers         {@Ci7rix unset.ch:max+github} openmaintainer
+license             Apache-2
+
+description         CLI tool to run policies against Kubernetes manifests YAML files or Helm charts
+long_description    Datree automatically validates Kubernetes objects for rule violations, ensuring no misconfigurations reach production
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  10a06b5dfa664a21d6ca803a574030b461bef1cb \
+                    sha256  54c373f9898fbbd6c6ab1dcce703f3816cf8c7cbb30605915e11a70c6d9ede4e \
+                    size    5448369
+
+set go_ldflags      "-s -w -X ${go.package}/cmd.CliVersion=${version}"
+build.args          -tags main -ldflags \"${go_ldflags}\"
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}

--- a/devel/deno/Portfile
+++ b/devel/deno/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        denoland deno 1.25.2 v
+github.setup        denoland deno 1.25.3 v
 github.tarball_from releases
 revision            0
 
@@ -30,13 +30,13 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 supported_archs     arm64 x86_64
 
 checksums           ${name}-x86_64-apple-darwin.zip \
-                    rmd160  cd54bc49dabef81e4182944189a02d5220c289f2 \
-                    sha256  9b372eefcf572a51b1bac6ea17dc4b51e86f62cf6e70b877bfc1c2aa993843d8 \
-                    size    33191823 \
+                    rmd160  45b513f0eea1827513aea7dc5376407fd9f4aded \
+                    sha256  9e6fbb91d3379a0101431e46bdf1534af3fceabb311c3637396b981d0a4ebe0a \
+                    size    33212876 \
                     ${name}-aarch64-apple-darwin.zip \
-                    rmd160  6e0b1a24a38f71cbfdf62bb3959b603f9c48a931 \
-                    sha256  2e2dc97315cc7a6d39b733993fb89c21ac336444c36d46412bad2fff1c099aa1 \
-                    size    34003031
+                    rmd160  ca2e53e433c13bb4f0a6e038ec0fbd6146d9280b \
+                    sha256  b8c45510ecacb9ba02244fe7eb9a8be244b7edc3d34ca38ddf7be2257e70a13e \
+                    size    34008612
 
 if {${build_arch} eq "arm64"} {
     set release_arch aarch64

--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/superfly/flyctl 0.0.390 v
+go.setup            github.com/superfly/flyctl 0.0.392 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ long_description    ${name} is a command-line interface for fly.io.
 
 homepage            https://fly.io
 
-checksums           rmd160  59182c2f154a8375330fc034265eacf3cb4c48b7 \
-                    sha256  23d0a8673e30c37e6b757bdcedfd577914f30fc80c646da89574914dfaff6af9 \
-                    size    1512568
+checksums           rmd160  9a5f672a44b3b592d908c6eb18438a20a51f2f53 \
+                    sha256  4bf3095167e0f8e5a94859de5b50688ffea9ddb9267d561a5bd2f715dcd18736 \
+                    size    1513435
 
 # Allow Go to download dependencies at runtime
 build.env-delete    GO111MODULE=off GOPROXY=off

--- a/devel/mongo-c-driver/Portfile
+++ b/devel/mongo-c-driver/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        mongodb mongo-c-driver 1.22.1
-checksums           rmd160  3c5e370806fab534e285063b2f744d40d49e6f9b \
-                    sha256  762735344e848bb2f100154ed2f7b0f8c9b25e37eafb2b79b54bf99c15a7c318 \
-                    size    7452368
+github.setup        mongodb mongo-c-driver 1.23.0
+checksums           rmd160  00ad9ce8fd794612d2680d6d2b5a5353f70ab088 \
+                    sha256  2b91d6a9c1a80ec82c5643676e44f1a9edf3849c7f25d490e1b5587eb408ad93 \
+                    size    7781409
 
 categories          devel
 maintainers         {ryandesign @ryandesign} openmaintainer
@@ -22,7 +22,7 @@ configure.args-append \
                     -DENABLE_UNINSTALL=OFF
 
 if {${subport} eq ${name}} {
-    revision        1
+    revision        0
 
     PortGroup       legacysupport 1.1
 

--- a/devel/nixpacks/Portfile
+++ b/devel/nixpacks/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        railwayapp nixpacks 0.5.5 v
+github.setup        railwayapp nixpacks 0.5.6 v
 github.tarball_from archive
 
 categories          devel
@@ -15,9 +15,9 @@ long_description    Nixpacks takes a source directory and produces an OCI compli
 homepage            https://nixpacks.com/
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  811fa7d0c92945f7f3c6a61e5f569d6b8745a551 \
-                    sha256  d6ce0e87afc871f1705e036d70d550edf3ea2ff209cf8bca4914868dbecae27c \
-                    size    30464104
+                    rmd160  1f0b008dfab6f2a199a779546daf3546b5e7e9d8 \
+                    sha256  52dc8173ca1c78c1fe0cc7fe7120effd21b0572bc9e5d42964272265c346dbd9 \
+                    size    30464185
 
 destroot {
   xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/nixpacks ${destroot}${prefix}/bin/

--- a/devel/nodejs18/Portfile
+++ b/devel/nodejs18/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs18
 version                 18.9.0
-revision                1
+revision                2
 
 categories              devel net
 platforms               darwin
@@ -43,11 +43,9 @@ depends_build-append    port:pkgconfig
 set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
-depends_lib-append      port:python${py_ver_nodot} \
+depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
+                        port:python${py_ver_nodot} \
                         port:zlib
-
-# TODO: when icu is upgraded to v68.x, use MacPorts'.
-#depends_lib-append             path:lib/pkgconfig/icu-uc.pc:icu
 
 # error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
 set min_darwin 13
@@ -96,15 +94,14 @@ post-patch {
 pre-configure {
     # Copy zlib headers here because we do not want to prepend the entire
     # ${prefix}/include to the include path (the build will then attempt to use
-    # ICU 67 headers)
+    # ICU headers)
     file mkdir ${workpath}/zlib-inc
     file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
         ${workpath}/zlib-inc/
 }
 
 configure.args-append   --without-npm
-# TODO: when icu is upgraded to v68.x, use MacPorts'.
-# configure.args-append   --with-intl=system-icu
+configure.args-append   --with-intl=system-icu
 configure.args-append   --shared-zlib
 configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
 configure.args-append   --shared-zlib-libpath=${prefix}/lib

--- a/devel/shellcheck/Portfile
+++ b/devel/shellcheck/Portfile
@@ -28,6 +28,8 @@ checksums           rmd160  2214d4630aa26c7215871ed2a0af670655f5e4c9 \
                     sha256  e19600ba044d9fcdd811a78a072f44549cb4d564973f6551565e6de3e706a979 \
                     size    240806
 
+livecheck.url       https://hackage.haskell.org/package/ShellCheck
+
 variant stack \
     description {Use stack to build.} {}
 

--- a/devel/spice-protocol/Portfile
+++ b/devel/spice-protocol/Portfile
@@ -10,14 +10,14 @@ checksums           rmd160  5a59b1347e4d0b2a54d0b9083e10e1b80341de08 \
                     sha256  f986e5bc2a1598532c4897f889afb0df9257ac21c160c083703ae7c8de99487a \
                     size    22224
 
-maintainers         nomaintainer
 categories          devel
-platforms           darwin
 license             BSD
+maintainers         nomaintainer
+supported_archs     noarch
+
 description         Remote virtual machine protocol
 long_description    {*}${description}
-
 homepage            https://www.spice-space.org
+
 master_sites        ${homepage}/download/releases/
 use_xz              yes
-supported_archs     noarch

--- a/devel/spice-server/Portfile
+++ b/devel/spice-server/Portfile
@@ -5,7 +5,7 @@ PortGroup           meson 1.0
 
 name                spice-server
 version             0.14.3
-revision            2
+revision            3
 
 categories          devel
 license             BSD
@@ -22,7 +22,7 @@ checksums           rmd160  fe99d8d0db4b275b1d19dc9a7231144133c5bfa0 \
                     sha256  551d4be4a07667cf0543f3c895beb6da8a93ef5a9829f2ae47817be5e616a114 \
                     size    1504304
 
-set py_ver_nodot    38
+set py_ver_nodot    310
 
 patchfiles-append \
                     meson-build.diff \

--- a/devel/spice-server/Portfile
+++ b/devel/spice-server/Portfile
@@ -27,11 +27,11 @@ patchfiles          meson-build.diff \
                     pthread-setname-args.diff \
                     no-msg-nosignal.diff \
                     no-tools.diff \
-                    no-tests.diff
+                    no-tests.diff \
+                    fix-py-module-search.diff
 
 configure.args-append \
-    -Dsasl=false \
-    -Dtests=no
+    -Dsasl=false
 
 depends_build-append \
     port:pkgconfig \

--- a/devel/spice-server/Portfile
+++ b/devel/spice-server/Portfile
@@ -6,23 +6,26 @@ PortGroup           meson 1.0
 name                spice-server
 version             0.14.3
 revision            2
-maintainers         nomaintainer
+
 categories          devel
-platforms           darwin
 license             BSD
+maintainers         nomaintainer
+
 description         Remote virtual machine server
 long_description    {*}${description}
-
 homepage            https://www.spice-space.org/
-master_sites        https://www.spice-space.org/download/releases/
 
+master_sites        https://www.spice-space.org/download/releases/
 use_bzip2           yes
 
 checksums           rmd160  fe99d8d0db4b275b1d19dc9a7231144133c5bfa0 \
                     sha256  551d4be4a07667cf0543f3c895beb6da8a93ef5a9829f2ae47817be5e616a114 \
                     size    1504304
 
-patchfiles          meson-build.diff \
+set py_ver_nodot    38
+
+patchfiles-append \
+                    meson-build.diff \
                     no-werror.diff \
                     pthread-setname-args.diff \
                     no-msg-nosignal.diff \
@@ -35,7 +38,9 @@ configure.args-append \
 
 depends_build-append \
     port:pkgconfig \
-    port:python38 port:py38-six port:py38-parsing
+    port:python${py_ver_nodot} \
+    port:py${py_ver_nodot}-six \
+    port:py${py_ver_nodot}-parsing
 
 depends_lib-append \
     port:lz4 \

--- a/devel/spice-server/files/fix-py-module-search.diff
+++ b/devel/spice-server/files/fix-py-module-search.diff
@@ -1,0 +1,12 @@
+--- subprojects/spice-common/meson.build        2022-08-14 21:05:58.000000000 +0900
++++ subprojects/spice-common/meson.build.new    2022-08-14 21:14:04.000000000 +0900
+@@ -136,7 +136,7 @@
+ if get_option('python-checks')
+   foreach module : ['six', 'pyparsing']
+     message('Checking for python module @0@'.format(module))
+-    cmd = run_command(python, '-m', module)
++    cmd = run_command(python, '-c', 'import @0@'.format(module))
+     if cmd.returncode() != 0
+       error('Python module @0@ not found'.format(module))
+     endif
+

--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
 version                 7.1.0
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -229,6 +229,14 @@ variant vnc description {Support VNC server} {
                             port:cyrus-sasl2 \
                             path:include/turbojpeg.h:libjpeg-turbo \
                             port:libpng
+}
+
+variant spice description {Support Spice server} {
+    configure.args-replace  --disable-spice --enable-spice
+    configure.args-append   --enable-gnutls
+    depends_lib-append      path:lib/pkgconfig/gnutls.pc:gnutls \
+                            port:spice-server \
+                            port:spice-protocol
 }
 
 variant vde description {Support VDE networking} {

--- a/graphics/converseen/Portfile
+++ b/graphics/converseen/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           qt5 1.0
 
-github.setup        Faster3ck converseen 0.9.9.7 v
+github.setup        Faster3ck converseen 0.9.9.8 v
 revision            0
 categories          graphics
 license             GPL-3
@@ -15,9 +15,9 @@ description         Converseen is an open source batch image converter and resiz
 long_description    {*}${description} Thanks to the Magick++ image libraries it supports \
                     more than 100 image formats.
 
-checksums           rmd160  9c0478e92b8fbf377467624ad2b7458384986b7d \
-                    sha256  2c68c90e401ff84a08a5533d357725e2b5c0260f689cf7772181bca8451f6217 \
-                    size    763867
+checksums           rmd160  744ad3564ca73668e7616a1fde657a58ea683d57 \
+                    sha256  15abd17f52e6a021e4302a90d40d1ce69370600023cf008fbe2d0e9ec7633703 \
+                    size    769355
 
 depends_lib-append  port:ImageMagick
 

--- a/graphics/ogre/Portfile
+++ b/graphics/ogre/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        OGRECave ogre 13.4.4 v
 github.tarball_from archive
-revision            0
+revision            1
 license             MIT
 categories          graphics
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -64,7 +64,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 }
 
 post-patch {
-    reinplace "s|@rpath|\${prefix}/lib|" ${worksrcpath}/CMake/Utils/OgreConfigTargets.cmake
+    reinplace "s|@rpath|${prefix}/lib|" ${worksrcpath}/CMake/Utils/OgreConfigTargets.cmake
     reinplace "s|/Release\"|\"|" ${worksrcpath}/CMake/Utils/OgreConfigTargets.cmake
     reinplace "s|\"/\${PLATFORM_NAME}\"|\"\"|" ${worksrcpath}/CMake/Utils/OgreConfigTargets.cmake
 }

--- a/graphics/opencv3-devel/Portfile
+++ b/graphics/opencv3-devel/Portfile
@@ -591,7 +591,7 @@ if {${name} eq ${subport}} {
 
         post-extract {
             # gunzip cannot handle multi-member .zip archives
-            exec unzip -oq ${distpath}/${version}.zip -d ${extract.dir}
+            system "unzip -oq ${distpath}/${version}.zip -d ${extract.dir}"
 
             # less than ideal way for patchfiles to be applied to contrib directory
             ln -s ${workpath}/opencv_contrib-${version} ${worksrcpath}/opencv_contrib

--- a/graphics/opencv3/Portfile
+++ b/graphics/opencv3/Portfile
@@ -591,7 +591,7 @@ if {${name} eq ${subport}} {
 
         post-extract {
             # gunzip cannot handle multi-member .zip archives
-            exec unzip -oq ${distpath}/${version}.zip -d ${extract.dir}
+            system "unzip -oq ${distpath}/${version}.zip -d ${extract.dir}"
 
             # less than ideal way for patchfiles to be applied to contrib directory
             ln -s ${workpath}/opencv_contrib-${version} ${worksrcpath}/opencv_contrib

--- a/lang/cabal/Portfile
+++ b/lang/cabal/Portfile
@@ -71,7 +71,15 @@ if {${build_arch} eq {arm64}} {
                     size    5494908
 }
 
-depends_run-append  port:curl \
+# cabal may use these MacPorts build tools:
+# alex, ar, strip, cpphs, happy, hscolour, ld, pkg-config
+# https://github.com/haskell/cabal/blob/master/Cabal/src/Distribution/Simple/Program/Builtin.hs
+depends_lib-append  port:cctools \
+                    port:ld64 \
+                    port:pkgconfig
+
+# cabal uses curl or wget
+depends_lib-append  port:curl \
                     port:wget
 
 if {${name} eq ${subport}} {
@@ -118,30 +126,41 @@ if {${name} eq ${subport}} {
                     port:py${python3_version}-yaml \
                     port:py${python3_version}-zipp
 
-    # use bootstrapped ghc
+    depends_lib-append  \
+                    port:gmp \
+                    port:libiconv \
+                    port:zlib
+
+    # alex, happy, and hscolour are bootstrapped using cabal-prebuilt
+    depends_lib-append  \
+                    path:bin/alex:alex \
+                    path:bin/happy:happy \
+                    path:bin/HsColour:hscolour
+
+    # use bootstrapped ghc -- reconfigure settings from PG haskell_cabal
     depends_build-delete \
                     port:ghc-prebuilt
     depends_lib-append \
                     path:bin/ghc:ghc
 
-    pre-configure {
-        foreach phase {configure build destroot test} {
-            ${phase}.env-replace \
-                    "GHC=${prefix}/bin/ghc-prebuilt" \
+    post-patch {
+        haskell_cabal.env-replace \
+                    "GHC=${haskell_cabal.cabal_root}/bin/ghc" \
                     "GHC=${prefix}/bin/ghc"
+        haskell_cabal.env-delete \
+                    "PATH=${haskell_cabal.cabal_root}/bin:$env(PATH)"
+        foreach phase {configure build destroot test} {
+            ${phase}.env \
+                    {*}${haskell_cabal.env}
         }
         delete ${haskell_cabal.cabal_root}/bin/ghc
         delete ${haskell_cabal.cabal_root}/bin/ghc-pkg
     }
 
     # https://github.com/haskell/cabal/issues/8360#issuecomment-1220918581
-    build.target    ${name}-install
-
-    foreach phase {build destroot test} {
-        ${phase}.post_args-prepend \
+    build.target    ${name}-install \
                     --project-file=cabal.project.release \
                     --allow-newer
-    }
 
     post-build {
         # https://github.com/haskell/cabal/blob/c1f490a50782cc89030889fae8edd9f95db7c1e4/Makefile#L207

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 
 name                ghc
 version             9.4.2
-revision            0
+revision            1
 categories          lang haskell
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
 license             BSD
@@ -180,7 +180,9 @@ if {${name} eq ${subport}} {
                     port:xz
 
     depends_lib-append  \
-                    port:gmp
+                    port:gmp \
+                    port:libiconv \
+                    port:ncurses
     
     # build depends upon these x86_64 binaries
     depends_skip_archcheck-append \
@@ -226,11 +228,13 @@ if {${name} eq ${subport}} {
         }
     }
 
-    pre-configure {
-        foreach phase {configure build destroot test} {
-            ${phase}.env-replace \
+    post-patch {
+        haskell_cabal.env-replace \
                     "PATH=${haskell_cabal.cabal_root}/bin:$env(PATH)" \
-                    "PATH=${workpath}/bin:$env(PATH)"
+                    "PATH=${workpath}/bin:${haskell_cabal.cabal_root}/bin:$env(PATH)"
+        foreach phase {configure build destroot test} {
+            ${phase}.env \
+                    {*}${haskell_cabal.env}
         }
     }
 
@@ -247,14 +251,6 @@ if {${name} eq ${subport}} {
                     --with-gmp-libraries=${prefix}/lib \
                     --with-iconv-includes=${prefix}/include \
                     --with-iconv-libraries=${prefix}/lib
-
-    pre-build {
-        build.env-append \
-                    CC=${configure.cc} \
-                    "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
-                    "CPPFLAGS=${configure.cppflags}" \
-                    "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]"
-    }
 
     post-build {
         system -W ${build.dir} \
@@ -382,6 +378,15 @@ subport ghc-prebuilt {
 subport hadrian {
     # find ${worksrcpath} -type f -exec egrep -E -o '"pkg-name":"shake","pkg-version":"[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+"' {} ';'
     version         0.19.6
+    revision        0
+
+    distname        ${name}-${ghc_version}
+    distfiles       [lindex ${ghc_source_checksums} 0]
+    checksums       {*}${ghc_source_checksums}
+    extract.only    [lindex ${ghc_source_checksums} 0]
+
+    worksrcdir      ${distname}
+    set worksrcpath ${workpath}/${worksrcdir}/${subport}
 
     variant stack \
         description {Use stack to build.} {}
@@ -424,17 +429,7 @@ subport hadrian {
         patchfiles-append \
                     patch-cabal_project.diff
 
-        foreach phase {build destroot test} {
-            ${phase}.post_args-prepend \
+        build.target-append \
                     --project-file=cabal.project
-        }
     }
-
-    distname        ${name}-${ghc_version}
-    distfiles       [lindex ${ghc_source_checksums} 0]
-    checksums       {*}${ghc_source_checksums}
-    extract.only    [lindex ${ghc_source_checksums} 0]
-
-    worksrcdir      ${distname}
-    set worksrcpath ${workpath}/${worksrcdir}/${subport}
 }

--- a/lang/jsmin/Portfile
+++ b/lang/jsmin/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        douglascrockford JSMin 20120415
+github.setup        douglascrockford JSMin 430bfe68dc0823d8c0f92c08d426e517cbc8de5e
 name                jsmin
+version             20191031
 categories          lang
 maintainers         sergiokas.com:dev openmaintainer
-platforms           darwin
 license             MIT
 
 description         JavaScript minifier tool
@@ -15,8 +15,10 @@ description         JavaScript minifier tool
 long_description    Douglas Crockford's original JavaScript minifier tool
 
 homepage            http://www.crockford.com/javascript/jsmin.html
-fetch.type          git
-git.branch          5ca277ea452beae1c25db3bc0ef5c81309a3daf4
+
+checksums           rmd160  fa16ff9fe5edfd7803cf238967609c8de16ebfc2 \
+                    sha256  314261fac2c97f27dba687c80785804be5dd33bd27a470c5faa150fcff9a3abe \
+                    size    4408
 
 use_configure       no
 

--- a/lua/lua-resty-core/Portfile
+++ b/lua/lua-resty-core/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        openresty lua-resty-core 0.1.23 v
+github.setup        openresty lua-resty-core 0.1.24 v
 revision            0
-checksums           rmd160  7f0610e448a01f21a967f9ea3f1c0b0d2a7669c9 \
-                    sha256  efd6b51520429e64b1bcc10f477d370ebed1631c190f7e4dc270d959a743ad7d \
-                    size    169382
+checksums           rmd160  9285ffda56b47b389fea1f4d2b5cb1f49d8e0ee3 \
+                    sha256  f6aabb0811cfd8b0b0c986399f713fd66c559623b6b534f33783da0e3bb68ea3 \
+                    size    169385
 
 categories          lua
 maintainers         {ryandesign @ryandesign} openmaintainer

--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/rclone/rclone 1.59.2 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://rclone.org
 
@@ -40,10 +40,20 @@ build.pre_args-append \
         -X github.com/rclone/rclone/fs.Version=${github.tag_prefix}${version} \
     \"
 
+set pre_args_tags -tags=noselfupdate
+
 if {${os.platform} eq "darwin"} {
-    build.pre_args-append   -tags=noselfupdate,darwin
-} else {
-    build.pre_args-append   -tags=noselfupdate
+    set pre_args_tags $pre_args_tags,darwin
+}
+
+if {[variant_isset mount]} {
+    set pre_args_tags $pre_args_tags,cmount
+}
+
+build.pre_args-append $pre_args_tags
+
+variant mount description {Compile with mount command, requires macFUSE} {
+    depends_run-append port:macfuse
 }
 
 destroot {

--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/rclone/rclone 1.59.1 v
+go.setup            github.com/rclone/rclone 1.59.2 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description \
     Backblaze B2, Yandex Disk, SFTP, and the local filesystem.
 
 checksums \
-    rmd160  b331f00cdb659da6897211cb7b15b09efe6ed9b8 \
-    sha256  3eb56502c49ffe53da0360b66d5c9ee6147433f1a9b0238686c1743855cc891f \
-    size    15946112
+    rmd160  3e51f5656abe0c472a90b5c3a067556672de0845 \
+    sha256  ef263bbb8c05ddf9d9309a88cc3b5c928467179b71d3ba3b442bfeafb94ed24b \
+    size    15946730
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See

--- a/net/tailscale/Portfile
+++ b/net/tailscale/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/tailscale/tailscale 1.30.1 v
+go.setup            github.com/tailscale/tailscale 1.30.2 v
 go.package          tailscale.com
 github.tarball_from archive
 revision            0
@@ -22,9 +22,9 @@ license             BSD
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  24d8d1a0314bc4a87e5cca9ca2d132ee9125a879 \
-                    sha256  afe563ad86b4c788e8b107f9d14ffb0611d920740a0cbda87970f1c1bb850a06 \
-                    size    1287059
+checksums           rmd160  96487014020469170b11e028c7acbc59f135e51c \
+                    sha256  4e5ee37ae734b8312153d4f8da340295e9a6a455e3f3943a62199b16d89c8bb5 \
+                    size    1287321
 
 set ts_build_sh     ${worksrcpath}/_build.sh
 

--- a/python/py-zope-proxy/Portfile
+++ b/python/py-zope-proxy/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-zope-proxy
 python.rootname     zope.proxy
-version             4.5.0
+version             4.5.1
 revision            0
 categories-append   zope
 license             ZPL-2.1
@@ -20,9 +20,9 @@ homepage            https://github.com/zopefoundation/zope.proxy
 
 python.versions     37 38 39 310
 
-checksums           rmd160  2a870a86def06af805a928466a3a426945053dcd \
-                    sha256  1329846261cf6c552b05579f3cfad199b2d178510d0b4703eb5f7cdd6ebad01a \
-                    size    43781
+checksums           rmd160  923f0ddc7af3e3e4259bb7e0a6f1faf9a5f7af51 \
+                    sha256  8fa4e9620791dcfaf483e341332dfdebca23ba05738a528faadb3c0902f9de42 \
+                    size    45608
 
 if {${name} ne ${subport}} {
     depends_lib-append  \

--- a/science/OpenCoarrays/Portfile
+++ b/science/OpenCoarrays/Portfile
@@ -1,15 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 
-github.setup        sourceryinstitute OpenCoarrays 2.9.2
+github.setup        sourceryinstitute OpenCoarrays 2.10.0
 github.tarball_from releases
-revision            1
+revision            0
 categories          science parallel devel
-platforms           darwin
 license             BSD
 maintainers         nomaintainer
 
@@ -18,35 +17,54 @@ long_description    OpenCoarrays is an open-source software project \
                     that produces an application binary interface (ABI) \
                     to support coarrays and other Fortran 2018 parallel \
                     programming features for gfortran in the GNU Compiler \
-                    Collection (GCC).  Gfortran has used OpenCoarrays \
+                    Collection (GCC). Gfortran has used OpenCoarrays \
                     since the GCC 5.1.0 release.
 homepage            http://www.opencoarrays.org
 
 mpi.setup           require require_fortran \
                     -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 \
                     -clang -fortran
+
 universal_variant   no
 
-checksums           rmd160  d0cf1f270b5d17b239825b8720dcacba1d6b6057 \
-                    sha256  6c200ca49808c75b0a2dfa984304643613b6bc77cc0044bee093f9afe03698f7 \
-                    size    324933
+checksums           rmd160  3e94a9fe478d60e027730e596ffe1c384de5da77 \
+                    sha256  c08717aea6ed5c68057f80957188a621b9862ad0e1460470e7ec82cdd84ae798 \
+                    size    329486
 
-#patchfiles          tests-compiler.patch
-
-cmake.out_of_source yes
+patchfiles          patch-isnan.diff
 
 post-patch {
-    reinplace "s|mpicc|${prefix}/bin/mpicc-${mpi.name}|g" \
+    reinplace "s|mpicc|${prefix}/bin/${mpi.cc}|g" \
         src/tests/unit/simple/CMakeLists.txt
 }
 
 # Required to run the test phase.
 pre-configure {
     configure.args-append \
-        -DMPIEXEC=${prefix}/bin/${mpi.exec} \
-        -DMPI_C_COMPILER=${prefix}/bin/mpicc-${mpi.name} \
-        -DMPI_Fortran_COMPILER=${prefix}/bin/mpif90-${mpi.name}
+        -DMPIEXEC_EXECUTABLE=${prefix}/bin/${mpi.exec} \
+        -DMPI_C_COMPILER=${prefix}/bin/${mpi.cc} \
+        -DMPI_Fortran_COMPILER=${prefix}/bin/${mpi.f90}
+}
+
+configure.args-append \
+        -DMPI_C_COMPILE_OPTIONS="-lpthread" \
+        -DMPI_Fortran_COMPILE_OPTIONS="-lpthread"
+
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append \
+        -latomic
+}
+
+variant events description {enable support for the Fortran 2015 events feature} {
+    configure.args-append \
+        -DCOMPILER_SUPPORTS_ATOMICS:BOOL=ON
+}
+
+# Do not make this default: known to trigger some bugs on Intel, broken on PPC.
+variant ULFM description {enable experimental ULFM support} {
+    configure.args-append \
+        -DCAF_ENABLE_FAILED_IMAGES:BOOL=ON
 }
 
 test.run            yes
-test.target         test
+test.target         check

--- a/science/OpenCoarrays/files/patch-isnan.diff
+++ b/science/OpenCoarrays/files/patch-isnan.diff
@@ -1,0 +1,76 @@
+--- src/tests/CMakeLists.txt.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/CMakeLists.txt	2022-09-11 01:15:32.000000000 +0700
+@@ -15,6 +15,10 @@
+     )
+ endif()
+ 
++if (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64")
++  add_compile_definitions(DARWIN_PPC)
++endif()
++
+ set( directory_list
+  utilities
+  integration
+
+# Changing extension from f90 to F90 is intended. See: https://stackoverflow.com/questions/31649691/stringify-macro-with-gnu-gfortran
+--- src/tests/integration/pde_solvers/coarrayHeatSimplified/CMakeLists.txt.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayHeatSimplified/CMakeLists.txt	2022-09-11 02:03:18.000000000 +0700
+@@ -4,7 +4,7 @@
+ add_dependencies(local_field caf_mpi_static)
+ add_dependencies(global_field local_field caf_mpi_static)
+ add_executable(co_heat
+-  main.f90
++  main.F90
+   $<TARGET_OBJECTS:local_field>
+   $<TARGET_OBJECTS:global_field>
+ )
+
+--- src/tests/integration/pde_solvers/coarrayHeatSimplified/main.F90.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayHeatSimplified/main.F90	2022-09-11 01:29:09.000000000 +0700
+@@ -26,7 +26,10 @@
+ !
+ 
+ program main
++#ifndef DARWIN_PPC
+   use IEEE_arithmetic, only : IEEE_is_NaN
++#endif
++  
+   use global_field_module, only : global_field
+   implicit none
+   type(global_field) :: T,laplacian_T,T_half
+@@ -44,7 +47,11 @@
+   block 
+     real, allocatable :: residual(:)
+     residual = laplacian_T%state()
++#ifdef DARWIN_PPC
++    if ( any(residual>tolerance) .or. any(isNaN(residual)) .or. any(residual<0) ) error stop "Test failed."
++#else
+     if ( any(residual>tolerance) .or. any(IEEE_is_NaN(residual)) .or. any(residual<0) ) error stop "Test failed."
++#endif
+   end block
+   if (this_image()==1) print *,"Test passed."
+ end program
+
+--- src/tests/integration/pde_solvers/coarrayBurgers/main.F90.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayBurgers/main.F90	2022-09-11 01:28:08.000000000 +0700
+@@ -1,6 +1,8 @@
+ program main
+   use iso_fortran_env, only : real64,int64,compiler_version,compiler_options
++#ifndef DARWIN_PPC
+   use ieee_arithmetic, only : ieee_is_nan
++#endif
+   use global_field_module, only : global_field,initial_condition
+   use ForTrilinos_assertion_utility, only : assert,error_message
+   implicit none
+@@ -39,7 +41,11 @@
+ contains
+   subroutine test(burgers_solution)
+     type(global_field), intent(in) :: burgers_solution
++#ifdef DARWIN_PPC
++    call assert(.not.any(isnan(u%state())),error_message("Test failed: u is not a number."))
++#else
+     call assert(.not.any(ieee_is_nan(u%state())),error_message("Test failed: u is not a number."))
++#endif
+     call assert(sinusoid(u),error_message("Test failed: improper shape."))
+   end subroutine
+ 

--- a/science/OpenCoarrays/files/patch-isnan.diff
+++ b/science/OpenCoarrays/files/patch-isnan.diff
@@ -25,8 +25,8 @@
    $<TARGET_OBJECTS:global_field>
  )
 
---- src/tests/integration/pde_solvers/coarrayHeatSimplified/main.F90.orig	2022-05-09 10:53:57.000000000 +0700
-+++ src/tests/integration/pde_solvers/coarrayHeatSimplified/main.F90	2022-09-11 01:29:09.000000000 +0700
+--- src/tests/integration/pde_solvers/coarrayHeatSimplified/main.f90.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayHeatSimplified/main.f90	2022-09-11 01:29:09.000000000 +0700
 @@ -26,7 +26,10 @@
  !
  
@@ -51,8 +51,8 @@
    if (this_image()==1) print *,"Test passed."
  end program
 
---- src/tests/integration/pde_solvers/coarrayBurgers/main.F90.orig	2022-05-09 10:53:57.000000000 +0700
-+++ src/tests/integration/pde_solvers/coarrayBurgers/main.F90	2022-09-11 01:28:08.000000000 +0700
+--- src/tests/integration/pde_solvers/coarrayBurgers/main.f90.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayBurgers/main.f90	2022-09-11 01:28:08.000000000 +0700
 @@ -1,6 +1,8 @@
  program main
    use iso_fortran_env, only : real64,int64,compiler_version,compiler_options

--- a/science/OpenCoarrays/files/patch-isnan.diff
+++ b/science/OpenCoarrays/files/patch-isnan.diff
@@ -51,8 +51,8 @@
    if (this_image()==1) print *,"Test passed."
  end program
 
---- src/tests/integration/pde_solvers/coarrayBurgers/main.f90.orig	2022-05-09 10:53:57.000000000 +0700
-+++ src/tests/integration/pde_solvers/coarrayBurgers/main.f90	2022-09-11 01:28:08.000000000 +0700
+--- src/tests/integration/pde_solvers/coarrayBurgers/main.F90.orig	2022-05-09 10:53:57.000000000 +0700
++++ src/tests/integration/pde_solvers/coarrayBurgers/main.F90	2022-09-11 01:28:08.000000000 +0700
 @@ -1,6 +1,8 @@
  program main
    use iso_fortran_env, only : real64,int64,compiler_version,compiler_options

--- a/security/grype/Portfile
+++ b/security/grype/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/anchore/grype 0.49.0 v
+go.setup            github.com/anchore/grype 0.50.1 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  e9c94752076c5b4b0a21b7938c662c465e77feae \
-                    sha256  0e0154d055ddc95cc57d8cc7f2addd9f7b4b3fedfe98f7eb11614e6dea8f2533 \
-                    size    1078469
+checksums           rmd160  2fffb42514321a17f87e4fcd5f8042ad7039ddd5 \
+                    sha256  5346247144e86c5d2f55a564e7b81f6c1d076a5ddf95d5502f10ebca68eb80aa \
+                    size    1079494
 
 build.env-delete    GO111MODULE=off GOPROXY=off
 

--- a/shells/xonsh/Portfile
+++ b/shells/xonsh/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        xonsh xonsh 0.13.1
+github.setup        xonsh xonsh 0.13.2
 revision            0
 categories          shells
 supported_archs     noarch
@@ -21,9 +21,9 @@ long_description    {*}${description} \
                     macOS, and Windows. Xonsh is meant for the daily use of \
                     experts and novices alike.
 
-checksums           rmd160  a315838bd1d75238d06e496097b57ec3d069852f \
-                    sha256  a58e37d36a03eecb02be57b23ec6f716c7e0650e7750a41c13b8bec961d440e9 \
-                    size    12676127
+checksums           rmd160  069bc1c28597e63d136677149e09c67a325c316a \
+                    sha256  67705bad6a20ad8af712a284dba6c2a25bb5c0a29518ff61ec556e7d942f4eda \
+                    size    12675682
 
 variant python37 conflicts python38 python39 python310 description {Use Python 3.7} {}
 variant python38 conflicts python37 python39 python310 description {Use Python 3.8} {}

--- a/sysutils/file/Portfile
+++ b/sysutils/file/Portfile
@@ -3,10 +3,10 @@
 PortSystem 1.0
 
 name                file
-version             5.42
-checksums           rmd160  bbe2169215e4c0f12b86b5155eaedfdb083d6122 \
-                    sha256  c076fb4d029c74073f15c43361ef572cfb868407d347190ba834af3b1639b0e4 \
-                    size    1105846
+version             5.43
+checksums           rmd160  dcc1c0bcefe65c44d4e7f040acacb652b59875d3 \
+                    sha256  8c8015e91ae0e8d0321d94c78239892ef9dbc70c4ade0008c0e95894abfb1991 \
+                    size    1162786
 
 categories          sysutils
 license             BSD

--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -25,7 +25,9 @@ long_description    Istio is an open, platform-independent service mesh designed
                     The port deploys the istioctl command line utility, \
                     used to create, list, modify, and delete configuration \
                     resources in a deployed Istio system.
-livecheck.url       ${github.homepage}/releases
+
+github.livecheck.regex \
+                    {([0-9.]+)}
 
 go.package          istio.io/istio
 

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -40,11 +40,11 @@ subport kubectl-1.24 {
     set source_build    yes
     supported_archs     x86_64 arm64
 
-    set patchNumber     4
+    set patchNumber     5
     revision            0
-    checksums           rmd160  0e1e6910fde1e10d679b9996dab537e687d2e48d \
-                        sha256  16e7112d8efa46c0a36976b001efe335eea4b9e1dd721824c9c2c064ae7f6bbe \
-                        size    37973948
+    checksums           rmd160  b453cf1113799c5118524d5bf416a3e627aac1cc \
+                        sha256  88a752fabed374d450159e7cffb43e08eccd630f2377c6eecb43700c57f154e5 \
+                        size    37984125
 }
 
 subport kubectl-1.23 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -29,11 +29,11 @@ subport kubectl-1.25 {
     set source_build    yes
     supported_archs     x86_64 arm64
 
-    set patchNumber     0
+    set patchNumber     1
     revision            0
-    checksums           rmd160  3843d0a60abf746c48dc09310a253ddb2d0b2d6e \
-                        sha256  80d560410896686b9c1f71f4fb9b5f8e8328d297d4d87bb0a545f766870f8f41 \
-                        size    40040646
+    checksums           rmd160  73236b1e22107a1e18742fd49ba06ac9d088b6d4 \
+                        sha256  7f00e351b99851cdfbc7536a960a32c10f0f3dfe8bb3a09b93b0c7b0af224e25 \
+                        size    38046191
 }
 
 subport kubectl-1.24 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -62,12 +62,12 @@ subport kubectl-1.22 {
     set source_build    yes
     supported_archs     x86_64 arm64
 
-    set patchNumber     13
+    set patchNumber     14
     revision            0
 
-    checksums           rmd160  087570adf7c8dc5a4cb00bcb59bea71785cd3a12 \
-                        sha256  6418fcdd6215002412c2eab92347b171664679dc432b65c39f38a1db51482bcb \
-                        size    36093191
+    checksums           rmd160  6f3284aa464850ab2e6ceaea63f83e0fb4d7152b \
+                        sha256  0c1fae5ba5386e86d8c199527ec395fc380dd71ae913fa374c7943c44b4ce91f \
+                        size    36106528
 }
 
 subport kubectl-1.21 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -51,11 +51,11 @@ subport kubectl-1.23 {
     set source_build    yes
     supported_archs     x86_64 arm64
 
-    set patchNumber     10
+    set patchNumber     11
     revision            0
-    checksums           rmd160  c118c76ef07560d4ab90720a43703ef909ceee9d \
-                        sha256  0199f4c948f1f686d850eee97a4d49e7ae3614aff4eff7794f499c065d721267 \
-                        size    38229682
+    checksums           rmd160  da668846e8d06499fbf37c954e6619e735ec5806 \
+                        sha256  5ef8cf053ab1464b5ee8fbc7754287b97991b792b521306c0863471a4045301c \
+                        size    38238863
 }
 
 subport kubectl-1.22 {

--- a/textproc/lhs2tex/Portfile
+++ b/textproc/lhs2tex/Portfile
@@ -30,13 +30,7 @@ if { [variant_isset "stack"] } {
     PortGroup       haskell_cabal 1.0
 
     depends_build-append \
-                    port:alex \
-                    port:cctools \
                     port:cpphs \
-                    port:happy \
-                    port:hscolour \
-                    port:ld64 \
-                    port:pkgconfig \
                     port:texlive-basic \
                     port:texlive-latex \
                     port:texlive-latex-extra \

--- a/textproc/libxslt/Portfile
+++ b/textproc/libxslt/Portfile
@@ -47,10 +47,6 @@ if {${name} eq ${subport}} {
     # Temporary patch to fix xsltproc.1 manpage; remove with next version.
     patchfiles-append   xsltproc.1.patch
 
-pre-configure {
-    reinplace s|need_relink=yes|need_relink=no| ${worksrcpath}/ltmain.sh
-}
-
 post-patch {
     if {![variant_isset doc]} {
         reinplace -E "/^install-data-am:/s|install-data-local||" ${worksrcpath}/doc/Makefile.in

--- a/textproc/libxslt/Portfile
+++ b/textproc/libxslt/Portfile
@@ -30,12 +30,14 @@ checksums       rmd160  46a5d1ac1524ad685447cec71c0f8313d727f0af \
 
 depends_build   port:pkgconfig
 
+patchfiles      dont-overlink-to-libxml2.patch
+
 configure.args  --without-python \
                 --without-crypto \
                 --disable-silent-rules
 
 if {${name} eq ${subport}} {
-    revision            7
+    revision            8
 
     depends_lib-append  path:lib/pkgconfig/icu-uc.pc:icu \
                         port:libiconv \
@@ -99,7 +101,7 @@ foreach v {27} {
 
 if {${name} ne ${subport}} {
     epoch                   1
-    revision                3
+    revision                4
     categories-append       python
 
     description             Python bindings for libxslt

--- a/textproc/libxslt/files/dont-overlink-to-libxml2.patch
+++ b/textproc/libxslt/files/dont-overlink-to-libxml2.patch
@@ -1,0 +1,18 @@
+Only link libxml2 statically in purely static build
+
+We now link libxml2 dynamically if both shared and static builds were
+requested. This avoids overlinking and should fix #36.
+
+https://gitlab.gnome.org/GNOME/libxslt/-/issues/36
+https://gitlab.gnome.org/GNOME/libxslt/-/commit/616b2418f7aaf453dac4bd5de5bc59a7ac8584e2
+--- configure.orig	2019-10-30 15:02:02.000000000 -0500
++++ configure	2022-09-15 02:14:18.000000000 -0500
+@@ -14707,7 +14707,7 @@
+ 
+ 
+ if test "x$LIBXML_CONFIG_PREFIX" = "x" -a "x$LIBXML_LIBS" = "x"; then
+-    if test "$build_static_libs" = "no"; then
++    if test "$build_static_libs" = "yes"; then
+ 
+ pkg_failed=no
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for LIBXML" >&5

--- a/textproc/qpdf/Portfile
+++ b/textproc/qpdf/Portfile
@@ -2,14 +2,13 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
 
-github.setup        qpdf qpdf 11.0.0 v
+github.setup        qpdf qpdf 11.1.0 v
 revision            0
-checksums           rmd160  4d37f8ae55027f1441a863a9324afd17d21ad6ef \
-                    sha256  8d99e98893f68f52ca3b579770e7e6f4c96612084d6a0e7e05854a6d631b8fe6 \
-                    size    18452218
+checksums           rmd160  90340e094ddf2dc1094f5635e2802fd74bf88ca1 \
+                    sha256  34a7cf3ac6e239510e9a20d7cbe10a4aff0f572c20e0a9bed0badb820a69e22d \
+                    size    18452386
 
 categories          textproc pdf
 license             Apache-2
@@ -37,11 +36,6 @@ configure.args      -DUSE_IMPLICIT_CRYPTO=NO \
                     -DREQUIRE_CRYPTO_NATIVE=YES \
                     -DREQUIRE_CRYPTO_GNUTLS=NO \
                     -DREQUIRE_CRYPTO_OPENSSL=NO
-
- # qPDF-11 builds with CMake which will use allready-installed
- # headers if they are available, unfortunately. So you cannot
- # simply `port update` if qPDF-10 is installed, sadly.
- conflicts_build    ${name}
 
 variant gnutls conflicts openssl description {Build against gnutls} {
     depends_lib-append      path:lib/pkgconfig/gnutls.pc:gnutls

--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.102.3 v
+go.setup            github.com/gohugoio/hugo 0.103.0 v
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  8e61640193d6d8b53e82e1c5d364a0e7430b8066 \
-                    sha256  5fab29ababef5294c891d687aef027c423771d4ad33af10c69f18ff9754d283b \
-                    size    28122223
+checksums           rmd160  db63a694b044b5fe77c5c38cf23274dbc65a47ea \
+                    sha256  6c100994bfbbac46e42876eb9387ba81db0a6142606afe16006741e32c096aea \
+                    size    27637570
 
 categories          www
 installs_libs       no

--- a/www/hurl/Portfile
+++ b/www/hurl/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 PortGroup           openssl 1.0
 
-github.setup        Orange-OpenSource hurl 1.6.1
+github.setup        Orange-OpenSource hurl 1.7.0
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ long_description    \
     used for both fetching data and testing HTTP sessions.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2de953f4a063ded7ab0a2adeaee1a1d21b58dca5 \
-                    sha256  5b3de8c0375a87094ecbccdd57b89a65b465c25e2ffd8dfdffb1ab08346e4cb1 \
-                    size    8384876
+                    rmd160  9c1afe185e51976a0ed56f899ec8b78bf46a8944 \
+                    sha256  6f5b01de19a1c3376a714c9636aa8d4497d060826a5656cb94785fb4be3468e5 \
+                    size    1043311
 
 categories          www
 installs_libs       no
@@ -46,31 +46,34 @@ destroot {
 
 cargo.crates \
     adler32                          1.2.0  aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234 \
-    aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
-    alloc-no-stdlib                  2.0.1  5192ec435945d87bc2f70992b4d818154b5feede43c09fb7592146374eac90a6 \
-    alloc-stdlib                     0.2.1  697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2 \
+    aho-corasick                    0.7.19  b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e \
+    alloc-no-stdlib                  2.0.4  cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3 \
+    alloc-stdlib                     0.2.2  94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece \
+    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
-    autocfg                          1.0.0  f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
     base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
-    bit-set                          0.5.1  e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80 \
-    bit-vec                          0.5.1  f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb \
-    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    block-buffer                    0.10.0  f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95 \
-    brotli                           3.3.3  f838e47a451d5a8fa552371f80024dd6ace9b7acdf25c4c3d0f9bc6816fb1c39 \
-    brotli-decompressor              2.3.1  1052e1c3b8d4d80eb84a8b94f0a1498797b5fb96314c001156a1c761940ef4ec \
-    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
-    cc                              1.0.72  22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee \
-    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    bit-set                          0.5.3  0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1 \
+    bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    block-buffer                    0.10.3  69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e \
+    brotli                           3.3.4  a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68 \
+    brotli-decompressor              2.3.2  59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80 \
+    bumpalo                         3.11.0  c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d \
+    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
+    cc                              1.0.73  2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                          0.4.19  670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73 \
-    clap                             3.0.4  d01c9347757e131122b19cd19a05c85805b68c2352a97b623efdc3c295290299 \
+    chrono                          0.4.22  bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1 \
+    clap                            3.2.21  1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7 \
+    clap_lex                         0.2.4  2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5 \
     colored                          2.0.0  b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd \
-    cpufeatures                      0.2.1  95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469 \
-    crc32fast                        1.2.1  81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a \
-    crypto-common                    0.1.0  567569e659735adb39ff2d4c20600f7cd78be5471f8c58ab162bce3c03fdbc5f \
-    curl                            0.4.42  7de97b894edd5b5bcceef8b78d7da9b75b1d2f2f9a910569d0bde3dd31d84939 \
-    curl-sys            0.4.52+curl-7.81.0  14b8c2d1023ea5fded5b7b892e4b8e95f70038a421126a056761a84246a28971 \
-    digest                          0.10.0  8549e6bfdecd113b7e221fe60b433087f6957387a20f8118ebca9b12af19143d \
+    core-foundation-sys              0.8.3  5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc \
+    cpufeatures                      0.2.5  28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320 \
+    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
+    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    curl                            0.4.44  509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22 \
+    curl-sys            0.4.56+curl-7.83.1  6093e169dd4de29e468fa649fbae11cdcd5551c81fe5bf1b0677adad7ef3d26f \
+    digest                          0.10.3  f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506 \
     encoding                        0.2.33  6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec \
     encoding-index-japanese   1.20141219.5  04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91 \
     encoding-index-korean     1.20141219.5  4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81 \
@@ -78,87 +81,100 @@ cargo.crates \
     encoding-index-singlebyte 1.20141219.5  3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a \
     encoding-index-tradchinese 1.20141219.5 fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18 \
     encoding_index_tests             0.1.4  a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569 \
+    fastrand                         1.8.0  a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499 \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
-    fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
-    form_urlencoded                  1.0.1  5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
-    generic-array                   0.14.4  501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817 \
-    getrandom                       0.1.14  7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb \
-    getrandom                        0.2.3  7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    form_urlencoded                  1.1.0  a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8 \
+    generic-array                   0.14.6  bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9 \
+    getrandom                        0.2.7  4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6 \
     glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
-    hashbrown                       0.11.2  ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e \
-    hermit-abi                       0.1.8  1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8 \
+    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hex-literal                      0.3.4  7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0 \
-    idna                             0.2.0  02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9 \
-    indexmap                         1.8.0  282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223 \
-    itoa                             1.0.1  1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35 \
+    iana-time-zone                  0.1.48  237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0 \
+    idna                             0.3.0  e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6 \
+    indexmap                         1.9.1  10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
+    itoa                             1.0.3  6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754 \
+    js-sys                          0.3.60  49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.101  3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21 \
-    libflate                         1.1.2  d2d57e534717ac3e0b8dc459fe338bdfb4e29d7eea8fd0926ba649ddd3f4765f \
+    libc                           0.2.132  8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5 \
+    libflate                         1.2.0  05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093 \
     libflate_lz77                    1.1.0  39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a \
-    libxml                           0.3.0  02c07ecb409949e5c5c0818e189e6bc766bcb8b08b3401772ca8c61a58c682b8 \
-    libz-sys                         1.1.2  602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655 \
-    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    libxml                           0.3.1  687f5a78939052c5d02865c0fe3ea2ce2acdca875f7f81db82f7aef256dd97ac \
+    libz-sys                         1.1.8  9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf \
+    log                             0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
     md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
-    memchr                           2.4.0  b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc \
-    num-integer                     0.1.44  d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db \
-    num-traits                      0.2.11  c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096 \
+    memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
+    num-integer                     0.1.45  225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9 \
+    num-traits                      0.2.15  578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd \
     numtoa                           0.1.0  b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef \
-    openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-    openssl-sys                     0.9.58  a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
-    os_str_bytes                     6.0.0  8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64 \
-    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    once_cell                       1.14.0  2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0 \
+    openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
+    openssl-sys                     0.9.75  e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f \
+    os_str_bytes                     6.3.0  9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff \
+    percent-encoding                 2.2.0  478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e \
     peresil                          0.3.0  f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57 \
-    pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
-    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    pkg-config                      0.3.25  1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae \
+    ppv-lite86                      0.2.16  eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872 \
+    proc-macro2                     1.0.43  0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab \
     proptest                         1.0.0  1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5 \
     quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quick-error                      2.0.1  a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3 \
-    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
-    rand                             0.8.4  2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8 \
-    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    quote                           1.0.21  bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179 \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
-    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_core                        0.6.3  d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7 \
-    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
     rand_xorshift                    0.3.0  d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f \
-    redox_syscall                   0.1.56  2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
-    redox_syscall                    0.2.9  5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee \
-    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
-    regex                            1.5.4  d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461 \
-    regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
-    remove_dir_all                   0.5.2  4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
-    rle-decode-fast                  1.0.1  cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac \
+    redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
+    redox_termios                    0.1.2  8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f \
+    regex                            1.6.0  4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b \
+    regex-syntax                    0.6.27  a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244 \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    rle-decode-fast                  1.0.3  3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422 \
     rusty-fork                       0.3.0  cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f \
-    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
-    schannel                        0.1.19  8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
-    serde                          1.0.136  ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789 \
-    serde_json                      1.0.78  d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085 \
-    sha2                            0.10.1  99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec \
-    socket2                          0.4.0  9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2 \
+    ryu                             1.0.11  4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09 \
+    schannel                        0.1.20  88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2 \
+    serde                          1.0.144  0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860 \
+    serde_json                      1.0.85  e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44 \
+    sha2                            0.10.5  cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5 \
+    socket2                          0.4.7  02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd \
     strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
     sxd-document                     0.3.2  94d82f37be9faf1b10a82c4bd492b74f698e40082f0f40de38ab275f31d42078 \
-    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
-    termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
+    syn                             1.0.99  58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13 \
+    tempfile                         3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
+    termcolor                        1.1.3  bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755 \
     termion                          1.5.6  077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e \
-    textwrap                        0.14.2  0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80 \
-    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
-    tinyvec                          0.3.4  238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117 \
-    toml                             0.5.8  a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa \
+    textwrap                        0.15.0  b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb \
+    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+    tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
+    toml                             0.5.9  8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7 \
     typed-arena                      1.7.0  a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d \
-    typenum                         1.13.0  879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06 \
-    unicode-bidi                     0.3.4  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
-    unicode-normalization           0.1.13  6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977 \
-    url                              2.2.2  a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c \
-    vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
-    version_check                    0.9.3  5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe \
+    typenum                         1.15.0  dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987 \
+    unicode-bidi                     0.3.8  099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992 \
+    unicode-ident                    1.0.3  c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf \
+    unicode-normalization           0.1.21  854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6 \
+    url                              2.3.1  0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643 \
+    vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
-    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
-    wasi     0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasm-bindgen                    0.2.83  eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268 \
+    wasm-bindgen-backend            0.2.83  4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142 \
+    wasm-bindgen-macro              0.2.83  052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810 \
+    wasm-bindgen-macro-support      0.2.83  07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c \
+    wasm-bindgen-shared             0.2.83  1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows-sys                     0.36.1  ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2 \
+    windows_aarch64_msvc            0.36.1  9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47 \
+    windows_i686_gnu                0.36.1  180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6 \
+    windows_i686_msvc               0.36.1  e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024 \
+    windows_x86_64_gnu              0.36.1  4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1 \
+    windows_x86_64_msvc             0.36.1  c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680 \
     winres                          0.1.12  b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c \
     xml-rs                           0.8.4  d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3 \
     xmltree                         0.10.3  d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb

--- a/x11/Xft2/Portfile
+++ b/x11/Xft2/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                Xft2
-version             2.3.4
+version             2.3.6
 revision            0
 categories          x11
 license             X11
@@ -23,12 +23,12 @@ platforms           darwin
 homepage            https://www.freedesktop.org/wiki/Software/Xft/
 master_sites        https://xorg.freedesktop.org/releases/individual/lib/
 distname            libXft-${version}
-use_bzip2           yes
+use_xz              yes
 use_parallel_build  yes
 
-checksums           rmd160  a346fef0d0416c9e58ca6cab4166e24bf8c8531f \
-                    sha256  57dedaab20914002146bdae0cb0c769ba3f75214c4c91bd2613d6ef79fc9abdd \
-                    size    359088
+checksums           rmd160  85605ece3e7c990e1a47f30accbbdb1ba6426344 \
+                    sha256  60a6e7319fc938bbb8d098c9bcc86031cc2327b5d086d3335fc5c76323c03022 \
+                    size    304252
 
 depends_build \
     port:pkgconfig
@@ -44,4 +44,4 @@ configure.args      --disable-silent-rules
 
 livecheck.type      regex
 livecheck.url       ${master_sites}?C=M&O=D
-livecheck.regex     libXft-(\[0-9.\]+)\\.tar\\.bz2
+livecheck.regex     libXft-(\[0-9.\]+)\\.tar\\.xz


### PR DESCRIPTION
#### Description

New release:
- update documentation
- add support for BGRA glyphs and scaling
- add option for tracking glyph memory usage, unloading oldest

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 x86_64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
