### PR TITLE
lagrange: update to 1.14.0

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -9,8 +9,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake the_Foundation 1.4.0 v
-revision            1
+gitea.setup         skyjake the_Foundation 1.5.0 v
+revision            0
 categories          devel
 license             BSD
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -18,9 +18,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  1468f4e59a84b3d3044de6ad33247c72931378b2 \
-                    sha256  dabed30250ca9f3da0a7930aeea8a7092f9946a37f85a04252eb0d3a363cd13d \
-                    size    210489
+checksums           rmd160  531aed53fc76120ebcfbdddcdab6a86c79e2f1a3 \
+                    sha256  b2609090132ec5d72d7c629c53708fc02d9300f4e8d4c481e0b0950717b8f4d3 \
+                    size    211135
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.13.8 v
+gitea.setup         gemini lagrange 1.14.0 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  03c07dd89e75b76e26b26c5631af9f874a23853e \
-                    sha256  7a34dea411668d0df0afde31cfc67f3e221a3871428b2df77625dfc813cd4ca2 \
-                    size    7425248
+checksums           rmd160  e916690823ea79a8698804edc95dc9b45171cfbc \
+                    sha256  c248a00fd69a60104344b0d6adf1ce87617c739f99cd7a8b6dea66860b8b038c \
+                    size    7456169
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.5.1
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
