### PR TITLE
openjdk18-temurin: obsolete, replaced by openjdk19-temurin

### DIFF
--- a/java/openjdk18-temurin/Portfile
+++ b/java/openjdk18-temurin/Portfile
@@ -1,95 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-04-01
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk18-temurin
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-# https://adoptium.net/temurin/releases/?version=18
-supported_archs  x86_64 arm64
-
-version      18.0.2.1
-set build    1
-revision     0
-
-description  Eclipse Temurin, based on OpenJDK 18
-long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
-
-master_sites https://github.com/adoptium/temurin18-binaries/releases/download/jdk-${version}%2B${build}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     OpenJDK18U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  6c82404d0c6fd60fda15dc162fab18fd19ffa6a7 \
-                 sha256  2ed916b0c9d197a6bf71b76e84d94125023c2609e0a9b22c64553eff5c9c29c1 \
-                 size    188272216
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     OpenJDK18U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  27b21b956bf47a9107b3864c4503b10ca4b57340 \
-                 sha256  c5ec423f52d8f3aa632941f29fd289f2e31dce5fe6f3abed9b72bd374f54cd41 \
-                 size    178821710
-}
-
-worksrcdir   jdk-${version}+${build}
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 16} {
-    # See https://adoptium.net/supported-platforms/
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
-        return -code error
-    }
-}
-
-homepage     https://adoptium.net
-
-livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin18-binaries/releases
-livecheck.regex     OpenJDK18U-jdk_.*_mac_hotspot_(18\.\[0-9\.\]+)_\[0-9\]+.tar.gz
-
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk18-temurin
+categories  java devel
+version     18.0.2.1
+revision    1
+replaced_by openjdk19-temurin


### PR DESCRIPTION
#### Description

Eclipse Temurin 18 reached end of life, replaced by Eclipse Temurin 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
