### PR TITLE
openjdk19-temurin: new submission

### DIFF
--- a/java/openjdk19-temurin/Portfile
+++ b/java/openjdk19-temurin/Portfile
@@ -1,0 +1,94 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk19-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/?version=19
+supported_archs  x86_64 arm64
+
+version      19
+set build    36
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK 19
+long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${version}%2B${build}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     OpenJDK19U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  ca5899f6c56a8452c9f68a4e54688cb3bd873f9d \
+                 sha256  6ee7e6b7efa083ef7a1f206807230a0c5c1ab79609b1b27e0c97211cb01c4556 \
+                 size    195195315
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     OpenJDK19U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  a2463c7b66e3dc11627c563a7c12586bf3d7dc2d \
+                 sha256  8ab27c4038dce4be7b0f73d3e4c6c9271f8f11e7e5d9c0a0bf37505986420ccf \
+                 size    185076247
+}
+
+worksrcdir   jdk-${version}+${build}
+
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # See https://adoptium.net/supported-platforms/
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
+        return -code error
+    }
+}
+
+homepage     https://adoptium.net
+
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin19-binaries/releases
+livecheck.regex     OpenJDK19U-.*_mac_hotspot_(19\[0-9\.\]*)_\[0-9\]+.tar.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Eclipse Temurin 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0 14A309

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?