### PR TITLE
openjdk17-temurin: update to 17.0.5

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.4.1
-set build    1
+version      17.0.5
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  fdc1f600ce30da3d736dad16dfad804d2dbc6e63 \
-                 sha256  ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a \
-                 size    186906753
+    checksums    rmd160  76c83a3b980791a14b02b8aa7a3d4f43219d3f51 \
+                 sha256  94fe50982b09a179e603a096e83fd8e59fd12c0ae4bcb37ae35f00ef30a75d64 \
+                 size    187174050
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  65e5e9f27671659ad604ea3e7feeb8971de7e4c1 \
-                 sha256  3a976943a9e6a635e68e2b06bd093fc096aad9f5894acda673d3bea0cb3a6f38 \
-                 size    177121101
+    checksums    rmd160  6906e750467b10e3e30bb460fc5906832bf8b2f5 \
+                 sha256  2dc3e425b52d1cd2915d93af5e468596b9e6a90112056abdcebac8b65bf57049 \
+                 size    177335828
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.5.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?