### PR TITLE
asciidoctor: update to ruby31, fixes PPC

### DIFF
--- a/textproc/asciidoctor/Portfile
+++ b/textproc/asciidoctor/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           ruby 1.0
 
-ruby.setup          asciidoctor 2.0.18 gem {} rubygems ruby30
+ruby.setup          asciidoctor 2.0.18 gem {} rubygems ruby31
 name                asciidoctor
 revision            0
 
@@ -11,7 +11,6 @@ revision            0
 ruby.link_binaries_suffix
 
 categories          textproc
-platforms           darwin
 supported_archs     noarch
 
 license             MIT


### PR DESCRIPTION
#### Description

This PR is motivated by fixing `asciidoctor` and `ccache` for PPC, where we currently have `ruby31`, but not `ruby30`.
If there are objections to updating `asciidoctor` to `ruby31`, there are two alternatives:

1. Update it only for ppc/ppc64, leaving everything else at `ruby30`.
2. Fix `ruby30` (possible, but a more painful option).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
