### PR TITLE
openjdk7-bootstrap: fix path for libfreetype

### DIFF
--- a/java/openjdk7-bootstrap/Portfile
+++ b/java/openjdk7-bootstrap/Portfile
@@ -27,8 +27,10 @@ distfiles           ${distname}.tar_.bz2
 use_bzip2           yes
 worksrcdir          ${distname}
 use_xcode           no
-use_configure    no
+use_configure       no
 
+# Incompatible library version: /Library/Java/JavaVirtualMachines/openjdk7-bootstrap/jre/lib/ppc/libfontmanager.dylib requires version 13.0.0 or later
+depends_lib         port:freetype
 
 build {}
 
@@ -48,4 +50,8 @@ destroot {
     copy ${worksrcpath}/src.zip ${destroot}${path}
     copy ${worksrcpath}/THIRD_PARTY_README ${destroot}${path}
 }
-destroot.violate_mtree      yes
+destroot.violate_mtree  yes
+
+post-destroot {
+    system "install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${prefix}/lib/libfreetype.6.dylib ${destroot}${path}/jre/lib/ppc/libfontmanager.dylib"
+}


### PR DESCRIPTION
#### Description

_This is a ppc-only port._

PR fixes an annoying error with incompatible library version (or missing library if X11 is not installed in the OS).
Idea borrowed from: https://github.com/corretto/corretto-8/issues/6#issuecomment-439166307

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10A190
Xcode 3.2

macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
