### PR TITLE
jello: New port (version 1.5.4)

### DIFF
--- a/sysutils/jello/Portfile
+++ b/sysutils/jello/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    jello
+version                 1.5.4
+revision                0
+
+homepage                https://kellyjonbrazil.github.io/jello/
+
+description             Filter JSON and JSON Lines data with Python syntax
+
+long_description        Jello is similar to jq in that it processes JSON and \
+                        JSON Lines data, except Jello uses standard Python \
+                        dict and list syntax.
+
+categories              sysutils textproc python
+license                 MIT
+maintainers             {ajhall.us:macports @ajhall} \
+                        openmaintainer
+supported_archs         noarch
+
+checksums               rmd160  265e60aabc0d550e4cd30405ba0d145277b42aef \
+                        sha256  6e536485ffd7a30e4d187ca1e2719452e833f1939c3b34330d75a831dabfcda9 \
+                        size    25574
+
+python.default_version  310
+
+depends_build-append    port:py${python.version}-setuptools
+
+depends_lib-append      port:py${python.version}-pygments
+
+post-destroot {
+    # Install man page
+    xinstall -m 0644 \
+        ${worksrcpath}/man/jello.1 ${destroot}${prefix}/share/man/man1/
+}


### PR DESCRIPTION
#### Description
jello: New port (version 1.5.4)

https://github.com/kellyjonbrazil/jello

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
