### PR TITLE
QT6: Update to 6.2.4, add qtcharts qtmultimedia qtshadertools

### DIFF
--- a/_resources/port1.0/group/qt6_variables-1.0.tcl
+++ b/_resources/port1.0/group/qt6_variables-1.0.tcl
@@ -97,11 +97,19 @@ set qt_qmake_cmd        ${qt_dir}/bin/qmake
 
 # standard moc command location
 global qt_moc_cmd
-set qt_moc_cmd          ${qt_dir}/moc
+set qt_moc_cmd          ${qt_dir}/bin/moc
 
 # standard uic command location
 global qt_uic_cmd
-set qt_uic_cmd          ${qt_dir}/uic
+set qt_uic_cmd          ${qt_dir}/bin/uic
+
+# standard lrelease command location
+global qt_lrelease_cmd
+set qt_lrelease_cmd     ${qt_dir}/bin/lrelease
+
+# standard lupdate command location
+global qt_lupdate_cmd
+set qt_lupdate_cmd     ${qt_dir}/bin/lupdate
 
 namespace eval qt6pg {
     ###############################################################################
@@ -118,38 +126,140 @@ namespace eval qt6pg {
     #
     ###############################################################################
     array set qt6_component_lib {
+        qt3d {
+            6.1
+            7.0
+            lib/cmake/Qt63DCore
+            ""
+        }
+        qt5compat {
+            6.0
+            7.0
+            lib/cmake/Qt6Core5Compat
+            ""
+        }
         qtbase {
+            6.0
+            7.0
+            libexec/qt6/lib/QtCore.framework/Versions/A/QtCore
+            ""
+        }
+        qtcharts {
+            6.1
+            7.0
+            lib/cmake/Qt6Charts
+            ""
+        }
+        qtconnectivity {
             6.2
             7.0
-            lib/pkgconfig/Qt6Core.pc
+            libexec/qt6/lib/QtBluetooth.framework/Versions/A/QtBluetooth
+            ""
+        }
+        qtdeclarative {
+            6.0
+            7.0
+            lib/cmake/Qt6Qml/Qt6QmlMacros.cmake
+            ""
+        }
+        qtimageformats {
+            6.1
+            7.0
+            lib/cmake/Qt6/FindLibmng.cmake
+            ""
+        }
+        qtmultimedia {
+            6.2
+            7.0
+            lib/cmake/Qt6Multimedia
+            ""
+        }
+        qtnetworkauth {
+            6.1
+            7.0
+            libexec/qt6/lib/QtNetworkAuth.framework/Versions/A/QtNetworkAuth
+            ""
+        }
+        qtpositioning {
+            6.2
+            7.0
+            lib/cmake/Qt6Positioning
+            ""
+        }
+        qtremoteobjects {
+            6.2
+            7.0
+            lib/cmake/Qt6RemoteObjects
+            ""
+        }
+        qtsensors {
+            6.2
+            7.0
+            lib/cmake/Qt6Sensors
+            ""
+        }
+        qtserialbus {
+            6.2
+            7.0
+            lib/cmake/Qt6SerialBus
+            ""
+        }
+        qtserialport {
+            6.2
+            7.0
+            libexec/qt6/lib/QtSerialPort.framework/Versions/A/QtSerialPort
+            ""
+        }
+        qtshadertools {
+            6.0
+            7.0
+            libexec/qt6/lib/QtShaderTools.framework/Versions/A/QtShaderTools
+            ""
+        }
+        qtsvg {
+            6.0
+            7.0
+            libexec/qt6/lib/QtSvgWidgets.framework/Versions/A/QtSvgWidgets
             ""
         }
         qttools {
-            6.2
+            6.0
             7.0
-            lib/cmake/Qt6Designer
+            libexec/qt6/lib/QtUiTools.framework/Versions/A/QtUiTools
             ""
         }
         qttranslations {
-            6.2
+            6.0
             7.0
             libexec/qt6/translations/qt_ar.qm
             ""
         }
-        sqlite-plugin {
+        qtwebchannel {
             6.2
+            7.0
+            lib/cmake/Qt6WebChannel
+            ""
+        }
+        qtwebsockets {
+            6.2
+            7.0
+            lib/cmake/Qt6WebSockets
+            ""
+        }
+        sqlite-plugin {
+            6.0
             7.0
             lib/cmake/Qt6Sql/Qt6Sql_QSQLiteDriverPlugin.cmake
             "-plugin"
         }
         psql-plugin {
-            6.2
+            6.0
             7.0
             lib/cmake/Qt6Sql/Qt6Sql_QPSQLDriverPlugin.cmake
             "-plugin"
         }
         mysql-plugin {
-            6.2
+            6.0
             7.0
             lib/cmake/Qt6Sql/Qt6Sql_QMYSQLDriverPlugin.cmake
             "-plugin"

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -13,7 +13,7 @@ license             {LGPL-3 GPL-3 OpenSSLException}
 
 homepage            https://www.qt.io
 
-version             6.2.1
+version             6.2.4
 set middle_name     everywhere
 
 PortGroup qt6_variables 1.0
@@ -103,13 +103,13 @@ set llvm_version 14
 array set modules {
     qt3d {
         {
-            18887bc685306ad2f2a1213a98763c5babb619b3 \
-            730c0e8e1a1a59c4acbeca68e206bab14ef770f5dacb94b84103a82243cfeeb3
-            104023248
+            0fbdabb59466c03bc622ce996a97e43bc9ea5d8f \
+            ff4478d32c0fc0999690b73418b26974b723d5520abf4035b330002d962c1523
+            104021044
         }
         ""
         "port:assimp"
-        "qtbase qtdeclarative qtimageformats"
+        "qtbase qtdeclarative qtmultimedia qtshadertools"
         {"Qt 3D"}
         ""
         "variant overrides: "
@@ -118,24 +118,24 @@ array set modules {
     }
     qt5compat {
         {
-            5f539c3eeda04b63124b1d14ee45c2ea28f9fb44 \
-            3865c031450a3c2616de1e20104ca9470ac5447adf51faa918f8b01a2c425de7
-            8198156
+        cb840056d1fabef6145ac68c9a2ed1efb67eefbb \
+        5de2b9e25bf7de161fbb88ecdd468ed1788bc899392fc05ed80aa590ebb352fa
+        8198524
         }
         ""
-        "path:lib/pkgconfig/icu-uc.pc:icu"
+        ""
         "qtbase qtdeclarative"
         {"Qt5 Compatibility"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 0"
         "License: "
     }
     qtbase {
         {
-            5f790b52b28e90e762929bc9c3a66ccd8953722a \
-            2c5f07b5c3ea27d3fc1a46686ea3fb6724f94dddf1fb007de3eb0bdb87429079
-            46641424
+            041294e299236903695a4f35449b0e59c758396a \
+            d9924d6fd4fa5f8e24458c87f73ef3dfc1e7c9b877a5407c040d89e6736e2634
+            46541252
         }
         "port:ninja port:pkgconfig"
         "port:assimp port:brotli path:bin/cmake:cmake path:bin/dbus-daemon:dbus port:double-conversion port:freetype
@@ -149,14 +149,29 @@ array set modules {
          "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 8"
+        "revision 0"
         "License: "
+    }
+    qtcharts {
+        {
+            1b7bc3b8323489e967c928ff29204e0cb8a638d9 \
+            3c2e6267ef0fb5345c7737e3a12e09ce9ec09117792e78af9a8617f828b2249a
+            4391060
+        }
+        ""
+        ""
+        "qtbase qtdeclarative qtmultimedia"
+        {"Qt Charts"}
+        "GPLv3 license only"
+        "variant overrides: "
+        "revision 0"
+        "License: GPL-3"
     }
     qtconnectivity {
         {
-            c15218f42ec48aad9633d82a6b5594d46e533c44 \
-            8dcc366b0f5f124b20bf25e1b207a5ae4b75e45c62d2cc1f4dce138075c2714e
-            1072208
+            766c472112aa7bc89a40177e6d5da2caf588b602 \
+            5db8c8de26c8561e8e349ad9650307bf7e08af4f00668447c53f3a8f7bd15d97
+            1087096
         }
         ""
         ""
@@ -169,9 +184,9 @@ array set modules {
     }
     qtdeclarative {
         {
-            13849d151710f3c8078c5b09ad1fc5f8a0c313d8 \
-            5aeb841a5665f79672a302569754ea7d541c69102c551707e43489e797213c71
-            29764804
+            2a50253c159a837046d1a33c65c986f1988a74c3 \
+            fa6a8b5bfe43203daf022b7949c7874240ec28b9c4b7ebc52b2e5ea440e6e94f
+            29475416
         }
         "port:python310"
         ""
@@ -184,39 +199,39 @@ array set modules {
     }
     qtimageformats {
         {
-            d7fc2ceddb89495a67644233feb47f3bf9fe70a9 \
-            df61dc1a517988bfa123117c78a7dbeda859cbb6d9cbd080ce60058277bca3df
-            1845284
+            5df81b2f5becde04c8accb0e9101ba697f7a8d83 \
+            ee22e84866ed3fb39bdaf88f533851658919ee92dad56eb6da3d31c311a97e5c
+            1846040
         }
         ""
-        "port:jasper port:libmng port:tiff port:webp"
+        "path:lib/pkgconfig/jasper.pc:jasper port:libmng port:tiff port:webp"
         "qtbase"
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 0"
         "License: "
     }
-    qtlocation {
+    qtmultimedia {
         {
-            438885e8a07f1a307cc278c95bb9b461533641d8 \
-            a99e92c762d45b17e14685cd8a3c1564a3da0ce1cfd1a68ffd5b3fd7c409dcad
-            6675600
+            cdca1e04909cf8c9efde2033f7159739586249a0 \
+            ea703487c21613fcc55dd0c3fb2dc8e1ae77003ae6212a60c85d5210b64832b6
+            3795508
         }
         ""
-        "path:lib/pkgconfig/icu-uc.pc:icu port:zlib"
-        "qtbase qtdeclarative qtserialport"
-        {"Qt Location" "Qt Positioning"}
+        ""
+        "qtbase qtdeclarative qtshadertools"
+        {"Qt Multimedia" "Qt Multimedia Widgets"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 0"
         "License: "
     }
     qtnetworkauth {
         {
-            56547cc10525dbf557c151a8455ac2055d680bb7 \
-            8027f85095a9c56d8cada988527454f786a5f8dd4157206db4f21299016d1c9e
-            144292
+            7203e279bcb4b2eb65791c1c9407a1f31db266d6 \
+            53e96704d34403e89b05ef8b46edb039cd2bb3dc85d62bffc5ac0856ecee0dcc
+            146148
         }
         ""
         ""
@@ -227,11 +242,26 @@ array set modules {
         "revision 0"
         "License: "
     }
+    qtpositioning {
+        {
+            e831cc791a9ec8b75cd59fb76f51e78f28664835 \
+            075eb22c86c05fd2367bcdc34a29aec8871dd8463d7b73f2a77bf27384c885ff
+            1492336 
+        }
+        ""
+        ""
+        "qtbase qtdeclarative qtserialport"
+        {"Provides the ability to determine a position by using a variety of possible sources"}
+        ""
+        "variant overrides: "
+        "revision 0"
+        "License: {GPL-3}"
+    }
     qtremoteobjects {
        {
-           94d3e5037e083243c7df9ef25c628ed8b3ad63e8 \
-           76681b03bb63e1cafa38a1bfde23c194f232aaff4b010d5f58c065fdcc0b379f
-           358628
+            892fad53e65bd6a439b4702e5bf00a4a52ab9da5 \
+            d23ab298d2ebf5b8437b0794af47266bb3048b0f4b733e0db1335a09fc18d883
+            367336
        }
        ""
        ""
@@ -244,9 +274,9 @@ array set modules {
     }
     qtsensors {
         {
-            d7f061244537b3b483529e8b5766198a978c502c \
-            5f55c972c52848f5c828148fded1b30de32955f7ee04867568c559991214739a
-            2045476
+            718054cf865c7de873ad29083584a286280a55a1 \
+            79d43e38431c93996f803c6f946856c5ab35a60f9c9438ccceaa312bdb4a6a06
+            2109744
         }
         ""
         ""
@@ -259,9 +289,9 @@ array set modules {
     }
     qtserialbus {
         {
-            00c46347f19928501a798a6f73a6a35af7c9a457 \
-            15e7a0a578dc9ed306ff2598edb9822081902ef1a4b52b20f1d2dd6461239f85
-            378596
+            2b0764da4ae9d8c7c4a68305eaf3f2c9a61dfb3b \
+            33c15752f8e7f99cc49b9d3bf9eabd857bfcd649e37ada8bffceedc5a66a8a64
+            380088
         }
         ""
         ""
@@ -274,9 +304,9 @@ array set modules {
     }
     qtserialport {
         {
-            13b54c9622e90aa17dbba118eba214882ffeddc8 \
-            ec77f4c9d6096588f3e735315f873976103479be453985b27f27fe8994e0776a
-            318916
+            17d011c970ef8d353ef9023f43d0b6cffa470eec \
+            8fdbfbb2aeee0e6400c90406927a784d3790bb0dfa7e5d7b9da7b2ded52bb744
+            320492
         }
         ""
         ""
@@ -287,11 +317,26 @@ array set modules {
         "revision 0"
         "License: "
     }
+    qtshadertools {
+        {
+            0513ce360d99dc01609ddb327f6bf9c4b7f91602 \
+            20881824cba0c1396c0fe6b27d0f995a261070b68fa3629b1a188147d58933cc
+            987564
+        }
+        ""
+        ""
+        "qtbase"
+        {"Qt ShaderTools"}
+        ""
+        "variant overrides: "
+        "revision 0"
+        "License: "
+    }
     qtsvg {
         {
-            dea5b2492dd16c71a30714c75ab3b3864063fffa \
-            86e27e005c2421052ca90e619c8d13f1bd19c6bf1a7b84dd4e0f7855fc884fd7
-            1717684
+            812b8590980228f96a861e674e4b993590beb1e6 \
+            23ec4c14259d799bb6aaf1a07559d6b1bd2cf6d0da3ac439221ebf9e46ff3fd2
+            1727160
         }
         ""
         ""
@@ -304,9 +349,9 @@ array set modules {
     }
     qttools {
         {
-            a2afeabfe2037491631891333d8d226db4479548 \
-            5a856d3d3d5fe6e15dc3f1af707a0ef1df2e687850403fc94af635edb9312bfb
-            8668512
+            47864565591ba588c9eb7f44a974661fa90c535d \
+            17f40689c4a1706a1b7db22fa92f6ab79f7b698a89e100cab4d10e19335f8267
+            8664772
         }
         ""
         "port:clang-${llvm_version}"
@@ -314,14 +359,14 @@ array set modules {
         {"Qt Designer" "Qt Help" "Qt UI Tools"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 0"
         "License: "
     }
     qttranslations {
         {
-            623817eb7f3967fe3911aad89f537d48dc2d291c \
-            3f680b520da585697fc725697a52c7d2074a6a728f6830366b491a6f8b9183c7
-            1444712
+            467b490bbddc8114a2d71aaeb7a0e82649b1e089 \
+            bd1aac74a892c60b2f147b6d53bb5b55ab7a6409e63097d38198933f8024fa51
+            1446208
         }
         ""
         ""
@@ -334,9 +379,9 @@ array set modules {
     }
     qtwebchannel {
         {
-            88773d8e3904df163d9593c04c5e9262412bad0d \
-            035ba2e9a0e9de0baddd40f9d50014e6eb5f0b4ec741e9aec1b434e7c9e4e9c9
-            211188
+            a1ba285374474a4b1c242493b4783ca7289f6682 \
+            20ce2bbc21b6f1fb665d37887d4af7e761baa3a1c1b9cc0f550ede212a8d296d
+            213476
         }
         ""
         ""
@@ -349,9 +394,9 @@ array set modules {
     }
     qtwebsockets {
         {
-            da59cdb38216ad2fd8a563b39bb6b697fe1399d1 \
-            23344e21e96a839697abed7bf7931a8c08a752f08bf25edf240748501aba3816
-            258064
+            11718a93bc62e904d69d0ee9759136a02a9ea7bf \
+            702f1e3248b256045d76898875bca51e70d8c452cbbff243e16c0ae5b962f964
+            265912
         }
         ""
         ""
@@ -522,7 +567,7 @@ foreach {module module_info} [array get modules] {
             depends_lib-append port:${name}-${qtdeps}
         }
 
-        description       Tools and Module(s) for Qt Tool Kit ${qt_major}
+        description     Tools and Module(s) for Qt Tool Kit ${qt_major}
 
         set modules_provided_list [lindex ${module_info} 4]
         if { [llength ${modules_provided_list}] == 1 } {
@@ -597,10 +642,6 @@ foreach {module module_info} [array get modules] {
             # respect MacPorts build variables
             patchfiles-append patch-mkspecs.diff
 
-            # Backported upstream patch to build with the macOS 12 SDK.
-            # https://github.com/qt/qtbase/commit/dece6f5840463ae2ddf927d65eb1b3680e34a547
-            patchfiles-append patch-qiosurfacegraphicsbuffer.h.diff
-
             # respect configure.compiler
             if { ${configure.compiler} eq "clang" } {
                 # let xargs find correct compiler (default behaviour)
@@ -650,7 +691,7 @@ foreach {module module_info} [array get modules] {
                     "s|__MACPORTS_DEPLOYMENT_TARGET__|${macosx_deployment_target}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
 
-                #respect configure.optflags
+                # respect configure.optflags
                 reinplace \
                     "s|__MACPORTS_OPTFLAGS__|${configure.optflags}|g" \
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
@@ -894,27 +935,32 @@ foreach {module module_info} [array get modules] {
             default_variants-append +openssl
 
         } else {
-
             # these subports use qt-cmake
-            PortGroup                    qt6 1.0
-            PortGroup                    active_variants 1.1
+            PortGroup   qt6 1.0
+            PortGroup   active_variants 1.1
 
-            # We need to use qt-cmake to configure the build
-            configure.cmd                ${qt_configure_module_cmd}
+            depends_build-append \
+                        path:bin/cmake:cmake \
+                        port:ninja
+
+            # use "qt-configure-module" to configure the build
+            configure.cmd   ${qt_configure_module_cmd}
 
             # Attempting to match module configure instructions from here: https://www.qt.io/blog/qt-6-build-system
             # --prefix is not recognized.
-            configure.pre_args-delete    --prefix=${prefix}
-            configure.pre_args-append    ${worksrcpath}
-            configure.dir                ${workpath}/build
+            configure.dir   ${workpath}/build
 
-            # Qt suggests using Ninja to build
-            depends_build-append         port:ninja
-            build.cmd                    ninja
-            build.post_args-append       -v
-            build.dir                    ${workpath}/build
+            configure.pre_args-delete   --prefix=${prefix}
+            configure.pre_args-append   ${worksrcpath}
 
-            destroot.target install
+            # build using using cmake
+            build.dir       ${workpath}/build
+            build.cmd       cmake --build ${build.dir}
+            build.target
+
+            destroot.target
+            destroot.cmd    cmake --install ${build.dir}
+
             # ninja needs the DESTDIR argument in the environment
             destroot.destdir
             destroot.env-append DESTDIR=${destroot}
@@ -1033,14 +1079,6 @@ foreach {module module_info} [array get modules] {
             ###############################################################################
             # Special Cases
             ###############################################################################
-
-            # special case
-            if { ${module} eq "qtlocation" } {
-                PortGroup       conflicts_build 1.0
-
-                # do not allow ${prefix}/include/boost to conflict with bundled boost (in bundled mapbox-gl-native)
-                conflicts_build boost
-            }
         }
     }
 }
@@ -1073,7 +1111,7 @@ foreach {sql_names sql_info} [array get sql_plugins] {
         set isSQL_module             true
         cmake.install_prefix         ${qt_dir}
 
-        # We need to use qt-cmake to configure the build
+        # use "qt-configure-module" to configure the build
         configure.cmd                ${qt_cmake_cmd}
         configure.dir                ${workpath}/build
 
@@ -1155,7 +1193,7 @@ foreach {sql_names sql_info} [array get sql_plugins] {
 if { ${subport} eq ${name} } {
     # the main port is Meta-port to install various modules
 
-    revision 0
+    revision    0
 
     description         Qt Tool Kit ${qt_major}
     long_description    Qt Tool Kit: A cross-platform framework \
@@ -1164,17 +1202,17 @@ if { ${subport} eq ${name} } {
 
     master_sites
     distfiles
-    use_configure     no
-    supported_archs   noarch
-    installs_libs     no
-    universal_variant no
+    use_configure       no
+    supported_archs     noarch
+    installs_libs       no
+    universal_variant   no
 
     build {}
 
     # create a dummy file so the port can be successfully activated
     destroot {
         xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${subport}
-        set docfile   [open ${destroot}${prefix}/share/doc/${subport}/README.txt "w"]
+        set docfile [open ${destroot}${prefix}/share/doc/${subport}/README.txt "w"]
         puts ${docfile} "Meta-port for ${name}"
         puts ${docfile} "${long_description}"
         close ${docfile}


### PR DESCRIPTION
#### Description

Update to latest QT 6.2 LTS (6.2.4)
- Add new subports for qtcharts qtmultimedia qtshadertools

[Trac 66019](https://trac.macports.org/ticket/66019)
[Trac 66020](https://trac.macports.org/ticket/66020)
[Trac 65030](https://trac.macports.org/ticket/65030)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
