### PR TITLE
nodejs{16,17}: Use MacPorts' newly upgraded ICU 71.1

### DIFF
--- a/devel/nodejs16/Portfile
+++ b/devel/nodejs16/Portfile
@@ -13,7 +13,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs16
 version                 16.17.1
-revision                0
+revision                1
 
 categories              devel net
 platforms               darwin
@@ -44,15 +44,13 @@ depends_build-append    port:pkgconfig
 set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
-depends_lib-append      port:python${py_ver_nodot} \
+depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
+                        port:python${py_ver_nodot} \
                         port:zlib
 
 if {![variant_isset openssl3]} {
     openssl.branch          1.1
 }
-
-# TODO: when icu is upgraded to v68.x, use MacPorts'.
-#depends_lib-append             path:lib/pkgconfig/icu-uc.pc:icu
 
 # error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
 set min_darwin 13
@@ -102,15 +100,14 @@ post-patch {
 pre-configure {
     # Copy zlib headers here because we do not want to prepend the entire
     # ${prefix}/include to the include path (the build will then attempt to use
-    # ICU 67 headers)
+    # ICU headers)
     file mkdir ${workpath}/zlib-inc
     file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
         ${workpath}/zlib-inc/
 }
 
 configure.args-append   --without-npm
-# TODO: when icu is upgraded to v68.x, use MacPorts'.
-# configure.args-append   --with-intl=system-icu
+configure.args-append   --with-intl=system-icu
 configure.args-append   --shared-openssl
 configure.args-append   --shared-openssl-includes=[openssl::include_dir]/openssl
 configure.args-append   --shared-openssl-libpath=[openssl::lib_dir]

--- a/devel/nodejs17/Portfile
+++ b/devel/nodejs17/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs17
 version                 17.9.1
-revision                1
+revision                2
 
 categories              devel net
 platforms               darwin
@@ -43,11 +43,9 @@ depends_build-append    port:pkgconfig
 set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
-depends_lib-append      port:python${py_ver_nodot} \
+depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
+                        port:python${py_ver_nodot} \
                         port:zlib
-
-# TODO: when icu is upgraded to v68.x, use MacPorts'.
-#depends_lib-append             path:lib/pkgconfig/icu-uc.pc:icu
 
 # error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
 set min_darwin 13
@@ -96,15 +94,14 @@ post-patch {
 pre-configure {
     # Copy zlib headers here because we do not want to prepend the entire
     # ${prefix}/include to the include path (the build will then attempt to use
-    # ICU 67 headers)
+    # ICU headers)
     file mkdir ${workpath}/zlib-inc
     file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
         ${workpath}/zlib-inc/
 }
 
 configure.args-append   --without-npm
-# TODO: when icu is upgraded to v68.x, use MacPorts'.
-# configure.args-append   --with-intl=system-icu
+configure.args-append   --with-intl=system-icu
 configure.args-append   --shared-zlib
 configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
 configure.args-append   --shared-zlib-libpath=${prefix}/lib


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Command Line Tools 14.0.0.0.1.1661618636

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
