### PR TITLE
openjdk15: update to 15.0.9

### DIFF
--- a/java/openjdk15/Portfile
+++ b/java/openjdk15/Portfile
@@ -4,24 +4,24 @@ PortSystem          1.0
 
 name                openjdk15
 # https://github.com/openjdk/jdk15u/tags
-version             15.0.8
-set build 4
+version             15.0.9
+set build 5
 revision            0
 categories          java devel
 platforms           darwin
 supported_archs     x86_64
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
-description         Openjdk 15
-long_description    JDK 15 builds of Openjdk, the Open-Source implementation \
+description         OpenJDK 15
+long_description    JDK 15 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk15u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  a4949e56b388c2bc78d9913d9e943a522622cc11 \
-                    sha256  391d92a99148e6cc29e461088faada0ee2d97ac44ddc52ce8c48998174eb33f1 \
-                    size    102192055
+checksums           rmd160  93b7381bb897932208d1832618ef78219559f38b \
+                    sha256  e6b8a4a9e654b1db940890adbdb5fa85063f5c4e427fbef0e4621ce000f58cd9 \
+                    size    102311583
 
 patchfiles          patch-openjdk15-build1.diff
 depends_lib         port:freetype


### PR DESCRIPTION
#### Description

Update to OpenJDK 15.0.9.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?