### PR TITLE
nanomq: new port

### DIFF
--- a/net/nanomq/Portfile
+++ b/net/nanomq/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem             1.0
+PortGroup              github 1.0
+PortGroup              cmake 1.1
+
+github.setup           emqx nanomq 0.13.1
+revision               0
+categories             net
+license                MIT
+maintainers            {@sikmir disroot.org:sikmir} openmaintainer
+description            An ultra-lightweight and blazing-fast MQTT broker for IoT edge
+long_description       {*}${description}
+homepage               https://nanomq.io/
+
+# Fetch from git instead of distfile because it needs submodules
+fetch.type             git
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+checksums              rmd160  a97e5762faa053041a2de3e68c59b92ebee6b6e5 \
+                       sha256  55ce01b39f2ee2e0b1e990ff27801ab808f79df620758569bfd4a282cbee0435 \
+                       size    7630839
+
+depends_lib-append     port:mbedtls \
+                       port:sqlite3
+
+configure.args-append  -DNNG_ENABLE_TLS=ON \
+                       -DNNG_ENABLE_SQLITE=ON


### PR DESCRIPTION
#### Description
**[nanomq](https://nanomq.io/)** - an ultra-lightweight and blazing-fast MQTT broker for IoT edge.
Alternative to [mosquitto](https://github.com/macports/macports-ports/blob/master/net/mosquitto/Portfile).

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 x86_64
Xcode 14.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
