### PR TITLE
openjdk15-zulu: update to 15.44.13

### DIFF
--- a/java/openjdk15-zulu/Portfile
+++ b/java/openjdk15-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-15-mts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      15.42.15
+version      15.44.13
 revision     0
 
-set openjdk_version 15.0.8
+set openjdk_version 15.0.9
 
 description  Azul Zulu Community OpenJDK 15 (Medium Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  f2feceac9bd43ae295b4761b63f485590dc8fc54 \
-                 sha256  3b2dfc8bc0d329649256666d169bb40547d43a227c4c086a125ada408aa5e1df \
-                 size    202593508
+    checksums    rmd160  e43347ce019d6aaedeecc9c15a692ad9ac732902 \
+                 sha256  77bbe87c522fbb99a1989f5bd229fbe251146498a6f7de4cfe2e51317603c987 \
+                 size    202973554
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  2c9e57204767fe803d0a58b7ab0476acef04e5dd \
-                 sha256  9005ee1f3c5bbfb46ddd1d6920a1ea5be918650cefddb749604ec929b7a3f9d1 \
-                 size    176884021
+    checksums    rmd160  23db4d5979560d66abbdbfcb7ab99fb986ed84c7 \
+                 sha256  eed59570c2c690cc963d5a0a4f7bdc5409f24c62a66ad36b193055e76a08438a \
+                 size    191782534
 }
 
 worksrcdir   ${distname}/zulu-15.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 15.44.13 (OpenJDK 15.0.9).

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?