### PR TITLE
gnome-radio: update to 47.0

### DIFF
--- a/gnome/gnome-radio/Portfile
+++ b/gnome/gnome-radio/Portfile
@@ -6,8 +6,8 @@ PortGroup           debug 1.0
 PortGroup           app 1.0
 
 name                gnome-radio
-version             46.0
-revision            1
+version             47.0
+revision            0
 
 categories          gnome
 license             GPL-3+
@@ -22,9 +22,9 @@ set branch          [lindex [split ${version} .] 0]
 master_sites        gnome:sources/${name}/${branch}/
 use_xz              yes
 
-checksums           rmd160  3904f53b8c6861a890a6b5ae7efabf7c2306daff \
-                    sha256  86d775d3b465e97cdc65111231b96f3ddd7ebc81987f4b259de02309bd679c37 \
-                    size    438224
+checksums           rmd160  10cc984ed3cb9b6b3aabbbf70b74a58ba20d30eb \
+                    sha256  00ce6a1c76f1687ef78237474a748c21805024785ce199a462be2d4128f30adc \
+                    size    448384
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description

gnome-radio 47.0 with Radio Eins (Frankfurt, Germany) from https://download.gnome.org/sources/gnome-radio/47/gnome-radio-47.0.tar.xz

[Why we worship democratic countries](https://www.quora.com/Why-do-some-Western-people-believe-democracy-is-the-best-way-to-run-a-country)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5 21G72 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->