### PR TITLE
lazydocker: update to 0.20.0

### DIFF
--- a/devel/lazydocker/Portfile
+++ b/devel/lazydocker/Portfile
@@ -3,23 +3,29 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jesseduffield/lazydocker 0.18.1 v
+go.setup            github.com/jesseduffield/lazydocker 0.20.0 v
+github.tarball_from archive
+revision            0
 
-checksums           rmd160  517878832b17f1248331e3262c428bc5e8fb8c07 \
-                    sha256  a7a1e2c934457c90e39af956688e849cacdbab17df2eb537eb346a57fedc056d \
-                    size    12641076
+checksums           rmd160  e80173d7897033ff37b5a636104b3b1f6f4f3793 \
+                    sha256  570ce8127b148bc99c2faa1d4a3530504e81d531d3546dd1f29a7258c4d9d9ea \
+                    size    13025402
 
 categories          devel
-platforms           darwin
+installs_libs       no
 license             MIT
 maintainers         {@NicolaiSkye icloud.com:nicolaiskye} openmaintainer
 
 description         The lazy way to manage everything docker
 
-long_description    A simple terminal UI for both docker and docker-compose, written in Go with the gocui library
+long_description    A simple terminal UI for both docker and docker-compose, \
+                    written in Go with the gocui library
 
-set time [clock format [clock seconds] -format %Y%m%dT%H%M%S]
-build.args-append   -ldflags=\"-X 'main.version=v${version}' -X 'main.date=${time}' -X 'main.commit=unknown' -X 'main.buildSource=MacPorts'\" -o ./lazydocker ./
+build.args-append   -ldflags=\" \
+                        -X 'main.version=${github.tag_prefix}${version}' \
+                        -X 'main.commit=unknown' \
+                        -X 'main.buildSource=MacPorts' \
+                    \" -o ./lazydocker .
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
