### PR TITLE
lens: update to 6.1.14

### DIFF
--- a/sysutils/lens/Portfile
+++ b/sysutils/lens/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        lensapp lens 6.1.10 v
+github.setup        lensapp lens 6.1.14 v
 github.tarball_from archive
 revision            0
 
@@ -24,9 +24,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {ajhall.us:macports @ajhall} \
                     openmaintainer
 
-checksums           rmd160  4e58823e9175ddf5787612c468be67ed968e725f \
-                    sha256  afa4748424b992ea3369d910e34721592b7a57352a718882fac2c99bb2c140c7 \
-                    size    8540098
+checksums           rmd160  e83f943469d40d27da3c9a118ec343ffd1541591 \
+                    sha256  5cdbd9c8f894afd9e338c3c751787e16a37b79541804bf8c3f7f74718e81da77 \
+                    size    8548310
 
 depends_build       path:bin/npm:npm8 \
                     path:/bin/node:nodejs16 \


### PR DESCRIPTION
#### Description
lens: update to 6.1.14

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
