### PR TITLE
openjdk17-graalvm: update to 22.3.0

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.2.0
+version      22.3.0
 revision     0
 
 description  GraalVM Community Edition based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java17-darwin-amd64-${version}
-    checksums    rmd160  447cfacab9fdc1357aad3d461658cf147172277c \
-                 sha256  b92b6f5f7f11282f20c8f8b94ea1c16d776cbadd7b254119836a7ace9f513b0d \
-                 size    259574942
+    checksums    rmd160  cc867360f8a4ee78f53befd071b1d0127ef56128 \
+                 sha256  422cd6abecfb8b40238460c09c42c5a018cb92fab4165de9691be2e3c3d0e8d1 \
+                 size    260752076
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-ce-java17-darwin-aarch64-${version}
-    checksums    rmd160  8fe8a28a14d8885df1a3493466f44f0a78c3e83d \
-                 sha256  cfbeb38cd707a330048ab2140cb185176201c5cb654df752fcb4bd95e899b4ec \
-                 size    256787870
+    checksums    rmd160  fa4e6707920d95ae417effff07a846cee96d18a6 \
+                 sha256  dfc0c8998b8d00fcca87ef1c866c6e4985fd20b0beba3021f9677f9b166dfaf8 \
+                 size    258085301
 }
 
 worksrcdir   graalvm-ce-java17-${version}
@@ -95,15 +95,15 @@ subport ${name}-native-image {
     if {${configure.build_arch} eq "x86_64"} {
         set jar_file native-image-installable-svm-java17-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  12063d0246ad5ce8e2ec1be96b3a85f15e1251e4 \
-                     sha256  a751d0c0dcdc7e06dd0166d731a482a6937f36a1b69ef62f9e9f443922e85861 \
-                     size    112202934
+        checksums    rmd160  8b1647a4e8df1a1c7dcefb8f7b3ed0f0a15d4532 \
+                     sha256  9ce13874e62877d3bbe3faa4a57fbbffc766fdc8191971e7b25de0226fe86598 \
+                     size    30512379
     } elseif {${configure.build_arch} eq "arm64"} {
         set jar_file native-image-installable-svm-java17-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  6bf4187f13883feeb8178ebc0249243a85f1c5b4 \
-                     sha256  c6584429fe443f5415a7ec0545072b069f2e10bef1dbd6e7cb7fdec6ddb89b62 \
-                     size    29367028
+        checksums    rmd160  046566633e75733ebaba341b8ccc4f4bb249cc03 \
+                     sha256  b6e44cb03f560bb43db1fd0aa862af36ba1df6717765920d91c18519712adfe9 \
+                     size    30420657
     }
 
     set java_home ${target}/Contents/Home


### PR DESCRIPTION
#### Description

Update to GraalVM 22.3.0 based on OpenJDK 17.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?