### PR TITLE
skaffold: update to 2.0.2

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.0.1 v
+github.setup        GoogleContainerTools skaffold 2.0.2 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  6c660777aeda829e273a3698df6f9d7e57f60c86 \
-                    sha256  58ca783891cb1dfe4a1c06027d637a3e699d1fd675b2235cdc8904400cc7744d \
-                    size    39794719
+checksums           rmd160  efabd8885134f4ef0e948dda04b3114c28405701 \
+                    sha256  fa5de4e9d83b2d2e5e08a10389ea93d768d18986353011069a642b9f32e85b54 \
+                    size    71689566
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.0.2.

###### Tested on

macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?