### PR TITLE
sfeed: update to 1.6

### DIFF
--- a/net/sfeed/Portfile
+++ b/net/sfeed/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                sfeed
-version             1.5
+version             1.6
 revision            0
 license             ISC
 
@@ -18,9 +18,9 @@ homepage            https://git.codemadness.org/${name}/
 
 master_sites        https://codemadness.org/releases/${name}/
 
-checksums           rmd160  bc9c87ff692b7b37f705a3d0618653ba2ac71877 \
-                    sha256  0a0024bd958b9b00f1b7c29501f1580e3859330102ffd75a8922f50ff8955fd1 \
-                    size    65067
+checksums           rmd160  c9371705f2c6e8ad15eadeac0b5e3202e3233d2c \
+                    sha256  bfd6d24ce98619726aa411a7a0d969806ad08a73c9adc3a8d04508e00eea6aea \
+                    size    65239
 
 depends_lib-append  port:ncurses
 


### PR DESCRIPTION
#### Description
[Changelog](https://git.codemadness.org/sfeed/)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
