### PR TITLE
py-brotlicffi: new port (version 1.0.9.2)

### DIFF
--- a/python/py-brotli/Portfile
+++ b/python/py-brotli/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  3e2402d137fd75f898007d3730773b32025a4857 \
                     sha256  b56a4371636e063ad3695f7c53aed5c18fc2303034564534981e7d6a11b75138 \
                     size    487046
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {$subport ne $name} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-brotlicffi/Portfile
+++ b/python/py-brotlicffi/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-brotlicffi
+version             1.0.9.2
+license             MIT
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+description         Python CFFI bindings to the Brotli library
+long_description    {*}${description}
+
+homepage            https://github.com/python-hyper/brotlicffi
+
+checksums           rmd160  a157bc47475ffa6812cea70ff11ec6701b3325e6 \
+                    sha256  0c248a68129d8fc6a217767406c731e498c3e19a7be05ea0a90c3c86637b7d96 \
+                    size    440077
+
+python.versions     37 38 39 310 311
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-cffi
+
+    set pybrotlipy_name py${python.version}-brotlipy
+} else {
+    set pybrotlipy_name py-brotlipy
+}
+
+#------------------------------------------------------------------------------
+# NOTE: Remove this logic - along with declaration of 'pybrotlipy_name', above,
+#   when obsolete port 'py-pybrotlipy' is ultimately deleted.
+#------------------------------------------------------------------------------
+pre-activate {
+    # Deactivate obsolete port 'py-brotlipy', if installed
+    if {![catch {set installed [lindex [registry_active ${pybrotlipy_name}] 0]}]} {
+        registry_deactivate_composite ${pybrotlipy_name} "" [list ports_nodepcheck 1]
+    }
+}

--- a/python/py-brotlipy/Portfile
+++ b/python/py-brotlipy/Portfile
@@ -1,43 +1,25 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           python 1.0
+PortGroup           obsolete 1.0
 
-github.setup        python-hyper brotlipy 0.7.0 v
-revision            1
 name                py-brotlipy
-license             MIT
-maintainers         nomaintainer
+version             0.7.0
+revision            2
 
-description         Python binding to the Brotli library
-long_description    ${description}
+#------------------------------------------------------------------------------
+# Obsolete Date: 2022-11-19
+#
+# NOTE: Also remove auto-deactivate logic related to this port, from
+#   'py-brotlicffi', when this port is ultimately deleted.
+#------------------------------------------------------------------------------
 
-fetch.type          git
+replaced_by         py-brotlicffi
 
-python.versions     37 38 39 310
-
-if {${name} ne ${subport}} {
-    post-fetch {
-        system -W ${worksrcpath} "git submodule update --init"
+set python_rootname [regsub ^py- [option name] ""]
+set python_versions {37 38 39 310}
+foreach pv ${python_versions} {
+    subport "py${pv}-${python_rootname}" {
+        replaced_by py${pv}-brotlicffi
     }
-
-    patchfiles      patch-test_simple_compression.py.diff
-
-    depends_build-append \
-                        port:py${python.version}-setuptools
-
-    depends_lib-append  port:py${python.version}-cffi
-
-    depends_test-append port:py${python.version}-pytest \
-                        port:py${python.version}-hypothesis
-
-    pre-test {
-        test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-    test.run            yes
-    test.cmd            py.test-${python.branch}
-    test.target         test
-
-    livecheck.type      none
 }

--- a/python/py-httpbin/Portfile
+++ b/python/py-httpbin/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-httpbin
 version             0.7.0
-revision            1
+revision            2
 
 supported_archs     noarch
 platforms           {darwin any}
@@ -29,7 +29,7 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-blinker \
-                    port:py${python.version}-brotlipy \
+                    port:py${python.version}-brotlicffi \
                     port:py${python.version}-decorator \
                     port:py${python.version}-flask \
                     port:py${python.version}-itsdangerous \

--- a/python/py-httpx/Portfile
+++ b/python/py-httpx/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-httpx
 version             0.23.0
-revision            1
+revision            2
 platforms           darwin
 license             BSD
 
@@ -29,7 +29,7 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-brotli \
-                    port:py${python.version}-brotlipy \
+                    port:py${python.version}-brotlicffi \
                     port:py${python.version}-certifi \
                     port:py${python.version}-charset-normalizer  \
                     port:py${python.version}-click \


### PR DESCRIPTION
#### Description

`py-brotlipy` was renamed to `py-brotlicffi` for a while, and I've made the same at MacPorts.

I've also added `py311` subport for `py-brotli`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->