### PR TITLE
qt*-qttranslations: remove qttools dependency

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -631,12 +631,12 @@ array set modules {
             1634516
         }
         ""
+        "port:qt5-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -547,12 +547,12 @@ array set modules {
             1424160
         }
         ""
+        "port:qt511-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -547,12 +547,12 @@ array set modules {
             1365880
         }
         ""
+        "port:qt513-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -388,12 +388,12 @@ array set modules {
             1047568
         }
         ""
+        "port:qt53-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtwebkit {

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -415,12 +415,12 @@ array set modules {
             1153132
         }
         ""
+        "port:qt55-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtwebchannel {

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -436,12 +436,12 @@ array set modules {
             1225908
         }
         ""
+        "port:qt56-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtwebchannel {

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -513,12 +513,12 @@ array set modules {
             1206116
         }
         ""
+        "port:qt57-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -526,12 +526,12 @@ array set modules {
             1209556
         }
         ""
+        "port:qt58-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -545,12 +545,12 @@ array set modules {
             1329900
         }
         ""
+        "port:qt59-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -369,12 +369,12 @@ array set modules {
             1446208
         }
         ""
+        "port:qt6-qttools"
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests noarch ~docs"
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtwebchannel {


### PR DESCRIPTION
#### Description

qttranslations is a port which contains only .qm files; this ports is runtime dependency for near of all Qt-based applications like wireshark. qttools depends on clang because qdoc uses it to parce C++ files. That makes wireshark to depends on clang via qttranslations.

Fixed this insanity.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

as removing `qt*-qttools` and running `LC_ALL=ru_RU open /Applications/MacPorts/Wireshark.app` and `LC_ALL=de_DE open /Applications/MacPorts/Wireshark.app` to confirm that different locales are working.

and as `port build qt5-qttranslations` and `port build qt6-qttranslations` to confirm that build dependency to `qttools` is required and working.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->