### PR TITLE
latte-int: new port (version 1.7.6)

### DIFF
--- a/devel/cddlib/Portfile
+++ b/devel/cddlib/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        cddlib cddlib 0.94m
-revision            0
+revision            1
 platforms           darwin
 categories          devel math
 license             GPL-2+
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 github.tarball_from releases
 
@@ -22,5 +22,6 @@ long_description    ${description}
 depends_lib-append  port:gmp
 
 post-destroot {
-    delete {*}[glob ${destroot}${prefix}/bin/*]
+    xinstall -m 755 -d ${destroot}${prefix}/libexec/${name}
+    move ${destroot}${prefix}/bin ${destroot}${prefix}/libexec/${name}
 }

--- a/math/4ti2/Portfile
+++ b/math/4ti2/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            4ti2 4ti2 1_6_9 Release_
+version                 [string map {_ .} ${github.version}]
+
+categories              math
+license                 GPL-2
+
+maintainers             {@catap korins.ky:kirill} openmaintainer
+
+homepage                https://4ti2.github.io
+description             A software package for algebraic, geometric and combinatorial problems on linear spaces.
+long_description        {*}${description}
+
+checksums               rmd160  ea1e2a1619bd4c49b94b78ac14dd91cbc83e8789 \
+                        sha256  3b6a17ce097bd489c70d3344e7020213b11064c51b4ef455e2f22a6ab807e886 \
+                        size    4999644
+
+use_autoreconf          yes
+autoreconf.args         -fvi
+
+compiler.cxx_standard   2011
+
+depends_lib-append      port:glpk \
+                        port:gmp
+
+# invert default behaviour by enabling shared library and disable static ones
+configure.args          --disable-static \
+                        --enable-shared

--- a/math/LiDIA/Portfile
+++ b/math/LiDIA/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            mkoeppe LiDIA 19281f81af411ec86858ba0eb4030f20b1396df7
+version                 2.3.0.20190901
+
+categories              math
+license                 GPL-2+
+
+maintainers             {@catap korins.ky:kirill} openmaintainer
+
+description             A library for computational number theory
+long_description        {*}${description}
+
+checksums               rmd160  52fb677e5bc6bf2595a5f3ddc870a854c7cf413c \
+                        sha256  73c9e6345c3d814206e4d95dafcaa4f46668b7f065644d92e0df54e53d823b53 \
+                        size    21981417
+
+depends_build-append    port:autoconf \
+                        port:automake \
+                        port:libtool
+
+depends_lib-append      port:glpk \
+                        port:gmp
+
+configure.cmd           ./bootstrap && ./configure
+configure.args          --disable-static \
+                        --enable-shared \
+                        --with-arithmetic=gmp

--- a/math/QSopt_ex/Portfile
+++ b/math/QSopt_ex/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            jonls qsopt-ex e5d498fde468e4669a3fbc4736e5d3b878e8c148
+name                    QSopt_ex
+version                 2.5.10.20170629
+
+categories              math
+license                 GPL-3+
+
+maintainers             {@catap korins.ky:kirill} openmaintainer
+
+homepage                https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM/
+description             an exact linear programming solver
+long_description        {*}${description}
+
+checksums               rmd160  4bbeeb0fb629fa629731b9870ac07b796fd54d0c \
+                        sha256  5f148537f0e815709fc274d6906946ced6117db3599a97b5acc347c6066909a1 \
+                        size    323613
+
+use_autoreconf          yes
+autoreconf.args         -fvi
+
+depends_lib-append      port:gmp \
+                        port:lbzip2 \
+                        port:zlib

--- a/math/TOPCOM/Portfile
+++ b/math/TOPCOM/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               boost 1.0
+
+name                    TOPCOM
+version                 1.1.2
+
+categories              math
+license                 GPL-2+
+
+maintainers             {@catap korins.ky:kirill} openmaintainer
+
+homepage                https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM/
+description             Triangulations Of Point Configurations and Oriented Matroids
+long_description        {*}${description}
+
+master_sites            https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM-Downloads/
+distname                ${name}-[string map {. _} ${version}]
+extract.suffix          .tgz
+
+checksums               rmd160  145443b533690b34529475661b58703d5be0011e \
+                        sha256  4fb10754ee5b76056441fea98f2c8dee5db6f2984d8c14283b49239ad4378ab6 \
+                        size    7924000
+
+patchfiles              system-cddlib-qso.diff
+
+compiler.cxx_standard   2017
+configure.cxxflags-append -std=c++17
+
+use_autoreconf          yes
+autoreconf.args         -fvi
+
+depends_lib-append      port:QSopt_ex \
+                        port:cddlib \
+                        port:gmp \
+                        port:soplex
+
+configure.args          --enable-soplex \
+                        --enable-qsoptex
+
+livecheck.type          regex
+livecheck.regex         "Download ${name}-(\[\\d.\]+)"
+livecheck.url           https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM-Downloads/index.html

--- a/math/TOPCOM/files/system-cddlib-qso.diff
+++ b/math/TOPCOM/files/system-cddlib-qso.diff
@@ -1,0 +1,166 @@
+diff --git configure.ac configure.ac
+index 2372711..a7c62dc 100644
+--- configure.ac
++++ configure.ac
+@@ -43,8 +43,23 @@ else
+   AC_MSG_NOTICE([... done])
+ fi
+ 
+-dnl Make libcddgmp:
+-make -C external cdd
++dnl Make cddlib if requested:
++AC_LANG_PUSH(C++)
++AC_CHECK_HEADERS([cddlib/setoper.h])
++AC_CHECK_HEADERS([cddlib/cdd.h], [], [],
++[#ifdef HAVE_CDDLIB_SETOPER_H
++# include <cddlib/setoper.h>
++# endif
++])
++AC_LANG_POP
++AM_CONDITIONAL(USE_LOCAL_CDD, [test "x$ac_cv_header_cddlib_cdd_h" = "xno"])
++if test "x$ac_cv_header_cddlib_cdd_h" = "xyes"; then
++  AC_MSG_NOTICE([system cddlib is used])
++else
++  AC_MSG_NOTICE([cddlib/cdd.h not found on system - building cdd locally ...])
++  make -C external cdd
++  AC_MSG_NOTICE([... done])
++fi
+ 
+ dnl Check for requests for third-party packages:
+ dnl Check for qsopt_ex:
+@@ -62,8 +77,17 @@ if test "x$enable_qsoptex" = "xyes"; then
+   AC_CHECK_LIB([z], [gzopen], [], AC_MSG_NOTICE([compiling without libz]))
+   AC_CHECK_LIB([bz2], [BZ2_bzopen], [], AC_MSG_NOTICE([compiling without libbz2]))
+ 
+-  dnl Make libqsopt_ex:
+-  make -C external qso
++  AC_LANG_PUSH(C++)
++  AC_CHECK_HEADERS([qsopt_ex/QSopt_ex.h])
++  AC_LANG_POP
++  AM_CONDITIONAL(USE_LOCAL_QSOPTEX, [test "x$ac_cv_header_qsopt_ex_QSopt_ex_h" = "xno"])
++  if test "x$ac_cv_header_qsopt_ex_QSopt_ex_h" = "xyes"; then
++    AC_MSG_NOTICE([system QSopt_ex is used])
++  else
++    AC_MSG_NOTICE([qsopt_ex/QSopt_ex.h not found on system - building cddQSopt_exlocally ...])
++    make -C external qso
++    AC_MSG_NOTICE([... done])
++  fi
+ else
+   AC_MSG_RESULT(no)
+ fi
+@@ -77,12 +101,23 @@ AC_ARG_ENABLE([soplex],
+ if test "x$enable_soplex" = "xyes"; then  
+   AC_MSG_RESULT(yes)
+ 
+-  dnl Check for compression library (soplex needs it):
+-  AC_CHECK_LIB([z], [gzopen], [LIBS="-lsoplex $LIBS"; AC_DEFINE(HAVE_LIBSOPLEX)], AC_MSG_NOTICE([libz missing => soplex not enabled]))
++
++  AC_LANG_PUSH(C++)
++  AC_CHECK_HEADERS([soplex.h])
++  AC_LANG_POP
++  AM_CONDITIONAL(USE_SOPLEX, [test "x$ac_cv_header_soplex_h" = "xyes"])
++  if test "x$ac_cv_header_soplex_h" = "xyes"; then
++    AC_MSG_NOTICE([system soplex is used])
++  else
++    AC_MSG_NOTICE([soplex.h not found on system - using external ...])
++      dnl Check for compression library (soplex needs it):
++    AC_CHECK_LIB([z], [gzopen], [LIBS="-lsoplex $LIBS"; AC_DEFINE(HAVE_LIBSOPLEX)], AC_MSG_NOTICE([libz missing => soplex not enabled]))
++    AC_MSG_NOTICE([... done])
++  fi
+ else
+   AC_MSG_RESULT(no)
+ fi
+-AM_CONDITIONAL(USE_SOPLEX, [test "x$ac_cv_lib_z_gzopen" = "xyes" -a "x$enable_soplex" = "xyes"])
++AM_CONDITIONAL(USE_LOCAL_SOPLEX, [test "x$ac_cv_lib_z_gzopen" = "xyes" -a "x$enable_soplex" = "xyes"])
+ 
+ dnl Check for Permlib:
+ dnl AC_MSG_CHECKING(whether permlib support was enabled)
+diff --git lib-src-reg/LPinterface.hh lib-src-reg/LPinterface.hh
+index 6522dbe..c376887 100644
+--- lib-src-reg/LPinterface.hh
++++ lib-src-reg/LPinterface.hh
+@@ -21,8 +21,8 @@
+ #include "LabelSet.hh"
+ #include "Rational.h"
+ 
+-#include "setoper.h"
+-#include "cdd.h"
++#include "cddlib/setoper.h"
++#include "cddlib/cdd.h"
+ 
+ namespace topcom {
+ 
+diff --git src-reg/Makefile.am src-reg/Makefile.am
+index ed4a016..c017871 100644
+--- src-reg/Makefile.am
++++ src-reg/Makefile.am
+@@ -3,15 +3,30 @@ bin_PROGRAMS = checkregularity
+ checkregularity_SOURCES = checkregularity.cc
+ 
+ LDADD           = ../lib-src/libTOPCOM.a \
+-                  ../lib-src-reg/libCHECKREG.a \
+-                  ../external/lib/libcddgmp.a
++                  ../lib-src-reg/libCHECKREG.a
++
++if USE_LOCAL_CDD
++LDADD          += ../external/lib/libcddgmp.a
++else
++LIBS           += -lcddgmp -lcdd
++endif
++
+ if USE_QSOPTEX
++if USE_LOCAL_QSOPTEX
+ LDADD          += ../external/lib/libqsopt_ex.a
++else
++LIBS           += -lqsopt_ex
++endif
+ endif
+ 
+ if USE_SOPLEX
++LIBS           += -lsoplexshared
++else
++if USE_LOCAL_SOPLEX
+ LDADD          += ../external/lib/libsoplex.a
+ endif
++endif
++
+ if USE_LOCAL_GMP
+ LDADD          += ../external/lib/libgmpxx.a \
+                   ../external/lib/libgmp.a
+diff --git src/Makefile.am src/Makefile.am
+index c97ecc5..4b26e1a 100644
+--- src/Makefile.am
++++ src/Makefile.am
+@@ -122,14 +122,30 @@ santos_dim4_triang_SOURCES         = santos_dim4_triang.cc
+ santos_22_triang_SOURCES           = santos_22_triang.cc
+ 
+ LDADD           = ../lib-src/libTOPCOM.a \
+-                  ../lib-src-reg/libCHECKREG.a \
+-                  ../external/lib/libcddgmp.a
++                  ../lib-src-reg/libCHECKREG.a
++
++if USE_LOCAL_CDD
++LDADD          += ../external/lib/libcddgmp.a
++else
++LIBS           += -lcddgmp -lcdd
++endif
++
+ if USE_QSOPTEX
++if USE_LOCAL_QSOPTEX
+ LDADD          += ../external/lib/libqsopt_ex.a
++else
++LIBS           += -lqsopt_ex
+ endif
++endif
++
+ if USE_SOPLEX
++LIBS           += -lsoplexshared
++else
++if USE_LOCAL_SOPLEX
+ LDADD          += ../external/lib/libsoplex.a
+ endif
++endif
++
+ if USE_LOCAL_GMP
+ LDADD          += ../external/lib/libgmpxx.a \
+                   ../external/lib/libgmp.a

--- a/math/latte-int/Portfile
+++ b/math/latte-int/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            latte-int latte 1_7_6 version_
+name                    latte-int
+version                 [string map {_ .} ${github.version}]
+
+categories              math
+license                 GPL-2
+
+maintainers             {@catap korins.ky:kirill} openmaintainer
+
+homepage                https://www.math.ucdavis.edu/~latte/
+description             LattE integrale, software for counting lattice points and integration over convex polytopes
+long_description        {*}${description}
+
+checksums               rmd160  1611fb65489800fea6f221ec64c0ebc7081445bc \
+                        sha256  458b487bd10ca0fa3b1e36fb0b3a4d58b448d77c69d8ce34be0b53e97cebb394 \
+                        size    9769267
+
+patchfiles              redundant-AC_CONFIG_MACRO_DIR.diff \
+                        remove-dynamic-exceptions.diff
+
+compiler.cxx_standard   2017
+configure.cxxflags-append -std=c++17
+
+use_autoreconf          yes
+autoreconf.args         -fvi
+
+depends_lib-append      port:4ti2 \
+                        port:LiDIA \
+                        port:TOPCOM \
+                        port:cddlib \
+                        port:gmp \
+                        port:lrslib \
+                        port:ntl
+
+configure.env           PATH=$env(PATH):${prefix}/libexec/cddlib/bin
+
+post-destroot {
+    move ${destroot}${prefix}/bin/count ${destroot}${prefix}/bin/latte-count
+}

--- a/math/latte-int/files/redundant-AC_CONFIG_MACRO_DIR.diff
+++ b/math/latte-int/files/redundant-AC_CONFIG_MACRO_DIR.diff
@@ -1,0 +1,10 @@
+--- configure.ac
++++ configure.ac
+@@ -17,7 +17,6 @@ AC_USE_SYSTEM_EXTENSIONS
+ LT_INIT
+ AC_PROG_CC
+ AC_PROG_CXX
+-AC_CONFIG_MACRO_DIR([m4])
+ # AC_PROG_LIBTOOL
+ 
+ # For Gnulib relocatable-prog

--- a/math/latte-int/files/remove-dynamic-exceptions.diff
+++ b/math/latte-int/files/remove-dynamic-exceptions.diff
@@ -1,0 +1,66 @@
+diff --git code/latte/ExponentialSubst.cpp code/latte/ExponentialSubst.cpp
+index a839b820..bcbfa934 100644
+--- code/latte/ExponentialSubst.cpp
++++ code/latte/ExponentialSubst.cpp
+@@ -57,7 +57,6 @@ mpq_vector
+ computeExponentialResidueWeights(const vec_ZZ &generic_vector,
+ 				 mpz_class &prod_ray_scalar_products,
+ 				 const listCone *cone, int numOfVars)
+-  throw(NotGenericException)
+ {
+   // Compute dimension; can be smaller than numOfVars
+   int dimension = 0;
+@@ -95,7 +94,6 @@ computeExponentialResidueWeights(const vec_ZZ &generic_vector,
+ mpq_vector
+ computeExponentialResidueWeights(const vec_ZZ &generic_vector,
+ 				 const listCone *cone, int numOfVars)
+-  throw(NotGenericException)
+ {
+   mpz_class prod_ray_scalar_products;
+   return computeExponentialResidueWeights(generic_vector,
+diff --git code/latte/ExponentialSubst.h code/latte/ExponentialSubst.h
+index c9fa4ace..43a4ab63 100644
+--- code/latte/ExponentialSubst.h
++++ code/latte/ExponentialSubst.h
+@@ -58,13 +58,11 @@ class Exponential_Single_Cone_Parameters
+ mpq_vector /* FIXME: This version can probably go away */
+ computeExponentialResidueWeights(const vec_ZZ &generic_vector,
+ 				 mpz_class &prod_ray_scalar_products,
+-				 const listCone *cone, int numOfVars)
+-  throw(NotGenericException);
++				 const listCone *cone, int numOfVars);
+ 
+ mpq_vector
+ computeExponentialResidueWeights(const vec_ZZ &generic_vector,
+-				 const listCone *cone, int numOfVars)
+-  throw(NotGenericException);
++				 const listCone *cone, int numOfVars);
+ 
+ ZZ
+ scalar_power(const vec_ZZ &generic_vector,
+diff --git code/latte/sqlite/IntegrationDB.cpp code/latte/sqlite/IntegrationDB.cpp
+index ab8df535..c1dde830 100644
+--- code/latte/sqlite/IntegrationDB.cpp
++++ code/latte/sqlite/IntegrationDB.cpp
+@@ -1277,7 +1277,7 @@ void  IntegrationDB::insertSpecficPolytopeIntegrationTest(string polymakeFile, i
+  * @parm filePath: to the latte-style polynomial.
+  * @return rowid of the inserted row.
+  */
+-int IntegrationDB::insertPolynomial(int dim, int degree, const char*filePath) throw(SqliteDBexception)
++int IntegrationDB::insertPolynomial(int dim, int degree, const char*filePath)
+ {
+ 	if ( doesPolynomialExist(filePath))
+ 		throw SqliteDBexception(string("insertPolynomial::Polynomial ")+filePath+" already exist");
+diff --git code/latte/sqlite/IntegrationDB.h code/latte/sqlite/IntegrationDB.h
+index d690a832..ce8cfac6 100644
+--- code/latte/sqlite/IntegrationDB.h
++++ code/latte/sqlite/IntegrationDB.h
+@@ -67,7 +67,7 @@ class IntegrationDB: public SqliteDB
+ 	int insertIntegrationTest(int polynomialID, int polytopeID);
+ 	void insertIntegrationTest(int dim, int degree, int vertexCount, int count);
+ 	void insertSpecficPolytopeIntegrationTest(string polymakeFile, int degree, int count);
+-	int insertPolynomial(int dim, int degree, const char*filePath) throw(SqliteDBexception);
++        int insertPolynomial(int dim, int degree, const char*filePath);
+ 
+ 	int insertPolytope(int dim, int vertexCount, int simple, int dualRowID, const char* latteFilePath, const char* polymakeFilePath);
+ 

--- a/math/lrslib/Portfile
+++ b/math/lrslib/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               makefile 1.0
+
+name                    lrslib
+version                 7.2
+
+categories              math
+license                 GPL-2+
+
+maintainers             {@catap korins.ky:kirill} openmaintainer
+
+homepage                http://cgm.cs.mcgill.ca/~avis/C/lrs.html
+description             self-contained ANSI C implementation of the reverse search algorithm for  vertex enumeration/convex hull problems
+long_description        {*}${description}
+
+master_sites            http://cgm.cs.mcgill.ca/~avis/C/lrslib/archive/
+set distfile_version    0[string map {. ""} ${version}]
+distfiles               ${name}-${distfile_version}${extract.suffix}
+
+checksums               rmd160  8e07d8f6615472b9530ecbf763be0d1b541426d9 \
+                        sha256  fc48754a1ded1d8445d40ecfbe3546e4f27d53aaee95dc2c8c0c79fb9cd532f0 \
+                        size    496411
+
+platform darwin {
+    post-patch {
+        # Darwin requires different arguments to build dynamic libraries
+        reinplace "s|-shared -Wl,-soname=|-dynamiclib -install_name ${prefix}/lib/|" ${worksrcpath}/Makefile
+
+        # Darwin's install is a bit different than linux one
+        reinplace {s|install -t $(DESTDIR)${prefix}/lib $(SHLIB)|install $(SHLIB) $(DESTDIR)${prefix}/lib|} ${worksrcpath}/Makefile
+        reinplace {s|install -t $(DESTDIR)${prefix}/include/lrslib ${INSTALL_INCLUDES}|install ${INSTALL_INCLUDES} $(DESTDIR)${prefix}/include/lrslib|} ${worksrcpath}/Makefile
+    }
+}
+
+makefile.prefix_name    prefix
+
+depends_lib-append      port:gmp
+
+build.target            single all-shared
+
+post-destroot {
+    file copy ${worksrcpath}/lrs1 ${worksrcpath}/lrs2 ${destroot}${prefix}/bin
+}
+
+livecheck.type          regex
+livecheck.version       ${distfile_version}
+livecheck.url           http://cgm.cs.mcgill.ca/~avis/C/lrslib/archive/
+livecheck.regex         "${name}-(\[\\da-z]+)"

--- a/math/soplex/Portfile
+++ b/math/soplex/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           boost 1.0
+PortGroup           cmake 1.1
+
+name                soplex
+version             6.0.2
+categories          math
+license             ZIB Academic Licence
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+description         Sequential object-oriented simPlex
+long_description    SoPlex is an optimization package for solving linear programming problems (LPs) \
+                    based on an advanced implementation of the primal and dual revised simplex algorithm.
+
+homepage            https://soplex.zib.de/
+master_sites        https://soplex.zib.de/download/release/
+distname            ${name}-${version}.0
+extract.suffix      .tgz
+
+checksums           rmd160  30745ef666d7493864fb8e54815c829b9e8bcb4d \
+                    sha256  47150ddd6eab9e51003fd2c303ebe8ec225e8ee9742f48548b9c74617d449962 \
+                    size    984865
+
+depends_lib-append  port:gmp \
+                    port:zlib
+
+configure.args      -DGMP=ON \
+                    -DQUADMATH=ON
+
+livecheck.type      regex
+livecheck.regex     Version (\[0-9.\]+) released


### PR DESCRIPTION
#### Description

This PR includes a few more math library which is required by latte-int.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->