### PR TITLE
gnuastro: fix wrong code for buildjobs, fix build on PPC

### DIFF
--- a/science/gnuastro/Portfile
+++ b/science/gnuastro/Portfile
@@ -33,6 +33,12 @@ depends_lib-append      port:cfitsio \
 depends_run-append      port:curl \
                         port:ghostscript
 
+patchfiles-append       patch-buildjobs.diff
+
+post-patch {
+    reinplace "s|@MP_BUILDJOBS@|${buildmakejobs}|" ${worksrcpath}/configure
+}
+
 # https://trac.macports.org/ticket/66254
 platform darwin powerpc {
     configure.args-append \

--- a/science/gnuastro/Portfile
+++ b/science/gnuastro/Portfile
@@ -32,3 +32,9 @@ depends_lib-append      port:cfitsio \
 # TODO: add port:ds9 when it will be fixed
 depends_run-append      port:curl \
                         port:ghostscript
+
+# https://trac.macports.org/ticket/66254
+platform darwin powerpc {
+    configure.args-append \
+                        --disable-dependency-tracking
+}

--- a/science/gnuastro/files/patch-buildjobs.diff
+++ b/science/gnuastro/files/patch-buildjobs.diff
@@ -1,0 +1,13 @@
+# https://trac.macports.org/ticket/66254
+
+--- configure.orig	2022-07-22 01:21:10.000000000 +0800
++++ configure	2022-11-14 15:15:22.000000000 +0800
+@@ -21228,7 +21228,7 @@
+ 
+         if test $has_sysctl = yes
+ then :
+-  jobs=$(sysctl -a | awk '/^hw\.ncpu/{print $2}')
++  jobs=@MP_BUILDJOBS@
+ else $as_nop
+   jobs=8
+ fi


### PR DESCRIPTION
#### Description

First commit adds `--disable-dependency-tracking` for PPC, which is necessary to fix the build.
Second replaces a broken code for determining build jobs with Macports setting.

Fixes: https://trac.macports.org/ticket/66254

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
