### PR TITLE
openssl11: Update to 1.1.1s

### DIFF
--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -6,14 +6,8 @@ PortGroup           muniversal 1.0
 set short_v         1.1
 name                openssl[string map {. {}} $short_v]
 
-# The revision of the openssl shim port should be bumped whenever
-# the version or revision is changed here.
-version             ${short_v}.1r
+version             ${short_v}.1s
 revision            0
-
-# Please revbump these ports when updating OpenSSL.
-#  - freeradius (#43461)
-#  - openssh (#54990)
 
 categories          devel security
 platforms           darwin
@@ -44,9 +38,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  c43cdd58466ebabc378f9280a43fb909938508e1 \
-                    sha256  e389352ae3d5ae4d38597bf8a54f1dcb6fb3c8b50f4fe58a94bb1bf7f85d82a0 \
-                    size    9868506
+checksums           rmd160  3f7e018ed07214ae4099f35a5205270cd7d19ee2 \
+                    sha256  c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa \
+                    size    9868981
 
 platform darwin 8 {
     # No Availability.h on Tiger


### PR DESCRIPTION
#### Description

Drop comments suggesting to revbump the openssl shim, freeradius, or openssh. The shim doesn't reference OpenSSL 1.1, and freeradius and openssh use 3.0, not 1.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
