### PR TITLE
universal-ctags: update to 5.9.20221002.0

### DIFF
--- a/devel/universal-ctags/Portfile
+++ b/devel/universal-ctags/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        universal-ctags ctags 5.9.20220911.0 p
+github.setup        universal-ctags ctags 5.9.20221002.0 p
 name                universal-ctags
 epoch               1
 revision            0
@@ -24,21 +24,9 @@ long_description \
 
 homepage            https://ctags.io
 
-checksums           rmd160  322388c3fe4379bb65c25c4f3978f8363f425455 \
-                    sha256  fde860e93b01ea89e6da20bc1c52c23dffb4916578c0063405fba155d228c141 \
-                    size    2953936
-
-pre-patch {
-    if {![file exists ${prefix}/bin/rst2man.py]} {
-        set files [glob -directory ${prefix}/bin "rst2man-*.py"]
-        foreach f $files {
-            if {[regexp {rst2man-.*\.py} $f result]} {
-                reinplace "s|rst2man3.py|${result}|g" \
-                    ${worksrcpath}/configure.ac
-            }
-        }
-    }
-}
+checksums           rmd160  5d48f5230cf95ae2f8438625c8f125ac88a5fe3b \
+                    sha256  d8bfbe47ca74b57bf05a743ac318dbfcb31a62085af601f0b4e957a948046d6e \
+                    size    2958952
 
 # LegacySupport is needed for strnlen before 10.7
 legacysupport.newest_darwin_requires_legacy 10
@@ -53,6 +41,7 @@ depends_build       port:autoconf \
                     port:libtool
 
 depends_lib         port:jansson \
+                    port:pcre2 \
                     port:libyaml
 
 universal_variant   no
@@ -79,5 +68,13 @@ variant libxml2 description {Extra support for XML based languages} {
 }
 
 variant manpages description {Enable documentation} {
-    depends_build-append    port:py-docutils
+    set python_branch       3.10
+    set python_version      [string map {. {}} ${python_branch}]
+
+    patchfiles              docutils.patch
+
+    depends_build-append    port:py${python_version}-docutils
+
+    configure.args-append   --with-rst2man=${prefix}/bin/rst2man-${python_branch}.py \
+                            --with-rst2html=${prefix}/bin/rst2html-${python_branch}.py
 }

--- a/devel/universal-ctags/files/docutils.patch
+++ b/devel/universal-ctags/files/docutils.patch
@@ -1,0 +1,38 @@
+commit b57c299c0249e9d783c7b8e1436cf953fcc92be3
+Author: Kirill A. Korinsky <kirill@korins.ky>
+Date:   Mon Oct 3 15:04:33 2022 +0200
+
+    Introduce `--with-rst2man` and `--with-rst2html`
+    
+    The idea is quite simple: let allow the user who builds it to suggest
+    which `rst2man` and `rst2html` should be used, instead of guessing.
+    
+    I've also extended the guess list to  python 3.10.
+
+diff --git configure.ac configure.ac
+index c5eb1c5dd..5cea58b86 100644
+--- configure.ac
++++ configure.ac
+@@ -363,9 +363,20 @@ AM_CONDITIONAL([RUN_TXT2CSTR], [test "${perl_found}" = "yes"])
+ # 	can be installed using pip ("pip install docutils"). On some
+ #	systems, rst2man and rst2html are actually installed as rst2man.py
+ #	and rst2html.py - create a symlink of that's the case.
+-AC_PATH_PROGS(RST2MAN, [rst2man rst2man.py rst2man-3 rst2man-3.6 rst2man-3.7 rst2man-3.8 rst2man-3.9], [no])
++#	Also, allow to define path as "--with-rst2man" and "--with-rst2html".
++AC_ARG_WITH([rst2man],
++  AS_HELP_STRING([--with-rst2man=PATH], [Location of rst2man (auto)]),
++  [RST2MAN="$withval"],
++  [AC_PATH_PROGS(RST2MAN,
++    [rst2man rst2man.py rst2man-3 rst2man-3.6 rst2man-3.7 rst2man-3.8 rst2man-3.9, rst2man-3.10],
++    [no])])
+ AM_CONDITIONAL([HAVE_RST2MAN], [test "x$RST2MAN" != "xno"])
+-AC_PATH_PROGS(RST2HTML, [rst2html rst2html.py rst2html-3 rst2html-3.6 rst2html-3.7 rst2html-3.8 rst2html-3.9], [no])
++AC_ARG_WITH([rst2html],
++  AS_HELP_STRING([--with-rst2html=PATH], [Location of rst2html (auto)]),
++  [RST2HTML="$withval"],
++  [AC_PATH_PROGS(RST2HTML,
++    [rst2html rst2html.py rst2html-3 rst2html-3.6 rst2html-3.7 rst2html-3.8 rst2html-3.9, rst2html-3.10],
++    [no])])
+ AM_CONDITIONAL([HAVE_RST2HTML], [test "x$RST2HTML" != "xno"])
+ 
+ # rst2pdf is a separate tool and can also be installed via pip (e.g.,


### PR DESCRIPTION
#### Description

I've also fixed usage of rst2man (patch was backported to upstream), and added a missed library dependency against PCRE2.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->