### PR TITLE
mrustc: it should parse on unsupported platforms

### DIFF
--- a/lang/mrustc/Portfile
+++ b/lang/mrustc/Portfile
@@ -41,9 +41,11 @@ checksums           mrustc-${github.version}.tar.gz \
 # i386 and ppc may requires future patches
 supported_archs     arm64 x86_64
 
-array set rust_platforms [list \
-    arm64   aarch64 \
-    x86_64  x86_64]
+set rust_platforms(arm64)  aarch64
+
+if {![info exists rust_platforms(${configure.build_arch})]} {
+    set rust_platforms(${configure.build_arch}) ${configure.build_arch}
+}
 
 set rust_platform   $rust_platforms(${configure.build_arch})
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

I've added `[skip ci]` to not overload it, this is syntax fix and I've tested it locally with portindex.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->