### PR TITLE
hdf5: Advertise correct stdlib with gcc flavors.

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -115,6 +115,9 @@ variant cxx description {
 } {
     configure.args-delete       --disable-cxx
     configure.args-append       --enable-cxx
+    if {[gcc_variant_isset]} {
+        configure.cxx_stdlib        libstdc++
+    }
 }
 
 variant fortran description {


### PR DESCRIPTION
Not rev-bumping as no change to built-bot (clang) results, and local installs would fail previously on rev-upgrade.

Fixes https://trac.macports.org/ticket/66208

Maintainer update.