### PR TITLE
atool: use a fixed path to perl5 in shebang

### DIFF
--- a/archivers/atool/Portfile
+++ b/archivers/atool/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                atool
 version             0.39.0
+revision            1
 categories          archivers
 platforms           darwin
 license             GPL-3
@@ -30,6 +31,11 @@ depends_build       port:gsed
 depends_lib         path:bin/perl:perl5
 
 configure.perl      ${prefix}/bin/perl
+
+post-build {
+    # use symlink but not resolved real path of perl5 in shebang
+    reinplace -E "1s|^#!.*$|#!${prefix}/bin/perl5 -w|" ${worksrcpath}/atool
+}
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

`atools` depends on `perl5`. The pre-built `atool` has shebang set as `/opt/local/bin/perl5.xx`, which is the realpath resolved from `/opt/local/bin/perl5`. 

What about using the symlink `/opt/local/bin/perl5` as the shebang to avoid following problem?

```
❯ port info perl5
perl5 @5.34.1 (lang)
Sub-ports:            perl5.16, perl5.18, perl5.20, perl5.22, perl5.24, perl5.26,
                      perl5.28, perl5.30, perl5.32, perl5.34, perl5.36
Variants:             [+]perl5_34, perl5_36

Description:          Wrapper port for Perl 5.x
Homepage:             https://www.perl.org/

Library Dependencies: perl5.34
Platforms:            any
License:              (Artistic-1 or GPL)
Maintainers:          Email: mojca@macports.org, GitHub: mojca
                      Policy: openmaintainer

❯ sudo port install -vt atool
--->  Computing dependencies for atool
--->  Fetching archive for atool
--->  Attempting to fetch atool-0.39.0_0.darwin_18.x86_64.tbz2 from http://jog.id.packages.macports.org/macports/packages/atool
--->  Attempting to fetch atool-0.39.0_0.darwin_18.x86_64.tbz2.rmd160 from http://jog.id.packages.macports.org/macports/packages/atool
--->  Installing atool @0.39.0_0
--->  Activating atool @0.39.0_0
--->  Cleaning atool
--->  Scanning binaries for linking errors
--->  No broken files found.
--->  No broken ports found.

❯ aunpack
zsh: /opt/local/bin/aunpack: bad interpreter: /opt/local/bin/perl5.28: no such file or directory
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
