### PR TITLE
micronaut: update to 3.7.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.7.0 v
+github.setup    micronaut-projects micronaut-starter 3.7.1 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  40776c4e8a5f1067e32f88a228248d84ddcd2662 \
-                sha256  f37ca1e5475db82b640645c32d2d7c636f3679ab091015d07642bd083e22a473 \
-                size    19940061
+checksums       rmd160  cfebfa4026785cdda8e20cc86ff8ef0b5e552880 \
+                sha256  64cc7d3cd95d9ad0db8e974bb9c4096305dc2e3ab05bfa5cc760b1b3f625f7d9 \
+                size    19949647
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.7.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?