### PR TITLE
php-xhprof: Update to "revived" fork with version 2.3.9 (formerly 2.3.7)

### DIFF
--- a/php/php-xhprof/Portfile
+++ b/php/php-xhprof/Portfile
@@ -13,11 +13,11 @@ php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1
 php.pecl                yes
 
 if {[vercmp ${php.branch} 7.0] >= 0} {
-    version             2.3.8
+    version             2.3.9
     revision            0
-    checksums           rmd160  fcc32e6555bcf6556c83b61001de4e8193ca295f \
-                        sha256  c88126717e895e9cbd15d49b8382238b69aee668adf8ae88cb9886fb083fa9f5 \
-                        size    842897
+    checksums           rmd160  48b7ffa9a583e2e9ef393c9c40cf8e15a8f23d90 \
+                        sha256  1dd421b25e0351e8074dec0b41ee67c5ca3a9f181ee90629e0222a12cd6f8774 \
+                        size    843027
 
 } else {
     version             0.9.4

--- a/php/php-xhprof/Portfile
+++ b/php/php-xhprof/Portfile
@@ -13,11 +13,11 @@ php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1
 php.pecl                yes
 
 if {[vercmp ${php.branch} 7.0] >= 0} {
-    version             2.3.7
+    version             2.3.8
     revision            0
-    checksums           rmd160  f6fa04037e0de6feb73cda777c4dce7348c29985 \
-                        sha256  378dd13f29185f8e5e9c0cc81e360e1ed71a4ac3eb3cc4e8d85e732da0300426 \
-                        size    842891
+    checksums           rmd160  fcc32e6555bcf6556c83b61001de4e8193ca295f \
+                        sha256  c88126717e895e9cbd15d49b8382238b69aee668adf8ae88cb9886fb083fa9f5 \
+                        size    842897
 
 } else {
     version             0.9.4

--- a/php/php-xhprof/Portfile
+++ b/php/php-xhprof/Portfile
@@ -4,23 +4,33 @@ PortSystem              1.0
 PortGroup               php 1.1
 
 name                    php-xhprof
-version                 2.3.7
 categories-append       devel
 platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 Apache-2
 
-php.branches            7.0 7.1 7.2 7.3 7.4 8.0 8.1
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1
 php.pecl                yes
+
+if {[vercmp ${php.branch} 7.0] >= 0} {
+    version             2.3.7
+    revision            0
+    checksums           rmd160  f6fa04037e0de6feb73cda777c4dce7348c29985 \
+                        sha256  378dd13f29185f8e5e9c0cc81e360e1ed71a4ac3eb3cc4e8d85e732da0300426 \
+                        size    842891
+
+} else {
+    version             0.9.4
+    revision            0
+    php.pecl.prerelease yes
+    checksums           rmd160  e484c4902f287ef18d9f75dda75a28d73bb8272d \
+                        sha256  002a2d4a825d16aeb3017c59f94d8c5e5d06611dd6197acd2f07fce197d3b8f8
+}
 
 description             A Hierarchical Profiler for PHP
 
 long_description        XHProf is a function-level hierarchical profiler for \
                         PHP and has a simple HTML based navigational interface.
-
-checksums               rmd160  f6fa04037e0de6feb73cda777c4dce7348c29985 \
-                        sha256  378dd13f29185f8e5e9c0cc81e360e1ed71a4ac3eb3cc4e8d85e732da0300426 \
-                        size    842891
 
 if {${name} ne ${subport}} {
     patchfiles          patch-callgraph_utils.php.diff

--- a/php/php-xhprof/Portfile
+++ b/php/php-xhprof/Portfile
@@ -4,35 +4,35 @@ PortSystem              1.0
 PortGroup               php 1.1
 
 name                    php-xhprof
-version                 0.9.4
+version                 2.3.7
 categories-append       devel
 platforms               darwin
-maintainers             ryandesign openmaintainer
+maintainers             {ryandesign @ryandesign} openmaintainer
 license                 Apache-2
 
-php.branches            5.3 5.4 5.5 5.6
+php.branches            7.0 7.1 7.2 7.3 7.4 8.0 8.1
 php.pecl                yes
-php.pecl.prerelease     yes
 
 description             A Hierarchical Profiler for PHP
 
 long_description        XHProf is a function-level hierarchical profiler for \
                         PHP and has a simple HTML based navigational interface.
 
-checksums               rmd160  e484c4902f287ef18d9f75dda75a28d73bb8272d \
-                        sha256  002a2d4a825d16aeb3017c59f94d8c5e5d06611dd6197acd2f07fce197d3b8f8
+checksums               rmd160  f6fa04037e0de6feb73cda777c4dce7348c29985 \
+                        sha256  378dd13f29185f8e5e9c0cc81e360e1ed71a4ac3eb3cc4e8d85e732da0300426 \
+                        size    842891
 
 if {${name} ne ${subport}} {
     patchfiles          patch-callgraph_utils.php.diff
-    
+
     post-patch {
         reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/xhprof_lib/utils/callgraph_utils.php
     }
-    
+
     php.build_dirs      ${worksrcpath}/extension
-    
+
     use_parallel_build  yes
-    
+
     post-destroot {
         # Install php files not installed by the Makefile
         xinstall -d ${destroot}${prefix}/www/${subport}
@@ -40,8 +40,10 @@ if {${name} ne ${subport}} {
         copy ${worksrcpath}/xhprof_lib ${destroot}${prefix}/www/${subport}/xhprof_lib
         copy ${worksrcpath}/xhprof_html ${destroot}${prefix}/www/${subport}/xhprof_html
     }
-    
+
     variant graphviz description {Build with graphviz, support for callgraphs} {
         depends_run-append      path:bin/dot:graphviz
     }
+
+    conflicts       ${php}-tideways_xhprof
 }

--- a/php/php-xhprof/Portfile
+++ b/php/php-xhprof/Portfile
@@ -9,7 +9,7 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 Apache-2
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2
 php.pecl                yes
 
 if {[vercmp ${php.branch} 7.0] >= 0} {


### PR DESCRIPTION
#### Description

Based on "official" fork that is used by PECL itself.

This has been tested with php72-php81 (self tests and some real apps) and it's working ok so far. Note it only includes the minimum changes required, not sure if there is anything else to modify (ports versions or things like that).

Note I'm not 100% sure about the declared incompatibility with the tideways-xhprof package, I borrowed it from other packages having incompatibilities. Maybe the opposite one should be added to the tideways one?

Also, note that this switch to the new package leaves PHP 5.x out from the equation.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.1 21G217 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
