### PR TITLE
boehmgc: fix build for +universal on arm64

### DIFF
--- a/devel/boehmgc/Portfile
+++ b/devel/boehmgc/Portfile
@@ -44,5 +44,13 @@ variant redirect description {Redirect malloc and friends to GC routines} {
                 --enable-redirect-malloc
 }
 
+if {[variant_isset universal] && \
+        "arm64" in ${configure.universal_archs} &&
+        "x86_64" in ${configure.universal_archs}} {
+    merger-post-destroot {
+        copy -force ${destroot}-x86_64${prefix}/lib/pkgconfig/bdw-gc.pc ${destroot}-arm64${prefix}/lib/pkgconfig/bdw-gc.pc
+    }
+}
+
 test.run        yes
 test.target     check


### PR DESCRIPTION
#### Description

The pkgconfig files differ between x86_64 and arm64 (in the Libs section). This patch overwrites the arm64 one with the x86_64 one (which additionally links with atomic_ops).

Closes: https://trac.macports.org/ticket/66287

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? Fails with `Command failed:  cd "/opt/local/var/macports/build/_Users_lucas_Code_macports-ports_devel_boehmgc/boehmgc/work" && /usr/bin/gzip -dc '/opt/local/var/macports/distfiles/boehmgc/bdwgc-8.2.2.tar.gz' | /usr/bin/tar -xf - `.
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
