### PR TITLE
git-extras: update to version 6.5.0

### DIFF
--- a/devel/git-extras/Portfile
+++ b/devel/git-extras/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            tj git-extras 6.4.0
+github.setup            tj git-extras 6.5.0
 
-checksums               rmd160  c9ddca421f9040bd911b149d04476d1fad0e893f \
-                        sha256  3d21a227195a5cf4111a3429e702eb25f48d4a3b02d279b5c8c07fa4863c9f23 \
-                        size    163556
+checksums               rmd160  3f6d2a0216721c0cf3bf9cee6eea244d6eaf3728 \
+                        sha256  844cd29f20d1ee07b8822ec54a42199ac958bcdc2e02cf25b86ba20f66c88597 \
+                        size    167023
 
 maintainers             {grimreaper @grimreaper} openmaintainer
 platforms               darwin


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.6.1 21G217 arm64
Xcode 13.4.1 13F100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?