### PR TITLE
openjdk11-zulu: update to 11.60.19

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.58.23
+version      11.60.19
 revision     0
 
-set openjdk_version 11.0.16.1
+set openjdk_version 11.0.17
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  deb05210ad6d6253f56a248dd8fc40aa2771de5d \
-                 sha256  7eee35218c02ee660178153ed91c283514f1b5c79ef2e0a90446a61e641d2601 \
-                 size    193695225
+    checksums    rmd160  834beaf15ab5d28e8b6af3bc82e32bdfcabcdfcd \
+                 sha256  f2b2fe82928b99f02ba60ed4df98ae3ad6564323441455fc9787498a79c0f263 \
+                 size    193947542
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  24c4ddc6b5388ffedb1ad40771e808b7b9ab4320 \
-                 sha256  53be67a043aeb6aabdfd2a02764c9374a6cb7056bc0a31114a87cd492d3e90cf \
-                 size    191781689
+    checksums    rmd160  a8fde2990037ad063a33d82cb9b785dcc4ab4840 \
+                 sha256  e3f9dbb08c11e116e5197aa37fefee43bb43e92a66dfc6b62c5f1518813c2df7 \
+                 size    192096016
 }
 
 worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.60.19 (OpenJDK 11.0.17).

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?