### PR TITLE
nauty: update to 2.8.6

### DIFF
--- a/math/nauty/Portfile
+++ b/math/nauty/Portfile
@@ -3,14 +3,14 @@
 PortSystem          1.0
 
 name                nauty
-version             2.7r4
+version             2.8.6
 categories          math science
 license             Apache-2
 platforms           darwin
 maintainers         {gmail.com:szhorvat @szhorvat} openmaintainer
 
-livecheck.version   [strsed ${version} {g/\.//}]
-livecheck.regex     ${name}(\[0-9r\]+)\\.tar
+livecheck.version   [strsed ${version} {g/\./_/}]
+livecheck.regex     ${name}(\[0-9\](_\[0-9\]+)+)\\.tar
 
 homepage            http://users.cecs.anu.edu.au/~bdm/nauty
 master_sites        ${homepage}
@@ -28,10 +28,10 @@ long_description    nauty and traces are programs for computing automorphism \
                     multigraphs, and programs for manipulating files of graphs \
                     in a compact format.
 
-checksums           rmd160  11dd337ad159f077d25a1baca171d0d21488cb14 \
-                    sha256  b810c85a6fe299f3b4c9f24aaf929cac7f9546c2f35c20e1dd0adbc7408848a6 \
-                    size    1731562
-					
+checksums           rmd160  8c4c24e9e1c3903d04e796b44d179d04b7ef86e1 \
+                    sha256  f2ce98225ca8330f5bce35f7d707b629247e09dda15fc479dc00e726fee5e6fa \
+                    size    1546765
+
 variant native description {Build optimized for your machine's specific processor} {
     archive_sites
 }
@@ -47,7 +47,9 @@ destroot {
     xinstall -W ${worksrcpath} \
         NRswitchg \
         addedgeg \
+        addptg \
         amtog \
+        ancestorg \
         assembleg \
         biplabg \
         catg \
@@ -58,6 +60,7 @@ destroot {
         cubhamg \
         deledgeg \
         delptg \
+        dimacs2g \
         directg \
         dreadnaut \
         dretodot \
@@ -66,6 +69,7 @@ destroot {
         genbg \
         genbgL \
         geng \
+        genposetg \
         genquarticg \
         genrang \
         genspecialg \
@@ -80,6 +84,7 @@ destroot {
         newedgeg \
         pickg \
         planarg \
+        productg \
         ranlabg \
         shortg \
         showg \
@@ -95,10 +100,10 @@ post-destroot {
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} \
-        nug27.pdf \
+        nug28.pdf \
         README \
         README_24 \
-        changes24-27.txt \
+        changes24-28.txt \
         formats.txt \
         schreier.txt \
         ${destroot}${docdir}


### PR DESCRIPTION
#### Description

 - update to 2.8.6
 - adapt livecheck to new versioning scheme

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
