### PR TITLE
postgresql12: version bump to 12.13

### DIFF
--- a/databases/postgresql12-doc/Portfile
+++ b/databases/postgresql12-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql12-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc \
     postgresql13-doc
-version             12.12
+version             12.13
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -22,9 +22,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql12
 
-checksums           rmd160  97003e54c9737fac0d3df995ebb37519f57456e2 \
-                    sha256  34b3f1c69408e22068c0c71b1827691f1c89153b0ad576c1a44f8920a858039c \
-                    size    21089064
+checksums           rmd160  5c6bf4b91576529a8250a48072f3ac3d3318dac6 \
+                    sha256  b6c623046af4548f11a84b407934d675d11ed070c793d15b04683bf5f322e02d \
+                    size    21114311
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql12-server/Portfile
+++ b/databases/postgresql12-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql12-server
-version             12.12
+version             12.13
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql12/Portfile
+++ b/databases/postgresql12/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql12
-version             12.12
-revision            2
+version             12.13
+revision            0
 
 categories          databases
 platforms           darwin
@@ -27,9 +27,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  97003e54c9737fac0d3df995ebb37519f57456e2 \
-                    sha256  34b3f1c69408e22068c0c71b1827691f1c89153b0ad576c1a44f8920a858039c \
-                    size    21089064
+checksums           rmd160  5c6bf4b91576529a8250a48072f3ac3d3318dac6 \
+                    sha256  b6c623046af4548f11a84b407934d675d11ed070c793d15b04683bf5f322e02d \
+                    size    21114311
 
 use_bzip2           yes
 


### PR DESCRIPTION
#### Description

postgresql12: version bump to 12.13

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
