### PR TITLE
miniflux: update to 2.0.39

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.38
+go.setup            github.com/miniflux/v2 2.0.39
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  616dce442eafb34404f702b20096b7bc2fb42ac7 \
-                        sha256  91f7c09381e412caabe45792eb84bc75403f1625fd3456f98eaf93be9acb663b \
-                        size    568515
+                        rmd160  419b5f664472706625a39ce3324ad56024daa984 \
+                        sha256  ebdf1b351f677940660f595ec23fd968803c47d8c3194079c7f5feb8a576f834 \
+                        size    575124
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -26,16 +26,16 @@ go.vendors          mvdan.cc/xurls \
                         rmd160  7273a8af3153a595e51a8631a103749bc8d18da2 \
                         sha256  eca62cdf7aeb8edb0effeedb68cb160fc3440e9f8c061e735d738b3cd2afb7ec \
                         size    26252 \
-                    gopkg.in/yaml.v3 \
-                        lock    9f266ea9e77c \
-                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
-                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
-                        size    86890 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
                     gopkg.in/square/go-jose.v2 \
-                        lock    v2.5.0 \
-                        rmd160  4e33b18c386d9f617a1d18dc8c627add26ae4074 \
-                        sha256  b5dcfcf94e79eaaabd4eaf1cf1e4211c9f443705ae2ac0cfa8775f08690c2ef0 \
-                        size    308121 \
+                        lock    v2.6.0 \
+                        rmd160  56e581a46f0364551657e2b7698bd022973e9d7c \
+                        sha256  565d45760f1ee44d3c076b9f5ee46e14e046c00304ddfab345fc48443fd6031c \
+                        size    310376 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
                         lock    v1.28.1 \
@@ -53,31 +53,36 @@ go.vendors          mvdan.cc/xurls \
                         rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
                         sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
                         size    8356115 \
+                    golang.org/x/term \
+                        lock    a9ba230a4035 \
+                        rmd160  2011606ab7a7f34f3deffe211d32ef2c89ebb195 \
+                        sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
+                        size    14845 \
                     golang.org/x/sys \
-                        lock    bc2c85ada10a \
-                        rmd160  c4b2c26618cd3f02fe04653b3a4fbe6707de5716 \
-                        sha256  b2526b52942c803a1687e16f87942bd0f0701b5d260fbaa35d53231e0a520577 \
-                        size    1303117 \
+                        lock    c680a09ffe64 \
+                        rmd160  a888af516046d59ceae0983ef656b6ea0a616ca5 \
+                        sha256  1c542763a49b094dedec13fc2b650d12b141a46d9237c947640745c47f72fefa \
+                        size    1358410 \
                     golang.org/x/oauth2 \
                         lock    ee480838109b \
                         rmd160  acb364be9c92be7d474ecc77f8b00bc5b3f91647 \
                         sha256  895bdcba756ffeca30fa286d97f0da2cca2b4e46ffa219c853f8427dad33a6a7 \
                         size    87815 \
                     golang.org/x/net \
-                        lock    27dd8689420f \
-                        rmd160  d7b9477ec487c7f547c2d6669088f0b77c4ecd3f \
-                        sha256  53a566616d208e83a2ec4a58651a450187a3bef980128571a04b01f6231e162d \
-                        size    1229543 \
+                        lock    83b083e8dc8b \
+                        rmd160  b07e74f0cce4986e46838bb8194adcc00eeca0d0 \
+                        sha256  555d8cd580927a2a3ac8376d231990200e1615db2ad2f65f3c53f440b5590649 \
+                        size    1226262 \
                     golang.org/x/crypto \
-                        lock    75b288015ac9 \
-                        rmd160  d0df189672060fb880ac1bd440bfe94a5fc3e6d9 \
-                        sha256  290dc7a301e9ad139c8a5bd91bc0fd9936c60e2d7e7f9361eb3766e8b5947e86 \
-                        size    1729939 \
+                        lock    bd7e27e6170d \
+                        rmd160  be1105998890006fc82c6608bd95230c42f23470 \
+                        sha256  4d9f5e8967513831f87029849603069fa0c30b4568996495b62cd68130d17f70 \
+                        size    1631305 \
                     github.com/yuin/goldmark \
-                        lock    v1.4.13 \
-                        rmd160  bb05cad916044abcb54304c02cc88b32e89776ad \
-                        sha256  d5f917488d17192777b40d1951506c5e1395cf3b2013a0ec4018cf3d6dfc890a \
-                        size    257808 \
+                        lock    v1.5.2 \
+                        rmd160  9e9d4e827f85ac2c97002d70b03af418fcd22cc4 \
+                        sha256  b778a831a92d5ea51354fdaca5a8467805602af60c62adc12182af04f733f2db \
+                        size    259706 \
                     github.com/technoweenie/multipartstreamer \
                         lock    v1.0.1 \
                         rmd160  f1ac41924fe0ca28bf79b5737680452a907b70b4 \
@@ -89,20 +94,20 @@ go.vendors          mvdan.cc/xurls \
                         sha256  ec3d36b70718e240d985ffb44998ff043680dbaf8800abb8acabd509ad3c06a5 \
                         size    2949 \
                     github.com/tdewolff/parse \
-                        lock    v2.6.1 \
-                        rmd160  8f9b13ba7c89f77cc69534cb12f2552cf528cdd5 \
-                        sha256  e004304c4dbc8c1be41dcd0a7f7c1c17a106aad6ede0f5ab3c949060df1db0fb \
-                        size    102301 \
+                        lock    v2.6.4 \
+                        rmd160  0612d3fec268f391bfef648eb9c80582b2311d13 \
+                        sha256  546b8ff32196b9bedff6e93d001ce784fc5ca1bd96b54c1cb62f17f7c18ef70d \
+                        size    102405 \
                     github.com/tdewolff/minify \
-                        lock    v2.12.0 \
-                        rmd160  c389b0d3a9cc107c27540fc4228b221e41d95369 \
-                        sha256  ba9f8cbc33ef8052bbb2737ab6819c2801bd47fe1451f6a57d3207b32142d9e8 \
-                        size    7012567 \
+                        lock    v2.12.4 \
+                        rmd160  4a18087fb935bed355030e6933e5e19b57ed7420 \
+                        sha256  0ad32e8938fe52e7e1963d4a78d4b4f0ceb73c851ebc0b9c9e10cf19d57d47dc \
+                        size    7008558 \
                     github.com/stretchr/testify \
-                        lock    v1.6.1 \
-                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
-                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
-                        size    84248 \
+                        lock    v1.4.0 \
+                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
+                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
+                        size    110114 \
                     github.com/rylans/getlang \
                         lock    4c3188ff8a2d \
                         rmd160  53d360a749a8a7c53b7ed2a88b3ceeb8f4214c17 \
@@ -149,10 +154,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
                         size    37197 \
                     github.com/lib/pq \
-                        lock    v1.10.6 \
-                        rmd160  cbacf9eea1412eb3a1c445cfce18310e1e35fd15 \
-                        sha256  1869d0b55f0c9c1cf1f8c0404c7da9c29cb50c406cc676bff00743f779ace42d \
-                        size    110044 \
+                        lock    v1.10.7 \
+                        rmd160  2d1613378f35b0f27c085769cacb6eca1be07f84 \
+                        sha256  8958d528b808839874ec50e0704a4e1ee43609a69bfdd659b1b9abe40a18fea7 \
+                        size    111537 \
                     github.com/gorilla/mux \
                         lock    v1.8.0 \
                         rmd160  0671fd049b24cb4c682168aef4e176793dd624a7 \
@@ -169,20 +174,20 @@ go.vendors          mvdan.cc/xurls \
                         sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
                         size    171736 \
                     github.com/golang/gddo \
-                        lock    721e228c7686 \
-                        rmd160  ff883ee0f935243223b9eb7568045d0d2d8503ab \
-                        sha256  1501412a0961f3f93f0b6b200accec9e50ccd4b8ba7574b42d3707bdcaf1e50b \
-                        size    3106988 \
+                        lock    20d68f94ee1f \
+                        rmd160  3360724400076512551129e5fa3a4a224b214174 \
+                        sha256  265fb8dd0fb4069357ffaf7cd6089893261738c524d033610260400a244ea769 \
+                        size    3108333 \
                     github.com/go-telegram-bot-api/telegram-bot-api \
                         lock    v4.6.4 \
                         rmd160  80821ad149f661570509a35adcf2d1d73fcf0c10 \
                         sha256  98e078b4f8909436790f12c39fcc589ac7b4e9b39e342966d60470aa2f14fad8 \
                         size    2076483 \
                     github.com/felixge/httpsnoop \
-                        lock    v1.0.1 \
-                        rmd160  0d3ce8473f93cb8cb901d811b37e765b7a528be3 \
-                        sha256  5a4589657bc09f824b17f1c30ea20b0ef2a1354070d6260a426e7afb4eedd9ec \
-                        size    10725 \
+                        lock    v1.0.3 \
+                        rmd160  909ff38f048a85840543a0f9e645908ce2dd9ced \
+                        sha256  cdd557fe7e45ce86f6c22c0030884e43c16f85daf2bb6e31b8bc00d03e5b8362 \
+                        size    11657 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.39)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
