### PR TITLE
dnscontrol: update to 3.21.0

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/StackExchange/dnscontrol 3.20.0 v
+go.setup            github.com/StackExchange/dnscontrol 3.21.0 v
 
-checksums           rmd160  a6cea0b57eeb7e8fc86faf320f0d5cb3385a26e1 \
-                    sha256  cd4cdbad7e3709f70c600fdfc8b1b0a49579dcd527af1560ebb1133d91a515d3 \
-                    size    2395297
+checksums           rmd160  1257815f1de4deca65ebe57bef2ffa7b6a138b80 \
+                    sha256  b88946116fd8ff0183da5e0436e0b9dead9ae239382f31e52fa65611b6509f63 \
+                    size    4961548
 
 homepage            https://stackexchange.github.io/dnscontrol/
 description         Synchronize your DNS to multiple providers from a simple DSL


### PR DESCRIPTION
#### Description
dnscontrol: update to 3.21.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
