### PR TITLE
caddy: update to 2.6.1

### DIFF
--- a/www/caddy/Portfile
+++ b/www/caddy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/caddyserver/caddy 2.5.1 v
+go.setup            github.com/caddyserver/caddy 2.6.1 v
 revision            0
 categories          www
 license             Apache-2
@@ -17,9 +17,9 @@ long_description    Caddy 2 is a powerful, enterprise-ready, open source web \
 homepage            https://caddyserver.com/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  5c73c9fc576acff2f04ded61154e9ae525d62af7 \
-                        sha256  1f542e14bb1125b6369a8b8e08ae04eb3f288b79b5dc1dbb1441840bcd9e2be0 \
-                        size    524849
+                        rmd160  71c1f4c9f887246460330da635e867f932a14cea \
+                        sha256  cf6ade31e77a865ed4e25f6e27e5fe8df8c50586f852e75b71e7940edb16eeaf \
+                        size    560109
 
 go.vendors          howett.net/plist \
                         repo    github.com/DHowett/go-plist \
@@ -28,10 +28,10 @@ go.vendors          howett.net/plist \
                         sha256  881f9c6bcb814fdfe2d51da53f75ffd28bd9d2149c9c7cc1e783bc5a54c9f9e8 \
                         size    52994 \
                     gopkg.in/yaml.v3 \
-                        lock    496545a6307b \
-                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
-                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
-                        size    90145 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
                     gopkg.in/yaml.v2 \
                         lock    v2.4.0 \
                         rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
@@ -59,22 +59,22 @@ go.vendors          howett.net/plist \
                         size    32368 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.27.1 \
-                        rmd160  a4ac7b66fd88a34a9ea447476d19ff3c1f2b57dd \
-                        sha256  fe1055b9bf6b8792aed1771f56c31f836c24a18d69eaeb13c88990db3d9da7ce \
-                        size    1278850 \
+                        lock    v1.28.0 \
+                        rmd160  076cb79b7651b0fdc12168a43cdc613d111fb371 \
+                        sha256  7efea04ee3dd363a74c04a25473bcc2361d669011086c85a8b04e0c0639ad432 \
+                        size    1280082 \
                     google.golang.org/grpc \
                         repo    github.com/grpc/grpc-go \
-                        lock    v1.44.0 \
-                        rmd160  aa75e5c88543c1c25e3b9b352dfb90a9278893ac \
-                        sha256  02acc338a51f8eb106f88c449df1dc653e624459312fe38ae2710ed48fdb3248 \
-                        size    1399756 \
+                        lock    v1.46.0 \
+                        rmd160  d5cf0e9fe6ca060a3a757b9af38a6cb6401cb1ba \
+                        sha256  bc4e9681e87f1d7742d20fcf0972c11a5400e4dc4b236d11ee22bda77dca90e5 \
+                        size    1520498 \
                     google.golang.org/genproto \
                         repo    github.com/googleapis/go-genproto \
-                        lock    43724f9ea8cf \
-                        rmd160  f3f3004cb5a5921e5d4941197833cf98b2f009b5 \
-                        sha256  d197ad56800b82be475a3f6eb91ffc9501cd4f1cf6dd4ea0229c358555f8eb63 \
-                        size    12783788 \
+                        lock    c8bf987b8c21 \
+                        rmd160  486221f2e9ce351f9cce2ca6dce78a604b04a1c9 \
+                        sha256  19bec8f036710c27707fda8e6f4844fc0227698ad09e1915df65915154c5d6d9 \
+                        size    13386722 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.7 \
@@ -93,10 +93,10 @@ go.vendors          howett.net/plist \
                         sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
                         size    13667 \
                     golang.org/x/tools \
-                        lock    v0.1.7 \
-                        rmd160  8ae3eece96ce5d618f012a71e4603c4d7e5f0b1f \
-                        sha256  a4ad7b10e5f5d4de2628602b5998601547d386eca0444666b9220076f355a5ea \
-                        size    2884433 \
+                        lock    v0.1.10 \
+                        rmd160  48d39865b0ef19c85818eea7d38c891ad7fdab7b \
+                        sha256  e3fb60b954bc56991f1fcd67cd09b68e58e5fdc62933846ee082b0f54f2a25fd \
+                        size    3014613 \
                     golang.org/x/text \
                         lock    5bd84dd9b33b \
                         rmd160  04b1ef275c8ad672175b805f587385082b0b1f00 \
@@ -108,10 +108,10 @@ go.vendors          howett.net/plist \
                         sha256  3673415a6d3d106d49b487715e151fc64245502ef547c16e8e13edb6b8f2f492 \
                         size    14975 \
                     golang.org/x/sys \
-                        lock    3681064d5158 \
-                        rmd160  dbf3935cbe2734d9189231077c342e7ae0c81457 \
-                        sha256  272c29ef9518ba877e16372f78d757e7b0d05abd87226fdcbe251992bf5b776c \
-                        size    1258642 \
+                        lock    3c1f35247d10 \
+                        rmd160  9128b74566b92dbfa971dba1cf861722abd06807 \
+                        sha256  78465a4d4db5424b9cbc10c644fa1707a27c62cf110a0fe9156bd98e078a717b \
+                        size    1336890 \
                     golang.org/x/sync \
                         lock    036812b2e83c \
                         rmd160  f42be6eb3565d2ed3d1066ea1a7f69437c8bb1e6 \
@@ -123,20 +123,25 @@ go.vendors          howett.net/plist \
                         sha256  7a0c986063c9580fed9223411152d3ea8126d54597be8184fe613097b95d7489 \
                         size    87604 \
                     golang.org/x/net \
-                        lock    cd36cc0744dd \
-                        rmd160  20670d7362e8b4ecb15f3c220c90bd3d1d32a610 \
-                        sha256  26df4f12cff0b1a98eb9376669e40e1a839fae744d9c0fc84e4fe3153961fe33 \
-                        size    1228706 \
+                        lock    1d4ff48094d1 \
+                        rmd160  54c9e5e5bff36339f55d9f8fad936f51c212ea1a \
+                        sha256  570df9f5274dc1960c50b1b48eaf3ee58e6ff29017af42359ba269f9e9b2c38e \
+                        size    1226265 \
                     golang.org/x/mod \
-                        lock    v0.4.2 \
-                        rmd160  0f3ca57198b4de4eb89b2c1a2bdb01af040d1f36 \
-                        sha256  e2e4cba5719f804f2ec901b4ccdf6d3abf05521868ed54f271be7c1bf6c48549 \
-                        size    104573 \
+                        lock    9b9b3d81d5e3 \
+                        rmd160  dd04a3d8842b92453a4813ea4c266fd1071efe6a \
+                        sha256  9c4e1592a4689f13dd3d61d03facf20acd41754410d516da6b4f170973f254fb \
+                        size    119487 \
+                    golang.org/x/exp \
+                        lock    a9213eeb770e \
+                        rmd160  22493ca7d5ce3968edbd955efc45c7611ec37477 \
+                        sha256  03cfb2ecf601c4f7d13cbc41b80e781e896f07349ae8cd710947c300c816e2ad \
+                        size    1556302 \
                     golang.org/x/crypto \
-                        lock    f4118a5b28e2 \
-                        rmd160  0701294f80df78857569a45a4ac5135f7ff64116 \
-                        sha256  7b96f88553b358931b070cf9daccfd94bd63b977d94df028cbc278a3ce5ffd27 \
-                        size    1626969 \
+                        lock    630584e8d5aa \
+                        rmd160  592a8bc8bab62d399ebd992b3f0a8d2f1d9ff603 \
+                        sha256  41bb49305186ca7a143b4044dc7ad0b85400f213a9ca6a5bb25e5048757430c2 \
+                        size    1631200 \
                     go.uber.org/zap \
                         repo    github.com/uber-go/zap \
                         lock    v1.21.0 \
@@ -163,40 +168,40 @@ go.vendors          howett.net/plist \
                         size    21353 \
                     go.step.sm/linkedca \
                         repo    github.com/smallstep/linkedca \
-                        lock    v0.15.0 \
-                        rmd160  90d3ea0cfdbdcaffa4300f174c7e1e55243d213b \
-                        sha256  7d81cbf254cb98b6a4fb3db228d2eaee74cbc42dfec8e021fa71e8baba7c5f11 \
-                        size    54244 \
+                        lock    v0.16.1 \
+                        rmd160  d97cfadae56827ad5a9b833d9e8406b7621ac5ef \
+                        sha256  32e97ca043ae70a142d09f16873251966e5ea2b18f551e7349dfef17dd21fb48 \
+                        size    56147 \
                     go.step.sm/crypto \
                         repo    github.com/smallstep/crypto \
-                        lock    v0.16.1 \
-                        rmd160  a8659ab02190032328111551c3eac04d69a9027d \
-                        sha256  1177fe6e65e596cf3f0c490255d17e08b314aea4381883220ea94f0408e9aeea \
-                        size    166553 \
+                        lock    v0.16.2 \
+                        rmd160  4b2aa4d0e6ae57d50fc613c2d62d1c417f5746a3 \
+                        sha256  c5c606e6cf52093f7db678b11589fdd1db420b707d7041a82931486b0736205c \
+                        size    167255 \
                     go.step.sm/cli-utils \
                         repo    github.com/smallstep/cli-utils \
-                        lock    v0.7.0 \
-                        rmd160  f78021ec73d1a6b3ab58d8b597f16b0b18aebb01 \
-                        sha256  d6fa55c4f9ca9d90ad5c1433b2564b045d1a6797ef334fa4559ceb6dcc312eef \
-                        size    139631 \
+                        lock    v0.7.3 \
+                        rmd160  c00be7cc2f12fbcac0bc89124646a30faef549b6 \
+                        sha256  1dce862c944b50e96228d24946819edf2b1b6a24eb41484b6e4ca4022c9fc79e \
+                        size    141624 \
                     go.opentelemetry.io/proto \
                         repo    github.com/open-telemetry/opentelemetry-proto-go \
-                        lock    v0.12.0 \
-                        rmd160  2dc48f0d9ce383111edb18e20665b598760beea2 \
-                        sha256  d8998c9bb43e606c6c597d2abcb3d1bfabdd1eab261b6ae248e6b8f8a2836515 \
-                        size    63540 \
+                        lock    v0.18.0 \
+                        rmd160  8348ed7d77843d4ba96773bd7e90561bc1ae684a \
+                        sha256  270ea5230c429404d04c4d6e37617dea150002f51acaa20d7f5c4f368de98ea6 \
+                        size    105132 \
                     go.opentelemetry.io/otel \
                         repo    github.com/open-telemetry/opentelemetry-go \
-                        lock    v1.4.0 \
-                        rmd160  14b706ac13f8daf80730663092890efa01b76022 \
-                        sha256  84b1384c7d1996d430b9ed42cf33be8a67e0ebbe71e59ee774d4c59a3593393c \
-                        size    813937 \
+                        lock    v1.9.0 \
+                        rmd160  e9140530ade343f7541f3a7925d0b9b37ca41405 \
+                        sha256  7c00fcfd469a0bd984f2f041ee0a5450e8fdebdee459844373e92acfa342fb36 \
+                        size    1000838 \
                     go.opentelemetry.io/contrib \
                         repo    github.com/open-telemetry/opentelemetry-go-contrib \
-                        lock    v1.4.0 \
-                        rmd160  0d2b2a788c0b5479648a64f6d7690811a6874615 \
-                        sha256  ec7de3a8da8cbdc41ce32f3d0d0a26c09d891e773613a5d66a453c47a2cf6748 \
-                        size    772286 \
+                        lock    v1.9.0 \
+                        rmd160  757a700cc2bacc5a69d698e0486d4f964c1708df \
+                        sha256  c7b993789a3532115908060b1f820a258db0847c868230341d37812dadb0fef6 \
+                        size    602935 \
                     go.opencensus.io \
                         repo    github.com/census-instrumentation/opencensus-go \
                         lock    v0.23.0 \
@@ -221,30 +226,40 @@ go.vendors          howett.net/plist \
                         sha256  c121c3e8258ba20e1dbfcf51e4bc31fdf351d28f419c493b52487c10e91795e3 \
                         size    10046 \
                     github.com/yuin/goldmark \
-                        lock    v1.4.8 \
-                        rmd160  c3470d2560a752567f88f8d86ba2e3977e78f18a \
-                        sha256  70dce22832bef2f6336bfa23b4ae6172dc93bec0499831b64b4e9294639bb1e6 \
-                        size    257417 \
+                        lock    v1.4.13 \
+                        rmd160  bb05cad916044abcb54304c02cc88b32e89776ad \
+                        sha256  d5f917488d17192777b40d1951506c5e1395cf3b2013a0ec4018cf3d6dfc890a \
+                        size    257808 \
                     github.com/urfave/cli \
                         lock    v1.22.5 \
                         rmd160  f26fef0516efcbf556d953be02bcfb0ae60a9c22 \
                         sha256  2122a2b193a2d096f3792e4f8d6a7bb2a504a0d5bba7b0d1bfe81707917831a3 \
                         size    78154 \
                     github.com/tailscale/tscert \
-                        lock    4509a5fbaf74 \
-                        rmd160  bfdce82b8e25b779d9a0efdece17ce53819700df \
-                        sha256  1af954404d0d96947164bd7248656781a44a8f6f24f84b9a4957211e08c6d817 \
-                        size    13793 \
+                        lock    54bbcb9f74e2 \
+                        rmd160  dc310dfb686fb67da75dc293d2917b8ca7007a10 \
+                        sha256  215a1aa4ee65aa2acb8a24b68f9f95aa7133126da64bb5b6125aefa73ffabbd6 \
+                        size    13789 \
                     github.com/stretchr/testify \
-                        lock    v1.7.1 \
-                        rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
-                        sha256  27cabaf81344157a188083266cf8ccc19d04c43d9a34b6276b760514b9c880a3 \
-                        size    94020 \
+                        lock    v1.8.0 \
+                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
+                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
+                        size    97622 \
                     github.com/stoewer/go-strcase \
                         lock    v1.2.0 \
                         rmd160  b8c644b1233496ac620e667bd8578079b7dcda04 \
                         sha256  b7b4dec40c80d32a53d9ac2c22e6b8db854c98e2b1c244fc7789e0ba2c8760ee \
                         size    5295 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/cobra \
+                        lock    v1.1.3 \
+                        rmd160  d9647d9a480ffb4d35ef6602c05cae452dcf30f9 \
+                        sha256  433b6fbdec0dc61ab23a2be8e7f004ff5608ba0778d4b4ede438f6d1227adb77 \
+                        size    146625 \
                     github.com/spf13/cast \
                         lock    v1.4.1 \
                         rmd160  cb1d2c13bdd8a4aafd7c4e768554bab0a65c5759 \
@@ -256,25 +271,25 @@ go.vendors          howett.net/plist \
                         sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
                         size    7396 \
                     github.com/smallstep/truststore \
-                        lock    v0.11.0 \
-                        rmd160  2ad8b41971ed226b328713bc5c20753c84b4a3c5 \
-                        sha256  786e983b58f7727d8001f7372b051a0b723512a4e04302fd411ba7bd1b1b9889 \
-                        size    12976 \
+                        lock    v0.12.0 \
+                        rmd160  357082d8d6d20671fefb7f4fffaf7ed7f9cf12e4 \
+                        sha256  0883c5547dd5bc30a7de5c343ef71cd0d7175b3d8df4d8fa459e71174257b926 \
+                        size    12990 \
                     github.com/smallstep/nosql \
                         lock    v0.4.0 \
                         rmd160  fb1ad42540a93a1af86b7dff7c876898e81d2654 \
                         sha256  edf3d61054a66e3c620185711042af2057c99009073e741bc42282191b0bd82f \
                         size    33740 \
                     github.com/smallstep/cli \
-                        lock    v0.18.0 \
-                        rmd160  01fc1cc23f781b058bc332fae593eb81dcbaf5d9 \
-                        sha256  1db94da704a46b454c6abbf3667ac8df2a7188b6766c47547a065827c998dfe3 \
-                        size    1804531 \
+                        lock    v0.21.0 \
+                        rmd160  b703908c74b15dbecf9b777ee4d1e53630afdba7 \
+                        sha256  8537d078920eb27bf07a4c0f9b8a2fa54ccb39886023696c0dfbc999e1a1ae2d \
+                        size    1848347 \
                     github.com/smallstep/certificates \
-                        lock    v0.19.0 \
-                        rmd160  b118e0b6edff9360be538dd7ec86c12402cfe6cd \
-                        sha256  cddc6c9aaf6b3fa3d3dd483c663353df0109ac4029520d30a00a098d4487c96d \
-                        size    17920186 \
+                        lock    v0.21.0 \
+                        rmd160  561ffc6a6072111bc4bc8f06d771b923c0f71a72 \
+                        sha256  7985ee8a9250bb9d825315167d857cf04ed02de61c4192c4afb064b787e9a098 \
+                        size    17979703 \
                     github.com/smallstep/assert \
                         lock    82e2b9b3b262 \
                         rmd160  c53f5cc57f5f31670d4d5564ec080febd65910af \
@@ -301,10 +316,10 @@ go.vendors          howett.net/plist \
                         sha256  efa72d6c6d5a261d614ac11ce5db7c2a76d671866300f087f4f4225b4b11f500 \
                         size    37774 \
                     github.com/russross/blackfriday \
-                        lock    v2.0.1 \
-                        rmd160  99cb49faff9bf24b8637dcdb3602c27c115810f3 \
-                        sha256  4078d2cd3b1c6952133b214e4eaca95f3b31a01f87a03adabd7712e7d5f20f60 \
-                        size    79665 \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
                     github.com/rs/xid \
                         lock    v1.2.1 \
                         rmd160  2cff9628752a94fc62ab0e83436c61df7195eed1 \
@@ -326,10 +341,10 @@ go.vendors          howett.net/plist \
                         sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
                         size    10985 \
                     github.com/prometheus/client_golang \
-                        lock    v1.12.1 \
-                        rmd160  70ab16c13d6f53cf3433dcba4e590cd93b637998 \
-                        sha256  ef1b1e7e68e01cf67193b25d1207bc7771919d81283976b109ec0d56a1e566f0 \
-                        size    194237 \
+                        lock    v1.12.2 \
+                        rmd160  6e2120fbbdd478bcbab9f1a7f014a2f85797db53 \
+                        sha256  df1e3c29b486c86bde89d01588b30c333265f8110a92c44bef38f21e147d2472 \
+                        size    197136 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -371,20 +386,20 @@ go.vendors          howett.net/plist \
                         sha256  e6cbd00eca63c91837cd094e89bda52d067163dc5b5db12758b8995c75fd3377 \
                         size    9936 \
                     github.com/miekg/dns \
-                        lock    v1.1.46 \
-                        rmd160  9a147f31793821eb5966787c67f8efc569a3bf90 \
-                        sha256  32950b2e11cc60d57f18d84a535590c998bcd65c4b66f39e39a99615abed6ff0 \
-                        size    204223 \
+                        lock    v1.1.50 \
+                        rmd160  e6a4cfbbaec8dd5e1c525385dd3e6192fd2054ab \
+                        sha256  2f0550c88bf45d12648df649bd25fe5eda97edb61102f5f3a759ead4a69281ed \
+                        size    208974 \
                     github.com/micromdm/scep \
                         lock    v2.1.0 \
                         rmd160  642db3182defb9403953730d98bda3874659daa3 \
                         sha256  0120218fb1bdbadb6559516169f8281dc457806b7784793c572356575069c25a \
                         size    64304 \
                     github.com/mholt/acmez \
-                        lock    v1.0.2 \
-                        rmd160  e0b9c443a36e53e77c0a36dcc360d7431110c013 \
-                        sha256  8fd52d7590d5328942813c663c632393781bb83bed6122bb078e4b68691b788c \
-                        size    50819 \
+                        lock    v1.0.4 \
+                        rmd160  78dcb7f7743e61c522e1da2dfba76978f7d203fd \
+                        sha256  04292a82f33b2ffb8c2cc6cc9b1af0bc4bf4b45022dd697caabd1a71848a5476 \
+                        size    52083 \
                     github.com/mgutz/ansi \
                         lock    d51e80ef957d \
                         rmd160  a32d3fd46ae68cfd82f31fadc3dfe551966f6a5b \
@@ -405,21 +420,16 @@ go.vendors          howett.net/plist \
                         rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
                         sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
                         size    9576 \
+                    github.com/marten-seemann/qtls-go1-19 \
+                        lock    v0.1.0 \
+                        rmd160  b9dff3d8a87608f6821790fafececbf994cb1063 \
+                        sha256  b4577afe819d720db7b7443503a637507038893eaf2eed35893bd301749c2bcd \
+                        size    422927 \
                     github.com/marten-seemann/qtls-go1-18 \
-                        lock    v0.1.1 \
-                        rmd160  5b98fd23d9def1ce7712c87868f54fac4b4d84f4 \
-                        sha256  1b2e0686b31bbf80177f2468e98041f68c2a96ab90f714ccc2f7c8b9a08e641c \
-                        size    422116 \
-                    github.com/marten-seemann/qtls-go1-17 \
-                        lock    v0.1.1 \
-                        rmd160  5769d30553c8a7e07bd86c7f6f06c0dea24e59b6 \
-                        sha256  61e20fe7c825db70c3355ff58f02518d64733ca5e74df1e1733daf9ad4278c7f \
-                        size    421546 \
-                    github.com/marten-seemann/qtls-go1-16 \
-                        lock    v0.1.5 \
-                        rmd160  b637315f29e75067cf7180257d64d65406967d04 \
-                        sha256  e7ca61ec715b8784521b1622f2b7ca0bc517b443a2c7e99b6f07689adf096132 \
-                        size    415747 \
+                        lock    v0.1.2 \
+                        rmd160  3ee741f1eeb1a14ab632c44f3021a19503b31666 \
+                        sha256  75fd40cf7f9c30e8a5b90ddcec8edd80a37b1a27dfd6584be6bb73e383b4d920 \
+                        size    422465 \
                     github.com/marten-seemann/qpack \
                         lock    v0.2.1 \
                         rmd160  64b0f70c593a63c55ec82047643ab2a8bbebb26b \
@@ -431,10 +441,10 @@ go.vendors          howett.net/plist \
                         sha256  bb66c3deb1709d13f67a00ec2421185792f7a1efc5836e7a1607639a46ce1178 \
                         size    25927 \
                     github.com/lucas-clemente/quic-go \
-                        lock    v0.26.0 \
-                        rmd160  c4ec8645b473b4772b67ddcf4ad3d46023269be9 \
-                        sha256  9feba2cd3de57559b7073202778ffe194ea7a0795970d063500f7ed5ad0822c0 \
-                        size    527240 \
+                        lock    9957668d4301 \
+                        rmd160  9072871469cc8e4e06c6a2e495412892e12d0d2d \
+                        sha256  82d5b447823f509a1159855ef69df8cbeeb46da458f82ac2dd83aff9ce448504 \
+                        size    531959 \
                     github.com/libdns/libdns \
                         lock    v0.2.1 \
                         rmd160  7cd2eb2452f9767d17aac199550e8fd4b2076ffb \
@@ -456,15 +466,15 @@ go.vendors          howett.net/plist \
                         sha256  253c4a190c9337800e08aba66b77ea3db0835e3ae61289d80093995a649eb7ae \
                         size    8769 \
                     github.com/klauspost/cpuid \
-                        lock    v2.0.11 \
-                        rmd160  f616c19e05db995e802448819c7584121af0b7b9 \
-                        sha256  f15f92c1c88bfcc86015c14550106be3ae1efea5cd6d299a0eabac549c141751 \
-                        size    343083 \
+                        lock    v2.1.0 \
+                        rmd160  ebb554eebcae9d18e7636c80d8a4a0e615661ab7 \
+                        sha256  8e0ea9b86bc35636430584882c4f4ca6bbcac5a0f8a50268e46f5f2b96fdb4df \
+                        size    437008 \
                     github.com/klauspost/compress \
-                        lock    v1.15.0 \
-                        rmd160  ce1a573a8e4e91276d113bef74020ce1b3064a99 \
-                        sha256  fc7dc5c49a9f305058c68cecee1c04c118f6fdf252e1c2f058a31db9e77b74c0 \
-                        size    15633291 \
+                        lock    v1.15.9 \
+                        rmd160  df7cb5c89ccfe6217c5b812ee321dbe01d35d2bc \
+                        sha256  c3bf850b50e015ff27501a9767ac92088f748a2b59710091880ccc99f6e94deb \
+                        size    24209515 \
                     github.com/jmespath/go-jmespath \
                         lock    v0.4.0 \
                         rmd160  ca4955ff89de514b5eff01a7a244626cecf0927e \
@@ -515,6 +525,11 @@ go.vendors          howett.net/plist \
                         rmd160  546d596d7e2c661b8f9086a1bbae8ff4ab945280 \
                         sha256  bc2ead05f2d930b05522ee6a70378c0937994c353cbf0bd891c835e22c743adc \
                         size    3043 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.0.0 \
+                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
+                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
+                        size    2291 \
                     github.com/imdario/mergo \
                         lock    v0.3.12 \
                         rmd160  44dbd1f58fd9ea7697f302c86f110ab796b5a041 \
@@ -526,10 +541,10 @@ go.vendors          howett.net/plist \
                         sha256  97bda2aeca4ae1b66f4113ce16d5d861c124baf8f38e22064f5dbd0accb04c57 \
                         size    17916 \
                     github.com/grpc-ecosystem/grpc-gateway \
-                        lock    v1.16.0 \
-                        rmd160  ee1c4871aeff641fea75ae5034c3c6c1171ef5be \
-                        sha256  7cc75b3dae4e1f22f3126741a161aaf3d5b74ee310e2d1cda2eb58e9f0836424 \
-                        size    521548 \
+                        lock    v2.7.0 \
+                        rmd160  47986a2c3f1efb4f1f595921d090b152c2c6b531 \
+                        sha256  71ebd5e1dadba850b29d37a0f170f5e1d207f85468fd39364afecc50f3798c66 \
+                        size    631090 \
                     github.com/googleapis/gax-go \
                         lock    v2.1.1 \
                         rmd160  aeaa07a395820f1d6a94b21fb39c2abd04c832d9 \
@@ -541,15 +556,15 @@ go.vendors          howett.net/plist \
                         sha256  ef8b7d74d99c8abd9706909eb3bbd063460d1970fbf62619599b78092b8687db \
                         size    16215 \
                     github.com/google/go-cmp \
-                        lock    v0.5.7 \
-                        rmd160  f8dffbbc09f05eff889202ab37f473e314ae1b09 \
-                        sha256  7fba30fac1ae84c4dc8c8592936e3fb4ada1f1985803005225e7d61d4159bcff \
-                        size    104517 \
+                        lock    v0.5.8 \
+                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
+                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
+                        size    104650 \
                     github.com/google/cel-go \
-                        lock    v0.7.3 \
-                        rmd160  79a5c8b1d680a99a0def566e2f68db748ff73626 \
-                        sha256  99b0ea925ba782ce0b3f36c7d63e0b3b4a210094b6171bc6a584435253c20f33 \
-                        size    2152002 \
+                        lock    v0.12.4 \
+                        rmd160  aee2d8b227d5a6c36ae06e729313d567ce8655c1 \
+                        sha256  e7fae39a9b6df73a03dfd4bd6a0921873765846f09502f020ad6350cf61ac083 \
+                        size    953194 \
                     github.com/golang/snappy \
                         lock    v0.0.4 \
                         rmd160  23c095b7e2bc6f5a978d771e4ecc9f7b0f204491 \
@@ -596,10 +611,10 @@ go.vendors          howett.net/plist \
                         sha256  694ed0928bb3e77d98e90d48e970dd2750b8fee1170a85897a5f256c3f459a1c \
                         size    9105 \
                     github.com/go-logr/logr \
-                        lock    v1.2.2 \
-                        rmd160  1ddc3393be8264eda110e19f1bd898b609d72a95 \
-                        sha256  073678e3a63e73699c334b4980d9f069b331dad2919146b08d1b873e3ad6ac47 \
-                        size    37113 \
+                        lock    v1.2.3 \
+                        rmd160  d01ead575f8495119dd19114173a491cbb8dcc0c \
+                        sha256  d0a22f8bd038fb17c0e536aca1920ac570d4a787da2e69dbbaba7ef280d71f43 \
+                        size    38566 \
                     github.com/go-logfmt/logfmt \
                         lock    v0.5.0 \
                         rmd160  bd625ba006d96954552800120b01c9263d6e9103 \
@@ -621,10 +636,10 @@ go.vendors          howett.net/plist \
                         sha256  699405dfda2fe02a305bee66f58046adb43f426ac905f85d80710e36846b3768 \
                         size    32714 \
                     github.com/felixge/httpsnoop \
-                        lock    v1.0.2 \
-                        rmd160  8831d9282455fcf0913da2c09c491e529c78a0ac \
-                        sha256  d401a3b5b97c9668ea326d7da0d664a4aaa84af523c3ccc6afe7ad5e2b74915f \
-                        size    11593 \
+                        lock    v1.0.3 \
+                        rmd160  909ff38f048a85840543a0f9e645908ce2dd9ced \
+                        sha256  cdd557fe7e45ce86f6c22c0030884e43c16f85daf2bb6e31b8bc00d03e5b8362 \
+                        size    11657 \
                     github.com/dustin/go-humanize \
                         lock    afde56e7acac \
                         rmd160  ebea78b8985e3737bb3f84bb89cfe06e27ce5cb1 \
@@ -656,10 +671,10 @@ go.vendors          howett.net/plist \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.0 \
-                        rmd160  85f342c341fa928e9ec874490c277bdabf1c39c6 \
-                        sha256  2f3f8bc701df4890a5a4baf0b632ad3290be1e0aaf572b2e58fd57df93efc306 \
-                        size    52040 \
+                        lock    v2.0.1 \
+                        rmd160  74c013e19d22e56a27d9a3ad61b4bd86975036d1 \
+                        sha256  d23365bceea7382b59ca41ad868a80e34f8066785fb371b85b51ee0b65be6a21 \
+                        size    64243 \
                     github.com/cockroachdb/apd \
                         lock    v1.1.0 \
                         rmd160  3753e33b093067db91575bd174f3061662346c1e \
@@ -680,11 +695,6 @@ go.vendors          howett.net/plist \
                         rmd160  105d839f798ba0c3e27b3db4e790d9d21a928029 \
                         sha256  947e61095044d310b0ad92f10ac77c36eaa3c3e2e6181e87428ad10c20930ba3 \
                         size    4351 \
-                    github.com/cheekybits/genny \
-                        lock    v1.0.0 \
-                        rmd160  c8f3f5af635b83ade08f9f8e08e7f2018cb5879c \
-                        sha256  528d149522e053aed14048608751da8ace5b44466038b1a8d47d04a050d81bdc \
-                        size    15585 \
                     github.com/cespare/xxhash \
                         lock    v2.1.2 \
                         rmd160  aa8f44c877aeb7a980aba19d9d84e6b20e52560d \
@@ -696,10 +706,10 @@ go.vendors          howett.net/plist \
                         sha256  9dd966323058af72dedc32d2f2da9123c5c899575b6a735cdd49d4bf963101cd \
                         size    9833 \
                     github.com/caddyserver/certmagic \
-                        lock    v0.16.1 \
-                        rmd160  e15bebfac11bda5840eef963aac7ccfa603771ca \
-                        sha256  c30433f9543df79c0cffefb4b58b108d691c6d8f5abf6df0f538474b0a3cd48c \
-                        size    109319 \
+                        lock    v0.17.1 \
+                        rmd160  8c0d83ee95aff50723a5e2e73b35801ba9b1d532 \
+                        sha256  faad44a250f49cb49e4faf4102107654d892eb0edc4b3fa23b1d347ff6cf17f8 \
+                        size    110244 \
                     github.com/beorn7/perks \
                         lock    v1.0.1 \
                         rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
@@ -721,10 +731,10 @@ go.vendors          howett.net/plist \
                         sha256  d2bb2c75fc77675bfe290a2db555ba1def9cd34c86bd3d008a0c809d22d729a9 \
                         size    5315 \
                     github.com/antlr/antlr4 \
-                        lock    621b933c7a7f \
-                        rmd160  2e69e367cde536868493d68a1ccdc6e7e2f65b03 \
-                        sha256  1dc72feb97c7365f08c6461219ba6f0b2533181efa3d7000459cb4007ec8a5b7 \
-                        size    4328303 \
+                        lock    f25a4f6275ed \
+                        rmd160  7d4a43216c51cac22bf8f7c46b2781755a6aa4bd \
+                        sha256  ed831324b8a99a331da501e6ef3dce2f9461d9a4aa6721242d044957472fb0c0 \
+                        size    4600406 \
                     github.com/alecthomas/chroma \
                         lock    v0.10.0 \
                         rmd160  41ff8340ec3b18ff636e56c5237ebb526d722150 \
@@ -751,10 +761,10 @@ go.vendors          howett.net/plist \
                         sha256  9c750be5c0666f133c0bf8d9439a2e428b800276d4ab28dfc406fad8d66face6 \
                         size    14849 \
                     github.com/BurntSushi/toml \
-                        lock    v1.0.0 \
-                        rmd160  cc46ecb976a41c9693f36914ba01bbe62a8c1b93 \
-                        sha256  f1c66e8a6c5bc63606d31bdfd4a89342256442fac49882a2150bf94de032ab00 \
-                        size    90406 \
+                        lock    v1.2.0 \
+                        rmd160  b6af60be88cbeac8ed5e5124d187cf5e1a98864d \
+                        sha256  7cc755999d3c804cfeee6e464cc800cee299a33877dfd901671f3574e2eb80fd \
+                        size    96599 \
                     github.com/AndreasBriese/bbloom \
                         lock    46b345b51c96 \
                         rmd160  37888ae5d833661314a5d2c0ee6ac65021e4cf85 \
@@ -773,11 +783,15 @@ go.vendors          howett.net/plist \
                         sha256  5b4b9ff34231611bd7276be629ab4f8f7f4a507751ba26d56724c56bff652040 \
                         size    6906445
 
+post-extract {
+    delete ${gopath}/src/github.com/google/cel-go/vendor
+}
+
 patch.dir           ${gopath}/src
 patchfiles          patch-nosql.diff patch-version.diff
 
 configure {
-    reinplace "s|@VERSION@|v${version}|" ${worksrcpath}/caddy.go
+    reinplace "s|@VERSION@|v${version}|g" ${worksrcpath}/caddy.go
 }
 
 build.dir           ${worksrcpath}/cmd/${name}

--- a/www/caddy/files/patch-version.diff
+++ b/www/caddy/files/patch-version.diff
@@ -1,10 +1,10 @@
---- github.com/caddyserver/caddy/caddy.go.orig	2022-05-06 20:25:31.000000000 +0400
-+++ github.com/caddyserver/caddy/caddy.go	2022-05-21 22:58:32.000000000 +0400
-@@ -778,6 +778,7 @@
- 				return dep
- 			}
- 		}
-+		bi.Main.Version = "@VERSION@"
- 		return &bi.Main
- 	}
- 	return mod
+--- github.com/caddyserver/caddy/caddy.go.orig	2022-09-21 22:59:44.000000000 +0400
++++ github.com/caddyserver/caddy/caddy.go	2022-09-23 14:45:56.000000000 +0400
+@@ -841,6 +841,7 @@
+ //
+ // This function is experimental and subject to change or removal.
+ func Version() (simple, full string) {
++	return "@VERSION@", "@VERSION@"
+ 	// the currently-recommended way to build Caddy involves
+ 	// building it as a dependency so we can extract version
+ 	// information from go.mod tooling; once the upstream


### PR DESCRIPTION
###### Tested on
macOS 12.6 21G115 x86_64
Xcode 14.0 14A309

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?