### PR TITLE
cmake: update to 3.25.0

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -7,6 +7,7 @@ if { ${os.platform} eq "darwin" && ${os.major} >= 20 && ${build_arch} eq "x86_64
     universal_variant no
 } else {
     PortGroup       muniversal 1.0
+
 }
 
 PortGroup           xcodeversion 1.0
@@ -33,10 +34,10 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake 3.23.5 v
-checksums           rmd160  0b304f6eeaaab75a0d3927627c165b731f11c8d5 \
-                    sha256  bff8e42741d77753fa5803ebe73d4bdbc09e6ec1983314308c1e2199c7cfdd15 \
-                    size    7650499
+gitlab.setup        cmake   cmake 3.25.0 v
+checksums           rmd160  dbd41928a6e93a2cb5dc97b1ba2b8d241be41fbe \
+                    sha256  7f1b54bbb9c896a9744aaa9746b67fd613f55c72917476c79d918f3a05346468 \
+                    size    8073322
 revision            0
 
 gitlab.livecheck.regex {([0-9.]+)}
@@ -234,7 +235,7 @@ if {![variant_isset qt5]} {
 }
 
 # Supported pythons
-set python_versions {35 36 37 38 39}
+set python_versions {35 36 37 38 39 310 311}
 
 # declare all +python* variants, with conflicts
 foreach pyver ${python_versions} {

--- a/devel/cmake/files/patch-CMakeFindFrameworks.cmake.diff
+++ b/devel/cmake/files/patch-CMakeFindFrameworks.cmake.diff
@@ -4,7 +4,7 @@
              ${CMAKE_FRAMEWORK_PATH}
              ${_cmff_CMAKE_FRAMEWORK_PATH}
              ~/Library/Frameworks
--            /usr/local/Frameworks
+-            ${_brew_framework_path}
 +            __FRAMEWORKS_DIR__
              /Library/Frameworks
              /System/Library/Frameworks

--- a/devel/cmake/files/patch-qt5gui.diff
+++ b/devel/cmake/files/patch-qt5gui.diff
@@ -51,16 +51,16 @@
  	<key>CFBundleShortVersionString</key>
  	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
  	<key>CFBundleSignature</key>
---- CMakeLists.txt.orig
-+++ CMakeLists.txt
-@@ -795,13 +795,20 @@
+--- CMakeLists.txt.orig	2022-11-22 16:39:25.000000000 -0500
++++ CMakeLists.txt	2022-11-22 16:41:04.000000000 -0500
+@@ -406,12 +406,19 @@
      if(APPLE)
        set(CMAKE_BUNDLE_VERSION
          "${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}")
 -      set(CMAKE_BUNDLE_LOCATION "${CMAKE_INSTALL_PREFIX}")
 -      # make sure CMAKE_INSTALL_PREFIX ends in /
 -      if(NOT CMAKE_INSTALL_PREFIX MATCHES "/$")
--        set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/")
+-        string(APPEND CMAKE_INSTALL_PREFIX "/")
 +      if(CMAKE_BUNDLE_LOCATION)
 +        message(STATUS "Using provided bundle location: ${CMAKE_BUNDLE_LOCATION}")
 +        message(STATUS "Using default install prefix: ${CMAKE_INSTALL_PREFIX}")
@@ -68,15 +68,13 @@
 +        set(CMAKE_BUNDLE_LOCATION "${CMAKE_INSTALL_PREFIX}")
 +        # make sure CMAKE_INSTALL_PREFIX ends in /
 +        if(NOT CMAKE_INSTALL_PREFIX MATCHES "/$")
-+          set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/")
++          string(APPEND CMAKE_INSTALL_PREFIX "/")
 +        endif()
-+        set(CMAKE_INSTALL_PREFIX
-+          "${CMAKE_INSTALL_PREFIX}CMake.app/Contents")
++        string(APPEND CMAKE_INSTALL_PREFIX "CMake.app/Contents")
 +        message(STATUS "Using default Qt bundle location: ${CMAKE_BUNDLE_LOCATION}")
 +        message(STATUS "Using special install prefix: ${CMAKE_INSTALL_PREFIX}")
        endif()
--      set(CMAKE_INSTALL_PREFIX
--        "${CMAKE_INSTALL_PREFIX}CMake.app/Contents")
+-      string(APPEND CMAKE_INSTALL_PREFIX "CMake.app/Contents")
      endif()
    endif()
  


### PR DESCRIPTION
#### Description

* Update cmake to upstream version 3.25.0
* add python310 and python311 as variant options

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 13.4.1 13F100 / Command Line Tools 13.4.0.0.1.1651278267

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
