### PR TITLE
libfaiss: depend on libomp only when building with Clang

### DIFF
--- a/math/libfaiss/Portfile
+++ b/math/libfaiss/Portfile
@@ -34,11 +34,13 @@ github.tarball_from archive
 
 compiler.cxx_standard   2011
 
-compiler.openmp_version 2.5
+if {[string match *clang* ${configure.compiler}]} {
+    compiler.openmp_version 2.5
 
-configure.ldflags-append \
+    configure.ldflags-append \
                     -L${prefix}/lib/libomp \
                     -lomp
+}
 
 configure.args-append \
                     -DFAISS_ENABLE_GPU:BOOL=OFF \


### PR DESCRIPTION
#### Description

The port builds fine with GCC, which automatically adds dependency on its `libgomp`. Only Clang needs to depend on `libomp`.
This fixes the build on systems where Clang is unavailable – all PPC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
