### PR TITLE
openjdk8: update to 8u352

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -9,8 +9,8 @@ name                openjdk8
 # Tags: https://github.com/openjdk/jdk8u/tags
 # remove 'jdk' from the latest tag without '-ga' that has commit that corresponds to the latest tag with '-ga'
 set major 8
-set update 345
-set build 01
+set update 352
+set build 08
 version             ${major}u${update}
 revision            0
 categories          java devel
@@ -25,9 +25,9 @@ homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk8u/archive/refs/tags/
 distname            jdk${major}u${update}-b${build}
 
-checksums           rmd160  a5f2ee5ee3db4b42b5640c3364a026523a0af8c7 \
-                    sha256  0b7cd73c6ad6c07cbcdd4b37559b8a49a5d43be2c8e2b922c41d4761108779c4 \
-                    size    88179096
+checksums           rmd160  27a2974269ef605d45f0332098c6012c0809b703 \
+                    sha256  eee2286a432c1c612aae9b4d97c5c10f4dd6d58f29b84d67c2cd982a192202c8 \
+                    size    87952054
 
 patchfiles          0001-8181503-Can-t-compile-hotspot-with-c-11.patch \
                     0002-Support-XCode-3-14.patch \


### PR DESCRIPTION
#### Description

Update to OpenJDK 8u352.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?