### PR TITLE
openjdk11-microsoft: update to 11.0.17

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk11-microsoft
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.16.1
-set build    1
+version      11.0.17
+set build    8
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  2fc1a89b2310905e0891bb2b1519c8df86998ab7 \
-                 sha256  22697e9bbf3135c0ef843e7f371fe563ea948c6d464dfc532a7995fe32aebb09 \
-                 size    187094964
+    checksums    rmd160  797417ed510a8f91abfc6d0cb1c91ce6fe92994d \
+                 sha256  a73c26cf725d8b9b30847b4c7a7866d1277fe9609fef4b680c45151d6cbf04d1 \
+                 size    187377007
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  feb696c4ba65ea42b68bb578e5e2de7b41e56669 \
-                 sha256  c50a20ca8764a5aa54dc0a0cf681d891dadbdccc1051792806d797206d59ba34 \
-                 size    184695872
+    checksums    rmd160  9bff64e9eb638ea002cb582b41f6d4a006d72d3d \
+                 sha256  c3cfc900c2c186130bb598393f1fbb8f5f17613251a6ed3dec0e2281ee179d6e \
+                 size    184949284
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.17.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?