### PR TITLE
google-cloud-sdk: update to 409.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             408.0.1
+version             409.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  67d018ea09fb13c8ea4d79e3a2b90f0271b84231 \
-                    sha256  cad23044f8f36d759cad30651edfc09e4c51ed1ac0d60b7fbb1432dda09dc7be \
-                    size    109677640
+    checksums       rmd160  80da854770db86c4b0f1bcb0a18d491018801f88 \
+                    sha256  7e2ae4df436a7df6d2566220de21d1a4e70f4c315a5c24219941b2296055815d \
+                    size    109772750
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b6dfa5459c673d23228834dc0236883c21cf04e4 \
-                    sha256  59a8492119cfbc81db1497eaea45b808522818c48faac630125041ac70839ab4 \
-                    size    98646454
+    checksums       rmd160  81d19e01d8fa7ebe02b4402671929e7bdd0b6116 \
+                    sha256  2abe477b42cc1eace25bbec42a6b8080e0bbfbbf5311d561851b5a005e2ce744 \
+                    size    98743339
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  dceec931f6fb0408dc2b174817bce51b8d804f2a \
-                    sha256  4498185caa5be96849c6cee73807ff94b33b38e6101cf2e31990dd12cf90c969 \
-                    size    97062196
+    checksums       rmd160  ea6a5b49ba617a45240bdc6c7a2a751b5d5cb1f8 \
+                    sha256  b943a6cc01797412c51cb6fce7d1d9151b574b7f4bc7d2a5b4cb8975e1b75820 \
+                    size    97151974
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 409.0.0.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?