### PR TITLE
swig: Add missing pcre2 dependency

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            swig
 version         4.1.0
-revision        0
+revision        1
 checksums       rmd160 dd137d71d8e3a7383e94da06f1459fddb9fa24a9 \
                 sha256  d6a9a8094e78f7cfb6f80a73cc271e1fe388c8638ed22668622c2c646df5bb3d \
                 size    8600226
@@ -252,7 +252,7 @@ subport swig-ruby {
 }
 
 if {${swig.lang} eq ""} {
-    depends_lib     port:pcre
+    depends_lib     port:pcre2
 
     set docdir      ${prefix}/share/doc/${name}-${version}
 


### PR DESCRIPTION
#### Description

The port failed to build in trace mode.

Increase revision since users that successfully built swig without trace mode now have incorrect dependency information in their registries.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
