### PR TITLE
epoxy: Make X11/GLX support a default variant

### DIFF
--- a/graphics/libepoxy/Portfile
+++ b/graphics/libepoxy/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           meson 1.0
 
 github.setup        anholt libepoxy 1.5.10
-revision            0
+revision            1
 license             MIT permissive
 categories          graphics
 maintainers         nomaintainer
@@ -20,29 +20,34 @@ checksums           rmd160  0c12937f3ab3645d4b1b96f29ffd2fb5ffc92712 \
                     sha256  b3e076c5bea209ffa7789cb460d76718be206ccad65a8c915757957c76318376 \
                     size    332119
 
-# Yes, mesa and xorg-libX11 are *build* dependencies.  The library will function correctly
-# if they are not present because it loads mesa dynamically only when GLX is used.  When
-# OpenGL.framework is used, there is no need to have mesa at runtime.
-#
-# Clients of this library must link mesa directly and have it listed as their dependency
-# in order to use mesa with libepoxy.
+set python_vers     3.10
 
 depends_build       port:pkgconfig \
-                    port:xorg-util-macros \
-                    port:mesa \
-                    port:xorg-libX11
+                    port:python310
 
 patchfiles          prefix.patch \
                     patch-src-gen_dispatch.py.diff
 
-# enable GLX support
-# without this any gtk3 +x11 app will fail on load as follows
-# dyld: Symbol not found: _epoxy_glXBindTexImageEXT
-#   Referenced from: /opt/local/lib/libgdk-3.0.dylib
-#   Expected in: /opt/local/lib/libepoxy.0.dylib
-#   in /opt/local/lib/libgdk-3.0.dylib
-configure.args-append \
-                    -Dglx=yes
+variant x11 description {Build with X11 and GLX support} {
+    # Yes, mesa and xorg-libX11 are *build* dependencies.  The library will function correctly
+    # if they are not present because it loads mesa dynamically only when GLX is used.  When
+    # OpenGL.framework is used, there is no need to have mesa at runtime.
+    #
+    # Clients of this library must link mesa directly and have it listed as their dependency
+    # in order to use mesa with libepoxy.
+
+    depends_build-append port:xorg-util-macros \
+                         port:mesa \
+                         port:xorg-libX11
+
+    # enable GLX support
+    # without this any gtk3 +x11 app will fail on load as follows
+    # dyld: Symbol not found: _epoxy_glXBindTexImageEXT
+    #   Referenced from: /opt/local/lib/libgdk-3.0.dylib
+    #   Expected in: /opt/local/lib/libepoxy.0.dylib
+    #   in /opt/local/lib/libgdk-3.0.dylib
+    configure.args-append -Dglx=yes
+}
 
 # https://trac.macports.org/ticket/64468
 platform darwin 8 {
@@ -50,8 +55,7 @@ platform darwin 8 {
     configure.cflags-append -DCGLReleaseContext=CGLDestroyContext
 }
 
-set python_vers     3.10
-depends_build-append    port:python310
+default_variants +x11
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/src/dispatch_common.c


### PR DESCRIPTION
The retains the existing behaviour, while allowing the X11 dependencies to be disabled.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
