### PR TITLE
openjdk19-oracle: update to 19.0.1

### DIFF
--- a/java/openjdk19-oracle/Portfile
+++ b/java/openjdk19-oracle/Portfile
@@ -14,24 +14,24 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/19/
-version      19
+version      19.0.1
 revision     0
 
 description  Oracle OpenJDK 19
 long_description Open-source Oracle build of OpenJDK 19, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/877d6127e982470ba2a7faa31cc93d04/36/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/afdd2e245b014143b62ccb916125e3ce/10/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  d69263ad5a95431ea6f44138e7c81f6367e3b597 \
-                 sha256  bfd33f5b2590fd552ae2d9231340c6b4704a872f927dce1c52860b78c49a5a11 \
-                 size    192323254
+    checksums    rmd160  34f4e6c8a9f9a06c3877f96842d76a84da06d0ab \
+                 sha256  469af195906979f96c1dc862c2f539a5e280d0daece493a95ebeb91962512161 \
+                 size    192577932
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  ab7a706471109466c270a3b219f55736b6743970 \
-                 sha256  6691c199fdc6d71826f37d89d2e1a2089ba8bdd98b7001c1d4e8d5d01d6b022b \
-                 size    190416515
+    checksums    rmd160  e1ce718a011d334d67d6156b6768ac5c04836e57 \
+                 sha256  915054b18fc17216410cea7aba2321c55b82bd414e1ef3c7e1bafc7beb6856c8 \
+                 size    190630653
 }
 
 worksrcdir   jdk-${version}.jdk
@@ -40,7 +40,7 @@ homepage     https://jdk.java.net/19/
 
 livecheck.type      regex
 livecheck.url       https://jdk.java.net/19/
-livecheck.regex     OpenJDK JDK (19\[0-9\.\]*)
+livecheck.regex     OpenJDK JDK (19\.\[0-9\.\]+)
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 19.0.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?