### PR TITLE
kube-ps1: update to 0.8.0

### DIFF
--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -3,23 +3,23 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonmosco kube-ps1 0.7.0 v
-revision            5
+github.setup        jonmosco kube-ps1 0.8.0 v
+revision            0
 categories          sysutils
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 maintainers         {breun.nl:nils @breun} openmaintainer
 license             Apache-2
 
-description         Kubernetes prompt info for bash and zshl
+description         Kubernetes prompt info for bash and zsh
 long_description    A script that lets you add the current Kubernetes context and namespace \
                     configured on kubectl to your Bash/Zsh prompt strings (i.e. the \$PS1).
 
-checksums           rmd160  0f67b76aa77ca7acbed74700d55e378dc9d3e09f \
-                    sha256  089bed64824784c282837f89f8708ec86d661afe4a8cd2b7bdcb16c2d11ac0e8 \
-                    size    491884
+checksums           rmd160  749bab8ee2c1bd9972e028a3f97e46a57d8c45ba \
+                    sha256  05ad37ad615c76d4c74b8933c71c97a0b1569a6c739d3362b4f31862ad5a859a \
+                    size    512934
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.21
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.25
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update to kube-ps1 0.8.0.

###### Tested on

macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?