### PR TITLE
openjdk19-corretto: update to 19.0.1.10.1

### DIFF
--- a/java/openjdk19-corretto/Portfile
+++ b/java/openjdk19-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-19/releases
-version      19.0.0.36.1
+version      19.0.1.10.1
 revision     0
 
 description  Amazon Corretto OpenJDK 19 (Short Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  0b2ae6a8685d1149d165085f85ee8f08d2bd51d8 \
-                 sha256  68e685a135f05a09c60b4801e0132545fb2201c62df56df918eb0c1af33a031b \
-                 size    195918127
+    checksums    rmd160  1c3af9efa539e5460663d0ce4c31fe8bf2d577f7 \
+                 sha256  9de65ad7cfcfcb0f28251f2bf11e0a42ebccd7c645e5df128e10df044ebcccd5 \
+                 size    196331530
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  6863b5fa0e340799e9ae6b2c2c929d81ffa379d5 \
-                 sha256  52b0bd18253d107199658cdc4cf506d0695d34adc4638213b22bb52e960e6ef8 \
-                 size    193992552
+    checksums    rmd160  286c413c2a040e24c07256dd4fff3fab90c5f3d5 \
+                 sha256  8a13665c1506410eadd0db4854560dc8e032668073b12483c31bfc96876c72e0 \
+                 size    194488733
 }
 
 worksrcdir   amazon-corretto-19.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-19/blob/release-19.0.0.36.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-19/blob/release-19.0.1.10.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 19.0.1.10.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?