### PR TITLE
flux: update to 0.36.0

### DIFF
--- a/sysutils/flux/Portfile
+++ b/sysutils/flux/Portfile
@@ -3,12 +3,12 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/fluxcd/flux2 0.35.0 v
+go.setup                github.com/fluxcd/flux2 0.36.0 v
 name                    flux
 
-checksums               rmd160  3ad324580a2d531035da420caa99a0e18a404236 \
-                        sha256  bed465c49a6c682f17564802b10dd21a24d653be1afc585e84f3af572c0bd740 \
-                        size    403052
+checksums               rmd160  627b7cd812f94a3f58fd21bf37abcd15b6036aec \
+                        sha256  f8b6b683b98e0fde0af15c7e1d095e49d95b77ee582905490e2f3fde0658f5c0 \
+                        size    388701
 
 homepage                https://fluxcd.io/
 description             Flux CLI


### PR DESCRIPTION
#### Description
flux: update to 0.36.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
