### PR TITLE
netpbm: modernize python dep: use python 3.10

### DIFF
--- a/graphics/netpbm/Portfile
+++ b/graphics/netpbm/Portfile
@@ -301,22 +301,20 @@ platform darwin 8 {
         set data [read $fl]
         close $fl
         if {[regexp "build 4061" ${data}]} {
-            ui_msg "On Mac OS X ${macosx_version}, ${name} @${version} does not work with gcc version \"${data}\"."
+            ui_msg "On Mac OS X ${macos_version}, ${name} @${version} does not work with gcc version \"${data}\"."
             return -code error "incompatible gcc version"
         }
     }
 }
 
 patchfiles-append       patch-python.diff
-if {${os.platform} eq "darwin" && (${os.major} < 10 || ${os.major} > 20)} {
-    # The system python on 10.5 and earlier is too old and 12.3 and
-    # later no longer have a system python.
-    depends_build-append \
-                        port:python27
-    configure.python    ${prefix}/bin/python2.7
-} else {
-    configure.python    /usr/bin/python
-}
+
+set python_branch       3.10
+set python_version      [string map {. {}} ${python_branch}]
+
+configure.python        ${prefix}/bin/python${python_branch}
+
+depends_build-append    port:python${python_version}
 post-patch {
     reinplace \
         "s|__MACPORTS_PYTHON__|${configure.python}|g" \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Updates the python dependency to python 3.10.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Can't do the last ones due to not sure how to connect this to my live install. I did try the compile for `icu` by copy and pasting.

Result of running tests (not great):

```
:info:test Test summary:
:info:test ==================
:info:test SUCCESS 147
:info:test FAILURE 53
:info:test NOT TESTABLE 2
:info:test TOTAL TESTABLE 200
:info:test ==================
```

It appears the tests depend on Ghostscript being installed.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

May be connected to [#65870](https://trac.macports.org/ticket/65870)