### PR TITLE
openjdk8-openj9: update to 8u352

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk8-openj9
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-version      8u345
-revision     1
+version      8u352
+revision     0
 
-set build    01
-set openj9_version 0.33.1
+set build    08
+set openj9_version 0.35.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 8
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -29,9 +29,9 @@ master_sites https://github.com/ibmruntimes/semeru8-binaries/releases/download/j
 distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  372400ffc0ec6e0c444337289eec66cb060265cf \
-             sha256  332da84b1cc928e32a4d4fc00f0bb1c102e489abe80df24aa7fab59133379359 \
-             size    129511642
+checksums    rmd160  fbda213fa5cb793b3416fef4f3b4661fe19afbe8 \
+             sha256  0d2b9746c3a06d9857e2675ecefaada8447dd6fe673b9279f9c3b4fa21ea2eee \
+             size    129630836
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8u352.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?