### PR TITLE
gawk: fix build for 10.5: do not use -no_pie ldflag

### DIFF
--- a/lang/gawk/Portfile
+++ b/lang/gawk/Portfile
@@ -10,7 +10,6 @@ categories              lang
 license                 GPL-3+
 installs_libs           no
 maintainers             {mps @Schamschula} openmaintainer
-platforms               darwin
 master_sites            gnu
 homepage                https://www.gnu.org/software/gawk/
 description             The GNU awk utility.
@@ -28,6 +27,15 @@ checksums               rmd160  3ce306fa834bf9e4a755bb09b819f8e31bb51ef0 \
 depends_build           port:gettext
 
 depends_lib             port:gettext-runtime
+
+platform darwin {
+    # https://trac.macports.org/ticket/65944
+    if {${os.major} < 10} {
+        post-patch {
+            reinplace   "s:-Xlinker -no_pie::" ${worksrcpath}/configure
+        }
+    }
+}
 
 configure.args          --with-libiconv-prefix=${prefix} \
                         --without-mpfr \


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65944

#### Description

Fixes the build on 10.5.8. All tests pass.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
