### PR TITLE
DeaDBeeF: update to 1.9.3

### DIFF
--- a/multimedia/DeaDBeeF/Portfile
+++ b/multimedia/DeaDBeeF/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           xcode 1.0
 PortGroup           github 1.0
 
-github.setup        DeaDBeeF-Player deadbeef 1.9.2
+github.setup        DeaDBeeF-Player deadbeef 1.9.3
 name                DeaDBeeF
 categories          multimedia
 platforms           macosx


### PR DESCRIPTION
#### Description
DeaDBeeF: update to 1.9.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
