### PR TITLE
sterile PG: introduce a new PG

### DIFF
--- a/_resources/port1.0/group/sterile-1.0.tcl
+++ b/_resources/port1.0/group/sterile-1.0.tcl
@@ -1,0 +1,40 @@
+
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+#===================================================================================================
+#
+# Portgroup to simplify building a port in sterilize build environment.
+# Sterilize build environment prevents port to picks anything up from MacPorts prefix.
+#
+#---------------------------------------------------------------------------------------------------
+#
+# Usage:
+#   PortGroup           sterile 1.0
+#
+#===================================================================================================
+
+# sterilize MacPorts build environment; we want nothing picked up from MP prefix
+default compiler.cpath                  {}
+default compiler.library_path           {}
+
+default configure.cxx_stdlib            {}
+
+default configure.cflags                {}
+default configure.cxxflags              {}
+default configure.cppflags              {}
+default configure.optflags              {}
+default configure.ldflags               {}
+
+default configure.universal_cflags      {}
+default configure.universal_cxxflags    {}
+default configure.universal_cppflags    {}
+default configure.universal_ldflags     {}
+default configure.universal_args        {}
+
+default configure.ccache                no
+default configure.distcc                no
+
+# sterilize PATH
+configure.env-append                    PATH=/usr/bin:/bin:/usr/sbin:/sbin
+build.env-append                        PATH=/usr/bin:/bin:/usr/sbin:/sbin
+destroot.env-append                     PATH=/usr/bin:/bin:/usr/sbin:/sbin

--- a/archivers/xz/Portfile
+++ b/archivers/xz/Portfile
@@ -41,22 +41,13 @@ if {${subport} eq ${name}} {
 
 # This port is used by clang-3.4 to bootstrap libcxx
 subport ${name}-bootstrap {
+    PortGroup               sterile 1.0
+
     revision                0
 
     # Avoid macports-clang dep (doesn't use C++ anyway)
     configure.cxx_stdlib
     compiler.whitelist      clang llvm-gcc-4.2 gcc-4.2 apple-gcc-4.2
-
-    # sterilize MacPorts build environment; we want nothing picked up from MP prefix
-    compiler.cpath
-    compiler.library_path
-
-    configure.ccache        no
-    configure.distcc        no
-
-    # sterilize PATH
-    configure.env-append    PATH=/usr/bin:/bin:/usr/sbin:/sbin
-    build.env-append        PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
     prefix                  ${prefix}/libexec/xz-bootstrap
     configure.args          --disable-doc \

--- a/devel/cmake-bootstrap/Portfile
+++ b/devel/cmake-bootstrap/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           clang_dependency 1.0
 PortGroup           muniversal 1.0
+PortGroup           sterile 1.0
 
 name                cmake-bootstrap
 categories          devel
@@ -43,8 +44,6 @@ post-patch {
     reinplace "s|__ORIG_PREFIX__|${orig_prefix}|g" ${worksrcpath}/Modules/CMakeFindFrameworks.cmake
 }
 
-configure.cxx_stdlib
-
 platform darwin {
     configure.env-append   CMAKE_OSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
 
@@ -59,10 +58,6 @@ platform darwin {
         configure.cxxflags-append -fpermissive
     }
 }
-
-# Clear CPATH and LIBRARY_PATH as we want to be completely independent of other ports
-compiler.cpath
-compiler.library_path
 
 configure.args-append --docdir=share/doc/cmake \
                       --parallel=${build.jobs} \

--- a/lang/clang-11-bootstrap/Portfile
+++ b/lang/clang-11-bootstrap/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           muniversal 1.0
+PortGroup           sterile 1.0
 
 # clang-11 is the last clang which can be build with the last version of cmake to not require c++11.
 name                clang-11-bootstrap
@@ -99,32 +100,6 @@ patchfiles          0001-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.pa
                     0029-compiler-rt-atomic-which-can-be-compiled-by-GCC.patch \
                     0035-clang-Implement-the-using_if_exists-attribute.patch \
                     0036-clang-Parse-Add-parsing-support-for-C-attributes-on-.patch
-
-# sterilize MacPorts build environment; we want nothing picked up from MP prefix
-compiler.cpath
-compiler.library_path
-
-configure.cxx_stdlib
-
-configure.cflags
-configure.cxxflags
-configure.cppflags
-configure.optflags
-configure.ldflags
-
-configure.universal_cflags
-configure.universal_cxxflags
-configure.universal_cppflags
-configure.universal_ldflags
-configure.universal_args
-
-configure.ccache    no
-configure.distcc    no
-
-# sterilize PATH
-configure.env-append \
-                    PATH=${workpath}/bins:/usr/bin:/bin:/usr/sbin:/sbin
-build.env-append    PATH=${workpath}/bins:/usr/bin:/bin:/usr/sbin:/sbin
 
 cmake.build_type    Release
 cmake.generator     {Unix Makefiles}

--- a/lang/gcc10-bootstrap/Portfile
+++ b/lang/gcc10-bootstrap/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
+PortGroup           sterile 1.0
 
 # ideally for this bootstrap port we want no deps on any MacPorts port. This port
 # should build cleanly from system roots and use and/or link to nothing in MacPorts.
@@ -118,31 +119,6 @@ post-patch {
         ${worksrcpath}/config/bootstrap-debug-lean.mk \
         ${worksrcpath}/config/bootstrap-debug-lib.mk
 }
-
-# sterilize MacPorts build environment; we want nothing picked up from MP prefix
-compiler.cpath
-compiler.library_path
-
-configure.cxx_stdlib
-
-configure.cflags
-configure.cxxflags
-configure.cppflags
-configure.optflags
-configure.ldflags
-
-configure.universal_cflags
-configure.universal_cxxflags
-configure.universal_cppflags
-configure.universal_ldflags
-configure.universal_args
-
-configure.ccache    no
-configure.distcc    no
-
-# sterilize PATH
-configure.env-append    PATH=/usr/bin:/bin:/usr/sbin:/sbin
-build.env-append        PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 platform darwin 8 {
     # Tiger comes with make 3.80 and we need 3.81

--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -73,6 +73,8 @@ if {${subport} eq ${name}} {
 
 # This port is used by clang-3.4 to bootstrap libcxx
 subport ${name}-bootstrap {
+    PortGroup               sterile 1.0
+
     depends_extract         port:xz-bootstrap
     depends_skip_archcheck-append \
                             xz-bootstrap
@@ -88,16 +90,6 @@ subport ${name}-bootstrap {
     # Avoid macports-clang dep (doesn't use C++ anyway)
     configure.cxx_stdlib
     compiler.whitelist      clang llvm-gcc-4.2 gcc-4.2 apple-gcc-4.2
-
-    # sterilize MacPorts build environment; we want nothing picked up from MP prefix
-    compiler.cpath
-    compiler.library_path
-
-    configure.distcc        no
-
-    # sterilize PATH
-    configure.env-append    PATH=/usr/bin:/bin:/usr/sbin:/sbin
-    build.env-append        PATH=/usr/bin:/bin:/usr/sbin:/sbin
 }
 # Also needed by later clangs.
 if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {

--- a/sysutils/diffutils-for-muniversal/Portfile
+++ b/sysutils/diffutils-for-muniversal/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           sterile 1.0
 
 name                diffutils-for-muniversal
 version             3.8
@@ -46,31 +47,6 @@ extract {
         }
     }
 }
-
-# sterilize MacPorts build environment; we want nothing picked up from MP prefix
-compiler.cpath
-compiler.library_path
-
-configure.cxx_stdlib
-
-configure.cflags
-configure.cxxflags
-configure.cppflags
-configure.optflags
-configure.ldflags
-
-configure.universal_cflags
-configure.universal_cxxflags
-configure.universal_cppflags
-configure.universal_ldflags
-configure.universal_args
-
-configure.ccache    no
-configure.distcc    no
-
-# sterilize PATH
-configure.env-append    PATH=/usr/bin:/bin:/usr/sbin:/sbin
-build.env-append        PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 universal_variant       no
 installs_libs           no


### PR DESCRIPTION
#### Description

MacPorts has at least 6 ports which is required to use sterilized environment to build, and such technic may be reused at different ports.

Let me keep it in one place to prevent copy-and-paste errors.

###### Type(s)
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

for example `clang-11-bootstrap` port configured as it should:

```
√ build % cmake -LA -N . | grep opt/local
CLANG_ORDER_FILE:FILEPATH=/opt/local/var/macports/build/_Users_catap_src_macports-ports_lang_clang-11-bootstrap/clang-11-bootstrap/work/build/tools/clang/clang.order
CMAKE_INSTALL_PREFIX:PATH=/opt/local/libexec/clang-11-bootstrap
LLVM_EXTERNAL_CLANG_SOURCE_DIR:PATH=/opt/local/var/macports/build/_Users_catap_src_macports-ports_lang_clang-11-bootstrap/clang-11-bootstrap/work/llvm-project/llvm/../clang
LLVM_EXTERNAL_COMPILER_RT_SOURCE_DIR:PATH=/opt/local/var/macports/build/_Users_catap_src_macports-ports_lang_clang-11-bootstrap/clang-11-bootstrap/work/llvm-project/llvm/../compiler-rt
LLVM_SRPM_USER_BINARY_SPECFILE:FILEPATH=/opt/local/var/macports/build/_Users_catap_src_macports-ports_lang_clang-11-bootstrap/clang-11-bootstrap/work/llvm-project/llvm/llvm.spec.in
PYTHON_EXECUTABLE:FILEPATH=/opt/local/libexec/python27-bootstrap/bin/python2.7
√ build 
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->