### PR TITLE
rmlint: blacklist old Apple clang of 10.6.8

### DIFF
--- a/sysutils/rmlint/Portfile
+++ b/sysutils/rmlint/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 PortGroup           muniversal 1.0
@@ -44,8 +45,8 @@ build.cmd           ${prefix}/bin/scons
 build.args          --prefix=${prefix} VERBOSE=1
 build.target
 
-# gcc-4.2 fails to build it
-compiler.blacklist-append   *gcc-4*
+# gcc-4.2 and Xcode clang of 10.6 fail to build it
+compiler.blacklist-append   *gcc-4* {clang < 421}
 
 if {[variant_isset universal]  && [info exists universal_archs_supported]} {
     # Without this SCons builds a fake universal with a single arch


### PR DESCRIPTION
#### Description

Xcode clang of 10.6 does not recognize needed flags. On Rosetta it also cannot build for `ppc`.
```
clang: warning: not using the clang compiler for the 'powerpc' architecture
cc1: error: unrecognized command line option "-Wno-implicit-fallthrough"
cc1: error: unrecognized command line option "-fcolor-diagnostics"
build_python_formatter(["lib/formats/py.c"], ["lib/formats/py.c.in"])
build_sh_formatter(["lib/formats/sh.c"], ["lib/formats/sh.c.in"])
scons: *** [lib/checksums/highwayhash.o] Error 1
scons: *** [lib/checksums/murmur3.o] Error 1
scons: *** [lib/checksums/sha3/sha3.o] Error 1
scons: building terminated because of errors.
```
Added to blacklist.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
