### PR TITLE
mvnd: update to 0.8.1

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       java 1.0
 
-version         0.8.0
+version         0.8.1
 revision        0
 name            mvnd
 categories      java
@@ -36,9 +36,9 @@ supported_archs x86_64
 master_sites    https://downloads.apache.org/maven/mvnd/${version}/
 distname        maven-mvnd-${version}-darwin-amd64
 
-checksums       rmd160  088ea924584215c123114b401c06e1b88c570325 \
-                sha256  b81c78393ec00104f55983b0944e941d2702a8d82d5517f20287d6486a514ca0 \
-                size    20710406
+checksums       rmd160  fdc05e3fd4aebc2d994977d110b66529d4821652 \
+                sha256  84b63929e11382e389d90753873a81d5c8e8e852c74ea05d5cac20801b3af07a \
+                size    21036504
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to mvnd 0.8.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?