### PR TITLE
openmotif: fix missing stdlib.h, sprintf() check

### DIFF
--- a/x11/openmotif/Portfile
+++ b/x11/openmotif/Portfile
@@ -2,7 +2,7 @@ PortSystem      1.0
 
 name            openmotif
 version         2.3.8
-revision        2
+revision        3
 categories      x11
 license         LGPL
 platforms       darwin
@@ -19,7 +19,9 @@ distname        motif-${version}
 
 checksums       md5    7572140bb52ba21ec2f0c85b2605e2b1 \
                 sha1   ca9d8d67544434c5883d8d0fb684a48f8b0108bd \
-                rmd160 a4c10db68d880d3096c97cc1c995351616a90a57
+                rmd160 a4c10db68d880d3096c97cc1c995351616a90a57 \
+                sha256 859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7 \
+                size   5704328
 
 depends_build \
 	port:pkgconfig \

--- a/x11/openmotif/files/include-stdlib.patch
+++ b/x11/openmotif/files/include-stdlib.patch
@@ -8,3 +8,52 @@
  #include <Xm/Xm.h>
  #include <Xm/Form.h>
  #include <Xm/PushB.h>
+
+
+
+See https://sourceforge.net/p/motif/code/merge-requests/2/
+and https://sourceforge.net/p/motif/code/merge-requests/3/
+
+# Commented out acinclude.m4 patch to avoid the build trying to run aclocal-1.15
+#--- acinclude.m4.orig
+#+++ acinclude.m4
+#@@ -18,6 +18,9 @@
+# CFLAGS="$X_CFLAGS $CFLAGS"
+# CPPFLAGS="$X_CFLAGS $CPPFLAGS"
+# AC_TRY_RUN([
+#+#ifdef HAVE_STDLIB_H
+#+#include <stdlib.h>
+#+#endif
+# #include <X11/Intrinsic.h>
+# int main() {
+# Boolean brc;
+#@@ -50,7 +53,7 @@
+# AC_DEFUN([AM_FUNC_VOID_SPRINTF],
+# [AC_CACHE_CHECK(whether sprintf returns void, ac_cv_func_void_sprintf,
+# [AC_TRY_RUN([#include <stdio.h>
+#-int sprintf(); main() { exit(sprintf(".")); }],
+#+int main() { char buf[1]; int i = sprintf(buf, ""); return 0; }
+#   ac_cv_func_void_sprintf=no, ac_cv_func_void_sprintf=yes, ac_cv_func_void_sprintf=yes)])
+# if test $ac_cv_func_void_sprintf = no; then
+#   AC_DEFINE(VOID_SPRINTF,1,
+--- configure.orig
++++ configure
+@@ -13172,6 +13172,9 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ #include <X11/Intrinsic.h>
+ int main() {
+ Boolean brc;
+@@ -14655,7 +14658,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdio.h>
+-int sprintf(); main() { exit(sprintf(".")); }
++int main() { char buf[1]; int i = sprintf(buf, ""); return 0; }
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+   ac_cv_func_void_sprintf=no


### PR DESCRIPTION
configure results were incorrect:
libXt reported as compiled without `-DXTHREADS`,
`sprintf()` reported as returning void rather than int

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7
Command Line Tools 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
