### PR TITLE
fricas: added openmaintainer

### DIFF
--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -6,7 +6,7 @@ name                fricas
 version             1.3.8
 revision            2
 categories          math
-maintainers         {@pietvo vanoostrum.org:pieter}
+maintainers         {@pietvo vanoostrum.org:pieter openmaintainer}
 platforms           darwin
 supported_archs     i386 x86_64
 license             BSD


### PR DESCRIPTION
#### Description

fricas: added openmaintainer policy to Portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?

No changes to the code, so no testing necessary, no revbump.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
