### PR TITLE
libass: fix Rosetta build, correct PPC merger_host

### DIFF
--- a/multimedia/libass/Portfile
+++ b/multimedia/libass/Portfile
@@ -13,7 +13,6 @@ checksums       rmd160  48cf8afae1161dd140afc159e4aa50e5c0532d82 \
 categories      multimedia
 license         ISC
 maintainers     nomaintainer
-platforms       darwin
 description     subtitle renderer for the ASS/SSA subtitle format
 
 long_description \
@@ -36,11 +35,18 @@ configure.args  --enable-fontconfig \
 # ass.h:421: error: wrong number of arguments specified for 'deprecated' attribute
 compiler.blacklist-append *gcc-3.* *gcc-4.*
 
+# https://trac.macports.org/ticket/65860
+platform darwin powerpc {
+    compiler.blacklist-append clang
+}
+
 if {${universal_possible} && [variant_isset universal]} {
     # Needed by configure to correctly set the yasm build flags.
-    foreach arch ${configure.universal_archs} {
-        set merger_host($arch) "${arch}-apple-${os.platform}${os.major}.${os.minor}.0"
-    }
+    set merger_host(arm64)  "aarch64-apple-${os.platform}${os.major}.${os.minor}.0"
+    set merger_host(i386)   "i386-apple-${os.platform}${os.major}.${os.minor}.0"
+    set merger_host(ppc)    "powerpc-apple-${os.platform}${os.major}.${os.minor}.0"
+    set merger_host(ppc64)  "powerpc64-apple-${os.platform}${os.major}.${os.minor}.0"
+    set merger_host(x86_64) "x86_64-apple-${os.platform}${os.major}.${os.minor}.0"
 
     # I don't feel safe using a *86* match here. Who knows what other arch could
     # be matching in the future.


### PR DESCRIPTION
#### Description

1. Blacklist Clang for Darwin PPC (otherwise it is invoked on 10.6.8 and breaks the build).
2. Correct PPC merger_host names (they should be `powerpc*-`, not `ppc*-`).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
