### PR TITLE
FAudio: Update to 22.09.01

### DIFF
--- a/audio/FAudio/Portfile
+++ b/audio/FAudio/Portfile
@@ -4,12 +4,11 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            FNA-XNA FAudio 22.05
+github.setup            FNA-XNA FAudio 22.09.01
 revision                0
 
 license                 zlib
 categories              audio
-platforms               darwin
 maintainers             nomaintainer
 description             XAudio reimplementation
 long_description        an XAudio reimplementation that focuses solely on developing \
@@ -18,9 +17,9 @@ long_description        an XAudio reimplementation that focuses solely on develo
 
 depends_lib-append      port:libsdl2
 
-checksums               rmd160  dcdea2f9212da074dbae6485c250d78b3fa7d0b3 \
-                        sha256  d80a9598ec9e94652e8b7f5cf503b7c9792c8f905e63c9d93aa5d03a8efa2cf5 \
-                        size    1109448
+checksums               rmd160  2054ec4311ea332c35e4a026cffa2962bbc8f91e \
+                        sha256  0a6996fc0f7c3fe5fac402fdad1f30c4bae345755db3ad5002f8f50e980e4589 \
+                        size    1109121
 
 # remove set deployment target and hard-coded RPATH setting
 patchfiles              patch-faudio-remove-deployment-target.diff
@@ -29,6 +28,15 @@ configure.args          -DBUILD_UTILS=OFF \
                         -DBUILD_TESTS=ON \
                         -DXNASONG=ON \
                         -DCMAKE_INSTALL_INCLUDEDIR=include/FAudio
+
+# FAudio has a hard requirment of SDL 2.24, since 22.09
+if {${os.major} <= 10} {
+    github.setup        FNA-XNA FAudio 22.08
+
+    checksums           rmd160  efcded088e1076b086d6db12b0cb135da66a794f \
+                        sha256  f3975715f7ba915fa6f2d6ca1d050e838ada814b327fec5a0833e52e26dec31b \
+                        size    1110469
+}
 
 #pre-destroot {
 #    there are some utilities to consider, but the facttool segfaulted when I tried to open an audio engine


### PR DESCRIPTION
#### Description

Updated to the latest release and force 22.08 below 10.7 due to a hard requirement on SDL 2.24

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
