### PR TITLE
aerc: update to 0.13.0

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                aerc
-version             0.12.0
+version             0.13.0
 revision            0
 categories          mail
 license             MIT
@@ -19,9 +19,9 @@ master_sites        https://git.sr.ht/~rjarry/aerc/archive/
 distname            ${version}
 worksrcdir          ${name}-${distname}
 
-checksums           rmd160  7f8e08802dfa22459a1ed4fd8e23aa79b040e859 \
-                    sha256  402b48367b87338188036e713b3a421e228199accfa5fdb551f5efa21edb23be \
-                    size    293215
+checksums           rmd160  e334ad72986aba223e8736a8a3829681d241319a \
+                    sha256  d8717ab2c259699b6e818a8f8db1e24033a2e09142e2e9b873fa5de6ee660bd8 \
+                    size    302649
 
 depends_build       port:go \
                     port:scdoc


### PR DESCRIPTION
#### Description
[Changelog](https://git.sr.ht/~rjarry/aerc/refs/0.13.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
