### PR TITLE
py-pytest: update to 7.2.0; add py311

### DIFF
--- a/python/py-attrs/Portfile
+++ b/python/py-attrs/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 supported_archs     noarch
 license             MIT
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 maintainers         {khindenburg @kurthindenburg} openmaintainer
 
@@ -33,7 +33,6 @@ if {${name} ne ${subport}} {
     depends_test-append \
         port:py${python.version}-hypothesis \
         port:py${python.version}-pytest \
-        port:py${python.version}-six \
         port:py${python.version}-zopeinterface
 
     if {${python.version} == 27} {

--- a/python/py-hypothesis/Portfile
+++ b/python/py-hypothesis/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MPL-2
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 maintainers         {khindenburg @kurthindenburg} \
                     {@catap korins.ky:kirill} \

--- a/python/py-iniconfig/Portfile
+++ b/python/py-iniconfig/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     36 37 38 39 310
+python.versions     36 37 38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -15,7 +15,7 @@ supported_archs     noarch
 
 python.versions     27 35 36 37 38 39 310 311
 
-maintainers         {stromnov @stromnov} openmaintainer
+maintainers         {stromnov @stromnov} {@catap korins.ky:kirill} openmaintainer
 
 description         py.test: simple powerful testing with Python
 

--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pytest
-version             6.2.5
+version             7.2.0
 revision            0
 
 categories-append   devel
@@ -13,7 +13,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -25,9 +25,9 @@ long_description    The pytest framework makes it easy to write small tests, \
 
 homepage            https://pytest.org
 
-checksums           rmd160  e426e585ff11f53d0523aa001a76eb7be7df6dc2 \
-                    sha256  131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89 \
-                    size    1118720
+checksums           rmd160  9943f6c377dca2db1e726ad2a89eb42aca4f1bf9 \
+                    sha256  c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59 \
+                    size    1300608
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -38,11 +38,17 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-iniconfig \
                         port:py${python.version}-packaging \
                         port:py${python.version}-pluggy \
-                        port:py${python.version}-py \
-                        port:py${python.version}-toml
+                        port:py${python.version}-py
 
     if {${python.version} < 38} {
-        depends_lib-append port:py${python.version}-importlib-metadata
+        depends_lib-append \
+                        port:py${python.version}-importlib-metadata
+    }
+
+    if {${python.version} < 311} {
+        depends_lib-append \
+                        port:py${python.version}-exceptiongroup \
+                        port:py${python.version}-tomli
     }
 
     depends_run         port:pytest_select
@@ -67,13 +73,24 @@ if {${name} ne ${subport}} {
                             sha256  7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8 \
                             size    1022353
         depends_lib-append  port:py${python.version}-more-itertools
+    } elseif {${python.version} eq 36} {
+        version             7.0.1
+        revision            0
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  530488f483b32848f0650ad490ce4e74e85263f8 \
+                            sha256  e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171 \
+                            size    1249154
     }
 
     if {${python.version} <= 35} {
         depends_lib-append  port:py${python.version}-wcwidth \
                             port:py${python.version}-pathlib2
         depends_lib-delete  port:py${python.version}-iniconfig \
-                            port:py${python.version}-toml
+                            port:py${python.version}-tomli
+    }
+
+    if {${python.version} <= 36} {
+        depends_lib-delete  port:py${python.version}-exceptiongroup
     }
 
     select.group        pytest

--- a/python/py-pytest/files/pytest311
+++ b/python/py-pytest/files/pytest311
@@ -1,0 +1,2 @@
+bin/pytest-3.11
+bin/py.test-3.11

--- a/python/py-sortedcontainers/Portfile
+++ b/python/py-sortedcontainers/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-zope-event/Portfile
+++ b/python/py-zope-event/Portfile
@@ -20,7 +20,7 @@ long_description    The zope.event package provides a simple event system, inclu
 supported_archs     noarch
 homepage            https://github.com/zopefoundation/zope.event
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 checksums           rmd160  1de457c479b1c8421ee81f7106ca7d02a924fb8c \
                     sha256  5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330 \

--- a/python/py-zopeinterface/Portfile
+++ b/python/py-zopeinterface/Portfile
@@ -5,9 +5,9 @@ PortGroup           python 1.0
 
 name                py-zopeinterface
 python.rootname     zope.interface
-version             5.3.0
+version             5.5.1
 revision            0
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 categories-append   zope
 license             ZPL-2.1
 platforms           darwin
@@ -17,9 +17,9 @@ long_description    {*}${description}
 
 homepage            https://zopetoolkit.readthedocs.io/
 
-checksums           rmd160  9a8ada33bdfec240e2665cd1c07cc9b104d2bd25 \
-                    sha256  b18a855f8504743e0a2d8b75d008c7720d44e4c76687e13f959e35d9a13eb397 \
-                    size    241964
+checksums           rmd160  9d4c18ef846cefd59b5809c7157571e625207478 \
+                    sha256  6d678475fdeb11394dc9aaa5c564213a1567cc663082e0ee85d52f78d1fbaab2 \
+                    size    300064
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

I've updated pytest to 7.2.0 that allows to add py311 subport. The py36 is pinned with version 7.0.1 which was the last version before support of python-3.6 was dropped.

I've also added a few py311 ports and updated a few ports to allow pass tests by `port test`.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->