### PR TITLE
Qt6: Fix universal builds

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -601,13 +601,6 @@ foreach {module module_info} [array get modules] {
                 }
             }
 
-            if { [variant_isset universal] } {
-                pre-fetch {
-                    ui_warn "Multiple architectures is not a Reference Configuration for Qt."
-                    ui_warn "See https://doc.qt.io/qt-6/supported-platforms.html#reference-configurations"
-                }
-            }
-
             minimum_developerversions 18 9
 
             # see https://trac.macports.org/ticket/63805#comment:13
@@ -750,9 +743,9 @@ foreach {module module_info} [array get modules] {
                     move -force ${worksrcpath}/mkspecs-save/common/${conf} ${worksrcpath}/mkspecs/common/${conf}
                 }
                 foreach spec {macx-clang macx-g++ macx-icc} {
-                        move -force ${worksrcpath}/mkspecs-save/${spec}/qmake.conf ${worksrcpath}/mkspecs/${spec}/qmake.conf
-                    }
+                    move -force ${worksrcpath}/mkspecs-save/${spec}/qmake.conf ${worksrcpath}/mkspecs/${spec}/qmake.conf
                 }
+            }
 
             # --prefix is not recognized.
             configure.pre_args-delete       --prefix=${prefix}
@@ -821,6 +814,10 @@ foreach {module module_info} [array get modules] {
                     -DCMAKE_CXX_COMPILER_LAUNCHER=${prefix}/bin/ccache \
                     -DCMAKE_OBJC_COMPILER_LAUNCHER=${prefix}/bin/ccache \
                     -DCMAKE_OBJCXX_COMPILER_LAUNCHER=${prefix}/bin/ccache
+            }
+            if {[variant_isset universal]} {
+                configure.post_args-append \
+                    "\"-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64\""
             }
 
             configure.args-append \
@@ -907,6 +904,7 @@ foreach {module module_info} [array get modules] {
             configure.universal_cflags
             configure.universal_cxxflags
             configure.universal_cppflags
+            configure.universal_args
 
             # configure script uses gawk if it can find it,
             #    so require it for consistency
@@ -960,6 +958,12 @@ foreach {module module_info} [array get modules] {
             configure.pre_args-delete   --prefix=${prefix}
             configure.pre_args-append   ${worksrcpath}
 
+            configure.universal_ldflags
+            configure.universal_cflags
+            configure.universal_cxxflags
+            configure.universal_cppflags
+            configure.universal_args
+
             # build using using cmake
             build.dir       ${workpath}/build
             build.cmd       cmake --build ${build.dir}
@@ -989,6 +993,20 @@ foreach {module module_info} [array get modules] {
                 -DCMAKE_OBJCXX_COMPILER=[option configure.objcxx]
             if {[option configure.ccache]} {
                 configure.post_args-append -DQT_USE_CCACHE=1
+            }
+            if {[variant_isset universal]} {
+                configure.post_args-append \
+                    "\"-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64\""
+            } else {
+                # If we don't specify anything, the qtbase universal flags will be used
+                platform i386 {
+                    configure.post_args-append \
+                        "-DCMAKE_OSX_ARCHITECTURES=x86_64"
+                }
+                platform arm {
+                    configure.post_args-append \
+                        "-DCMAKE_OSX_ARCHITECTURES=arm64"
+                }
             }
 
             # determine which variants are to be turned off

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -141,7 +141,7 @@ array set modules {
         "port:assimp port:brotli path:bin/cmake:cmake path:bin/dbus-daemon:dbus port:double-conversion port:freetype
             path:lib/pkgconfig/glib-2.0.pc:glib2 path:lib/pkgconfig/harfbuzz.pc:harfbuzz
             port:hunspell path:lib/pkgconfig/icu-uc.pc:icu port:jasper path:include/turbojpeg.h:libjpeg-turbo port:libb2
-            port:libiconv port:libpng port:md4c path:bin/node:nodejs16 path:lib/pkgconfig/libpcre2-posix.pc:pcre2
+            port:libiconv port:libpng port:md4c path:lib/pkgconfig/libpcre2-posix.pc:pcre2
             port:tiff port:webp port:zlib path:lib/pkgconfig/libzstd.pc:zstd"
 
         ""


### PR DESCRIPTION
#### Description

- Fixes universal builds of qt6 (previously failed to build)
- Cleans up the dependency list of qt6-base to not include things that are only needed by other qt6 subpackages
- Moves cmake to a build dependency
- Removes nodejs16 dependency
  - nodejs doesn't have a universal variant which broke attempts to do universal installs, and nothing seemed to use it.  Qt's website indicates that it's needed for Qt WebEngine and Qt PDF, but neither of those are included in this port at the moment.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0 22A380 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
