### PR TITLE
pnpm: update to 7.12.0

### DIFF
--- a/devel/pnpm/Portfile
+++ b/devel/pnpm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pnpm
-version             7.11.0
+version             7.12.0
 revision            0
 
 categories          devel
@@ -18,6 +18,6 @@ long_description    pnpm is a fast, disk space efficient package manager, \
 
 homepage            https://pnpm.io
 
-checksums           rmd160  39e32dd1349acb2eea28f65948c1f5fe2b1b1ed5 \
-                    sha256  4806143590b74b52b5cca2e8851f1aefc7e8a66b6d06188920a1b3321653b913 \
-                    size    2928030
+checksums           rmd160  22f42572bc47c6921d8dddb7f55dde72b10893d0 \
+                    sha256  20e3413496d5b9f3b55c051c882c400d8f33f6e574bb4191d6a4c8708e0c60ec \
+                    size    2929569


### PR DESCRIPTION
#### Description

Created with [seaport](https://seaport.rtfd.io/), the modern MacPorts portfile updater.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?