### PR TITLE
mpich: app a patch from libfabric upstream for a case of missing AI_NUMERICSERV

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -188,7 +188,8 @@ if {${subport_enabled}} {
     patchfiles-append \
                     patch-no_qmkshrobj.diff \
                     patch-ch4-ipv6.diff \
-                    patch-mpich-darwin-powerpc.diff
+                    patch-mpich-darwin-powerpc.diff \
+                    patch-pingpong.diff
 
     platform darwin powerpc {
         # libfabric calls for atomicops, on PPC at least

--- a/science/mpich/files/patch-pingpong.diff
+++ b/science/mpich/files/patch-pingpong.diff
@@ -1,0 +1,15 @@
+# https://github.com/ofiwg/libfabric/commit/522a3db73657e6eaf4ba225d88b4d76ec1b9f2f2
+
+--- modules/libfabric/util/pingpong.c.orig	2021-10-28 02:49:37.000000000 +0800
++++ modules/libfabric/util/pingpong.c	2022-10-04 05:00:51.000000000 +0800
+@@ -65,6 +65,10 @@
+ #define OFI_MR_BASIC_MAP (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR)
+ #endif
+ 
++#ifndef AI_NUMERICSERV
++#define AI_NUMERICSERV 0
++#endif
++
+ static const uint64_t TAG = 1234;
+ 
+ enum precision {


### PR DESCRIPTION
#### Description

(Small and hopefully uncontroversial PR, submitting now otherwise may get forgotten.)

This fix – borrowed originally from `graphviz` code – is already merged into upstream: https://github.com/ofiwg/libfabric/commit/522a3db73657e6eaf4ba225d88b4d76ec1b9f2f2
However since `mpich` uses an old version of `libfabric`, it makes sense to have a patch until `mpich` moves to a newer version.
The problem of missing `AI_NUMERICSERV` has been resurfacing with several ports and different OS. See:
https://github.com/macports/macports-ports/pull/14932 (MoarVM)
https://trac.macports.org/ticket/41916 (graphviz)


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 PPC
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
