### PR TITLE
fricas: revbump for sbcl update

### DIFF
--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fricas
 version             1.3.8
-revision            2
+revision            3
 categories          math
 maintainers         {@pietvo vanoostrum.org:pieter} openmaintainer
 platforms           darwin


### PR DESCRIPTION
#### Description

Revbump because a new version of sbcl has been released.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
