### PR TITLE
openjdk19-temurin: update to 19.0.1

### DIFF
--- a/java/openjdk19-temurin/Portfile
+++ b/java/openjdk19-temurin/Portfile
@@ -5,7 +5,8 @@ PortSystem       1.0
 name             openjdk19-temurin
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+# See https://adoptium.net/supported-platforms/
+platforms        {darwin any} {darwin >= 16}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=19
 supported_archs  x86_64 arm64
 
-version      19
-set build    36
+version      19.0.1
+set build    10
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 19
@@ -25,27 +26,17 @@ master_sites https://github.com/adoptium/temurin19-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK19U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  ca5899f6c56a8452c9f68a4e54688cb3bd873f9d \
-                 sha256  6ee7e6b7efa083ef7a1f206807230a0c5c1ab79609b1b27e0c97211cb01c4556 \
-                 size    195195315
+    checksums    rmd160  93436c3f2a3bc3aa7a05889d0c11ac6e1f6142d3 \
+                 sha256  0d80a8787fa97f5fc2f0000a849b54f4d41c5b87726c29ea1de215e382c8380c \
+                 size    195454218
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK19U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  a2463c7b66e3dc11627c563a7c12586bf3d7dc2d \
-                 sha256  8ab27c4038dce4be7b0f73d3e4c6c9271f8f11e7e5d9c0a0bf37505986420ccf \
-                 size    185076247
+    checksums    rmd160  74085ee63ccf4c564a73cb52c418b6aa1412541e \
+                 sha256  2be4ffbf7c59b3148886b48ecf3f7d7edb7c745917ceae2a6be145a4678bf014 \
+                 size    185292307
 }
 
 worksrcdir   jdk-${version}+${build}
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 16} {
-    # See https://adoptium.net/supported-platforms/
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
-        return -code error
-    }
-}
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 19.0.1.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?