### PR TITLE
igraph: Xcode 14.1 compatibility

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -52,7 +52,8 @@ configure.args-append   -DUSE_CCACHE=OFF \
                         -DIGRAPH_USE_INTERNAL_GMP=OFF \
                         -DIGRAPH_USE_INTERNAL_LAPACK=OFF \
                         -DIGRAPH_USE_INTERNAL_PLFIT=ON \
-                        -DIGRAPH_OPENMP_SUPPORT=OFF
+                        -DIGRAPH_OPENMP_SUPPORT=OFF \
+                        -DIGRAPH_WARNINGS_AS_ERRORS=OFF
 
 pre-configure {
     # Link to chosen BLAS/LAPACK

--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -70,6 +70,7 @@ if {${name} ne ${subport}} {
             -DIGRAPH_USE_INTERNAL_PLFIT=ON
             -DIGRAPH_OPENMP_SUPPORT=OFF
             -DBLA_VENDOR=Apple
+            -DIGRAPH_WARNINGS_AS_ERRORS=OFF
         }
 
         build.env-append        IGRAPH_CMAKE_EXTRA_ARGS=[join $extra_cmake_args]


### PR DESCRIPTION
#### Description

This is a quick pre-emptive fix for igraph to allow it to compile with the Xcode 14.1 toolchain on Ventura, for whenever MacPorts starts using Xcode 14.1. A proper fix is [made upstream](https://github.com/igraph/igraph/commit/74df89a2a76b40803b261c32d7d18589b758f457) and will be in the next igraph version.

In short, the problem was that the igraph build system treats warnings as errors by default and since Xcode 14.1, Apple Clang complains about any use of `sprintf()`. This PR merely disables treating warning as errors, so no revbump needed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Only indirectly tested, change is minor.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
