### PR TITLE
tippecanoe: update to 2.8.1

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -6,7 +6,7 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            felt tippecanoe 2.6.0
+github.setup            felt tippecanoe 2.8.1
 revision                0
 categories              gis
 license                 BSD
@@ -14,9 +14,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Build vector tilesets from large collections of GeoJSON features
 long_description        {*}${description}
 
-checksums               rmd160  2c2e10de56195772a416b7334fc463c50824d02b \
-                        sha256  dc598907d707cf088b5a29fe04b255ff81920f3e6863f3144481383c50774fd7 \
-                        size    17318392
+checksums               rmd160  a006b4991e7c8b6e368ef9b17f098ff9984ef207 \
+                        sha256  287dd9e6cd274e3c5838a65b2116772ae056018c9e8d944b917a5fc08f1c8d0a \
+                        size    18117562
 
 depends_lib-append      port:sqlite3 \
                         port:zlib


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/felt/tippecanoe/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
