### PR TITLE
gpac: fix linking with legacy-support

### DIFF
--- a/multimedia/gpac/Portfile
+++ b/multimedia/gpac/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        gpac gpac 2.0.0 v
-revision            0
+revision            1
 categories          multimedia
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 license             LGPL-2.1+
@@ -60,6 +60,7 @@ patchfiles          patch-configure.diff \
 
 post-patch {
     reinplace "s|@APPLICATIONS_DIR@|${applications_dir}|g" ${worksrcpath}/configure
+    reinplace "s|LDFLAGS=\"-L\$prefix/\$libdir|LDFLAGS=\"\$LDFLAGS -L\$prefix/\$libdir|g" ${worksrcpath}/configure
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 12} {


### PR DESCRIPTION
#### Description

Patch the configure script so that the values inserted into LDFLAGS by Macports (for legacy-support) no longer are overwritten. This fixes a linker error on OS X 10.11 and earlier, which do not support `clock_gettime`.

I have suggested the same change on gpac’s master repo (see [this pull request](https://github.com/gpac/gpac/pull/2304)), but even if it gets accepted, I do know when the next version will be released. Therefore I suggest patching the portfile in the meantime, so that the port builds on OS X 10.11 and earlier without having to wait for the release of the next gpac version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->