### PR TITLE
zig: fix depends_lib: clang-XX for libc++

### DIFF
--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -25,7 +25,7 @@ homepage            https://ziglang.org/
 
 set llvm_version    13
 
-depends_lib-append  port:llvm-${llvm_version}
+depends_lib-append  port:clang-${llvm_version}
 
 checksums           rmd160  0bee29c8a68f0bfb2bb0454783c8be8ff12f7080 \
                     sha256  2a6ba6a72b9619b83dab77f5b6e2b6f0958bb0f85cded055be2c632386e0ff2d \


### PR DESCRIPTION
bin/zig requires `libexec/llvm-{ver}/lib/libc++.1.dylib`, which is provided by `clang-{ver}`, not `llvm-{ver}`.

cc: @felix 