### PR TITLE
openjdk19-zulu: update to 19.30.11

### DIFF
--- a/java/openjdk19-zulu/Portfile
+++ b/java/openjdk19-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-19-sts&os=macos&package=jdk
-version      19.28.81
+version      19.30.11
 revision     0
 
-set openjdk_version 19.0.0
+set openjdk_version 19.0.1
 
 description  Azul Zulu Community OpenJDK 19 (Short Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  78e2a8a19bda131bee94e781acb9a893e5556a3e \
-                 sha256  eb0b083dca8cce602f9f1bc4dacbdde879519c55b46786f8676f1d3bb1b97917 \
-                 size    201360399
+    checksums    rmd160  b66e1aa27716ab16739fbf7d1d2309dffd003972 \
+                 sha256  56cfc2fa05b63aafd6c0c316683505069178c9b1edad190d285ef6fb3a9018c0 \
+                 size    201612286
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  a7abd5e61b1e952dec3b17f6ce6d6ec125398047 \
-                 sha256  6901c7d663ca6ff415043843ea240ba4653faed0c3ec1ec1687ac4b29fe1991e \
-                 size    199414290
+    checksums    rmd160  8e0cb5a28db5cd1f26cb9ef8b690510ef9c169a2 \
+                 sha256  d362f01e4dbbb92b0dfa938abb2840b3eda7c320c0b908bb4166bb02c319113d \
+                 size    199656100
 }
 
 worksrcdir   ${distname}/zulu-19.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 19.30.11 (OpenJDK 19.0.1).

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?