### PR TITLE
mint: update to 0.17.2, add universal variant

### DIFF
--- a/devel/mint/Portfile
+++ b/devel/mint/Portfile
@@ -31,8 +31,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
     }
 }
 
-# Universal support handled manually
-universal_variant       no
+# Xcode 12 (Swift 5.3) adds the --arch flag, letting us make a universal build.
+set can_build_universal [expr [vercmp ${xcodeversion} 12.0] >= 0]
+
+universal_variant       ${can_build_universal}
 
 use_configure           no
 use_xcode               yes
@@ -43,10 +45,12 @@ build.args              --configuration release --disable-sandbox
 
 set builtproductdir     ${worksrcpath}/.build/release
 
-# Xcode 12 (Swift 5.3) adds the --arch flag, letting us make a universal build.
-# Doing so changes the output directory of the product.
-if {[vercmp ${xcodeversion} 12.0] >= 0} {
-    build.args-append   --arch x86_64 --arch arm64
+if {${universal_possible} && ${can_build_universal} && [variant_isset universal]} {
+    foreach arch ${configure.universal_archs} {
+        build.args-append --arch ${arch}
+    }
+
+    # Building universal changes the output directory of the product.
     set builtproductdir ${worksrcpath}/.build/apple/Products/Release
 }
 

--- a/devel/mint/Portfile
+++ b/devel/mint/Portfile
@@ -4,8 +4,8 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               xcodeversion 1.0
 
-github.setup            yonaskolb Mint 0.17.1
-revision                1
+github.setup            yonaskolb Mint 0.17.2
+revision                0
 github.tarball_from     archive
 
 name                    mint
@@ -17,9 +17,9 @@ maintainers             {kylelanchman.com:macports @klanchman} openmaintainer
 description             A package manager that installs and runs executable Swift packages
 long_description        {*}${description}
 
-checksums               rmd160  9e5d01ecb931cb17d88e29c146ebf2a4ba77b463 \
-                        sha256  0e3ab23e548a752f6eee3a7b98d1c137a30371e4a0ec9212840baaa56741d2e4 \
-                        size    23308
+checksums               rmd160  06e52d2626cc66b17c6dc96889be4f0f4cd67524 \
+                        sha256  12a1b91b506f0f8cc4ecede0686c894a798ae9c9130717f875d6969df7274793 \
+                        size    23486
 
 minimum_xcodeversions-append {18 10.2}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- Update mint to 0.17.2
- Add a proper universal variant instead of always building universal (resolves [this comment](https://github.com/macports/macports-ports/pull/13235#issuecomment-985883336) on an older PR)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
