### PR TITLE
gcc10-bootstrap: displays output when extracing files only on debug

### DIFF
--- a/lang/gcc10-bootstrap/Portfile
+++ b/lang/gcc10-bootstrap/Portfile
@@ -69,13 +69,11 @@ checksums           gcc-10.3.0.tar.gz \
 extract {
     foreach f ${distfiles} {
         set f [lindex [split ${f} :] 0]
-        ui_msg "Extracting: ${f}"
+        ui_debug "Extracting: ${f}"
         if {[string match "*bz2*" ${f}]} {
-            ui_msg "${workpath} \"/usr/bin/tar xjf ${distpath}/${f}\""
             system -W ${workpath} "/usr/bin/tar xjf ${distpath}/${f}"
         }
         if {[string match "*gz*" ${f}]}  {
-            ui_msg "${workpath} \"/usr/bin/tar xzf ${distpath}/${f}\""
             system -W ${workpath} "/usr/bin/tar xzf ${distpath}/${f}"
         }
     }


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/66015

[skip ci]

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

tested only extracing on:

macOS 12.6 21G115 x86_64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->