### PR TITLE
qbs: Switch to Qt6

### DIFF
--- a/devel/qbs/Portfile
+++ b/devel/qbs/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           qt5 1.0
+PortGroup           qt6 1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
@@ -25,8 +25,7 @@ checksums           rmd160  69a2581f7eb1bea1847c37bb0aaeacca2bfa0a95 \
                     sha256  c86aa775446aec728bcbbed782ec128f4e6e2c26536710017343e684bb616d7a \
                     size    5078941
 
-qt5.depends_component qtscript
-qt5.min_version     5.14.0
+qt6.min_version     6.2.0
 
 compiler.cxx_standard 2017
 # requires std::optional, above is not enough :(
@@ -53,7 +52,7 @@ subport ${name}-docs {
 
     universal_variant  no
     supported_archs    noarch
-    qt5.depends_build_component sqlite-plugin qttools
+    qt6.depends_build_component qt5compat sqlite-plugin qttools
     depends_build-append       port:python310 \
                                port:py310-beautifulsoup4 \
                                port:py310-lxml


### PR DESCRIPTION
The CMakeLists.txt prefers Qt6, so use it.
We must add the qt5compat component dependency.

#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix
