### PR TITLE
icu-devel: update to 72.1

### DIFF
--- a/devel/icu-devel/Portfile
+++ b/devel/icu-devel/Portfile
@@ -22,7 +22,7 @@ set my_name         icu
 # Please confirm that all ports and its subport can be build. To find the list, use:
 #  port file all | sort -u | xargs grep -El ':icu( |$)' | rev | cut -d / -f 2 | rev | xargs port info --name --subport | cut -d : -f 2 | tr ',' ' ' | grep -v '\-\-' | tr ' ' '\n' | sort -u
 
-version             72.rc
+version             72.1
 revision            0
 epoch               1
 subport             ${name}-docs         { revision 0 }
@@ -44,7 +44,7 @@ long_description \
     support for supplementary Unicode characters (needed for GB 18030 repertoire support).
 
 homepage            https://icu.unicode.org/
-master_sites        https://github.com/unicode-org/icu/releases/download/release-[string map {. _} [string map {.rc -rc} ${version}]]/
+master_sites        https://github.com/unicode-org/icu/releases/download/release-[string map {. -} [string map {.rc -rc} ${version}]]/
 dist_subdir         ${my_name}
 set docdir          ${prefix}/share/doc/${my_name}
 
@@ -66,9 +66,9 @@ if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
     worksrcdir          icu/source
 
     # please also update the icu-docs checksums at the bottom of the Portfile
-    checksums           rmd160  74227ab11588ea9f4fedb7c86087aaab6c3e5de5 \
-                        sha256  e94cfb91fc0d1934449eadb28c68967b5b29d0c0916490ccd50098972a420a2d \
-                        size    26299864
+    checksums           rmd160  c383e013579f9b83574d6a4b15a789d3d520cc40 \
+                        sha256  a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68 \
+                        size    26303933
 
     # use full pathnames to libraries in tools
     patchfiles-append   patch-config-mh-darwin.diff
@@ -169,9 +169,9 @@ if {${subport} eq "${name}-docs"} {
 
     use_zip                 yes
     distname                icu4c-[string map {. _} [string map {.rc rc} ${version}]]-docs
-    checksums               rmd160  c847139ddff4684bcecce1193b5f688d53a3ea56 \
-                            sha256  8162e377764ca5a9e0fc536eecfd910541c990d685eeb1f59446ea093e9bdb99 \
-                            size    8395712
+    checksums               rmd160  cca05e06ddedb2eea25de7283ca5415dbc7d01b7 \
+                            sha256  49109e06a0b2da13cd79029d76fa3c203d980e430cb8893ab19c5c78a4786bd2 \
+                            size    8442040
 
     extract.dir             ${worksrcpath}/doc/html
     use_configure           no


### PR DESCRIPTION
#### Description

A brand new ICU is released. To allow easy test it, I've updated only `icu-devel` port.

The `icu` port will be updated in two weeks.

I've skip ci because it won't pass anyway.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 x86_64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->