### PR TITLE
google-cloud-sdk: update to 410.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             409.0.0
+version             410.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  80da854770db86c4b0f1bcb0a18d491018801f88 \
-                    sha256  7e2ae4df436a7df6d2566220de21d1a4e70f4c315a5c24219941b2296055815d \
-                    size    109772750
+    checksums       rmd160  edd7e7b98bbe4ec06f825a412eea83c23743f749 \
+                    sha256  4454ccbe404847952d313f08c3aa758bcb736417702c788e75634f3d54fcd470 \
+                    size    109893414
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  81d19e01d8fa7ebe02b4402671929e7bdd0b6116 \
-                    sha256  2abe477b42cc1eace25bbec42a6b8080e0bbfbbf5311d561851b5a005e2ce744 \
-                    size    98743339
+    checksums       rmd160  d4b5423b58a4223d2b5f7ed82656cdcf33f11a28 \
+                    sha256  eea3ca9a271a81f36d07e39beb7748d07a3a0c3ffc394dbeb06405c3de11ddb9 \
+                    size    98865495
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  ea6a5b49ba617a45240bdc6c7a2a751b5d5cb1f8 \
-                    sha256  b943a6cc01797412c51cb6fce7d1d9151b574b7f4bc7d2a5b4cb8975e1b75820 \
-                    size    97151974
+    checksums       rmd160  61769453ed29049939c70a871052568820459afd \
+                    sha256  c4d7cd11ead7ab4038a7072802714b82615b0b92983d6347405bbf02bfd16b26 \
+                    size    97276932
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -41,8 +41,8 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 
 worksrcdir          ${name}
 
-# Recommended Python version according to https://cloud.google.com/sdk/docs/install#mac
-python.default_version 37
+# Most recent supported Python version according to https://cloud.google.com/sdk/docs/install#mac
+python.default_version 39
 
 post-patch {
     # Default to the MacPorts Python binary


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 410.0.0.

###### Tested on

macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?