### PR TITLE
icu-devel: added a patch to support PPC

### DIFF
--- a/devel/icu-devel/Portfile
+++ b/devel/icu-devel/Portfile
@@ -24,7 +24,7 @@ set my_name         icu
 #  port file all | sort -u | xargs grep -El ':icu( |$)' | rev | cut -d / -f 2 | rev | xargs port info --name --subport | cut -d : -f 2 | tr ',' ' ' | grep -v '\-\-' | tr ' ' '\n' | sort -u
 
 version             72.1
-revision            0
+revision            1
 epoch               1
 subport             ${name}-docs         { revision 0 }
 subport             ${name}-lx           { revision 0 }
@@ -74,7 +74,9 @@ if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
     # use full pathnames to libraries in tools
     patchfiles-append   patch-config-mh-darwin.diff \
                         patch-i18n-formatted_string_builder.h.diff \
-                        patch-cinttypes-header.diff
+                        patch-cinttypes-header.diff \
+                        patch-balign-to-align.diff
+
 
     compiler.cxx_standard   2011
 

--- a/devel/icu-devel/files/patch-balign-to-align.diff
+++ b/devel/icu-devel/files/patch-balign-to-align.diff
@@ -1,0 +1,15 @@
+--- tools/toolutil/pkg_genc.cpp
++++ tools/toolutil/pkg_genc.cpp
+@@ -153,7 +153,12 @@ static const struct AssemblyType {
+         "#endif\n"
+         "\t.data\n"
+         "\t.const\n"
++        /* macOS PPC should use .align instead .balign because is unknown pseudo ops for it*/
++        "#if defined(__APPLE__) && defined(__POWERPC__)\n"
++        "\t.align 16\n"
++        "#else\n"
+         "\t.balign 16\n"
++        "#endif\n"
+         "_%s:\n\n",
+ 
+         ".long ","",HEX_0X

--- a/devel/icu-devel/files/patch-cinttypes-header.diff
+++ b/devel/icu-devel/files/patch-cinttypes-header.diff
@@ -1,14 +1,16 @@
 https://github.com/unicode-org/icu/pull/2239
 
-diff --git tools/toolutil/writesrc.cpp tools/toolutil/writesrc.cpp
-index 0bd8b85bb8a..bdfa84afbf9 100644
---- tools/toolutil/writesrc.cpp
-+++ tools/toolutil/writesrc.cpp
-@@ -19,7 +19,7 @@
+--- tools/toolutil/writesrc.cpp.orig	2022-10-19 11:53:21.000000000 +1100
++++ tools/toolutil/writesrc.cpp	2022-11-06 22:32:29.000000000 +1100
+@@ -19,7 +19,11 @@
  */
  
  #include <stdio.h>
 -#include <inttypes.h>
++// cinttypes includes inttypes.h internally for the format macros
++// (PRId64 et al.) On some systems, that follows C99 which says those
++// macros should be hidden to C++ without this define.
++#define __STDC_FORMAT_MACROS 1
 +#include <cinttypes>
  #include <time.h>
  #include "unicode/utypes.h"


### PR DESCRIPTION
#### Description

It also syncronized patches with main port

See: https://trac.macports.org/ticket/66258

I've skiped CI because it can't build icu-devel due to conflict with icu port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

Working was confirmed by test via ticeket

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->