### PR TITLE
rawtherapee: set cmake build type; ensure optimization disabled, for debug build

### DIFF
--- a/graphics/rawtherapee/Portfile
+++ b/graphics/rawtherapee/Portfile
@@ -67,6 +67,17 @@ if {${build_arch} eq "x86_64"} {
     configure.args-append   -DPROC_TARGET_NUMBER=2
 }
 
+
+if {[variant_isset debug]} {
+    cmake.build_type    Debug
+    configure.optflags  -O0
+} else {
+    cmake.build_type    RelWithDebInfo
+
+    # Clear optflags for non-debug build; controlled by project
+    configure.optflags
+}
+
 app.executable      ${build.dir}/rtgui/${name}
 app.icon            tools/osx/${name}.icns
 app.retina          yes


### PR DESCRIPTION
### Description

Set CMake build type as appropriate, for debug and non-debug builds.

Supports troubleshooting of open issue, related to segfault at launch:
* [65851 - rawtherapee: app segfaults during launch](https://trac.macports.org/ticket/65851)