### PR TITLE
openjdk11: update to 11.0.17

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 name                openjdk11
 # https://github.com/openjdk/jdk11u/tags
 # remove 'jdk-' from the latest tag without '-ga' that has commit that corresponds to the latest tag with '-ga'
-version             11.0.16.1
-set build 1
+version             11.0.17
+set build 8
 revision            0
 categories          java devel
 platforms           darwin
@@ -20,9 +20,9 @@ homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  22919c59d4f3561b7e42cbb35c13e7ca91701620 \
-                    sha256  72eae6ec11a0f04dbe2a18d314cbc8cd0aa64da8dd4709f0aea3d5c0a536e931 \
-                    size    123137897
+checksums           rmd160  056241e275817cca40aeb315b12a2ea6d73e38d6 \
+                    sha256  32488930787e3c8a3dcc1b77b52efa2af19772302145e64fa17676dd12acc0d6 \
+                    size    123287943
 
 depends_lib         port:freetype
 depends_build       port:autoconf \


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.17.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?