### PR TITLE
lighttpd: Update to 1.4.67

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -4,11 +4,11 @@ PortSystem                  1.0
 PortGroup                   legacysupport 1.0
 
 name                        lighttpd
-version                     1.4.66
+version                     1.4.67
 revision                    0
-checksums                   rmd160  c17cd736be60da4ff377a212d4a8f39c68b650ce \
-                            sha256  47ac6e60271aa0196e65472d02d019556dc7c6d09df3b65df2c1ab6866348e3b \
-                            size    1039520
+checksums                   rmd160  e710c084bfa45d6e9bce549198372538130aa2da \
+                            sha256  7e04d767f51a8d824b32e2483ef2950982920d427d1272ef4667f49d6f89f358 \
+                            size    1039872
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  www


### PR DESCRIPTION
#### Description
lighttpd: Update to 1.4.67

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?