### PR TITLE
mrustc: update to 20221110

### DIFF
--- a/lang/mrustc/Portfile
+++ b/lang/mrustc/Portfile
@@ -5,14 +5,14 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        thepowersgang mrustc a04f166ea5762037895738d88d144803e2e433f5
+github.setup        thepowersgang mrustc 1b1416bb2b44e2c331c7201833305cac29d571e8
 
 set rust_version    1.54.0
 set rust_version_major [join [lrange [split ${rust_version} .-] 0 1] .]
 set rust_version_major_underscore [join [lrange [split ${rust_version} .-] 0 1] _]
 
 # subport mrustc-rust has its own versioning
-version             ${rust_version_major}-20220904
+version             ${rust_version_major}-20221110
 revision            0
 epoch               1
 
@@ -30,18 +30,26 @@ master_sites-append https://static.rust-lang.org/dist/:rust
 distfiles-append    rustc-${rust_version}-src.tar.gz:rust
 
 checksums           mrustc-${github.version}.tar.gz \
-                    rmd160  d608075c56b6aa8175b25016ff0e64190f5e94cd \
-                    sha256  4d25c6e55d8b1c05a87a408a9edbdd5ec8416f40be660619442e12e0d23356af \
-                    size    1189691 \
+                    rmd160  f6d266872d57de4dbb8a99e672f82e40c5fad682 \
+                    sha256  348d67de705ab1e0049602fac866f2d775ab699195f1b00406e00dcc8b4041f5 \
+                    size    1191744 \
                     rustc-${rust_version}-src.tar.gz \
                     rmd160  be2de16e2deaf91aee723e631a36f6de52636ddd \
                     sha256  ac8511633e9b5a65ad030a1a2e5bdaa841fdfe3132f2baaa52cc04e71c6c6976 \
                     size    170480637
 
-# arm64 and i386 requires future patches
-supported_archs     x86_64
+# i386 and ppc may requires future patches
+supported_archs     arm64 x86_64
+
+array set rust_platforms [list \
+    arm64   aarch64 \
+    x86_64  x86_64]
+
+set rust_platform   $rust_platforms(${configure.build_arch})
 
 use_configure       no
+
+universal_variant   no
 
 compiler.cxx_standard 2014
 compiler.c_standard 2011
@@ -134,8 +142,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 
 legacysupport.use_static    yes
 
-set cxxflags        "${configure.cxxflags} ${configure.universal_cxxflags}"
-set ldflags         "${configure.ldflags} ${configure.universal_ldflags}"
+set cxxflags        "${configure.cxxflags}"
+set ldflags         "${configure.ldflags}"
 
 if { ${os.platform} eq "darwin" && ${os.major} <= [option legacysupport.newest_darwin_requires_legacy] } {
     set cxxflags    "${cxxflags} [legacysupport::get_cpp_flags]"
@@ -160,6 +168,13 @@ build.env-append    CC=${configure.cc} \
                     "LINKFLAGS_EXTRA=${ldflags}" \
                     RUSTC_VERSION=${rust_version} \
                     MRUSTC_TARGET_VER=${rust_version_major}
+
+# mrustc had hardcoded x86_64 as target platform
+build.env-append    RUSTC_TARGET=${rust_platform}-apple-${os.platform}
+post-patch {
+    reinplace "s|STD_ENV_ARCH=x86_64|STD_ENV_ARCH=${rust_platform}|g" \
+        ${worksrcpath}/script-overrides/stable-${rust_version}-macos/build_std.txt
+}
 
 # Step 1: building mrustc, its libs and minicargo
 if {${subport} eq ${name}} {
@@ -294,34 +309,34 @@ subport mrustc-rust {
             ${destroot}${prefix}/libexec/${subport}/lib
 
         system -W ${destroot}${prefix}/libexec/${subport}/bin \
-            "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${build_arch}-apple-darwin/release/deps/librustc_driver.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/librustc_driver.dylib ./rustc_binary"
+            "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${rust_platform}-apple-${os.platform}/release/deps/librustc_driver.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/librustc_driver.dylib ./rustc_binary"
 
         system -W ${destroot}${prefix}/libexec/${subport}/bin \
-            "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std2/${build_arch}-apple-darwin/release/deps/libtest.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libtest.dylib ./rustc_binary"
+            "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std2/${rust_platform}-apple-${os.platform}/release/deps/libtest.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libtest.dylib ./rustc_binary"
 
         system -W ${destroot}${prefix}/libexec/${subport}/bin \
-            "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std2/${build_arch}-apple-darwin/release/deps/libstd.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libstd.dylib ./rustc_binary"
+            "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std2/${rust_platform}-apple-${os.platform}/release/deps/libstd.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libstd.dylib ./rustc_binary"
 
-        system -W ${destroot}${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib \
-            "install_name_tool -id ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/librustc_driver.dylib ./librustc_driver.dylib"
+        system -W ${destroot}${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib \
+            "install_name_tool -id ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/librustc_driver.dylib ./librustc_driver.dylib"
 
-        system -W ${destroot}${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib \
-            "install_name_tool -id ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libstd.dylib ./libstd.dylib"
+        system -W ${destroot}${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib \
+            "install_name_tool -id ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libstd.dylib ./libstd.dylib"
 
-        system -W ${destroot}${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib \
-            "install_name_tool -id ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libtest.dylib ./libtest.dylib"
+        system -W ${destroot}${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib \
+            "install_name_tool -id ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libtest.dylib ./libtest.dylib"
 
         foreach f [ exec find ${destroot}${prefix}/libexec/${subport}/lib -name "*.dylib" ] {
-            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${build_arch}-apple-darwin/release/deps/librustc_driver.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/librustc_driver.dylib $f"
-            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${build_arch}-apple-darwin/release/deps/librustc_codegen_llvm.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/librustc_codegen_llvm.dylib $f"
-            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${build_arch}-apple-darwin/release/deps/libtest.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libtest.dylib $f"
-            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${build_arch}-apple-darwin/release/deps/libstd.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libstd.dylib $f"
+            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${rust_platform}-apple-${os.platform}/release/deps/librustc_driver.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/librustc_driver.dylib $f"
+            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${rust_platform}-apple-${os.platform}/release/deps/librustc_codegen_llvm.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/librustc_codegen_llvm.dylib $f"
+            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${rust_platform}-apple-${os.platform}/release/deps/libtest.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libtest.dylib $f"
+            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-rustc/${rust_platform}-apple-${os.platform}/release/deps/libstd.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libstd.dylib $f"
 
-            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std/${build_arch}-apple-darwin/release/deps/libtest.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libtest.dylib $f"
-            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std/${build_arch}-apple-darwin/release/deps/libstd.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libstd.dylib $f"
+            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std/${rust_platform}-apple-${os.platform}/release/deps/libtest.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libtest.dylib $f"
+            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std/${rust_platform}-apple-${os.platform}/release/deps/libstd.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libstd.dylib $f"
 
-            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std2/${build_arch}-apple-darwin/release/deps/libtest.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libtest.dylib $f"
-            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std2/${build_arch}-apple-darwin/release/deps/libstd.dylib ${prefix}/libexec/${subport}/lib/rustlib/${build_arch}-apple-darwin/lib/libstd.dylib $f"
+            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std2/${rust_platform}-apple-${os.platform}/release/deps/libtest.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libtest.dylib $f"
+            system "install_name_tool -change ${worksrcpath}/run_rustc/output-${rust_version}/build-std2/${rust_platform}-apple-${os.platform}/release/deps/libstd.dylib ${prefix}/libexec/${subport}/lib/rustlib/${rust_platform}-apple-${os.platform}/lib/libstd.dylib $f"
         }
     }
 


### PR DESCRIPTION
#### Description

Here the initial support of arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 13.1 13A1030d

macOS 12.6 21G115 x86_64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->