### PR TITLE
libedit: fix a broken patch

### DIFF
--- a/devel/libedit/files/wcsdup.patch
+++ b/devel/libedit/files/wcsdup.patch
@@ -1,17 +1,15 @@
-https://trac.macports.org/ticket/51891#comment:12
+# https://trac.macports.org/ticket/51891#comment:12
+# https://trac.macports.org/ticket/66045#comment:1
 
-diff -Naurp libedit-20160618-3.1.orig/src/sys.h libedit-20160618-3.1/src/sys.h
---- src/sys.h	2016-08-06 23:48:04.000000000 -0700
-+++ src/sys.h	2016-08-07 00:01:18.000000000 -0700
-@@ -96,6 +96,11 @@ size_t	strlcpy(char *dst, const char *sr
- ssize_t	getline(char **line, size_t *len, FILE *fp);
+--- src/sys.h.orig	2022-10-09 20:16:55.000000000 +0800
++++ src/sys.h	2022-10-22 11:48:38.000000000 +0800
+@@ -105,7 +105,8 @@
  #endif
  
-+#ifndef HAVE_WCSDUP
+ #ifndef HAVE_WCSDUP
+-wchar_t * wcsdup(const wchar_t *str);
 +#include <wchar.h>
-+wchar_t * wcsdup(const wchar_t *str);
-+#endif
-+
- #ifndef _DIAGASSERT
- #define _DIAGASSERT(x)
++wchar_t *wcsdup(const wchar_t *str);
  #endif
+ 
+ #ifndef _DIAGASSERT


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66045

#### Description

Existing patch has to be updated, it applies wrongly, and leaves the build broken on older OSs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
