### PR TITLE
py-maxminddb: update to version 2.2.0 and add python 3.10 to the build matrix

### DIFF
--- a/python/py-maxminddb/Portfile
+++ b/python/py-maxminddb/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-maxminddb
-version             1.5.2
+version             2.2.0
 revision            0
 platforms           darwin
 license             Apache-2
 
-python.versions     37 38
+python.versions     37 38 310
 
 maintainers         {@gstaniak gmail.com:gstaniak} openmaintainer
 
@@ -23,9 +23,9 @@ long_description    This is a Python module for reading MaxMind DB files. The mo
 
 homepage            https://www.maxmind.com/en/home
 
-checksums           rmd160 caaa546c1daae6781c45a17be906a21a3b4ff654 \
-                    sha256 d0ce131d901eb11669996b49a59f410efd3da2c6dbe2c0094fe2fef8d85b6336 \
-                    size 274594
+checksums           rmd160  0aeb4674939cda91af15a685a093170ad518f913 \
+                    sha256  e37707ec4fab115804670e0fb7aedb4b57075a8b6f80052bdc648d3c005184e5 \
+                    size    330865
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

* update to upstream version 2.2.0
* add python 3.10 to the build matrix

The new version of the python package
* drops python < 3.6 support (does not affect the macports pacakge)
* adds type hints (does not affect API)
* other minor things that do not affect the API.

(replaces #16134)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
