### PR TITLE
cmake{,-devel}: fix build before 10.10

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -7,6 +7,7 @@ if { ${os.platform} eq "darwin" && ${os.major} >= 20 && ${build_arch} eq "x86_64
     universal_variant no
 } else {
     PortGroup       muniversal 1.0
+
 }
 
 PortGroup           xcodeversion 1.0
@@ -49,7 +50,7 @@ epoch               1
 dist_subdir         ${my_name}
 
 compiler.cxx_standard \
-                    2011
+                    2014
 
 platform darwin {
     if {!((${os.major} < 9) || ${build_arch} eq "ppc" || ${build_arch} eq "ppc64")} {
@@ -101,15 +102,6 @@ configure.env-append \
     CMAKE_PREFIX_PATH=${prefix} \
     CMAKE_INCLUDE_PATH=${prefix}/include/ncurses \
     CMAKE_LIBRARY_PATH=${prefix}/lib
-
-# On Lion, Clang 3.3 produces bad stream reading code when using
-# libc++.  See https://trac.macports.org/ticket/44129 . Clang 3.4
-# works. But Clang 3.7 doesn't work.
-if {${os.platform} eq "darwin" && ${os.major} == 11 &&
-    ${configure.cxx_stdlib} eq "libc++"} {
-    compiler.whitelist \
-        macports-clang-3.4
-}
 
 # clang 3.4 can't build certain parts of the
 # cmake self-testing infrastructure

--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -41,7 +41,7 @@ checksums           rmd160  09373f97fee569133852498f0de6e9f6db10084b \
 revision            0
 
 gitlab.livecheck.regex {([0-9.]+)}
-compiler.cxx_standard 2011
+compiler.cxx_standard 2014
 
 platform darwin {
     if {!((${os.major} < 9) || ${build_arch} eq "ppc" ||
@@ -100,14 +100,6 @@ configure.env-append \
 if {${os.platform} eq "darwin" && ${os.major} <= 10 &&
     ${cxx_stdlib} eq "libc++" && ![file exists ${configure.cxx}]} {
     set cmake_bootstrapping yes
-}
-
-# On Lion, Clang 3.3 produces bad stream reading code when using
-# libc++.  See https://trac.macports.org/ticket/44129 . Clang 3.4
-# works. But Clang 3.7 doesn't work.
-if {${os.platform} eq "darwin" && ${os.major} == 11 &&
-    ${configure.cxx_stdlib} eq "libc++"} {
-    compiler.whitelist macports-clang-3.4
 }
 
 # clang 3.4 can't build certain parts of the


### PR DESCRIPTION
#### Description

cmake is required to build all clangs, and to prevent dependency loop I've used clang-11-bootstrap to build it on platforms which can't build it by compiler which is ships with it.

Closes: https://trac.macports.org/ticket/66340
Closes: https://trac.macports.org/ticket/66040

I've also made `port lint --nitpick cmake-devel` happy.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->