### PR TITLE
fix gjs build. Configure requires dbus

### DIFF
--- a/gnome/gjs-devel/Portfile
+++ b/gnome/gjs-devel/Portfile
@@ -9,7 +9,7 @@ conflicts           gjs
 set my_name         gjs
 
 version             1.72.2
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
@@ -35,6 +35,7 @@ depends_build       port:pkgconfig \
 
 depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    port:dbus \
                     port:libffi \
                     path:lib/pkgconfig/cairo.pc:cairo \
                     port:mozjs91 \

--- a/gnome/gjs/Portfile
+++ b/gnome/gjs/Portfile
@@ -9,7 +9,7 @@ conflicts           gjs-devel
 set my_name         gjs
 
 version             1.72.2
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
@@ -35,6 +35,7 @@ depends_build       port:pkgconfig \
 
 depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    port:dbus \
                     port:libffi \
                     path:lib/pkgconfig/cairo.pc:cairo \
                     port:mozjs91 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

`gjs` did not configure properly due to missing `dbus-run-session`

```
Program dbus-run-session found: NO

meson.build:299:0: ERROR: Program 'dbus-run-session' not found or n
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

I've not tested as I'm not able to do a source install. The testing I did was to `sudo port -N install dbus` with build from source enabled, and then `sudo port -N install gjs`. The build then completed successfully.