### PR TITLE
aquaterm: fix xcode build

### DIFF
--- a/aqua/aquaterm/Portfile
+++ b/aqua/aquaterm/Portfile
@@ -23,7 +23,7 @@ checksums               rmd160  007db0806a2b1b1263043647035fa428b15560e3 \
 
 build.dir               ${worksrcpath}/aquaterm
 
-patchfiles              no-NSMailDelivery.patch 
+patchfiles              no-NSMailDelivery.patch project-copyfiles.patch
 
 xcode.target            AquaTerm
 xcode.configuration     Default

--- a/aqua/aquaterm/files/project-copyfiles.patch
+++ b/aqua/aquaterm/files/project-copyfiles.patch
@@ -1,0 +1,38 @@
+--- aquaterm/AquaTerm.xcodeproj/project.pbxproj.orig	2013-08-09 08:08:35 -0700
++++ aquaterm/AquaTerm.xcodeproj/project.pbxproj	2022-10-25 13:36:48 -0400
+@@ -28,7 +28,6 @@
+ 		CB3949DA0E8D7A5B00BA7404 /* AquaTerm.bridgesupport in Resources */ = {isa = PBXBuildFile; fileRef = CB3949D90E8D7A5B00BA7404 /* AquaTerm.bridgesupport */; };
+ 		CB58A20006F9A60900AF8A5E /* AQTAdapter.html in Resources */ = {isa = PBXBuildFile; fileRef = CB58A1FE06F9A60900AF8A5E /* AQTAdapter.html */; };
+ 		CB58A20106F9A60900AF8A5E /* help.html in Resources */ = {isa = PBXBuildFile; fileRef = CB58A1FF06F9A60900AF8A5E /* help.html */; };
+-		CB58A20206F9A62300AF8A5E /* help.html in CopyFiles */ = {isa = PBXBuildFile; fileRef = CB58A1FF06F9A60900AF8A5E /* help.html */; };
+ 		CB58A23B06FA0FB600AF8A5E /* ReadMe.rtf in Resources */ = {isa = PBXBuildFile; fileRef = CB58A23A06FA0FB600AF8A5E /* ReadMe.rtf */; };
+ 		CB72184906072CF6008DCEAD /* ReleaseNotes in Resources */ = {isa = PBXBuildFile; fileRef = CB72184806072CF6008DCEAD /* ReleaseNotes */; };
+ 		CB91252B07CB488C001D5EAF /* AQTAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF3082D04D51B9300EBD329 /* AQTAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+@@ -112,19 +111,6 @@
+ 		};
+ /* End PBXContainerItemProxy section */
+ 
+-/* Begin PBXCopyFilesBuildPhase section */
+-		CB58A1F406F9A53300AF8A5E /* CopyFiles */ = {
+-			isa = PBXCopyFilesBuildPhase;
+-			buildActionMask = 2147483647;
+-			dstPath = "";
+-			dstSubfolderSpec = 7;
+-			files = (
+-				CB58A20206F9A62300AF8A5E /* help.html in CopyFiles */,
+-			);
+-			runOnlyForDeploymentPostprocessing = 0;
+-		};
+-/* End PBXCopyFilesBuildPhase section */
+-
+ /* Begin PBXFileReference section */
+ 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+ 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+@@ -546,7 +532,6 @@
+ 				CBC4B43205E4C784001BE8D7 /* Resources */,
+ 				CBC4B43B05E4C784001BE8D7 /* Sources */,
+ 				CBC4B44505E4C784001BE8D7 /* Frameworks */,
+-				CB58A1F406F9A53300AF8A5E /* CopyFiles */,
+ 			);
+ 			buildRules = (
+ 			);


### PR DESCRIPTION
#### Description
Fixes aquaterm build on newer versions of XCode. A file was specified in the bundle twice, which newer versions of xcode seem to error out on. In the past this was fixed using '-UseNewBuildSystem=NO' on xcode >=10, but this fix no longer works. (I kept this line in, in case it's still necessary for other xcode/macOS combinations).

Closes: https://trac.macports.org/ticket/65749
References: https://trac.macports.org/ticket/56895

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
