### PR TITLE
terragrunt: update to 0.38.12

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -19,11 +19,11 @@ set latestVersion       terragrunt-0.38
 
 subport terragrunt-0.38 {
     set dependsOn       1.2
-    set patchNumber     9
+    set patchNumber     12
 
-    checksums           rmd160  293b4ed0252fa62b5b32a4cc6f84a8977f6ea96d \
-                        sha256  978fc09f6b439a3860476f547df4ddedd8fcb45a2a922b7eabc95752f778616b \
-                        size    2306674
+    checksums           rmd160  89ffa2c0cf99dbd3aa82294eebe9e2530a56e769 \
+                        sha256  bcb7e5396948c65895d87780bfcc257ca1e9cb44c9e37fdb1c1d18e892fafeda \
+                        size    2307124
 }
 
 subport terragrunt-0.37 {


### PR DESCRIPTION
#### Description
terragrunt: update to 0.38.12

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
