### PR TITLE
openjdk8-corretto: update to 8.352.08.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.342.07.3
+version      8.352.08.1
 revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  966b129d1ae0255d7d9cbfd202c2f9511af048e1 \
-                 sha256  ab4db316b4c5bb886355bbe192a71a5328e43609631477857a1992ca80975fcf \
-                 size    118790575
+    checksums    rmd160  a65407ecbab9a079a44baaab25455f936bb86f51 \
+                 sha256  73d363cf04a6ab923df6e7166c21c462e20973578d02dd74c8282ca555ebd7fa \
+                 size    118776147
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  192cf91d72d450cbaf229e5e0981365e40a4b5b8 \
-                 sha256  cb29f72976f9e9be525c8ec58edc8bfc20a24f3ec13c5c7259cf1ded3a921eeb \
-                 size    104196362
+    checksums    rmd160  e636acbb012814cb21ab724df6aaa6c0ed34e860 \
+                 sha256  19300a5b56732d6a42104a07cfd2955e100e4e48de76186c29a9219d5bb4b291 \
+                 size    104206983
 }
 
 worksrcdir   amazon-corretto-8.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-8/blob/release-8.342.07.3/CHANGELOG.md
+    # See https://github.com/corretto/corretto-8/blob/release-8.352.08.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.352.08.1.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?