### PR TITLE
postgresql13–15: fix build with new icu on PPC

### DIFF
--- a/databases/postgresql13/Portfile
+++ b/databases/postgresql13/Portfile
@@ -36,6 +36,13 @@ use_bzip2           yes
 # do not build man or html files (use postgresqlXY-doc instead)
 patchfiles-append   patch-no_doc.diff
 
+# https://trac.macports.org/ticket/66060
+# https://postgrespro.ru/list/thread-id/2551610
+# The problem is specific to PPC: https://github.com/macports/macports-ports/pull/16460
+platform darwin powerpc {
+    patchfiles-append  patch-icu.diff
+}
+
 depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib port:libxml2 port:libxslt path:lib/pkgconfig/icu-uc.pc:icu path:lib/libgssapi_krb5.dylib:kerberos5
 depends_build       port:bison port:pkgconfig
 depends_run         port:postgresql_select

--- a/databases/postgresql13/files/patch-icu.diff
+++ b/databases/postgresql13/files/patch-icu.diff
@@ -1,0 +1,25 @@
+--- src/include/utils/pg_locale.h.orig	2021-11-09 06:00:24.000000000 +0800
++++ src/include/utils/pg_locale.h	2022-10-25 01:48:04.000000000 +0800
+@@ -17,6 +17,9 @@
+ #endif
+ #ifdef USE_ICU
+ #include <unicode/ucol.h>
++#ifdef bool
++#undef bool
++#endif
+ #endif
+ 
+ #include "utils/guc.h"
+
+--- src/backend/utils/adt/formatting.c.orig	2022-10-25 02:07:10.000000000 +0800
++++ src/backend/utils/adt/formatting.c	2022-10-25 02:07:21.000000000 +0800
+@@ -81,6 +81,9 @@
+ 
+ #ifdef USE_ICU
+ #include <unicode/ustring.h>
++#ifdef bool
++#undef bool
++#endif
+ #endif
+ 
+ #include "catalog/pg_collation.h"

--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -36,6 +36,13 @@ use_bzip2           yes
 # do not build man or html files (use postgresqlXY-doc instead)
 patchfiles-append   patch-no_doc.diff
 
+# https://trac.macports.org/ticket/66060
+# https://postgrespro.ru/list/thread-id/2551610
+# The problem is specific to PPC: https://github.com/macports/macports-ports/pull/16460
+platform darwin powerpc {
+    patchfiles-append  patch-icu.diff
+}
+
 depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib port:libxml2 port:libxslt path:lib/pkgconfig/icu-uc.pc:icu path:lib/libgssapi_krb5.dylib:kerberos5
 depends_build       port:bison port:pkgconfig
 depends_run         port:postgresql_select

--- a/databases/postgresql14/files/patch-icu.diff
+++ b/databases/postgresql14/files/patch-icu.diff
@@ -1,0 +1,25 @@
+--- src/include/utils/pg_locale.h.orig	2022-08-09 04:44:29.000000000 +0800
++++ src/include/utils/pg_locale.h	2022-10-25 01:49:09.000000000 +0800
+@@ -17,6 +17,9 @@
+ #endif
+ #ifdef USE_ICU
+ #include <unicode/ucol.h>
++#ifdef bool
++#undef bool
++#endif
+ #endif
+ 
+ #include "utils/guc.h"
+
+--- src/backend/utils/adt/formatting.c.orig	2022-10-25 02:07:10.000000000 +0800
++++ src/backend/utils/adt/formatting.c	2022-10-25 02:07:21.000000000 +0800
+@@ -81,6 +81,9 @@
+ 
+ #ifdef USE_ICU
+ #include <unicode/ustring.h>
++#ifdef bool
++#undef bool
++#endif
+ #endif
+ 
+ #include "catalog/pg_collation.h"

--- a/databases/postgresql15/Portfile
+++ b/databases/postgresql15/Portfile
@@ -35,6 +35,14 @@ use_bzip2           yes
 # do not build man or html files (use postgresqlXY-doc instead)
 patchfiles-append   patch-no_doc.diff
 
+# https://trac.macports.org/ticket/66060
+# https://trac.macports.org/ticket/67365
+# https://postgrespro.ru/list/thread-id/2551610
+# The problem is specific to PPC: https://github.com/macports/macports-ports/pull/16460
+platform darwin powerpc {
+    patchfiles-append  patch-icu.diff
+}
+
 depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib port:libxml2 port:libxslt path:lib/pkgconfig/icu-uc.pc:icu path:lib/libgssapi_krb5.dylib:kerberos5
 depends_build       port:bison port:pkgconfig
 depends_run         port:postgresql_select

--- a/databases/postgresql15/files/patch-icu.diff
+++ b/databases/postgresql15/files/patch-icu.diff
@@ -1,0 +1,25 @@
+--- src/include/utils/pg_locale.h.orig	2022-08-09 04:44:29.000000000 +0800
++++ src/include/utils/pg_locale.h	2022-10-25 01:49:09.000000000 +0800
+@@ -17,6 +17,9 @@
+ #endif
+ #ifdef USE_ICU
+ #include <unicode/ucol.h>
++#ifdef bool
++#undef bool
++#endif
+ #endif
+ 
+ #include "utils/guc.h"
+
+--- src/backend/utils/adt/formatting.c.orig	2022-10-25 02:07:10.000000000 +0800
++++ src/backend/utils/adt/formatting.c	2022-10-25 02:07:21.000000000 +0800
+@@ -81,6 +81,9 @@
+ 
+ #ifdef USE_ICU
+ #include <unicode/ustring.h>
++#ifdef bool
++#undef bool
++#endif
+ #endif
+ 
+ #include "catalog/pg_collation.h"


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66060

#### Description

Fixes the build of `postgresql13` and `postgresql14` with new `icu`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
