### PR TITLE
nodejs16: Make python a build dependency

### DIFF
--- a/devel/nodejs16/Portfile
+++ b/devel/nodejs16/Portfile
@@ -13,7 +13,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs16
 version                 16.18.1
-revision                0
+revision                1
 
 categories              devel net
 platforms               darwin
@@ -39,13 +39,12 @@ checksums               rmd160  82ab4a17640901ff4c473503fae6ed7ef696941e \
 
 distname                node-v${version}
 
-depends_build-append    port:pkgconfig
-
 set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
+depends_build-append    port:pkgconfig \
+                        port:python${py_ver_nodot}
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
-                        port:python${py_ver_nodot} \
                         port:zlib
 
 if {![variant_isset openssl3]} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Makes python a build dependency instead of a library dependency because seems like it is not needed at runtime (used only for gyp), just like how the brew counterpart formula already declares

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
