### PR TITLE
google-cloud-sdk: update to 407.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             406.0.0
+version             407.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4b3aad5c54a982cd09ebc9f97902f909d490b967 \
-                    sha256  aa5f85bb4a087d77b5651dd968442b7a18ca4ce46387b633906ad4828212874e \
-                    size    109590151
+    checksums       rmd160  6f270d5b1bffe1acf21a4994acdbb3a6187e3961 \
+                    sha256  f3dcb35c4dd390c47559ef9055be90117a6affb0fb461450fc61682328d50c77 \
+                    size    109655356
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  25d0ff286aa05bd71db4e939098c48c0666ab4e0 \
-                    sha256  e2da841066c7678d7ed723fd612234c9afe7bd7a38056e456157b618cb54bf45 \
-                    size    98560566
+    checksums       rmd160  fe862153995915825118e45b4aef55e45158c650 \
+                    sha256  c79e98ca75204b7b043388c1617f6362233557a6c327ba37e10233cf31afcb81 \
+                    size    98624658
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e48a4cd8e13fc1dd26000cf6f0b76b4ae2346c0f \
-                    sha256  0062810694941abf453e8616b48182fa8f1379d0d09a74a2ac725ad94185f861 \
-                    size    96977934
+    checksums       rmd160  2d141ec385ee90f8afa3e04cb89c0376b690982b \
+                    sha256  f72f96987bdf87da77e7649c8564fa16d9c727e39833d7b7a74fabf5c984faa6 \
+                    size    97037070
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 407.0.0.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?