### PR TITLE
qt5-qtwebengine: Fix undefined CGRect

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -91,6 +91,8 @@ if { ${subport} in [list "${name}-qtwebengine" "${name}-qtwebengine-docs"] } {
 
     # https://trac.macports.org/ticket/66165
     patchfiles-append patch-qt5-qtwebengine-RectF-ambiguous.diff
+    # https://trac.macports.org/ticket/66219
+    patchfiles-append patch-qt5-qtwebengine-CGRect-undefined.diff
 
 }
 
@@ -678,7 +680,7 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtwebglplugin {

--- a/aqua/qt5/files/patch-qt5-qtwebengine-CGRect-undefined.diff
+++ b/aqua/qt5/files/patch-qt5-qtwebengine-CGRect-undefined.diff
@@ -1,0 +1,11 @@
+diff -u src/3rdparty/chromium/ui/gfx/geometry/rect.h.\~1\~ src/3rdparty/chromium/ui/gfx/geometry/rect.h
+--- src/3rdparty/chromium/ui/gfx/geometry/rect.h.~1~
++++ src/3rdparty/chromium/ui/gfx/geometry/rect.h
+@@ -26,6 +26,7 @@
+ #if defined(OS_WIN)
+ typedef struct tagRECT RECT;
+ #elif defined(OS_APPLE)
++#include <CoreGraphics/CoreGraphics.h>
+ typedef struct CGRect CGRect;
+ #endif
+ 


### PR DESCRIPTION
fixes: https://trac.macports.org/ticket/66219

#### Description

Bugfix for compilation error with regard to CGRect.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
