### PR TITLE
PULL_REQUEST_TEMPLATE.md: add line about variants

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,5 +27,6 @@ Have you
 - [ ] tried existing tests with `sudo port test`?
 - [ ] tried a full install with `sudo port -vst install`?
 - [ ] tested basic functionality of all binary files?
+- [ ] checked that any [variants](https://trac.macports.org/wiki/Variants) the Portfile may have haven't been broken?
 
 <!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,6 @@ Have you
 - [ ] tried existing tests with `sudo port test`?
 - [ ] tried a full install with `sudo port -vst install`?
 - [ ] tested basic functionality of all binary files?
-- [ ] checked that any [variants](https://trac.macports.org/wiki/Variants) the Portfile may have haven't been broken?
+- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
 
 <!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->


### PR DESCRIPTION
#### Description

One of the things I like about MacPorts is how many ports offer variants to enable extra features. I often try to install my ports with maximum possible variants enabled when possible. Unfortunately, it seems that some of the non-default variants don't get tested as much, which often leads to breakage when I try to update. This PR simply adds an extra checkbox to the PR template reminding PR authors to check their variants. The header for that section includes a `<!-- (delete not applicable items) -->` comment, so if it isn't relevant to certain ports, it can always be skipped. This is just to give a bit of an extra reminder for the cases where variants *are* relevant.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 11.7.1 20G918 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked that any [variants](https://trac.macports.org/wiki/Variants) the Portfile may have haven't been broken?
