### PR TITLE
josm: update to 18583

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18543
+version             18583
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  bd61d7bace36dc0981ff458ae90aea08c9d763d7 \
-                    sha256  a46567f8d81f4a5c98713d010938fe36d6deeddd25e8b2527838bdc6f7b42b88 \
-                    size    77902486
+checksums           rmd160  6d314bc612b5f88a15379a3250c56df3f0f3c1e4 \
+                    sha256  dd71284825c4a5ea998f5cb89e7b39fb4251d5220d604d6bb264387cc7e5c514 \
+                    size    78073192
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2022-11-01: Stable release 18583](https://josm.openstreetmap.de/wiki/Changelog#a2022-11-01:Stablerelease1858322.10)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS macOS 11.7
Xcode 12.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?