### PR TITLE
shared-mime-info: clean up cache on deactivate + auto-update watcher/daemon

### DIFF
--- a/devel/shared-mime-info/Portfile
+++ b/devel/shared-mime-info/Portfile
@@ -17,7 +17,9 @@ platforms           darwin
 description         Database of common types.
 
 long_description    The core database of common types and the \
-                    update-mime-database command used to extend it.
+                    update-mime-database command used to extend it. \n\
+                    Installs and starts a watcher daemon that keeps the \
+                    cache up-to-date when other ports add or remove mime definitions.
 
 homepage            https://www.freedesktop.org/wiki/Software/shared-mime-info/
 master_sites        https://gitlab.freedesktop.org/xdg/shared-mime-info/-/archive/${version}/
@@ -43,11 +45,45 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
 #     xinstall -m 644 ${filespath}/ObjCpp.xml \
 #         ${destroot}${prefix}/share/mime/packages
 # }
+post-destroot {
+    xinstall -d -m 755 ${destroot}${prefix}/Library/LaunchDaemons
+    xinstall -m 644 ${filespath}/org.macports.shared-mime-info-updater.plist \
+        ${destroot}${prefix}/Library/LaunchDaemons
+    reinplace -locale C "s|@PREFIX@|${prefix}|g" \
+        ${destroot}${prefix}/Library/LaunchDaemons/org.macports.shared-mime-info-updater.plist
+}
 
 post-activate {
-    ui_debug "Updating MIME database..."
-    system "env XDG_DATA_DIRS=${prefix}/share ${prefix}/bin/update-mime-database -V ${prefix}/share/mime"
+    if {${os.platform} eq "darwin"} {
+        ui_msg "Activating MIME database auto-updater..."
+        system "sudo launchctl load ${prefix}/Library/LaunchDaemons/org.macports.shared-mime-info-updater.plist"
+    } else {
+        ui_msg "Updating MIME database..."
+        system "env XDG_DATA_DIRS=${prefix}/share ${prefix}/bin/update-mime-database -V ${prefix}/share/mime"
+    }
 }
+
+pre-deactivate {
+    if {${os.platform} eq "darwin"} {
+        ui_debug "Deactivating MIME database auto-updater..."
+        system "sudo launchctl unload ${prefix}/Library/LaunchDaemons/org.macports.shared-mime-info-updater.plist"
+    }
+}
+
+post-deactivate {
+    # cleanup
+    foreach f [glob -nocomplain ${prefix}/share/mime/*] {
+        if {${f} ne "${prefix}/share/mime/packages"} {
+            file delete -force ${f}
+        }
+    }
+    ui_msg [join ${notes}]
+}
+
+notes-append "Please check if the auto-updater is still active after reactivating (another) version of) this port: \n\
+    `sudo launchctl list | fgrep shared-mime-info-updater` \n\
+    If the updater is not active, load it manually with \n\
+    `sudo launchctl load ${prefix}/Library/LaunchDaemons/org.macports.shared-mime-info-updater.plist`"
 
 pre-pkg {
     xinstall -m 0755 ${filespath}/postinstall ${package.scripts}/

--- a/devel/shared-mime-info/Portfile
+++ b/devel/shared-mime-info/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gitlab 1.0
 PortGroup           meson 1.0
 
-name                shared-mime-info
-version             2.2
+gitlab.instance     https://gitlab.freedesktop.org
+gitlab.setup        xdg shared-mime-info 2.2
+revision            1
 
 checksums           rmd160  c8efc1e91c23b82c37d9f78f6d9b1ffbf7be8a11 \
                     sha256  418c480019d9865f67f922dfb88de00e9f38bf971205d55cdffab50432919e61 \
@@ -13,7 +15,6 @@ checksums           rmd160  c8efc1e91c23b82c37d9f78f6d9b1ffbf7be8a11 \
 maintainers         {gmail.com:rjvbertin @RJVB} openmaintainer
 categories          devel
 license             GPL-2+
-platforms           darwin
 description         Database of common types.
 
 long_description    The core database of common types and the \
@@ -22,17 +23,28 @@ long_description    The core database of common types and the \
                     cache up-to-date when other ports add or remove mime definitions.
 
 homepage            https://www.freedesktop.org/wiki/Software/shared-mime-info/
-master_sites        https://gitlab.freedesktop.org/xdg/shared-mime-info/-/archive/${version}/
 use_bzip2           yes
 installs_libs       no
 
 depends_build-append \
-                    port:pkgconfig \
+                    port:gettext \
                     port:itstool \
+                    port:pkgconfig \
                     port:xmlto
 
-depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
+# Note: gettext only used at build time; lib dep for gettext-runtime not needed
+depends_lib-append \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libxml2
+
+set startupitem_file \
+                    org.macports.shared-mime-info-updater.plist
+
+post-extract {
+    copy ${filespath}/${startupitem_file} ${worksrcpath}
+    reinplace -locale C "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/${startupitem_file}
+}
 
 # add an entry for Objective C++
 # (https://bugs.freedesktop.org/show_bug.cgi?id=98823)
@@ -45,28 +57,11 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
 #     xinstall -m 644 ${filespath}/ObjCpp.xml \
 #         ${destroot}${prefix}/share/mime/packages
 # }
-post-destroot {
-    xinstall -d -m 755 ${destroot}${prefix}/Library/LaunchDaemons
-    xinstall -m 644 ${filespath}/org.macports.shared-mime-info-updater.plist \
-        ${destroot}${prefix}/Library/LaunchDaemons
-    reinplace -locale C "s|@PREFIX@|${prefix}|g" \
-        ${destroot}${prefix}/Library/LaunchDaemons/org.macports.shared-mime-info-updater.plist
-}
 
 post-activate {
-    if {${os.platform} eq "darwin"} {
-        ui_msg "Activating MIME database auto-updater..."
-        system "sudo launchctl load ${prefix}/Library/LaunchDaemons/org.macports.shared-mime-info-updater.plist"
-    } else {
+    if {${os.platform} ne "darwin"} {
         ui_msg "Updating MIME database..."
         system "env XDG_DATA_DIRS=${prefix}/share ${prefix}/bin/update-mime-database -V ${prefix}/share/mime"
-    }
-}
-
-pre-deactivate {
-    if {${os.platform} eq "darwin"} {
-        ui_debug "Deactivating MIME database auto-updater..."
-        system "sudo launchctl unload ${prefix}/Library/LaunchDaemons/org.macports.shared-mime-info-updater.plist"
     }
 }
 
@@ -80,17 +75,14 @@ post-deactivate {
     ui_msg [join ${notes}]
 }
 
-notes-append "Please check if the auto-updater is still active after reactivating (another) version of) this port: \n\
-    `sudo launchctl list | fgrep shared-mime-info-updater` \n\
-    If the updater is not active, load it manually with \n\
-    `sudo launchctl load ${prefix}/Library/LaunchDaemons/org.macports.shared-mime-info-updater.plist`"
+startupitem.autostart    yes
+startupitem.create       yes
+startupitem.custom_file  ${worksrcpath}/${startupitem_file}
+startupitem.install      yes
+startupitem.name         ${name}-updater
 
 pre-pkg {
     xinstall -m 0755 ${filespath}/postinstall ${package.scripts}/
     reinplace -locale C "s|@PREFIX@|${prefix}|g" ${package.scripts}/postinstall
     long_description-append  Install prefix: ${prefix}
 }
-
-livecheck.url       https://gitlab.freedesktop.org/xdg/shared-mime-info/-/tags
-livecheck.type      regex
-livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}

--- a/devel/shared-mime-info/files/org.macports.shared-mime-info-updater.plist
+++ b/devel/shared-mime-info/files/org.macports.shared-mime-info-updater.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+        <string>org.macports.shared-mime-info-updater</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+           <key>XDG_DATA_DIRS</key>
+           <string>@PREFIX@/share</string>
+    </dict>
+    <key>ProgramArguments</key>
+        <array>
+            <string>@PREFIX@/bin/update-mime-database</string>
+            <string>-V</string>
+            <string>@PREFIX@/share/mime</string>
+        </array>
+    <key>RunAtLoad</key>
+        <true/>
+    <key>WatchPaths</key>
+        <array>
+            <string>@PREFIX@/share/mime/packages</string>
+        </array>
+    <key>ThrottleInterval</key>
+        <integer>60</integer>
+    <key>Disabled</key>
+        <false/>
+</dict>
+</plist>


### PR DESCRIPTION
#### Description
Clean the mime cache after deactivating the port, as requested in https://trac.macports.org/ticket/45396 .

_Note that in my testing and experience the `post-activate` step is only performed after an install. So this change means that the mime cache is removed after a `port deactivate shared-mime-info` so also after a `port activate shared-mime-info` to activate a different version - in which case a new cache is not built automatically.

I see no way to warn the user of this fact other than after an install/upgrade, which is why I am not in favour of this new behaviour personally._

This PR also proposes to replace the post-activate call to `update-mime-database` with a launchd daemon watching `$prefix/share/mime/packages`. To make this change as transparent as possible the daemon's plist is loaded in the `post-activate` and unloaded in the `pre-deactivate`; the user is informed of this via `port info` and `port notes` (which also contains instructions related to the re-activation issue mentioned above).

If this change is accepted all dependent Portfiles could lose their post-activate call to `update-mime-database`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
Mac OS X 10.9.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
