### PR TITLE
spring-boot-cli: update to 2.7.4

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.7.3
+version         2.7.4
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  387ab3068a4c3c38e198526133c7cd7f35d1f76e \
-                sha256  48e4cb4895189d392dfc65ab2f333e22a062cf54e49120a8a0cb331d6ca17013 \
-                size    14324541
+checksums       rmd160  c6969eeee3cfe4a64480980f411bf0dc2d608a5d \
+                sha256  5609f3be7f6a2f55dec7b27fa8aadc239d84ea3f9be45c66bf9c32400d06ca64 \
+                size    14328245
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.7.4.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?