### PR TITLE
Fix build on macOS 13

### DIFF
--- a/devel/ftnchek/Portfile
+++ b/devel/ftnchek/Portfile
@@ -5,7 +5,7 @@ PortGroup       compilers 1.0
 
 name            ftnchek
 version         3.3.1
-revision        1
+revision        2
 categories      devel
 platforms       darwin
 license         MIT
@@ -37,10 +37,21 @@ long_description \
                 function of the compiler. Prior to using ftnchek, the \
                 user should verify that the program compiles correctly.
 
+if {${os.major} >= 22} {
+   depends_build-append port:groff
+}
+
 # Fix universal builds and implicit declaration of functions.
 use_autoreconf  yes
 
 configure.args --disable-submodel
+
+# no way found to do this in configure
+if {${os.major} >= 22} {
+    post-configure {
+        reinplace -W ${worksrcpath} "s|= soelim|= ${prefix}/bin/soelim|g" Makefile
+    }
+}
 
 destroot {
     xinstall -m 0755 -W ${worksrcpath} dcl2inc ftnchek  \


### PR DESCRIPTION
#### Description

macOS 13 requires a fix. Apple has removed soelim, groff and nroff.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`? **** port has no tests ****
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
