### PR TITLE
KeePassXC-devel: update to latest devel & update patch

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -64,22 +64,23 @@ if {${subport} eq ${name}} {
     }
 } else {
     # devel subport
-    github.setup        keepassxreboot keepassxc d83743ea0b207e4a5c034af6a049ba157470e093
+    github.setup        keepassxreboot keepassxc 9ba88e2f13695add13f0391badf49aedae115b6f
     set githash         [string range ${github.version} 0 6]
-    version             20221023.git${githash}
+    version             20221102.git${githash}
     revision            0
 
     conflicts           KeePassXC
 
-    checksums           rmd160  90569580342ee0acd98e05a0ffaa442ac0f99bf3 \
-                        sha256  80b279e1e173c2693bddc098036054d771fcfbc161fc34e4b59571f1ea698b4d \
-                        size    11243794
+    checksums           rmd160  6b8b9a94b886e3062553b14ec1507324e7f7ec15 \
+                        sha256  13a870d347837c6c8769dbf3f9ea9f074d0a9d039e4e7b11ac65187eb1520c66 \
+                        size    11421690
 
     gpg_verify.use_gpg_verification \
                         no
 
     patchfiles-append    devel/patch-no-findpackage-path.diff \
-                         devel/patch-touch-id.diff
+                         devel/add_support_for_old_macos.diff \
+                         devel/add_support_for_qt5.6.diff
 }
 
 if {[option gpg_verify.use_gpg_verification]} {

--- a/security/KeePassXC/files/devel/add_support_for_old_macos.diff
+++ b/security/KeePassXC/files/devel/add_support_for_old_macos.diff
@@ -1,10 +1,27 @@
-diff -Naur CMakeLists.txt CMakeLists.txt
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Wed, 13 Nov 2022 09:38:48 +0100
+Subject: [PATCH] Fix build failure on macos versions < 10.11
+
+This patch will permit to fix build issues on macos versions < 10.11
+
+Strategy is to check at configure time which functions are available.
+Those that are not available, are hidden by preprocessor checks
+
+Upstream doesn't want to merge patches to build on versions prior to macos
+10.13, so this patch is not forwarded upstream.
+See: https://github.com/keepassxreboot/keepassxc/pull/8650#issuecomment-1291750066
+
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -81,6 +81,32 @@
+@@ -81,6 +81,42 @@ if(APPLE)
         ${CMAKE_CURRENT_BINARY_DIR}/tiometry_test/
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_watch_support.mm)
      message(STATUS "Apple watch compiler support: ${XC_APPLE_COMPILER_SUPPORT_WATCH}")
++
++    try_compile(XC_APPLE_COMPILER_SUPPORT_errSecUserCanceled
++       ${CMAKE_CURRENT_BINARY_DIR}/errSecUserCanceled_test/
++       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_errSecUserCanceled_support.mm)
++    message(STATUS "errSecUserCanceled compiler support: ${XC_APPLE_COMPILER_SUPPORT_errSecUserCanceled}")
 +
 +    try_compile(XC_APPLE_COMPILER_SUPPORT_LocalAuthentication
 +       ${CMAKE_CURRENT_BINARY_DIR}/LocalAuthentication_test/
@@ -31,11 +48,38 @@ diff -Naur CMakeLists.txt CMakeLists.txt
 +       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm)
 +    message(STATUS "kSecUseOperationPrompt compiler support: ${XC_APPLE_COMPILER_SUPPORT_kSecUseOperationPrompt}")
 +
++    try_compile(XC_APPLE_COMPILER_SUPPORT_SecAccessControlRef
++       ${CMAKE_CURRENT_BINARY_DIR}/SecAccessControlRef_test/
++       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler-checks/macos/control_SecAccessControlRef_support.mm)
++    message(STATUS "SecAccessControlRef compiler support: ${XC_APPLE_COMPILER_SUPPORT_SecAccessControlRef}")
++
  endif()
  
  if(WITH_CCACHE)
-diff -Naur cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm
---- cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm
+--- /dev/null
++++ cmake/compiler-checks/macos/control_LocalAuthentication_support.mm
+@@ -0,0 +1,2 @@
++#include <LocalAuthentication/LocalAuthentication.h>
++int main() { return 0; }
+--- /dev/null
++++ cmake/compiler-checks/macos/control_SecAccessControlRef_support.mm
+@@ -0,0 +1,6 @@
++#include <Security/Security.h>
++
++int main() {
++   SecAccessControlRef;
++   return 0;
++}
+--- /dev/null
++++ cmake/compiler-checks/macos/control_errSecUserCanceled_support.mm
+@@ -0,0 +1,6 @@
++#include <Security/Security.h>
++
++int main() {
++   errSecUserCanceled;
++   return 0;
++}
+--- /dev/null
 +++ cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm
 @@ -0,0 +1,6 @@
 +#include <Security/Security.h>
@@ -44,8 +88,7 @@ diff -Naur cmake/compiler-checks/macos/control_kSecAttrAccessControl_support.mm 
 +   kSecAttrAccessControl;
 +   return 0;
 +}
-diff -Naur cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm
---- cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm
+--- /dev/null
 +++ cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm
 @@ -0,0 +1,6 @@
 +#include <Security/Security.h>
@@ -54,8 +97,7 @@ diff -Naur cmake/compiler-checks/macos/control_kSecAttrSynchronizable_support.mm
 +   kSecAttrSynchronizable;
 +   return 0;
 +}
-diff -Naur cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm
---- cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm
+--- /dev/null
 +++ cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.mm
 @@ -0,0 +1,6 @@
 +#include <Security/Security.h>
@@ -64,8 +106,7 @@ diff -Naur cmake/compiler-checks/macos/control_kSecUseAuthenticationUI_support.m
 +   kSecUseAuthenticationUI;
 +   return 0;
 +}
-diff -Naur cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm
---- cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm
+--- /dev/null
 +++ cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm
 @@ -0,0 +1,6 @@
 +#include <Security/Security.h>
@@ -74,37 +115,33 @@ diff -Naur cmake/compiler-checks/macos/control_kSecUseOperationPrompt_support.mm
 +   kSecUseOperationPrompt;
 +   return 0;
 +}
-diff -Naur cmake/compiler-checks/macos/control_localAuthentication_support.mm cmake/compiler-checks/macos/control_localAuthentication_support.mm
---- cmake/compiler-checks/macos/control_LocalAuthentication_support.mm
-+++ cmake/compiler-checks/macos/control_LocalAuthentication_support.mm
-@@ -0,0 +1,2 @@
-+#include <LocalAuthentication/LocalAuthentication.h>
-+int main() { return 0; }
-diff -Naur src/config-keepassx.h.cmake src/config-keepassx.h.cmake
 --- src/config-keepassx.h.cmake
 +++ src/config-keepassx.h.cmake
-@@ -41,10 +41,20 @@
+@@ -41,10 +41,24 @@
  #cmakedefine01 XC_APPLE_COMPILER_SUPPORT_BIOMETRY()
  #cmakedefine01 XC_APPLE_COMPILER_SUPPORT_TOUCH_ID()
  #cmakedefine01 XC_APPLE_COMPILER_SUPPORT_WATCH()
++#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_errSecUserCanceled()
 +#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_LocalAuthentication()
 +#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_kSecAttrSynchronizable()
 +#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_kSecUseAuthenticationUI()
 +#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_kSecAttrAccessControl()
 +#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_kSecUseOperationPrompt()
++#cmakedefine01 XC_APPLE_COMPILER_SUPPORT_SecAccessControlRef()
  
  #define XC_COMPILER_SUPPORT(X) XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_##X()
  #define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_APPLE_BIOMETRY() XC_APPLE_COMPILER_SUPPORT_BIOMETRY()
  #define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_TOUCH_ID() XC_APPLE_COMPILER_SUPPORT_TOUCH_ID()
  #define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_WATCH_UNLOCK() XC_APPLE_COMPILER_SUPPORT_WATCH()
++#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_errSecUserCanceled() XC_APPLE_COMPILER_SUPPORT_errSecUserCanceled()
 +#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_LocalAuthentication() XC_APPLE_COMPILER_SUPPORT_LocalAuthentication()
 +#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_kSecAttrSynchronizable() XC_APPLE_COMPILER_SUPPORT_kSecAttrSynchronizable()
 +#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_kSecUseAuthenticationUI() XC_APPLE_COMPILER_SUPPORT_kSecUseAuthenticationUI()
 +#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_kSecAttrAccessControl() XC_APPLE_COMPILER_SUPPORT_kSecAttrAccessControl()
 +#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_kSecUseOperationPrompt() XC_APPLE_COMPILER_SUPPORT_kSecUseOperationPrompt()
++#define XC_COMPILER_SUPPORT_PRIVATE_DEFINITION_SecAccessControlRef() XC_APPLE_COMPILER_SUPPORT_SecAccessControlRef()
  
  #endif // KEEPASSX_CONFIG_KEEPASSX_H
-diff -Naur src/touchid/TouchID.mm src/touchid/TouchID.mm
 --- src/touchid/TouchID.mm
 +++ src/touchid/TouchID.mm
 @@ -9,7 +9,9 @@
@@ -117,7 +154,33 @@ diff -Naur src/touchid/TouchID.mm src/touchid/TouchID.mm
  #include <Security/Security.h>
  
  #include <QCoreApplication>
-@@ -164,9 +166,15 @@
+@@ -131,7 +133,9 @@ bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKe
+     // We need both runtime and compile time checks here to solve the following problems:
+     // - Not all flags are available in all OS versions, so we have to check it at compile time
+     // - Requesting Biometry/TouchID when to fingerprint sensor is available will result in runtime error
++#if XC_COMPILER_SUPPORT(SecAccessControlRef)
+     SecAccessControlCreateFlags accessControlFlags = 0;
++#endif
+     if (isTouchIdAvailable()) {
+ #if XC_COMPILER_SUPPORT(APPLE_BIOMETRY)
+        // Prefer the non-deprecated flag when available
+@@ -147,6 +151,7 @@ bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKe
+ #endif
+    }
+ 
++#if XC_COMPILER_SUPPORT(SecAccessControlRef)
+    SecAccessControlRef sacObject = SecAccessControlCreateWithFlags(
+        kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, accessControlFlags, &error);
+ 
+@@ -155,6 +160,7 @@ bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKe
+         debug("TouchID::storeKey - Error creating security flags: %s", e.localizedDescription.UTF8String);
+         return false;
+     }
++#endif
+ 
+     NSString *accountName = keyName.toNSString(); // The NSString is released by Qt
+ 
+@@ -168,15 +174,23 @@ bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKe
      CFDictionarySetValue(attributes, kSecClass, kSecClassGenericPassword);
      CFDictionarySetValue(attributes, kSecAttrAccount, (__bridge CFStringRef) accountName);
      CFDictionarySetValue(attributes, kSecValueData, (__bridge CFDataRef) keychainValueData);
@@ -127,13 +190,21 @@ diff -Naur src/touchid/TouchID.mm src/touchid/TouchID.mm
 +#if XC_COMPILER_SUPPORT(kSecUseAuthenticationUI)
      CFDictionarySetValue(attributes, kSecUseAuthenticationUI, kSecUseAuthenticationUIAllow);
 +#endif
-+#if XC_COMPILER_SUPPORT(kSecAttrAccessControl)
++#if XC_COMPILER_SUPPORT(kSecAttrAccessControl) && XC_COMPILER_SUPPORT(SecAccessControlRef)
      CFDictionarySetValue(attributes, kSecAttrAccessControl, sacObject);
 +#endif
  
      // add to KeyChain
      OSStatus status = SecItemAdd(attributes, NULL);
-@@ -218,7 +226,9 @@
+     LogStatusError("TouchID::storeKey - Status adding new entry", status);
+ 
++#if XC_COMPILER_SUPPORT(SecAccessControlRef)
+     CFRelease(sacObject);
++#endif
+     CFRelease(attributes);
+ 
+     if (status != errSecSuccess) {
+@@ -222,18 +236,23 @@ bool TouchID::getKey(const QString& databasePath, QByteArray& passwordKey) const
      CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
      CFDictionarySetValue(query, kSecAttrAccount, (__bridge CFStringRef) accountName);
      CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
@@ -143,3 +214,18 @@ diff -Naur src/touchid/TouchID.mm src/touchid/TouchID.mm
  
      // get data from the KeyChain
      CFTypeRef dataTypeRef = NULL;
+     OSStatus status = SecItemCopyMatching(query, &dataTypeRef);
+     CFRelease(query);
+ 
++#if XC_COMPILER_SUPPORT(errSecUserCanceled)
+     if (status == errSecUserCanceled) {
+         // user canceled the authentication, return true with empty key
+         debug("TouchID::getKey - User canceled authentication");
+         return true;
+-    } else if (status != errSecSuccess || dataTypeRef == NULL) {
++    } else
++#endif
++    if (status != errSecSuccess || dataTypeRef == NULL) {
+         LogStatusError("TouchID::getKey - key query error", status);
+         return false;
+     }

--- a/security/KeePassXC/files/devel/add_support_for_qt5.6.diff
+++ b/security/KeePassXC/files/devel/add_support_for_qt5.6.diff
@@ -1,0 +1,38 @@
+From: tenzap <fabstz-it@yahoo.fr>
+Date: Wed, 13 Nov 2022 09:38:48 +0100
+Subject: [PATCH] Fix build failure with Qt5.6
+
+On macos 10.7 which uses Qt 5.6, build fails with this error:
+
+src/gui/tag/TagView.cpp:79:38: error: no matching constructor for initialization of 'QAction'
+        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Search"))}, mapToGlobal(pos));
+                                     ^       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is because in Qt 5.6, the 3rd argument is not optional. Starting from Qt
+5.7 the default value for the 3rd argument is nullptr, so setting it to
+nullptr.
+
+https://doc.qt.io/archives/qt-5.6/qaction.html#QAction-2
+https://doc.qt.io/archives/qt-5.7/qaction.html#QAction-2
+
+Upstream doesn't want to merge patches to build on versions prior to macos
+10.13, so this patch is not forwarded upstream.
+
+--- src/gui/tag/TagView.cpp
++++ src/gui/tag/TagView.cpp
+@@ -76,14 +76,14 @@ void TagView::contextMenuRequested(const QPoint& pos)
+     if (type == TagModel::SAVED_SEARCH) {
+         // Allow deleting saved searches
+         QMenu menu;
+-        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Search"))}, mapToGlobal(pos));
++        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Search"), nullptr)}, mapToGlobal(pos));
+         if (action) {
+             m_db->metadata()->deleteSavedSearch(index.data(Qt::DisplayRole).toString());
+         }
+     } else if (type == TagModel::TAG) {
+         // Allow removing tags from all entries in a database
+         QMenu menu;
+-        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Tag"))}, mapToGlobal(pos));
++        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Tag"), nullptr)}, mapToGlobal(pos));
+         if (action) {
+             auto tag = index.data(Qt::DisplayRole).toString();
+             auto ans = MessageBox::question(this,


### PR DESCRIPTION
Update patch to fix build on macos

Fixes these build errors on macos 10.8

/src/touchid/TouchID.mm:132:5: error: unknown type name 'SecAccessControlCreateFlags'
/src/touchid/TouchID.mm:148:4: error: use of undeclared identifier 'SecAccessControlRef'

Fix build when built with Qt5.6 (used on macos 10.7)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Command Line Tools 12.4.0.0.1.1610135815

Builds on 10.15 but couldn't test on 10.8, 10.7...

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
