### PR TITLE
openjdk18-corretto: obsolete, replaced by openjdk19-corretto

### DIFF
--- a/java/openjdk18-corretto/Portfile
+++ b/java/openjdk18-corretto/Portfile
@@ -1,99 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-03-21
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk18-corretto
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://github.com/corretto/corretto-18/releases
-version      18.0.2.9.1
-revision     0
-
-description  Amazon Corretto OpenJDK 18 (Short Term Support)
-long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
-
-master_sites https://corretto.aws/downloads/resources/${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  e44c83158182621bd5b795996f9cdf90d4b2a281 \
-                 sha256  243313e935abd7c76c2c1f4b541b6cd6e0b7ac8b97e222245bb50249fb18a9d3 \
-                 size    188835751
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  ed66d255f047d22eba63debc4b8a3551589bd9cd \
-                 sha256  f003000033a25d0ce8f00adfc1b88935da0d330b0ab5587c520f793869415462 \
-                 size    187052397
-}
-
-worksrcdir   amazon-corretto-18.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-18/blob/release-18.0.2.9.1/CHANGELOG.md
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
-        return -code error
-    }
-}
-
-homepage     https://aws.amazon.com/corretto/
-
-livecheck.type      regex
-livecheck.url       https://github.com/corretto/corretto-18/releases
-livecheck.regex     amazon-corretto-(18\.\[0-9\.\]+)-macosx-.*\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk18-corretto
+categories  java devel
+version     18.0.2.9.1
+revision    1
+replaced_by openjdk19-corretto


### PR DESCRIPTION
#### Description

Support for Amazon Corretto 18 ended, replace with Amazon Corretto 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?