### PR TITLE
DeaDBeeF: update to 1.9.2

### DIFF
--- a/multimedia/DeaDBeeF/Portfile
+++ b/multimedia/DeaDBeeF/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           xcode 1.0
 PortGroup           github 1.0
 
-github.setup        DeaDBeeF-Player deadbeef 1.9.1
+github.setup        DeaDBeeF-Player deadbeef 1.9.2
 name                DeaDBeeF
 categories          multimedia
 platforms           macosx
@@ -25,6 +25,15 @@ license             zlib LGPL-2.1 GPL-2
 fetch.type          git
 post-fetch {
     system -W ${worksrcpath} "git submodule update --init"
+
+    # Fix case-sensitive inconsistencies
+    move \
+        ${worksrcpath}/plugins/cocoaui/images \
+        ${worksrcpath}/plugins/cocoaui/Images
+
+    move \
+        ${worksrcpath}/plugins/cocoaui/widgets \
+        ${worksrcpath}/plugins/cocoaui/Widgets
 }
 
 xcode.configuration     Release


### PR DESCRIPTION
#### Description
DeaDBeeF: update to 1.9.2

The previous version of this (1.9.1) succeeded locally and in the PR build, but failed on all buildbots. I couldn't figure out what was causing the issue, so if this version fails too, I might just remove this port until they update the MacOS version of this app to a beta version or something.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
