### PR TITLE
gq: fix the broken port

### DIFF
--- a/net/gq/Portfile
+++ b/net/gq/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       openssl 1.0
 
 name            gq
 version         1.2.3
-revision        4
+revision        5
 categories      net
 platforms       darwin
 maintainers     nomaintainer
@@ -18,14 +19,16 @@ master_sites    sourceforge:project/gqclient/GQ%20LDAP%20Client/${version}/
 checksums       rmd160  4e8bf1700f4d7aacd906559e01a11654f6ce0f90 \
                 sha256  f27bd461afd226f410d42a287b7d529ce834353e101d6f88e13f51ea55c582bd
 
+openssl.branch  1.0
+
 depends_build   port:intltool \
                 port:pkgconfig
 
-depends_lib     path:lib/pkgconfig/glib-2.0.pc:glib2 \
+depends_lib-append \
+                path:lib/pkgconfig/glib-2.0.pc:glib2 \
                 path:lib/pkgconfig/gtk+-2.0.pc:gtk2 \
                 port:expat \
                 path:lib/libldap.dylib:openldap \
-                path:lib/libssl.dylib:openssl \
                 port:libgnome-keyring \
                 port:libglade2 \
                 port:libiconv
@@ -34,7 +37,8 @@ patchfiles      patch-glib-2.32.diff \
                 patch-echo-n.diff
 
 configure.ldflags-append -lcrypto -liconv
-configure.args  --disable-update-mimedb \
+configure.args-append \
+                --disable-update-mimedb \
                 --with-ssl-prefix=${prefix} \
                 --with-ldap-prefix=${prefix}
 

--- a/net/gq/Portfile
+++ b/net/gq/Portfile
@@ -34,15 +34,19 @@ depends_lib-append \
                 port:libiconv
 
 patchfiles      patch-glib-2.32.diff \
-                patch-echo-n.diff
+                patch-echo-n.diff \
+                patch-ldap.h.diff
 
 configure.args-append \
                 --disable-update-mimedb \
                 --with-ssl-prefix=${prefix} \
                 --with-ldap-prefix=${prefix}
 
+configure.cflags-append \
+                -DLDAP_DEPRECATED=1
+
 configure.ldflags-append \
-                "-lcrypto -liconv"
+                "-lcrypto -liconv -lldap"
 
 post-activate {
     system "${prefix}/bin/update-mime-database ${prefix}/share/mime; true"

--- a/net/gq/Portfile
+++ b/net/gq/Portfile
@@ -7,7 +7,6 @@ name            gq
 version         1.2.3
 revision        5
 categories      net
-platforms       darwin
 maintainers     nomaintainer
 license         {GPL-2+ OpenSSLException}
 
@@ -17,7 +16,8 @@ homepage        https://web.archive.org/web/20081013223833/http://gq-project.org
 master_sites    sourceforge:project/gqclient/GQ%20LDAP%20Client/${version}/
 
 checksums       rmd160  4e8bf1700f4d7aacd906559e01a11654f6ce0f90 \
-                sha256  f27bd461afd226f410d42a287b7d529ce834353e101d6f88e13f51ea55c582bd
+                sha256  f27bd461afd226f410d42a287b7d529ce834353e101d6f88e13f51ea55c582bd \
+                size    423119
 
 openssl.branch  1.0
 
@@ -27,20 +27,22 @@ depends_build   port:intltool \
 depends_lib-append \
                 path:lib/pkgconfig/glib-2.0.pc:glib2 \
                 path:lib/pkgconfig/gtk+-2.0.pc:gtk2 \
-                port:expat \
                 path:lib/libldap.dylib:openldap \
-                port:libgnome-keyring \
+                port:expat \
                 port:libglade2 \
+                port:libgnome-keyring \
                 port:libiconv
 
 patchfiles      patch-glib-2.32.diff \
                 patch-echo-n.diff
 
-configure.ldflags-append -lcrypto -liconv
 configure.args-append \
                 --disable-update-mimedb \
                 --with-ssl-prefix=${prefix} \
                 --with-ldap-prefix=${prefix}
+
+configure.ldflags-append \
+                "-lcrypto -liconv"
 
 post-activate {
     system "${prefix}/bin/update-mime-database ${prefix}/share/mime; true"

--- a/net/gq/files/patch-ldap.h.diff
+++ b/net/gq/files/patch-ldap.h.diff
@@ -1,0 +1,60 @@
+# error: implicit declaration of function 'ldap_search_s' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+--- src/browse-dnd.c.orig	2007-05-15 00:26:50.000000000 +0800
++++ src/browse-dnd.c	2022-10-24 22:13:08.000000000 +0800
+@@ -33,6 +33,8 @@
+ #include <glib/gi18n.h>
+ #include <gtk/gtk.h>
+ 
++#include <ldap.h>
++
+ #include "browse-dnd.h"
+ #include "debug.h"
+ #include "errorchain.h"
+
+--- src/gq-browser-node-server.c.orig	2007-05-15 00:26:50.000000000 +0800
++++ src/gq-browser-node-server.c	2022-10-24 22:13:35.000000000 +0800
+@@ -35,6 +35,8 @@
+ # include <config.h>
+ #endif /* HAVE_CONFIG_H */
+ 
++#include <ldap.h>
++
+ #include "gq-browser-node-dn.h"
+ #include "gq-tab-browse.h"
+ #include "prefs.h"			/* create_edit_server_window */
+
+--- src/gq-tab-browse.c.orig	2008-01-09 00:36:10.000000000 +0800
++++ src/gq-tab-browse.c	2022-10-24 22:13:49.000000000 +0800
+@@ -36,6 +36,8 @@
+ # include <config.h>
+ #endif /* HAVE_CONFIG_H */
+ 
++#include <ldap.h>
++
+ #include "common.h"
+ #include "configfile.h"
+ 
+--- src/input.c.orig	2007-05-15 00:26:51.000000000 +0800
++++ src/input.c	2022-10-24 22:14:12.000000000 +0800
+@@ -38,6 +38,8 @@
+ # include <config.h>
+ #endif /* HAVE_CONFIG_H */
+ 
++#include <ldap.h>
++
+ #include "mainwin.h"
+ #include "common.h"
+ #include "configfile.h"
+
+--- src/browse-export.c.orig	2007-05-15 00:26:50.000000000 +0800
++++ src/browse-export.c	2022-10-24 22:07:02.000000000 +0800
+@@ -37,6 +37,8 @@
+ # include  <config.h>
+ #endif /* HAVE_CONFIG_H */
+ 
++#include <ldap.h>
++
+ #include "common.h"
+ #include "gq-browser-node-dn.h"
+ #include "gq-browser-node-reference.h"


### PR DESCRIPTION
#### Description

The port is currently broken across the board: https://ports.macports.org/port/gq/details/
This PR, hopefully, fixes it :)

UPD. Yes, now it does ^ ^

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
