### PR TITLE
gopass: update to 1.14.7

### DIFF
--- a/security/git-credential-gopass/Portfile
+++ b/security/git-credential-gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/git-credential-gopass 1.14.6 v
+go.setup            github.com/gopasspw/git-credential-gopass 1.14.7 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  9ca7f7b01f2869a9f30fe8eb9519675f488e40f7 \
-                        sha256  e009294586318b083507d97a179c3623270b943389c7ea4a9086021edf9f066f \
-                        size    19914
+                        rmd160  b04aa65e0f91a6d3b64d1c1b51bcdaa72127f675 \
+                        sha256  fe298c0a88a6a5c1dfdf83a70f05358faf4e846e2fba3a5ac0252f208fb91d62 \
+                        size    19909
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -35,30 +35,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    a9ba230a4035 \
-                        rmd160  2011606ab7a7f34f3deffe211d32ef2c89ebb195 \
-                        sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
-                        size    14845 \
+                        lock    7a66f970e087 \
+                        rmd160  41c0ec1933a371ad67cb43763a5f056beb4f4863 \
+                        sha256  eb75717073f7fa08879333df6cc9ddcefd6dff51fdcd68769a144f480b754d89 \
+                        size    14836 \
                     golang.org/x/sys \
-                        lock    aba9fc2a8ff2 \
-                        rmd160  c8a64d0065845de9f024b7464d0717fe68fa311b \
-                        sha256  42b5dfe405f20247c891865b7caded763c606a157432ca853d007c6745d0b410 \
-                        size    1357840 \
+                        lock    fb04ddd9f9c8 \
+                        rmd160  41dd5a1d760c494464ed1b39f7f9ad1dd8da6ce6 \
+                        sha256  41f195441e43743942e294caa8cfa6d7bf1fb64c84661f5e49af5ff207ee912f \
+                        size    1358320 \
                     golang.org/x/net \
-                        lock    bea034e7d591 \
-                        rmd160  36a6cdfee8b5a1c679b4555e099c1cc58a730f62 \
-                        sha256  931a5438035243928b15e139d29e2f6a0fbc16a76b30f15c569882739a1328a3 \
-                        size    1226358 \
+                        lock    2e0b12c274b7 \
+                        rmd160  a4badb7c7e2d0af72505c1f8044fa39961f30f21 \
+                        sha256  55ae5e198f1c830d02964ccc46b56ee7971f0261133407d40be27e92c482f430 \
+                        size    1227014 \
                     golang.org/x/exp \
-                        lock    5c715a9e8561 \
-                        rmd160  70b2b52094db383d55f73a2ee5190cee0c6410f9 \
-                        sha256  b13ce42f14361b187012869848458057040d33b0cbb0a6455322b7946520da5a \
-                        size    1580357 \
+                        lock    b168a2c6b86b \
+                        rmd160  7e3b3c394be4421e28e0a65bac71df5d23f539f7 \
+                        sha256  84bbcce0d41ce37251316b67ceed7861029eb2ee9581086b3b0cb5b2e6aad9bc \
+                        size    1580715 \
                     golang.org/x/crypto \
-                        lock    c86fa9a7ed90 \
-                        rmd160  d10541162293e950d1c79f5b0cff231d0158b53c \
-                        sha256  d97beb5e040b73b1997e0c9b34e1fa78bbbca789f17cfdfb52e3d25c880112bb \
-                        size    1631830 \
+                        lock    35f4265a4bc0 \
+                        rmd160  05b8525d7b42a0d68533ffbc19154d6eb1b27a09 \
+                        sha256  077b25ae82ba66e33061eb19b286f2e085a734c00f50c849d40658cf5dd981ff \
+                        size    1631669 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -77,10 +77,10 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.16.0 \
-                        rmd160  bbe0ba0f1a5e793a5afa88120f061896136dfa51 \
-                        sha256  a60db5151a58c450f73b5791913a0af424270de796201f401c0e556593a99cdc \
-                        size    3467764 \
+                        lock    v2.16.3 \
+                        rmd160  adb83ade0b2179e2e317399b92b0847400e50657 \
+                        sha256  99806c3033219a905b006c8cae96c8ba4cd08a94ce966886b0f3855b36440850 \
+                        size    3469448 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -207,10 +207,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.6 \
-                        rmd160  21f784422760dcb1f20f4818340a8cf07c9850b4 \
-                        sha256  3e15d8b90e23e3df571b2b63e55aeda57ec451667628b0aefb65a38256b5a70a \
-                        size    2249043 \
+                        lock    v1.14.7 \
+                        rmd160  2cfcaebfdd0eecc85e4d7b6395ab0fb429ebe029 \
+                        sha256  63b3db24f57f50b2f3d800c9deaf0ca2ac850279132dadbc0418b522d158010a \
+                        size    2250633 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \

--- a/security/gopass-hibp/Portfile
+++ b/security/gopass-hibp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-hibp 1.14.6 v
+go.setup            github.com/gopasspw/gopass-hibp 1.14.7 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    ${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  a112c4d0be1e17fd889326b2b41e2e9c6491b0e1 \
-                        sha256  342fba9e54212d5f2d333276b85dcd542f80690274156134e5a7a0cb3b35ca7f \
-                        size    22206
+                        rmd160  476a089cad569f9c7883ae1a651c108cd7d4a528 \
+                        sha256  7a5b68fe9c4e0966f559f714cafb3e74b8c4abb8476c07ee219f277caa8082a5 \
+                        size    22211
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -35,30 +35,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    a9ba230a4035 \
-                        rmd160  2011606ab7a7f34f3deffe211d32ef2c89ebb195 \
-                        sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
-                        size    14845 \
+                        lock    7a66f970e087 \
+                        rmd160  41c0ec1933a371ad67cb43763a5f056beb4f4863 \
+                        sha256  eb75717073f7fa08879333df6cc9ddcefd6dff51fdcd68769a144f480b754d89 \
+                        size    14836 \
                     golang.org/x/sys \
-                        lock    aba9fc2a8ff2 \
-                        rmd160  c8a64d0065845de9f024b7464d0717fe68fa311b \
-                        sha256  42b5dfe405f20247c891865b7caded763c606a157432ca853d007c6745d0b410 \
-                        size    1357840 \
+                        lock    fb04ddd9f9c8 \
+                        rmd160  41dd5a1d760c494464ed1b39f7f9ad1dd8da6ce6 \
+                        sha256  41f195441e43743942e294caa8cfa6d7bf1fb64c84661f5e49af5ff207ee912f \
+                        size    1358320 \
                     golang.org/x/net \
-                        lock    bea034e7d591 \
-                        rmd160  36a6cdfee8b5a1c679b4555e099c1cc58a730f62 \
-                        sha256  931a5438035243928b15e139d29e2f6a0fbc16a76b30f15c569882739a1328a3 \
-                        size    1226358 \
+                        lock    2e0b12c274b7 \
+                        rmd160  a4badb7c7e2d0af72505c1f8044fa39961f30f21 \
+                        sha256  55ae5e198f1c830d02964ccc46b56ee7971f0261133407d40be27e92c482f430 \
+                        size    1227014 \
                     golang.org/x/exp \
-                        lock    5c715a9e8561 \
-                        rmd160  70b2b52094db383d55f73a2ee5190cee0c6410f9 \
-                        sha256  b13ce42f14361b187012869848458057040d33b0cbb0a6455322b7946520da5a \
-                        size    1580357 \
+                        lock    b168a2c6b86b \
+                        rmd160  7e3b3c394be4421e28e0a65bac71df5d23f539f7 \
+                        sha256  84bbcce0d41ce37251316b67ceed7861029eb2ee9581086b3b0cb5b2e6aad9bc \
+                        size    1580715 \
                     golang.org/x/crypto \
-                        lock    c86fa9a7ed90 \
-                        rmd160  d10541162293e950d1c79f5b0cff231d0158b53c \
-                        sha256  d97beb5e040b73b1997e0c9b34e1fa78bbbca789f17cfdfb52e3d25c880112bb \
-                        size    1631830 \
+                        lock    35f4265a4bc0 \
+                        rmd160  05b8525d7b42a0d68533ffbc19154d6eb1b27a09 \
+                        sha256  077b25ae82ba66e33061eb19b286f2e085a734c00f50c849d40658cf5dd981ff \
+                        size    1631669 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -77,10 +77,10 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.16.0 \
-                        rmd160  bbe0ba0f1a5e793a5afa88120f061896136dfa51 \
-                        sha256  a60db5151a58c450f73b5791913a0af424270de796201f401c0e556593a99cdc \
-                        size    3467764 \
+                        lock    v2.16.3 \
+                        rmd160  adb83ade0b2179e2e317399b92b0847400e50657 \
+                        sha256  99806c3033219a905b006c8cae96c8ba4cd08a94ce966886b0f3855b36440850 \
+                        size    3469448 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -207,10 +207,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.6 \
-                        rmd160  21f784422760dcb1f20f4818340a8cf07c9850b4 \
-                        sha256  3e15d8b90e23e3df571b2b63e55aeda57ec451667628b0aefb65a38256b5a70a \
-                        size    2249043 \
+                        lock    v1.14.7 \
+                        rmd160  2cfcaebfdd0eecc85e4d7b6395ab0fb429ebe029 \
+                        sha256  63b3db24f57f50b2f3d800c9deaf0ca2ac850279132dadbc0418b522d158010a \
+                        size    2250633 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \

--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.14.6 v
+go.setup            github.com/gopasspw/gopass-jsonapi 1.14.7 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,8 +14,8 @@ long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  2157e83b2920f209796ce8b197f17810040ce244 \
-                        sha256  6511d033e3ec9362b2a53ee5a10343f5547f0691758b03be298fd52ff5b20bb8 \
+                        rmd160  d05d17df7759c129b5e6cb28094e51c098d3ca70 \
+                        sha256  318d423d3cd97e11904b7d400a2287cd985089a83b0b2587de047098bce14a70 \
                         size    30861
 
 go.vendors          gotest.tools \
@@ -35,30 +35,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    a9ba230a4035 \
-                        rmd160  2011606ab7a7f34f3deffe211d32ef2c89ebb195 \
-                        sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
-                        size    14845 \
+                        lock    7a66f970e087 \
+                        rmd160  41c0ec1933a371ad67cb43763a5f056beb4f4863 \
+                        sha256  eb75717073f7fa08879333df6cc9ddcefd6dff51fdcd68769a144f480b754d89 \
+                        size    14836 \
                     golang.org/x/sys \
-                        lock    aba9fc2a8ff2 \
-                        rmd160  c8a64d0065845de9f024b7464d0717fe68fa311b \
-                        sha256  42b5dfe405f20247c891865b7caded763c606a157432ca853d007c6745d0b410 \
-                        size    1357840 \
+                        lock    fb04ddd9f9c8 \
+                        rmd160  41dd5a1d760c494464ed1b39f7f9ad1dd8da6ce6 \
+                        sha256  41f195441e43743942e294caa8cfa6d7bf1fb64c84661f5e49af5ff207ee912f \
+                        size    1358320 \
                     golang.org/x/net \
-                        lock    bea034e7d591 \
-                        rmd160  36a6cdfee8b5a1c679b4555e099c1cc58a730f62 \
-                        sha256  931a5438035243928b15e139d29e2f6a0fbc16a76b30f15c569882739a1328a3 \
-                        size    1226358 \
+                        lock    2e0b12c274b7 \
+                        rmd160  a4badb7c7e2d0af72505c1f8044fa39961f30f21 \
+                        sha256  55ae5e198f1c830d02964ccc46b56ee7971f0261133407d40be27e92c482f430 \
+                        size    1227014 \
                     golang.org/x/exp \
-                        lock    5c715a9e8561 \
-                        rmd160  70b2b52094db383d55f73a2ee5190cee0c6410f9 \
-                        sha256  b13ce42f14361b187012869848458057040d33b0cbb0a6455322b7946520da5a \
-                        size    1580357 \
+                        lock    b168a2c6b86b \
+                        rmd160  7e3b3c394be4421e28e0a65bac71df5d23f539f7 \
+                        sha256  84bbcce0d41ce37251316b67ceed7861029eb2ee9581086b3b0cb5b2e6aad9bc \
+                        size    1580715 \
                     golang.org/x/crypto \
-                        lock    c86fa9a7ed90 \
-                        rmd160  d10541162293e950d1c79f5b0cff231d0158b53c \
-                        sha256  d97beb5e040b73b1997e0c9b34e1fa78bbbca789f17cfdfb52e3d25c880112bb \
-                        size    1631830 \
+                        lock    35f4265a4bc0 \
+                        rmd160  05b8525d7b42a0d68533ffbc19154d6eb1b27a09 \
+                        sha256  077b25ae82ba66e33061eb19b286f2e085a734c00f50c849d40658cf5dd981ff \
+                        size    1631669 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -77,10 +77,10 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.16.0 \
-                        rmd160  bbe0ba0f1a5e793a5afa88120f061896136dfa51 \
-                        sha256  a60db5151a58c450f73b5791913a0af424270de796201f401c0e556593a99cdc \
-                        size    3467764 \
+                        lock    v2.16.3 \
+                        rmd160  adb83ade0b2179e2e317399b92b0847400e50657 \
+                        sha256  99806c3033219a905b006c8cae96c8ba4cd08a94ce966886b0f3855b36440850 \
+                        size    3469448 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -207,10 +207,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.6 \
-                        rmd160  21f784422760dcb1f20f4818340a8cf07c9850b4 \
-                        sha256  3e15d8b90e23e3df571b2b63e55aeda57ec451667628b0aefb65a38256b5a70a \
-                        size    2249043 \
+                        lock    v1.14.7 \
+                        rmd160  2cfcaebfdd0eecc85e4d7b6395ab0fb429ebe029 \
+                        sha256  63b3db24f57f50b2f3d800c9deaf0ca2ac850279132dadbc0418b522d158010a \
+                        size    2250633 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \

--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.14.6 v
+go.setup            github.com/gopasspw/gopass 1.14.7 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  21f784422760dcb1f20f4818340a8cf07c9850b4 \
-                        sha256  3e15d8b90e23e3df571b2b63e55aeda57ec451667628b0aefb65a38256b5a70a \
-                        size    2249043
+                        rmd160  2cfcaebfdd0eecc85e4d7b6395ab0fb429ebe029 \
+                        sha256  63b3db24f57f50b2f3d800c9deaf0ca2ac850279132dadbc0418b522d158010a \
+                        size    2250633
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -55,35 +55,35 @@ go.vendors          rsc.io/qr \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/term \
-                        lock    a9ba230a4035 \
-                        rmd160  2011606ab7a7f34f3deffe211d32ef2c89ebb195 \
-                        sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
-                        size    14845 \
+                        lock    7a66f970e087 \
+                        rmd160  41c0ec1933a371ad67cb43763a5f056beb4f4863 \
+                        sha256  eb75717073f7fa08879333df6cc9ddcefd6dff51fdcd68769a144f480b754d89 \
+                        size    14836 \
                     golang.org/x/sys \
-                        lock    aba9fc2a8ff2 \
-                        rmd160  c8a64d0065845de9f024b7464d0717fe68fa311b \
-                        sha256  42b5dfe405f20247c891865b7caded763c606a157432ca853d007c6745d0b410 \
-                        size    1357840 \
+                        lock    fb04ddd9f9c8 \
+                        rmd160  41dd5a1d760c494464ed1b39f7f9ad1dd8da6ce6 \
+                        sha256  41f195441e43743942e294caa8cfa6d7bf1fb64c84661f5e49af5ff207ee912f \
+                        size    1358320 \
                     golang.org/x/oauth2 \
                         lock    f21342109be1 \
                         rmd160  3d35eb173cd9439471d136f4bd66b152f4b00e43 \
                         sha256  3dfaafffd26bd211fa3e89c4daceceaf209ee241c120330d19cc33cc6ba036a7 \
                         size    104307 \
                     golang.org/x/net \
-                        lock    bea034e7d591 \
-                        rmd160  36a6cdfee8b5a1c679b4555e099c1cc58a730f62 \
-                        sha256  931a5438035243928b15e139d29e2f6a0fbc16a76b30f15c569882739a1328a3 \
-                        size    1226358 \
+                        lock    2e0b12c274b7 \
+                        rmd160  a4badb7c7e2d0af72505c1f8044fa39961f30f21 \
+                        sha256  55ae5e198f1c830d02964ccc46b56ee7971f0261133407d40be27e92c482f430 \
+                        size    1227014 \
                     golang.org/x/exp \
-                        lock    5c715a9e8561 \
-                        rmd160  70b2b52094db383d55f73a2ee5190cee0c6410f9 \
-                        sha256  b13ce42f14361b187012869848458057040d33b0cbb0a6455322b7946520da5a \
-                        size    1580357 \
+                        lock    b168a2c6b86b \
+                        rmd160  7e3b3c394be4421e28e0a65bac71df5d23f539f7 \
+                        sha256  84bbcce0d41ce37251316b67ceed7861029eb2ee9581086b3b0cb5b2e6aad9bc \
+                        size    1580715 \
                     golang.org/x/crypto \
-                        lock    c86fa9a7ed90 \
-                        rmd160  d10541162293e950d1c79f5b0cff231d0158b53c \
-                        sha256  d97beb5e040b73b1997e0c9b34e1fa78bbbca789f17cfdfb52e3d25c880112bb \
-                        size    1631830 \
+                        lock    35f4265a4bc0 \
+                        rmd160  05b8525d7b42a0d68533ffbc19154d6eb1b27a09 \
+                        sha256  077b25ae82ba66e33061eb19b286f2e085a734c00f50c849d40658cf5dd981ff \
+                        size    1631669 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -102,10 +102,10 @@ go.vendors          rsc.io/qr \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.15.0 \
-                        rmd160  c50c152b70abc533724366da795dee0b9ec9d04e \
-                        sha256  060268b4cc06f995cf61140c926694b14dc8830403536a0a7416e7fd63069055 \
-                        size    3465047 \
+                        lock    v2.16.3 \
+                        rmd160  adb83ade0b2179e2e317399b92b0847400e50657 \
+                        sha256  99806c3033219a905b006c8cae96c8ba4cd08a94ce966886b0f3855b36440850 \
+                        size    3469448 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.14.7)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
