### PR TITLE
librsvg: disable vala on <10 and PPC until fixed

### DIFF
--- a/graphics/librsvg-devel/Portfile
+++ b/graphics/librsvg-devel/Portfile
@@ -122,6 +122,16 @@ configure.args      --enable-vala=yes \
                     --disable-silent-rules \
                     --disable-Bsymbolic
 
+# Temprorary fix for older systems until Vala is fixed.
+# See: https://trac.macports.org/ticket/65407
+# And: https://gitlab.gnome.org/GNOME/vala/-/issues/1297
+platform darwin {
+    if {${os.major} < 10 || ${build_arch} eq "ppc"} {
+        configure.args-replace \
+                    --enable-vala=yes --enable-vala=no
+    }
+}
+
 configure.ldflags-append    -lobjc
 
 test.run            yes

--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -122,6 +122,16 @@ configure.args      --enable-vala=yes \
                     --disable-silent-rules \
                     --disable-Bsymbolic
 
+# Temprorary fix for older systems until Vala is fixed.
+# See: https://trac.macports.org/ticket/65407
+# And: https://gitlab.gnome.org/GNOME/vala/-/issues/1297
+platform darwin {
+    if {${os.major} < 10 || ${build_arch} eq "ppc"} {
+        configure.args-replace \
+                    --enable-vala=yes --enable-vala=no
+    }
+}
+
 configure.ldflags-append    -lobjc
 
 test.run            yes


### PR DESCRIPTION
See: https://trac.macports.org/ticket/65407
And: https://gitlab.gnome.org/GNOME/vala/-/issues/1297

#### Description

Currently broken vapigen breaks the build of `librsvg` on 10.5.8 and 10.6.8 Rosetta. Disable vala until fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

I get this lint error, but it has nothing to do with my changes:
```
macmini:macports-ports svacchanda$ port lint --nitpick librsvg
--->  Verifying Portfile for librsvg
Error: Line 90 repeats inclusion of PortGroup gobject_introspection
--->  1 errors and 0 warnings found.
```