### PR TITLE
onetbb: fix build on macOS 10.6

### DIFF
--- a/devel/onetbb/Portfile
+++ b/devel/onetbb/Portfile
@@ -26,6 +26,8 @@ checksums           rmd160  0648cff27e3683eb6583c0e4db56f259e2aae113 \
                     sha256  2cae2a80cda7d45dc7c072e4295c675fff5ad8316691f26f40539f7e7e54c0cc \
                     size    2571727
 
+patchfiles          patch-onetbb-older-malloc.diff
+
 compiler.blacklist-append   {clang < 700}
 
 depends_lib-append  port:hwloc

--- a/devel/onetbb/files/patch-onetbb-older-malloc.diff
+++ b/devel/onetbb/files/patch-onetbb-older-malloc.diff
@@ -1,0 +1,24 @@
+--- src/tbbmalloc_proxy/proxy_overload_osx.h
++++ src/tbbmalloc_proxy/proxy_overload_osx.h
+@@ -135,9 +135,11 @@ struct DoMallocReplacement {
+         introspect.force_unlock = &zone_force_unlock;
+         introspect.statistics = zone_statistics;
+         introspect.zone_locked = &zone_locked;
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+         introspect.enable_discharge_checking = &impl_zone_enable_discharge_checking;
+         introspect.disable_discharge_checking = &impl_zone_disable_discharge_checking;
+         introspect.discharge = &impl_zone_discharge;
++#endif
+ 
+         zone.size = &impl_malloc_usable_size;
+         zone.malloc = &impl_malloc;
+@@ -151,7 +153,9 @@ struct DoMallocReplacement {
+         zone.version = 8;
+         zone.memalign = impl_memalign;
+         zone.free_definite_size = &impl_free_definite_size;
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+         zone.pressure_relief = &impl_pressure_relief;
++#endif
+ 
+         // make sure that default purgeable zone is initialized
+         malloc_default_purgeable_zone();


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/66222

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->