### PR TITLE
pipenv: update to 2022.11.5

### DIFF
--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                pipenv
-version             2022.10.4
+version             2022.11.5
 revision            0
 categories-append   devel
 platforms           darwin
@@ -34,9 +34,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  08b860dc855e34abda82ee2dbb67b643323479ca \
-                    sha256  dc2539c7f4ad10737f6c211493f99e2bbc8161571d71ac29f162dfed86886bb0 \
-                    size    5180156
+checksums           rmd160  b50f874bec35cd315c841a730729eb8d76bc5f72 \
+                    sha256  af8595e38f1d87af3b00d209390bce41c97b10fca1c956e9ba1208438af55c6a \
+                    size    4786517
 
 python.default_version 310
 


### PR DESCRIPTION
#### Description

Tested locally

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
