### PR TITLE
openjdk17-microsoft: update to 17.0.5

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk17-microsoft
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.4.1
-set build    1
+version      17.0.5
+set build    8
 revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  a9886b101c1153d899dcc5b1f2eb868d3a124095 \
-                 sha256  da2352bf73f26a2dbda4de187962163f809c43391fd672c0252308033cc1179d \
-                 size    187255412
+    checksums    rmd160  1a7b656ac5638063897b218e9ee455c38e101868 \
+                 sha256  45548b3788eb6f4e912412a0a2805f42ccee7ca1c67c4f7ae09887c0e16c50c1 \
+                 size    187548732
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  39c237acd197d0198ac4845a11a900afa3a7953f \
-                 sha256  29d9c48640818eb041a9a4cbf01ef48684f1fe4a591585b1631186693a131431 \
-                 size    177474164
+    checksums    rmd160  fd3e2effa227b1307c9b4ddede5de26b868675f6 \
+                 sha256  d14e4af5c175efdde2b71678a0cb012be5fceb8ae12db15273fd331b5e64073a \
+                 size    177713686
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.5.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?