### PR TITLE
py27-attrs: fixed tests

### DIFF
--- a/python/py-attrs/Portfile
+++ b/python/py-attrs/Portfile
@@ -39,18 +39,16 @@ if {${name} ne ${subport}} {
         version         21.4.0
         revision        0
 
-        depends_test-append port:py${python.version}-typing
+        depends_test-append \
+                        port:py${python.version}-six \
+                        port:py${python.version}-typing
 
         checksums       rmd160  9374ffd2f02c588f82e9f3e32e3400a80bc4d711 \
                         sha256  626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd \
                         size    201839
-
     }
 
     test.run            yes
-    test.cmd            py.test-${python.branch}
-    test.target
-    test.env            PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description

All tests are passed when I run it as `port -N test py{27,3{5,6,7,8,9,10,11}}-attrs` on clean system.

Thus, it depends on https://github.com/macports/macports-ports/pull/16641

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->