### PR TITLE
ortep3: fix livecheck

### DIFF
--- a/science/ortep3/Portfile
+++ b/science/ortep3/Portfile
@@ -58,3 +58,7 @@ destroot {
     xinstall -m 0444 -W ${worksrcpath} LICENSE \
         ${destroot}${prefix}/share/doc/ortep3
 }
+
+livecheck.type  regex
+livecheck.url   ${homepage}
+livecheck.regex "VERSION (\\d+(?:\\.\\d+)*) \\(JAN. 31, 2000\\)"


### PR DESCRIPTION
#### Description

Fixed livecheck with proper type, url and regex.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
