### PR TITLE
gawk: reenable arm64 build

### DIFF
--- a/lang/gawk/Portfile
+++ b/lang/gawk/Portfile
@@ -5,7 +5,7 @@ PortGroup               legacysupport 1.1
 
 name                    gawk
 version                 5.2.1
-revision                0
+revision                1
 categories              lang
 license                 GPL-3+
 installs_libs           no
@@ -28,12 +28,20 @@ depends_build           port:gettext
 
 depends_lib             port:gettext-runtime
 
-platform darwin {
-    # See README.macos: gawk has to be built as a x86_64 binary
-    if {${build_arch} eq "arm64"} {
-        PortGroup       active_variants 1.1
+configure.args          --with-libiconv-prefix=${prefix} \
+                        --without-mpfr \
+                        --without-readline \
+                        ac_cv_libsigsegv=no \
+                        ac_cv_prog_AWK=awk
 
-        require_active_variants gettext-runtime universal
+platform darwin {
+    if {${build_arch} eq "arm64" || ${os.major} >= 21} {
+        # See README_d/README.macosx: PMA (persistent memory allocator) requires
+        # non-PIE (position-independent executable), but this is impossible on
+        # mac-arm64, and deprecated when targeting macOS 12 and later. Disable
+        # the PMA feature in those cases.
+        configure.args-append \
+                        --disable-pma
     }
 
     # https://trac.macports.org/ticket/65944
@@ -43,12 +51,6 @@ platform darwin {
         }
     }
 }
-
-configure.args          --with-libiconv-prefix=${prefix} \
-                        --without-mpfr \
-                        --without-readline \
-                        ac_cv_libsigsegv=no \
-                        ac_cv_prog_AWK=awk
 
 # fix build on Tiger see https://trac.macports.org/ticket/55145
 platform darwin 8 {


### PR DESCRIPTION
Upstream gawk has added a “PMA” (persistent memory allocator) feature that unfortunately requires gawk to be built as a non-PIE (position-independent executable). Non-PIE is not supported at all on mac-arm64, so the upstream default as of
[0d9727bcd312](https://git.savannah.gnu.org/cgit/gawk.git/commit?id=0d9727bcd312da8555ca59942790adfee5fcafea) is to forcibly build gawk as mac-x86_64, requiring it to run under Rosetta binary translation on mac-arm64. Informed opinion: the upstream’s approach is misguided for multiple reasons.

The recent update of the `gawk` port to 5.2.1 at 42141802c346 honored this upstream default, causing problems for mac-arm64 systems without Rosetta installed, and problems upgrading the `gawk` port to this new version in the likely case that the existing `gettext-runtime` dependency was not installed as its universal variant.

To reenable the arm64 build of gawk, configure it to disable its PMA feature, allowing it to be built as PIE and thus as a proper arm64 executable.

As non-PIE is deprecated when targeting macOS ≥ 12 on any architecture, disable gawk’s PMA feature in that case as well.

Closes: https://trac.macports.org/ticket/66327

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
