### PR TITLE
gnupg2: update to version 2.3.8

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 
 set my_name         gnupg
 name                ${my_name}2
-version             2.2.40
+version             2.3.8
 revision            0
 
 # Putting the SHA1 hash because that is published on the website
-checksums           rmd160  ed3d03254ac23d85277ce111b30a637345ceb156 \
-                    sha1    2a8b52d08cc78e4ebeb07ec2fc8d95e290a3c4a7 \
-                    sha256  1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28 \
-                    size    7301631
+checksums           rmd160  2520856047bc5bf9b54455cb215543ad1239cea1 \
+                    sha1    1f31b7b4c9c9adad97f94ea3acf1aa64c0424bcc \
+                    sha256  540b7a40e57da261fb10ef521a282e0021532a80fd023e75fb71757e8a4969ed \
+                    size    7644926
 
 # https://trac.macports.org/ticket/63552
 epoch               1


### PR DESCRIPTION
#### Description

Update gnupg2 to version 2.3.8, which fixes the Libksba vulnerability
CVE-2022-3515

Please note, I am not sure if this is an appropriate pull request because I believe that 2.2.x is the long term support version, but I am submitting anyway for your consideration.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.1 21G217 arm64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
