### PR TITLE
ddrescueview: fix livecheck

### DIFF
--- a/sysutils/ddrescueview/Portfile
+++ b/sysutils/ddrescueview/Portfile
@@ -55,3 +55,5 @@ destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/ddrescueview
     xinstall -m 644 {*}[glob ${savedsrcdir}/*.txt] ${destroot}${prefix}/share/doc/ddrescueview
 }
+
+livecheck.distname ${name}-source


### PR DESCRIPTION
#### Description

livecheck fixed by using correct live check.distname

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?  *** port has no tests ***
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
