### PR TITLE
gopass: update to 1.14.11

### DIFF
--- a/security/git-credential-gopass/Portfile
+++ b/security/git-credential-gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/git-credential-gopass 1.14.9 v
+go.setup            github.com/gopasspw/git-credential-gopass 1.14.11 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  1c7d84ebb7596e9c2ce1509e62c3ea903e4d37c5 \
-                        sha256  7ee2f5f4e991904433b74ad558abaad751f2366b8ae1cc35117b03ef4d610248 \
-                        size    20552
+                        rmd160  7e783b0eb859b8f50bcc78e66c0b24335169c644 \
+                        sha256  9f8d897b25f9c61fb1c62366efc486fc5a48e31c88faed223d3cad69ff01681c \
+                        size    20716
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -35,30 +35,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    7a66f970e087 \
-                        rmd160  41c0ec1933a371ad67cb43763a5f056beb4f4863 \
-                        sha256  eb75717073f7fa08879333df6cc9ddcefd6dff51fdcd68769a144f480b754d89 \
-                        size    14836 \
+                        lock    v0.2.0 \
+                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
+                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
+                        size    14797 \
                     golang.org/x/sys \
-                        lock    f11e5e49a4ec \
-                        rmd160  9a3d80028b63286705afae2e0ac56db4ead87393 \
-                        sha256  0d9b8a224175ae48e956e9819f3956ab99e424d972392dc14f2767f7ed5cc08e \
-                        size    1358598 \
+                        lock    v0.2.0 \
+                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
+                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
+                        size    1411246 \
                     golang.org/x/net \
-                        lock    f486391704dc \
-                        rmd160  ad3567fe403e6f60af35e23a16148a64ba897ada \
-                        sha256  552e03ea9ace20d5dc0d2a8e38a70b46fb129a949ff5ede12647ff7f1cb0db63 \
-                        size    1228309 \
+                        lock    v0.2.0 \
+                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
+                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
+                        size    1243767 \
                     golang.org/x/exp \
-                        lock    c76eaa363f9d \
-                        rmd160  6a5edb9a872e69af22259e1788a4232e5de90a4e \
-                        sha256  45bd97165cabf719fa62fb6ab9a6e76244485d948814b09e59b1b05615678083 \
-                        size    1581437 \
+                        lock    850992195362 \
+                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
+                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
+                        size    1605708 \
                     golang.org/x/crypto \
-                        lock    eccd6366d1be \
-                        rmd160  ab1c320cdf6095b7b631d84be10a670bf1fb93ef \
-                        sha256  b521c71cb061835f7613fa91303a40cf3453ba09727f952a2363b6e403f3bde2 \
-                        size    1631515 \
+                        lock    v0.3.0 \
+                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
+                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
+                        size    1633434 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -82,25 +82,25 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.16.3 \
-                        rmd160  adb83ade0b2179e2e317399b92b0847400e50657 \
-                        sha256  99806c3033219a905b006c8cae96c8ba4cd08a94ce966886b0f3855b36440850 \
-                        size    3469448 \
+                        lock    v2.23.5 \
+                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
+                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
+                        size    3478097 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
                         sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
                         size    11986 \
                     github.com/stretchr/testify \
-                        lock    v1.8.0 \
-                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
-                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
-                        size    97622 \
+                        lock    v1.8.1 \
+                        rmd160  4d80635834e01b3ddb67babdd8de2eac2c5a7587 \
+                        sha256  9848272e238f98fc0555b514c4522e70c4df25331b4ee3f9cb9244a04935934e \
+                        size    97722 \
                     github.com/stretchr/objx \
-                        lock    v0.4.0 \
-                        rmd160  7c15794276cc01606b1af8f7c1464f3c6267d669 \
-                        sha256  2e19a33cf951b8d9d19ce9ac9ddbdf7bf866e8ee5a730a08020e612418ef3f3a \
-                        size    163135 \
+                        lock    v0.5.0 \
+                        rmd160  9ff3c4d1d122c7e389f2d8b0b0c5503fd1c15e0a \
+                        sha256  21b1f19a64c553c9ee77ab25f498ceafe839a84aa9380f04154ea28217c60974 \
+                        size    165551 \
                     github.com/skip2/go-qrcode \
                         lock    da1b6568686e \
                         rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
@@ -217,10 +217,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.9 \
-                        rmd160  461fa3f1f7214d6a62be3a30cf33900f9aae5e75 \
-                        sha256  6ec5ba719ea87e5a86f58925b60eacef55cb76f291eff7ca5d6003714caf1f54 \
-                        size    2252771 \
+                        lock    v1.14.11 \
+                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
+                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
+                        size    2255917 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -272,10 +272,10 @@ go.vendors          gotest.tools \
                         sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
                         size    64382 \
                     github.com/cloudflare/circl \
-                        lock    v1.2.0 \
-                        rmd160  57ecd1876b3db3338e04ee26399ba504d67e15af \
-                        sha256  2d9d0e87698fceae275c06f5641c4dacf1e505217a981a21bac72438d0972ab7 \
-                        size    4702712 \
+                        lock    v1.3.0 \
+                        rmd160  0a2756e43e5d01217e3ac910831ce324cb028db4 \
+                        sha256  c6ed975caf7d6eccb95bfe8d192ff3946a6261a31a218106616510109459992c \
+                        size    4764393 \
                     github.com/chzyer/readline \
                         lock    v1.5.1 \
                         rmd160  cea52b55bd592a89cb49da082f5f0f3b6e8ad48a \
@@ -312,10 +312,10 @@ go.vendors          gotest.tools \
                         sha256  ab26daceb19d4973dd1bf37105473f8d27697b5a04b124d790fd45124450b9a2 \
                         size    7552 \
                     github.com/ProtonMail/go-crypto \
-                        lock    4b6e5c587895 \
-                        rmd160  d4b9fbd23c062647ad52781906cb8a7bf94fee3d \
-                        sha256  83ff491e152d6c47a8a8c7813a782581c4782f94c8b2573a47ada6b08449d917 \
-                        size    329665 \
+                        lock    cf6655e29de4 \
+                        rmd160  0c878f2d4a5a2e8869df40d99ee219bdff7503de \
+                        sha256  5b94489154983036fbaf619202a3f92700817fd57b3a1010f0a39bf2e2432665 \
+                        size    330467 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
                         lock    v1.0.0 \

--- a/security/gopass-hibp/Portfile
+++ b/security/gopass-hibp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-hibp 1.14.9 v
+go.setup            github.com/gopasspw/gopass-hibp 1.14.11 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    ${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  63f6b10c754f4ca623802af615a24fc87987585e \
-                        sha256  ef361b62533e03019d5d87d9d0b23c49564860238306ad01f2638faccf000d05 \
-                        size    22929
+                        rmd160  45ee724b0ac24554e1362731d497324699c0836f \
+                        sha256  23d8553e50dacfdf2da4ecdf1f20d76cc1c7aebef3ae39db8781332899912e25 \
+                        size    23296
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -35,30 +35,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    7a66f970e087 \
-                        rmd160  41c0ec1933a371ad67cb43763a5f056beb4f4863 \
-                        sha256  eb75717073f7fa08879333df6cc9ddcefd6dff51fdcd68769a144f480b754d89 \
-                        size    14836 \
+                        lock    v0.2.0 \
+                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
+                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
+                        size    14797 \
                     golang.org/x/sys \
-                        lock    f11e5e49a4ec \
-                        rmd160  9a3d80028b63286705afae2e0ac56db4ead87393 \
-                        sha256  0d9b8a224175ae48e956e9819f3956ab99e424d972392dc14f2767f7ed5cc08e \
-                        size    1358598 \
+                        lock    v0.2.0 \
+                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
+                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
+                        size    1411246 \
                     golang.org/x/net \
-                        lock    f486391704dc \
-                        rmd160  ad3567fe403e6f60af35e23a16148a64ba897ada \
-                        sha256  552e03ea9ace20d5dc0d2a8e38a70b46fb129a949ff5ede12647ff7f1cb0db63 \
-                        size    1228309 \
+                        lock    v0.2.0 \
+                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
+                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
+                        size    1243767 \
                     golang.org/x/exp \
-                        lock    c76eaa363f9d \
-                        rmd160  6a5edb9a872e69af22259e1788a4232e5de90a4e \
-                        sha256  45bd97165cabf719fa62fb6ab9a6e76244485d948814b09e59b1b05615678083 \
-                        size    1581437 \
+                        lock    850992195362 \
+                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
+                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
+                        size    1605708 \
                     golang.org/x/crypto \
-                        lock    eccd6366d1be \
-                        rmd160  ab1c320cdf6095b7b631d84be10a670bf1fb93ef \
-                        sha256  b521c71cb061835f7613fa91303a40cf3453ba09727f952a2363b6e403f3bde2 \
-                        size    1631515 \
+                        lock    v0.3.0 \
+                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
+                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
+                        size    1633434 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -82,25 +82,25 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.16.3 \
-                        rmd160  adb83ade0b2179e2e317399b92b0847400e50657 \
-                        sha256  99806c3033219a905b006c8cae96c8ba4cd08a94ce966886b0f3855b36440850 \
-                        size    3469448 \
+                        lock    v2.23.5 \
+                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
+                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
+                        size    3478097 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
                         sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
                         size    11986 \
                     github.com/stretchr/testify \
-                        lock    v1.8.0 \
-                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
-                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
-                        size    97622 \
+                        lock    v1.8.1 \
+                        rmd160  4d80635834e01b3ddb67babdd8de2eac2c5a7587 \
+                        sha256  9848272e238f98fc0555b514c4522e70c4df25331b4ee3f9cb9244a04935934e \
+                        size    97722 \
                     github.com/stretchr/objx \
-                        lock    v0.4.0 \
-                        rmd160  7c15794276cc01606b1af8f7c1464f3c6267d669 \
-                        sha256  2e19a33cf951b8d9d19ce9ac9ddbdf7bf866e8ee5a730a08020e612418ef3f3a \
-                        size    163135 \
+                        lock    v0.5.0 \
+                        rmd160  9ff3c4d1d122c7e389f2d8b0b0c5503fd1c15e0a \
+                        sha256  21b1f19a64c553c9ee77ab25f498ceafe839a84aa9380f04154ea28217c60974 \
+                        size    165551 \
                     github.com/skip2/go-qrcode \
                         lock    da1b6568686e \
                         rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
@@ -191,6 +191,11 @@ go.vendors          gotest.tools \
                         rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
                         sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
                         size    10043 \
+                    github.com/kjk/lzmadec \
+                        lock    19ac3ee91a71 \
+                        rmd160  b470f1e9ec2ec51cf25ad3e85d27a319fde7a48c \
+                        sha256  ded416afeed650053d348edd7702982e1d016f638269bd8461595c4ab332b375 \
+                        size    3919 \
                     github.com/kballard/go-shellquote \
                         lock    95032a82bc51 \
                         rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
@@ -217,10 +222,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.9 \
-                        rmd160  461fa3f1f7214d6a62be3a30cf33900f9aae5e75 \
-                        sha256  6ec5ba719ea87e5a86f58925b60eacef55cb76f291eff7ca5d6003714caf1f54 \
-                        size    2252771 \
+                        lock    v1.14.11 \
+                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
+                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
+                        size    2255917 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -272,20 +277,20 @@ go.vendors          gotest.tools \
                         sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
                         size    64382 \
                     github.com/cloudflare/circl \
-                        lock    v1.2.0 \
-                        rmd160  57ecd1876b3db3338e04ee26399ba504d67e15af \
-                        sha256  2d9d0e87698fceae275c06f5641c4dacf1e505217a981a21bac72438d0972ab7 \
-                        size    4702712 \
+                        lock    v1.3.0 \
+                        rmd160  0a2756e43e5d01217e3ac910831ce324cb028db4 \
+                        sha256  c6ed975caf7d6eccb95bfe8d192ff3946a6261a31a218106616510109459992c \
+                        size    4764393 \
                     github.com/chzyer/readline \
                         lock    v1.5.1 \
                         rmd160  cea52b55bd592a89cb49da082f5f0f3b6e8ad48a \
                         sha256  9e5d6daaf4e6fa8d924e82ddec8b1fcfec42f4b1385aa8448b09816478c55c84 \
                         size    37579 \
                     github.com/cenkalti/backoff \
-                        lock    v4.1.3 \
-                        rmd160  440a499ec3b80e7ec9f003924219aba222cd3472 \
-                        sha256  105a8b5dfc4b46016f9efac2940abb78cb9dceca5e0803672039938311fe6d65 \
-                        size    9871 \
+                        lock    v4.2.0 \
+                        rmd160  be7ce317e4e5d7c66e8b21459f299cd34da3c324 \
+                        sha256  76ce74517c04226e2df72a964cf599156baf1f8dfd7a9b701de470fd42e7eeb0 \
+                        size    10382 \
                     github.com/caspr-io/yamlpath \
                         lock    502e8d113a9b \
                         rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
@@ -312,10 +317,10 @@ go.vendors          gotest.tools \
                         sha256  ab26daceb19d4973dd1bf37105473f8d27697b5a04b124d790fd45124450b9a2 \
                         size    7552 \
                     github.com/ProtonMail/go-crypto \
-                        lock    4b6e5c587895 \
-                        rmd160  d4b9fbd23c062647ad52781906cb8a7bf94fee3d \
-                        sha256  83ff491e152d6c47a8a8c7813a782581c4782f94c8b2573a47ada6b08449d917 \
-                        size    329665 \
+                        lock    cf6655e29de4 \
+                        rmd160  0c878f2d4a5a2e8869df40d99ee219bdff7503de \
+                        sha256  5b94489154983036fbaf619202a3f92700817fd57b3a1010f0a39bf2e2432665 \
+                        size    330467 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
                         lock    v1.0.0 \

--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.14.9 v
+go.setup            github.com/gopasspw/gopass-jsonapi 1.14.11 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  639db14823810164ec28c360d673a1337c1dd010 \
-                        sha256  23f02c2bf49b3467e974009a47e94c0cc9cb140a87d092c835b508e087861ad3 \
-                        size    31605
+                        rmd160  920c02f351267df2761f86842fa8f32bdb51829d \
+                        sha256  c158c2a5bcc939bd8f2b4b27bc66c729e484cbe5e1279c1b39c443e9011a34fc \
+                        size    31592
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -35,30 +35,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    7a66f970e087 \
-                        rmd160  41c0ec1933a371ad67cb43763a5f056beb4f4863 \
-                        sha256  eb75717073f7fa08879333df6cc9ddcefd6dff51fdcd68769a144f480b754d89 \
-                        size    14836 \
+                        lock    v0.2.0 \
+                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
+                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
+                        size    14797 \
                     golang.org/x/sys \
-                        lock    f11e5e49a4ec \
-                        rmd160  9a3d80028b63286705afae2e0ac56db4ead87393 \
-                        sha256  0d9b8a224175ae48e956e9819f3956ab99e424d972392dc14f2767f7ed5cc08e \
-                        size    1358598 \
+                        lock    v0.2.0 \
+                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
+                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
+                        size    1411246 \
                     golang.org/x/net \
-                        lock    f486391704dc \
-                        rmd160  ad3567fe403e6f60af35e23a16148a64ba897ada \
-                        sha256  552e03ea9ace20d5dc0d2a8e38a70b46fb129a949ff5ede12647ff7f1cb0db63 \
-                        size    1228309 \
+                        lock    v0.2.0 \
+                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
+                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
+                        size    1243767 \
                     golang.org/x/exp \
-                        lock    c76eaa363f9d \
-                        rmd160  6a5edb9a872e69af22259e1788a4232e5de90a4e \
-                        sha256  45bd97165cabf719fa62fb6ab9a6e76244485d948814b09e59b1b05615678083 \
-                        size    1581437 \
+                        lock    850992195362 \
+                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
+                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
+                        size    1605708 \
                     golang.org/x/crypto \
-                        lock    eccd6366d1be \
-                        rmd160  ab1c320cdf6095b7b631d84be10a670bf1fb93ef \
-                        sha256  b521c71cb061835f7613fa91303a40cf3453ba09727f952a2363b6e403f3bde2 \
-                        size    1631515 \
+                        lock    v0.3.0 \
+                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
+                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
+                        size    1633434 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -82,25 +82,25 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.16.3 \
-                        rmd160  adb83ade0b2179e2e317399b92b0847400e50657 \
-                        sha256  99806c3033219a905b006c8cae96c8ba4cd08a94ce966886b0f3855b36440850 \
-                        size    3469448 \
+                        lock    v2.23.5 \
+                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
+                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
+                        size    3478097 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
                         sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
                         size    11986 \
                     github.com/stretchr/testify \
-                        lock    v1.8.0 \
-                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
-                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
-                        size    97622 \
+                        lock    v1.8.1 \
+                        rmd160  4d80635834e01b3ddb67babdd8de2eac2c5a7587 \
+                        sha256  9848272e238f98fc0555b514c4522e70c4df25331b4ee3f9cb9244a04935934e \
+                        size    97722 \
                     github.com/stretchr/objx \
-                        lock    v0.4.0 \
-                        rmd160  7c15794276cc01606b1af8f7c1464f3c6267d669 \
-                        sha256  2e19a33cf951b8d9d19ce9ac9ddbdf7bf866e8ee5a730a08020e612418ef3f3a \
-                        size    163135 \
+                        lock    v0.5.0 \
+                        rmd160  9ff3c4d1d122c7e389f2d8b0b0c5503fd1c15e0a \
+                        sha256  21b1f19a64c553c9ee77ab25f498ceafe839a84aa9380f04154ea28217c60974 \
+                        size    165551 \
                     github.com/skip2/go-qrcode \
                         lock    da1b6568686e \
                         rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
@@ -217,10 +217,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.9 \
-                        rmd160  461fa3f1f7214d6a62be3a30cf33900f9aae5e75 \
-                        sha256  6ec5ba719ea87e5a86f58925b60eacef55cb76f291eff7ca5d6003714caf1f54 \
-                        size    2252771 \
+                        lock    v1.14.11 \
+                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
+                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
+                        size    2255917 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -272,10 +272,10 @@ go.vendors          gotest.tools \
                         sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
                         size    64382 \
                     github.com/cloudflare/circl \
-                        lock    v1.2.0 \
-                        rmd160  57ecd1876b3db3338e04ee26399ba504d67e15af \
-                        sha256  2d9d0e87698fceae275c06f5641c4dacf1e505217a981a21bac72438d0972ab7 \
-                        size    4702712 \
+                        lock    v1.3.0 \
+                        rmd160  0a2756e43e5d01217e3ac910831ce324cb028db4 \
+                        sha256  c6ed975caf7d6eccb95bfe8d192ff3946a6261a31a218106616510109459992c \
+                        size    4764393 \
                     github.com/chzyer/readline \
                         lock    v1.5.1 \
                         rmd160  cea52b55bd592a89cb49da082f5f0f3b6e8ad48a \
@@ -312,10 +312,10 @@ go.vendors          gotest.tools \
                         sha256  ab26daceb19d4973dd1bf37105473f8d27697b5a04b124d790fd45124450b9a2 \
                         size    7552 \
                     github.com/ProtonMail/go-crypto \
-                        lock    4b6e5c587895 \
-                        rmd160  d4b9fbd23c062647ad52781906cb8a7bf94fee3d \
-                        sha256  83ff491e152d6c47a8a8c7813a782581c4782f94c8b2573a47ada6b08449d917 \
-                        size    329665 \
+                        lock    cf6655e29de4 \
+                        rmd160  0c878f2d4a5a2e8869df40d99ee219bdff7503de \
+                        sha256  5b94489154983036fbaf619202a3f92700817fd57b3a1010f0a39bf2e2432665 \
+                        size    330467 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
                         lock    v1.0.0 \

--- a/security/gopass-summon-provider/Portfile
+++ b/security/gopass-summon-provider/Portfile
@@ -1,0 +1,342 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/gopasspw/gopass-summon-provider 1.14.11 v
+revision            0
+categories          security
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+license             MIT
+
+description         Gopass Summon Provider
+long_description    {*}${description}
+homepage            https://www.gopass.pw
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  2ee643a62e164b44c1e136e8c384f592fd8bf767 \
+                        sha256  955958dec7334571d4a3550e40308194e9a1978f365452f544ffeed9126376da \
+                        size    17479
+
+go.vendors          gotest.tools \
+                        repo    github.com/gotestyourself/gotest.tools \
+                        lock    v3.0.2 \
+                        rmd160  ccc2d160fcdb27d0e8461506d0c38e27487c8bd7 \
+                        sha256  9b17efa7751a66942c72f54e62716574bc34561bdcdaf8337bea3612e85a7025 \
+                        size    61955 \
+                    gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    gopkg.in/check.v1 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
+                    golang.org/x/term \
+                        lock    v0.2.0 \
+                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
+                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
+                        size    14797 \
+                    golang.org/x/sys \
+                        lock    v0.2.0 \
+                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
+                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
+                        size    1411246 \
+                    golang.org/x/net \
+                        lock    v0.2.0 \
+                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
+                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
+                        size    1243767 \
+                    golang.org/x/exp \
+                        lock    850992195362 \
+                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
+                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
+                        size    1605708 \
+                    golang.org/x/crypto \
+                        lock    v0.3.0 \
+                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
+                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
+                        size    1633434 \
+                    go.uber.org/multierr \
+                        repo    github.com/uber-go/multierr \
+                        lock    v1.8.0 \
+                        rmd160  b09e4eae9a41c2b84204346c264e0749998272f5 \
+                        sha256  b172f7c7e805cfd8e7ec423e19e4ed47fab099fb9ff42b0910876098f557f8ee \
+                        size    15600 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.10.0 \
+                        rmd160  3b3e329c78468d0b4711b28f323069a1d6afbeec \
+                        sha256  c03c44af9133c1c06829842b6db2a1bff49818d1cb96c709d65301651f4bc390 \
+                        size    23092 \
+                    github.com/zalando/go-keyring \
+                        lock    v0.2.1 \
+                        rmd160  68131dd6797b9f9b43a8dda031db9764c9e085bc \
+                        sha256  a797635b69933eddc3676fd0134262f5ec63b3a45203b1d67102e5cdaea05b38 \
+                        size    10759 \
+                    github.com/xrash/smetrics \
+                        lock    039620a65673 \
+                        rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
+                        sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
+                        size    1823438 \
+                    github.com/urfave/cli \
+                        lock    v2.23.5 \
+                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
+                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
+                        size    3478097 \
+                    github.com/twpayne/go-pinentry \
+                        lock    v0.2.0 \
+                        rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
+                        sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
+                        size    11986 \
+                    github.com/stretchr/testify \
+                        lock    v1.8.1 \
+                        rmd160  4d80635834e01b3ddb67babdd8de2eac2c5a7587 \
+                        sha256  9848272e238f98fc0555b514c4522e70c4df25331b4ee3f9cb9244a04935934e \
+                        size    97722 \
+                    github.com/stretchr/objx \
+                        lock    v0.5.0 \
+                        rmd160  9ff3c4d1d122c7e389f2d8b0b0c5503fd1c15e0a \
+                        sha256  21b1f19a64c553c9ee77ab25f498ceafe839a84aa9380f04154ea28217c60974 \
+                        size    165551 \
+                    github.com/skip2/go-qrcode \
+                        lock    da1b6568686e \
+                        rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
+                        sha256  28f73bbd2c7f78308c9189c5c8abb2a329b3e02f11dec7a54254c457630ad581 \
+                        size    36689 \
+                    github.com/schollz/closestmatch \
+                        lock    1fbe626be92e \
+                        rmd160  0c09dba0d527a6046585125a6fb2a93bc08c635c \
+                        sha256  52174a0c7551cbaeb0253dd9a00506e285877fe2cb464c6c79dcf65ed02f7ec9 \
+                        size    623995 \
+                    github.com/russross/blackfriday \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
+                    github.com/rs/zerolog \
+                        lock    v1.28.0 \
+                        rmd160  4b23fe27020af1b1b3de36eba648c42ff8af3fee \
+                        sha256  cf98c2e0609d78d49b8c0896583115cb29c3c2c2fd16976795adf248704a549d \
+                        size    166068 \
+                    github.com/rogpeppe/go-internal \
+                        lock    86f73c517451 \
+                        rmd160  12ae7289b3b9f3f0339d1ffe90bfefdd28944914 \
+                        sha256  243fd03669a7f2563d066de31a537dc3e99fb3180fcf36f1b492f84e3c8dbd76 \
+                        size    131803 \
+                    github.com/pquerna/otp \
+                        lock    c62dc589378a \
+                        rmd160  b95abaf61d798b40eb4c4305f99ebb09f07f57d2 \
+                        sha256  5d5dea17234e378773448f455188ad5614947e35963108028d4f66a533e99a98 \
+                        size    14210 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/nbutton23/zxcvbn-go \
+                        lock    fa2cb2858354 \
+                        rmd160  17c2ab9843836ee904acced65d6d22f13a4b614c \
+                        sha256  5f33a658c9daf086423450a9ad27297f7589ce58c1e4ddff3bb623ef8da276ae \
+                        size    881860 \
+                    github.com/muesli/crunchy \
+                        lock    v0.4.0 \
+                        rmd160  3029073bbcf95a9154c93b01803f3b48d7a3ec7e \
+                        sha256  039c5f45b9d1f7a02562cad503749bce7820d510657f720d2db2ea593093d438 \
+                        size    7791 \
+                    github.com/mitchellh/go-ps \
+                        lock    v1.0.0 \
+                        rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
+                        sha256  8e158a59a9b7e407b27a4cf6100f33648b7c8bffb4ac07bd074f43d4796afa87 \
+                        size    7631 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/mattn/go-tty \
+                        lock    v0.0.4 \
+                        rmd160  aeef24ae0b469f8a83cd43f40843ba3dc58f057d \
+                        sha256  a9ee7c2dc5fcaf640eb3be20fbeab1cebd6fc56a160296c815d1129a0ff0091f \
+                        size    7735 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.16 \
+                        rmd160  dcdf01553caa079315f2293c109de17fc72f0c6b \
+                        sha256  391d25a98e2cc92a2ed5c6abd07cde1053411706bb24e5843562931e6085ab46 \
+                        size    4693 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.13 \
+                        rmd160  c9e8ab9d0773c0984f36235e3c9f8c033552ac1a \
+                        sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
+                        size    9778 \
+                    github.com/martinhoefling/goxkcdpwgen \
+                        lock    v0.1.1 \
+                        rmd160  56164d6a8b2620f53897f85abe3ff7659e0aa0c5 \
+                        sha256  0ee21438461014724b2a3afe08e6db51649748ff23f7f90705b2617d80e568a6 \
+                        size    89925 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.3.0 \
+                        rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
+                        sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
+                        size    10043 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/jsimonetti/pwscheme \
+                        lock    67a4d090f150 \
+                        rmd160  9ed2510ff345bfef395695de051320b164ce2928 \
+                        sha256  5bfc0f715708344425f740650042bc09c53ec4bd7b795944eb123fbb000887ba \
+                        size    5268 \
+                    github.com/hashicorp/golang-lru \
+                        lock    v0.5.4 \
+                        rmd160  833d8d87b84f13bc545ecffff9358a19671d185a \
+                        sha256  c358bb5050adae91e443f59ff70b7c0ad6906fc4abe1b30066bf0c408fdf9b5c \
+                        size    13435 \
+                    github.com/hashicorp/go-multierror \
+                        lock    v1.1.1 \
+                        rmd160  94493cc3074dc39be0de76f04fa2a44a405d0a42 \
+                        sha256  52e986cca6d6335bfcd23b4867f884311cfb5ca060325496b6692029797d64e2 \
+                        size    13805 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.1.0 \
+                        rmd160  25e655fc958685dd949900eea8c3d97f33d85eab \
+                        sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
+                        size    8586 \
+                    github.com/gopasspw/gopass \
+                        lock    v1.14.11 \
+                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
+                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
+                        size    2255917 \
+                    github.com/google/go-querystring \
+                        lock    v1.1.0 \
+                        rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
+                        sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
+                        size    10418 \
+                    github.com/google/go-github \
+                        lock    v17.0.0 \
+                        rmd160  2c1917adfc161a2252354d558352180079005d8d \
+                        sha256  c064b8849dcf8e184e1333f8411c7285e0abeb321ffc268b3798f84d6db5f947 \
+                        size    212064 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.9 \
+                        rmd160  9832ae80123461baed8aa20e830199c0e21e337b \
+                        sha256  3058d20d61f03aa05fca0fc07acb8c50850c68086998c542857aec7ad1529482 \
+                        size    104431 \
+                    github.com/golang/mock \
+                        lock    v1.6.0 \
+                        rmd160  ed853462703f04ce365bb17b8c88a92994aa5006 \
+                        sha256  4b107f6d26db03f8a36ae38f7b017399ed56571cdbf7b7ebc7bff0006c7dffb5 \
+                        size    69263 \
+                    github.com/godbus/dbus \
+                        lock    v5.1.0 \
+                        rmd160  c9b400a865c27debfcc741f2f2c18f088125c91d \
+                        sha256  870c356aa2ab1d1ea7f18afef3cfc4f5a4795c66c3d542e309f5dfa0e21a1be1 \
+                        size    74088 \
+                    github.com/fatih/color \
+                        lock    v1.13.0 \
+                        rmd160  0c56533948a292eb8c5181e9a88a45fbd1267bf5 \
+                        sha256  a65b114bfe507384e1660730803ffb4437c63a24dd11a5d7f61c77f048caa55f \
+                        size    10828 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.0 \
+                        rmd160  e8641035159ea3e8839ee086f01f966443956303 \
+                        sha256  e45e3181c07b3e2dad8e1317e91a5bbbee4845067e3e3879a585a5254bc6a334 \
+                        size    17273 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/danieljoos/wincred \
+                        lock    v1.1.2 \
+                        rmd160  5f2c0d7c7ee4aafbb4737ab8206fe94b0e5211e4 \
+                        sha256  8d880ad47b0c2724dfafff8bc881964acc28158ca8dfcee41027db4d873e3751 \
+                        size    10268 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v2.0.2 \
+                        rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
+                        sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
+                        size    64382 \
+                    github.com/cloudflare/circl \
+                        lock    v1.3.0 \
+                        rmd160  0a2756e43e5d01217e3ac910831ce324cb028db4 \
+                        sha256  c6ed975caf7d6eccb95bfe8d192ff3946a6261a31a218106616510109459992c \
+                        size    4764393 \
+                    github.com/chzyer/readline \
+                        lock    v1.5.1 \
+                        rmd160  cea52b55bd592a89cb49da082f5f0f3b6e8ad48a \
+                        sha256  9e5d6daaf4e6fa8d924e82ddec8b1fcfec42f4b1385aa8448b09816478c55c84 \
+                        size    37579 \
+                    github.com/cenkalti/backoff \
+                        lock    v2.2.1 \
+                        rmd160  568461ff9b5b063c18d20a2814ca4a0629b547c1 \
+                        sha256  4f6a3d7d9fdc5e02522faed8e96539476f646ab64983633a92ea1b71e18bca4f \
+                        size    8633 \
+                    github.com/caspr-io/yamlpath \
+                        lock    502e8d113a9b \
+                        rmd160  7b3d05122f821aac68278a797aa205b09312d25a \
+                        sha256  4975c9a92c5f4eb1034e916cdea2aaa96dd912dabc8f7e6379900a1a6e579d58 \
+                        size    6334 \
+                    github.com/boombuler/barcode \
+                        lock    v1.0.1 \
+                        rmd160  fe7247722491a03f56b9a41ae144ab05487f29fc \
+                        sha256  bd623e3ea8d79f74464b9ee4f16808545842b0e2c06b07e9b96e2dc5df80e40f \
+                        size    62985 \
+                    github.com/blang/semver \
+                        lock    v4.0.0 \
+                        rmd160  ab0e0d974dcbc784840d4bcc76584242436c51fa \
+                        sha256  bf4d622c039173a4e0903738d8b5c788c3c63bb8cfa7485611f38aece3504d0f \
+                        size    27781 \
+                    github.com/atotto/clipboard \
+                        lock    v0.1.4 \
+                        rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
+                        sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
+                        size    5023 \
+                    github.com/alessio/shellescape \
+                        lock    v1.4.1 \
+                        rmd160  669d9a26af060752e544e09551b8835dc89b336a \
+                        sha256  ab26daceb19d4973dd1bf37105473f8d27697b5a04b124d790fd45124450b9a2 \
+                        size    7552 \
+                    github.com/ProtonMail/go-crypto \
+                        lock    cf6655e29de4 \
+                        rmd160  0c878f2d4a5a2e8869df40d99ee219bdff7503de \
+                        sha256  5b94489154983036fbaf619202a3f92700817fd57b3a1010f0a39bf2e2432665 \
+                        size    330467 \
+                    filippo.io/edwards25519 \
+                        repo    github.com/FiloSottile/edwards25519 \
+                        lock    v1.0.0 \
+                        rmd160  47330d4bd65ec5e115038359a989a1a3f775e130 \
+                        sha256  f9474496e781cc9985cc575fbd108a5ca1992cc9fdfd35ee0efcb2818fab928c \
+                        size    39898 \
+                    filippo.io/age \
+                        repo    github.com/FiloSottile/age \
+                        lock    v1.0.0 \
+                        rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
+                        sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
+                        size    59693 \
+                    bitbucket.org/creachadair/stringset \
+                        lock    v0.0.10 \
+                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
+                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
+                        size    19241
+
+set go_ldflags      "-s -w -X main.version=${version}"
+build.args          -ldflags \"${go_ldflags}\"
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}

--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.14.10 v
+go.setup            github.com/gopasspw/gopass 1.14.11 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  a5a20b6ffafba1ea558890d39068cbad84b95e5c \
-                        sha256  75f232ad49e4fe595d25b7e5dff45f9c2679fe783f53e6df928786f0fa85f2c7 \
-                        size    2255072
+                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
+                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
+                        size    2255917
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -65,25 +65,25 @@ go.vendors          rsc.io/qr \
                         sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
                         size    1411246 \
                     golang.org/x/oauth2 \
-                        lock    v0.1.0 \
-                        rmd160  71fb7e8c0f281ddda0db1f4f5dbd4a6b256dbcdd \
-                        sha256  c774ea99cf6b6c929018973432243585741d91fb4690b19b4402a8ffedcc1827 \
-                        size    104853 \
+                        lock    v0.2.0 \
+                        rmd160  48360c3782cbcbf4bee62b295f25e78dd1a2b232 \
+                        sha256  f9d6706b090000deeaff12aec7bba2bfff89968f0740650297677de1f30467f4 \
+                        size    85700 \
                     golang.org/x/net \
                         lock    v0.2.0 \
                         rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
                         sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
                         size    1243767 \
                     golang.org/x/exp \
-                        lock    5d533826c662 \
-                        rmd160  060b3f97a883ca451cabfe22a43468c9507ce2cc \
-                        sha256  486c2eadd2f1fdd81194c50a495fe63600bbcd6453e893bea806e320095115da \
-                        size    1603258 \
+                        lock    850992195362 \
+                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
+                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
+                        size    1605708 \
                     golang.org/x/crypto \
-                        lock    v0.1.0 \
-                        rmd160  909910cef0db632e2c590f9fad5dd47a25a44979 \
-                        sha256  35e3d04761ad1510dd2b2df74774f529b6e4e176a966f78e423aa30ce436153c \
-                        size    1633135 \
+                        lock    v0.3.0 \
+                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
+                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
+                        size    1633434 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -302,10 +302,10 @@ go.vendors          rsc.io/qr \
                         sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
                         size    64382 \
                     github.com/cloudflare/circl \
-                        lock    v1.2.0 \
-                        rmd160  57ecd1876b3db3338e04ee26399ba504d67e15af \
-                        sha256  2d9d0e87698fceae275c06f5641c4dacf1e505217a981a21bac72438d0972ab7 \
-                        size    4702712 \
+                        lock    v1.3.0 \
+                        rmd160  0a2756e43e5d01217e3ac910831ce324cb028db4 \
+                        sha256  c6ed975caf7d6eccb95bfe8d192ff3946a6261a31a218106616510109459992c \
+                        size    4764393 \
                     github.com/chzyer/test \
                         lock    v1.0.0 \
                         rmd160  ee8ba7f33ad3ff52b6a991375519772dfafc1750 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
