### PR TITLE
pbsecret: new port (20200119)

### DIFF
--- a/sysutils/pbsecret/Portfile
+++ b/sysutils/pbsecret/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       github 1.0
+PortGroup       makefile 1.0
+
+github.setup    roosto pbsecret 9e91917de001a73fc01aa8ba96c5c83c4b7f5a34
+version         20200219
+revision        0
+
+categories      sysutils
+maintainers     {@midnightrocket} \
+                openmaintainer
+
+platforms       macosx
+
+description     CLI util to write text to pasteboard as `org.nspasteboard.ConcealedType`
+long_description    \
+                Copies data from STDIN to the general pasteboard as UTF-8 text. Copied \
+                data is tagged with "org.nspasteboard.ConcealedType" to prevent it from \
+                being saved in the history of a clipboard manager, as per the spec at:
+
+license         MIT
+
+checksums       rmd160  e2402c186f6d67e4af66f83c183869706c226e93 \
+                sha256  6d4b8ccca1bfc6a37102cf9b774d2b3e83037baed5600c7350d27209c7d688f3 \
+                size    2365
+
+
+destroot {
+    copy ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
https://github.com/roosto/pbsecret

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
