### PR TITLE
maxima: update to 5.46.0

### DIFF
--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -35,14 +35,14 @@ depends_run     port:rlwrap \
 subport maxima-devel {
     conflicts   maxima
 
-    # git describe --tags : branch-5_43-base-278-gd806e84c7
-    # Date:  Sun Jan 26 20:10:05 2020 -0800
-    # commit 8b2da334e1f6c6b56d90cf3e00c2d67274fa6550
-    version     5.43-dev-20200126
-    revision    28
+    # git describe --tags : branch-5_46-base-480-g5b42cccfd
+    # Date:  Sat Oct 29 16:24:21 2022 +0000
+    # commit 5b42cccfd9eee54d0458d8f4e63e6b44c55d48a1
+    version     5.46-dev-20221029
+    revision    0
     fetch.type  git
     git.url     https://git.code.sf.net/p/maxima/code
-    git.branch  d806e84c719a9fcf023f8829535f593ce9bb7d0c
+    git.branch  5b42cccfd9eee54d0458d8f4e63e6b44c55d48a1
 
     use_autoreconf  yes
 
@@ -52,14 +52,14 @@ subport maxima-devel {
 if {${subport} eq ${name}} {
     conflicts   maxima-devel
 
-    version     5.45.1
-    revision    10
+    version     5.46.0
+    revision    0
     # get the source tarball from sourceforge.
     master_sites    sourceforge:project/maxima/Maxima-source/${version}-source
 
-    checksums   rmd160  41e6282961e7541573115a7d3855896c2b4d70c8 \
-                sha256  fe9016276970bef214a1a244348558644514d7fdfaa4fc8b9d0e87afcbb4e7dc \
-                size    39951932
+    checksums   rmd160  d41d004ef5c1d53f21d4427c4926d04b7d6b60a1 \
+                sha256  7390f06b48da65c9033e8b2f629b978b90056454a54022db7de70e2225aa8b07 \
+                size    47492457
 
     livecheck.regex     {<title>.*/Maxima-source/(.*)-source/maxima.*</title>}
 }

--- a/math/maxima/files/no-xmaxima.patch
+++ b/math/maxima/files/no-xmaxima.patch
@@ -1,19 +1,17 @@
---- Makefile.in.orig	2016-12-11 00:11:57.000000000 -0500
-+++ Makefile.in	2017-03-06 09:43:05.000000000 -0500
-@@ -101,8 +101,8 @@
+--- Makefile.in.orig	2022-04-13 07:06:15.000000000 +0200
++++ Makefile.in	2022-10-29 17:45:05.000000000 +0200
+@@ -98,7 +98,7 @@
  am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
   configure.lineno config.status.lineno
  mkinstalldirs = $(install_sh) -d
 -CONFIG_CLEAN_FILES = maxima-local xmaxima-local maxima.spec maxima.iss \
--	doc/man/ru/maxima.1 interfaces/xmaxima/Tkmaxima/Header.tcl
 +CONFIG_CLEAN_FILES = maxima-local maxima.spec maxima.iss \
-+	doc/man/ru/maxima.1
+ 	interfaces/xmaxima/Tkmaxima/Header.tcl
  CONFIG_CLEAN_VPATH_FILES =
  AM_V_P = $(am__v_P_@AM_V@)
- am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
---- interfaces/Makefile.in.orig	2016-12-11 00:11:58.000000000 -0500
-+++ interfaces/Makefile.in	2017-03-06 09:46:26.000000000 -0500
-@@ -322,8 +322,7 @@
+--- interfaces/Makefile.in.orig	2022-04-13 07:06:16.000000000 +0200
++++ interfaces/Makefile.in	2022-10-29 17:43:14.000000000 +0200
+@@ -318,8 +318,7 @@
  win32 = @win32@
  win64 = @win64@
  win64_installer = @win64_installer@

--- a/math/maxima/files/src_maxima.in.patch
+++ b/math/maxima/files/src_maxima.in.patch
@@ -1,6 +1,6 @@
---- src/maxima.in.orig	2016-05-13 00:59:30.000000000 -0400
-+++ src/maxima.in	2017-03-06 09:39:58.000000000 -0500
-@@ -207,7 +207,7 @@
+--- src/maxima.in.orig	2021-05-16 01:20:53.000000000 +0200
++++ src/maxima.in	2022-10-29 17:07:55.000000000 +0200
+@@ -245,7 +245,7 @@
    if [ -x "$MAXIMA_IMAGESDIR/binary-$MAXIMA_LISP/maxima" ]; then
      exec "$MAXIMA_IMAGESDIR/binary-$MAXIMA_LISP/maxima" --noinform $MAXIMA_LISP_OPTIONS --end-runtime-options --eval '(cl-user::run)' --end-toplevel-options "$@"
    else


### PR DESCRIPTION
#### Description

Update maxima to 5.46.0.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

macOS 10.13.6 17G14042 x86_64
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
