### PR TITLE
rust PG: set build_major on non-Darwin

### DIFF
--- a/_resources/port1.0/group/rust-1.0.tcl
+++ b/_resources/port1.0/group/rust-1.0.tcl
@@ -163,7 +163,7 @@ proc rust.add_bootstrap_components {architectures {components {rust-std rustc ca
             set rustc_version       ${version_m1}
         } else {
             set build_vendor        macports
-            if { ${os.major} >= 11 } {
+            if { ${os.major} >= 11 || [option os.platform] ne "darwin" } {
                 set rustc_version   ${version_m1}+0
                 set build_major     ""
             } elseif { ${os.major} >= 10 } {


### PR DESCRIPTION
On non-darwin, ports using the rust PG fail to parse since the variable `build_major` hasn't been set. This PR aims to correct that.

```
> sudo port -v sync
...
Failed to parse file devel/cargo/Portfile: can't read "build_major": no such variable
```
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Linux raspberrypi 5.10.103-v7+ #1529 SMP Tue Mar 8 12:21:37 GMT 2022 armv7l GNU/Linux

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
