### PR TITLE
google-cloud-sdk: update to 405.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             405.0.0
+version             405.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6699455e92655e60acc5ebd856fe08a9c8bbe60f \
-                    sha256  cf0f32e3d24cbc8a87f7102b0f59423d9df8ffcbd252d3c7175351680266dcd3 \
-                    size    109462047
+    checksums       rmd160  7abce971c352844bf85e1ae48fda56d79d2159ef \
+                    sha256  49d75fb4ef1938619625eb513ff567162437febf4b73cd8c472c3030b44cab73 \
+                    size    109462152
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  488f6265bb1b5214fda2031698547421c3ed47fb \
-                    sha256  c355609d010ad6be4341329a07622c615c92c62655e03d31cb3106fd60500ecd \
-                    size    96899523
+    checksums       rmd160  b2041aa114c30be6c6f97dc10525175f43b35f64 \
+                    sha256  551ef7a329cd16e8bd306cd35b66faf8f9fc2793adb75ed40fa663685719dfea \
+                    size    96899598
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d81873b15aaf959e837b01477f3e08789a675f8f \
-                    sha256  a5915ab89be22b6ee7c28f54db6f289dbd24fe41b90262ea87fc804b71c9708c \
-                    size    95515070
+    checksums       rmd160  8930407d68e77796fa2a7f65effd2b760e832b54 \
+                    sha256  cb27b3a6884fc691775c851990143b2ad2bcd7d1ea8e11239755e64fe328a3df \
+                    size    95514981
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -94,6 +94,7 @@ variant kubectl description {Add kubectl} { dict set variant_to_component kubect
 variant kubectl_oidc description {Add kubectl-oidc} { dict set variant_to_component kubectl_oidc kubectl-oidc }
 variant kustomize description {Add Kustomize} { dict set variant_to_component kustomize kustomize }
 variant local_extract description {Add On-Demand Scanning API extraction helper} { dict set variant_to_component local_extract local-extract }
+variant log_streaming {Add Log Streaming} { dict set variant_to_component log_streaming log-streaming }
 variant minikube description {Add Minikube} { dict set variant_to_component minikube minikube }
 variant nomos description {Add Nomos CLI} { dict set variant_to_component nomos nomos }
 variant package_go_module description {Add Artifact Registry Go Module Package Helper} { dict set variant_to_component package_go_module package-go-module }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 405.0.1, added variant `log_streaming`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?