### PR TITLE
libxml2: update to 2.10.0

### DIFF
--- a/textproc/libxml2/Portfile
+++ b/textproc/libxml2/Portfile
@@ -6,8 +6,8 @@ PortGroup           clang_dependency 1.0
 # Please keep the version of the libxml2 and py-libxml2 ports the same.
 
 name                libxml2
-version             2.9.14
-revision            1
+version             2.10.0
+revision            0
 categories          textproc
 license             MIT
 maintainers         nomaintainer
@@ -26,27 +26,19 @@ depends_lib         port:libiconv \
                     port:xz \
                     port:zlib
 
-master_sites        https://download.gnome.org/sources/libxml2/2.9/
+master_sites        https://download.gnome.org/sources/libxml2/2.10/
 
-checksums           rmd160  1feadd3f7e3a801f1fc1b9f4e90054f2f2c8fc33 \
-                    sha256  60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee \
-                    size    3129968
+checksums           rmd160  e93f4a6dae72cb20793a61097273a4b7d5c4ce7c \
+                    sha256  2dd33110ea778676de14bea4999ee1173c4ca55d5ff1452bca224e06f0152595 \
+                    size    2698684
 
 use_xz yes
-
-set icu_cxx_version 201103L
 
 patchfiles-append   include.patch
 
 post-patch {
     reinplace "s|@ICONV_PREFIX@|${prefix}|" ${worksrcpath}/include/libxml/encoding.h
-    reinplace "s|@ICU_PREFIX@|${prefix}|" ${worksrcpath}/include/libxml/encoding.h
-    reinplace "s|@ICU_CXX_VERSION@|${icu_cxx_version}|" ${worksrcpath}/include/libxml/encoding.h
     reinplace -locale C "s|/etc|${prefix}/etc|g" \
-        ${worksrcpath}/catalog.c \
-        ${worksrcpath}/runtest.c \
-        ${worksrcpath}/xmlcatalog.c \
-        ${worksrcpath}/xmllint.c \
         ${worksrcpath}/doc/xmlcatalog.1 \
         ${worksrcpath}/doc/xmllint.1
 }
@@ -54,7 +46,8 @@ post-patch {
 configure.args      --disable-silent-rules \
                     --enable-static \
                     --with-icu \
-                    --without-python
+                    --without-python \
+                    --sysconfdir=${prefix}/etc
 
 destroot.keepdirs   ${destroot}${prefix}/etc/xml
 post-destroot {

--- a/textproc/libxml2/files/include.patch
+++ b/textproc/libxml2/files/include.patch
@@ -1,22 +1,11 @@
-Ensure MacPorts libiconv and icu are found even if -I/opt/local/include
-is not in CPPFLAGS. Also don't expose the ICU C++ API if using a C++
-version that is too old.
---- include/libxml/encoding.h.orig	2017-11-14 08:00:17.000000000 +1100
-+++ include/libxml/encoding.h	2019-11-21 19:10:55.000000000 +1100
-@@ -25,10 +25,14 @@
+--- include/libxml/encoding.h.orig	2022-05-02 14:10:21.000000000 +0200
++++ include/libxml/encoding.h	2022-09-19 15:58:07.000000000 +0200
+@@ -25,7 +25,7 @@
  #include <libxml/xmlversion.h>
  
  #ifdef LIBXML_ICONV_ENABLED
 -#include <iconv.h>
 +#include <@ICONV_PREFIX@/include/iconv.h>
  #endif
- #ifdef LIBXML_ICU_ENABLED
--#include <unicode/ucnv.h>
-+/* ICU C++ API requires C++11 */
-+#if defined(__cplusplus) && __cplusplus < @ICU_CXX_VERSION@
-+#define U_SHOW_CPLUSPLUS_API 0
-+#endif
-+#include <@ICU_PREFIX@/include/unicode/ucnv.h>
- #endif
+ 
  #ifdef __cplusplus
- extern "C" {


### PR DESCRIPTION
 - Update libxml2 to 2.10.0
 - Closes https://trac.macports.org/ticket/65865

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
