### PR TITLE
R-app: restore support for older systems and PPC

### DIFF
--- a/math/R-app/Portfile
+++ b/math/R-app/Portfile
@@ -1,10 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup xcode 1.0
+PortSystem              1.0
+PortGroup               xcode 1.0
 
 name                    R-app
-version                 1.78
+
+# Update for newer systems, keep pegged for older. Compatibility see in R.xcodeproj/project.pbxproj
+if {${os.platform} eq "darwin" && ${os.major} > 12} {
+    version             1.78
+} else {
+    # Version for older systems, including PPC. 1.73 still builds but freezes on quit.
+    version             1.72
+}
 revision                1
 set rel_r_ver           4.2.0
 # The version of R when this version of R-app was released, used for changing version
@@ -19,16 +26,59 @@ long_description        ${description}
 
 homepage                http://R.research.att.com/
 platforms               macosx
-supported_archs         x86_64 arm64
 
 master_sites            http://cran.rstudio.com/bin/macosx/ \
                         http://cran.us.r-project.org/bin/macosx/
 
 distname                Mac-GUI-${version}
 
-checksums               rmd160  01fda817e1d16609908c2db8235a6a7cc1bc4746 \
+if {${os.platform} eq "darwin" && ${os.major} > 12} {
+    checksums           ${distname}.tar.gz \
+                        rmd160  01fda817e1d16609908c2db8235a6a7cc1bc4746 \
                         sha256  158bfa738dce96cbdc4cbc0f5b9e888ed0827a858f7576e30716ded2a209898d \
                         size    1298306
+} else {
+    checksums           ${distname}.tar.gz \
+                        rmd160  022ddae8a3988c5a33928d520742ddfca73ac21d \
+                        sha256  a30c97b37645b55aff62bc88cccaf92c307f1e84d84d3ecd5c1333afa2b78e76 \
+                        size    1311627
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # We need to use xib files from older version, newer fail to build with Xcode 3.x.
+    set legacy_ver      1.70
+    set legacy_dist     Mac-GUI-${legacy_ver}.tar.gz
+    set main_dist       ${distname}.tar.gz
+    distfiles-append    ${legacy_dist}
+    checksums-append    ${legacy_dist} \
+                        rmd160  1d351ae2b736bb9f6bd26ce164c37c6926d0e171 \
+                        sha256  8be56f2705c5d20ebecb36948e70fe0a89ba01a9fee214e5fe58f24c3f2eee48 \
+                        size    1795622
+
+    pre-patch {
+        delete ${worksrcpath}/de.lproj
+        delete ${worksrcpath}/English.lproj
+        delete ${worksrcpath}/fr.lproj
+        delete ${worksrcpath}/it.lproj
+        delete ${worksrcpath}/ja.lproj
+        delete ${worksrcpath}/nl.lproj
+
+        move ${workpath}/Mac-GUI-${legacy_ver}/de.lproj ${worksrcpath}
+        move ${workpath}/Mac-GUI-${legacy_ver}/English.lproj ${worksrcpath}
+        move ${workpath}/Mac-GUI-${legacy_ver}/fr.lproj ${worksrcpath}
+        move ${workpath}/Mac-GUI-${legacy_ver}/it.lproj ${worksrcpath}
+        move ${workpath}/Mac-GUI-${legacy_ver}/ja.lproj ${worksrcpath}
+        move ${workpath}/Mac-GUI-${legacy_ver}/nl.lproj ${worksrcpath}
+    }
+
+    post-patch {
+        # These are intended for 1.72 (see above). Other versions set different compatibility.
+        if {${os.major} == 9} {
+            reinplace "s|Xcode 3.2|Xcode 3.1|g" ${worksrcpath}/R.xcodeproj/project.pbxproj
+        }
+        reinplace "s|MACOSX_DEPLOYMENT_TARGET = 10.11|MACOSX_DEPLOYMENT_TARGET = ${macosx_deployment_target}|g" ${worksrcpath}/R.xcodeproj/project.pbxproj
+    }
+}
 
 post-patch {
     reinplace "s|/Library/Frameworks/R.framework|${frameworks_dir}/R.framework|g" \


### PR DESCRIPTION
#### Description

Restores support for older OSs and PPC (perhaps i368 too, cannot test it).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
