### PR TITLE
stern: update to 1.22.0

### DIFF
--- a/sysutils/stern/Portfile
+++ b/sysutils/stern/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/stern/stern 1.21.0 v
+go.setup            github.com/stern/stern 1.22.0 v
 maintainers         {breun.nl:nils @breun} openmaintainer
 platforms           darwin
 categories          sysutils
@@ -15,9 +15,9 @@ long_description    Stern allows you to tail multiple pods on Kubernetes and \
                     multiple containers within the pod. Each result is color \
                     coded for quicker debugging.
 
-checksums           rmd160  e5ff05a447856d97ad8de504cf091615ab5f52ba \
-                    sha256  b95061eca122a65083e81f2f38d439920d8e4b6057419dc3ffa177c47c642106 \
-                    size    124825
+checksums           rmd160  a304d8293ca58b5f8c03f9d87ab6bfebd1b2e016 \
+                    sha256  89b6c809d5a4e4b69d8a8373367f5275134df8e132a16f2dc96bfef7f05added \
+                    size    40726
 
 set go_ldflags      "-s -w -X ${go.package}/cmd.version=${version}"
 build.args          -ldflags \"${go_ldflags}\" -o bin/${name}


### PR DESCRIPTION
#### Description

Update to Stern 1.22.0.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?