### PR TITLE
crystal: update to 1.6.0

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 1.5.0
+github.setup        crystal-lang crystal 1.6.0
 github.tarball_from archive
 revision            0
 categories          lang
@@ -40,13 +40,13 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e9b19bf3e1ea50f96478d366ee8ed3eb604b3661 \
-                    sha256  f53e459ef6c7227df922a76fb62e350c90d52d30bfaa84b90feda9731bb98655 \
-                    size    2909586 \
+                    rmd160  29bef9e811f02ac3e6172c68fbafd213318b8739 \
+                    sha256  8119bc099d898be0d2e5055f783d41325a10e4b7824240272eb6ecb30c8c9a2e \
+                    size    3058366 \
                     ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix} \
-                    rmd160  420ad659f69828e0fc61546ac78f7b5431d6ca99 \
-                    sha256  294ebe1cb165a58252252e05d7394705e06dfebcf16fb539ec69aa4509cb9b46 \
-                    size    46174958
+                    rmd160  d24c2e7a5277fc08569a0225ab05f3483db1851e \
+                    sha256  6e597788260a68d70e2c71ff4a8c4d611537de49eb0dbfd2e73405ec2a368f71 \
+                    size    46743537
 
 patchfiles          patch-static.diff
 


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? clarification: tried `port upgrade crystal`
- [x] tested basic functionality of all binary files?

```
❯ crystal -v
Crystal 1.6.0 (2022-10-06)

LLVM: 14.0.6
Default target: aarch64-apple-darwin21.6.0

❯ shards --version
Shards 0.17.0 (2022-03-24)
```
