### PR TITLE
google-cloud-sdk: update to 406.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             405.0.0
+version             406.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6699455e92655e60acc5ebd856fe08a9c8bbe60f \
-                    sha256  cf0f32e3d24cbc8a87f7102b0f59423d9df8ffcbd252d3c7175351680266dcd3 \
-                    size    109462047
+    checksums       rmd160  4b3aad5c54a982cd09ebc9f97902f909d490b967 \
+                    sha256  aa5f85bb4a087d77b5651dd968442b7a18ca4ce46387b633906ad4828212874e \
+                    size    109590151
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  488f6265bb1b5214fda2031698547421c3ed47fb \
-                    sha256  c355609d010ad6be4341329a07622c615c92c62655e03d31cb3106fd60500ecd \
-                    size    96899523
+    checksums       rmd160  25d0ff286aa05bd71db4e939098c48c0666ab4e0 \
+                    sha256  e2da841066c7678d7ed723fd612234c9afe7bd7a38056e456157b618cb54bf45 \
+                    size    98560566
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d81873b15aaf959e837b01477f3e08789a675f8f \
-                    sha256  a5915ab89be22b6ee7c28f54db6f289dbd24fe41b90262ea87fc804b71c9708c \
-                    size    95515070
+    checksums       rmd160  e48a4cd8e13fc1dd26000cf6f0b76b4ae2346c0f \
+                    sha256  0062810694941abf453e8616b48182fa8f1379d0d09a74a2ac725ad94185f861 \
+                    size    96977934
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -94,6 +94,7 @@ variant kubectl description {Add kubectl} { dict set variant_to_component kubect
 variant kubectl_oidc description {Add kubectl-oidc} { dict set variant_to_component kubectl_oidc kubectl-oidc }
 variant kustomize description {Add Kustomize} { dict set variant_to_component kustomize kustomize }
 variant local_extract description {Add On-Demand Scanning API extraction helper} { dict set variant_to_component local_extract local-extract }
+variant log_streaming description {Add Log Streaming} { dict set variant_to_component log_streaming log-streaming }
 variant minikube description {Add Minikube} { dict set variant_to_component minikube minikube }
 variant nomos description {Add Nomos CLI} { dict set variant_to_component nomos nomos }
 variant package_go_module description {Add Artifact Registry Go Module Package Helper} { dict set variant_to_component package_go_module package-go-module }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 406.0.0, and added `log_streaming` variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?