### PR TITLE
swagger-codegen: Update to 3.0.36

### DIFF
--- a/devel/swagger-codegen/Portfile
+++ b/devel/swagger-codegen/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        swagger-api swagger-codegen 3.0.36 v
 categories          devel
 license             Apache-2
-platforms           darwin
+platforms           any
 maintainers         nomaintainer
 supported_archs     noarch
 
@@ -20,8 +20,8 @@ homepage            https://swagger.io/tools/swagger-codegen/
 master_sites        https://repo1.maven.org/maven2/io/swagger/codegen/v3/${name}-cli/${version}/
 distfiles           ${name}-cli-${version}.jar
 
-checksums           rmd160 37af728046c9fd9a161a66ef4b158cbd0517c1a7 \
-                    sha256 9c9b23193b5333d663b2a64228a645acb3d9e23229d45d12a62e91cdeb82cda9 \
+checksums           rmd160  37af728046c9fd9a161a66ef4b158cbd0517c1a7 \
+                    sha256  9c9b23193b5333d663b2a64228a645acb3d9e23229d45d12a62e91cdeb82cda9 \
                     size    21906448
 
 java.version        1.8+

--- a/devel/swagger-codegen/Portfile
+++ b/devel/swagger-codegen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           java 1.0
 PortGroup           github 1.0
 
-github.setup        swagger-api swagger-codegen 3.0.22 v
+github.setup        swagger-api swagger-codegen 3.0.36 v
 categories          devel
 license             Apache-2
 platforms           darwin
@@ -20,9 +20,9 @@ homepage            https://swagger.io/tools/swagger-codegen/
 master_sites        https://repo1.maven.org/maven2/io/swagger/codegen/v3/${name}-cli/${version}/
 distfiles           ${name}-cli-${version}.jar
 
-checksums           rmd160  be547027354fb613c59780c6e4baf5d5a3aedbd2 \
-                    sha256  70d60f2ee764d3ed409136602d1a753a52c68413c1d4a16c7bd25648600aacc8 \
-                    size    20035104
+checksums           rmd160 37af728046c9fd9a161a66ef4b158cbd0517c1a7 \
+                    sha256 9c9b23193b5333d663b2a64228a645acb3d9e23229d45d12a62e91cdeb82cda9 \
+                    size    21906448
 
 java.version        1.8+
 


### PR DESCRIPTION
#### Description

update devel/swagger-codegen/Portfile 3.0.22 to 3.0.36

###### Type(s)

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

