### PR TITLE
newlisp: update to 10.7.5, restore PPC and i386

### DIFF
--- a/lang/newlisp/Portfile
+++ b/lang/newlisp/Portfile
@@ -1,42 +1,99 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
 
 name                newlisp
-version             10.4.3
-revision            4
+version             10.7.5
+revision            0
 categories          lang
 maintainers         nomaintainer
-platforms           darwin
 license             GPL-3
 description         newLISP is a LISP-like scripting language
-long_description \
-                    newLISP is a LISP-like scripting language for doing things you \
-                    typically do with scripting languages: programming for the \
-                    internet, system administration, text processing, gluing other \
-                    programs together, etc. newLISP is a scripting LISP for people \
-                    who are fascinated by LISP's beauty and power of expression, but \
-                    who need it stripped down to easy-to-learn essentials.
+long_description    newLISP is a LISP-like scripting language for doing things \
+                    you typically do with scripting languages: programming \
+                    for the internet, system administration, text processing, \
+                    gluing other programs together, etc. newLISP is a scripting LISP \
+                    for people who are fascinated by LISP's beauty and power of expression, \
+                    but who need it stripped down to easy-to-learn essentials.
 
 homepage            http://www.newlisp.org
 master_sites        sourceforge
 extract.suffix      .tgz
-checksums           md5     f744b2ef55cba3f4b8729a34a647b43b \
-                    sha1    7caf5b54311d0004ed1fd7b14e1929ad2ae5977c \
-                    rmd160  ca51e93e672e5bd57f9fb7cff5d81f26ebece37a
+checksums           rmd160  62acd6c9fc31438689cc221cf3541de23ef0b4d3 \
+                    sha256  dc2d0ff651c2b275bc4af3af8ba59851a6fb6e1eaddc20ae75fb60b1e90126ec \
+                    size    1168896
                     
-supported_archs     x86_64
 depends_lib         port:readline \
                     port:libffi
 
-post-configure {
-    # default configure script would pick 32 bit makefile, we're going with 64 bit
+patchfiles          patch-darwin.diff
+
+post-patch {
     copy -force ${filespath}/makefile_build ${worksrcpath}
-    reinplace "s|%CFLAGS%|${configure.cflags} ${configure.cc_archflags}|" ${worksrcpath}/makefile_build
+    reinplace "s|%COMPILER%|${configure.cc}|" ${worksrcpath}/makefile_build
+    reinplace "s|%COMPILER%|${configure.cc}|" ${worksrcpath}/makefile_darwinLP64_utf8_lib
+    reinplace "s|%COMPILER%|${configure.cc}|" ${worksrcpath}/makefile_darwin_utf8_lib
+    reinplace "s|%COMPILER%|${configure.cc}|" ${worksrcpath}/makefile_darwinLP64_utf8_ffi
+    reinplace "s|%COMPILER%|${configure.cc}|" ${worksrcpath}/makefile_darwin_utf8_leopardPPC_ffi
+    reinplace "s|%COMPILER%|${configure.cc}|" ${worksrcpath}/makefile_darwin_utf8_leopardIntel_ffi
+    reinplace "s|%DEVDIR%|${developer_dir}|" ${worksrcpath}/makefile_darwin_utf8_leopardPPC_ffi
+    reinplace "s|%DEVDIR%|${developer_dir}|" ${worksrcpath}/makefile_darwin_utf8_leopardIntel_ffi
+    reinplace "s|%VER%|${macosx_deployment_target}|" ${worksrcpath}/makefile_darwin_utf8_leopardPPC_ffi
+    reinplace "s|%VER%|${macosx_deployment_target}|" ${worksrcpath}/makefile_darwin_utf8_leopardIntel_ffi
+    reinplace "s|%SDK%|${macosx_sdk_version}|" ${worksrcpath}/makefile_darwin_utf8_leopardPPC_ffi
+    reinplace "s|%SDK%|${macosx_sdk_version}|" ${worksrcpath}/makefile_darwin_utf8_leopardIntel_ffi
+    reinplace "s|%CFLAGS%|${configure.cflags} ${configure.cc_archflags}|g" ${worksrcpath}/makefile_build
+    reinplace "s|%CFLAGS%|${configure.cflags} ${configure.cc_archflags}|g" ${worksrcpath}/makefile_darwinLP64_utf8_lib
+    reinplace "s|%CFLAGS%|${configure.cflags} ${configure.cc_archflags}|g" ${worksrcpath}/makefile_darwin_utf8_lib
+    reinplace "s|%CFLAGS%|${configure.cflags} ${configure.cc_archflags}|g" ${worksrcpath}/makefile_darwinLP64_utf8_ffi
+    reinplace "s|%CFLAGS%|${configure.cflags} ${configure.cc_archflags}|g" ${worksrcpath}/makefile_darwin_utf8_leopardPPC_ffi
+    reinplace "s|%CFLAGS%|${configure.cflags} ${configure.cc_archflags}|g" ${worksrcpath}/makefile_darwin_utf8_leopardIntel_ffi
+
+    if {${build_arch} eq "x86_64"} {
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwinLP64_utf8_ffi|" ${worksrcpath}/configure
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwinLP64_utf8_ffi|" ${worksrcpath}/makefile_build
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwinLP64_utf8_ffi|" ${worksrcpath}/Makefile
+        reinplace "s|%MAKEFILE_DYLIB%|makefile_darwinLP64_utf8_lib|" ${worksrcpath}/Makefile
+    }
+    if {${build_arch} eq "ppc64"} {
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardPPC_ffi|" ${worksrcpath}/configure
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardPPC_ffi|" ${worksrcpath}/makefile_build
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardPPC_ffi|" ${worksrcpath}/Makefile
+        reinplace "s|%MAKEFILE_DYLIB%|makefile_darwinLP64_utf8_lib|" ${worksrcpath}/Makefile
+    }
+    if {${build_arch} eq "i386"} {
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardIntel_ffi|" ${worksrcpath}/configure
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardIntel_ffi|" ${worksrcpath}/makefile_build
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardIntel_ffi|" ${worksrcpath}/Makefile
+        reinplace "s|%MAKEFILE_DYLIB%|makefile_darwin_utf8_lib|" ${worksrcpath}/Makefile
+    }
+    if {${build_arch} eq "ppc"} {
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardPPC_ffi|" ${worksrcpath}/configure
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardPPC_ffi|" ${worksrcpath}/makefile_build
+        reinplace "s|%MAKEFILE_DARWIN%|makefile_darwin_utf8_leopardPPC_ffi|" ${worksrcpath}/Makefile
+        reinplace "s|%MAKEFILE_DYLIB%|makefile_darwin_utf8_lib|" ${worksrcpath}/Makefile
+    }
+    if {${build_arch} in [list i386 ppc]} {
+        reinplace "s|64-bit|32-bit|" ${worksrcpath}/configure
+        # Remove 64-bit flag:
+        reinplace "s|-DNEWLISP64| |" ${worksrcpath}/makefile_build
+    }
+    # Set NEWLISPDIR to Macports prefix:
+    reinplace "s|%PREFIX%|${prefix}|" ${worksrcpath}/newlisp.h
+    reinplace "s|%PREFIX%|${prefix}|" ${worksrcpath}/makefile_original_install
 }
 
-# there's a %COMPILER% placeholder for CC as well
 build.args-append   CC=${configure.cc}
+
+build.target        macosall
+
+pre-destroot {
+    move ${worksrcpath}/makefile_original_install ${worksrcpath}/makefile_install
+}
 
 # newlisp's makefile don't support DESTDIR but provide an install_home target using $HOME
 # remember to check makefile_install and remove the following if DESTDIR gets supported
 destroot.args       HOME=${destroot}${prefix}
 destroot.target     install_home
+
+test.run            yes
+test.target         check

--- a/lang/newlisp/files/makefile_build
+++ b/lang/newlisp/files/makefile_build
@@ -4,11 +4,11 @@
 #
 
 OBJS = newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
-	nl-sock.o nl-import.o nl-xml.o nl-web.o nl-matrix.o nl-debug.o pcre.o nl-utf8.o
+	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o pcre.o nl-utf8.o
 
 CFLAGS = %CFLAGS% -c -O1 -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DNEWLISP64 -DFFI
 
-CC = %COMPILER% 
+CC = %COMPILER%
 
 default: $(OBJS)
 	$(CC) %CFLAGS% $(OBJS) -lm -lreadline -lffi -o newlisp
@@ -17,6 +17,6 @@ default: $(OBJS)
 .c.o:
 	$(CC) $(CFLAGS) $<
 
-$(OBJS): primes.h protos.h makefile_darwinLP64_utf8_llvm_ffi
+$(OBJS): primes.h protos.h %MAKEFILE_DARWIN%
 
 

--- a/lang/newlisp/files/patch-darwin.diff
+++ b/lang/newlisp/files/patch-darwin.diff
@@ -1,0 +1,175 @@
+--- configure.orig	2019-05-13 00:44:17.000000000 +0800
++++ configure	2022-10-20 01:57:19.000000000 +0800
+@@ -69,7 +69,7 @@
+ echo
+ 
+ if   [ ${os_type} = MAC_OSX ] ; then
+-	cp makefile_darwinLP64_utf8_ffi makefile_build
++	cp %MAKEFILE_DARWIN% makefile_build
+ elif [ ${os_type} = LINUX ] ; then
+ 	if [ -f /etc/redhat-release ] ; then
+ 		libffi_version=$(ls -d /usr/lib*/libffi*/include)
+
+--- Makefile.orig	2019-05-13 00:44:17.000000000 +0800
++++ Makefile	2022-10-20 02:36:33.000000000 +0800
+@@ -103,9 +103,9 @@
+ # make macOS newlisp 64bit executable and dynamic link library
+ macosall:
+ 	make clean
+-	make -f makefile_darwinLP64_utf8_ffi
++	make -f %MAKEFILE_DARWIN%
+ 	rm *.o
+-	make -f makefile_darwinLP64_utf8_lib
++	make -f %MAKEFILE_DYLIB%
+ 	rm *.o
+ 	./newlisp qa-dot
+ 	tar czvf newlisp-macos-utf8.tgz newlisp newlisp.dylib
+
+--- makefile_darwinLP64_utf8_lib.orig	2019-05-13 00:44:17.000000000 +0800
++++ makefile_darwinLP64_utf8_lib	2022-10-20 02:52:27.000000000 +0800
+@@ -6,12 +6,12 @@
+ OBJS = newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
+ 	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o pcre.o nl-utf8.o unix-lib.o
+ 
+-CFLAGS = -m64 -Wall -O1 -c -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DLIBRARY -DNEWLISP64
++CFLAGS = %CFLAGS% -c -O1 -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DLIBRARY -DNEWLISP64
+ 
+-CC = cc
++CC = %COMPILER%
+ 
+ default: $(OBJS)
+-	$(CC) $(OBJS) -m64 -lm -lreadline -bundle -o newlisp.dylib
++	$(CC) %CFLAGS% $(OBJS) -lm -lreadline -bundle -o newlisp.dylib
+ 
+ .c.o:
+ 	$(CC) $(CFLAGS) $<
+
+--- makefile_darwin_utf8_lib.orig	2019-05-13 00:44:17.000000000 +0800
++++ makefile_darwin_utf8_lib	2022-10-20 02:52:09.000000000 +0800
+@@ -6,12 +6,12 @@
+ OBJS = newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
+ 	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o pcre.o nl-utf8.o unix-lib.o
+ 
+-CFLAGS = -m32 -Wall -O1 -c -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DLIBRARY
++CFLAGS = %CFLAGS% -c -O1 -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DLIBRARY
+ 
+-CC = cc
++CC = %COMPILER%
+ 
+ default: $(OBJS)
+-	$(CC) $(OBJS) -m32 -lm -lreadline -bundle -o newlisp.dylib
++	$(CC) %CFLAGS% $(OBJS) -lm -lreadline -bundle -o newlisp.dylib
+ 
+ .c.o:
+ 	$(CC) $(CFLAGS) $<
+
+--- makefile_darwinLP64_utf8_ffi.orig	2019-05-13 00:44:17.000000000 +0800
++++ makefile_darwinLP64_utf8_ffi	2022-10-20 03:53:32.000000000 +0800
+@@ -6,13 +6,12 @@
+ OBJS = newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
+ 	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o pcre.o nl-utf8.o
+ 
+-CFLAGS = -m64 -Wall -O1 -c -DREADLINE -DNEWLISP64 -DMAC_OSX -DSUPPORT_UTF8 -DFFI
++CFLAGS = %CFLAGS% -c -O1 -DREADLINE -DNEWLISP64 -DMAC_OSX -DSUPPORT_UTF8 -DFFI
+ 
+-CC = cc
+-#CC = gcc 
++CC = %COMPILER%
+ 
+ default: $(OBJS)
+-	$(CC) $(OBJS) -m64 -lm -lreadline -lffi -o newlisp
++	$(CC) %CFLAGS% $(OBJS) -lm -lreadline -lffi -o newlisp
+ 	strip newlisp
+ 
+ .c.o:
+
+--- makefile_darwin_utf8_leopardPPC_ffi.orig	2019-05-13 00:44:17.000000000 +0800
++++ makefile_darwin_utf8_leopardPPC_ffi	2022-10-20 03:50:24.000000000 +0800
+@@ -14,18 +14,18 @@
+ 
+ # to run on 10.4 we must use gcc-4.0
+ #CC = /usr/bin/gcc-4.0
+-CC = /usr/bin/gcc-4.2
++CC = %COMPILER%
+ 
+ # SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk
+-SDKROOT = /Developer/SDKs/MacOSX10.5.sdk
++SDKROOT = %DEVDIR%/SDKs/MacOSX%SDK%.sdk
+ 
+-CFLAGS = -m32 -Wall -arch ppc -Os -c -g -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DFFI -isysroot $(SDKROOT) 
++CFLAGS = %CFLAGS% -Os -c -g -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DFFI -isysroot $(SDKROOT) 
+ 
+ OBJS = newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
+ 	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o nl-utf8.o pcre.o
+ 
+ default: $(OBJS)
+-	$(CC) $(OBJS) -m32 -mmacosx-version-min=10.5 -arch ppc -g -lm -lreadline -lffi -o newlisp
++	$(CC) %CFLAGS% $(OBJS) -mmacosx-version-min=%VER% -g -lm -lreadline -lffi -o newlisp
+ 	strip newlisp
+ 
+ .c.o:
+
+--- makefile_darwin_utf8_leopardIntel_ffi.orig	2019-05-13 00:44:17.000000000 +0800
++++ makefile_darwin_utf8_leopardIntel_ffi	2022-10-20 03:48:20.000000000 +0800
+@@ -11,16 +11,16 @@
+ #CC = /usr/bin/gcc-4.0
+ #SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk
+ 
+-CC = /usr/bin/gcc-4.2
+-SDKROOT = /Developer/SDKs/MacOSX10.5.sdk
++CC = %COMPILER%
++SDKROOT = %DEVDIR%/SDKs/MacOSX%SDK%.sdk
+ 
+-CFLAGS = -Wall -arch i386 -Os -c -g -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DFFI -isysroot $(SDKROOT) 
++CFLAGS = %CFLAGS% -Os -c -g -DREADLINE -DMAC_OSX -DSUPPORT_UTF8 -DFFI -isysroot $(SDKROOT) 
+ 
+ OBJS = newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
+ 	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o nl-utf8.o pcre.o
+ 
+ default: $(OBJS)
+-	$(CC) $(OBJS) -mmacosx-version-min=10.5 -arch i386 -g -lm -lreadline -lffi -o newlisp
++	$(CC) %CFLAGS% $(OBJS) -mmacosx-version-min=%VER% -g -lm -lreadline -lffi -o newlisp
+ 	strip newlisp
+ 
+ .c.o:
+
+--- nl-filesys.c.orig	2019-05-13 00:44:17.000000000 +0800
++++ nl-filesys.c	2022-10-20 03:10:53.000000000 +0800
+@@ -65,7 +65,12 @@
+ #endif /* LINUX || KFREEBSD */
+ 
+ #ifndef TRU64
+-extern char ** environ;
++#ifdef __APPLE__
++#include <crt_externs.h>
++#define environ (*_NSGetEnviron())
++#else
++ extern char **environ;
++#endif
+ #endif
+ 
+ #ifdef WINDOWS
+
+--- newlisp.h.orig	2019-05-13 00:44:17.000000000 +0800
++++ newlisp.h	2022-10-20 03:18:41.000000000 +0800
+@@ -37,7 +37,7 @@
+ #ifdef NEWCONFIG
+ #include "config.h"
+ #else
+-#define NEWLISPDIR "/usr/local/share/newlisp"
++#define NEWLISPDIR "%PREFIX%/share/newlisp"
+ #endif
+ 
+ /* force ISO_C90 restrictions */
+
+--- makefile_original_install.orig	2019-05-13 00:44:17.000000000 +0800
++++ makefile_original_install	2022-10-20 03:26:13.000000000 +0800
+@@ -6,7 +6,7 @@
+ # run in an environment, where NEWLISPDIR is predefined,
+ # else NEWLISPDIR will be defined during newlisp startup
+ # as /usr/share/newlisp which is hardcoded in newlisp.c
+-prefix=/usr/local
++prefix=%PREFIX%
+ datadir=$(prefix)/share
+ bindir=$(prefix)/bin
+ mandir=$(prefix)/share/man


### PR DESCRIPTION
#### Description

Update, restore archs dropped for no good reason. Add test target.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.8.5
Xcode 5.1.1

macOS 10.6.8 Server (ppc, x86_64)
Xcode 3.2.6

macOS 10A190 (ppc)
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
