### PR TITLE
py-nbconvert: update to 7.2.1

### DIFF
--- a/python/py-nbconvert/Portfile
+++ b/python/py-nbconvert/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-nbconvert
-version             7.0.0
-revision            1
+version             7.2.1
+revision            0
 categories-append   textproc
 license             BSD
 supported_archs     noarch
@@ -23,9 +23,9 @@ homepage            https://jupyter.org/
 
 checksums-append \
                     ${python.rootname}-${version}${extract.suffix} \
-                    rmd160  4662b28c439e9ff1e06767468233f9455ba96107 \
-                    sha256  fd1e361da30e30e4c5a5ae89f7cae95ca2a4d4407389672473312249a7ba0060 \
-                    size    860724
+                    rmd160  1cd7669e2dc8a483e429794df4c19e39fac9f9d8 \
+                    sha256  1e180801205ad831b6e2480c5a03307dfb6327fa5b2f9b156d6fed45f9700686 \
+                    size    731368
 
 set css_fetch_dir \
     ${distpath}/css


### PR DESCRIPTION
#### Description

Update py-nbconvert to 7.2.1. Fixes a bug which prevents Markdown tables to be rendered.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
