### PR TITLE
qt4-mac: enforce deployment target < 13

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -54,6 +54,19 @@ platform darwin 10 {
     }
 }
 
+# the ATSFont* functions are being removed from MacOS. They are still available using
+# the MacOSX13.sdk if the deployment_target is set to 12 or less.
+# they are to be removed from the MacOSX14.sdk
+platform darwin {
+    if {${os.version} > 21} {
+
+        # TODO: will have to also ensure (and force?) SDK 13.x or less
+
+        macosx_deployment_target 12.0
+    }
+}
+
+
 # find a way to specify the OS MINOR version.  For OSX 10.X, this
 # value will be X.  The type is this variable is integer, so we can
 # use "==" and so forth for comparison.
@@ -413,15 +426,12 @@ post-extract {
         ${worksrcpath}/src/3rdparty/javascriptcore/VERSION.txt
 }
 
-# error out if trying to build on a new OSX version (> 11.0).
-
 platform darwin {
     if { ( ${MAJOR} == 10 && ${MINOR} > 15 ) || ${MAJOR} > 12 } {
-        # This project needs to be updated to build with clang++ against libc++
         depends_lib
         depends_run
         pre-fetch {
-            ui_error "$name does not currently build on Mac OS X later than 11 'Big Sur'."
+            ui_error "$name does not currently build with a deployment target > 12."
             error "unsupported platform"
         }
     }


### PR DESCRIPTION
the ATSFont* functions are being removed from macOS. They are still available in MacOSX13.sdk if the deployment target is set to < 13.

They are to be removed from MacOSX14.sdk.

closes: https://trac.macports.org/ticket/66114

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0 22A380 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
