### PR TITLE
openjpeg: fix universal for PPC

### DIFF
--- a/graphics/openjpeg/Portfile
+++ b/graphics/openjpeg/Portfile
@@ -9,7 +9,6 @@ cmake.out_of_source yes
 
 github.setup        uclouvain openjpeg 2.5.0 v
 categories          graphics
-platforms           darwin
 license             BSD
 
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -37,3 +36,10 @@ depends_lib         port:libpng \
                     port:jbigkit
 
 configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
+
+if {${universal_possible} && [variant_isset universal]} {
+    if {${build_arch} in [list ppc ppc64]} {
+        PortGroup  muniversal 1.0
+
+    }
+}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65241

#### Description

Despite `openjpeg` can be built with `gcc-4.2`, universal fails on PPC. `muniversal 1.0` PG works.

@kencu Is this safe way to add it? So that nothing besides PPC is affected, but ppc+ppc64 is finally fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
