### PR TITLE
ruby31: fix the patch, unbreak build; ruby-devel: update to current upstream

### DIFF
--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -11,13 +11,13 @@ PortGroup           legacysupport 1.1
 # MAP_ANONYMOUS
 legacysupport.newest_darwin_requires_legacy 14
 
-github.setup        ruby ruby 8dfe3bdf48ff73052de1262e4644c08742abd8e6
+github.setup        ruby ruby d055c44b0cfeeed2d02f8899200863d69758abc1
 
 set ruby_ver        3.2
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2022.10.23
+version             2022.11.27
 revision            0
 
 categories          lang ruby
@@ -33,9 +33,9 @@ long_description    Ruby is the interpreted scripting language \
 homepage            https://www.ruby-lang.org/
 license             {Ruby BSD}
 
-checksums           rmd160  c20c4ffcea6fd5e53a8d96a14c5e0971918ac889 \
-                    sha256  d44f9c5c6ff5a36dd65621c6533f3b0038f83627b70097af72afb067e0efa531 \
-                    size    15463281
+checksums           rmd160  00b4e784882f59c1371e4c27d334fb582b5fcb9c \
+                    sha256  dffcf97eb44e5be51bd1f95cef7d7a82b902667e0fe1f1dcd796c4162eacf968 \
+                    size    15510869
 
 universal_variant   no
 

--- a/lang/ruby31/files/patch-configure-ppc.diff
+++ b/lang/ruby31/files/patch-configure-ppc.diff
@@ -1,6 +1,6 @@
---- configure.orig	2022-04-12 19:11:17.000000000 +0800
-+++ configure	2022-10-24 06:05:15.000000000 +0800
-@@ -8505,6 +8505,8 @@
+--- configure.orig	2022-11-27 23:20:23.000000000 +0800
++++ configure	2022-11-27 23:52:56.000000000 +0800
+@@ -9328,6 +9328,8 @@
      ARCH_FLAG=-m64 ;; #(
    i[3-6]86) :
      ARCH_FLAG=-m32 ;; #(
@@ -9,7 +9,16 @@
    *) :
      as_fn_error $? "unknown target architecture: $target_archs" "$LINENO" 5
  	 ;;
-@@ -23979,7 +23981,7 @@
+@@ -9428,6 +9430,8 @@
+     ARCH_FLAG=-m64 ;; #(
+   i[3-6]86) :
+     ARCH_FLAG=-m32 ;; #(
++  powerpc|ppc) :
++    ARCH_FLAG=-m32 ;; #(
+   *) :
+     as_fn_error $? "unknown target architecture: $target_archs" "$LINENO" 5
+ 	 ;;
+@@ -25441,7 +25445,7 @@
  
  
  case "${target_cpu}-${target_os}:${target_archs}" in #(
@@ -18,29 +27,24 @@
  
  
    ALLOCA=\${LIBOBJDIR}alloca.${ac_objext}
-@@ -23996,17 +23998,17 @@
+@@ -25456,13 +25460,13 @@
  
    ALLOCA=\${LIBOBJDIR}alloca.${ac_objext}
  
 -      printf "#if %s\n" "defined __powerpc__" >>confdefs.h
 +      printf "#if %s\n" "defined __POWERPC__" >>confdefs.h
- cat >>confdefs.h <<_ACEOF
- #define C_ALLOCA 1
- _ACEOF
+ printf "%s\n" "#define C_ALLOCA 1" >>confdefs.h
 -    printf "#endif /* %s */\n" "defined __powerpc__" >>confdefs.h
 +    printf "#endif /* %s */\n" "defined __POWERPC__" >>confdefs.h
  
--      printf "#if %s\n" "defined __powerpc__" >>confdefs.h
-+      printf "#if %s\n" "defined __POWERPC__" >>confdefs.h
- cat >>confdefs.h <<_ACEOF
- #define alloca alloca
- _ACEOF
+       printf "#if %s\n" "defined __powerpc__" >>confdefs.h
+ printf "%s\n" "#define alloca alloca" >>confdefs.h
 -    printf "#endif /* %s */\n" "defined __powerpc__" >>confdefs.h
 +    printf "#endif /* %s */\n" "defined __POWERPC__" >>confdefs.h
  
     ;; #(
    *) :
-@@ -28450,6 +28452,14 @@
+@@ -29462,6 +29466,14 @@
  
              coroutine_type=arm64
           ;; #(


### PR DESCRIPTION
#### Description

1. Recent update to `ruby31` broke the build on PPC, since one of the patches was not updated: https://github.com/macports/macports-ports/commit/a58658e8b028942a43ff6a855f255fa7f540a912#commitcomment-91212616
Fixed.
2. `ruby-devel` updated to current upstream master.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
