### PR TITLE
google-cloud-sdk: update to 408.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             407.0.0
+version             408.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -16,24 +16,24 @@ long_description    Google Cloud SDK is a set of tools for Google Cloud Platform
                     products and services from the command-line. You can run these tools \
                     interactively or in your automated scripts.
 
-platforms           darwin
+platforms           {darwin any}
 supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6f270d5b1bffe1acf21a4994acdbb3a6187e3961 \
-                    sha256  f3dcb35c4dd390c47559ef9055be90117a6affb0fb461450fc61682328d50c77 \
-                    size    109655356
+    checksums       rmd160  fa307be06212ab2a46da775b876cb65a22a19c52 \
+                    sha256  2312a9a7a64f4080403d1b60b1ec6c546b90bc071f2b1e05f731841421413e41 \
+                    size    109677216
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  fe862153995915825118e45b4aef55e45158c650 \
-                    sha256  c79e98ca75204b7b043388c1617f6362233557a6c327ba37e10233cf31afcb81 \
-                    size    98624658
+    checksums       rmd160  b24940f11987f8350ab266734b1a7f08c93ecfe7 \
+                    sha256  810d7e111a732829574154a15905d5a9915947c93c468585c02a5549c3407257 \
+                    size    98645763
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  2d141ec385ee90f8afa3e04cb89c0376b690982b \
-                    sha256  f72f96987bdf87da77e7649c8564fa16d9c727e39833d7b7a74fabf5c984faa6 \
-                    size    97037070
+    checksums       rmd160  50780d9574699e9930a470ddf8a6f0ac6cc57a6a \
+                    sha256  999a8178d28de7baadac4d0aeb2d44804bbcfe1beaba502675bba76c27347cd7 \
+                    size    97062109
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 408.0.0.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?