### PR TITLE
python 3.11 subports for py-igraph and py-texttable, update py-texttable

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -12,7 +12,7 @@ categories-append   math science
 platforms           darwin
 license             GPL-2+
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 maintainers         {snc @nerdling} {gmail.com:szhorvat @szhorvat} openmaintainer
 
@@ -78,11 +78,18 @@ if {${name} ne ${subport}} {
 
     # python-igraph optionally makes use of these, and some tests depend on them.
     # If they are not installed, the corresponding tests will simply be skipped.
-    depends_test-append     port:py${python.version}-matplotlib \
-                            port:py${python.version}-networkx \
-                            port:py${python.version}-numpy \
-                            port:py${python.version}-pandas \
-                            port:py${python.version}-scipy
+    if {${subport} eq "py311-igraph"} {
+        # Temporary workaround:
+        # Skip test dependencies not yet available as py311 ports.
+        depends_test-append     port:py${python.version}-networkx \
+                                port:py${python.version}-numpy
+    } else {
+        depends_test-append     port:py${python.version}-matplotlib \
+                                port:py${python.version}-networkx \
+                                port:py${python.version}-numpy \
+                                port:py${python.version}-pandas \
+                                port:py${python.version}-scipy
+    }
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]

--- a/python/py-texttable/Portfile
+++ b/python/py-texttable/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-texttable
-version             1.6.4
+version             1.6.5
 revision            0
 
 categories-append   textproc
@@ -17,11 +17,11 @@ long_description    ${description}
 
 homepage            https://github.com/foutaise/texttable/
 
-checksums           rmd160  2aa715a0e90b695cb3b1295f6dbb86e93d03d224 \
-                    sha256  42ee7b9e15f7b225747c3fa08f43c5d6c83bc899f80ff9bae9319334824076e9 \
-                    size    12565
+checksums           rmd160  806d9400521863674fd98f84ad1e0f7069b461b6 \
+                    sha256  fc3f763a89796ae03789a02343bd4e8fed9735935123b1bfb9537a5935852315 \
+                    size    12876
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

 - updates py-texttable to 1.6.5
 - adds py311 subport for py-texttable
 - adds py311 subport for py-igraph (the ultimate goal of this PR)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
