### PR TITLE
codeblocks-devel: update to 20221120-r13056

### DIFF
--- a/devel/codeblocks-devel/Portfile
+++ b/devel/codeblocks-devel/Portfile
@@ -20,9 +20,9 @@ long_description        {*}${description}. This port tracks the upstream develop
 
 fetch.type              svn
 svn.url                 svn://svn.code.sf.net/p/codeblocks/code/trunk
-svn.revision            13000
+svn.revision            13056
 svn.method              checkout
-version                 20221102-r${svn.revision}
+version                 20221120-r${svn.revision}
 revision                0
 
 # fix boost detection with i386 systems


### PR DESCRIPTION
run by CI before committing
