### PR TITLE
openjdk11-temurin: update to 11.0.17

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.16.1
-set build    1
+version      11.0.17
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  efbc5bea3b4279b2112c940ed07488f596c42477 \
-                 sha256  723548e36e0b3e0a5a2f36a38b22ea825d3004e26054a0e254854adc57045352 \
-                 size    186335152
+    checksums    rmd160  7734e533a4a79f324ef94c03ff860725de59a658 \
+                 sha256  f408a12f10d93b3205bef851af62707531b699963cef79408d59197d08763c94 \
+                 size    186594836
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  b36984a0b0dfbad9ee75d194a9ac382ecae1e4e0 \
-                 sha256  1953f06702d45eb54bae3ccf453b57c33de827015f5623a2dfc16e1c83e6b0a1 \
-                 size    185088495
+    checksums    rmd160  9e3f8874eb2027b4b32db526a7f37ff039cc725c \
+                 sha256  79b18cbd398b67a52ebaf033dfca15c7af4c1a84ec5fa68a88f3bf742bb082f7 \
+                 size    185315542
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.17.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?