### PR TITLE
py-notify-python: fix missing python 2.7 symbols

### DIFF
--- a/python/py-notify-python/Portfile
+++ b/python/py-notify-python/Portfile
@@ -45,8 +45,8 @@ if {${name} ne ${subport}} {
 
     depends_lib-append  port:libnotify \
                         port:py${python.version}-pygtk
-    
-    
+
+
     use_configure       yes
 
     build.type          gnu
@@ -61,8 +61,9 @@ if {${name} ne ${subport}} {
 
     patchfiles          patch-src-pynotifymodule-c.diff \
                         implicit.patch \
-                        libnotify07.patch
-                   
+                        libnotify07.patch \
+                        missing-python27-symbols.patch
+
     configure.python    ${python.bin}
     configure.pkg_config_path   ${python.prefix}/lib/pkgconfig
     configure.pre_args      --prefix=${python.prefix}

--- a/python/py-notify-python/files/missing-python27-symbols.patch
+++ b/python/py-notify-python/files/missing-python27-symbols.patch
@@ -1,0 +1,12 @@
+diff --git a/configure b/configure
+index f2385bc..2957dd7 100755
+--- configure.orig
++++ configure
+@@ -18983,6 +18983,7 @@ if test -n "$PKG_CONFIG"; then
+   (exit $ac_status); }; then
+   pkg_cv_NOTIFY_PYTHON_LIBS=`$PKG_CONFIG --libs "pygtk-2.0 >= $PYGTK_REQUIRED
+                                   libnotify >= $LIBNOTIFY_REQUIRED" 2>/dev/null`
++  pkg_cv_NOTIFY_PYTHON_LIBS+=" -lpython2.7"
+ else
+   pkg_failed=yes
+ fi


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/65092

#### Description
I applied the solution given in the ticket comments and it fixed the build issue.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.5.1 21G83 arm64
Command Line Tools 14.1.0.0.1.1666437224

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`? Yes, but `Error: Unknown platform: any`was already there before.
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
