### PR TITLE
spring-boot-cli: update to 2.7.5

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,11 +4,11 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.7.4
+version         2.7.5
 revision        0
 
 categories      java
-platforms       darwin
+platforms       {darwin any}
 maintainers     {breun.nl:nils @breun} openmaintainer
 license         Apache-2
 supported_archs noarch
@@ -30,9 +30,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  c6969eeee3cfe4a64480980f411bf0dc2d608a5d \
-                sha256  5609f3be7f6a2f55dec7b27fa8aadc239d84ea3f9be45c66bf9c32400d06ca64 \
-                size    14328245
+checksums       rmd160  e78d545987f997eb0109e765891bec8aad6b6593 \
+                sha256  a34052b0da3946671a1805a1ce8a747d16e812a90cd19f1a59b4d1e812d4035b \
+                size    14328402
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.7.5.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?