### PR TITLE
neovim: update to 0.8.0

### DIFF
--- a/devel/libvterm/Portfile
+++ b/devel/libvterm/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libvterm
-version             0.1.4
+version             0.3
 categories          devel
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -23,9 +23,9 @@ homepage            http://www.leonerd.org.uk/code/libvterm/
 
 master_sites        ${homepage}
 
-checksums           rmd160  827234390d2ac60377786c896808736827cbfbee \
-                    sha256  bc70349e95559c667672fc8c55b9527d9db9ada0fb80a3beda533418d782d3dd \
-                    size    69122
+checksums           rmd160  af29912c984b56a593cb6c003d7aefac5c2abc1c \
+                    sha256  61eb0d6628c52bdf02900dfd4468aa86a1a7125228bab8a67328981887483358 \
+                    size    83861
 
 compiler.c_standard 1999
 

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -6,7 +6,7 @@ PortGroup github 1.0
 # use cmake 1.0 for CMAKE_BUILD_TYPE=Release
 PortGroup cmake 1.0
 
-github.setup            neovim neovim 0.7.2 v
+github.setup            neovim neovim 0.8.0 v
 revision                0
 categories              editors
 platforms               darwin
@@ -25,9 +25,9 @@ long_description \
 
 homepage                https://neovim.io
 
-checksums               rmd160  b93064e926d6cf21b48605ce0f02dda5452554f5 \
-                        sha256  e06d8f3e594b981dc5500cba76a29636fd10668dceb6b5b9d371c307d41f4727 \
-                        size    10935577
+checksums               rmd160  a98b29d45ab66b00ddfa11c990cd7d8e2a018735 \
+                        sha256  30a488b8dc77016c1f1dd9583f5d200772248c40c49eae9dae8d8a62b3964e44 \
+                        size    11388345
 
 depends_build-append    port:pkgconfig
 


### PR DESCRIPTION
#### Description

update to 0.8.0. Requires libvterm 0.3.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 x86_64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
