### PR TITLE
ocaml-num: fix the build on PPC by removing ocamlopt from targets

### DIFF
--- a/ocaml/ocaml-num/Portfile
+++ b/ocaml/ocaml-num/Portfile
@@ -19,6 +19,11 @@ checksums           rmd160  8ce8a2e8f3bd6941b0d1ce2d09f0e78a512f1b05 \
                     sha256  d3b0b448739b96cd90faa096cdaf8925eff824a654b0fd6cb877a94e9f6d49bd \
                     size    66364
 
+platform darwin powerpc {
+    # Compilation freezes due to ocamlopt not being found.
+    patchfiles-append patch-no-ocamlopt.diff
+}
+
 ocaml.use_findlib   yes
 
 use_configure       no

--- a/ocaml/ocaml-num/files/patch-no-ocamlopt.diff
+++ b/ocaml/ocaml-num/files/patch-no-ocamlopt.diff
@@ -1,0 +1,125 @@
+# At the moment, there is no ocamlopt on PPC due to broken assembler implementation in OCaml.
+# Compilation freezes, since ocamlopt cannot be found.
+
+# Not to be used on officially supported by OCaml platforms.
+
+--- src/Makefile.orig	2020-11-10 00:22:09.000000000 +0800
++++ src/Makefile	2022-11-20 19:52:31.000000000 +0800
+@@ -1,5 +1,4 @@
+ OCAMLC=ocamlc
+-OCAMLOPT=ocamlopt
+ OCAMLDEP=ocamldep
+ OCAMLMKLIB=ocamlmklib
+ OCAMLFIND=ocamlfind
+@@ -20,39 +19,20 @@
+ 
+ CAMLCFLAGS=-w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g \
+           -safe-string -strict-sequence -strict-formats
+-CAMLOPTFLAGS=$(CAMLCFLAGS)
+-ifeq "$(FLAMBDA)" "true"
+-CAMLOPTFLAGS+=-O3
+-endif
+ 
+ CMIS=big_int.cmi nat.cmi num.cmi ratio.cmi arith_status.cmi
+ CMOS=int_misc.cmo nat.cmo big_int.cmo arith_flags.cmo \
+   ratio.cmo num.cmo arith_status.cmo
+-CMXS=$(CMOS:.cmo=.cmx)
+ COBJS=bng.$(O) nat_stubs.$(O)
+ 
+ all:: libnums.$(A) nums.cma
+ 
+-ifneq "$(ARCH)" "none"
+-all:: nums.cmxa
+-endif
+-
+-ifeq "$(NATDYNLINK)" "true"
+-all:: nums.cmxs
+-endif
+-
+ libnums.$(A): $(COBJS)
+ 	$(OCAMLMKLIB) -oc nums $(COBJS)
+ 
+ nums.cma: $(CMOS)
+ 	$(OCAMLMKLIB) -o nums -oc nums -linkall $(CMOS)
+ 
+-nums.cmxa: $(CMXS)
+-	$(OCAMLMKLIB) -o nums -oc nums -linkall $(CMXS)
+-
+-nums.cmxs: nums.cmxa libnums.$(A)
+-	$(OCAMLOPT) $(CAMLOPTFLAGS) -I . -shared -o nums.cmxs nums.cmxa
+-
+ # We hard-code the C dependencies rather than having them generated
+ # because the dependencies are so simple.
+ bng.$(O): bng.h bng_*.c
+@@ -62,8 +42,6 @@
+ 	$(OCAMLC) $(CAMLCFLAGS) -c $*.mli
+ %.cmo: %.ml
+ 	$(OCAMLC) $(CAMLCFLAGS) -c $*.ml
+-%.cmx: %.ml
+-	$(OCAMLOPT) $(CAMLOPTFLAGS) -c $*.ml
+ %.$(O): %.c
+ 	$(OCAMLC) -ccopt -DBNG_ARCH_$(BNG_ARCH) -c $*.c
+ 
+@@ -71,12 +49,6 @@
+ # is installed via findlib
+ 
+ TOINSTALL=nums.cma libnums.$(A) $(CMIS) $(CMIS:.cmi=.mli) $(CMIS:.cmi=.cmti)
+-ifneq "$(ARCH)" "none"
+-TOINSTALL+=nums.cmxa nums.$(A) $(CMXS)
+-endif
+-ifeq "$(NATDYNLINK)" "true"
+-TOINSTALL+=nums.cmxs
+-endif
+ ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+ TOINSTALL_STUBS=dllnums$(EXT_DLL)
+ else
+@@ -111,7 +83,7 @@
+ endif
+ 
+ clean:
+-	rm -f *.cm[ioxta] *.cmx[as] *.cmti *.$(O) *.$(A) *$(EXT_DLL)
++	rm -f *.cm[ioxta] *.cmti *.$(O) *.$(A) *$(EXT_DLL)
+ 
+ depend:
+ 	$(OCAMLDEP) -slash *.mli *.ml > .depend
+
+--- test/Makefile.orig	2020-11-10 00:22:09.000000000 +0800
++++ test/Makefile	2022-11-20 19:42:30.000000000 +0800
+@@ -1,11 +1,9 @@
+ OCAMLC=ocamlc
+-OCAMLOPT=ocamlopt
+ OCAMLRUN=ocamlrun
+ 
+ include $(shell $(OCAMLC) -where)/Makefile.config
+ 
+ CAMLCFLAGS=
+-CAMLOPTFLAGS=$(CAMLCFLAGS)
+ 
+ FILES=test.ml test_nats.ml test_big_ints.ml test_ratios.ml test_nums.ml test_io.ml end_test.ml
+ 
+@@ -13,24 +11,13 @@
+ 	@echo "----- Testing in bytecode..."
+ 	$(OCAMLRUN) -I ../src ./test.byt
+ 
+-ifneq "$(ARCH)" "none"
+-all:: test.exe
+-	@echo "----- Testing in native code..."
+-	./test.exe
+-endif
+-
+ test.byt: $(FILES) ../src/nums.cma ../src/libnums.$(A)
+ 	$(OCAMLC) -I ../src $(CAMLCFLAGS) ../src/nums.cma $(FILES) -o test.byt
+ 
+-test.exe: $(FILES) ../src/nums.cmxa ../src/libnums.$(A)
+-	$(OCAMLOPT) -I ../src $(CAMLOPTFLAGS) ../src/nums.cmxa $(FILES) -o test.exe
+-
+ %.cmi: %.mli
+ 	$(OCAMLC) $(CAMLCFLAGS) -c $*.mli
+ %.cmo: %.ml
+ 	$(OCAMLC) $(CAMLCFLAGS) -c $*.ml
+-%.cmx: %.ml
+-	$(OCAMLOPT) $(CAMLOPTFLAGS) -c $*.ml
+ 
+ clean:
+-	rm -f *.cm[ioxt] *.$(O) test.byt test.exe
++	rm -f *.cm[ioxt] *.$(O) test.byt


### PR DESCRIPTION
#### Description

This is a PPC-only fix, other platforms are not affected.
On PPC this port freezes towards the end of the build, apparently because `ocamlopt` is missing (we do not build it on PPC due to broken assembler in the source).
Partial removal of related targets leads to an explicit error of `/opt/local/bin/ocamlopt` being missing.
The removes non-bytecode portions. It is used only for PPC, where we de facto have only bytecode.

@pmetzger I would really appreciate if we can work together on a few OCaml ports. I am trying to bring `Stan` probabilistic language and tools into Macports: https://mc-stan.org
One of its core components is `stanc` interpreter written in OCaml. Its dependencies require about 50 ports to be implemented – and a few existing ones fixed (few actually means very few – for the most part, OCaml ports just build).
I have completed that locally yesterday (whole OCaml part and `stanc` build).
`ocaml-num` is an indirect dependency – `ocaml-sexplib` depends on it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
