### PR TITLE
New port: ddrescueview

### DIFF
--- a/sysutils/ddrescueview/Portfile
+++ b/sysutils/ddrescueview/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem 1.0
+
+name            ddrescueview
+version         0.4.5
+revision        0
+categories      sysutils aqua
+license         GPL-2
+maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
+description     Graphical viewer for GNU ddrescue log files.
+
+long_description \
+                This small tool allows the user to graphically examine ddrescue's log \
+                files in a user friendly GUI application. The Main window displays a \
+                block grid with each block's color representing the block types it \
+                contains. Many people know this type of view from defragmentation \
+                programs. The program is written in Object Pascal using the Lazarus IDE.
+
+homepage        https://sourceforge.net/projects/${name}
+master_sites    sourceforge:${name}/Test%20builds/v${version}/
+distname        ${name}-source-${version}
+use_xz          yes
+
+checksums       rmd160  aca84a816122891b4c824f02a27b2cf2da64908b \
+                sha256  57383c394e62612ce2a799438b00c6e3c465c31f9ba940e077f624e2e7028465 \
+                size    211184
+
+depends_build   port:lazarus port:makeicns
+
+patch {
+# remove incorrect linux linker options
+    reinplace "s|-z relro --as-needed||g" source/ddrescueview.lpi
+}
+
+use_configure   no
+
+build {
+    system -W ${worksrcpath}/source "lazbuild ddrescueview.lpi"
+    system -W ${worksrcpath}/source "makeicns -in ddrescueview.ico -out ddrescueview.icns"
+# patch the app
+    delete ${worksrcpath}/source/ddrescueview.app/Contents/MacOS/ddrescueview
+    move ${worksrcpath}/source/ddrescueview ${worksrcpath}/source/ddrescueview.app/Contents/MacOS/
+    move ${worksrcpath}/source/ddrescueview.icns ${worksrcpath}/source/ddrescueview.app/Contents/Resources/
+    reinplace "s|English|English</string> <key>CFBundleIconFile</key> <string>ddrescueview|g" ${worksrcpath}/source/ddrescueview.app/Contents/Info.plist
+}
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/ddrescueview
+    move ${worksrcpath}/source/ddrescueview.app ${destroot}${prefix}/share/ddrescueview
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/ddrescueview
+    xinstall -m 644 {*}[glob ${worksrcpath}/*.txt] ${destroot}${prefix}/share/doc/ddrescueview
+}
+
+post-destroot {
+    ln -s ${prefix}/share/ddrescueview/ddrescueview.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description

ddrescueview is a graphical viewer for GNU ddrescue log files. It is created with the Object Pascal IDE lazarus.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?   (Port has no test)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
