### PR TITLE
miniflux: update to 2.0.40

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.39
+go.setup            github.com/miniflux/v2 2.0.40
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  419b5f664472706625a39ce3324ad56024daa984 \
-                        sha256  ebdf1b351f677940660f595ec23fd968803c47d8c3194079c7f5feb8a576f834 \
-                        size    575124
+                        rmd160  7bd074b4c6518a9d5234c9efddea1ac83e1ab581 \
+                        sha256  a9db26c6454dd9c1bca62b54ecaacf09be19c66c6fbd2ac6104085fe8aefdb52 \
+                        size    575536
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -26,11 +26,11 @@ go.vendors          mvdan.cc/xurls \
                         rmd160  7273a8af3153a595e51a8631a103749bc8d18da2 \
                         sha256  eca62cdf7aeb8edb0effeedb68cb160fc3440e9f8c061e735d738b3cd2afb7ec \
                         size    26252 \
-                    gopkg.in/yaml.v2 \
-                        lock    v2.4.0 \
-                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
-                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
-                        size    73231 \
+                    gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
                     gopkg.in/square/go-jose.v2 \
                         lock    v2.6.0 \
                         rmd160  56e581a46f0364551657e2b7698bd022973e9d7c \
@@ -44,45 +44,45 @@ go.vendors          mvdan.cc/xurls \
                         size    1281110 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
-                        lock    v1.6.6 \
-                        rmd160  ee3e5a6d2742607fd310e18634c1268156f39ad4 \
-                        sha256  084ba3a248eccd0c7606dc6cff3918326a0adb2e8d30babcbaf6f1c00e1d28f9 \
-                        size    333013 \
+                        lock    v1.6.7 \
+                        rmd160  32e6de431630b8126df1d04e36eba2abb57626f1 \
+                        sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
+                        size    333026 \
                     golang.org/x/text \
-                        lock    v0.3.7 \
-                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
-                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
-                        size    8356115 \
+                        lock    v0.4.0 \
+                        rmd160  a3215f5c266b2d6cc0ae945858b543031fcb5a54 \
+                        sha256  c4e794a9e732f422df4e005f87ddba1e640b5bb7d6ce10ad56e40fa8c7d56ee2 \
+                        size    8359157 \
                     golang.org/x/term \
-                        lock    a9ba230a4035 \
-                        rmd160  2011606ab7a7f34f3deffe211d32ef2c89ebb195 \
-                        sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
-                        size    14845 \
+                        lock    v0.2.0 \
+                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
+                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
+                        size    14797 \
                     golang.org/x/sys \
-                        lock    c680a09ffe64 \
-                        rmd160  a888af516046d59ceae0983ef656b6ea0a616ca5 \
-                        sha256  1c542763a49b094dedec13fc2b650d12b141a46d9237c947640745c47f72fefa \
-                        size    1358410 \
+                        lock    v0.2.0 \
+                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
+                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
+                        size    1411246 \
                     golang.org/x/oauth2 \
-                        lock    ee480838109b \
-                        rmd160  acb364be9c92be7d474ecc77f8b00bc5b3f91647 \
-                        sha256  895bdcba756ffeca30fa286d97f0da2cca2b4e46ffa219c853f8427dad33a6a7 \
-                        size    87815 \
+                        lock    v0.2.0 \
+                        rmd160  48360c3782cbcbf4bee62b295f25e78dd1a2b232 \
+                        sha256  f9d6706b090000deeaff12aec7bba2bfff89968f0740650297677de1f30467f4 \
+                        size    85700 \
                     golang.org/x/net \
-                        lock    83b083e8dc8b \
-                        rmd160  b07e74f0cce4986e46838bb8194adcc00eeca0d0 \
-                        sha256  555d8cd580927a2a3ac8376d231990200e1615db2ad2f65f3c53f440b5590649 \
-                        size    1226262 \
+                        lock    v0.2.0 \
+                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
+                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
+                        size    1243767 \
                     golang.org/x/crypto \
-                        lock    bd7e27e6170d \
-                        rmd160  be1105998890006fc82c6608bd95230c42f23470 \
-                        sha256  4d9f5e8967513831f87029849603069fa0c30b4568996495b62cd68130d17f70 \
-                        size    1631305 \
+                        lock    v0.2.0 \
+                        rmd160  bffcd0123418d8fb0d5d891c3600f7bf996221b8 \
+                        sha256  466bed7b7ebc652403ff0b6775944b569124d856a46981fc66027ee3ec0ed0d5 \
+                        size    1633095 \
                     github.com/yuin/goldmark \
-                        lock    v1.5.2 \
-                        rmd160  9e9d4e827f85ac2c97002d70b03af418fcd22cc4 \
-                        sha256  b778a831a92d5ea51354fdaca5a8467805602af60c62adc12182af04f733f2db \
-                        size    259706 \
+                        lock    v1.5.3 \
+                        rmd160  19ec5216062b33aa1442099e489ffc81fef34679 \
+                        sha256  be4f796428f98b24196b09c626909b7aa88b8eb14ab21102193f1287f6e48be7 \
+                        size    259890 \
                     github.com/technoweenie/multipartstreamer \
                         lock    v1.0.1 \
                         rmd160  f1ac41924fe0ca28bf79b5737680452a907b70b4 \
@@ -104,15 +104,15 @@ go.vendors          mvdan.cc/xurls \
                         sha256  0ad32e8938fe52e7e1963d4a78d4b4f0ceb73c851ebc0b9c9e10cf19d57d47dc \
                         size    7008558 \
                     github.com/stretchr/testify \
-                        lock    v1.4.0 \
-                        rmd160  86bd663e13ea7266334c47689074df16252db5ff \
-                        sha256  8ed95078bfd318ea477da509e6b16e6cf8d0d1b6b8d93b1f6097c6ba2a6df788 \
-                        size    110114 \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
                     github.com/rylans/getlang \
-                        lock    4c3188ff8a2d \
-                        rmd160  53d360a749a8a7c53b7ed2a88b3ceeb8f4214c17 \
-                        sha256  79003ca68407b3b358db8ef8e073dbec1f7aaab3cafd44f21818d6bc0e08c326 \
-                        size    22092 \
+                        lock    9e7f44ff8aa0 \
+                        rmd160  f1a0fc33eb1e627f0609029369b367ba76098409 \
+                        sha256  7d433ce89160e19d0375617b62e84bc4efce07e02428c09f2dacb7dcf6e6cfce \
+                        size    18598 \
                     github.com/prometheus/procfs \
                         lock    v0.8.0 \
                         rmd160  0cd72a082087a0c3dd922a362316063f79364968 \
@@ -124,35 +124,35 @@ go.vendors          mvdan.cc/xurls \
                         sha256  ed4d3dbcb57018812d44094380bb26c0c331ef6d99d4df13b4ed907aa221bc47 \
                         size    148974 \
                     github.com/prometheus/client_model \
-                        lock    v0.2.0 \
-                        rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
-                        sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
-                        size    10985 \
+                        lock    v0.3.0 \
+                        rmd160  a0b906835c5e39f188c88e71d319eac4a240567d \
+                        sha256  54817b98ddf4cde06a2f122c6d811d37ce25cc4f74d0a32bebf5620389c08c00 \
+                        size    14955 \
                     github.com/prometheus/client_golang \
-                        lock    v1.13.0 \
-                        rmd160  4e0a400d5ec02a478288bf851637b98f7fcc04f4 \
-                        sha256  23ec964ec317fdfb5fbe481cf0f41d213befaa1693b804bef86934fb478b649c \
-                        size    218821 \
+                        lock    v1.14.0 \
+                        rmd160  9f502ae011c53f72a9cba178310ffeed13d67a4a \
+                        sha256  81e046e141f490525685ab27ce96b089ebb48640641da3e64d169611c42e2717 \
+                        size    236365 \
                     github.com/pquerna/cachecontrol \
-                        lock    1555304b9b35 \
-                        rmd160  0a0f37cba23e467f89c717d93a37c5b34005b64e \
-                        sha256  51832af12991acba3c87afe472abf3e0c44fdc152f88d53d53db36eb2f63eec2 \
-                        size    18999 \
+                        lock    v0.1.0 \
+                        rmd160  e819f8dcacadd42bbe783a3c1810f17f3e43fa95 \
+                        sha256  0b40f48dd0734d739f3e360fea8f43fedd86cee3abfbdf85813573f8eab97fb3 \
+                        size    19877 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
                         sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
                         size    11409 \
-                    github.com/mitchellh/go-server-timing \
-                        lock    feb680ab92c2 \
-                        rmd160  60c6a906372d8486f21905a9bb3382cf32918f08 \
-                        sha256  f614f2e7a905b8865bd3b8070adaf91065c8795d24d091e070bbe7cfadc86e3d \
-                        size    78468 \
                     github.com/matttproud/golang_protobuf_extensions \
-                        lock    v1.0.1 \
-                        rmd160  e28c4169919e72c08ee6520ad2ce16943d18e40c \
-                        sha256  c40d4c38e7dc2a7bae57e3740bb28d463e173d82e4603622d04d01741ff7a083 \
-                        size    37197 \
+                        lock    v1.0.4 \
+                        rmd160  5cd0af4220838331f336b1dca99297e11441be69 \
+                        sha256  6c32596468a03ca847e3cc29e74d64e0b7a0bba64166343494696c418415d114 \
+                        size    37528 \
+                    github.com/matrix-org/gomatrix \
+                        lock    ceba4d9f7530 \
+                        rmd160  9f447aad7e63fbd3dd4167f0921833e03b82e360 \
+                        sha256  96ecd3f6db41b69df8ea8ae4eff694b2fc1916c40bef88e488fed3241ce3a31e \
+                        size    26592 \
                     github.com/lib/pq \
                         lock    v1.10.7 \
                         rmd160  2d1613378f35b0f27c085769cacb6eca1be07f84 \
@@ -173,21 +173,11 @@ go.vendors          mvdan.cc/xurls \
                         rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
                         sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
                         size    171736 \
-                    github.com/golang/gddo \
-                        lock    20d68f94ee1f \
-                        rmd160  3360724400076512551129e5fa3a4a224b214174 \
-                        sha256  265fb8dd0fb4069357ffaf7cd6089893261738c524d033610260400a244ea769 \
-                        size    3108333 \
                     github.com/go-telegram-bot-api/telegram-bot-api \
                         lock    v4.6.4 \
                         rmd160  80821ad149f661570509a35adcf2d1d73fcf0c10 \
                         sha256  98e078b4f8909436790f12c39fcc589ac7b4e9b39e342966d60470aa2f14fad8 \
                         size    2076483 \
-                    github.com/felixge/httpsnoop \
-                        lock    v1.0.3 \
-                        rmd160  909ff38f048a85840543a0f9e645908ce2dd9ced \
-                        sha256  cdd557fe7e45ce86f6c22c0030884e43c16f85daf2bb6e31b8bc00d03e5b8362 \
-                        size    11657 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.40)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
