### PR TITLE
jdk18: obsolete, replaced by jdk19

### DIFF
--- a/java/jdk18/Portfile
+++ b/java/jdk18/Portfile
@@ -1,91 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-03-20
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             jdk18
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          NFTC NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://www.oracle.com/java/technologies/downloads/#jdk18-mac
-version      18.0.2.1
-revision     0
-
-description  Oracle Java SE Development Kit 18
-long_description Java Platform, Standard Edition Development Kit (JDK). \
-    The JDK is a development environment for building applications and components using the Java programming language. \
-    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
-
-master_sites https://download.oracle.com/java/18/archive/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  081abed3c2fa1be7aa0bbd17d2cc25865af54b49 \
-                 sha256  4c0bfa05cf27b9bee6586933581204d6757b5939769a7c25e13a52bf07a9b9db \
-                 size    178759371
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  d4c243eb6e25acd03888be1341735ea3d62505a0 \
-                 sha256  ee900a062e0a4b76e9da4f90933ea560c9129b24685f78664a892beeb4f53c64 \
-                 size    176602474
-}
-
-worksrcdir   jdk-${version}.jdk
-
-homepage     https://www.oracle.com/java/
-
-livecheck.type      regex
-livecheck.url       https://www.oracle.com/java/technologies/downloads/
-livecheck.regex     Java SE Development Kit (18\.\[0-9\.\]+)
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        jdk18
+categories  java devel
+replaced_by jdk19
+version     18.0.2.1
+revision    1


### PR DESCRIPTION
#### Description

Support for Oracle JDK 18 ended, replace with Oracle JDK 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?