### PR TITLE
libsdl12: use correct macros for PPC

### DIFF
--- a/devel/libsdl12/Portfile
+++ b/devel/libsdl12/Portfile
@@ -27,6 +27,8 @@ github.tarball_from archive
 checksums       rmd160 e6e43e35bf2dbd5d57790a322411a797d4a78a80 \
                 sha256 ba08fe8547e69757f4f0b15ccd4336343db15726f2d0e3bd09aabbcd5b8ab367
 
+patchfiles      patch-fix-ppc.diff
+
 minimum_xcodeversions {8 2.4.1}
 
 configure.args  --disable-esd \

--- a/devel/libsdl12/files/patch-fix-ppc.diff
+++ b/devel/libsdl12/files/patch-fix-ppc.diff
@@ -1,0 +1,37 @@
+--- src/video/quartz/SDL_QuartzVideo.h.orig	2022-08-01 04:28:40.000000000 +0800
++++ src/video/quartz/SDL_QuartzVideo.h	2022-11-03 08:14:25.000000000 +0800
+@@ -68,7 +68,7 @@
+ #include "../../events/SDL_events_c.h"
+ 
+ 
+-#ifdef __powerpc__
++#ifdef __POWERPC__
+ /* 
+     This is a workaround to directly access NSOpenGLContext's CGL context
+     We need this to check for errors NSOpenGLContext doesn't support
+
+
+--- src/video/quartz/SDL_QuartzGL.m.orig	2022-08-01 04:28:40.000000000 +0800
++++ src/video/quartz/SDL_QuartzGL.m	2022-11-03 08:15:38.000000000 +0800
+@@ -41,7 +41,7 @@
+ #define NSOpenGLPFASamples ((NSOpenGLPixelFormatAttribute) 56)
+ #endif
+ 
+-#ifdef __powerpc__   /* we lost this in 10.6, which has no PPC support. */
++#ifdef __POWERPC__   /* we lost this in 10.7, which has no PPC support. */
+ @implementation NSOpenGLContext (CGLContextAccess)
+ - (CGLContextObj) cglContext;
+ {
+
+
+--- src/video/quartz/SDL_QuartzVideo.m.orig	2022-08-01 04:28:40.000000000 +0800
++++ src/video/quartz/SDL_QuartzVideo.m	2022-11-03 08:13:50.000000000 +0800
+@@ -586,7 +586,7 @@
+                 QZ_TearDownOpenGL (this);
+             }
+ 
+-            #ifdef __powerpc__  /* we only use this for pre-10.3 compatibility. */
++            #ifdef __ppc__  /* we only use this for pre-10.3 compatibility. */
+             CGLSetFullScreen (NULL);
+             #endif
+         }


### PR DESCRIPTION
#### Description

This is an archaic port, but I accidentally found out its code occasionally uses wrong macros for Darwin PPC (in other places correct ones are used). Fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
