### PR TITLE
jdupes: update to 1.21.0

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jbruchon jdupes 1.20.2 v
+github.setup        jbruchon jdupes 1.21.0 v
 revision            0
-checksums           rmd160  ffad1b8a7e1c15247aa8dc4cbe7f9b07c57ce4c5 \
-                    sha256  54a03a338bac1081c57d2ca64c72f6f616d85b728ada47690a86010ac63cee23 \
-                    size    94371
+checksums           rmd160  98b06f0c5689ff224cdd01ada9712c921d916ab3 \
+                    sha256  00f3deb05a1e919a16cacd83475b57807b0a7a882e29e84b2217083d739b0e9a \
+                    size    96443
 
 platforms           darwin
 categories          sysutils
@@ -16,6 +16,11 @@ maintainers         {isi.edu:calvin @cardi} openmaintainer
 description         identify and take actions upon duplicate files
 long_description    ${name} is a powerful duplicate file finder and an \
                     enhanced fork of 'fdupes'.
+
+# <https://github.com/jbruchon/jdupes/pull/210>
+# fix stack size linker option
+# remove after >1.21.0
+patchfiles          makefile-fix-compiler-options.patch
 
 use_configure       no
 

--- a/sysutils/jdupes/files/makefile-fix-compiler-options.patch
+++ b/sysutils/jdupes/files/makefile-fix-compiler-options.patch
@@ -1,0 +1,11 @@
+--- Makefile.orig	2022-09-03 11:09:32.000000000 -0700
++++ Makefile	2022-10-23 23:13:04.000000000 -0700
+@@ -119,6 +119,8 @@
+ # The ld syntax for Windows is the same for both Cygwin and MinGW
+ ifeq ($(OS), Windows_NT)
+ COMPILER_OPTIONS += -Wl,--stack=16777216
++else ifeq ($(UNAME_S), Darwin)
++COMPILER_OPTIONS += -Wl,-stack_size -Wl,0x1000000
+ else
+ COMPILER_OPTIONS += -Wl,-z,stack-size=16777216
+ endif


### PR DESCRIPTION
#### Description
jdupes: update to 1.21.0
* adds a patch from upstream to fix stack size linker option in Makefile (to be removed after >1.21.0)

###### Tested on
macOS 12.6 21G115 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?