### PR TITLE
sqlcheck: new port (version 1.3)

### DIFF
--- a/databases/sqlcheck/Portfile
+++ b/databases/sqlcheck/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+PortGroup           cmake   1.1
+
+github.setup        jarulraj sqlcheck 1.3 v
+github.tarball_from archive
+revision            0
+
+description         \
+    Automatically identify anti-patterns in SQL queries
+
+long_description    \
+    ${name} automatically detects common SQL anti-patterns. Such \
+    anti-patterns often slow down queries. Addressing them will, therefore, \
+    help accelerate queries. ${name} targets all major SQL dialects.
+
+categories          databases
+installs_libs       no
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  1357cd9d279a65aa40b8adacf0464be1120932c7 \
+                    sha256  7300964364d4ef8ed576cf1b1fe5c52321ab429fa78cff0f6984b9954eed60de \
+                    size    43916
+
+depends_lib-append  port:gflags \
+                    port:gtest
+
+patchfiles-append   patch-CMakeLists.diff       \
+                    patch-src-CMakeLists.diff   \
+                    patch-test-CMakeLists.diff

--- a/databases/sqlcheck/files/patch-CMakeLists.diff
+++ b/databases/sqlcheck/files/patch-CMakeLists.diff
@@ -1,0 +1,36 @@
+--- ./CMakeLists.txt.orig	2022-11-13 16:18:14.000000000 -0500
++++ ./CMakeLists.txt	2022-11-13 16:19:21.000000000 -0500
+@@ -53,31 +53,12 @@
+ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb")
+ 
+ # -- [ GTest
+-enable_testing()
+-set(GOOGLETEST_ROOT external/googletest/googletest CACHE STRING "Google Test source root")
+-include_directories(
+-    ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}
+-    ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/include
+-    )
+-set(GOOGLETEST_SOURCES
+-    ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest-all.cc
+-    ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest_main.cc
+-    )
+-foreach(_source ${GOOGLETEST_SOURCES})
+-    set_source_files_properties(${_source} PROPERTIES GENERATED 1)
+-endforeach()
+ 
+-add_library(googletest ${GOOGLETEST_SOURCES})
++find_package(gtest REQUIRED)
+ 
+ # -- [ GFlags
+ 
+-set(GFLAGS_ROOT external/gflags CACHE STRING "Google Flags")
+-
+-add_subdirectory(${PROJECT_SOURCE_DIR}/${GFLAGS_ROOT})
+-
+-include_directories(
+-    ${PROJECT_BINARY_DIR}/${GFLAGS_ROOT}/include
+-)
++find_package(gflags REQUIRED)
+ 
+ # --[ Threads
+ 

--- a/databases/sqlcheck/files/patch-src-CMakeLists.diff
+++ b/databases/sqlcheck/files/patch-src-CMakeLists.diff
@@ -1,0 +1,8 @@
+--- ./src/CMakeLists.txt.orig	2022-11-13 16:26:13.000000000 -0500
++++ ./src/CMakeLists.txt	2022-11-13 16:26:53.000000000 -0500
+@@ -22,4 +22,4 @@
+ )
+ 
+ # Add installation target
+-install (TARGETS sqlcheck sqlcheck_library DESTINATION bin)
++install (TARGETS sqlcheck DESTINATION bin)

--- a/databases/sqlcheck/files/patch-test-CMakeLists.diff
+++ b/databases/sqlcheck/files/patch-test-CMakeLists.diff
@@ -1,0 +1,11 @@
+--- ./test/CMakeLists.txt.orig	2022-11-13 16:21:26.000000000 -0500
++++ ./test/CMakeLists.txt	2022-11-13 16:21:35.000000000 -0500
+@@ -9,7 +9,7 @@
+ add_executable(test_suite test_suite.cpp)
+ target_link_libraries(test_suite sqlcheck_library 
+ ${GTEST_BOTH_LIBRARIES} 
+-googletest
++gtest
+ ${GLOG_LIBRARIES} 
+ ${CMAKE_THREAD_LIBS_INIT}
+ )


### PR DESCRIPTION
https://github.com/jarulraj/sqlcheck

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
