### PR TITLE
py-awscli2: update to 2.8.0

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.7.33
+github.setup        aws aws-cli 2.8.0
 revision            0
 
 categories          python devel
@@ -19,11 +19,14 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  e86694c4626e3ff2d166aeb06de7c97f0d1270e8 \
-                    sha256  5056a7e3f3c0f7010853498a145cbc7d6fe71f6b90e0b71d8ca6dd2913614540 \
-                    size    11261690
+checksums           rmd160  f51dffe11495fe7e95b6df2cb3462270b9cd494f \
+                    sha256  8ed982f7256189eaf04bf1132413a2d18913957d0e632c8761af20fd7c8e9523 \
+                    size    11317725
 
 python.versions     38 39 310
+python.pep517       yes
+python.pep517_backend \
+                    flit
 
 if {${name} ne ${subport}} {
     if {${os.platform} eq "darwin" && ${os.major} <= 15} {
@@ -71,9 +74,6 @@ if {${name} ne ${subport}} {
     }
 
     post-destroot {
-        move ${worksrcpath}/scripts/gen-ac-index ${worksrcpath}
-        system -W ${worksrcpath} "${prefix}/bin/python${python.branch} ./gen-ac-index --include-builtin-index --index-location ${destroot}${python.pkgd}/awscli/data/ac.index"
-
         delete ${destroot}${prefix}/bin/aws.cmd-${python.branch}
 
         set bash_compl_path ${prefix}/share/bash-completion/completions

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,35 +1,35 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-diff -ru aws-cli-2.7.26-orig/setup.cfg aws-cli-2.7.26/setup.cfg
---- aws-cli-2.7.26-orig/setup.cfg	2022-08-24 14:34:39.000000000 -0400
-+++ aws-cli-2.7.26/setup.cfg	2022-08-24 21:56:22.727217713 -0400
-@@ -29,17 +29,17 @@
- python_requires = >=3.8
- include_package_data = True
- install_requires =
--    colorama>=0.2.5,<0.4.4
--    docutils>=0.10,<0.16
--    cryptography>=3.3.2,<37.0.0
--    ruamel.yaml>=0.15.0,<=0.17.21
--    wcwidth<0.2.0
--    prompt-toolkit>=3.0.24,<3.0.29
--    distro>=1.5.0,<1.6.0
--    awscrt>=0.12.4,<=0.14.0
--    python-dateutil>=2.1,<3.0.0
--    jmespath>=0.7.1,<1.1.0
--    urllib3>=1.25.4,<1.27
-+    colorama
-+    docutils
-+    cryptography
-+    ruamel.yaml
-+    wcwidth
-+    prompt-toolkit
-+    distro
-+    awscrt==0.14.0
-+    python-dateutil
-+    jmespath
-+    urllib3
+diff -ru aws-cli-2.8.0-orig/pyproject.toml aws-cli-2.8.0/pyproject.toml
+--- aws-cli-2.8.0-orig/pyproject.toml	2022-09-30 13:59:35.000000000 -0400
++++ aws-cli-2.8.0/pyproject.toml	2022-10-03 10:00:25.740109770 -0400
+@@ -27,17 +27,17 @@
+     "Programming Language :: Python :: 3.10",
+ ]
+ dependencies = [
+-    "colorama>=0.2.5,<0.4.4",
+-    "docutils>=0.10,<0.16",
+-    "cryptography>=3.3.2,<37.0.0",
+-    "ruamel.yaml>=0.15.0,<=0.17.21",
+-    "wcwidth<0.2.0",
+-    "prompt-toolkit>=3.0.24,<3.0.29",
+-    "distro>=1.5.0,<1.6.0",
+-    "awscrt>=0.12.4,<=0.14.0",
+-    "python-dateutil>=2.1,<3.0.0",
+-    "jmespath>=0.7.1,<1.1.0",
+-    "urllib3>=1.25.4,<1.27",
++    "colorama",
++    "docutils",
++    "cryptography",
++    "ruamel.yaml",
++    "wcwidth",
++    "prompt-toolkit",
++    "distro",
++    "awscrt==0.14.0",
++    "python-dateutil",
++    "jmespath",
++    "urllib3",
+ ]
+ dynamic = ["version"]
 
- [options.packages.find]
- exclude =


### PR DESCRIPTION
#### Description
The build now uses pep517 and builds the autocomplete database by itself. Everything seems to be working fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
