### PR TITLE
auto-multiple-choice: update to version 1.5.2

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -17,7 +17,7 @@ long_description        Utility to manage multiple choice questionnaires, \
                         with optionally mixed questions and answers. \
                         AMC provides automatic marking from papers' scans. \
                         Annotated papers are produced. Marks can be exported \
-                        as an OpenOffice.org sheet file.
+                        as an LibreOffice.org sheet file.
 
 homepage                http://www.auto-multiple-choice.net/
 
@@ -27,27 +27,27 @@ subport auto-multiple-choice-devel {}
 
 if {${subport} eq ${name}} {
     # release
-    set amc.version.main        1.5.1
+    set amc.version.main        1.5.2
+    set amc.version.secondary   20221031112254
     version                 ${amc.version.main}
-    revision                3
-    checksums               rmd160  e7c260b0ff2f93e70a2e27ec7a33e68c89622805 \
-                            sha256  329b2a0c8f9ad2a8219865acc79ac0441ef7c7179c19b1cb4795fb2186a4760e \
-                            size    11251717
+    checksums               rmd160  76a1b398c30a1f70a79fd069397af39522e8d5f9 \
+                            sha256  4087a8fefd184fa325af958980ce36d03c9a04f14912e056da12b2202c33b338 \
+                            size    13107480
 
     conflicts               auto-multiple-choice-devel
 
 } else {
     # devel
-    set amc.version.main        1.5.1
-    set amc.version.secondary   75-ge55d8e1e
-    version                 ${amc.version.main}-${amc.version.secondary}
-    revision                1
-    checksums               rmd160  ff1e07ec51c6ddabda8c410e90033eef5ed51460 \
-                            sha256  d0e4aba705c591adca4a552e31756f6ce1c27a9be1515e8b78896082d393151d \
-                            size    12904898
+    set amc.version.main        1.5.2
+    set amc.version.secondary   20221108151552
+    checksums               rmd160  6531e7e6b41b3580c9e72842cacf703cae527ffd \
+                            sha256  71c2e53a343a87a1aabe4818fb9b9d1ee166fd7d046190d916915640f2d28f86 \
+                            size    13124174
 
     conflicts               auto-multiple-choice
 }
+set amc.version         ${amc.version.main}+git${amc.version.secondary}
+version                 ${amc.version.main}-git${amc.version.secondary}
 
 
 set opencv_ver          4
@@ -55,7 +55,7 @@ depends_lib-append      path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv
 build.env-append        PKG_CONFIG_PATH=${prefix}/lib/opencv${opencv_ver}/pkgconfig
 
 master_sites            https://download.auto-multiple-choice.net/precomp/
-distfiles               ${name}_${version}_dist${extract.suffix}
+distfiles               ${name}_${amc.version}_dist${extract.suffix}
 
 use_configure           no
 
@@ -197,4 +197,5 @@ post-deactivate {
 
 livecheck.type          regex
 livecheck.url           [lindex ${master_sites} 0]#
-livecheck.regex         ${name}_(\[0-9.a-z-\]+_\[0-9.a-z-\]+)_
+livecheck.regex         ${name}_(\[0-9.\]+\\+\[0-9.a-z-\]+)_dist.tar.gz
+livecheck.version       ${amc.version}


### PR DESCRIPTION
auto-multiple-choice: update to version 1.5.2 (1.5.2+git20221031112254)
auto-multiple-choice-devel : update to version 1.5.2+git20221108151552

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b 
Command Line Tools 14.1.0.0.1.1666437224
MacPorts 2.8.0

macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
