### PR TITLE
creduce: fix parse error on non-Darwin

### DIFF
--- a/devel/creduce/Portfile
+++ b/devel/creduce/Portfile
@@ -24,14 +24,12 @@ homepage                http://embed.cs.utah.edu/creduce
 patch.pre_args          -p1
 
 # INSTALL.md notes the specific version of LLVM that is required.
-platform darwin {
-    if { !([variant_isset llvm90] || [variant_isset llvm11]) } {
-        # LLVM-11 needed for Big Sur and later
-        if {${os.major} >= 20} {
-            default_variants    +llvm11
-        } else {
-            default_variants    +llvm90
-        }
+if { !([variant_isset llvm90] || [variant_isset llvm11]) } {
+    # LLVM-11 needed for Big Sur and later
+    if {${os.major} >= 20} {
+        default_variants    +llvm11
+    } else {
+        default_variants    +llvm90
     }
 }
 


### PR DESCRIPTION
#### Description
This PR fixes a parse error on non-Darwin with the creduce port. It does this by setting a default variant on all platforms, not just Darwin.

```
> sudo port -v sync
...
Failed to parse file devel/creduce/Portfile: One variant must be selected
```

https://github.com/macports/macports-ports/blob/127805107c1543567ad5df00e88516d9f2f9241f/devel/creduce/Portfile#L45

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Linux raspberrypi 5.10.103-v7+ https://github.com/macports/macports-ports/pull/1529 SMP Tue Mar 8 12:21:37 GMT 2022 armv7l GNU/Linux

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
