### PR TITLE
openjdk8-temurin: update to 8u352

### DIFF
--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -5,7 +5,8 @@ PortSystem       1.0
 name             openjdk8-temurin
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+# See https://adoptium.net/supported_platforms.html
+platforms        {darwin any} {darwin >= 16}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64
 
-version      8u345
-set build    01
+version      8u352
+set build    08
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 8
@@ -25,19 +26,9 @@ master_sites https://github.com/adoptium/temurin8-binaries/releases/download/jdk
 distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  ecf6e0243ac503ebe5903f7e3b137c593077697c \
-             sha256  3eeba0e76101b9f5e8eb9eb14ad991293cf0cc064df35f6a89882b603630f0c8 \
-             size    107934646
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 16} {
-    # See https://adoptium.net/supported_platforms.html
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
-        return -code error
-    }
-}
+checksums    rmd160  c264fb961bb8eb2ede0a52fa66632f9c4e4b9741 \
+             sha256  f74d949aaaabd6116eaeccc34cc5ff707d3317b2cdbd3a8147920e1851d20cf2 \
+             size    107947323
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u352.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?