### PR TITLE
diffoscope: Update to 222, use Python 3.10

### DIFF
--- a/sysutils/diffoscope/Portfile
+++ b/sysutils/diffoscope/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                diffoscope
-version             137
+version             222
 categories          sysutils python
 platforms           darwin
 supported_archs     noarch
@@ -24,11 +24,11 @@ long_description    diffoscope will try to get to the bottom of what makes \
 homepage            https://diffoscope.org/
 master_sites        pypi:d/diffoscope
 
-checksums           rmd160  f69e86b7c6334bb0a69ef7a8d241a2faed1a9794 \
-                    sha256  e1fc59dbbae133da65c827ba990243119f30731b1489002c396d49c66300b9da \
-                    size    1557283
+checksums           rmd160  1d91698559acf0aecc9b67237ab06820d686e3d5 \
+                    sha256  ffb90a9f6000c9b27763eb58bcdd9e3681fccec857e6807d4568680a3801098e \
+                    size    3145249
 
-python.default_version 38
+python.default_version 310
 
 depends_build-append \
                     port:py${python.version}-setuptools
@@ -41,11 +41,13 @@ depends_run-append  port:gnutar \
                     bin:gzip:gzip \
                     bin:cpio:cpio
 
-patchfiles          patch-locale.diff
+patchfiles          patch-locale.diff \
+                    patch-tests__tests-source__py.diff
 
 depends_test-append \
                     port:py${python.version}-py \
-                    port:py${python.version}-pytest
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-black
 
 test.run            yes
 

--- a/sysutils/diffoscope/files/patch-locale.diff
+++ b/sysutils/diffoscope/files/patch-locale.diff
@@ -1,10 +1,10 @@
---- diffoscope/environ.py
-+++ diffoscope/environ.py
-@@ -55,6 +55,6 @@ def normalize_environment():
-         os.environ[x] = 'C'
+--- ./diffoscope/environ.py.orig	2022-09-23 10:04:51.000000000 +0200
++++ ./diffoscope/environ.py	2022-09-27 17:22:36.000000000 +0200
+@@ -54,6 +54,6 @@
+         os.environ[x] = "C"
  
-     os.environ['TZ'] = 'UTC'
--    os.environ['LC_CTYPE'] = 'C.UTF-8'
-+    os.environ['LC_CTYPE'] = 'UTF-8'
+     os.environ["TZ"] = "UTC"
+-    os.environ["LC_CTYPE"] = "C.UTF-8"
++    os.environ["LC_CTYPE"] = "UTF-8"
  
      time.tzset()

--- a/sysutils/diffoscope/files/patch-tests__tests-source__py.diff
+++ b/sysutils/diffoscope/files/patch-tests__tests-source__py.diff
@@ -1,0 +1,24 @@
+--- ./tests/test_source.py.orig	2022-09-27 17:48:13.000000000 +0200
++++ ./tests/test_source.py	2022-09-27 17:48:39.000000000 +0200
+@@ -246,7 +246,7 @@
+ 
+ def black_version():
+     try:
+-        out = subprocess.check_output(("black", "--version"))
++        out = subprocess.check_output(("black-3.10", "--version"))
+     except subprocess.CalledProcessError as e:
+         out = e.output
+ 
+@@ -257,10 +257,10 @@
+     ]
+ 
+ 
+-@skip_unless_tool_is_at_least("black", black_version, "22.1.0")
++@skip_unless_tool_is_at_least("black-3.10", black_version, "22.1.0")
+ def test_code_is_black_clean():
+     output = subprocess.check_output(
+-        ("black", "--diff", "."), stderr=subprocess.PIPE
++        ("black-3.10", "--diff", "."), stderr=subprocess.PIPE
+     ).decode("utf-8")
+ 
+     # Display diff in "captured stdout call"


### PR DESCRIPTION
#### Description

Upstream asked us to ship a newer version. Some of the tests still fail, but that's probably due to missing dependencies or specifics of macOS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
