### PR TITLE
openjdk11-graalvm: update to 22.3.0

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.2.0
+version      22.3.0
 revision     0
 
 description  GraalVM Community Edition based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java11-darwin-amd64-${version}
-    checksums    rmd160  152b654b107058bb1e9a4b561210ed28f960d1d7 \
-                 sha256  3c6aca6faefa9e1f73de45fc56cc07d6f7864f63ce0b95148002dadb8f78cd86 \
-                 size    253271371
+    checksums    rmd160  c0c8bc78bea75f7b8dec958ede569d1ad0263d37 \
+                 sha256  b8b39d6a3e3a9ed6348c2776ff071fc64ca90f98999ee846e6ca7e5fdc746a8b \
+                 size    254057238
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-ce-java11-darwin-aarch64-${version}
-    checksums    rmd160  99b80b02754a9ea7cd5bc5165150069272ffe656 \
-                 sha256  ee513cec2ef7b34ae6fbb8a3015c227ab2a24bfb2771c16152f15a1846df01f4 \
-                 size    248090327
+    checksums    rmd160  0e8e04f543c80044eceac29066522c0d3c5b18f8 \
+                 sha256  c9657e902c2ba674931c3cf233a38c4de3d5186ae5d70452f9df75ac0c4cacff \
+                 size    249005669
 }
 
 worksrcdir   graalvm-ce-java11-${version}
@@ -95,15 +95,15 @@ subport ${name}-native-image {
     if {${configure.build_arch} eq "x86_64"} {
         set jar_file native-image-installable-svm-java11-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  b484f8c9b78afe5230a1c712a2c2e83728994906 \
-                     sha256  de9bf830d000a54934a01149691a9a8d4ef6e33414776abd14f95c65b149c908 \
-                     size    110346461
+        checksums    rmd160  a24346538f1be6ae1fcde9b4c050cec01af22828 \
+                     sha256  00fe13c42813f581955eb35370bb8409ba17c7fdc83971d000baf695be2a0cb5 \
+                     size    28340748
     } elseif {${configure.build_arch} eq "arm64"} {
         set jar_file native-image-installable-svm-java11-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  30811497def96c32a75940616a98efd4f14870ca \
-                     sha256  aba76d671017f93cdaae5102607d0bc7a1398adc5de8a4b1e308fa366d5983f9 \
-                     size    27717768
+        checksums    rmd160  00a17b9ea645aadbe57c9785b5fd063bfb2d8d86 \
+                     sha256  dd9f91a970c7270b3f7fe8e711ba1ae081d34ed433c75f2bb0459aaf19e0fbe7 \
+                     size    28417062
     }
 
     set java_home ${target}/Contents/Home


### PR DESCRIPTION
#### Description

Update to GraalVM 22.3.0 based on OpenJDK 11.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?