### PR TITLE
openjdk19-oracle: new submission

### DIFF
--- a/java/openjdk19-oracle/Portfile
+++ b/java/openjdk19-oracle/Portfile
@@ -1,0 +1,89 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk19-oracle
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://jdk.java.net/19/
+version      19
+revision     0
+
+description  Oracle OpenJDK 19
+long_description Open-source Oracle build of OpenJDK 19, the Java Development Kit, an implementation of the Java SE Platform.
+
+master_sites https://download.java.net/java/GA/jdk${version}/877d6127e982470ba2a7faa31cc93d04/36/GPL/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     openjdk-${version}_macos-x64_bin
+    checksums    rmd160  d69263ad5a95431ea6f44138e7c81f6367e3b597 \
+                 sha256  bfd33f5b2590fd552ae2d9231340c6b4704a872f927dce1c52860b78c49a5a11 \
+                 size    192323254
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     openjdk-${version}_macos-aarch64_bin
+    checksums    rmd160  ab7a706471109466c270a3b219f55736b6743970 \
+                 sha256  6691c199fdc6d71826f37d89d2e1a2089ba8bdd98b7001c1d4e8d5d01d6b022b \
+                 size    190416515
+}
+
+worksrcdir   jdk-${version}.jdk
+
+homepage     https://jdk.java.net/19/
+
+livecheck.type      regex
+livecheck.url       https://jdk.java.net/19/
+livecheck.regex     OpenJDK JDK (19\[0-9\.\]*)
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Oracle OpenJDK 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?