### PR TITLE
Fix gpsd when global -python27

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -71,8 +71,9 @@ foreach s ${pythons_suffixes} {
     }
 }
 if {${pyver_no_dot} eq ""} {
-    ui_error "\n\nYou must select one of the Python variants (+pythonXY).\n"
-return -code error "Invalid Python variant selection"
+    set pyver_no_dot [lindex ${pythons_suffixes} [llength ${pythons_suffixes}]-1]
+    ui_error "\n\nA Python variant must be selected (+pythonXY).\nForcing +python${pyver_no_dot}.\n\n"
+    default_variants +python${pyver_no_dot}
 }
 
 set pyver_dotted [dotted_ver ${pyver_no_dot}]


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This means that gpsd won't fail to load when `-python27` is set globally (in variants). Without this fix, `port clean --all all` will fail on `gpsd`.

Alternative would be to disable all preset variants when doing `port clean`.

This is the only port that fails when doing `port clean` and `-python27` is set globally.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

I did test that `port clean --all all` worked properly in this situation.