### PR TITLE
doxygen: redirect_bins to fix malloc errors with gcc

### DIFF
--- a/textproc/doxygen-devel/Portfile
+++ b/textproc/doxygen-devel/Portfile
@@ -11,7 +11,7 @@ conflicts               doxygen
 set my_name             doxygen
 
 version                 1.9.5
-revision                0
+revision                1
 epoch                   0
 checksums               rmd160  1dd6332ac49879bbb5a7bdbed3616590f1cf77ce \
                         sha256  55b454b35d998229a96f3d5485d57a0a517ce2b78d025efb79d57b5a2e4b2eec \
@@ -134,6 +134,9 @@ if {[string match *clang* ${configure.cxx}]} {
 
 # build fails out of source :/
 cmake.out_of_source     no
+
+# https://trac.macports.org/ticket/65814 etc.
+legacysupport.redirect_bins doxygen
 
 test.run                yes
 

--- a/textproc/doxygen/Portfile
+++ b/textproc/doxygen/Portfile
@@ -11,7 +11,7 @@ conflicts               doxygen-devel
 set my_name             doxygen
 
 version                 1.9.3
-revision                2
+revision                3
 epoch                   1
 checksums               rmd160  91d9ad3ed0f7262667bb2e9b6695ede1eaecd609 \
                         sha256  1a413e7122a0f9bb519697613ba05247afad1adc5699390b6e6ee387d42c0b2d \
@@ -136,6 +136,9 @@ if {[string match *clang* ${configure.cxx}]} {
 
 # build fails out of source :/
 cmake.out_of_source     no
+
+# https://trac.macports.org/ticket/65814 etc.
+legacysupport.redirect_bins doxygen
 
 test.run                yes
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65814
Fixes: https://trac.macports.org/ticket/65770

#### Description

Credits to @kencu for suggesting a working fix for this old and annoying problem with Doxygen’s `malloc` errors.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
