### PR TITLE
openjdk19-sap: update to 19.0.1

### DIFF
--- a/java/openjdk19-sap/Portfile
+++ b/java/openjdk19-sap/Portfile
@@ -13,7 +13,7 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-version      19
+version      19.0.1
 revision     0
 
 description  SAP Machine 19
@@ -23,14 +23,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  9c7318ae560dbcd0a5fa7b19a7d82897ff0821b3 \
-                 sha256  5db122e254cfea9ea86938bfe529f152458841b36f103d512384ac2a94fcf621 \
-                 size    187667436
+    checksums    rmd160  f349018e8029319269f01ee85cf9edaabc94a344 \
+                 sha256  720d2a956fa7ad4ea89b5f3d9f9ee1c9c2e464bccc54f9cb72f8e2bb40850505 \
+                 size    187898408
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  25022d39cf7a015f589b4c1f234f26fd433163b9 \
-                 sha256  c677b1b9bd021557cfa68d0d0a36c54217387be37a0b4fc84bc67121da341af8 \
-                 size    185742738
+    checksums    rmd160  43a20161a1e55f01e8c67ab6177be674d20fdb00 \
+                 sha256  19830ca15d0038c01a888794588547079ad747a2696b62f4b0a3d263138eb189 \
+                 size    185937953
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 19.0.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?