### PR TITLE
Xft2: Update to 2.3.6

### DIFF
--- a/x11/Xft2/Portfile
+++ b/x11/Xft2/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                Xft2
-version             2.3.4
+version             2.3.6
 revision            0
 categories          x11
 license             X11
@@ -23,12 +23,12 @@ platforms           darwin
 homepage            https://www.freedesktop.org/wiki/Software/Xft/
 master_sites        https://xorg.freedesktop.org/releases/individual/lib/
 distname            libXft-${version}
-use_bzip2           yes
+use_xz              yes
 use_parallel_build  yes
 
-checksums           rmd160  a346fef0d0416c9e58ca6cab4166e24bf8c8531f \
-                    sha256  57dedaab20914002146bdae0cb0c769ba3f75214c4c91bd2613d6ef79fc9abdd \
-                    size    359088
+checksums           rmd160  85605ece3e7c990e1a47f30accbbdb1ba6426344 \
+                    sha256  60a6e7319fc938bbb8d098c9bcc86031cc2327b5d086d3335fc5c76323c03022 \
+                    size    304252
 
 depends_build \
     port:pkgconfig
@@ -44,4 +44,4 @@ configure.args      --disable-silent-rules
 
 livecheck.type      regex
 livecheck.url       ${master_sites}?C=M&O=D
-livecheck.regex     libXft-(\[0-9.\]+)\\.tar\\.bz2
+livecheck.regex     libXft-(\[0-9.\]+)\\.tar\\.xz


### PR DESCRIPTION
New release.

#### Description

Changes:
- update/improve documentation
- add support for BGRA glyphs display and scaling
- add option for improving memory usage

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 x86_64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
