### PR TITLE
jdk19: new submission

### DIFF
--- a/java/jdk19/Portfile
+++ b/java/jdk19/Portfile
@@ -1,0 +1,91 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             jdk19
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          NFTC NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://www.oracle.com/java/technologies/downloads/#jdk19-mac
+version      19
+revision     0
+
+description  Oracle Java SE Development Kit 19
+long_description Java Platform, Standard Edition Development Kit (JDK). \
+    The JDK is a development environment for building applications and components using the Java programming language. \
+    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
+
+master_sites https://download.oracle.com/java/19/archive/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     jdk-${version}_macos-x64_bin
+    checksums    rmd160  f58d12513db70c40fef9c361a4d093ff910db68b \
+                 sha256  4d0e387c6a016da5f09afeeb06674a311dd599be4d9cd70c2c01324312303305 \
+                 size    185908835
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  3ae0914053d000f49357fc32fc350555463a5684 \
+                 sha256  c1b1a125435ff7423f23453da28e516e6fa4bafe445d303fee917d373d2e1e53 \
+                 size    184002617
+}
+
+worksrcdir   jdk-${version}.jdk
+
+homepage     https://www.oracle.com/java/
+
+livecheck.type      regex
+livecheck.url       https://www.oracle.com/java/technologies/downloads/
+livecheck.regex     Java SE Development Kit (19\[0-9\.\]?)
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Oracle JDK for Java SE 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?