### PR TITLE
openjdk18-zulu: obsolete, replaced by openjdk19-zulu

### DIFF
--- a/java/openjdk18-zulu/Portfile
+++ b/java/openjdk18-zulu/Portfile
@@ -1,104 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-03-21
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk18-zulu
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://www.azul.com/downloads/?version=java-18-sts&os=macos&package=jdk
-version      18.32.13
-revision     0
-
-set openjdk_version 18.0.2.1
-
-description  Azul Zulu Community OpenJDK 18 (Short Term Support)
-long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
-                 specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
-                 verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
-                 respective Java SE version.
-
-master_sites https://cdn.azul.com/zulu/bin/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  8c74a654326219ffc7ba41302b972a4f128e9405 \
-                 sha256  b873dcc8e83151d4e0ce6215469fdac2dc2f7bdcd2b7ed5364d79fec352ea118 \
-                 size    194044334
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  2a553dc61f3998ea07db994c0a282a5b381351b0 \
-                 sha256  8c0643831b5632affbe32280c40ebda0e5340bd9d7bca1b93239992ec2b4e223 \
-                 size    191949023
-}
-
-worksrcdir   ${distname}/zulu-18.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 18} {
-    # See https://www.azul.com/downloads/?version=java-18-sts&os=macos&package=jdk
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.14 Mojave or later."
-        return -code error
-    }
-}
-
-homepage     https://www.azul.com/downloads/
-
-livecheck.type      regex
-livecheck.url       https://cdn.azul.com/zulu/bin/
-livecheck.regex     zulu(18\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk18-zulu
+categories  java devel
+version     18.32.13
+revision    1
+replaced_by openjdk19-zulu


### PR DESCRIPTION
#### Description

Support for Azul Zulu OpenJDK 18 ended, replace with Azul Zulu OpenJDK 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?