### PR TITLE
py-openssl: update to 22.1.0

### DIFF
--- a/python/py-openssl/Portfile
+++ b/python/py-openssl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup python    1.0
 PortGroup github    1.0
 
-github.setup        pyca pyopenssl 21.0.0
+github.setup        pyca pyopenssl 22.1.0
 revision            0
 name                py-openssl
 categories-append   devel security
@@ -21,9 +21,9 @@ homepage            https://pyopenssl.org/
 supported_archs     noarch
 installs_libs       no
 
-checksums           rmd160  5806276d4716458a77c32f91a0c7f8ee30fe1dfb \
-                    sha256  5d1d93fb3d55be740e444b991bccc5db26b1cfd3666cbbd8b6d01dc7a6cc5430 \
-                    size    172965
+checksums           rmd160  673afd6a9f136a627324fdf8ddc2ddd9b356d6fe \
+                    sha256  63ce2278a8437c0f43c5049d604341595d09caef9d36f5b4fd388a60fdaa1255 \
+                    size    178218
 
 python.versions     27 37 38 39 310
 


### PR DESCRIPTION
#### Description

This fixes a number of errors such as:
AttributeError: module 'lib' has no attribute 'SSL_CTX_set_ecdh_auto'

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b

<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
