### PR TITLE
kotlin: update to 1.7.21

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.7.20 v
+github.setup        JetBrains kotlin 1.7.21 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
-platforms           darwin
+platforms           {darwin any}
 maintainers         {breun.nl:nils @breun} openmaintainer
 license             Apache-2
 
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  509f564033788aaaa67a806578d1c9e85eac2066 \
-                    sha256  5e3c8d0f965410ff12e90d6f8dc5df2fc09fd595a684d514616851ce7e94ae7d \
-                    size    78925146
+checksums           rmd160  191b7449a84ec6563c5047b7572ab94939a643de \
+                    sha256  8412b31b808755f0c0d336dbb8c8443fa239bf32ddb3cdb81b305b25f0ad279e \
+                    size    78964847
 
 java.version        1.8+
 java.fallback       openjdk17


### PR DESCRIPTION
#### Description

Update to Kotlin 1.7.21.

###### Tested on

macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?