### PR TITLE
fricas: added a patch for SBCL_HOME

### DIFF
--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fricas
 version             1.3.8
-revision            1
+revision            2
 categories          math
 maintainers         {@pietvo vanoostrum.org:pieter}
 platforms           darwin
@@ -33,6 +33,8 @@ checksums           rmd160  1c1b051cf333325b0e5a75e319e01d88113ec85c \
                     sha256  6a60063cb428ef49ca013c9933b877c97e66314c42c0e1706ff7d32160798544 \
                     size    10878913
 
+patchfiles          sbcl-home.patch
+
 configure.dir       ${workpath}/fricas-build
 configure.cmd       ${worksrcpath}/configure
 pre-configure       {file mkdir ${configure.dir}}
@@ -59,7 +61,8 @@ variant sbcl conflicts ccl ecl \
     description {Use SBCL as lisp implementation} {
     depends_lib-append      port:sbcl
     configure.args-append   --with-lisp='sbcl \
-        --control-stack-size 512 --dynamic-space-size 6000'
+        --control-stack-size 512 --dynamic-space-size 6000' \
+        --with-sbcl-home=${prefix}/lib/sbcl
 }
 
 if { ${configure.build_arch} eq "x86_64" } {

--- a/math/fricas/files/sbcl-home.patch
+++ b/math/fricas/files/sbcl-home.patch
@@ -1,0 +1,115 @@
+commit 0a6b5f7ffdebfed60f80da777318d0a41c5fee5a
+Author: Kirill A. Korinsky <kirill@korins.ky>
+Date:   Fri Oct 28 18:45:26 2022 +0200
+
+    Introduced a way to hardcode SBCL_HOME
+    
+    I've added a configure argument `--with-sbcl-home` which allows to
+    specify desired `SBCL_HOME`.
+    
+    Without it fricas' lisp can't be really used without specification of
+    `SBCL_HOME` environment variable at some cases that leads to wired
+    issue like:
+    ```
+    (1) -> )lisp (require :asdf)
+    
+       >> System error:
+       Don't know how to REQUIRE ASDF.
+    See also:
+      The SBCL Manual, Variable SB-EXT:*MODULE-PROVIDER-FUNCTIONS*
+      The SBCL Manual, Function REQUIRE
+    
+    (1) ->
+    ```
+
+diff --git Makefile.in Makefile.in
+index d814d46f..75c07d2b 100644
+--- Makefile.in
++++ Makefile.in
+@@ -142,6 +142,9 @@ install-src:
+ 	echo FRICAS_VERSION='"${PACKAGE_VERSION}"' >> '${COMMAND}'.tmp
+ 	echo FRICAS_LISP_FLAVOR='"${FRICAS_LISP_FLAVOR}"' >> '${COMMAND}'.tmp
+ 	echo FRICAS_LISP_VERSION='"${FRICAS_LISP_VERSION}"' >> '${COMMAND}'.tmp
++	if test "x$(SBCL_HOME)" != "x" ; then \
++		echo export SBCL_HOME='"$${SBCL_HOME:-$(SBCL_HOME)}"' >> '${COMMAND}'.tmp ; \
++	fi
+ 	cat $(fricas_src_srcdir)/etc/fricas >> '${COMMAND}'.tmp
+ 	$(INSTALL_SCRIPT) '${COMMAND}'.tmp '${COMMAND}'
+ 	-rm '${COMMAND}'.tmp
+diff --git config/var-def.mk config/var-def.mk
+index 2247de76..65d09551 100644
+--- config/var-def.mk
++++ config/var-def.mk
+@@ -170,6 +170,8 @@ FASLEXT = @fricas_fasl_type2@
+ FRICAS_LISP_FLAVOR=@fricas_lisp_flavor@
+ FRICAS_LISP_VERSION=@fricas_lisp_version@
+ 
++SBCL_HOME=@sbcl_home@
++
+ ##
+ 
+ ##
+diff --git configure configure
+index 804f0364..db73e99c 100755
+--- configure
++++ configure
+@@ -663,6 +663,7 @@ GMP_LIBDIR
+ GMP_LDFLAGS
+ GMP_CPPFLAGS
+ GMP_WRAP_SO_TARGET
++sbcl_home
+ SOLIB_FLAGS
+ LIBSPAD_SO_TARGET
+ fricas_lisp_version
+@@ -752,6 +753,7 @@ enable_case_insensitive_file_system_check
+ with_pre_generated
+ with_lisp
+ with_lisp_flavor
++with_sbcl_home
+ with_gmp
+ with_gmp_include
+ with_gmp_lib
+@@ -1419,6 +1421,7 @@ Optional Packages:
+                           code.
+   --with-lisp=L           use L as Lisp platform
+   --with-lisp-flavor=F    obsolete and ignored
++  --with-sbcl-home=PATH   specify the path of hardcoded SBCL_HOME
+   --with-gmp=PATH         specify prefix directory for the installed GMP
+                           package. Equivalent to
+                           --with-gmp-include=PATH/include plus
+@@ -4202,6 +4205,17 @@ esac
+ 
+ 
+ 
++## Configure desired SBCL_HOME
++
++# Check whether --with-sbcl-home was given.
++if test "${with_sbcl_home+set}" = set; then :
++  withval=$with_sbcl_home; sbcl_home=$withval
++else
++  sbcl_home=""
++fi
++
++
++
+ ## In case our underlying lisp is SBCL or Closure CL, we provide a
+ ## wrapper to enable GMP bignums in lisp
+ GMP_WRAP_SO_TARGET=""
+diff --git configure.ac configure.ac
+index ff7fe65c..650ad5a6 100644
+--- configure.ac
++++ configure.ac
+@@ -325,6 +325,13 @@ esac
+ AC_SUBST(LIBSPAD_SO_TARGET)
+ AC_SUBST(SOLIB_FLAGS)
+ 
++## Configure desired SBCL_HOME
++AC_ARG_WITH([sbcl-home],
++    AS_HELP_STRING([--with-sbcl-home=PATH], [specify the path of hardcoded SBCL_HOME]),
++    sbcl_home=$withval,
++    sbcl_home="")
++AC_SUBST(sbcl_home)
++
+ ## In case our underlying lisp is SBCL or Closure CL, we provide a
+ ## wrapper to enable GMP bignums in lisp
+ GMP_WRAP_SO_TARGET=""


### PR DESCRIPTION
#### Description

Here a fix for fricas that fixed embedded lisp at sbcl. Without this patch it is impossible to use anything outside of basic lisp operations like `(+ 2 2)` :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 x86_64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->