### PR TITLE
jdk17: update to 17.0.5

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.4.1
+version      17.0.5
 revision     0
 
 description  Oracle Java SE Development Kit 17
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  4ae7cf5ad074e752b1a1ca6aa81628ca044ab473 \
-                 sha256  1419160aa761fbe25431a20bd8ea8483704668700f1d3eb8774745f7263560b9 \
-                 size    178265322
+    checksums    rmd160  45be176b56050b1251229b1b392974ecbf1ee42f \
+                 sha256  2b3f7aeef5d568e751cf0bb50c28eede4285b3cb5d15479c6a937f589469742d \
+                 size    178596850
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  59107acfe786aac0543b721b9a19aa2a340de3d1 \
-                 sha256  2712f7d169f989bf34e6879c0822be7a37906f4f927b8763ac8e719d39cd853f \
-                 size    175604899
+    checksums    rmd160  6270fddd40ba5730c3e663357bbda6767808b7f2 \
+                 sha256  73d2bc6f3527061e602d42870a5b51f4a730e2553877abada887bc20b4d80781 \
+                 size    175850363
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 17.0.5.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?