### PR TITLE
mvnd: update to 0.8.2

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -1,9 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       java 1.0
 
-version         0.8.1
+version         0.8.2
 revision        0
 name            mvnd
 categories      java
@@ -31,27 +30,23 @@ long_description mvnd aims at providing faster Maven builds using techniques kno
                 but also to all code coming from the JDK itself.
 
 homepage        https://github.com/apache/maven-mvnd
-supported_archs x86_64
+supported_archs x86_64 arm64
 
 master_sites    https://downloads.apache.org/maven/mvnd/${version}/
-distname        maven-mvnd-${version}-darwin-amd64
-
-checksums       rmd160  fdc05e3fd4aebc2d994977d110b66529d4821652 \
-                sha256  84b63929e11382e389d90753873a81d5c8e8e852c74ea05d5cac20801b3af07a \
-                size    21036504
 
 use_zip         yes
 use_configure   no
 
 if {${configure.build_arch} eq "x86_64"} {
-    # mvnd native client is used on x86_64 systems, which doesn't need a separate JDK to run
-    # Only requires a JDK to compile Maven projects
-    java.version    1.7+
-    java.fallback   openjdk11
-} else {
-    # mvnd JVM client is used on non-x86_64 systems, which requires Java 11 to run
-    java.version    11+
-    java.fallback   openjdk11
+    distname        maven-mvnd-${version}-darwin-amd64
+    checksums       rmd160  673495348a736fde0d4ca56ca7c0421c4105d575 \
+                    sha256  87b430637038e0700af3e1a22bc4a05594d18e5e3624f1700de7f5e8fd629ce6 \
+                    size    20890053
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname        maven-mvnd-${version}-darwin-aarch64
+    checksums       rmd160  61b905860b20583fb4c2a7078be54f06cafec388 \
+                    sha256  48c0bcb1f44ed416c7c42bec6d19c8df2ef8af539a67b5b3f40f8d1e030b8c07 \
+                    size    21072232
 }
 
 build {}
@@ -73,13 +68,6 @@ destroot {
 
     # Create launch script
     set launch_script [open ${destroot}${prefix}/bin/mvnd w 0755]
-    puts $launch_script "#!/usr/bin/env bash"
-    if {${configure.build_arch} eq "x86_64"} {
-        # Use mvnd native client
-        puts $launch_script "${target}/bin/mvnd $@"
-    } else {
-        # Use mvnd JVM client
-        puts $launch_script "${target}/bin/mvnd.sh $@"
-    }
+    puts $launch_script "${target}/bin/mvnd $@"
     close $launch_script
 }


### PR DESCRIPTION
#### Description

Update to Apache Maven Daemon 0.8.2, add support for new native arm64 version.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?