### PR TITLE
ci: Fix errors during step summary creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
               else
                 echo "##### ⚠️ ${subport}" >> $GITHUB_STEP_SUMMARY
               fi
-              printf "```\n%s```\n" "$messages" >> $GITHUB_STEP_SUMMARY
+              printf '```\n%s```\n' "$messages" >> $GITHUB_STEP_SUMMARY
 
               # See https://github.com/actions/toolkit/issues/193#issuecomment-605394935
               encoded_messages="port lint ${subport}:%0A"
@@ -167,10 +167,6 @@ jobs:
               echo "::error::Failed to install dependencies for ${subport}"
 
               echo "⚠️ Failed to install dependencies" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "```" >> $GITHUB_STEP_SUMMARY
-              tail -n20 "$workdir/logs/depdendencies-progress.txt" >> $GITHUB_STEP_SUMMARY
-              echo "```" >> $GITHUB_STEP_SUMMARY
 
               fail=1
               continue


### PR DESCRIPTION
#### Description

It seems the linebreaks inside of double quotes are not correctly rendered, but since '\n' is successfully used further down with tr -d, that should work instead.

Remove the tail of the dependency progress log, since it seems to no longer be available at the point where we are trying to print it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix