### PR TITLE
google-cloud-sdk: update to 404.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             403.0.0
+version             404.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e7b42b3cf0e3fe74645b09597549eafc9265a469 \
-                    sha256  8966967aa8f5817327563e1e7bda850ad568f98131bc16d02bc85cfe335d3892 \
-                    size    109263059
+    checksums       rmd160  a75257a1777afffeee7a5bfc282bfffa08cc1fb6 \
+                    sha256  96f78fcc7e51c46f6efec20855a9db2cc128680beadf34dd3dbba808ff8337e2 \
+                    size    109378161
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  92d05f0c0193bfad6d07bc52dbe959c7af8a6a4d \
-                    sha256  3e9d68f6b3b60a8c0e48a9490870f948971b51d0713e8060521c6f9d6c251f55 \
-                    size    96705042
+    checksums       rmd160  52b6ac21672a65583766c71e92b9827ad87b892c \
+                    sha256  5467436b59a724e3d8c2ace57aff73abb36a31307b722e230dba0f85bcfd7f86 \
+                    size    96818999
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  ede03ad75060809f609b9d30fa6a5014b77c1b56 \
-                    sha256  94cf159917035370d3c112dea96576b8cf1a449f3d1dc49c3b34bf9f0b5c57ba \
-                    size    95321532
+    checksums       rmd160  5ff6bc1d5c9aedf4763ac87d40fbd84c0ccef469 \
+                    sha256  89905e462a0302b0d669fcd7c887c0fe87dde9ba900ec7514f7ed235260c6c0d \
+                    size    95434037
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 404.0.0.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?