### PR TITLE
skaffold: update to 2.0.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 1.39.2 v
+github.setup        GoogleContainerTools skaffold 2.0.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  68b6c9b724388f190b531bbffa13a7bd94394f3c \
-                    sha256  d45d5079119e95197093cf5dc1ee6392bcc5b87b634fa0464011f4add077fbe7 \
-                    size    21359059
+checksums           rmd160  ec94445d584bd9b472adcc69333e7f46828dd14b \
+                    sha256  d86fcbd0810f999ea0ddfb6853f683fe905549926f77dd395f96b443718c456e \
+                    size    39778102
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Scaffold 2.0.0.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?