### PR TITLE
py-llvmlite: fix build on MacOS 13 - DO NOT MERGE

### DIFF
--- a/python/py-llvmlite/Portfile
+++ b/python/py-llvmlite/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_wrapper 1.0
 
 github.setup        numba llvmlite 0.39.1 v
 name                py-llvmlite
-revision            0
+revision            1
 categories-append   devel science
 license             BSD
 
@@ -37,9 +37,15 @@ if {${name} ne ${subport}} {
             # https://trac.macports.org/ticket/61302
             reinplace "s|%%MP_EXTRA_LDFLAGS%%|-framework CoreFoundation|" \
                 ${worksrcpath}/ffi/Makefile.osx
+        } elseif {${os.major} >= 22} {
+            reinplace "s|%%MP_EXTRA_LDFLAGS%%|-lLLVM|" ${worksrcpath}/ffi/Makefile.osx
         } else {
             reinplace "s|%%MP_EXTRA_LDFLAGS%%||" ${worksrcpath}/ffi/Makefile.osx
         }
+    }
+
+    post-destroot {
+        system "/usr/bin/install_name_tool -change @rpath/libLLVM.dylib ${prefix}/libexec/llvm-${llvmver}/lib/libLLVM.dylib ${destroot}${python.pkgd}/llvmlite/binding/libllvmlite.dylib"
     }
 
     depends_build-append \

--- a/python/py-llvmlite/Portfile
+++ b/python/py-llvmlite/Portfile
@@ -38,14 +38,10 @@ if {${name} ne ${subport}} {
             reinplace "s|%%MP_EXTRA_LDFLAGS%%|-framework CoreFoundation|" \
                 ${worksrcpath}/ffi/Makefile.osx
         } elseif {${os.major} >= 22} {
-            reinplace "s|%%MP_EXTRA_LDFLAGS%%|-lLLVM|" ${worksrcpath}/ffi/Makefile.osx
+            reinplace "s|%%MP_EXTRA_LDFLAGS%%|-Wl,-rpath,${prefix}/libexec/llvm-${llvmver}/lib -lLLVM|" ${worksrcpath}/ffi/Makefile.osx
         } else {
             reinplace "s|%%MP_EXTRA_LDFLAGS%%||" ${worksrcpath}/ffi/Makefile.osx
         }
-    }
-
-    post-destroot {
-        system "/usr/bin/install_name_tool -change @rpath/libLLVM.dylib ${prefix}/libexec/llvm-${llvmver}/lib/libLLVM.dylib ${destroot}${python.pkgd}/llvmlite/binding/libllvmlite.dylib"
     }
 
     depends_build-append \


### PR DESCRIPTION
#### Description

I had trouble installing `py310-llvmlite` (required for `py-numba`) on MacOS 13. The error I was seeing when building was something like this:

```
LLVM version... MACOSX_DEPLOYMENT_TARGET=13.0 clang++-mp-11 -std=c++11 -stdlib=libc++ -dynamiclib -I/opt/local/libexec/llvm-11/include -std=c++14 -stdlib=libc++ -fno-exceptions -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fno-rtti -g assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp linker.cpp object_file.cpp custom_passes.cpp -o libllvmlite.dylib -arch x86_64 "-Wl,-exported_symbol,_LLVMPY_*" -L/opt/local/libexec/llvm-11/lib -Wl,-search_paths_first -Wl,-headerpad_max_install_names  -lLLVMXRay -lLLVMWindowsManifest -lLLVMTableGen -lLLVMSymbolize -lLLVMDebugInfoPDB -lLLVMOrcJIT -lLLVMOrcError -lLLVMJITLink -lLLVMObjectYAML -lLLVMMCA -lLLVMLTO -lLLVMPasses -lLLVMCoroutines -lLLVMObjCARCOpts -lLLVMExtensions -lLLVMLineEditor -lLLVMLibDriver -lLLVMInterpreter -lLLVMFuzzMutate -lLLVMMCJIT -lLLVMExecutionEngine -lLLVMRuntimeDyld -lLLVMDWARFLinker -lLLVMDlltoolDriver -lLLVMOption -lLLVMDebugInfoGSYM -lLLVMCoverage -lLLVMXCoreDisassembler -lLLVMXCoreCodeGen -lLLVMXCoreDesc -lLLVMXCoreInfo -lLLVMX86Disassembler -lLLVMX86AsmParser -lLLVMX86CodeGen -lLLVMX86Desc -lLLVMX86Info -lLLVMWebAssemblyDisassembler -lLLVMWebAssemblyCodeGen -lLLVMWebAssemblyDesc -lLLVMWebAssemblyAsmParser -lLLVMWebAssemblyInfo -lLLVMSystemZDisassembler -lLLVMSystemZCodeGen -lLLVMSystemZAsmParser -lLLVMSystemZDesc -lLLVMSystemZInfo -lLLVMSparcDisassembler -lLLVMSparcCodeGen -lLLVMSparcAsmParser -lLLVMSparcDesc -lLLVMSparcInfo -lLLVMRISCVDisassembler -lLLVMRISCVCodeGen -lLLVMRISCVAsmParser -lLLVMRISCVDesc -lLLVMRISCVUtils -lLLVMRISCVInfo -lLLVMPowerPCDisassembler -lLLVMPowerPCCodeGen -lLLVMPowerPCAsmParser -lLLVMPowerPCDesc -lLLVMPowerPCInfo -lLLVMNVPTXCodeGen -lLLVMNVPTXDesc -lLLVMNVPTXInfo -lLLVMMSP430Disassembler -lLLVMMSP430CodeGen -lLLVMMSP430AsmParser -lLLVMMSP430Desc -lLLVMMSP430Info -lLLVMMipsDisassembler -lLLVMMipsCodeGen -lLLVMMipsAsmParser -lLLVMMipsDesc -lLLVMMipsInfo -lLLVMLanaiDisassembler -lLLVMLanaiCodeGen -lLLVMLanaiAsmParser -lLLVMLanaiDesc -lLLVMLanaiInfo -lLLVMHexagonDisassembler -lLLVMHexagonCodeGen -lLLVMHexagonAsmParser -lLLVMHexagonDesc -lLLVMHexagonInfo -lLLVMBPFDisassembler -lLLVMBPFCodeGen -lLLVMBPFAsmParser -lLLVMBPFDesc -lLLVMBPFInfo -lLLVMAVRDisassembler -lLLVMAVRCodeGen -lLLVMAVRAsmParser -lLLVMAVRDesc -lLLVMAVRInfo -lLLVMARMDisassembler -lLLVMARMCodeGen -lLLVMARMAsmParser -lLLVMARMDesc -lLLVMARMUtils -lLLVMARMInfo -lLLVMAMDGPUDisassembler -lLLVMAMDGPUCodeGen -lLLVMMIRParser -lLLVMipo -lLLVMInstrumentation -lLLVMVectorize -lLLVMLinker -lLLVMIRReader -lLLVMAsmParser -lLLVMFrontendOpenMP -lLLVMAMDGPUAsmParser -lLLVMAMDGPUDesc -lLLVMAMDGPUUtils -lLLVMAMDGPUInfo -lLLVMAArch64Disassembler -lLLVMMCDisassembler -lLLVMAArch64CodeGen -lLLVMCFGuard -lLLVMGlobalISel -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoDWARF -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMAggressiveInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMTextAPI -lLLVMBitReader -lLLVMCore -lLLVMRemarks -lLLVMBitstreamReader -lLLVMAArch64AsmParser -lLLVMMCParser -lLLVMAArch64Desc -lLLVMMC -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMBinaryFormat -lLLVMAArch64Utils -lLLVMAArch64Info -lLLVMSupport -lLLVMDemangle -lz -lcurses -lm -lxml2
Undefined symbols for architecture x86_64:
  "VTT for std::__1::basic_stringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >", referenced from:
      llvm::NVPTXRegisterInfo::getName(unsigned int) const in libLLVMNVPTXCodeGen.a(NVPTXAsmPrinter.cpp.o)
      (anonymous namespace)::HexagonAsmBackend::HandleFixupError(int, int, long long, char const*) const in libLLVMHexagonDesc.a(HexagonAsmBackend.cpp.o)
      (anonymous namespace)::InstrOrderFile::run(llvm::Module&) in libLLVMInstrumentation.a(InstrOrderFile.cpp.o)
      llvm::NVPTXTargetLowering::getPrototype(llvm::DataLayout const&, llvm::Type*, std::__1::vector<llvm::TargetLoweringBase::ArgListEntry, std::__1::allocator<llvm::TargetLoweringBase::ArgListEntry> > const&, llvm::SmallVectorImpl<llvm::ISD::OutputArg> const&, llvm::MaybeAlign, llvm::CallBase const&) const in libLLVMNVPTXCodeGen.a(NVPTXISelLowering.cpp.o)
      llvm::inlineCostStr(llvm::InlineCost const&) in libLLVMAnalysis.a(InlineAdvisor.cpp.o)
      getStatString(char const*, int, int, char const*, bool) in libLLVMTransformUtils.a(ImportedFunctionsInliningStatistics.cpp.o)
      llvm::MachO::InterfaceFile::addUUID(llvm::MachO::Target const&, unsigned char*) in libLLVMTextAPI.a(InterfaceFile.cpp.o)
      ...
  "vtable for std::__1::basic_stringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >", referenced from:
      llvm::NVPTXRegisterInfo::getName(unsigned int) const in libLLVMNVPTXCodeGen.a(NVPTXAsmPrinter.cpp.o)
      (anonymous namespace)::HexagonAsmBackend::HandleFixupError(int, int, long long, char const*) const in libLLVMHexagonDesc.a(HexagonAsmBackend.cpp.o)
      (anonymous namespace)::InstrOrderFile::run(llvm::Module&) in libLLVMInstrumentation.a(InstrOrderFile.cpp.o)
      llvm::NVPTXTargetLowering::getPrototype(llvm::DataLayout const&, llvm::Type*, std::__1::vector<llvm::TargetLoweringBase::ArgListEntry, std::__1::allocator<llvm::TargetLoweringBase::ArgListEntry> > const&, llvm::SmallVectorImpl<llvm::ISD::OutputArg> const&, llvm::MaybeAlign, llvm::CallBase const&) const in libLLVMNVPTXCodeGen.a(NVPTXISelLowering.cpp.o)
      llvm::inlineCostStr(llvm::InlineCost const&) in libLLVMAnalysis.a(InlineAdvisor.cpp.o)
      getStatString(char const*, int, int, char const*, bool) in libLLVMTransformUtils.a(ImportedFunctionsInliningStatistics.cpp.o)
      llvm::MachO::InterfaceFile::addUUID(llvm::MachO::Target const&, unsigned char*) in libLLVMTextAPI.a(InterfaceFile.cpp.o)
      ...
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
```

I looked for the missing symbols and they were apparently located in `/opt/local/libexec/llvm-11/lib/libLLVM.dylib`. I thus modified the py-llvmlite Portfile as follows:
```
             # https://trac.macports.org/ticket/61302
             reinplace "s|%%MP_EXTRA_LDFLAGS%%|-framework CoreFoundation|" \
                 ${worksrcpath}/ffi/Makefile.osx
+        } elseif {${os.major} >= 22} {
+            reinplace "s|%%MP_EXTRA_LDFLAGS%%|-lLLVM|" ${worksrcpath}/ffi/Makefile.osx
         } else {
             reinplace "s|%%MP_EXTRA_LDFLAGS%%||" ${worksrcpath}/ffi/Makefile.osx
         }
```

As a result `py310-llvmlite` was installed. However, when then trying to import `py310-numba` I was seeing this error:
```
OSError: dlopen(/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llvmlite/binding/libllvmlite.dylib, 0x0006): Library not loaded: @rpath/libLLVM.dylib
  Referenced from: <74A0092F-F3EE-3432-AC64-01C33A81F8A3> /opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llvmlite/binding/libllvmlite.dylib
  Reason: tried: '/System/Volumes/Preboot/Cryptexes/OS@rpath/libLLVM.dylib' (no such file), '/usr/local/lib/libLLVM.dylib' (no such file), '/usr/lib/libLLVM.dylib' (no such file, not in dyld cache)
```

It turns out that the `libLLVM.dylib` file is in a path that cannot be found:

```
 otool -L /opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llvmlite/binding/libllvmlite.dylib
/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llvmlite/binding/libllvmlite.dylib:
	libllvmlite.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libLLVM.dylib (compatibility version 1.0.0, current version 11.1.0)
	/opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.13)
	/opt/local/lib/libncurses.6.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
	/opt/local/lib/libxml2.2.dylib (compatibility version 13.0.0, current version 13.3.0)
	@rpath/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
```

I solved this problem with the following addition:
```
+    post-destroot {
+        system "/usr/bin/install_name_tool -change @rpath/libLLVM.dylib ${prefix}/libexec/llvm-${llvmver}/lib/libLLVM.dylib ${destroot}${python.pkgd}/llvmlite/binding/libllvmlite.dylib"
+    }
+
```

Now the library can be found:
```
otool -L /opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llvmlite/binding/libllvmlite.dylib
/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/llvmlite/binding/libllvmlite.dylib:
	libllvmlite.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/local/libexec/llvm-11/lib/libLLVM.dylib (compatibility version 1.0.0, current version 11.1.0)
	/opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.13)
	/opt/local/lib/libncurses.6.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
	/opt/local/lib/libxml2.2.dylib (compatibility version 13.0.0, current version 13.3.0)
	@rpath/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
```

And, importantly, py310-numba module can be imported.

There's likely a better way to do this, but I hope this can be useful as a starting point to fix the problem with MacOS 13 + Numba

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0 22A380 x86_64
Xcode 14.1 14B47b


###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
