### PR TITLE
openjdk17: update to 17.0.5

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk17
 # https://github.com/openjdk/jdk17u/tags
-version             17.0.4.1
-set build 1
+version             17.0.5
+set build 8
 revision            0
 categories          java devel
 platforms           darwin
@@ -19,9 +19,9 @@ homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  c7de36c4dee6cd8006eb8d30539df0ae1028d319 \
-                    sha256  2164a1e2a426c0353b80817f83ee85f16f7fc9ce47bc0ff5024e491616a1cd24 \
-                    size    104892822
+checksums           rmd160  babea0fc04402a066cf04680f285d2f530a91789 \
+                    sha256  6717fbf68472e9dca520998504a25ad5cfaa610d0066cad169bb7b78a108fbfc \
+                    size    105064912
 
 depends_lib         port:freetype
 depends_build       port:autoconf \


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.5.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?