### PR TITLE
ffmpeg*: adjustments for PPC systems, reflecting what is fixed and what fails

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg ffmpeg-upstream
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.2
-revision            6
+revision            7
 epoch               2
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -93,6 +93,7 @@ depends_lib-append \
                     port:fribidi \
                     path:lib/libspeex.dylib:speex \
                     port:soxr \
+                    port:dav1d \
                     port:bzip2 \
                     port:xz \
                     port:zimg \
@@ -158,6 +159,7 @@ configure.args-append \
                     --enable-fontconfig \
                     --enable-libfreetype \
                     --enable-libfribidi \
+                    --enable-libdav1d \
                     --enable-zlib \
                     --disable-libjack \
                     --disable-libopencore-amrnb \
@@ -209,12 +211,6 @@ platform darwin {
         # but builds on Snow Leopard
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
-
-        # Dav1d: 10.6+ No PowerPC or Apple Silicon (for now)
-        if {![regexp -all (arm64|ppc*) [get_canonical_archs]]} {
-            configure.args-append   --enable-libdav1d
-            depends_lib-append      port:dav1d
-        }
     }
 
     # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -206,9 +206,9 @@ platform darwin {
         configure.args-replace --disable-audiotoolbox --enable-audiotoolbox
     }
 
-    if {${os.major} > 9} {
+    if {${os.major} > 9 && ${build_arch} ni [list ppc ppc64]} {
         # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
-        # but builds on Snow Leopard
+        # but builds on Snow Leopard x86. Exclude ppc until fixed.
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
     }

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -236,16 +236,22 @@ platform darwin {
         configure.args-append --disable-indev=avfoundation
     }
 
-    # av1 codecs, available on 10.7+
-    if {${os.major} >= 11} {
+    # av1 codecs, available on 10.5+
+    if {${os.major} >= 9} {
         configure.args-append \
                         --enable-libaom \
-                        --enable-librav1e \
                         --enable-libsvtav1
         depends_lib-append \
                         port:aom \
-                        port:rav1e \
                         port:svt-av1
+    }
+
+    # Available on 10.7+
+    if {${os.major} >= 11} {
+        configure.args-append \
+                        --enable-librav1e
+        depends_lib-append \
+                        port:rav1e
     }
 }
 

--- a/multimedia/ffmpeg-upstream/Portfile
+++ b/multimedia/ffmpeg-upstream/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             6.0
-revision            0
+revision            1
 epoch               0
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg-upstream/Portfile
+++ b/multimedia/ffmpeg-upstream/Portfile
@@ -229,16 +229,22 @@ platform darwin {
         configure.args-append --disable-indev=avfoundation
     }
 
-    # av1 codecs, available on 10.7+
-    if {${os.major} >= 11} {
+    # av1 codecs, available on 10.5+
+    if {${os.major} >= 9} {
         configure.args-append \
                         --enable-libaom \
-                        --enable-librav1e \
                         --enable-libsvtav1
         depends_lib-append \
                         port:aom \
-                        port:rav1e \
                         port:svt-av1
+    }
+
+    # Available on 10.7+
+    if {${os.major} >= 11} {
+        configure.args-append \
+                        --enable-librav1e
+        depends_lib-append \
+                        port:rav1e
     }
 }
 

--- a/multimedia/ffmpeg-upstream/Portfile
+++ b/multimedia/ffmpeg-upstream/Portfile
@@ -199,9 +199,9 @@ platform darwin {
         configure.args-replace --disable-audiotoolbox --enable-audiotoolbox
     }
 
-    if {${os.major} > 9} {
+    if {${os.major} > 9 && ${build_arch} ni [list ppc ppc64]} {
         # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
-        # but builds on Snow Leopard
+        # but builds on Snow Leopard x86. Exclude ppc until fixed.
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
     }

--- a/multimedia/ffmpeg-upstream/Portfile
+++ b/multimedia/ffmpeg-upstream/Portfile
@@ -93,6 +93,7 @@ depends_lib-append \
                     port:fribidi \
                     path:lib/libspeex.dylib:speex \
                     port:soxr \
+                    port:dav1d \
                     port:bzip2 \
                     port:lzo2 \
                     port:xz \
@@ -150,6 +151,7 @@ configure.args-append \
                     --enable-fontconfig \
                     --enable-libfreetype \
                     --enable-libfribidi \
+                    --enable-libdav1d \
                     --enable-zlib \
                     --disable-libjack \
                     --disable-libopencore-amrnb \
@@ -202,12 +204,6 @@ platform darwin {
         # but builds on Snow Leopard
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
-
-        # Dav1d: 10.6+ No PowerPC or Apple Silicon (for now)
-        if {![regexp -all (arm64|ppc*) [get_canonical_archs]]} {
-            configure.args-append   --enable-libdav1d
-            depends_lib-append      port:dav1d
-        }
     }
 
     # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -93,6 +93,7 @@ depends_lib-append \
                     port:fribidi \
                     path:lib/libspeex.dylib:speex \
                     port:soxr \
+                    port:dav1d \
                     port:bzip2 \
                     port:xz \
                     port:zimg \
@@ -158,6 +159,7 @@ configure.args-append \
                     --enable-fontconfig \
                     --enable-libfreetype \
                     --enable-libfribidi \
+                    --enable-libdav1d \
                     --enable-zlib \
                     --disable-libjack \
                     --disable-libopencore-amrnb \
@@ -209,12 +211,6 @@ platform darwin {
         # but builds on Snow Leopard
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
-
-        # Dav1d: 10.6+ No PowerPC or Apple Silicon (for now)
-        if {![regexp -all (arm64|ppc*) [get_canonical_archs]]} {
-            configure.args-append   --enable-libdav1d
-            depends_lib-append      port:dav1d
-        }
     }
 
     # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -206,9 +206,9 @@ platform darwin {
         configure.args-replace --disable-audiotoolbox --enable-audiotoolbox
     }
 
-    if {${os.major} > 9} {
+    if {${os.major} > 9 && ${build_arch} ni [list ppc ppc64]} {
         # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
-        # but builds on Snow Leopard
+        # but builds on Snow Leopard x86. Exclude ppc until fixed.
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
     }

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg-devel ffmpeg-upstream
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.2
-revision            6
+revision            7
 epoch               1
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -236,16 +236,22 @@ platform darwin {
         configure.args-append --disable-indev=avfoundation
     }
 
-    # av1 codecs, available on 10.7+
-    if {${os.major} >= 11} {
+    # av1 codecs, available on 10.5+
+    if {${os.major} >= 9} {
         configure.args-append \
                         --enable-libaom \
-                        --enable-librav1e \
                         --enable-libsvtav1
         depends_lib-append \
                         port:aom \
-                        port:rav1e \
                         port:svt-av1
+    }
+
+    # Available on 10.7+
+    if {${os.major} >= 11} {
+        configure.args-append \
+                        --enable-librav1e
+        depends_lib-append \
+                        port:rav1e
     }
 }
 


### PR DESCRIPTION
#### Description

1. `libvpx` has been long fixed for PPC (presently using `gnu-generic` target). Should be enabled for PPC.
Fixes: https://trac.macports.org/ticket/64675
This, of course, must be merged: https://github.com/macports/macports-ports/pull/16564 (someone broke destroot of `libvpx`)

2. While I was able to build `libsdl2` version that is sufficient for FFMPEG, it is a) not in Macports and b) not ready to be in Macports. Obviously, 10.7 SDK which Macports uses on 10.6 to build `libsdl2` has no PPC support. So `libsdl2` does not presently build on Rosetta. Disabled for PPC until fixed.
Discussion here: https://trac.macports.org/ticket/64655

3. I have no idea why someone decided to enable `dav1d` for 10+, it builds fine even on Tiger. Remove OS-based condition, remove PPC ban, leave only arm64. (It is still broken there?)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
