### PR TITLE
google-cloud-sdk: update to 405.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             404.0.0
+version             405.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a75257a1777afffeee7a5bfc282bfffa08cc1fb6 \
-                    sha256  96f78fcc7e51c46f6efec20855a9db2cc128680beadf34dd3dbba808ff8337e2 \
-                    size    109378161
+    checksums       rmd160  6699455e92655e60acc5ebd856fe08a9c8bbe60f \
+                    sha256  cf0f32e3d24cbc8a87f7102b0f59423d9df8ffcbd252d3c7175351680266dcd3 \
+                    size    109462047
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  52b6ac21672a65583766c71e92b9827ad87b892c \
-                    sha256  5467436b59a724e3d8c2ace57aff73abb36a31307b722e230dba0f85bcfd7f86 \
-                    size    96818999
+    checksums       rmd160  488f6265bb1b5214fda2031698547421c3ed47fb \
+                    sha256  c355609d010ad6be4341329a07622c615c92c62655e03d31cb3106fd60500ecd \
+                    size    96899523
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  5ff6bc1d5c9aedf4763ac87d40fbd84c0ccef469 \
-                    sha256  89905e462a0302b0d669fcd7c887c0fe87dde9ba900ec7514f7ed235260c6c0d \
-                    size    95434037
+    checksums       rmd160  d81873b15aaf959e837b01477f3e08789a675f8f \
+                    sha256  a5915ab89be22b6ee7c28f54db6f289dbd24fe41b90262ea87fc804b71c9708c \
+                    size    95515070
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -55,8 +55,7 @@ post-patch {
         ${worksrcpath}/bin/java_dev_appserver.sh
 
     reinplace "s|^#!/usr/bin/env python$|#!${python.bin}|" \
-        ${worksrcpath}/bin/dev_appserver.py \
-        ${worksrcpath}/bin/endpointscfg.py
+        ${worksrcpath}/bin/dev_appserver.py
 
     # Disable updater
     reinplace "s|\"disable_updater\": false|\"disable_updater\": true|" ${worksrcpath}/lib/googlecloudsdk/core/config.json


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 405.0.0.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?