### PR TITLE
Update port `ruby-build`: Add a standalone variant for ruby-build

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        rbenv ruby-build 20221225 v
+revision            1
 categories          ruby
 license             MIT
 platforms           any
@@ -24,3 +25,7 @@ destroot.cmd        ./install.sh
 destroot.env        PREFIX=${destroot}${prefix}
 
 depends_lib         port:rbenv
+
+variant standalone description {Installs ruby-build without also installing rbenv} {
+    depends_lib-delete port:rbenv
+}


### PR DESCRIPTION
#### Description

https://trac.macports.org/ticket/65329

This is the weak fix for #65329, where `rbenv` should not be a dependency for installing ruby-build by adding a `+standalone` variant.



###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6 21G115 arm64
Xcode 13.4.1 13F100

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
