### PR TITLE
checkssl: update to 0.4.4

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/szazeski/checkssl 0.4.3 v
+go.setup            github.com/szazeski/checkssl 0.4.4 v
 revision            0
 
 homepage            https://www.checkssl.org
@@ -20,9 +20,9 @@ installs_libs       no
 maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 
-checksums           rmd160  00c576877b4459dbb7960f8994615c6a04535af9 \
-                    sha256  e5e5717779b7aa93f5c69b83634a6e335863b42abe61f3a2cdd8a41ea13f61ca \
-                    size    10662
+checksums           rmd160  af2456093bdb4d758633ac7f76cba7966207cd1f \
+                    sha256  5880709808f1e090d27328e7d86c6b9ffc328181de3245ab259998c2bb1d64bd \
+                    size    11150
 
 destroot {
     set doc_dir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to checkssl 0.4.4.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?