### PR TITLE
libunwind: default +universal only if not ppc

### DIFF
--- a/devel/libunwind/Portfile
+++ b/devel/libunwind/Portfile
@@ -6,7 +6,6 @@ version                 5.0.1
 subport ${name}-headers {}
 epoch                   1
 categories              devel
-platforms               darwin
 license                 MIT NCSA
 maintainers             {jeremyhu @jeremyhu} openmaintainer
 description             A version of Apple's libunwind library that is included in libSystem
@@ -22,7 +21,8 @@ use_xz                  yes
 distname                ${name}-${version}.src
 
 checksums               rmd160  26d3dac149e2fd355e1b8b367a9bf61e01c38fbf \
-                        sha256  6bbfbf6679435b858bd74bdf080386d084a76dfbf233fb6e47b2c28e0872d0fe
+                        sha256  6bbfbf6679435b858bd74bdf080386d084a76dfbf233fb6e47b2c28e0872d0fe \
+                        size    72180
 
 use_configure           no
 
@@ -88,8 +88,11 @@ if {${subport} eq "${name}-headers"} {
     compiler.blacklist-append {clang < 100} *gcc-4.\[0123456\]
 
     variant universal   {}
-    if {$universal_possible} {
-        default_variants +universal
+    platform darwin {
+        # Do not make +universal default on 10.4, 10.5 and 10.6 Rosetta:
+        if {${os.major} > 9 && ${build_arch} ni [list ppc ppc64] && {$universal_possible}} {
+            default_variants +universal
+        }
     }
 
     set cxx_stdlibflags {}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65939

#### Description

`libunwind` requires a modern compiler (in a sense of Apple GCC not fitting):
```
macmini:macports-ports svacchanda$ port deps libunwind
Full Name: libunwind @5.0.1_0
Extract Dependencies: xz
Build Dependencies:   libmacho, cctools, gcc12
Library Dependencies: libunwind-headers, libgcc
```
However Macports GCC presently does not support ppc(64) + x86(_64), therefore requiring `+universal` on systems with support for PowerPC results in error and is wrong. (ppc+ppc64 is supported as such, but dependencies are not yet fixed in the master, and are largely untested. As of now, ppc+ppc64 should not be used as hardcoded setting on 10..5.8.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
