### PR TITLE
gtk4: fix older systems

### DIFF
--- a/gnome/gtk4/Portfile
+++ b/gnome/gtk4/Portfile
@@ -3,8 +3,10 @@
 PortSystem          1.0
 PortGroup           meson 1.0
 PortGroup           active_variants 1.1
-#PortGroup           legacysupport 1.1
+PortGroup           legacysupport 1.1
 
+# O_CLOEXEC
+legacysupport.newest_darwin_requires_legacy 10
 
 name                gtk4
 #conflicts           gtk4-devel
@@ -66,6 +68,8 @@ license_noconflict  gobject-introspection
 patchfiles-append   patch-docs-rst2man.diff
 
 patchfiles-append   patch-testsuite-python.diff
+
+patchfiles-append   patch-meson-dont-werror-on-missing-declarations.diff
 
 post-patch {
     reinplace "s|@@PYTHON_VERSION@@|${python_branch}|" \

--- a/gnome/gtk4/files/patch-meson-dont-werror-on-missing-declarations.diff
+++ b/gnome/gtk4/files/patch-meson-dont-werror-on-missing-declarations.diff
@@ -1,0 +1,14 @@
+GLIB uses the technique of defining the macro to nothing
+if it can't be used on a given compiler. But having this
+defined to nothing generates a Werror, so that can't work.
+
+--- meson.build.orig	2022-11-02 00:37:51.000000000 -0700
++++ meson.build	2022-11-02 00:38:13.000000000 -0700
+@@ -306,7 +306,6 @@
+     'int-to-pointer-cast',
+     'main',
+     'missing-braces',
+-    'missing-declarations',
+     'missing-prototypes',
+     'nonnull',
+     'pointer-to-int-cast',


### PR DESCRIPTION
gtk4 can't Werror on missing declarations, because GLIB defines macros to nothing based on compiler support, etc.

legacysupport is needed for missing defines, at least

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8

still need to test 10.6 to show it is fixed there, too

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
