### PR TITLE
compilers PG: allow latest on non-darwin

### DIFF
--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -77,7 +77,7 @@ options compilers.allow_arguments_mismatch
 default compilers.allow_arguments_mismatch no
 
 # Set a default gcc version
-if {${os.major} < 10} {
+if {${os.major} < 10 && ${os.platform} eq "darwin" } {
     # see https://trac.macports.org/ticket/57135
     set compilers.gcc_default gcc7
 } else {
@@ -88,7 +88,7 @@ set compilers.list {cc cxx cpp objc fc f77 f90}
 
 # build database of gcc compiler attributes
 # Should match those in compilers/gcc_compilers.tcl
-if { ${os.arch} eq "arm" } {
+if { ${os.arch} eq "arm" || ${os.platform} ne "darwin" } {
     set gcc_versions {10 11 12 devel}
 } else {
     set gcc_versions {}
@@ -101,7 +101,7 @@ if { ${os.arch} eq "arm" } {
 }
 # GCC version providing the primary runtime
 # Note settings here *must* match those in the lang/libgcc port.
-if { ${os.major} < 10 } {
+if { ${os.major} < 10 && ${os.platform} eq "darwin" } {
     set gcc_main_version 7
 } else {
     set gcc_main_version 12
@@ -156,7 +156,7 @@ foreach ver ${gcc_versions} {
 # build database of clang compiler attributes
 # Should match those in compilers/clang_compilers.tcl
 set clang_versions {}
-if { ${os.arch} ne "arm" } {
+if { ${os.arch} ne "arm" && ${os.platform} eq "darwin" } {
     if {${os.major} < 16} {
         if {${os.major} < 9} {
             lappend clang_versions 3.3
@@ -176,9 +176,9 @@ if { ${os.arch} ne "arm" } {
         lappend clang_versions 9.0 10
     }
 }
-if { ${os.major} >= 10 } {
+if { ${os.major} >= 10 || ${os.platform} ne "darwin" } {
     lappend clang_versions 11
-    if { ${os.major} >= 11 } {
+    if { ${os.major} >= 11 || ${os.platform} ne "darwin"} {
         lappend clang_versions 12 13 14 15
     }
     if { ${os.major} >= 14 } {


### PR DESCRIPTION
#### Description

This PR continues from @jmroot's work in https://github.com/macports/macports-ports/commit/a24826ee8d386288e73ae20a8cb6701acf8f2944 by using the latest compiler versions for non-Darwin in the compilers PG.

This also fixes a parse error for me since my raspberry pi has an `os.arch` of arm (suggesting a newer compiler version) but its `os.major` is 5 (suggesting an older version).

```
> sudo port -v sync
...
> Failed to parse file archivers/snappy/Portfile: can't read "cdb(gcc7,descrip)": no such element in array
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Linux raspberrypi 5.10.103-v7+ #1529 SMP Tue Mar 8 12:21:37 GMT 2022 armv7l GNU/Linux

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
