### PR TITLE
llvm-10: fix build problem, Apple removed Python 2.x from the system

### DIFF
--- a/lang/llvm-10/Portfile
+++ b/lang/llvm-10/Portfile
@@ -287,7 +287,9 @@ if {[lsearch -exact $PortInfo(depends_build) port:cctools] != -1} {
 }
 
 # use the system python27 if present
-if {${os.platform} eq "darwin" && ${os.major} >= 11} {
+if {${os.platform} eq "darwin" && ${os.major} >= 22} {
+    set pythonfullpath   /usr/bin/python3
+} elseif {${os.platform} eq "darwin" && ${os.major} >= 11} {
     set pythonfullpath   /usr/bin/python2.7
 } else {
     set pythonfullpath   ${prefix}/bin/python2.7
@@ -537,7 +539,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/tools/scan-build/libexec/c++-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/scan-build
 
-            # pythonfullpath is set above, depending on presence of system python2.7
+            # pythonfullpath is set above, depending on presence of system python2.7 or python3
             reinplace "s|/usr/bin/env python|${pythonfullpath}|g" \
                  ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
 


### PR DESCRIPTION
according to https://www.macrumors.com/2022/01/28/apple-removing-python-2-in-macos-12-3/ Python 2.x got removed from macOS 12.3 (Monterey) https://support.apple.com/en-us/HT201260

Make it work with Ventura, based off of https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version it should be Darwin version 22.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0
Xcode Version 14.1 (14B47b) / Command Line Tools 14.1.0.0.1.1666437224

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
