### PR TITLE
ci: Switch to environment files, latexmk: Update to 4.78

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
               | tr '\n' '/')
 
           echo "${portlist[@]}"
-          echo "::set-output name=portlist::${portlist[@]}"
+          echo "portlist=${portlist[@]}" >> $GITHUB_OUTPUT
       - name: Determine list of subports from portlist
         id: subportlist
         run: |
@@ -81,7 +81,7 @@ jobs:
             echo "::endgroup::"
           done
 
-          echo "::set-output name=subportlist::${subportlist}"
+          echo "subportlist=${subportlist}" >> $GITHUB_OUTPUT
         env:
           portlist: ${{ steps.portlist.outputs.portlist }}
       - name: Run port lint for all changed subports

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,10 +58,13 @@ jobs:
 
           echo "${portlist[@]}"
           echo "portlist=${portlist[@]}" >> $GITHUB_OUTPUT
+
       - name: Determine list of subports from portlist
         id: subportlist
         run: |
           set -eu
+
+          echo "#### Changed Ports" >> $GITHUB_STEP_SUMMARY
 
           subportlist=""
           for port in $portlist; do
@@ -76,6 +79,7 @@ jobs:
               | tr '\n' ' ')
             for subport in $new_subports; do
               echo "$subport"
+              echo "- ${subport}" >> $GITHUB_STEP_SUMMARY
               subportlist="$subportlist $subport"
             done
             echo "::endgroup::"
@@ -88,6 +92,8 @@ jobs:
         run: |
           set -eu
 
+          echo "#### Lint Results" >> $GITHUB_STEP_SUMMARY
+
           fail=0
           for subport in $subportlist; do
             echo "::group::${subport}"
@@ -97,12 +103,24 @@ jobs:
               messagetype="error"
               fail=1
             fi
+
+
             if [ -n "$messages" ]; then
               echo "$messages"
+
+              if [ "$fail" -eq 1 ]; then
+                echo "##### ❌ ${subport}" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "##### ⚠️ ${subport}" >> $GITHUB_STEP_SUMMARY
+              fi
+              printf "```\n%s```\n" "$messages" >> $GITHUB_STEP_SUMMARY
+
               # See https://github.com/actions/toolkit/issues/193#issuecomment-605394935
               encoded_messages="port lint ${subport}:%0A"
               encoded_messages+="$(echo "${messages}" | sed -E 's/$/%0A/g' | tr -d '\n')"
               echo "::${messagetype} file=${path#${PWD}/ports/},line=1,col=1::${encoded_messages}"
+            else
+                echo "##### ✅ ${subport}" >> $GITHUB_STEP_SUMMARY
             fi
             echo "::endgroup::"
           done
@@ -114,10 +132,13 @@ jobs:
         run: |
           set -eu
 
+          echo "#### Build Results" >> $GITHUB_STEP_SUMMARY
+
           fail=0
           for subport in $subportlist; do
             workdir="/tmp/mpbb/$subport"
             mkdir -p "$workdir/logs"
+            echo "##### ${subport}" >> $GITHUB_STEP_SUMMARY
             touch "$workdir/logs/dependencies-progress.txt"
 
             echo "::group::Cleaning up between ports"
@@ -144,6 +165,13 @@ jobs:
             if [ "$deps_exit" -ne 0 ]; then
               echo "::endgroup::"
               echo "::error::Failed to install dependencies for ${subport}"
+
+              echo "⚠️ Failed to install dependencies" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "```" >> $GITHUB_STEP_SUMMARY
+              tail -n20 "$workdir/logs/depdendencies-progress.txt" >> $GITHUB_STEP_SUMMARY
+              echo "```" >> $GITHUB_STEP_SUMMARY
+
               fail=1
               continue
             fi
@@ -163,9 +191,14 @@ jobs:
             if [ "$install_exit" -ne 0 ]; then
               echo "::endgroup::"
               echo "::error::Failed to install ${subport}"
+
+              echo "❌ Failed to install, see the log for more details" >> $GITHUB_STEP_SUMMARY
+
               fail=1
               continue
             fi
+
+            echo "✅ Successfully built" >> $GITHUB_STEP_SUMMARY
             echo "::endgroup::"
           done
 
@@ -175,6 +208,7 @@ jobs:
       - name: Make logfiles readable
         if: always()
         run: |
+          mkdir -p /tmp/mpbb
           sudo find \
             /tmp/mpbb \
             -maxdepth 1 \

--- a/tex/latexmk/Portfile
+++ b/tex/latexmk/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                latexmk
-version             4.77
+version             4.78
 
-checksums           rmd160  6017b112e6c591184649fb5176f158cc7d0b2e8f \
-                    sha256  2acd5ba06d8b2a8046379b41dc8b35ebe0f22203b7aa290e37f356a49e331949 \
-                    size    475933
+checksums           rmd160  51553629f3ae36db13bf68c6dff2186331484233 \
+                    sha256  c6d8357b86e47e296a7bfb8acd2f64ba01c654ce75b361216c1efba262aa5da2 \
+                    size    492506
 
 categories          tex print
 platforms           darwin

--- a/www/libsass/Portfile
+++ b/www/libsass/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        sass libsass 3.6.2
-checksums           rmd160  2f33aeddb5716d4da29a9f37dd788527f799eccc \
-                    sha256  aa615c75c80e7a8589178af4cb34bb2e6789a8f08262a5f6da168d9c9ca3867d \
-                    size    331062
+github.setup        sass libsass 3.6.5
+checksums           rmd160  ed1232a9f453f06d2e88b90d1861e89b9db47177 \
+                    sha256  56b57224069e435ed227e8cae0c3f5c745e7744f98fdc468f053af2c7104f6b4 \
+                    size    342513
 
 maintainers         {cal @neverpanic} openmaintainer
 categories          www textproc

--- a/www/sassc/Portfile
+++ b/www/sassc/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        sass sassc 3.6.1
-checksums           rmd160  b750f31d5e731c3549716c332ad37700f7291ba2 \
-                    sha256  3c18c58b966b82c797af46e6c658a4a849b414ec7e3b41e79050c03e2acc72e6 \
-                    size    26131
+github.setup        sass sassc 3.6.2
+checksums           rmd160  058fbc3f91c2418e68962f4bcab6c040710c811b \
+                    sha256  080dc272b6f8f12e9fd68c2689c03536850c6faa8d055f1875a42a7957304f4b \
+                    size    26643
 
 maintainers         {cal @neverpanic} openmaintainer
 categories          www textproc


### PR DESCRIPTION
#### Description

GitHub has deprecated set-output in favor of writing to environment files. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

Test this change with an update of latexmk to 4.78.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
