### PR TITLE
spring-boot-cli: update to 3.0.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         2.7.6
+version         3.0.0
 revision        0
 
 categories      java
@@ -30,11 +30,11 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  9b875a88be8771c80d0e8af15a2f5269c5967d7f \
-                sha256  39f9edb89ad3c694cb1b6e7b111591101ba0c7cdc2901a8365289746b105bd52 \
-                size    14328698
+checksums       rmd160  f26256e7cf74cdb879469051cd27e8b480779576 \
+                sha256  70a7ec90fafdd637e5778662c94ef324a24e7fd193ff79ba7ffc0346596155b1 \
+                size    4692185
 
-worksrcdir      spring-${version}.RELEASE
+worksrcdir      spring-${version}
 
 use_configure   no
 
@@ -66,13 +66,12 @@ destroot {
 
     # Add symlink to the script
     ln -s ../share/java/${name}/bin/spring ${destroot}${prefix}/bin
-}
 
-variant bash_completion {
-    depends_run-append path:etc/bash_completion:bash-completion
-    post-destroot {
-        xinstall -d ${destroot}${prefix}/etc/bash_completion.d
-        copy ${worksrcpath}/shell-completion/bash/spring \
-             ${destroot}${prefix}/etc/bash_completion.d/spring
-    }
+    # Bash shell completion
+    xinstall -d ${destroot}${prefix}/etc/bash_completion.d
+    copy ${worksrcpath}/shell-completion/bash/spring ${destroot}${prefix}/etc/bash_completion.d/spring
+
+    # Zsh shell completion
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    copy ${worksrcpath}/shell-completion/zsh/_spring ${destroot}${prefix}/share/zsh/site-functions/_spring
 }


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.0.0.

###### Tested on

macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?