### PR TITLE
istioctl: update to 1.15.2

### DIFF
--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 name                istioctl
 revision            0
 
-go.setup            github.com/istio/istio 1.15.1
+go.setup            github.com/istio/istio 1.15.2
 categories          sysutils
 supported_archs     x86_64 arm64
 license             Apache-2
@@ -30,9 +30,9 @@ github.livecheck.regex \
 
 go.package          istio.io/istio
 
-checksums           rmd160  ac291061c0e59f1b52fdae09257b72c211df98a3 \
-                    sha256  a76445201e9f3e027690ef5d877d58b1ea9e15531b1b76cc0d43deb62dc540b4 \
-                    size    4860370
+checksums           rmd160  6c90928d6c21ad3f26cd52c270c8c35e2a912409 \
+                    sha256  cabef8afb7a620e049313157cb1546eefaa2636c858b5152b0f62a203b9835a5 \
+                    size    4879243
 
 build.cmd           make
 build.target        ${name}


### PR DESCRIPTION
#### Description
istioctl: update to 1.15.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
