### PR TITLE
openjdk11-sap: update to 11.0.17

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.16.1
+version      11.0.17
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  02fd47852bf6185914d980bbc9c9d33ea2ea6cc1 \
-                 sha256  1d6d0b4f8f8fd32b559102ab4fe7e571ed3eee3848877d055ce4d475448ad9a3 \
-                 size    186897220
+    checksums    rmd160  6c8908c06f5ca02688eb69d7f1f8952a48cf7651 \
+                 sha256  f5a0a04f4fcc0044bdb8f8ba071e996e9686152e9c38ab645d741e2e2ea724ab \
+                 size    187166175
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  9ef2448cdbaa98c055783f0f2e41b300578af5c4 \
-                 sha256  e3d8d11afd3766c300b02f5c4b4158041807ef2b6dba63d3de7320f9ce5a4826 \
-                 size    185066000
+    checksums    rmd160  fd85e2fd606a9416df435af22212d6deb9af9a38 \
+                 sha256  3b77efd1a2df2517b98c260a31926700f73ae5336aa4db1aa7ffa3eb1724de8b \
+                 size    185296295
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.17.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?