### PR TITLE
liblangtag: update to 0.6.4, fix sed

### DIFF
--- a/textproc/liblangtag/Portfile
+++ b/textproc/liblangtag/Portfile
@@ -3,10 +3,9 @@
 PortSystem              1.0
 PortGroup               bitbucket 1.0
 
-bitbucket.setup         tagoh liblangtag 0.6.3
+bitbucket.setup         tagoh liblangtag 0.6.4
 categories              textproc devel
 license                 {LGPL-3+ MPL-2}
-platforms               darwin
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 
 description             an interface library to access tags for identifying languages
@@ -15,15 +14,16 @@ long_description        liblangtag is ${description}.
 use_bzip2               yes
 bitbucket.tarball_from  downloads
 
-checksums               rmd160  b8ecae0f83dfb0e8c937053fac4fdf1517ce2be1 \
-                        sha256  1f12a20a02ec3a8d22e54dedb8b683a43c9c160bda1ba337bf1060607ae733bd \
-                        size    755492
+checksums               rmd160  9ab882d8ce8667a2fb241ca43c0c125cd0f6dc9e \
+                        sha256  5701062c17d3e73ddaa49956cbfa5d47d2f8221988dec561c0af2118c1c8a564 \
+                        size    764946
 
-patchfiles-append       patch-libtool.diff
+patchfiles-append       patch-libtool.diff \
+                        patch-sed.diff
 
 depends_build-append    port:gtk-doc \
-                        port:pkgconfig \
-                        port:libtool
+                        port:libtool \
+                        port:pkgconfig
 
 depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \

--- a/textproc/liblangtag/files/patch-sed.diff
+++ b/textproc/liblangtag/files/patch-sed.diff
@@ -1,0 +1,29 @@
+--- liblangtag-gobject/gengir.sh.orig	2021-09-27 12:52:04.000000000 +0800
++++ liblangtag-gobject/gengir.sh	2022-10-10 03:41:05.000000000 +0800
+@@ -42,14 +42,14 @@
+ echo "#include <glib.h>" > $_tmpgen
+ capitalize "$srcdir/$target" $_tmpgen $_cl
+ 
+-sed -i -e 's,^\(#include[ \t]<\)liblangtag\(/lt-.*\)\(\.h>\),\1liblangtag-gobject\2.gir\3,' $_tmpgen
+-sed -i -e 's/ssize_t/gssize/g' -e 's/size_t/gsize/g' $_tmpgen
++sed -i '' -e 's,^\(#include[ \t]<\)liblangtag\(/lt-.*\)\(\.h>\),\1liblangtag-gobject\2.gir\3,' $_tmpgen
++sed -i '' -e 's/ssize_t/gssize/g' -e 's/size_t/gsize/g' $_tmpgen
+ 
+ while [ 1 ]; do
+     if [ "x$type" = "xh" ]; then
+ 	line=`grep -E "${_ns}_[a-z_].*_t[ \t;)].*" $_tmpgen`
+     elif [ "x$type" = "xc" ]; then
+-	line=`sed -n -e '/\/\*< public >\*\//{:a p;n;b a};{d}' $_tmpgen|grep "[^#]${_ns}_.*_t[^a-z]"|grep -v -E "(func)"`
++	line=`sed -n -e '/\/\*< public >\*\//{' -e ':a p;n;b a' -e '}' -e '{' -e 'd' -e '}' $_tmpgen|grep "[^#]${_ns}_.*_t[^a-z]"|grep -v -E "(func)"`
+     else
+ 	echo "Unknown source type: $2"
+ 	exit 1
+@@ -58,7 +58,7 @@
+ 	break;
+     fi
+     _tmpsed=`mktemp gengir.XXXXXXXX`
+-    printf "/${_ns}_[a-z_].*_t/{s/.*\(${_ns}_[a-z_].*_t\)[^a-z]*/\\\1/;p}\n" > $_tmpsed
++    printf "/${_ns}_[a-z_].*_t/{s/.*\(${_ns}_[a-z_].*_t\)[^a-z]*/\\\1/;p;}\n" > $_tmpsed
+     _n=1
+     _tt=
+     while [ 1 ]; do


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65978

#### Description

Existing version of `liblangtag` is broken on 10.5.8.
0.6.4 builds fine until GIR extensions, where sed in broken in `gengir.sh` script.
The PR addressed these errors.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
