### PR TITLE
isl-devel: update to 0.25

### DIFF
--- a/devel/isl-devel/Portfile
+++ b/devel/isl-devel/Portfile
@@ -1,15 +1,112 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           obsolete 1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           muniversal 1.1
 
 name                isl-devel
-replaced_by         isl
+conflicts           isl
+set my_name         isl
 
-set gitSHA1         f8b5d3df1e4dd2c4a300d25954d344b757347f2c
-version             0.21-20190404-[string range $gitSHA1 0 6]
-revision            1
+# for library name changes, cross-compilers do *not* show up in traditional dependency searches
+# (e.g. port file all | sort -u | xargs grep -E ':isl( |$)' | cut -d / -f 13 | sort -u)
+# see https://lists.macports.org/pipermail/macports-dev/2019-May/040678.html
+epoch               4
+version             0.25
+revision            0
 
 categories          devel math
+license             MIT
+maintainers         nomaintainer
 
-# Note: Port obsoleted 2021-12-20
+description         Integer Set Library
+long_description    isl is a library for manipulating sets and \
+                    relations of integer points bounded by linear \
+                    constraints. Supported operations on sets include \
+                    intersection, union, set difference, emptiness \
+                    check, convex hull, (integer) affine hull, integer \
+                    projection, computing the lexicographic minimum \
+                    using parametric integer programming, coalescing \
+                    and parametric vertex enumeration. It also \
+                    includes an ILP solver based on generalized basis \
+                    reduction, transitive closures on maps (which may \
+                    encode infinite graphs), dependence analysis and \
+                    bounds on piecewise step-polynomials.
+homepage            https://libisl.sourceforge.io
+
+depends_lib         port:gmp
+
+master_sites        sourceforge:libisl
+distname            ${my_name}-${version}
+use_bzip2           yes
+
+checksums           rmd160  73b9005b8e7fe52eb9500b98ba65450bdfb9f7fb \
+                    sha256  4305c54d4eebc4bf3ce365af85f04984ef5aa97a52e01128445e26da5b1f467a \
+                    size    2304378
+
+if {${subport} eq ${name}} {
+    platform darwin {
+        # Be more strict about detecting C++11 for older compilers
+        patchfiles-append   patch-configure_c++11.diff
+    
+        # https://trac.macports.org/ticket/65532
+        if {${os.major} > 10 && ${os.major} < 18} {
+            # cxx17 support on these systems is incomplete when building against libc++
+            patchfiles-append   patch-configure-force-cxx17-to-fail.diff
+        }
+        
+        # ./include/isl/typed_cpp.h:2132:12: error: no matching conversion for functional-style cast from 'const isl::basic_set' to 'isl::typed::basic_set<>'
+        compiler.blacklist {clang < 500}
+    }
+}
+
+configure.args      --disable-silent-rules
+
+triplet.add_build   cross
+
+test.run            yes
+test.target         check
+
+livecheck.type      regex
+livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
+
+subport isl14 {
+    epoch           0
+    version         0.14.1
+    revision        0
+
+    checksums       rmd160  e4e45a8b777f89108303c165b149404ef84fd190 \
+                    sha256  1f20561843eb9f6ae2076800bc45f3680ff7696520257cd5734ccfb843464cae \
+                    size    1402630
+
+    distname       isl-${version}
+
+    # Don't link using "-flat_namespace -undefined suppress" on Yosemite and later.
+    patchfiles-append   yosemite-libtool.patch
+
+    configure.pre_args  --prefix=${prefix}/libexec/${subport}
+
+    livecheck.regex     isl-([join [lrange [split ${version} .] 0 2] .]\[0-9.\]*)${extract.suffix}
+}
+
+subport isl18 {
+    epoch           0
+    version         0.18
+    revision        0
+
+    checksums           rmd160  e876f1049893de5be4a82a63f272f62547d455ca \
+                        sha256  6b8b0fd7f81d0a957beb3679c81bbb34ccc7568d5682844d8924424a0dadcb1b \
+                        size    1658291
+
+    distname            isl-${version}
+
+    # Add a missing include to the isl_int headers. Upstream doesn't want to
+    # bother fixing deprecated APIs
+    # (https://groups.google.com/d/msg/isl-development/N6UWJDbKXNA/2CY6WHDvOYoJ),
+    # so this should be applied until they remove the headers outright.
+    patchfiles          fix-deprecated-headers.patch
+
+    configure.pre_args  --prefix=${prefix}/libexec/${subport}
+
+    livecheck.regex     isl-([join [lrange [split ${version} .] 0 2] .]\[0-9.\]*)${extract.suffix}
+}

--- a/devel/isl-devel/Portfile
+++ b/devel/isl-devel/Portfile
@@ -11,7 +11,7 @@ set my_name         isl
 # for library name changes, cross-compilers do *not* show up in traditional dependency searches
 # (e.g. port file all | sort -u | xargs grep -E ':isl( |$)' | cut -d / -f 13 | sort -u)
 # see https://lists.macports.org/pipermail/macports-dev/2019-May/040678.html
-epoch               4
+epoch               0
 version             0.25
 revision            0
 
@@ -44,20 +44,18 @@ checksums           rmd160  73b9005b8e7fe52eb9500b98ba65450bdfb9f7fb \
                     sha256  4305c54d4eebc4bf3ce365af85f04984ef5aa97a52e01128445e26da5b1f467a \
                     size    2304378
 
-if {${subport} eq ${name}} {
-    platform darwin {
-        # Be more strict about detecting C++11 for older compilers
-        patchfiles-append   patch-configure_c++11.diff
-    
-        # https://trac.macports.org/ticket/65532
-        if {${os.major} > 10 && ${os.major} < 18} {
-            # cxx17 support on these systems is incomplete when building against libc++
-            patchfiles-append   patch-configure-force-cxx17-to-fail.diff
-        }
-        
-        # ./include/isl/typed_cpp.h:2132:12: error: no matching conversion for functional-style cast from 'const isl::basic_set' to 'isl::typed::basic_set<>'
-        compiler.blacklist {clang < 500}
+platform darwin {
+    # Be more strict about detecting C++11 for older compilers
+    patchfiles-append   patch-configure_c++11.diff
+
+    # https://trac.macports.org/ticket/65532
+    if {${os.major} > 10 && ${os.major} < 18} {
+        # cxx17 support on these systems is incomplete when building against libc++
+        patchfiles-append   patch-configure-force-cxx17-to-fail.diff
     }
+
+    # ./include/isl/typed_cpp.h:2132:12: error: no matching conversion for functional-style cast from 'const isl::basic_set' to 'isl::typed::basic_set<>'
+    compiler.blacklist {clang < 500}
 }
 
 configure.args      --disable-silent-rules
@@ -69,44 +67,3 @@ test.target         check
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
-
-subport isl14 {
-    epoch           0
-    version         0.14.1
-    revision        0
-
-    checksums       rmd160  e4e45a8b777f89108303c165b149404ef84fd190 \
-                    sha256  1f20561843eb9f6ae2076800bc45f3680ff7696520257cd5734ccfb843464cae \
-                    size    1402630
-
-    distname       isl-${version}
-
-    # Don't link using "-flat_namespace -undefined suppress" on Yosemite and later.
-    patchfiles-append   yosemite-libtool.patch
-
-    configure.pre_args  --prefix=${prefix}/libexec/${subport}
-
-    livecheck.regex     isl-([join [lrange [split ${version} .] 0 2] .]\[0-9.\]*)${extract.suffix}
-}
-
-subport isl18 {
-    epoch           0
-    version         0.18
-    revision        0
-
-    checksums           rmd160  e876f1049893de5be4a82a63f272f62547d455ca \
-                        sha256  6b8b0fd7f81d0a957beb3679c81bbb34ccc7568d5682844d8924424a0dadcb1b \
-                        size    1658291
-
-    distname            isl-${version}
-
-    # Add a missing include to the isl_int headers. Upstream doesn't want to
-    # bother fixing deprecated APIs
-    # (https://groups.google.com/d/msg/isl-development/N6UWJDbKXNA/2CY6WHDvOYoJ),
-    # so this should be applied until they remove the headers outright.
-    patchfiles          fix-deprecated-headers.patch
-
-    configure.pre_args  --prefix=${prefix}/libexec/${subport}
-
-    livecheck.regex     isl-([join [lrange [split ${version} .] 0 2] .]\[0-9.\]*)${extract.suffix}
-}

--- a/devel/isl-devel/files/fix-deprecated-headers.patch
+++ b/devel/isl-devel/files/fix-deprecated-headers.patch
@@ -1,0 +1,84 @@
+commit dbf64e83af8d4b5a55fed546e0c615cd51141bd7
+Author: Lawrence Velázquez <larryv@macports.org>
+Date:   Tue Nov 25 01:50:58 2014 -0500
+
+    Include space.h in deprecated headers using isl_dim_type
+    
+    These headers should not assume that space.h will be included
+    transitively through another header or by an including source file, as
+    compilation can fail if those assumptions don't hold.
+    
+    Signed-off-by: Lawrence Velázquez <larryv@macports.org>
+
+Index: include/isl/deprecated/aff_int.h
+===================================================================
+--- include/isl/deprecated/aff_int.h.orig
++++ include/isl/deprecated/aff_int.h
+@@ -3,6 +3,7 @@
+ 
+ #include <isl/deprecated/int.h>
+ #include <isl/aff_type.h>
++#include <isl/space.h>
+ 
+ #if defined(__cplusplus)
+ extern "C" {
+Index: include/isl/deprecated/constraint_int.h
+===================================================================
+--- include/isl/deprecated/constraint_int.h.orig
++++ include/isl/deprecated/constraint_int.h
+@@ -3,6 +3,7 @@
+ 
+ #include <isl/deprecated/int.h>
+ #include <isl/constraint.h>
++#include <isl/space.h>
+ 
+ #if defined(__cplusplus)
+ extern "C" {
+Index: include/isl/deprecated/map_int.h
+===================================================================
+--- include/isl/deprecated/map_int.h.orig
++++ include/isl/deprecated/map_int.h
+@@ -3,6 +3,7 @@
+ 
+ #include <isl/deprecated/int.h>
+ #include <isl/map_type.h>
++#include <isl/space.h>
+ 
+ #if defined(__cplusplus)
+ extern "C" {
+Index: include/isl/deprecated/point_int.h
+===================================================================
+--- include/isl/deprecated/point_int.h.orig
++++ include/isl/deprecated/point_int.h
+@@ -3,6 +3,7 @@
+ 
+ #include <isl/deprecated/int.h>
+ #include <isl/point.h>
++#include <isl/space.h>
+ 
+ #if defined(__cplusplus)
+ extern "C" {
+Index: include/isl/deprecated/polynomial_int.h
+===================================================================
+--- include/isl/deprecated/polynomial_int.h.orig
++++ include/isl/deprecated/polynomial_int.h
+@@ -3,6 +3,7 @@
+ 
+ #include <isl/deprecated/int.h>
+ #include <isl/polynomial.h>
++#include <isl/space.h>
+ 
+ #if defined(__cplusplus)
+ extern "C" {
+Index: include/isl/deprecated/set_int.h
+===================================================================
+--- include/isl/deprecated/set_int.h.orig
++++ include/isl/deprecated/set_int.h
+@@ -3,6 +3,7 @@
+ 
+ #include <isl/deprecated/int.h>
+ #include <isl/set_type.h>
++#include <isl/space.h>
+ 
+ #if defined(__cplusplus)
+ extern "C" {

--- a/devel/isl-devel/files/patch-configure-force-cxx17-to-fail.diff
+++ b/devel/isl-devel/files/patch-configure-force-cxx17-to-fail.diff
@@ -1,0 +1,25 @@
+# https://github.com/macports/macports-ports/pull/15558
+
+--- configure.orig	2022-07-29 10:01:55.000000000 -0700
++++ configure	2022-07-29 10:02:40.000000000 -0700
+@@ -9283,6 +9285,9 @@
+
+ #else
+
++// MacPorts
++#error "C++17 support forced off"
++
+ #include <initializer_list>
+ #include <utility>
+ #include <type_traits>
+@@ -10105,6 +10110,9 @@
+
+ #else
+
++// MacPorts
++#error "C++17 support forced off"
++
+ #include <initializer_list>
+ #include <utility>
+ #include <type_traits>
+ 

--- a/devel/isl-devel/files/patch-configure_c++11.diff
+++ b/devel/isl-devel/files/patch-configure_c++11.diff
@@ -1,0 +1,11 @@
+--- configure.orig	2019-03-14 10:17:13.000000000 -0700
++++ configure	2019-05-04 13:11:19.000000000 -0700
+@@ -7198,6 +7198,8 @@
+ 
+ #else
+ 
++#include <type_traits>
++
+ namespace cxx11
+ {
+ 

--- a/devel/isl-devel/files/yosemite-libtool.patch
+++ b/devel/isl-devel/files/yosemite-libtool.patch
@@ -1,0 +1,13 @@
+Index: configure
+===================================================================
+--- configure.orig
++++ configure
+@@ -9137,7 +9137,7 @@ $as_echo "$lt_cv_ld_force_load" >&6; }
+       case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+ 	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[012]*)
++	10.[012][,.]*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+ 	10.*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;

--- a/devel/isl/Portfile
+++ b/devel/isl/Portfile
@@ -5,6 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.1
 
 name                isl
+conflicts           isl-devel
 
 # for library name changes, cross-compilers do *not* show up in traditional dependency searches
 # (e.g. port file all | sort -u | xargs grep -E ':isl( |$)' | cut -d / -f 13 | sort -u)
@@ -14,7 +15,6 @@ version             0.24
 revision            1
 
 categories          devel math
-platforms           darwin
 license             MIT
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 


### PR DESCRIPTION
#### Description

There were issues with building `isl` 0.25 on some systems, which led to reverting the port upgrade: https://github.com/macports/macports-ports/pull/15391
@kencu made a fix for those, however PR was not merged: https://github.com/macports/macports-ports/pull/15558

Since we already have `isl-devel` sitting useless, put 0.25 there as an option.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
