### PR TITLE
welle.io: upgrade to 2.4

### DIFF
--- a/_resources/port1.0/group/qt6-1.0.tcl
+++ b/_resources/port1.0/group/qt6-1.0.tcl
@@ -190,3 +190,18 @@ proc qt6pg::check_min_version {} {
 port::register_callback qt6pg::check_min_version
 
 unset private_building_qt6
+
+# If using Portgroup cmake + qt6 it means configure.cmd is set to cmake (for example by use of cmake porgroup),
+# So that qt6 finds itself correctly, we use the helper script 'qt-cmake' provided by Qt
+# This will permit configuration step to succeed & find the Qt6 modules
+if { [string equal ${configure.cmd} "${prefix}/bin/cmake"] } {
+    configure.cmd   ${qt_bins_dir}/qt-cmake
+}
+
+# Qt6 makes uses of rpath. This is managed correctly when building with qmake, but with cmake
+# we have to set -DCMAKE_INSTALL_RPATH=${qt_libs_dir}
+# Actually the cmake portgroup sets CMAKE_INSTALL_RPATH to a value that doesn't fit for Qt6
+# This will result in a correct LC_RPATH in the binaries
+if { [string equal ${configure.cmd} "${qt_bins_dir}/qt-cmake"] } {
+    configure.args-append   -DCMAKE_INSTALL_RPATH=${qt_libs_dir}
+}

--- a/multimedia/welle.io/Portfile
+++ b/multimedia/welle.io/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               qt5 1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
@@ -22,13 +21,6 @@ license                 GPL-3+
 license_noconflict      openssl mpg123
 
 homepage                https://www.welle.io/
-
-qt5.depends_component   qtcharts \
-                        qtdeclarative \
-                        qtmultimedia \
-                        qtquickcontrols \
-                        qtquickcontrols2
-qt5.min_version         5.10.0
 
 depends_lib-append      port:faad2 \
                         port:fftw-3-single \
@@ -94,30 +86,47 @@ variant kiss_fft description {Use KISS FFT instead of FFTW} {
 
 if {${subport} eq ${name}} {
     # stable
-    github.setup            AlbrechtL welle.io 2.3 v
+    PortGroup               qt5 1.0
+    github.setup            AlbrechtL welle.io 2.4 v
     github.tarball_from     archive
     epoch                   1
     revision                0
 
     conflicts               welle.io-devel
 
-    checksums               rmd160  f7d8290701e86e3859cf165910c0228ad63e965b \
-                            sha256  e7aa936bf46499ce0abbbf617dd7984ccdaade955a5afb0c86886a0873f015c0 \
-                            size    6771774
+    checksums               rmd160  e0ae521ea2c9bc7becc1610bd616fb1f575059d3 \
+                            sha256  7c2a2ff7b6e0780aee8a30a2beedfa831ce67683e1d076a73cebc897637d0202 \
+                            size    6764741
+
+    qt5.depends_component   qtcharts \
+                            qtdeclarative \
+                            qtmultimedia \
+                            qtquickcontrols \
+                            qtquickcontrols2
+    qt5.min_version         5.10.0
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${version}
 } else {
     # devel
-    github.setup            AlbrechtL welle.io 66675c9a4160c644a5ade5bf7a0cd0647647f33c
+    PortGroup               qt6 1.0
+    github.setup            AlbrechtL welle.io 6b69a78c99df4b46ec2589093cd39f05c9ac4641
     set githash             [string range ${github.version} 0 6]
-    version                 20210522+git${githash}
+    version                 20221214.git${githash}
+    revision                0
 
     conflicts               welle.io
 
-    checksums               rmd160  b59b2c23af4405b0220980b21fa7c5da0f9640cb \
-                            sha256  84bcd5835e462bc2cb829df594ecc0accaa6e2c232c8ba1bc75dbf0cd30fdb3c \
-                            size    6772022
+    checksums               rmd160  5fc4c3be4cc027f6491b142dc14963a0d776e84c \
+                            sha256  4cadc5062a78819641a8a63425d0650be69b961c4958d1c4e51c0a0514386ee2 \
+                            size    6721458
+
+    qt6.depends_component   qt5compat \
+                            qtcharts \
+                            qtdeclarative \
+                            qtmultimedia
+
+    qt6.min_version         6.2
 
     configure.pre_args-append \
         -DGIT_COMMIT_HASH=${githash}


### PR DESCRIPTION
Also:
- update welle.io-devel to use qt6
- add a rule in qt6 porgroup that we should configure with qt-cmake if
configure.cmd is set to cmake (for example through cmake PG).
This is because qt-cmake is a helper script provided by Qt that will permit
to find itself at configure time

BTW: remove + character from version string (see #65073)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G65
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
