### PR TITLE
openjdk17-zulu: update to 17.38.21

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.36.17
+version      17.38.21
 revision     0
 
-set openjdk_version 17.0.4.1
+set openjdk_version 17.0.5
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  c9d70a65bec54e0d5a23a279aad6f9bcf95acb8f \
-                 sha256  a078284cc127155f9d72c85649a13405288ec690a5908b8a039b93357a01149d \
-                 size    193484983
+    checksums    rmd160  df7e42281a10fd5d6c7c2cef425254069f6ecedd \
+                 sha256  e6317cee4d40995f0da5b702af3f04a6af2bbd55febf67927696987d11113b53 \
+                 size    193801252
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  88fe4ac0c25917cd46146e4e643067c4208c313e \
-                 sha256  47e27e38ed09279d826e14cae4b5bf91dd93c3efc2a1d1a20235b8df74964f34 \
-                 size    191313750
+    checksums    rmd160  7b88361ab6a5fe4de439cd30f793267cb660f1b7 \
+                 sha256  515dd56ec99bb5ae8966621a2088aadfbe72631818ffbba6e4387b7ee292ab09 \
+                 size    191590524
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.38.21 (OpenJDK 17.0.5).

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?