### PR TITLE
terragrunt: update to 0.39.0

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -15,7 +15,16 @@ maintainers         {mjrc.nl:macports @mjrc} openmaintainer
 
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       terragrunt-0.38
+set latestVersion       terragrunt-0.39
+
+subport terragrunt-0.39 {
+    set dependsOn       1.2
+    set patchNumber     0
+
+    checksums           rmd160  81e57db97a55878ef29033898c736e1e4ab6c278 \
+                        sha256  a47b0a984d2ba22cb345250ea37ff95e22a90b5e5333b0b47e2acbe8693a9ae5 \
+                        size    2307589
+}
 
 subport terragrunt-0.38 {
     set dependsOn       1.2


### PR DESCRIPTION
#### Description
terragrunt: update to 0.39.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
