### PR TITLE
sbcl: hardcode MacPorts XDG_DATA_DIRS

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -9,7 +9,7 @@ name            sbcl
 # Please bump the revision of math/maxima (and when it exists
 # math/maxima-devel) when this port changes.
 version         2.2.9
-revision        0
+revision        1
 
 categories      lang
 license         BSD
@@ -34,6 +34,7 @@ use_bzip2       yes
 
 patchfiles \
     patch-contrib-sb-posix-posix-tests.lisp.diff \
+    patch-macports-xdg-data-dir.diff \
     patch-sbcl-realtime.diff
 
 distfiles       ${name}-${version}-source${extract.suffix}:sbcl
@@ -79,6 +80,9 @@ if {${build_arch} eq "arm64"} {
 }
 
 post-patch {
+    reinplace "s|@@PREFIX@@|${prefix}|g" \
+        ${worksrcpath}/contrib/asdf/uiop.lisp
+
     reinplace "s|/usr/local/lib/${name}|${prefix}/lib/${name}|g" \
         ${worksrcpath}/doc/sbcl.1
     # <https://trac.macports.org/attachment/ticket/51733/>

--- a/lang/sbcl/files/patch-macports-xdg-data-dir.diff
+++ b/lang/sbcl/files/patch-macports-xdg-data-dir.diff
@@ -1,0 +1,13 @@
+diff --git contrib/asdf/uiop.lisp contrib/asdf/uiop.lisp
+index 5e52e7745..25c1a6365 100644
+--- contrib/asdf/uiop.lisp
++++ contrib/asdf/uiop.lisp
+@@ -7188,7 +7188,7 @@ also \"Configuration DSL\"\) in the ASDF manual."
+             (or (remove nil (getenv-absolute-directories "XDG_DATA_DIRS"))
+                 (os-cond
+                  ((os-windows-p) (mapcar 'get-folder-path '(:appdata :common-appdata)))
+-                 (t (mapcar 'parse-unix-namestring '("/usr/local/share/" "/usr/share/")))))))
++                 (t (mapcar 'parse-unix-namestring '("@@PREFIX@@/share/" "/usr/local/share/" "/usr/share/")))))))
+ 
+   (defun xdg-config-dirs (&rest more)
+     "The preference-ordered set of additional base paths to search for configuration files.


### PR DESCRIPTION
#### Description

Suggest for sbcl where it should also looks for installed packages.

This hardcoded path allows to start packagining lisp code to MacPorts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.0.1 14A400

right now MacPorts has only one lisp port: cl-ppcre, so, I've used it to test it as:
```lisp
(require :asdf)
(require :cl-ppcre)
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->