### PR TITLE
meson-1.0: allow control over downloading of subprojects, via new option 'meson.wrap_mode'

### DIFF
--- a/_resources/port1.0/group/meson-1.0.tcl
+++ b/_resources/port1.0/group/meson-1.0.tcl
@@ -8,6 +8,11 @@
 #
 
 
+# Wrap mode handling for subprojects.
+# Possible values: default, nofallback, nodownload, forcefallback, nopromote
+options meson.wrap_mode
+default meson.wrap_mode     {default}
+
 # meson builds need to be done out-of-source
 default build_dir           {${workpath}/build}
 
@@ -38,15 +43,15 @@ proc meson::get_post_args {} {
     if {[info exists muniversal.build_arch]} {
         # muniversal 1.1 PG is being used
         if {[option muniversal.is_cross.[option muniversal.build_arch]]} {
-            return "${configure.dir} ${build.dir} --cross-file=[option muniversal.build_arch]-darwin"
+            return "${configure.dir} ${build.dir} --cross-file=[option muniversal.build_arch]-darwin --wrap-mode=[option meson.wrap_mode]"
         } else {
-            return "${configure.dir} ${build.dir}"
+            return "${configure.dir} ${build.dir} --wrap-mode=[option meson.wrap_mode]"
         }
     } elseif {[info exists muniversal.current_arch]} {
         # muniversal 1.0 PG is being used
-        return "${configure.dir} ${build_dir}-${muniversal.current_arch} --cross-file=${muniversal.current_arch}-darwin"
+        return "${configure.dir} ${build_dir}-${muniversal.current_arch} --cross-file=${muniversal.current_arch}-darwin --wrap-mode=[option meson.wrap_mode]"
     } else {
-        return "${configure.dir} ${build_dir}"
+        return "${configure.dir} ${build_dir} --wrap-mode=[option meson.wrap_mode]"
     }
 }
 

--- a/graphics/gdk-pixbuf2/Portfile
+++ b/graphics/gdk-pixbuf2/Portfile
@@ -16,7 +16,7 @@ set my_name         gdk-pixbuf2
 set gname           gdk-pixbuf
 
 version             2.42.10
-revision            0
+revision            1
 epoch               2
 
 checksums           rmd160  38a225271d100b58aacec52ab18144871e7073bc \
@@ -37,6 +37,9 @@ master_sites        gnome:sources/${gname}/${branch}/
 distname            ${gname}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
+
+# Disable unexpected download of subprojects
+meson.wrap_mode     nodownload
 
 set python_branch   3.11
 set python_version  [string map {. {}} ${python_branch}]


### PR DESCRIPTION
#### Description

https://mesonbuild.com/Wrap-dependency-system-manual.html
> The Wrap dependency system of Meson aims to provide an automated way to do this.

This really goes against what packages managers want to be doing, so disable this functionality by default.

Added a new option `wrap_mode` this defaults to `nodownload` but can be overwritten as needed by the Port
> possible values: default, nofallback, nodownload, forcefallback or nopromote

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
