### PR TITLE
wcslib: for for 32-bit platforms

### DIFF
--- a/science/wcslib/Portfile
+++ b/science/wcslib/Portfile
@@ -37,6 +37,11 @@ configure.args      --disable-fortran \
                     --with-cfitsiolib=${prefix}/lib \
                     --without-pgplot
 
+# https://trac.macports.org/ticket/66253
+if {${build_arch} in [list i386 ppc]} {
+    configure.ldflags-append -read_only_relocs suppress
+}
+
 # The -I flag from CPPFLAGS ends up in the wrong place on the build line
 # (before the -I flags for source directories). The build system will add
 # its own -I and -L flags from the --with-cfitsioinc and --with-cfitsiolib


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/48047
Fixes: https://trac.macports.org/ticket/66253

#### Description

@kencu I hope you can review this. The port has no universal variant presently, and I am not gonna struggle implementing it at the moment. Looking through existing ports that use `-read_only_relocs suppress`, it appears that i386 needs that as well. So I add the flag for i386 and ppc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
