### PR TITLE
mold: new port (v1.5.1)

### DIFF
--- a/devel/mold/Portfile
+++ b/devel/mold/Portfile
@@ -1,0 +1,17 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        rui314 mold 1.5.1 v
+github.tarball_from archive
+
+license             AGPL-3
+categories          devel
+maintainers         {@crowell crowell.biz:jeff} openmaintainer
+description         A modern linker.
+long_description    {*}${description}
+checksums           rmd160  91823da0e212492e1061e83c9b0ad056740e0ece \
+                    sha256  ec94aa74758f1bc199a732af95c6304ec98292b87f2f4548ce8436a7c5b054a1 \
+                    size    8254552


### PR DESCRIPTION
add mold: a modern linker

#### Description

https://github.com/rui314/mold

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
