### PR TITLE
scute: new port

### DIFF
--- a/security/scute/Portfile
+++ b/security/scute/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem           1.0
+
+name                 scute
+
+version              1.7.0
+revision             0
+categories           security
+maintainers          {@gouttegd incenp.org:dgouttegattat} \
+                     openmaintainer
+description          PKCS#11 interface to the GnuPG Agent
+long_description     Scute is a PKCS#11 implementation relying on the GnuPG Agent. \
+                     It enables the use of an OpenPGP smartcard for TLS client     \
+                     authentication and for CMS digital signatures with Mozilla    \
+                     and other PKCS#11-compatible applications.
+homepage             https://gnupg.org/
+license              LGPL-2.1+
+
+master_sites         https://gnupg.org/ftp/gcrypt/scute
+
+checksums            rmd160  e14690f5ab4eaee4b934c7b5af6fc47c39c4146b \
+                     sha256  437fe758b27c243a5ee2535c6b065ea1d09f2c9a02d83567d2f934bb6395c249 \
+                     size    851177
+use_bzip2            yes
+post-extract {
+  # We hardcode the path to gpgconf, so that if Scute is called from an
+  # application started from the graphical environment (rather than from
+  # a terminal), it can still find gpgconf even if the application's
+  # PATH does not include the MacPorts' bin directory.
+  reinplace "s|pgmname = \"gpgconf\";|pgmname = \"${prefix}/bin/gpgconf\";|" "${worksrcpath}/src/get-path.c"
+}
+
+patchfiles-append    scute-${version}-fix-global-definition.diff \
+                     scute-${version}-add-no-chain-option.diff
+
+test.run             yes
+test.target          check
+
+depends_build-append port:pkgconfig port:ImageMagick
+depends_lib-append   port:gnupg2
+
+livecheck.type       regex
+livecheck.url        https://gnupg.org/ftp/gcrypt/${name}/
+livecheck.regex      ${name}-(\\d+(?:\\.\\d+)*)

--- a/security/scute/files/scute-1.7.0-add-no-chain-option.diff
+++ b/security/scute/files/scute-1.7.0-add-no-chain-option.diff
@@ -1,0 +1,69 @@
+--- doc/scute.texi	2022-09-16 12:34:52.944579251 +0100
++++ doc/scute.texi	2022-09-16 12:39:49.165461792 +0100
+@@ -208,6 +208,12 @@
+ log to @var{file}.  Writing to a socket will be possible by prefixing
+ the @var{file} with the string @code{socket://}.
+ 
++@item no-chain
++@opindex no-chain
++By default, when Scute is asked for a certificate, it returns the
++requested certificate along with the chain of signing certificates.
++This option makes Scute return only the leaf certificate.
++
+ @end table
+ 
+ @mansect notes (Firefox)
+--- src/gpgsm.c	2022-09-16 12:34:52.945579240 +0100
++++ src/gpgsm.c	2022-09-16 12:35:03.810464946 +0100
+@@ -118,7 +118,7 @@
+   search.found = false;
+   search.cert_get_cb = cert_get_cb;
+   search.hook = hook;
+-  search.with_chain = false;
++  search.with_chain = !_scute_opt.no_chain;
+   search.kinfo = kinfo;
+ 
+   DEBUG (DBG_INFO, "scute_gpgsm_get_cert: keyref='%s'", kinfo->keyref);
+@@ -136,7 +136,6 @@
+     }
+ 
+   DEBUG (DBG_INFO, "scute_gpgsm_get_cert: falling back to gpgsm");
+-  search.with_chain = true;
+   err = scute_gpgsm_search_certs (KEYLIST_BY_GRIP, kinfo->grip,
+                                   search_cb, &search);
+   return err;
+--- src/options.h	2022-09-16 12:34:52.945579240 +0100
++++ src/options.h	2022-09-16 12:35:34.672140238 +0100
+@@ -25,6 +25,7 @@
+ typedef struct {
+   char *user;
+   int debug_flags;
++  int no_chain;
+ } _scute_opt_t;
+ 
+ extern _scute_opt_t _scute_opt;
+--- src/readconf.c	2022-09-16 12:34:52.945579240 +0100
++++ src/readconf.c	2022-09-16 12:36:53.867306894 +0100
+@@ -53,12 +53,13 @@
+ void
+ _scute_read_conf (void)
+ {
+-  enum { oNull = 500, oUser, oDebug, oLogfile };
++  enum { oNull = 500, oUser, oDebug, oLogfile, oNoChain };
+   gpgrt_opt_t opts[] =
+     {
+      ARGPARSE_s_s(oUser, "user", NULL ),
+      ARGPARSE_s_s(oDebug, "debug", NULL),
+      ARGPARSE_s_s(oLogfile, "log-file", NULL),
++     ARGPARSE_s_n(oNoChain, "no-chain", NULL),
+      ARGPARSE_end()
+     };
+   int dummy_argc = 0;
+@@ -78,6 +79,7 @@
+           break;
+         case oDebug: _scute_opt.debug_flags = 1; break;
+         case oLogfile: break;
++        case oNoChain: _scute_opt.no_chain = 1; break;
+         case ARGPARSE_CONFFILE: break;
+         default : pargs.err = ARGPARSE_PRINT_WARNING; break;
+ 	}

--- a/security/scute/files/scute-1.7.0-fix-global-definition.diff
+++ b/security/scute/files/scute-1.7.0-fix-global-definition.diff
@@ -1,0 +1,28 @@
+--- src/options.h
++++ src/options.h
+@@ -22,10 +22,12 @@
+ #define OPTIONS_H 1
+ 
+ /* Global options.  */
+-struct {
++typedef struct {
+   char *user;
+   int debug_flags;
+-} _scute_opt;
++} _scute_opt_t;
++
++extern _scute_opt_t _scute_opt;
+ 
+ 
+ /*-- readconf.c --*/
+--- src/readconf.c
++++ src/readconf.c
+@@ -31,6 +31,8 @@
+ 
+ #include "options.h"
+ 
++_scute_opt_t _scute_opt;
++
+ static const char *
+ my_strusage (int level)
+ {


### PR DESCRIPTION
Add a new port for Scute, a PKCS#11 interface to the GnuPG Agent.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

###### Testing details
The signing functionality has been successfully tested with
- LibreOffice,
- [JSignPDF](https://jsignpdf.sourceforge.net/),
- pdfsig (as provided by MacPorts‘ `poppler` package).

Of note, while Scute provides a test suite (`make check`), and while the suite passes when I run it myself, it _fails_ when it is triggered by MacPorts as part of the `port test` command. I am still trying to understand why (any help welcome!), but I submit the port anyway since the installed port is working as expected.