### PR TITLE
openjdk18-sap: obsolete, replaced by openjdk19-sap

### DIFF
--- a/java/openjdk18-sap/Portfile
+++ b/java/openjdk18-sap/Portfile
@@ -1,88 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-03-21
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk18-sap
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-version      18.0.2.1
-revision     0
-
-description  SapMachine 18
-long_description An OpenJDK 18 release maintained and supported by SAP
-
-master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  23c0c5a4382663ebac61015a24f91d6be5dc9c65 \
-                 sha256  b1a125af11804e90ebb6d4eb1be8336b706cb39a38ffafdbf5906de9dd0cdf86 \
-                 size    181284233
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  6de3a3abeab10c4f57c0c7e3c645e48b76fb95bd \
-                 sha256  3ec5a50c2404c2bbe19e6d9b2beb59763642ad9ab4d800e10ff8ca76c96ccf70 \
-                 size    179140169
-}
-
-worksrcdir   sapmachine-jdk-${version}.jdk
-
-homepage     https://sap.github.io/SapMachine/
-
-livecheck.type      regex
-livecheck.url       https://github.com/SAP/SapMachine/releases
-livecheck.regex     sapmachine-jdk-(18\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk18-sap
+categories  java devel
+version     18.0.2.1
+revision    1
+replaced_by openjdk19-sap


### PR DESCRIPTION
#### Description

Support for SAP Machine 18 ended, replace with SAP Machine 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?