### PR TITLE
kubescape: update to 2.0.172

### DIFF
--- a/sysutils/kubescape/Portfile
+++ b/sysutils/kubescape/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang  1.0
 
-go.setup            github.com/armosec/kubescape 2.0.164 v
+go.setup            github.com/armosec/kubescape 2.0.172 v
 github.tarball_from archive
 revision            0
 
@@ -12,15 +12,15 @@ description         Tool for testing if Kubernetes is deployed securely as \
 
 long_description    {*}${description}
 
-categories          sysutils security 
+categories          sysutils security
 installs_libs       no
 license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  b9bbbf01e61203a9eddb9ebc70657febd546df5d \
-                    sha256  331f38cc0868737439b409ad73ce34274fc7542b7699ca44a11f6447db15acbb \
-                    size    17596345
+checksums           rmd160  f3a1f4face30631741371a6e0dbe70a6dfad1302 \
+                    sha256  4e0112fa280642dec41d973d32f443c1ab936e1fb5d03c4ded369f91120be6f2 \
+                    size    54762183
 
 # Allow Go to fetch dependencies at build time
 build.env-delete    GO111MODULE=off GOPROXY=off
@@ -32,7 +32,7 @@ set py_branch       [string index ${py_ver} 0].[string range ${py_ver} 1 end]
 depends_build-append \
                     port:python${py_ver}
 
-build.cmd           ${prefix}/bin/python${py_branch} 
+build.cmd           ${prefix}/bin/python${py_branch}
 build.target        ./build.py
 
 destroot {


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
