### PR TITLE
gflags: blacklist gcc-4.0, fixes build on 10.5.8

### DIFF
--- a/devel/gflags/Portfile
+++ b/devel/gflags/Portfile
@@ -26,8 +26,9 @@ checksums           rmd160  9748753d2cf4d581cd0881bd5f5c1e3dac365896 \
 # While gflags builds fine with gcc-4.2, its dependent google-glog does not.
 # However they both should be built by the same compiler, otherwise google-glog build fails.
 # https://trac.macports.org/ticket/65645
+# https://trac.macports.org/ticket/65994
 compiler.blacklist-append \
-                    *gcc-4.2 *gcc-4.3 *gcc-4.4 *gcc-4.5
+                    *gcc-4.0 *gcc-4.2 *gcc-4.3 *gcc-4.4 *gcc-4.5
 
 # Rosetta ignores blacklist and still tries to use llvm-g++-4.2.
 # Prioritize newer gcc; list versions that are realistically used and confirmed to build and work.


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65994

#### Description

On Leopard gcc-4.0 gets invoked, which fails. Blacklisted.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
