### PR TITLE
graphviz{,-devel}: disable generation man pdfs

### DIFF
--- a/graphics/graphviz-devel/Portfile
+++ b/graphics/graphviz-devel/Portfile
@@ -58,7 +58,7 @@ PortGroup                       legacysupport 1.1
 # strndup
 legacysupport.newest_darwin_requires_legacy 10
 
-revision                        0
+revision                        1
 
 conflicts                       graphviz${otherbranch}
 
@@ -120,6 +120,7 @@ configure.args                  --disable-silent-rules \
                                 --disable-io \
                                 --disable-java \
                                 --disable-lua \
+                                --disable-man-pdfs \
                                 --disable-ocaml \
                                 --disable-perl \
                                 --disable-php \

--- a/graphics/graphviz/Portfile
+++ b/graphics/graphviz/Portfile
@@ -58,7 +58,7 @@ PortGroup                       legacysupport 1.1
 # strndup
 legacysupport.newest_darwin_requires_legacy 10
 
-revision                        0
+revision                        1
 
 conflicts                       graphviz${otherbranch}
 
@@ -120,6 +120,7 @@ configure.args                  --disable-silent-rules \
                                 --disable-io \
                                 --disable-java \
                                 --disable-lua \
+                                --disable-man-pdfs \
                                 --disable-ocaml \
                                 --disable-perl \
                                 --disable-php \


### PR DESCRIPTION
#### Description

MacPorts never builds man-pdfs. Anyway, the last updated migrated graphviz to the version which contains inverted condition.

See: https://gitlab.com/graphviz/graphviz/-/commit/def16bd0dd2cc161ac474c2ac1e2003a30224f0b

Closes: https://trac.macports.org/ticket/65868

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->