### PR TITLE
openjdk8: fixed a typo

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -82,7 +82,7 @@ configure.args      --with-boot-jdk \
 if { [string match *clang* ${configure.compiler}] } {
     configure.args-append \
                     --with-toolchain-type=clang
-} elseif { [string *gcc* ${configure.compiler}] } {
+} elseif { [string match *gcc* ${configure.compiler}] } {
     configure.args-append \
                     --with-toolchain-type=gcc
 }


### PR DESCRIPTION
This typo prevents to parsing openjdk8 Portfile on system without clang