### PR TITLE
openjdk8-zulu: update 8.66.0.15

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
-version      8.64.0.19
+version      8.66.0.15
 revision     0
 
-set openjdk_version 8.0.345
+set openjdk_version 8.0.352
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  952c27457b74f77ecfedbd5a8478ae8e475cceb2 \
-                 sha256  5ff596d9af2e82eeaa2012c0bb96f0e208f0a7c2bdb7bc44153997fa46274f59 \
-                 size    108138728
+    checksums    rmd160  1cfeabb2aabda53adf36872b73e0797e4b46a9e0 \
+                 sha256  685c000870a71f6fa08653f9836d2c7bbf331722188a3d1b7ad63060f993c7e2 \
+                 size    108181745
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  96124aaa14093705d117c477ac204282dbaae64d \
-                 sha256  b7516f10489f9e787d330a478bfa2efdf7b9cb3c0186832b2c010557c5b2ba5f \
-                 size    106047013
+    checksums    rmd160  2ada5b6c29b752e3ced110da49a30ff4117268a7 \
+                 sha256  7998aec4b6a8084646a2968c7e5e8666d80c998e07508379eb47bfb37040bb27 \
+                 size    106088447
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.66.0.15 (OpenJDK 8u352).

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?