### PR TITLE
Update to LaTeXML: Add dependency on Pod::Parser, since it is no-longer core in Perl 5.34

### DIFF
--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -5,7 +5,7 @@ PortGroup           texlive 1.0
 
 name                LaTeXML
 version             0.8.6
-revision            1
+revision            2
 checksums           rmd160  3f71105b7da576ab73e714430626888080716602 \
                     sha256  9529c651b67f5e8ddef1fd1852f974e756a17b711c46d4118f0677ad0e6e9bb1 \
                     size    13776498
@@ -17,6 +17,7 @@ long_description \
 
 # Written in Perl, but it is an application, not just modules
 PortGroup           perl5 1.0
+
 perl5.branches      5.34
 perl5.setup         ${name} ${version}
 perl5.link_binaries_suffix
@@ -38,6 +39,7 @@ depends_lib-append \
         port:p${perl5.major}-json-xs \
         port:p${perl5.major}-libwww-perl \
         port:p${perl5.major}-parse-recdescent \
+        port:p${perl5.major}-pod-parser \
         port:p${perl5.major}-text-unidecode \
         port:p${perl5.major}-time-hires \
         port:p${perl5.major}-uri \


### PR DESCRIPTION
#### Description

This PR adds a dependency on Pod::Parser, since its modules are no-longer included in the core of Perl 5.34.

Fixes  [Trac](https://trac.macports.org/ticket/66005) 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.1
Xcode 14.0.1 / Command Line Tools 14.0.0.0.1.1661618636

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
