### PR TITLE
qt5pas: update to version 2.2.4

### DIFF
--- a/devel/qt5pas/Portfile
+++ b/devel/qt5pas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           qmake5 1.0
 
 name                qt5pas
-version             2.2.0-0
+version             2.2.4-0
 revision            0
 categories          devel
 license             GPL-2 LGPL-2
@@ -21,9 +21,9 @@ homepage            https://wiki.freepascal.org/Qt5_Interface
 dist_subdir         lazarus
 master_sites        sourceforge:lazarus
 distname            lazarus-${version}
-checksums           rmd160  101bd48ae7bae9fdf941d96ea62c4b386085526f \
-                    sha256  b6b5d516511e3dfb34910d7656db068d4bba80f009692500aebbcae79cb12160 \
-                    size    76777421
+checksums           rmd160  878d64c1e5a7c0842d51d3f37d2644a00d32fdb5 \
+                    sha256  b84093218181f66b545218d1aaaf62a8bfb6abd40beba32387253d66fc5bc24c \
+                    size    77272959
 
 worksrcdir          lazarus/lcl/interfaces/qt5/cbindings
 
@@ -33,3 +33,5 @@ post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/qt5pas
     xinstall -m 644 {*}[glob ${worksrcpath}/*.TXT] ${destroot}${prefix}/share/doc/qt5pas
 }
+
+livecheck.regex "lazarus-(\\d+(?:\\.\\d+)*-\\d)"


### PR DESCRIPTION
#### Description

Update qt5pas to version 2.2.4. Also fix livecheck with proper regex.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
