### PR TITLE
clamav: update to 0.105.1

### DIFF
--- a/sysutils/clamav/Portfile
+++ b/sysutils/clamav/Portfile
@@ -3,7 +3,7 @@ PortGroup legacysupport 1.0
 PortGroup cmake 1.1
 
 name			clamav
-version		 	0.104.4
+version		 	0.105.1
 categories		sysutils
 maintainers	 	{geeklair.net:dluke @danielluke}
 description	 	clamav antivirus software
@@ -15,21 +15,22 @@ long_description	Clam AntiVirus is a GPL anti-virus toolkit for UNIX. The \
 
 homepage		http://www.clamav.net
 master_sites		http://www.clamav.net/downloads/production
-checksums	rmd160	9158544048971e28c71ebf60ea39b42afcb8ce04 \
-		sha256	8ac32e910aa744cc7f921c5122ba523ef1ffbbbf94545f94fc4a976b502be74b \
-		size	12027448
+checksums	rmd160	b6e8909c4fc6359e20c3d1967048f681a44f5331 \
+		sha256	d2bc16374db889a6e5a6ac40f8c6e700254a039acaa536885a09eeea4b8529f6 \
+		size	29467856
 
 platforms		darwin
 
 # Disable tests to avoid extra dependencies
 configure.args-append	-DENABLE_TESTS=OFF
 
-#Parallel build causes build failures as of 0.104.0
-#use_parallel_build	yes
+use_parallel_build	yes
 
 depends_build		path:bin/cmake:cmake \
 			port:pkgconfig \
-			bin:git:git
+			bin:git:git \
+			port:rust \
+			port:cargo
 
 depends_lib		port:libiconv \
 			port:zlib \


### PR DESCRIPTION
* enable parallel building again

#### Description

update clamav to 0.105.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? used with test variant
- [ ] tried a full install with `sudo port -vst install`? trace mode fails to extract source fails
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
