### PR TITLE
py-awscli2: fix flit version pinning

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 
 name                py-awscli2
 github.setup        aws aws-cli 2.9.0
-revision            0
+revision            1
 
 categories          python devel
 platforms           darwin

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,9 +1,17 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-diff -ru aws-cli-2.8.3-orig/pyproject.toml aws-cli-2.8.3/pyproject.toml
---- aws-cli-2.8.3-orig/pyproject.toml	2022-10-18 13:18:20.576387790 -0400
-+++ aws-cli-2.8.3/pyproject.toml	2022-10-18 13:19:25.537583801 -0400
+diff -ru aws-cli-2.9.0-orig/pyproject.toml aws-cli-2.9.0/pyproject.toml
+--- aws-cli-2.9.0-orig/pyproject.toml	2022-11-18 12:06:59.000000000 -0500
++++ aws-cli-2.9.0/pyproject.toml	2022-11-22 09:39:18.160892465 -0500
+@@ -1,6 +1,6 @@
+ [build-system]
+ requires = [
+-"flit_core>=3.7.1,<3.7.2",
++"flit_core",
+ ]
+ build-backend = "pep517"
+ backend-path = ["backends"]
 @@ -27,17 +27,17 @@
      "Programming Language :: Python :: 3.10",
  ]


### PR DESCRIPTION
#### Description

Remove version pinning on flit build tool

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
