### PR TITLE
lazarus: update to newer upstream version (2.2.4)

### DIFF
--- a/devel/lazarus/Portfile
+++ b/devel/lazarus/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                lazarus
-version             2.2.0-0
+version             2.2.4-0
 revision            0
 categories          devel
 platforms           darwin
@@ -25,9 +25,9 @@ long_description    Lazarus is an open-source development system that builds \
 homepage            https://wiki.freepascal.org/Main_Page
 master_sites        sourceforge:lazarus
 
-checksums           rmd160  101bd48ae7bae9fdf941d96ea62c4b386085526f \
-                    sha256  b6b5d516511e3dfb34910d7656db068d4bba80f009692500aebbcae79cb12160 \
-                    size    76777421
+checksums           rmd160  878d64c1e5a7c0842d51d3f37d2644a00d32fdb5 \
+                    sha256  b84093218181f66b545218d1aaaf62a8bfb6abd40beba32387253d66fc5bc24c \
+                    size    77272959
 
 depends_lib         port:fpc port:fpc-sources
 supported_archs     x86_64 arm64
@@ -84,9 +84,6 @@ post-patch {
         </History>\\
       </DebuggerFilename>|g" ${patchtarget}
 
-# fix path to X11
-    reinplace "s|-Fl/usr/X11R6/lib -Fl/sw/lib|\"-Fl${prefix}/lib -Fl${prefix}/lib/pango-ft219/lib -Fl/opt/X11/lib\"|g" ${worksrcpath}/ide/Makefile
-
 # some more fixes for nogui taking cocoa as a template
 # if cocoa or nogui get updated, the files in ${filespath} need to be updated manually
 
@@ -118,5 +115,5 @@ post-destroot {
 
 notes "
 Release Notes:
-  https://wiki.freepascal.org/Lazarus_2.0.0_release_notes
+  https://wiki.freepascal.org/Lazarus_2.2.0_release_notes
 "

--- a/devel/lazarus/files/noGUI-Printer.patch
+++ b/devel/lazarus/files/noGUI-Printer.patch
@@ -31,5 +31,5 @@
 +      {$I cupsprndialogs.inc}
 +    {$ENDIF}
      {$IFDEF LCLGtk2}
-       uses udlgSelectPrinter, udlgPropertiesPrinter, udlgPageSetup;
+       uses udlgSelectPrinter, udlgPropertiesPrinter, udlgPageSetup, Printer4LazStrConst;
        {$I cupsprndialogs.inc}


### PR DESCRIPTION
#### Description

lazarus: update to newer upstream version (2.2.4)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`? | Does not work
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
