### PR TITLE
luajit: fix PPC build

### DIFF
--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -35,10 +35,16 @@ post-patch {
 
 use_configure       no
 
-compiler.blacklist  {clang < 700} *gcc-4.2 macports-clang-3.3 macports-clang-3.4
+compiler.blacklist  {clang < 700} *gcc-4.0 *gcc-4.2 macports-clang-3.3 macports-clang-3.4
 
 # changes to compiler flags must be made before `CFLAGS=...`
 xcode_workaround.type append_to_compiler_flags
+
+# https://trac.macports.org/ticket/65996
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append \
+                    -lgcc_eh
+}
 
 build.target        amalg
 build.args-append   CC="${configure.cc}" \


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65996

#### Description

1. Sources explicitly require at least `gcc-4.3`, so `gcc-4.0` must be added to blacklist, otherwise it is pulled and build fails.
2. Build with GCC, at least on PPC (both Leopard and SL), fail with undefined unwinder symbols. I have tried a number of ways to fix that, what worked was adding `-lgcc_eh` ldflag. Closes my own ticket referred to above.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
