### PR TITLE
qemu: Fix configuration for vnc variant

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -224,7 +224,7 @@ variant vnc description {Support VNC server} {
     configure.args-append   --enable-gnutls \
                             --enable-vnc-sasl \
                             --enable-vnc-jpeg \
-                            --enable-vnc-png
+                            --enable-png
     depends_lib-append      path:lib/pkgconfig/gnutls.pc:gnutls \
                             port:cyrus-sasl2 \
                             path:include/turbojpeg.h:libjpeg-turbo \


### PR DESCRIPTION
#### Description

QEMU 7.1.0 has dropped the configuration flag `--enable-vnc-png` (relevant commit in upstream [here](
https://gitlab.com/qemu-project/qemu/-/commit/95f8510ef428f988897176b9585b8ba1432f939f#0cc1139e3347f573ae1feee5b73dbc8a8a21fcfa_1559_1562)), breaking the vnc variant. This PR removes it from the Portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 13.4.1 13F100


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
