### PR TITLE
ucommon: fix missing definition of AI_NUMERICSERV

### DIFF
--- a/devel/ucommon/Portfile
+++ b/devel/ucommon/Portfile
@@ -11,7 +11,6 @@ checksums           rmd160  7af41f1dc3d965ac165cce56f19164aa18482f24 \
 
 categories          devel
 license             LGPL-3+ {GPL-2+ Permissive}
-platforms           darwin
 maintainers         nomaintainer
 
 description         GNU uCommon C++ Framework
@@ -25,8 +24,9 @@ master_sites        gnu:commoncpp
 
 depends_lib         port:gettext path:lib/pkgconfig/gnutls.pc:gnutls
 
-patchfiles          thread.cpp.patch
-patchfiles-append   platform.h.patch
+patchfiles-append   thread.cpp.patch \
+                    platform.h.patch \
+                    patch-socket.diff
 
 test.run            yes
 test.target         check

--- a/devel/ucommon/files/patch-socket.diff
+++ b/devel/ucommon/files/patch-socket.diff
@@ -1,0 +1,16 @@
+# See: https://github.com/macports/macports-ports/blob/master/devel/lua-luasocket/files/patch-src-udp.c.diff
+
+--- corelib/socket.cpp.orig	2015-12-13 19:28:25.000000000 +0800
++++ corelib/socket.cpp	2022-11-26 23:45:27.000000000 +0800
+@@ -1269,7 +1269,10 @@
+     snprintf(svc, sizeof(svc), "%d", port(addr));
+     memset(&hints, 0, sizeof(hints));
+     hints.ai_family = addr->sa_family;
+-    hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
++    hints.ai_flags = AI_NUMERICHOST;
++#ifdef  AI_NUMERICSERV
++    hints.ai_flags |= AI_NUMERICSERV;
++#endif
+     node = NULL;
+     getaddrinfo(buf, svc, &hints, &node);
+     if (!node)


### PR DESCRIPTION
See: https://github.com/macports/macports-ports/blob/master/devel/lua-luasocket/files/patch-src-udp.c.diff

#### Description

Old systems do not have `AI_NUMERICSERV`. In one place a due fix was forgotten.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
