### PR TITLE
lrslib: fix build on case sensitive FS

### DIFF
--- a/math/lrslib/Portfile
+++ b/math/lrslib/Portfile
@@ -23,6 +23,23 @@ checksums               rmd160  8e07d8f6615472b9530ecbf763be0d1b541426d9 \
                         sha256  fc48754a1ded1d8445d40ecfbe3546e4f27d53aaee95dc2c8c0c79fb9cd532f0 \
                         size    496411
 
+worksrcdir              ${name}-${distfile_version}
+
+post-extract {
+    # Extracted files do not have correct 'group' and 'other' permissions.
+    fs-traverse item ${worksrcpath} {
+        if {[file isfile ${item}]} {
+            file attributes ${item} -permissions 0644
+        }
+
+        if {[file isdirectory ${item}]} {
+            file attributes ${item} -permissions 0755
+        }
+    }
+
+    move ${worksrcpath}/makefile ${worksrcpath}/Makefile
+}
+
 platform darwin {
     post-patch {
         # Darwin requires different arguments to build dynamic libraries


### PR DESCRIPTION
#### Description

Extracted files do not have correct 'group' and 'other' permissions that may lead to wired issues during biuld.

Fix a build: https://build.macports.org/builders/ports-11_x86_64-builder/builds/91931

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->