### PR TITLE
openjdk17-sap: update to 17.0.5

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.4.1
+version      17.0.5
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  96b9e64f7849b609ad1dc80c418173cf36509e39 \
-                 sha256  9650dfe7f85edf28bf01f5d1243e60c2b351e4434e6f0207664534af8e220f1c \
-                 size    179970596
+    checksums    rmd160  46d889206c72808aa7faecd7588ed794856f487d \
+                 sha256  ced97fe7eef75beede2a70e59263353c3862b05d20153d2381bd7e9fa3d3ebff \
+                 size    180226806
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  1b5a315e6a8ddb93c60802cba2496656b44c55e4 \
-                 sha256  0f77e79f2314243c736170f90527418f8dcad404e3a8b7c991052f1d6f53d9f6 \
-                 size    177743026
+    checksums    rmd160  39c853c9d7b7864714ac0c5ca7e9ed580622111d \
+                 sha256  62325dd21f25bdb403e04dc3661241ac485d79444953aaeaf354b1be48040f93 \
+                 size    177943813
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.5.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?