### PR TITLE
ReadyMedia: update to 1.3.2

### DIFF
--- a/net/ReadyMedia/Portfile
+++ b/net/ReadyMedia/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                ReadyMedia
-version             1.3.0
-revision            2
+version             1.3.2
+revision            0
 categories          net multimedia
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 license             GPL-2
@@ -20,9 +20,9 @@ master_sites        sourceforge:project/minidlna/minidlna/${version}/
 distname            minidlna-${version}
 dist_subdir         minidlna
 
-checksums           rmd160  9fb89198c95cc4c7b7f291eedff9ae94794b18ad \
-                    sha256  47d9b06b4c48801a4c1112ec23d24782728b5495e95ec2195bbe5c81bc2d3c63 \
-                    size    509576
+checksums           rmd160  1eef618fcdb91ab3c4fd3c1a51970e45ad300c3f \
+                    sha256  222ce45a1a60c3ce3de17527955d38e5ff7a4592d61db39577e6bf88e0ae1cb0 \
+                    size    736820
 
 depends_lib         path:lib/libavcodec.dylib:ffmpeg \
                     port:flac \
@@ -30,6 +30,9 @@ depends_lib         path:lib/libavcodec.dylib:ffmpeg \
                     port:libid3tag \
                     port:libexif \
                     port:sqlite3
+
+# https://sourceforge.net/p/minidlna/bugs/351/
+patchfiles          patch-kqueue.diff
 
 set db_path         ${prefix}/var/cache/minidlna
 

--- a/net/ReadyMedia/files/patch-kqueue.diff
+++ b/net/ReadyMedia/files/patch-kqueue.diff
@@ -1,0 +1,10 @@
+--- kqueue.c.orig	2022-08-30 09:42:54.000000000 +0400
++++ kqueue.c	2022-10-01 19:05:23.000000000 +0400
+@@ -28,6 +28,7 @@
+ 
+ #include <sys/types.h>
+ #include <sys/event.h>
++#include <sys/time.h>
+ #include <assert.h>
+ #include <errno.h>
+ #include <stdlib.h>


### PR DESCRIPTION
###### Tested on
macOS 12.6 21G115 x86_64
Xcode 14.0.1 14A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?