### PR TITLE
py-hypothesis/py-wekzeug: updates

### DIFF
--- a/python/py-hypothesis/Portfile
+++ b/python/py-hypothesis/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-hypothesis
-version             6.54.5
+version             6.54.6
 revision            0
 categories-append   devel
 platforms           darwin
@@ -25,9 +25,9 @@ long_description \
 
 homepage            https://pypi.python.org/pypi/hypothesis
 
-checksums           rmd160  718fe4f21090289b7bb4b5ef1eeb471de78b7804 \
-                    sha256  8a9056825695f415bfad4e808ae719fc01383a9ab659775319724365afcc7ec7 \
-                    size    329386
+checksums           rmd160  5d33e038cd66fa2df9b0911bdcb444254bd69570 \
+                    sha256  2d5e2d5ccd0efce4e0968a6164f4e4853f808e33f4d91490c975c98beec0c7c3 \
+                    size    329584
 
 if {${name} ne ${subport}} {
     depends_build-append  port:py${python.version}-setuptools
@@ -44,6 +44,8 @@ if {${name} ne ${subport}} {
                             size    233528
 
         depends_lib-append  port:py${python.version}-enum34
+
+        livecheck.type none
     }
 
     if {${python.version} == 35} {
@@ -52,6 +54,8 @@ if {${name} ne ${subport}} {
         checksums           rmd160  ba112a0d4a97ffaf0a0aa6e6ab2c135e0dd96d10 \
                             sha256  5cc9073ee5a5c109c8d731a52c304729dbb6affed570eb7d35908bfdd937975e \
                             size    267988
+
+        livecheck.type none
     }
 
     if {${python.version} == 36} {
@@ -60,6 +64,8 @@ if {${name} ne ${subport}} {
         checksums           rmd160  fa5b58a419eafda77d1b0fe21723034da51c76b3 \
                             sha256  d54be6a80b160ad5ea4209b01a0d72e31d910510ed7142fa9907861911800771 \
                             size    316859
+
+        livecheck.type none
     }
 
     if {${python.version} > 36 && ${python.version} < 311} {

--- a/python/py-werkzeug/Portfile
+++ b/python/py-werkzeug/Portfile
@@ -46,6 +46,8 @@ if {${name} ne ${subport}} {
         checksums           rmd160  9dc625e19c6cb90783972a8d467bd5270aafe30c \
                             sha256  6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c \
                             size    904455
+
+        livecheck.type      none
     }
 
     post-destroot {


### PR DESCRIPTION
#### Description

This is a follow up for https://github.com/macports/macports-ports/pull/16153 
 - py-hypothesis was upgraded right away => update it one more time;
 - py-hypothesis and py-werkzeug has pinned version which should have an explicit `livecheck.type none`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 x86_64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->