### PR TITLE
MoarVM, nqp, rakudo: use legacysupport.redirect_bins to fix malloc errors

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                MoarVM
 version             2022.07
-revision            0
+revision            1
 categories          lang devel
 license             Artistic-2 MIT BSD ISC public-domain
 maintainers         {mojca @mojca} openmaintainer

--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -39,6 +39,10 @@ patchfiles          patch-Configure.diff \
                     patch-dyncall.diff \
                     patch-syncsocket.diff
 
+# Building nqp on PPC results in malloc errors (though build still succeeds):
+# malloc: *** error for object: incorrect checksum for freed object - object was probably modified after being freed.
+legacysupport.redirect_bins MoarVM
+
 # https://trac.macports.org/ticket/53950
 compiler.blacklist  cc gcc-* apple-gcc-* llvm-gcc-*
 

--- a/lang/nqp/Portfile
+++ b/lang/nqp/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        Raku nqp 2022.07
-revision            0
+revision            1
 description         A lightweight Perl-6 like language for virtual machines
 long_description    This is "Not Quite Perl" -- a lightweight Perl 6-like \
                     environment for virtual machines.  The key feature of \

--- a/lang/nqp/Portfile
+++ b/lang/nqp/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        Raku nqp 2022.07
 revision            0
@@ -31,6 +32,10 @@ depends_build       port:perl5
 # Decide on which backends you want it to run, and configure and build it as follows:
 # --backends=moar,parrot,jvm
 depends_lib         port:MoarVM
+
+# Building rakudo on PPC results in malloc errors (though build still succeeds):
+# nqp-m malloc: *** error for object 0x80a02ab0: incorrect checksum for freed object - object was probably modified after being freed.
+legacysupport.redirect_bins nqp
 
 configure.cmd       ${prefix}/bin/perl Configure.pl
 configure.args      --prefix=${prefix} \

--- a/lang/rakudo/Portfile
+++ b/lang/rakudo/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        rakudo rakudo 2022.07
-revision            0
+revision            1
 description         Raku compiler
 long_description    Rakudo is a compiler for the Raku language \
                     Rakudo is built using NQP (Not Quite Perl), which in \

--- a/lang/rakudo/Portfile
+++ b/lang/rakudo/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        rakudo rakudo 2022.07
 revision            0
@@ -26,6 +27,8 @@ depends_build       port:perl5
 
 depends_lib         port:MoarVM \
                     port:nqp
+
+legacysupport.redirect_bins rakudo
 
 configure.cmd       ${prefix}/bin/perl Configure.pl
 configure.args      --prefix=${prefix} \


### PR DESCRIPTION
#### Description

When building `nqp`, `MoarVM` on PPC spits out a number of malloc errors, though the build completes:
```
--->  Configuring nqp
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_nqp/nqp/work/nqp-2022.07" && /opt/local/bin/perl Configure.pl --prefix=/opt/local --prefix=/opt/local --backends=moar --with-moar=/opt/local/bin/moar 
fatal: not in a git directory
fatal: not in a git directory
moar(70297,0x802fc540) malloc: *** error for object 0x80a02360: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
moar(70297,0x802fc540) malloc: *** error for object 0x80a02354: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
moar(70297,0x802fc540) malloc: *** error for object 0x80a02350: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
moar(70297,0x802fc540) malloc: *** error for object 0x80a02334: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
moar(70297,0x802fc540) malloc: *** error for object 0x80a02330: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
moar(70297,0x802fc540) malloc: *** error for object 0x80a022f4: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
```
The same happens when `nqp` is used to build `rakudo`:
```
nqp-m(80044,0x802fc540) malloc: *** error for object 0x80a02af0: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
nqp-m(80044,0x802fc540) malloc: *** error for object 0x80a02ae0: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
nqp-m(80044,0x802fc540) malloc: *** error for object 0x80a02ab0: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
nqp-m(80044,0x802fc540) malloc: *** error for object 0x80a02a70: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
nqp-m(80044,0x802fc540) malloc: *** error for object 0x80a02a50: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
```
Following recent case of Doxygen: https://github.com/macports/macports-ports/pull/16324 – add `legacysupport.redirect_bins` to all three.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
