### PR TITLE
libvpx, libvpx-devel: fix portfile code that breaks destroot on PPC

### DIFF
--- a/multimedia/libvpx-devel/Portfile
+++ b/multimedia/libvpx-devel/Portfile
@@ -64,7 +64,7 @@ configure.args      --enable-vp8 \
                     --enable-unit-tests
 
 platform darwin {
-    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+    if {${build_arch} in [list ppc ppc64]} {
         # disable a wrong kind of abi
         patchfiles-append      patch-vpx_ports.diff
         # with shared enabled the build fails
@@ -134,7 +134,7 @@ if {${universal_possible} && [variant_isset universal]} {
     # single-arch build
     
     # force the target: generic fix for PowerPC
-    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+    if {${configure.build_arch} in {ppc ppc64}} {
            configure.args-append --force-target=generic-gnu
     } else {
            configure.args-append --force-target=${configure.build_arch}-${os.platform}${os.major}-gcc

--- a/multimedia/libvpx-devel/Portfile
+++ b/multimedia/libvpx-devel/Portfile
@@ -68,6 +68,7 @@ platform darwin {
         # disable a wrong kind of abi
         patchfiles-append      patch-vpx_ports.diff
         # with shared enabled the build fails
+        # if shared is fixed, make sure to modify post-destroot block below
         configure.args-append  --disable-shared
     } else {
         configure.args-append  --enable-shared
@@ -157,14 +158,17 @@ if {${universal_possible} && [variant_isset universal]} {
 
 # shared library uses relative path in install name
 # override with absolute path
-post-destroot {
-    foreach f [glob ${destroot}${prefix}/lib/${my_name}.*.dylib] {
-        system "install_name_tool -id [string map [list ${destroot} ""] ${f}] ${f}"
-    }
-    foreach f [glob ${destroot}${prefix}/bin/*] {
-        system "install_name_tool -change \
-        [lindex [split [glob ${destroot}${prefix}/lib/${my_name}.*.dylib] "/"] end] \
-        [string map [list ${destroot} ""] [glob ${destroot}${prefix}/lib/${my_name}.*.dylib]] ${f}"
+# on PPC no shared lib is built presently, see above
+if {${build_arch} ni [list ppc ppc64]} {
+    post-destroot {
+        foreach f [glob ${destroot}${prefix}/lib/${my_name}.*.dylib] {
+            system "install_name_tool -id [string map [list ${destroot} ""] ${f}] ${f}"
+        }
+        foreach f [glob ${destroot}${prefix}/bin/*] {
+            system "install_name_tool -change \
+            [lindex [split [glob ${destroot}${prefix}/lib/${my_name}.*.dylib] "/"] end] \
+            [string map [list ${destroot} ""] [glob ${destroot}${prefix}/lib/${my_name}.*.dylib]] ${f}"
+        }
     }
 }
 

--- a/multimedia/libvpx-devel/Portfile
+++ b/multimedia/libvpx-devel/Portfile
@@ -67,6 +67,8 @@ platform darwin {
     if {${build_arch} in [list ppc ppc64]} {
         # disable a wrong kind of abi
         patchfiles-append      patch-vpx_ports.diff
+        # use static linking, until shared is fixed:
+        patchfiles-append      patch-static-linking.diff
         # with shared enabled the build fails
         # if shared is fixed, make sure to modify post-destroot block below
         configure.args-append  --disable-shared

--- a/multimedia/libvpx-devel/files/patch-static-linking.diff
+++ b/multimedia/libvpx-devel/files/patch-static-linking.diff
@@ -1,0 +1,38 @@
+--- libs.mk.orig	2022-11-12 18:02:53.000000000 +0800
++++ libs.mk	2022-11-12 20:01:26.000000000 +0800
+@@ -660,7 +660,7 @@
+ $(LIBVPX_TEST_BIN): $(TEST_LIBS)
+ $(eval $(call linkerxx_template,$(LIBVPX_TEST_BIN), \
+               $(LIBVPX_TEST_OBJS) \
+-              -L. -lvpx -lgtest $(extralibs) -lm))
++              libvpx.a libgtest.a $(extralibs) -lm))
+ 
+ ifneq ($(strip $(TEST_INTRA_PRED_SPEED_OBJS)),)
+ $(TEST_INTRA_PRED_SPEED_OBJS) $(TEST_INTRA_PRED_SPEED_OBJS:.o=.d): CXXFLAGS += $(GTEST_INCLUDES)
+@@ -670,7 +670,7 @@
+ $(TEST_INTRA_PRED_SPEED_BIN): $(TEST_LIBS)
+ $(eval $(call linkerxx_template,$(TEST_INTRA_PRED_SPEED_BIN), \
+               $(TEST_INTRA_PRED_SPEED_OBJS) \
+-              -L. -lvpx -lgtest $(extralibs) -lm))
++              libvpx.a libgtest.a $(extralibs) -lm))
+ endif  # TEST_INTRA_PRED_SPEED
+ 
+ ifeq ($(CONFIG_ENCODERS),yes)
+@@ -683,7 +683,7 @@
+ $(RC_INTERFACE_TEST_BIN): $(TEST_LIBS) libvpxrc.a
+ $(eval $(call linkerxx_template,$(RC_INTERFACE_TEST_BIN), \
+               $(RC_INTERFACE_TEST_OBJS) \
+-              -L. -lvpx -lgtest -lvpxrc $(extralibs) -lm))
++              libvpx.a libgtest.a libvpxrc.a $(extralibs) -lm))
+ endif  # RC_INTERFACE_TEST
+ endif  # CONFIG_ENCODERS
+ 
+@@ -696,7 +696,7 @@
+ $(SIMPLE_ENCODE_TEST_BIN): $(TEST_LIBS) libsimple_encode.a
+ $(eval $(call linkerxx_template,$(SIMPLE_ENCODE_TEST_BIN), \
+               $(SIMPLE_ENCODE_TEST_OBJS) \
+-              -L. -lsimple_encode -lvpx -lgtest $(extralibs) -lm))
++              libvpx.a libgtest.a libsimple_encode.a $(extralibs) -lm))
+ endif  # SIMPLE_ENCODE_TEST
+ 
+ endif  # CONFIG_UNIT_TESTS

--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -64,7 +64,7 @@ configure.args      --enable-vp8 \
                     --enable-unit-tests
 
 platform darwin {
-    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+    if {${build_arch} in [list ppc ppc64]} {
         # disable a wrong kind of abi
         patchfiles-append      patch-vpx_ports.diff
         # with shared enabled the build fails
@@ -134,7 +134,7 @@ if {${universal_possible} && [variant_isset universal]} {
     # single-arch build
     
     # force the target: generic fix for PowerPC
-    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+    if {${configure.build_arch} in {ppc ppc64}} {
            configure.args-append --force-target=generic-gnu
     } else {
            configure.args-append --force-target=${configure.build_arch}-${os.platform}${os.major}-gcc

--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -68,6 +68,7 @@ platform darwin {
         # disable a wrong kind of abi
         patchfiles-append      patch-vpx_ports.diff
         # with shared enabled the build fails
+        # if shared is fixed, make sure to modify post-destroot block below
         configure.args-append  --disable-shared
     } else {
         configure.args-append  --enable-shared
@@ -157,14 +158,17 @@ if {${universal_possible} && [variant_isset universal]} {
 
 # shared library uses relative path in install name
 # override with absolute path
-post-destroot {
-    foreach f [glob ${destroot}${prefix}/lib/${my_name}.*.dylib] {
-        system "install_name_tool -id [string map [list ${destroot} ""] ${f}] ${f}"
-    }
-    foreach f [glob ${destroot}${prefix}/bin/*] {
-        system "install_name_tool -change \
-        [lindex [split [glob ${destroot}${prefix}/lib/${my_name}.*.dylib] "/"] end] \
-        [string map [list ${destroot} ""] [glob ${destroot}${prefix}/lib/${my_name}.*.dylib]] ${f}"
+# on PPC no shared lib is built presently, see above
+if {${build_arch} ni [list ppc ppc64]} {
+    post-destroot {
+        foreach f [glob ${destroot}${prefix}/lib/${my_name}.*.dylib] {
+            system "install_name_tool -id [string map [list ${destroot} ""] ${f}] ${f}"
+        }
+        foreach f [glob ${destroot}${prefix}/bin/*] {
+            system "install_name_tool -change \
+            [lindex [split [glob ${destroot}${prefix}/lib/${my_name}.*.dylib] "/"] end] \
+            [string map [list ${destroot} ""] [glob ${destroot}${prefix}/lib/${my_name}.*.dylib]] ${f}"
+        }
     }
 }
 

--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -67,6 +67,8 @@ platform darwin {
     if {${build_arch} in [list ppc ppc64]} {
         # disable a wrong kind of abi
         patchfiles-append      patch-vpx_ports.diff
+        # use static linking, until shared is fixed:
+        patchfiles-append      patch-static-linking.diff
         # with shared enabled the build fails
         # if shared is fixed, make sure to modify post-destroot block below
         configure.args-append  --disable-shared

--- a/multimedia/libvpx/files/patch-static-linking.diff
+++ b/multimedia/libvpx/files/patch-static-linking.diff
@@ -1,0 +1,38 @@
+--- libs.mk.orig	2022-11-12 18:02:53.000000000 +0800
++++ libs.mk	2022-11-12 20:01:26.000000000 +0800
+@@ -660,7 +660,7 @@
+ $(LIBVPX_TEST_BIN): $(TEST_LIBS)
+ $(eval $(call linkerxx_template,$(LIBVPX_TEST_BIN), \
+               $(LIBVPX_TEST_OBJS) \
+-              -L. -lvpx -lgtest $(extralibs) -lm))
++              libvpx.a libgtest.a $(extralibs) -lm))
+ 
+ ifneq ($(strip $(TEST_INTRA_PRED_SPEED_OBJS)),)
+ $(TEST_INTRA_PRED_SPEED_OBJS) $(TEST_INTRA_PRED_SPEED_OBJS:.o=.d): CXXFLAGS += $(GTEST_INCLUDES)
+@@ -670,7 +670,7 @@
+ $(TEST_INTRA_PRED_SPEED_BIN): $(TEST_LIBS)
+ $(eval $(call linkerxx_template,$(TEST_INTRA_PRED_SPEED_BIN), \
+               $(TEST_INTRA_PRED_SPEED_OBJS) \
+-              -L. -lvpx -lgtest $(extralibs) -lm))
++              libvpx.a libgtest.a $(extralibs) -lm))
+ endif  # TEST_INTRA_PRED_SPEED
+ 
+ ifeq ($(CONFIG_ENCODERS),yes)
+@@ -683,7 +683,7 @@
+ $(RC_INTERFACE_TEST_BIN): $(TEST_LIBS) libvpxrc.a
+ $(eval $(call linkerxx_template,$(RC_INTERFACE_TEST_BIN), \
+               $(RC_INTERFACE_TEST_OBJS) \
+-              -L. -lvpx -lgtest -lvpxrc $(extralibs) -lm))
++              libvpx.a libgtest.a libvpxrc.a $(extralibs) -lm))
+ endif  # RC_INTERFACE_TEST
+ endif  # CONFIG_ENCODERS
+ 
+@@ -696,7 +696,7 @@
+ $(SIMPLE_ENCODE_TEST_BIN): $(TEST_LIBS) libsimple_encode.a
+ $(eval $(call linkerxx_template,$(SIMPLE_ENCODE_TEST_BIN), \
+               $(SIMPLE_ENCODE_TEST_OBJS) \
+-              -L. -lsimple_encode -lvpx -lgtest $(extralibs) -lm))
++              libvpx.a libgtest.a libsimple_encode.a $(extralibs) -lm))
+ endif  # SIMPLE_ENCODE_TEST
+ 
+ endif  # CONFIG_UNIT_TESTS


### PR DESCRIPTION
#### Description

When a fix for dylib was added, PPC case was not considered; since on PPC only static lib is built, dylib fix breaks destroot on PPC. Obviously, it should not be used on PPC at all.
PR also improves arch-related syntax in portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
