### PR TITLE
mint: fix minimum Xcode version

### DIFF
--- a/devel/mint/Portfile
+++ b/devel/mint/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               xcodeversion 1.0
 
 github.setup            yonaskolb Mint 0.17.2
-revision                0
+revision                1
 github.tarball_from     archive
 
 name                    mint
@@ -21,7 +21,7 @@ checksums               rmd160  06e52d2626cc66b17c6dc96889be4f0f4cd67524 \
                         sha256  12a1b91b506f0f8cc4ecede0686c894a798ae9c9130717f875d6969df7274793 \
                         size    23486
 
-minimum_xcodeversions-append {18 10.2}
+minimum_xcodeversions-append {18 11}
 
 if {${os.platform} eq "darwin" && ${os.major} < 18} {
     known_fail yes


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

SwiftCLI dependency needs Swift 5.1, which is
included in Xcode 11.

Closes: https://trac.macports.org/ticket/66037

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
