### PR TITLE
ccache: add missing limits.h for PATH_MAX

### DIFF
--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -35,8 +35,10 @@ homepage            https://ccache.dev
 github.tarball_from releases
 use_xz              yes
 
+patchfiles-append       patch-limits.diff
+
 platform darwin 8 {
-    patchfiles-append  patch-ccache-no-posix-tiger.diff
+    patchfiles-append   patch-ccache-no-posix-tiger.diff
 }
 
 compiler.c_standard 1999

--- a/devel/ccache/files/patch-limits.diff
+++ b/devel/ccache/files/patch-limits.diff
@@ -1,0 +1,25 @@
+# https://github.com/ccache/ccache/commit/c33609aa7df381451eb9bdf203f185972acdc21b
+
+--- src/Util.cpp.orig	2022-10-23 01:48:41.000000000 +0800
++++ src/Util.cpp	2022-11-01 17:30:45.000000000 +0800
+@@ -35,6 +35,8 @@
+ #include <util/path.hpp>
+ #include <util/string.hpp>
+ 
++#include <limits.h> // NOLINT: PATH_MAX is defined in limits.h
++
+ extern "C" {
+ #include "third_party/base32hex.h"
+ }
+
+--- src/MiniTrace.cpp.orig	2022-10-23 01:48:41.000000000 +0800
++++ src/MiniTrace.cpp	2022-11-01 17:37:30.000000000 +0800
+@@ -26,6 +26,8 @@
+ #include <core/wincompat.hpp>
+ #include <util/TimePoint.hpp>
+ 
++#include <limits.h> // NOLINT: PATH_MAX is defined in limits.h
++
+ #ifdef HAVE_UNISTD_H
+ #  include <unistd.h>
+ #endif


### PR DESCRIPTION
See: https://github.com/ccache/ccache/commit/c33609aa7df381451eb9bdf203f185972acdc21b

#### Description

Borrowed from upstream. Fixes build on PPC.
@ryandesign We need this patch though.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. I get this from `lint`, which is _unrelated to my change:_
```
Warning: Line 7 should be a newline (after PortGroup)
Error: Unknown dependency: perl
--->  1 errors and 1 warnings found.
```