### PR TITLE
cmake-devel: fix a build error on 10.6: undefined _posix_spawn_file_actions_addinherit_np

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -52,8 +52,7 @@ compiler.cxx_standard \
                     2011
 
 platform darwin {
-    if {!((${os.major} < 9) || ${build_arch} eq "ppc" ||
-          ${build_arch} eq "ppc64")} {
+    if {!((${os.major} < 9) || ${build_arch} eq "ppc" || ${build_arch} eq "ppc64")} {
         depends_lib-append port:libcxx
         configure.cxx_stdlib libc++
     }
@@ -78,7 +77,8 @@ patchfiles-append \
     patch-cmake-leopard-tiger.diff \
     patch-fix-clock_gettime-test.diff \
     patch-qt5gui.diff \
-    patch-cmake-cmInstallRuntime-initializer-fix.diff
+    patch-cmake-cmInstallRuntime-initializer-fix.diff \
+    patch-uv_spawn.diff
 
 depends_lib-append \
     port:curl \

--- a/devel/cmake-devel/files/patch-uv_spawn.diff
+++ b/devel/cmake-devel/files/patch-uv_spawn.diff
@@ -1,0 +1,46 @@
+# Undefined symbols: "_posix_spawn_file_actions_addinherit_np",
+# referenced from: _uv_spawn in uv-src-unix-process.c.o
+
+--- Utilities/cmlibuv/src/unix/process.c.orig	2022-10-19 23:22:54.000000000 +0800
++++ Utilities/cmlibuv/src/unix/process.c	2022-10-23 08:17:02.000000000 +0800
+@@ -37,7 +37,10 @@
+ #include <sched.h>
+ 
+ #if defined(__APPLE__)
++# include <AvailabilityMacros.h>
++# if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ # include <spawn.h>
++# endif
+ # include <paths.h>
+ # include <sys/kauth.h>
+ # include <sys/types.h>
+@@ -428,7 +431,7 @@
+ #endif
+ 
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+ typedef struct uv__posix_spawn_fncs_tag {
+   struct {
+     int (*addchdir_np)(const posix_spawn_file_actions_t *, const char *);
+@@ -629,9 +632,11 @@
+       }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     if (fd == use_fd)
+         err = posix_spawn_file_actions_addinherit_np(actions, fd);
+     else
++#endif
+         err = posix_spawn_file_actions_adddup2(actions, use_fd, fd);
+     assert(err != ENOSYS);
+     if (err != 0)
+@@ -880,7 +885,7 @@
+   int exec_errorno;
+   ssize_t r;
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+   uv_once(&posix_spawn_init_once, uv__spawn_init_posix_spawn);
+ 
+   /* Special child process spawn case for macOS Big Sur (11.0) onwards


### PR DESCRIPTION
#### Description

Failure on 10.6.8:
```
Undefined symbols:
  "_posix_spawn_file_actions_addinherit_np", referenced from:
      _uv_spawn in uv-src-unix-process.c.o
ld: symbol(s) not found
collect2: error: ld returned 1 exit status
gmake: *** [Makefile:2: cmake] Error 1
```

Fix is borrowed from `libuv` port’s patch.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
