### PR TITLE
n: update to 9.0.1

### DIFF
--- a/devel/n/Portfile
+++ b/devel/n/Portfile
@@ -3,19 +3,21 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        tj n 9.0.0 v
+github.setup        tj n 9.0.1 v
 categories          devel
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@akierig fastmail.de:akierig} \
+                    openmaintainer
+
 license             MIT
 
 description         A simple tool to interactively manage Node.js versions
 
 long_description    ${description}
 
-checksums           rmd160  89bfffd9b7d7b29f890dde2137d427a574e63b80 \
-                    sha256  021b8b57bd3460e8f6b0b24499ac2403ac93850ca2c3200033d58c5a641096ed \
-                    size    34917
+checksums           rmd160  7a18c34d3fd92a805c46cc299ff7af839c28951b \
+                    sha256  e9c14f9fb2957b86c1adc79697572e49f2b46f92af78b1ba42f67e12ffa6b344 \
+                    size    35027
 
 use_configure       no
 
@@ -26,6 +28,6 @@ destroot.args       PREFIX=${destroot}${prefix}
 notes {
 Set the environment variable N_PREFIX to install to a user-writable area:
 
-    export N_PREFIX=$HOME/.n
+    export N_PREFIX=$HOME/.local/n
 
 }


### PR DESCRIPTION
#### Description

- update to v9.0.1
- adopts unmaintained port (closes https://trac.macports.org/ticket/66237)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 arm64
Xcode 14.1 14B47b

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?