### PR TITLE
postgresql14: version bump to 14.6

### DIFF
--- a/databases/postgresql14-doc/Portfile
+++ b/databases/postgresql14-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql14-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc postgresql12-doc \
     postgresql13-doc
-version             14.5
+version             14.6
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -22,9 +22,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql14
 
-checksums           rmd160  f3e37d178e8eae60cf247f03ea3009a717ff558f \
-                    sha256  d4f72cb5fb857c9a9f75ec8cf091a1771272802f2178f0b2e65b7b6ff64f4a30 \
-                    size    22132996
+checksums           rmd160  f2b1ebf2f622cc38b4f39ff65cf31ce2f610805d \
+                    sha256  508840fc1809d39ab72274d5f137dabb9fd7fb4f933da4168aeebb20069edf22 \
+                    size    22177474
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql14-server/Portfile
+++ b/databases/postgresql14-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql14-server
-version             14.5
+version             14.6
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql14
-version             14.5
-revision            2
+version             14.6
+revision            0
 
 categories          databases
 platforms           darwin
@@ -27,9 +27,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  f3e37d178e8eae60cf247f03ea3009a717ff558f \
-                    sha256  d4f72cb5fb857c9a9f75ec8cf091a1771272802f2178f0b2e65b7b6ff64f4a30 \
-                    size    22132996
+checksums           rmd160  f2b1ebf2f622cc38b4f39ff65cf31ce2f610805d \
+                    sha256  508840fc1809d39ab72274d5f137dabb9fd7fb4f933da4168aeebb20069edf22 \
+                    size    22177474
 
 use_bzip2           yes
 


### PR DESCRIPTION
#### Description

version bump to 14.6

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
