### PR TITLE
KeePassXC: rebuild to work around qt5 linking error

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -33,7 +33,7 @@ license_noconflict      openssl openssl10 openssl11 openssl3
 if {${subport} eq ${name}} {
     # stable
     github.setup        keepassxreboot keepassxc 2.7.1
-    revision            0
+    revision            1
     github.tarball_from releases
     distname            keepassxc-${version}-src
     use_xz              yes
@@ -59,7 +59,7 @@ if {${subport} eq ${name}} {
     github.setup        keepassxreboot keepassxc 5916a8f8dd93eb6a5de544caedd7a9d8e9a3b1ee
     set githash         [string range ${github.version} 0 6]
     version             20220406+git${githash}
-    revision            0
+    revision            1
 
     conflicts           KeePassXC
 


### PR DESCRIPTION
#### Description

KeePassX fails to launch currently with
```
/Applications/MacPorts/KeePassXC.app/Contents/MacOS/KeePassXC
dyld[87749]: Symbol not found: (__ZN12QtConcurrent16ThreadEngineBase13startBlockingEv)
  Referenced from: '/Applications/MacPorts/KeePassXC.app/Contents/MacOS/KeePassXC'
  Expected in: '/opt/local/libexec/qt5/lib/QtConcurrent.framework/Versions/5/QtConcurrent'
Abort trap: 6
[Exit 134 (ABRT)]
```
I went and looked at qt5-qtbase port, and found a recent [PR](https://github.com/macports/macports-ports/pull/16058) which might have skipped CI.
Rebuilding with `sudo port install -s` fixes the issue.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
