### PR TITLE
CMake py311 sphinx ports add py311 support

### DIFF
--- a/python/py-babel/Portfile
+++ b/python/py-babel/Portfile
@@ -12,7 +12,7 @@ platforms           {darwin any}
 license             BSD
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-pygments/Portfile
+++ b/python/py-pygments/Portfile
@@ -13,7 +13,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-pygments/files/py311-pygments
+++ b/python/py-pygments/files/py311-pygments
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.11/bin/pygmentize

--- a/python/py-sphinx/Portfile
+++ b/python/py-sphinx/Portfile
@@ -27,7 +27,7 @@ checksums           md5 b752f7b0177865a36cbcdcef4ac80cd4 \
                     rmd160 b9d212a39f7dc632b595d92f5cd0e8c48213b571 \
                     sha256 51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-docutils

--- a/python/py-sphinx/files/py311-sphinx
+++ b/python/py-sphinx/files/py311-sphinx
@@ -1,0 +1,4 @@
+${frameworks_dir}/Python.framework/Versions/3.11/bin/sphinx-apidoc
+${frameworks_dir}/Python.framework/Versions/3.11/bin/sphinx-quickstart
+${frameworks_dir}/Python.framework/Versions/3.11/bin/sphinx-autogen
+${frameworks_dir}/Python.framework/Versions/3.11/bin/sphinx-build

--- a/python/py-sphinxcontrib-applehelp/Portfile
+++ b/python/py-sphinxcontrib-applehelp/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  b0118252ece8c2c37bf7f0effc6af4bededa1477 \
                     sha256  a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58 \
                     size    24548
 
-python.versions     35 36 37 38 39 310
+python.versions     35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-devhelp/Portfile
+++ b/python/py-sphinxcontrib-devhelp/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  10ab655ca874f228604f17c7cd521f0bcb1f446f \
                     sha256  ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4 \
                     size    17398
 
-python.versions     35 36 37 38 39 310
+python.versions     35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-htmlhelp/Portfile
+++ b/python/py-sphinxcontrib-htmlhelp/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  8aafaebaac69398a3c3ba0a60ac0ad7b0548f4bb \
                     sha256  f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2 \
                     size    28144
 
-python.versions     35 36 37 38 39 310
+python.versions     35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-jsmath/Portfile
+++ b/python/py-sphinxcontrib-jsmath/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  9ff064c88f8f121bd7876ae3f79b4c31f5a9264f \
                     sha256  a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8 \
                     size    5787
 
-python.versions     35 36 37 38 39 310
+python.versions     35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-qthelp/Portfile
+++ b/python/py-sphinxcontrib-qthelp/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  b41a6b415c5653b0828009bcd73b18823d3cc1b8 \
                     sha256  4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
                     size    21658
 
-python.versions     35 36 37 38 39 310
+python.versions     35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-serializinghtml/Portfile
+++ b/python/py-sphinxcontrib-serializinghtml/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  c8e1910f916f8d07d5e87bc433c964634146773f \
                     sha256  aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952 \
                     size    21019
 
-python.versions     35 36 37 38 39 310
+python.versions     35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-websupport/Portfile
+++ b/python/py-sphinxcontrib-websupport/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  360dec014f96f95fd2c9c2f07787ae021549abff \
                     sha256  4edf0223a0685a7c485ae5a156b6f529ba1ee481a1417817935b20bde1956232 \
                     size    602360
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${subport} ne ${name}} {
     if {${python.version} == 27} {


### PR DESCRIPTION
#### Description

Add Python 3.11 support to Python ports required by `cmake +python311` from [this commit](https://github.com/macports/macports-ports/commit/9f6f6bc9cfdbeffe587b236259740d80886ef6f8).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.2 20G1008
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
