### PR TITLE
py-iso8601: remove py27, py35, and py36 subports

### DIFF
--- a/python/py-iso8601/Portfile
+++ b/python/py-iso8601/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39 310
+python.versions     37 38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,17 +24,8 @@ checksums           rmd160  46834e6e67ccde654c2b4128993d566e796f450e \
                     size    12836
 
 if {${name} ne ${subport}} {
-    if {${python.version} < 37} {
-        version             0.1.16
-        revision            0
-        distname            ${python.rootname}-${version}
-        checksums           rmd160  41542c76de750e905485e241a9964cc135d0c555 \
-                            sha256  36532f77cc800594e8f16641edae7f1baf7932f05d8e508545b95fc53c6dc85b \
-                            size    19599
-    } else {
-        python.pep517       yes
-        python.pep517_backend   poetry
-    }
+    python.pep517   yes
+    python.pep517_backend   poetry
 
     depends_test-append \
                     port:py${python.version}-pytest


### PR DESCRIPTION
While converting the Python ≥ 3.7 subports to PEP517, b30e85e49e43 inadvertently removed the `setuptools` build-time dependency from the non-PEP517 build used by the `py27-iso8601`, `py35-iso8601`, and `py36-iso8601` subports. This restores that missing dependency.

The missing dependency was discovered while testing https://github.com/macports/macports-ports/pull/16765.

Note: I could not run `port test py35-iso8601` successfully, because the current `py35-more-itertools` port that `py35-pytest` depends on is anemic and results in `ImportError: No module named 'more_itertools'` on attempt to `import more_itertools`. However, the tests run successfully for `py27-iso8601` and `py36-iso8601`.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
