### PR TITLE
KeePassXC-devel: upgrade to latest commit of 2.7.x branch

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -54,22 +54,31 @@ if {${subport} eq ${name}} {
     gpg_verify.use_gpg_verification \
                         yes
 
+    patchfiles-append   patch-no-findpackage-path.diff \
+                        patch-touch-id.diff
+
+    # In the future the Touch ID feature may require Darwin 17 (10.13)
+    # https://github.com/keepassxreboot/keepassxc/issues/2484
+    if {${os.major} < 16} {
+        configure.pre_args-append   -DWITH_XC_TOUCHID=OFF
+    }
 } else {
     # devel subport
-    github.setup        keepassxreboot keepassxc 5916a8f8dd93eb6a5de544caedd7a9d8e9a3b1ee
+    github.setup        keepassxreboot keepassxc edae652d6f25e5170cdfc5424e59e847983b9a25
     set githash         [string range ${github.version} 0 6]
-    version             20220406+git${githash}
-    revision            1
+    version             20221018.git${githash}
+    revision            0
 
     conflicts           KeePassXC
 
-    checksums           rmd160  a2c24f7f12b19baaf47a4f25399f33bee6cefe13 \
-                        sha256  5193db2c656bdbb29605df573057e23316e4572327d616b6ac052e857cf4af73 \
-                        size    11171009
+    checksums           rmd160  661e9aa854515d5f6e0bed3bb5b54e5db1973364 \
+                        sha256  8d0daa4e99119916f080fb4945499ee2c588a5637df581f91645ceb462cf77b5 \
+                        size    11236977
 
     gpg_verify.use_gpg_verification \
                         no
 
+    patchfiles-append    devel/patch-no-findpackage-path.diff
 }
 
 if {[option gpg_verify.use_gpg_verification]} {
@@ -101,9 +110,8 @@ depends_lib-append      port:argon2 \
                         port:ykpers \
                         port:zlib
 
-patchfiles              patch-no-deployqt.diff \
-                        patch-no-findpackage-path.diff \
-                        patch-touch-id.diff
+patchfiles-append       patch-no-deployqt.diff
+
 
 # KeePassXC uses -fstack-protector-strong on Clang [1]. That flag is not
 # available until clang 602 [2] or upstream clang 3.5 [3]
@@ -128,12 +136,6 @@ configure.pre_args-append \
     -DWITH_XC_YUBIKEY=ON \
     -DWITH_XC_UPDATECHECK=OFF \
     -DWITH_XC_DOCS=OFF
-
-# In the future the Touch ID feature may require Darwin 17 (10.13)
-# https://github.com/keepassxreboot/keepassxc/issues/2484
-if {${os.major} < 16} {
-    configure.pre_args-append   -DWITH_XC_TOUCHID=OFF
-}
 
 # QTest::addRow was introduced in Qt 5.9
 # Don't build tests in that case

--- a/security/KeePassXC/files/devel/patch-no-findpackage-path.diff
+++ b/security/KeePassXC/files/devel/patch-no-findpackage-path.diff
@@ -1,0 +1,21 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -478,16 +478,8 @@
+     endif()
+     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} DBus REQUIRED)
+ elseif(APPLE)
+-    find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED HINTS
+-            /usr/local/opt/qt@5/lib/cmake
+-            /usr/local/Cellar/qt@5/*/lib/cmake
+-            /opt/homebrew/opt/qt@5/lib/cmake
+-            ENV PATH)
+-    find_package(Qt5 COMPONENTS MacExtras HINTS
+-            /usr/local/opt/qt@5/lib/cmake
+-            /usr/local/Cellar/qt@5/*/lib/cmake
+-            /opt/homebrew/opt/qt@5/lib/cmake
+-            ENV PATH)
++     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED)
++     find_package(Qt5 COMPONENTS MacExtras)
+ else()
+     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED)
+ endif()


### PR DESCRIPTION
on KeePassXC-devel:
 - patch-touch-id.diff is not needed anymore
 - -DWITH_XC_TOUCHID=OFF is not needed anymore

BTW: remove + character from version string (see #65073)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
