### PR TITLE
openjdk11-corretto: update to 11.0.17.8.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-11/releases
 supported_archs  x86_64 arm64
 
-version      11.0.16.9.1
+version      11.0.17.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  88e9e20a173a194f5f83c39168da5933e495bc7b \
-                 sha256  ea7f0141aa9664af7cfdb381af2f69d53132c53ede6e80e9e1b16754a4895b84 \
-                 size    187515535
+    checksums    rmd160  c5ad3a26b69bbef92e6f6da68e7b9954b60fedb1 \
+                 sha256  a64f436ad92d46a6fb3a2e48dd34c0e11849256b302fd53cc9b2614500c54cbd \
+                 size    187788049
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  3b435c37ee1d07bd9c5db759b5994c07a81d3da3 \
-                 sha256  9408d780d838149ba64451d78c5978b183ba0d75ea0cfa883f3c18309ac469bc \
-                 size    185881208
+    checksums    rmd160  64d95b55ee6a9be52bb45dae22466538e2720f83 \
+                 sha256  badca7ba0fda3c3d5e2637669525f29c0d4ec7d726b58faedc9e340a806f4fc3 \
+                 size    186148916
 }
 
 worksrcdir   amazon-corretto-11.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-11/blob/release-11.0.16.9.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-11/blob/release-11.0.17.8.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.17.8.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?