### PR TITLE
GPXSee: update to 11.8

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 11.5
+github.setup        tumic0 GPXSee 11.8
 revision            0
 
-checksums           rmd160  95dbd636db3f881f890c0c6a8e07788dbed325e0 \
-                    sha256  61125260f32d2c7fd12653f8d32236bf0b3dc8cce2732bc3c877deec47fb859b \
-                    size    5338822
+checksums           rmd160  2b68a17875221bd549d7675d6720178079d8ad6c \
+                    sha256  8bea34393ead04d7006a17f4fd6bc2c06f24ee76630445f839c7c18c409e4865 \
+                    size    5472586
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
