### PR TITLE
Update ports rbenv and ruby-build: Break rbenv dependency from ruby-build

### DIFF
--- a/ruby/rbenv/Portfile
+++ b/ruby/rbenv/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        rbenv rbenv 1.2.0 v
+revision            0
 license             MIT
 categories          ruby
 platforms           any
@@ -29,4 +30,8 @@ destroot {
     xinstall -d ${destroot}${prefix}/share/zsh/site-functions
     xinstall ${worksrcpath}/completions/rbenv.zsh \
         ${destroot}${prefix}/share/zsh/site-functions/rbenv.zsh_completion
+}
+
+notes {
+    To enable the rbenv subcommand 'install', install port ruby-build.
 }

--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20221225 v
+github.setup        rbenv ruby-build 20230208 v
 categories          ruby
 license             MIT
 platforms           any
@@ -14,13 +14,16 @@ maintainers         {mojca @mojca} openmaintainer
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  d6b29467efcbfbc3cb289bf2b5e24c0b3fd51074 \
-                    sha256  18cf31c9081a90f00d8810a48db8caf6f190926f9a9736130f1e90c9f483f49e \
-                    size    79455
+checksums           rmd160  720cc0c4b8ee5f0e835d3b358afe04f784e7b29f \
+                    sha256  db5597e6beea530ed9b6b97f0bbdf4395ac909a04e9f552b45c05b90d172e419 \
+                    size    78320
 
 use_configure       no
 build {}
 destroot.cmd        ./install.sh
 destroot.env        PREFIX=${destroot}${prefix}
 
-depends_lib         port:rbenv
+notes {
+    The ruby-build port no longer installs rbenv automatically. If required, please
+    install the port rbenv manually.
+}


### PR DESCRIPTION
#### Description

rbenv: update to version 1.2.0

Add a notes block advising the installation of port ruby-build if the
subcommand `rbenv install` is desired.

Closes: https://trac.macports.org/ticket/65329
Signed-off-by: Austin Ziegler <austin@zieglers.ca>

ruby-build: remove incorrect dependency

- Removes the dependency on `rbenv`, as ruby-build does not require
  rbenv to work (but rbenv can integrate ruby-build as a plug-in).

- Add a notes block that this port no longer installs port rbenv
  automatically, and advising manual installation of port rbenv.

Closes: https://trac.macports.org/ticket/65329
Closes: https://github.com/macports/macports-ports/pulls/16273
Closes: https://github.com/macports/macports-ports/pulls/16274
Signed-off-by: Austin Ziegler <austin@zieglers.ca>

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6 21G115 arm64
Xcode 13.4.1 13F100

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
