### PR TITLE
libctl: blacklist old compilers which fail; fix lint warnings

### DIFF
--- a/science/libctl/Portfile
+++ b/science/libctl/Portfile
@@ -2,12 +2,12 @@
 
 PortSystem          1.0
 PortGroup           compilers 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                libctl
 version             3.2.2
 revision            2
 categories          science
-platforms           darwin
 license				GPL-2+
 
 maintainers         saabusa.com:Yogesh.Sharma openmaintainer
@@ -29,6 +29,10 @@ depends_lib         port:guile
 
 compilers.choose    f77
 compilers.setup     require_fortran
+
+# gcc-4.2 fails with multiple errors: https://trac.macports.org/ticket/66164
+# Xcode clang of 10.6 fails on guile headers.
+compiler.blacklist-append *gcc-4.* {clang < 421}
 
 livecheck.type      regex
 livecheck.url       ${homepage}

--- a/science/libctl/Portfile
+++ b/science/libctl/Portfile
@@ -8,22 +8,22 @@ name                libctl
 version             3.2.2
 revision            2
 categories          science
-license				GPL-2+
+license             GPL-2+
 
 maintainers         saabusa.com:Yogesh.Sharma openmaintainer
 
 description         Scheme/Guile-based scripting of scientific code.
 long_description    \
-	Libctl is a free Guile-based library implementing flexible control files \
-	for scientific simulations. It was written to support the MIT Photonic \
-	Bands and Meep software, but has proven useful in other programs too.
+    Libctl is a free Guile-based library implementing flexible control files \
+    for scientific simulations. It was written to support the MIT Photonic \
+    Bands and Meep software, but has proven useful in other programs too.
 
 homepage            http://ab-initio.mit.edu/wiki/index.php/Libctl
 master_sites        http://ab-initio.mit.edu/libctl/
 
-checksums           md5     5fd7634dc9ae8e7fa70a68473b9cbb68 \
-                    sha1    d7f860313d5cc226c51f868bbe9bb930d143ab9c \
-                    rmd160  2390548f7a30e709e22b3ee12f21ec9f7e45def7
+checksums           rmd160  2390548f7a30e709e22b3ee12f21ec9f7e45def7 \
+                    sha256  8abd8b58bc60e84e16d25b56f71020e0cb24d75b28bc5db86d50028197c7efbc \
+                    size    505796
 
 depends_lib         port:guile
 


### PR DESCRIPTION
#### Description

The first commit blacklists old compilers of <11 which fail to build the port.
The second fixes lint warnings (checksums and tabs).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
