### PR TITLE
google-cloud-sdk: update to 403.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             402.0.0
+version             403.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e356209d08b6f499e0fa309853195665a82adabc \
-                    sha256  943470764f8426fe97132a6f82a1559c786c009f939532dcac71e8466341d1fb \
-                    size    109172516
+    checksums       rmd160  e7b42b3cf0e3fe74645b09597549eafc9265a469 \
+                    sha256  8966967aa8f5817327563e1e7bda850ad568f98131bc16d02bc85cfe335d3892 \
+                    size    109263059
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  672ca2aa768f3207a24d8f907ec1e48d832b1340 \
-                    sha256  b8a9758e9689216e1a300bd8c25ca8b0a310cd8111aa366382846187cd2fc168 \
-                    size    96613044
+    checksums       rmd160  92d05f0c0193bfad6d07bc52dbe959c7af8a6a4d \
+                    sha256  3e9d68f6b3b60a8c0e48a9490870f948971b51d0713e8060521c6f9d6c251f55 \
+                    size    96705042
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c6fcc743629147749be0e0addee885475c76a14f \
-                    sha256  d06707dcd8cfdcc9d833662a5d78ceca76e4cabba3195fee11eac52aba2cc0cc \
-                    size    95228264
+    checksums       rmd160  ede03ad75060809f609b9d30fa6a5014b77c1b56 \
+                    sha256  94cf159917035370d3c112dea96576b8cf1a449f3d1dc49c3b34bf9f0b5c57ba \
+                    size    95321532
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 403.0.0.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?