### PR TITLE
nodejs18: Make python a build dependency

### DIFF
--- a/devel/nodejs18/Portfile
+++ b/devel/nodejs18/Portfile
@@ -12,7 +12,7 @@ compiler.cxx_standard   2014
 
 name                    nodejs18
 version                 18.12.1
-revision                1
+revision                2
 
 categories              devel net
 platforms               darwin
@@ -38,13 +38,12 @@ checksums               rmd160  d181bc43ee46111082bcabea28fb39476e8f05b3 \
 
 distname                node-v${version}
 
-depends_build-append    port:pkgconfig
-
 set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
+depends_build-append    port:pkgconfig \
+                        port:python${py_ver_nodot}
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
-                        port:python${py_ver_nodot} \
                         port:zlib
 
 # error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Makes python a build dependency instead of a library dependency because seems like it is not needed at runtime (used only for gyp), just like how the brew counterpart formula already declares

Related for nodejs16: https://github.com/macports/macports-ports/pull/16482

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.0.1 14A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
