### PR TITLE
dnscontrol: update to 3.22.1

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/StackExchange/dnscontrol 3.21.0 v
+go.setup            github.com/StackExchange/dnscontrol 3.22.1 v
 
-checksums           rmd160  1257815f1de4deca65ebe57bef2ffa7b6a138b80 \
-                    sha256  b88946116fd8ff0183da5e0436e0b9dead9ae239382f31e52fa65611b6509f63 \
-                    size    4961548
+checksums           rmd160  98f93ed23489c76dae597711d00c328e61eb4a7d \
+                    sha256  95e3060065205cfb03d850448fefd2c51a612ecabc0a95d59cfe2cc4e19b78e9 \
+                    size    4961948
 
 homepage            https://stackexchange.github.io/dnscontrol/
 description         Synchronize your DNS to multiple providers from a simple DSL


### PR DESCRIPTION
#### Description
dnscontrol: update to 3.22.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
