### PR TITLE
net/wireshark4: revbump to 4.0.1

### DIFF
--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -30,12 +30,12 @@ if { ${os.platform} eq "darwin" && ${os.major} < 16 } {
     }
 }
 
-version         4.0.0
+version         4.0.1
 revision        0
 
-checksums       sha256  3dc125ef85e85c2a756a74cc739b3eb11ce38e30a08e085e77d378ee7fdcaded \
-                sha1    2a495346c46dadeb405d0b89cec18fe7edc77e1a \
-                size    41323336
+checksums       sha256  b3b002f99d13bbf47f9ed3be7eb372cb0c2454bd0faea29a756819ce019ffdc2 \
+                sha1    dfd83a3b589c690e79e5dafe60a62be72152c2c0 \
+                size    41282116
 
 livecheck.type  regex
 livecheck.url   ${homepage}download.html


### PR DESCRIPTION
#### Description
net/wireshark4: revbump to 4.0.1

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
