### PR TITLE
f77chk: fix livecheck

### DIFF
--- a/devel/f77chk/Portfile
+++ b/devel/f77chk/Portfile
@@ -40,3 +40,5 @@ destroot {
     xinstall -m 0644 -W ${worksrcpath} COPYING README README.jp \
         ${destroot}${prefix}/share/doc/f77chk
 }
+
+livecheck.regex "f77chk-(\\d+(?:\\.\\d+)*f)"


### PR DESCRIPTION
#### Description

Fixed livecheck with proper regex

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
