### PR TITLE
openjdk11-microsoft: fix checksums

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  278b7d8bf8130fa2c00ada843e74a069d16b15b2 \
-                 sha256  ae4da8381f9bd27e7a9f2a01083eb524290d480aed1dc239c477f6f2f525e7b0 \
-                 size    187070226
+    checksums    rmd160  2fc1a89b2310905e0891bb2b1519c8df86998ab7 \
+                 sha256  22697e9bbf3135c0ef843e7f371fe563ea948c6d464dfc532a7995fe32aebb09 \
+                 size    187094964
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  6705543351c5b55963210802f68c3626e2170d49 \
-                 sha256  46912c2f0ba11595b54b1c5cf6e9ef97538729e4ffb26f462fca99615f26c44e \
-                 size    184693905
+    checksums    rmd160  feb696c4ba65ea42b68bb578e5e2de7b41e56669 \
+                 sha256  c50a20ca8764a5aa54dc0a0cf681d891dadbdccc1051792806d797206d59ba34 \
+                 size    184695872
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Fix checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?