### PR TITLE
bitwarden-cli: update to 2022.10.0

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                bitwarden-cli
-version             2022.9.0
+version             2022.10.0
 revision            0
 
 npm.rootname        @bitwarden/cli
@@ -19,6 +19,6 @@ description         Bitwarden password manager CLI
 long_description    CLI implementation of the Bitwarden password manager.
 homepage            https://bitwarden.com
 
-checksums           rmd160  e17af948ff200d0cf41c878add0135fe28eae16f \
-                    sha256  66df0a2f1dc842863d6342ff386018e204c08e721edf667ed78651aa822ec26c \
-                    size    587164
+checksums           rmd160  fa5eec8d99a6f6baef8ffd7473b403b12a8d9418 \
+                    sha256  93a952c653577a388ba29821edccd6db62155cd267e2a46c808aa77c48b47b14 \
+                    size    599231


### PR DESCRIPTION
#### Description

Created with [seaport](https://seaport.rtfd.io/), the modern MacPorts portfile updater.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?