### PR TITLE
New Portfile for "HackTV" project.

### DIFF
--- a/science/hacktv/Portfile
+++ b/science/hacktv/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+
+github.setup        fsphil hacktv b3d9ecb87f042bb6729824fabb40d55d145c3e65
+version             0.1.20221001
+
+categories          science
+license             GPL-3+
+maintainers         {@kesterlester cern.ch:lester} \
+                    openmaintainer
+description         Broadcast TV using an SDR like HackRF One
+long_description    Broadcast TV using a Software Defined Radio like HackRF One
+
+checksums           sha256  9d2f65aa25427983192331c3cf0b1e88702c0392e02dec5184bb8efcb5657563 \
+                    rmd160  6a64cf2f5fe7f4b2ab1fe492c9441b31327136bd \
+                    size    255617
+
+patchfiles          destdir-fix.diff
+
+depends_build       port:pkgconfig
+
+depends_lib         port:ffmpeg-devel \
+                    port:SoapySDR \
+                    port:hackrf
+
+PortGroup           makefile 1.0
+# Above line alegedly does things including:
+# build.args-append       CC=${configure.cc} \
+#                         CXX=${configure.cxx} \
+#                         CPP=${configure.cpp}
+
+use_configure       no

--- a/science/hacktv/files/destdir-fix.diff
+++ b/science/hacktv/files/destdir-fix.diff
@@ -1,0 +1,33 @@
+--- Makefile.orig	2022-10-09 22:13:57.000000000 +0100
++++ Makefile	2022-10-09 23:19:38.000000000 +0100
+@@ -1,8 +1,8 @@
+ 
+-CC      := $(CROSS_HOST)gcc
+-PKGCONF := $(CROSS_HOST)pkg-config
+-CFLAGS  := -g -Wall -pthread -O3 $(EXTRA_CFLAGS)
+-LDFLAGS := -g -lm -pthread $(EXTRA_LDFLAGS)
++CC      ?= $(CROSS_HOST)gcc
++PKGCONF ?= $(CROSS_HOST)pkg-config
++CFLAGS  ?= -g -Wall -pthread -O3 $(EXTRA_CFLAGS)
++LDFLAGS ?= -g -lm -pthread $(EXTRA_LDFLAGS)
+ OBJS    := hacktv.o common.o fir.o vbidata.o teletext.o wss.o video.o mac.o dance.o eurocrypt.o videocrypt.o videocrypts.o syster.o acp.o vits.o nicam728.o test.o ffmpeg.o file.o hackrf.o
+ PKGS    := libavcodec libavformat libavdevice libswscale libswresample libavutil libhackrf $(EXTRA_PKGS)
+ 
+@@ -32,8 +32,16 @@
+ 	$(CC) $(CFLAGS) -c $< -o $@
+ 	@$(CC) $(CFLAGS) -MM $< -o $(@:.o=.d)
+ 
++# Macports wants the install phase to be "make install DESTDIR=blah" 
++# (see https://guide.macports.org/chunked/reference.phases.html ) so 
++# to allow both macports and non-macports builds, we reallly should
++# either detect macports or DESTDIR and act accordingly. However, for
++# now let's just assume it's only macports trying to build us.
++# Macports wants opt/local
+ install:
+-	cp -f hacktv $(PREFIX)/usr/local/bin/
++	mkdir -p $(DESTDIR)/bin/
++	install -c hacktv $(DESTDIR)/opt/local/bin/
++#OLD	cp -f hacktv $(PREFIX)/usr/local/bin/
+ 
+ clean:
+ 	rm -f *.o *.d hacktv hacktv.exe


### PR DESCRIPTION
#### Description

This patch provides a Portfile for an applciation called "hacktv" which can be used to make sofware defined radios (SDRs) act as television transmitters.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 arm64
Xcode 13.4.1 13F100

