### PR TITLE
KeePassXC-devel: fix compilation on macOS <= 10.10

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -78,7 +78,8 @@ if {${subport} eq ${name}} {
     gpg_verify.use_gpg_verification \
                         no
 
-    patchfiles-append    devel/patch-no-findpackage-path.diff
+    patchfiles-append    devel/patch-no-findpackage-path.diff \
+                         devel/patch-touch-id.diff
 }
 
 if {[option gpg_verify.use_gpg_verification]} {

--- a/security/KeePassXC/files/devel/patch-touch-id.diff
+++ b/security/KeePassXC/files/devel/patch-touch-id.diff
@@ -1,0 +1,145 @@
+diff -Naur CMakeLists.txt CMakeLists.txt
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -81,6 +81,32 @@
+        ${CMAKE_CURRENT_BINARY_DIR}/tiometry_test/
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_watch_support.mm)
+     message(STATUS "Apple watch compiler support: ${XC_APPLE_COMPILER_SUPPORT_WATCH}")
++
++    try_compile(XC_APPLE_COMPILER_SUPPORT_LocalAuthentication
++       ${CMAKE_CURRENT_BINARY_DIR}/LocalAuthentication_test/
++       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_LocalAuthentication_support.mm)
++    message(STATUS "LocalAuthentication compiler support: ${XC_APPLE_COMPILER_SUPPORT_LocalAuthentication}")
++
++    try_compile(XC_APPLE_COMPILER_SUPPORT_kSecAttrSynchronizable
++       ${CMAKE_CURRENT_BINARY_DIR}/kSecAttrSynchronizable_test/
++       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm)
++    message(STATUS "kSecAttrSynchronizable compiler support: ${XC_APPLE_COMPILER_SUPPORT_kSecAttrSynchronizable}")
++
++    try_compile(XC_APPLE_COMPILER_SUPPORT_kSecUseAuthenticationUI
++       ${CMAKE_CURRENT_BINARY_DIR}/kSecUseAuthenticationUI_test/
++       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm)
++    message(STATUS "kSecUseAuthenticationUI compiler support: ${XC_APPLE_COMPILER_SUPPORT_kSecUseAuthenticationUI}")
++
++    try_compile(XC_APPLE_COMPILER_SUPPORT_kSecAttrAccessControl
++       ${CMAKE_CURRENT_BINARY_DIR}/kSecAttrAccessControl_test/
++       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm)
++    message(STATUS "kSecAttrAccessControl compiler support: ${XC_APPLE_COMPILER_SUPPORT_kSecAttrAccessControl}")
++
++    try_compile(XC_APPLE_COMPILER_SUPPORT_kSecUseOperationPrompt
++       ${CMAKE_CURRENT_BINARY_DIR}/kSecUseOperationPrompt_test/
++       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm)
++    message(STATUS "kSecUseOperationPrompt compiler support: ${XC_APPLE_COMPILER_SUPPORT_kSecUseOperationPrompt}")
++
+ endif()
+ 
+ if(WITH_CCACHE)
+diff -Naur cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm
+--- cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm
++++ cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm
+@@ -0,0 +1,6 @@
++#include <Security/Security.h>
++
++int main() {
++   kSecAttrAccessControl;
++   return 0;
++}
+diff -Naur cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm
+--- cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm
++++ cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm
+@@ -0,0 +1,6 @@
++#include <Security/Security.h>
++
++int main() {
++   kSecAttrSynchronizable;
++   return 0;
++}
+diff -Naur cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm
+--- cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm
++++ cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm
+@@ -0,0 +1,6 @@
++#include <Security/Security.h>
++
++int main() {
++   kSecUseAuthenticationUI;
++   return 0;
++}
+diff -Naur cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm
+--- cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm
++++ cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm
+@@ -0,0 +1,6 @@
++#include <Security/Security.h>
++
++int main() {
++   kSecUseOperationPrompt;
++   return 0;
++}
+diff -Naur cmake/compiler-checks/macos/control_localAuthentication_support.mm cmake/compiler-checks/macos/control_localAuthentication_support.mm
+--- cmake/compiler-checks/macos/control_localAuthentication_support.mm
++++ cmake/compiler-checks/macos/control_localAuthentication_support.mm
+@@ -0,0 +1,2 @@
++#include <LocalAuthentication/LocalAuthentication.h>
++int main() { return 0; }
+diff -Naur src/config-keepassx.h.cmake src/config-keepassx.h.cmake
+--- src/config-keepassx.h.cmake
++++ src/config-keepassx.h.cmake
+@@ -41,10 +41,20 @@
+ #cmakedefine01 XC_APPLE_COMPILER_SUPPORT_BIOMETRY()
+ #cmakedefine01 XC_APPLE_COMPILER_SUPPORT_TOUCH_ID()
+ #cmakedefine01 XC_APPLE_COMPILER_SUPPORT_WATCH()
++#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_LocalAuthentication()
++#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_kSecAttrSynchronizable()
++#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_kSecUseAuthenticationUI()
++#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_kSecAttrAccessControl()
++#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_kSecUseOperationPrompt()
+ 
+ #define XC_COMPILER_SUPPORT(X) XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_##X()
+ #define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_APPLE_BIOMETRY() XC_APPLE_COMPILER_SUPPORT_BIOMETRY()
+ #define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_TOUCH_ID() XC_APPLE_COMPILER_SUPPORT_TOUCH_ID()
+ #define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_WATCH_UNLOCK() XC_APPLE_COMPILER_SUPPORT_WATCH()
++#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_LocalAuthentication() XC_APPLE_COMPILER_SUPPORT_LocalAuthentication()
++#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_kSecAttrSynchronizable() XC_APPLE_COMPILER_SUPPORT_kSecAttrSynchronizable()
++#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_kSecUseAuthenticationUI() XC_APPLE_COMPILER_SUPPORT_kSecUseAuthenticationUI()
++#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_kSecAttrAccessControl() XC_APPLE_COMPILER_SUPPORT_kSecAttrAccessControl()
++#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_kSecUseOperationPrompt() XC_APPLE_COMPILER_SUPPORT_kSecUseOperationPrompt()
+ 
+ #endif // KEEPASSX_CONFIG_KEEPASSX_H
+diff -Naur src/touchid/TouchID.mm src/touchid/TouchID.mm
+--- src/touchid/TouchID.mm
++++ src/touchid/TouchID.mm
+@@ -9,7 +9,9 @@
+ 
+ #include <Foundation/Foundation.h>
+ #include <CoreFoundation/CoreFoundation.h>
++#if XC_COMPILER_SUPPORT(LocalAuthentication)
+ #include <LocalAuthentication/LocalAuthentication.h>
++#endif
+ #include <Security/Security.h>
+ 
+ #include <QCoreApplication>
+@@ -164,9 +166,15 @@
+     CFDictionarySetValue(attributes, kSecClass, kSecClassGenericPassword);
+     CFDictionarySetValue(attributes, kSecAttrAccount, (__bridge CFStringRef) accountName);
+     CFDictionarySetValue(attributes, kSecValueData, (__bridge CFDataRef) keychainValueData);
++#if XC_COMPILER_SUPPORT(kSecAttrSynchronizable)
+     CFDictionarySetValue(attributes, kSecAttrSynchronizable, kCFBooleanFalse);
++#endif
++#if XC_COMPILER_SUPPORT(kSecUseAuthenticationUI)
+     CFDictionarySetValue(attributes, kSecUseAuthenticationUI, kSecUseAuthenticationUIAllow);
++#endif
++#if XC_COMPILER_SUPPORT(kSecAttrAccessControl)
+     CFDictionarySetValue(attributes, kSecAttrAccessControl, sacObject);
++#endif
+ 
+     // add to KeyChain
+     OSStatus status = SecItemAdd(attributes, NULL);
+@@ -218,7 +226,9 @@
+     CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+     CFDictionarySetValue(query, kSecAttrAccount, (__bridge CFStringRef) accountName);
+     CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
++#if XC_COMPILER_SUPPORT(kSecUseOperationPrompt)
+     CFDictionarySetValue(query, kSecUseOperationPrompt, (__bridge CFStringRef) touchPromptMessage);
++#endif
+ 
+     // get data from the KeyChain
+     CFTypeRef dataTypeRef = NULL;


### PR DESCRIPTION
#### Description

trial to fix compilation on macos <= 10.10
because build fails on the builders

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

Build works, on 10.11 but can't test that it's ok on <=10.10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
