### PR TITLE
openjdk17-oracle: update replacement to openjdk19-oracle

### DIFF
--- a/java/openjdk17-oracle/Portfile
+++ b/java/openjdk17-oracle/Portfile
@@ -7,6 +7,6 @@ PortGroup        obsolete 1.0
 
 name             openjdk17-oracle
 categories       java devel
-replaced_by      openjdk18-oracle
+replaced_by      openjdk19-oracle
 version          17.0.2
 revision         1


### PR DESCRIPTION
#### Description

Update replacement to `openjdk19-oracle`, because `openjdk18-oracle` reached end of life.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?