### PR TITLE
openjdk18-oracle: obsolete, replaced by openjdk19-oracle

### DIFF
--- a/java/openjdk18-oracle/Portfile
+++ b/java/openjdk18-oracle/Portfile
@@ -1,89 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-03-21
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk18-oracle
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://jdk.java.net/18/
-version      18.0.2.1
-revision     0
-
-description  Oracle OpenJDK 18
-long_description Open-source Oracle build of OpenJDK 18, the Java Development Kit, an implementation of the Java SE Platform.
-
-master_sites https://download.java.net/java/GA/jdk${version}/db379da656dc47308e138f21b33976fa/1/GPL/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  e051eacb45fac420b9b8eb80f047c165233c1add \
-                 sha256  604ba4b3ccb594973a3a73779a367363c53dd91e5a9de743f4fbfae89798f93a \
-                 size    185436355
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  b6c8724094398842b3a63d2b4f969c29c406260d \
-                 sha256  c05aec589f55517b8bedd01463deeba80f666da3fb193be024490c9d293097a8 \
-                 size    183270307
-}
-
-worksrcdir   jdk-${version}.jdk
-
-homepage     https://jdk.java.net/18/
-
-livecheck.type      regex
-livecheck.url       https://jdk.java.net/18/
-livecheck.regex     OpenJDK JDK (18\.\[0-9\.\]+)
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk18-oracle
+categories  java devel
+version     18.0.2.1
+revision    1
+replaced_by openjdk19-oracle


### PR DESCRIPTION
#### Description

Support for Oracle OpenJDK 18 ended, replace with Oracle OpenJDK 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?