### PR TITLE
jdk19: update to 19.0.1

### DIFF
--- a/java/jdk19/Portfile
+++ b/java/jdk19/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk19-mac
-version      19
+version      19.0.1
 revision     0
 
 description  Oracle Java SE Development Kit 19
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/19/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  f58d12513db70c40fef9c361a4d093ff910db68b \
-                 sha256  4d0e387c6a016da5f09afeeb06674a311dd599be4d9cd70c2c01324312303305 \
-                 size    185908835
+    checksums    rmd160  969af56173678efb2a08c0cd54f10095cd1bbfef \
+                 sha256  44dbb6e9c4db2e1fc08fac922ce95a94e51e54429132b4ef5811b0c4709d2077 \
+                 size    186160766
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  3ae0914053d000f49357fc32fc350555463a5684 \
-                 sha256  c1b1a125435ff7423f23453da28e516e6fa4bafe445d303fee917d373d2e1e53 \
-                 size    184002617
+    checksums    rmd160  57acc6ee6371b03da25b2e2d0e2f8e2d63404bc4 \
+                 sha256  cd6fab160195d5b72ecb43fd7e3bfc5e4bc4523172ad306f33f8ee2b9fe28c54 \
+                 size    184200706
 }
 
 worksrcdir   jdk-${version}.jdk
@@ -42,7 +42,7 @@ homepage     https://www.oracle.com/java/
 
 livecheck.type      regex
 livecheck.url       https://www.oracle.com/java/technologies/downloads/
-livecheck.regex     Java SE Development Kit (19\[0-9\.\]?)
+livecheck.regex     Java SE Development Kit (19\.\[0-9\.\]+)
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Oracle JDK 19.0.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?