### PR TITLE
openjdk19-graalvm: new submission

### DIFF
--- a/java/openjdk19-graalvm/Portfile
+++ b/java/openjdk19-graalvm/Portfile
@@ -1,0 +1,135 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk19-graalvm
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://github.com/graalvm/graalvm-ce-builds/releases
+supported_archs  x86_64 arm64
+
+version      22.3.0
+revision     0
+
+set openjdk_major 19
+
+description  GraalVM Community Edition based on OpenJDK ${openjdk_major}
+long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
+                 JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
+
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     graalvm-ce-java${openjdk_major}-darwin-amd64-${version}
+    checksums    rmd160  0c1a4ea206b5ad10114dba876c98951a1641ced9 \
+                 sha256  f3e5e9637bb3df68f59269bfdc98278cf518361384a06a399d784e0a641ebd2c \
+                 size    268362893
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     graalvm-ce-java${openjdk_major}-darwin-aarch64-${version}
+    checksums    rmd160  f06cdb7f114f035e2063927196965235dc28834f \
+                 sha256  01850d79359cf2cdee72fdf80fa7fe789823fcb4a50fd3d04bdf5b94f5c9fe55 \
+                 size    266075348
+}
+
+worksrcdir   graalvm-ce-java${openjdk_major}-${version}
+
+homepage     https://www.graalvm.org
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"
+
+subport ${name}-native-image {
+    depends_lib        port:${name}
+    description        Native Image component for GraalVM
+    long_description   ${description}
+
+    if {${configure.build_arch} eq "x86_64"} {
+        set jar_file native-image-installable-svm-java${openjdk_major}-darwin-amd64-${version}.jar
+        distfiles    ${jar_file}
+        checksums    rmd160  d3ef22aa045f8bd0756afe60c9a7e0d28cdafba0 \
+                     sha256  3b81d7ef58b46a18ae1f3f3daed0e94555ab4eb3a014cfe037f0b6f6b528ea29 \
+                     size    31174308
+    } elseif {${configure.build_arch} eq "arm64"} {
+        set jar_file native-image-installable-svm-java${openjdk_major}-darwin-aarch64-${version}.jar
+        distfiles    ${jar_file}
+        checksums    rmd160  4f9221037929d4f03fe260af343fde919295ca90 \
+                     sha256  e0aeddc82ee0667314b69cf5232059c82607e43ae1b6eb0b1c9a5e0b3ea73678 \
+                     size    31297315
+    }
+
+    set java_home ${target}/Contents/Home
+
+    extract {}
+
+    destroot {
+        xinstall -d -m 0755 ${destroot}${prefix}/share/java/${subport}
+        file copy ${distpath}/${jar_file} ${destroot}${prefix}/share/java/${subport}
+    }
+
+    post-activate {
+        # Graal Updater doesn't signal errors if the component is already installed.
+        # Unfortunately, we require root privileges to invoke Graal Updater.
+        system "sudo ${java_home}/bin/gu -L install ${prefix}/share/java/${subport}/${jar_file}"
+    }
+
+    post-deactivate {
+        # This helps prevent breakage if the user removed native-image themselves
+        # and wants to deactivate or uninstall this port.
+        if {[regexp {(?i)native-image} [exec ${java_home}/bin/gu list] match]} {
+            system "sudo ${java_home}/bin/gu remove native-image"
+        }
+    }
+
+    notes "The Native Image component of GraalVM has been installed for you"
+}


### PR DESCRIPTION
#### Description

New port for GraalVM 22.3.0 based on OpenJDK 19.

###### Tested on

macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?