### PR TITLE
py-more-itertools: update to 9.0.0; add py311

### DIFF
--- a/python/py-more-itertools/Portfile
+++ b/python/py-more-itertools/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-more-itertools
-version             8.14.0
+version             9.0.0
 revision            0
 categories-append   devel
 license             MIT
@@ -21,9 +21,9 @@ long_description    ${description}
 
 homepage            https://github.com/erikrose/more-itertools
 
-checksums           rmd160  12a70ca52a8c8c2650c962764b5523bad5648de5 \
-                    sha256  c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750 \
-                    size    102642
+checksums           rmd160  dbf7e1b0c250d4c16ce781140d2b9f88f7f4c629 \
+                    sha256  5a6257e40878ef0520b1803990e3e22303a41b5714006c32a3fd8304b26ea1ab \
+                    size    104237
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -37,10 +37,30 @@ if {${name} ne ${subport}} {
                             sha256  38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4 \
                             size    67359
         depends_lib-append  port:py${python.version}-six
+
+        python.pep517       no
+    } elseif {${python.version} eq 35} {
+        version             8.12.0
+        revision            0
+        epoch               1
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  92e25b8097001dbf10dffced771e4c74a3d8923d \
+                            sha256  7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064 \
+                            size    108698
+
+        python.pep517       no
+    } elseif {${python.version} eq 36} {
+        version             8.14.0
+        revision            1
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  12a70ca52a8c8c2650c962764b5523bad5648de5 \
+                            sha256  c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750 \
+                            size    102642
     }
 
-    if {${python.version} < 37} {
-        python.pep517       no
+    if {${python.version} >= 36} {
+        test.run            yes
+        test.target         tests
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

I've also downgraded py35 and py36 subports that fixes pytest-3.5.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->