### PR TITLE
openjdk13: update to 13.0.13

### DIFF
--- a/java/openjdk13/Portfile
+++ b/java/openjdk13/Portfile
@@ -5,24 +5,24 @@ PortSystem          1.0
 name                openjdk13
 # https://github.com/openjdk/jdk13u/tags
 # remove 'jdk-' from the latest tag without '-ga' that has commit that corresponds to the latest tag with '-ga'
-version             13.0.12
-set build 4
+version             13.0.13
+set build 5
 revision            0
 categories          java devel
 platforms           darwin
 supported_archs     x86_64
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
-description         Openjdk 13
-long_description    JDK 13 builds of Openjdk, the Open-Source implementation \
+description         OpenJDK 13
+long_description    JDK 13 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk13u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  dd2df2a54ed969b7678ae8e3a5b2a3348e303bda \
-                    sha256  cb22e3418da39ef60512b52a043216a453e36279defaaeb1b91463c31486ce79 \
-                    size    109318129
+checksums           rmd160  7379e843b56740a6d3619692c1c37210de86fb69 \
+                    sha256  7740ba43918b32cf15c6d712400006aae267a576fae85ffb6547c7cc2af69d09 \
+                    size    109415981
 
 depends_lib         port:freetype
 depends_build       port:autoconf \


### PR DESCRIPTION
#### Description

Update to OpenJDK 13.0.13.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?