### PR TITLE
vim, MacVim: Update to 9.0.0472

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -8,11 +8,11 @@ PortGroup           compiler_blacklist_versions 1.0
 # is because they both share the same set of configuration files and ensures
 # that the user's configuration files will always work with both.
 set vim_version     9.0
-set snapshot        173
-github.setup        macvim-dev macvim ${snapshot} snapshot-
-revision            1
+set release         174
+github.setup        macvim-dev macvim ${release} release-
+revision            0
 name                MacVim
-version             ${vim_version}.snapshot${snapshot}
+version             ${vim_version}.release${release}
 categories          editors
 platforms           darwin
 license             Vim GPL-2+
@@ -25,9 +25,9 @@ long_description \
 
 homepage            https://macvim-dev.github.io/macvim/
 
-checksums           rmd160  88e64d4c6c5352a998f92a759b2a64118f93f844 \
-                    sha256  edf8cb0cd4215281374af95585830721d7200020a081e213ecaf92c19710381a \
-                    size    24213601
+checksums           rmd160  5db536887934411f93238f1db1c4537b7ba17b1b \
+                    sha256  bd8cfba37a7dfc9eba30fdfb9fd3b2082ca3bbc6740eac9f61964bb802415ea0 \
+                    size    23694113
 
 depends_lib         port:ncurses \
                     port:gettext \
@@ -122,50 +122,32 @@ variant perl description {Enable Perl scripting} {
     depends_lib-append      path:bin/perl:perl5
 }
 
-variant python27 description {Enable Python scripting} {
-    configure.args-append   --enable-pythoninterp --with-python-command=${prefix}/bin/python2.7
-    patchfiles-append       patch-python.diff
-    depends_lib-append      port:python27
+set pythons_suffixes {27 36 37 38 39 310}
 
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
+set pythons_ports {}
+foreach s ${pythons_suffixes} {
+    lappend pythons_ports python${s}
 }
-variant python36 conflicts python37 python38 python39 description {Enable Python scripting} {
-    configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python3.6
-    patchfiles-append       patch-python3.diff
-    depends_lib-append      port:python36
 
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
-}
-variant python37 conflicts python36 python38 python39 description {Enable Python scripting} {
-    configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python3.7
-    patchfiles-append       patch-python3.diff
-    depends_lib-append      port:python37
-
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
-}
-variant python38 conflicts python36 python37 python39 description {Enable Python scripting} {
-    configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python3.8
-    patchfiles-append       patch-python3.diff
-    depends_lib-append      port:python38
-
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
-}
-variant python39 conflicts python36 python37 python38 description {Enable Python scripting} {
-    configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python3.9
-    patchfiles-append       patch-python3.diff
-    depends_lib-append      port:python39
-
-    use_autoconf yes
-    # Overwriting autoconf.cmd above removes dependency, add it again
-    depends_build-append port:autoconf
+foreach s ${pythons_suffixes} {
+    set p python${s}
+    set major [string index ${s} 0]
+    set v ${major}.[string range ${s} 1 end]
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    variant ${p} description "Enable Python scripting" conflicts {*}${c} "
+        if {${major} == 2} {
+            configure.args-append   --enable-pythoninterp --with-python-command=${prefix}/bin/python${v}
+            patchfiles-append       patch-python.diff
+        } else {
+            configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python${v}
+            patchfiles-append       patch-python3.diff
+        }
+        depends_lib-append      port:${p}
+        use_autoconf yes
+        # overwriting autoconf.cmd above removes dependency, add it again
+        depends_build-append port:autoconf
+    "
 }
 
 variant ruby requires ruby18 description {Compatibility variant, requires +ruby18} {}

--- a/editors/MacVim/files/patch-remove-Homebrew-python.diff
+++ b/editors/MacVim/files/patch-remove-Homebrew-python.diff
@@ -1,10 +1,9 @@
 --- src/MacVim/vimrc	2021-04-01 10:32:44.000000000 +0200
 +++ src/MacVim/vimrc	2021-04-05 14:56:37.000000000 +0200
-@@ -8,36 +8,3 @@
- " The default for 'backspace' is very confusing to new users, so change it to a
+@@ -9,36 +9,4 @@
  " more sensible value.  Add "set backspace&" to your ~/.vimrc to reset it.
  set backspace+=indent,eol,start
--
+
 -" Python2
 -" MacVim is configured by default to use the pre-installed System python2
 -" version. However, following code tries to find a Homebrew, MacPorts or
@@ -28,12 +27,13 @@
 -" or an installation from python.org:
 -if exists("&pythonthreedll") && exists("&pythonthreehome") &&
 -      \ !filereadable(&pythonthreedll)
--  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.9/Python")
--    " MacPorts python 3.9
--    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.9/Python
--  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.9/Python")
+-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python")
+-    " MacPorts python 3.10
+-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python
+-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.10/Python")
 -    " https://www.python.org/downloads/mac-osx/
--    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.9/Python
+-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.10/Python
 -  endif
 -endif
 -
+ " vim: sw=2 ts=2 et

--- a/editors/MacVim/files/patch-remove-updater.diff
+++ b/editors/MacVim/files/patch-remove-updater.diff
@@ -25,13 +25,13 @@
              </connections>
          </customObject>
          <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-@@ -180,49 +178,6 @@
-                         </popUpButton>
+@@ -210,49 +208,6 @@
+                         </textField>
                      </subviews>
                  </customView>
 -                <customView id="0hT-y8-Hge" userLabel="Updater">
--                    <rect key="frame" x="19" y="22" width="444" height="36"/>
--                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+-                    <rect key="frame" x="20" y="20" width="444" height="36"/>
+-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
 -                    <subviews>
 -                        <button id="122">
 -                            <rect key="frame" x="188" y="18" width="258" height="18"/>
@@ -73,5 +73,5 @@
 -                    </subviews>
 -                </customView>
              </subviews>
-             <point key="canvasLocation" x="138" y="20"/>
+             <point key="canvasLocation" x="137.5" y="21.5"/>
          </customView>

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 # is because they both share the same set of configuration files and ensures
 # that the user's configuration files will always work with both.
 set vim_version     9.0
-set vim_patchlevel  0065
+set vim_patchlevel  0472
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v
 revision            0
 
@@ -23,9 +23,9 @@ long_description    Vim is an advanced text editor that seeks to provide the\
 
 homepage            https://www.vim.org/
 
-checksums           rmd160  1ae829aec84c7101c2713d9712c060f32e55cac6 \
-                    sha256  0e2b58f34ea6faee10f06bfefb163cc4d27a6f1b69e068d581c4e224b850acb3 \
-                    size    16704943
+checksums           rmd160  ee809eb300deaf735c86b6e5b7f4bc4a8fe79a41 \
+                    sha256  7185577d6cd3708b62b2079b69a29215bb6a6048070d34e960d2d565c18b8a9b \
+                    size    16851486
 
 depends_lib         port:ncurses \
                     port:gettext \
@@ -50,7 +50,7 @@ configure.args      --disable-gui \
                     --mandir=${prefix}/share/man \
                     --with-tlib=ncurses \
                     --enable-multibyte \
-                    --with-developer-dir=${developer_dir} \
+                    --with-developer-dir=${configure.developer_dir} \
                     --enable-fail-if-missing \
                     --with-compiledby="MacPorts"
 


### PR DESCRIPTION
#### Description

- Updated both Vim and MacVim to 9.0.0472.
- Removed `--with-developer-dir` from Vim configure because it was failing when `-t` (trace) was enabled. I am not sure if there is a better way to fix this?
- Changed all references of `snapshot` to `release` for MacVim, to match the new naming convention.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
  - There is an [open PR](https://github.com/macports/macports-ports/pull/16632) to update Vim to a later patchlevel (852). This PR instead uses the same patchlevel as MacVim 174 (472), as suggested there.
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

