### PR TITLE
openjdk17-corretto: update to 17.0.5.8.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.4.9.1
+version      17.0.5.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  efc182053540746766c5261e7d2e47227a789fd2 \
-                 sha256  fd0f4005ec2e77b0ec6dff01ad9107daa317b96640c73b0198e0f55966d1dbb9 \
-                 size    187796293
+    checksums    rmd160  bd49a1d6359563aa2f1c0db4f847e0f6ffda62e3 \
+                 sha256  34fcab7e6386c19be3f4367397c17a3d2061c6901bbacfbd3dc6818755e50ef8 \
+                 size    188047893
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  d40d89c8455433cb1ededfb643b511b87005ef25 \
-                 sha256  304d6c1d5aa497e720bd04d6cd5f8310e6a8262bf4a688616de10eefb7c9ea52 \
-                 size    185913116
+    checksums    rmd160  d6b083da56d024a354b3c8cecd77effc54d2e593 \
+                 sha256  fe74ec7b1a81f8afaea09fa76e566350259fa861c49d41e14f6a5fffd5f181e3 \
+                 size    186119535
 }
 
 worksrcdir   amazon-corretto-17.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-17/blob/release-17.0.4.9.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-17/blob/release-17.0.5.8.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.5.8.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?