### PR TITLE
google-cloud-sdk: update to 408.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             408.0.0
+version             408.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  fa307be06212ab2a46da775b876cb65a22a19c52 \
-                    sha256  2312a9a7a64f4080403d1b60b1ec6c546b90bc071f2b1e05f731841421413e41 \
-                    size    109677216
+    checksums       rmd160  67d018ea09fb13c8ea4d79e3a2b90f0271b84231 \
+                    sha256  cad23044f8f36d759cad30651edfc09e4c51ed1ac0d60b7fbb1432dda09dc7be \
+                    size    109677640
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b24940f11987f8350ab266734b1a7f08c93ecfe7 \
-                    sha256  810d7e111a732829574154a15905d5a9915947c93c468585c02a5549c3407257 \
-                    size    98645763
+    checksums       rmd160  b6dfa5459c673d23228834dc0236883c21cf04e4 \
+                    sha256  59a8492119cfbc81db1497eaea45b808522818c48faac630125041ac70839ab4 \
+                    size    98646454
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  50780d9574699e9930a470ddf8a6f0ac6cc57a6a \
-                    sha256  999a8178d28de7baadac4d0aeb2d44804bbcfe1beaba502675bba76c27347cd7 \
-                    size    97062109
+    checksums       rmd160  dceec931f6fb0408dc2b174817bce51b8d804f2a \
+                    sha256  4498185caa5be96849c6cee73807ff94b33b38e6101cf2e31990dd12cf90c969 \
+                    size    97062196
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 408.0.1.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?