### PR TITLE
Add py311 subports for 28 Python modules

### DIFF
--- a/python/py-blinker/Portfile
+++ b/python/py-blinker/Portfile
@@ -26,7 +26,7 @@ checksums           sha256  471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466
                     rmd160  54a649ae37e54924ebfe75149c3d19b0d25aa1a4 \
                     size    111476
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     livecheck.type  none

--- a/python/py-coverage/Portfile
+++ b/python/py-coverage/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  4e506ae4cf3790b053ef55883cdd4dbbd346aa82 \
                     sha256  f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84 \
                     size    775224
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-cpuinfo/Portfile
+++ b/python/py-cpuinfo/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  2b89e64c6501a24f2ff28736f6fa937189f5cf7b \
                     sha256  5f269be0e08e33fd959de96b34cd4aeeeacac014dd8305f70eb28d06de2345c5 \
                     size    99791
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-crcmod/Portfile
+++ b/python/py-crcmod/Portfile
@@ -20,10 +20,12 @@ checksums           rmd160  503b415394d7c833b22e5a999454c0d67598cd54 \
                     sha256  dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e \
                     size    89670
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
-    build.args-append -f
+    if {!${python.pep517}} {
+        build.args-append -f
+    }
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]

--- a/python/py-execnet/Portfile
+++ b/python/py-execnet/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  de3fae0a9a4c7731a11333af8a17f65c17136933 \
                     sha256  8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
                     size    173884
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-freezegun/Portfile
+++ b/python/py-freezegun/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  fe7a03df9a03ed58f602150d6a9fd0a89fad02fb \
                     sha256  3bd449003f847ec97b3ebcae8e3439c56f3faf75ebf29c11e886c30aead5ed29 \
                     size    25977
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-geographiclib/Portfile
+++ b/python/py-geographiclib/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  209b98a6197abd2f2804c4af9f577aa285798d0f \
                     sha256  12bd46ee7ec25b291ea139b17aa991e7ef373e21abd053949b75c0e9ca55c632 \
                     size    33532
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-iso8601/Portfile
+++ b/python/py-iso8601/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 license             MIT
 supported_archs     noarch
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jwt/Portfile
+++ b/python/py-jwt/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  c862a165978caaa8a28ec56658fec189bae2d043 \
                     sha256  b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41 \
                     size    62279
 
-python.versions     27 36 37 38 39 310
+python.versions     27 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-mock/Portfile
+++ b/python/py-mock/Portfile
@@ -21,7 +21,7 @@ checksums           sha256  7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2
                     rmd160  05ce80ebd49bfc1c4e6ade8f14d8ed10dfdbf8b2 \
                     size    72316
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -26,7 +26,7 @@ if {${name} ne ${subport}} {
     pre-destroot { set_compilers }
 }
 
-python.versions         27 35 36 37 38 39 310
+python.versions         27 35 36 37 38 39 310 311
 
 # http://trac.macports.org/ticket/34562
 python.consistent_destroot yes
@@ -90,6 +90,9 @@ if {${name} ne ${subport}} {
         livecheck.regex     {(1\.21(?:\.\d+)+)}
     } else {
         github.tarball_from releases
+        if {${python.pep517}} {
+            build.args      --skip-dependency-check
+        }
     }
 
     patchfiles-append       patch-numpy_core_setup.py${PATCH_PY_EXT}.diff \

--- a/python/py-oauthlib/Portfile
+++ b/python/py-oauthlib/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  1ee81d217311e971298be031730cc72a5dc4bafd \
                     sha256  8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3 \
                     size    161395
 
-python.versions     27 37 38 39 310
+python.versions     27 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-pbr/Portfile
+++ b/python/py-pbr/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  0de39204ed139dd71896acf94a52e542feb8223d \
                     sha256  b97bc6695b2aff02144133c2e7399d5885223d42b7912ffaec2ca3898e673bfe \
                     size    127505
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_lib-append \

--- a/python/py-pytest-benchmark/Portfile
+++ b/python/py-pytest-benchmark/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  b481e3b9047730c831a46be9550d47d8d2e43399 \
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-pytest-cov/Portfile
+++ b/python/py-pytest-cov/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  56b4eb3164c153f306bc8019178b41cf1a535f0d \
                     sha256  996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470 \
                     size    62013
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     if {${python.version} in "27 35"} {

--- a/python/py-pytest-forked/Portfile
+++ b/python/py-pytest-forked/Portfile
@@ -21,9 +21,13 @@ checksums           rmd160  98a3298258979cc2ec39134b7ba74e0cda9cc205 \
                     sha256  6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca \
                     size    9850
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
+    if {${python.pep517}} {
+        build.args  --skip-dependency-check
+    }
+
     depends_build-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm

--- a/python/py-pytest-subtests/Portfile
+++ b/python/py-pytest-subtests/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 supported_archs     noarch
 license             MIT
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 maintainers         nomaintainer
 

--- a/python/py-pytest-xdist/Portfile
+++ b/python/py-pytest-xdist/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  b720976b2924ac7e660cb342e4b59545f6d44bb3 \
                     sha256  718887296892f92683f6a51f25a3ae584993b06f7076ce1e1fd482e59a8220a2 \
                     size    64956
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-requests-mock/Portfile
+++ b/python/py-requests-mock/Portfile
@@ -22,7 +22,7 @@ checksums           sha256  8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f
                     rmd160  cbcbb150f07ab4d5e5c1eadee0bf88782d557ed5 \
                     size    67988
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-requests-oauthlib/Portfile
+++ b/python/py-requests-oauthlib/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  ca29983b1c777d1b89d12f16d571177c918322ad \
                     sha256  6807c32046ac493d51e4efe236803413871de3ce34bf97b9e36ae578287ac1f1 \
                     size    48352
 
-python.versions     27 37 38 39 310
+python.versions     27 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-svgelements/Portfile
+++ b/python/py-svgelements/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  c51c2a4fd52497b9d6cca71fcb0b41c6b48656b6 \
                     sha256  9f57b9eab52dbabdf67c420ff0bb5b52b67f929ffd8bd8f1390bd03d0de4ab46 \
                     size    143840
 
-python.versions     39 310
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-toml/Portfile
+++ b/python/py-toml/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160 0bf696ef18e4bb20549157b5f2a864dd71222738 \
                     size 22253
 
 # keep version for PY27 and PY34, these are (indirect) dependencies of py-virtualenv
-python.versions     27 34 35 36 37 38 39 310
+python.versions     27 34 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-yapf/Portfile
+++ b/python/py-yapf/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  155b231807d88737660b0c101befd3a2092f8f8d \
                     sha256  410ed0f592c898d75d73f7792aee6569bdbc0b57bc72b417c722c17f41f66b12 \
                     size    178621
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_lib-append \

--- a/python/py-yapf/files/py311-yapf
+++ b/python/py-yapf/files/py311-yapf
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.11/bin/yapf


### PR DESCRIPTION
#### Description

Python 3.11 subports are added for the following modules:

 - `py311-crcmod`
 - `py311-mock`
 - `py311-freezegun`
 - `py311-coverage`
 - `py311-toml`
 - `py311-pytest-cov`
 - `py311-six`
 - `py311-tz`
 - `py311-dateutil`
 - `py311-geographiclib`
 - `py311-numpy`
 - `py311-iso8601`
 - `py311-cpuinfo`
 - `py311-pytest-benchmark`
 - `py311-setuptools_scm_git_archive`
 - `py311-pytest-subtests`
 - `py311-execnet`
 - `py311-pytest-forked`
 - `py311-pytest-xdist`
 - `py311-cryptography`
 - `py311-jwt`
 - `py311-blinker`
 - `py311-oauthlib`
 - `py311-pbr`
 - `py311-requests-mock`
 - `py311-requests-oauthlib`
 - `py311-svgelements`
 - `py311-yapf`

I’m sending this as a single pull request with independent commits rather than a series of 28 pull requests because many of the new py311 subports depend on others in this group. The commit sequence ensures that no new subport will fail for a missing dependency. Dependencies within this pull request are annotated in commit messages.

In most instances, this simply adds `py311` to `python.versions`. These special cases occurred because the PEP517 build is now the default for Python 3.11 subports:

 - When using the PEP517 build, `py-crcmod` cannot tolerate the `-f` build argument, so this is made conditional on `python.pep517`.
 - When using the PEP517 build, `py-numpy` failed because the bundled versioneer.py in numpy 1.23.5 hasn’t caught up with https://github.com/python-versioneer/python-versioneer/commit/c56a7e4559788b16153e87c927b086ba78f89ef0. This was recently brought into `py-numpy` as part of https://github.com/numpy/numpy/commit/b6d94fab5a7ef8897fe06d0b7a161bc8080fff26, not yet in any numpy release. Rather than patching versioneer.py, this conditionally (based on `python.pep517`) adds the `--skip-dependency-check` build argument, which avoids the problem. This is durable, as even if versioneer.py were patched so that the dependency check could be enabled, the check would insist on rather old pinned versions such as `wheel==0.37.0` (MacPorts has 0.38.4) and `setuptools==59.2.0` (MacPorts has 65.6.0). That precise `setuptools` requirement was set [rather intentionally](https://github.com/numpy/numpy/issues/22623#issuecomment-1320890687). Note that `--skip-dependency-check` restores the same behavior as is used in the non-PEP517 build.
 - A similar situation exists for `py-pytest-forked`, whose `pyproject.toml` specifies `setuptools ~= 41.4`, `setuptools_scm ~= 3.3` (MacPorts has 7.0.5), and `wheel ~= 0.33.6`.

I ran all tests. Many of these ports do not have tests. Most that do pass all tests. Some ports have tests that were already failing for their py310 subports, and are still failing for their new py311 subports. There are no ports with new test failures. Failures, which appeared harmless, were discovered in py310 and py311 subports for:

 - `py-dateutil`
 - `py-cryptography`
 - `py-freezegun`
 - `py-mock`
 - `py-pytest-benchmark`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
