### PR TITLE
ghc: Bugfix build with existing ghc installed

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -192,15 +192,7 @@ if {${name} eq ${subport}} {
                     HsColour
 
     post-patch {
-        # bootstrap build/destroot from cabal-prebuilt and ghc-prebuilt
         xinstall -d ${workpath}/bin
-        ln -s       ${haskell_cabal.bin} \
-                    ${workpath}/bin/cabal
-        ln -s       ${prefix}/bin/ghc-prebuilt \
-                    ${workpath}/bin/ghc
-        # the versions of ghc and ghc-pkg must match
-        ln -s       ${prefix}/bin/ghc-pkg-prebuilt \
-                    ${workpath}/bin/ghc-pkg
         ln -s       ${python3_bin} \
                     ${workpath}/bin/python3
         ln -s       ${prefix}/bin/sphinx-build-${python3_branch} \


### PR DESCRIPTION
* See: https://github.com/haskell/cabal/blob/master/release-notes/Cabal-3.6.1.0.md

@mascguy I discovered another initial condition that tickles this issue with `cabal` finding a pre-existing `ghc-pkg`.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
