### PR TITLE
Switched a few ports to OneTBB instead TBB

### DIFF
--- a/cad/freecad/Portfile
+++ b/cad/freecad/Portfile
@@ -8,7 +8,7 @@ PortGroup               qt4 1.0
 PortGroup               boost 1.0
 
 github.setup            FreeCAD FreeCAD 0.18.5
-revision                1
+revision                2
 name                    freecad
 categories              cad
 platforms               darwin

--- a/lang/qore/Portfile
+++ b/lang/qore/Portfile
@@ -8,6 +8,7 @@ github.tarball_from releases
 
 PortGroup           cmake 1.1
 
+revision            1
 categories          lang
 license             {LGPL-2.1 MIT}
 maintainers         {davidnichols @davidnich} openmaintainer
@@ -33,7 +34,7 @@ depends_lib-append  path:lib/libssl.dylib:openssl \
                     port:bzip2 \
                     port:gmp \
                     port:mpfr \
-                    port:tbb
+                    port:onetbb
 
 compiler.thread_local_storage yes
 

--- a/math/deal.ii/Portfile
+++ b/math/deal.ii/Portfile
@@ -7,9 +7,8 @@ PortGroup               mpi            1.0
 PortGroup               linear_algebra 1.0
 PortGroup               boost          1.0
 
-github.setup            dealii dealii 9.3.1 v
+github.setup            dealii dealii 9.4.0 v
 name                    deal.ii
-revision                3
 categories              math science
 license                 LGPL-2.1+
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -19,9 +18,9 @@ long_description        ${name} is {*}${description}.
 
 homepage                https://www.dealii.org/
 
-checksums               rmd160  04a433ae8072ec71ef3a3d071c43b82a297ccd47 \
-                        sha256  771e275b0058c5a306502f1ba846c265a1b77de0998e7fe27055eacc26732c0a \
-                        size    24460495
+checksums               rmd160  08e967217d8dfe3fb907a7b66641f1edff48dcf5 \
+                        sha256  44bd3fb7c28839d2d7eca66ab3b263be0266cffdc236ffab92386f8c9d907245 \
+                        size    30299000
 
 mpi.setup               require_fortran
 veclibfort              no
@@ -94,7 +93,7 @@ configure.args-append \
                         -DSUNDIALS_CONFIG_H=${sundials_include}/sundials/sundials_config.h
 depends_lib-append      port:sundials${sundials_ver} \
                         port:symengine \
-                        port:tbb
+                        port:onetbb
 
 if {[mpi_variant_isset]} {
     mpi.enforce_variant   hdf5

--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -8,7 +8,7 @@ PortGroup               muniversal     1.0
 
 name                    gmsh
 version                 4.9.3
-revision                2
+revision                3
 categories              science
 license                 GPL-2+
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/kicad/Portfile
+++ b/science/kicad/Portfile
@@ -29,7 +29,7 @@ if {${name} eq ${subport}} {
     checksums           rmd160  3603cc21857468ed0edb8fe941c92776004237eb \
                         sha256  808063f728a8c3ed42af2126b465c9a4aa3e6df8e025387b9b11c6a15710d9ce \
                         size    34045371
-    revision            0
+    revision            1
 
     patchfiles-append \
         wxwidgets-4.1-deprecated.patch \

--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -12,7 +12,7 @@ gitlab.setup            nektar nektar 5.2.0 v
 boost.version           1.71
 
 name                    nektarpp
-revision                1
+revision                2
 
 categories              science
 platforms               darwin

--- a/science/opencascade/Portfile
+++ b/science/opencascade/Portfile
@@ -5,7 +5,7 @@ PortGroup                   cmake      1.1
 PortGroup                   muniversal 1.0
 
 name                        opencascade
-version                     7.6.0
+version                     7.7.0
 revision                    0
 categories                  science
 platforms                   darwin
@@ -20,9 +20,9 @@ master_sites                "https://git.dev.opencascade.org/gitweb/?p=occt.git;
 extract.suffix              .tgz
 worksrcdir                  occt-V${git_version}
 
-checksums                   rmd160  693c252be09f30832db9fe81e410119c1f28e2d5 \
-                            sha256  e7f989d52348c3b3acb7eb4ee001bb5c2eed5250cdcceaa6ae97edc294f2cabd \
-                            size    48193117
+checksums                   rmd160  2cd1b528d2f1fb40bd9b0f2646ddea3fef0d3733 \
+                            sha256  075ca1dddd9646fcf331a809904925055747a951a6afd07a463369b9b441b445 \
+                            size    48391263
 
 # OCE is the Open CASCADE Community Edition
 conflicts                   oce
@@ -38,7 +38,7 @@ depends_build-append        path:lib/pkgconfig/RapidJSON.pc:rapidjson
 
 depends_lib-append          port:freeimage \
                             port:freetype \
-                            port:tbb \
+                            port:onetbb \
                             port:tcl \
                             port:tk
 
@@ -46,13 +46,6 @@ configure.args-append       -DUSE_FREEIMAGE=ON \
                             -DUSE_RAPIDJSON=ON \
                             -DUSE_TBB=ON \
                             -DBUILD_DOC_Overview=OFF \
-                            -D3RDPARTY_FREEIMAGE_DIR=${prefix} \
-                            -D3RDPARTY_FREETYPE_DIR=${prefix} \
-                            -D3RDPARTY_RAPIDJSON=${prefix} \
-                            -D3RDPARTY_TBB_DIR=${prefix} \
-                            -D3RDPARTY_TCL_DIR=${prefix} \
-                            -D3RDPARTY_TCL_INCLUDE_DIR=${prefix}/include \
-                            -D3RDPARTY_TK_INCLUDE_DIR=${prefix}/include \
                             -D3RDPARTY_DIR=${prefix}
 
 # see https://trac.macports.org/ticket/59917

--- a/science/opencascade/files/patch-CMakeLists.txt.diff
+++ b/science/opencascade/files/patch-CMakeLists.txt.diff
@@ -1,15 +1,17 @@
---- CMakeLists.txt.orig	2018-05-29 03:14:02.000000000 -0700
-+++ CMakeLists.txt	2018-06-28 09:22:16.000000000 -0700
-@@ -4,7 +4,7 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index fd17283f77..6d1450124c 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -4,7 +4,7 @@ set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/adm/cmake")
  
  set (CMAKE_SUPPRESS_REGENERATION TRUE)
  
 -set (CMAKE_CONFIGURATION_TYPES Release Debug RelWithDebInfo CACHE INTERNAL "" FORCE)
 +set (CMAKE_CONFIGURATION_TYPES MacPorts Release Debug RelWithDebInfo CACHE INTERNAL "" FORCE)
  
- # macro: include patched file if it exists
- macro (OCCT_INCLUDE_CMAKE_FILE BEING_INCLUDED_FILE)
-@@ -886,16 +886,7 @@
+ # set using C++ standard
+ set (BUILD_CPP_STANDARD "C++11" CACHE STRING "Select using c++ standard.")
+@@ -1020,16 +1020,7 @@ else()
    set (ADDITIONAL_CUSTOM_CONTENT "\nif [ -e \"\${aScriptPath}/${SUB_CUSTOM_NAME}\" ]; then\n  source \"\${aScriptPath}/${SUB_CUSTOM_NAME}\" \"\$1\" \"\$2\" \nfi")
  endif()
  
@@ -26,23 +28,29 @@
  
  if (WIN32)
    set (THIRDPARTY_DIR_REPLACE "%THIRDPARTY_DIR%")
-@@ -1122,7 +1113,7 @@
- endforeach()
- # install OpenCASCADE config file with compile definitions and C/C++ flags ONLY for current configuration
- install (CODE "string (TOLOWER \"\${CMAKE_INSTALL_CONFIG_NAME}\" CMAKE_INSTALL_CONFIG_NAME_LOWER)")
--install (CODE "configure_file(\"${CMAKE_BINARY_DIR}/OpenCASCADECompileDefinitionsAndFlags-\${CMAKE_INSTALL_CONFIG_NAME_LOWER}.cmake\" \"${INSTALL_DIR}/${INSTALL_DIR_CMAKE}/OpenCASCADECompileDefinitionsAndFlags-\${CMAKE_INSTALL_CONFIG_NAME_LOWER}.cmake\" COPYONLY)")
-+install (CODE "configure_file(\"${CMAKE_BINARY_DIR}/OpenCASCADECompileDefinitionsAndFlags-\${CMAKE_INSTALL_CONFIG_NAME_LOWER}.cmake\" \"\$ENV{DESTDIR}${INSTALL_DIR}/${INSTALL_DIR_CMAKE}/OpenCASCADECompileDefinitionsAndFlags-\${CMAKE_INSTALL_CONFIG_NAME_LOWER}.cmake\" COPYONLY)")
+diff --git adm/cmake/occt_macros.cmake adm/cmake/occt_macros.cmake
+index 9fd3ec4cfb..c992c2e942 100644
+--- adm/cmake/occt_macros.cmake
++++ adm/cmake/occt_macros.cmake
+@@ -592,7 +592,7 @@ macro (OCCT_UPDATE_TARGET_FILE)
  
- foreach (OCCT_MODULE ${OCCT_MODULES})
-   if (BUILD_MODULE_${OCCT_MODULE})
---- adm/cmake/occt_macros.cmake.orig	2018-05-29 03:14:02.000000000 -0700
-+++ adm/cmake/occt_macros.cmake	2018-06-28 11:39:17.000000000 -0700
-@@ -598,7 +598,7 @@
-   "cmake_policy(PUSH)
-   cmake_policy(SET CMP0007 NEW)
-   string (TOLOWER \"\${CMAKE_INSTALL_CONFIG_NAME}\" CMAKE_INSTALL_CONFIG_NAME_LOWERCASE)
+   install (CODE
+   "string (TOLOWER \"\${CMAKE_INSTALL_CONFIG_NAME}\" CMAKE_INSTALL_CONFIG_NAME_LOWERCASE)
 -  file (GLOB ALL_OCCT_TARGET_FILES \"${INSTALL_DIR}/${INSTALL_DIR_CMAKE}/OpenCASCADE*Targets-\${CMAKE_INSTALL_CONFIG_NAME_LOWERCASE}.cmake\")
 +  file (GLOB ALL_OCCT_TARGET_FILES \"\$ENV{DESTDIR}${INSTALL_DIR}/${INSTALL_DIR_CMAKE}/OpenCASCADE*Targets-\${CMAKE_INSTALL_CONFIG_NAME_LOWERCASE}.cmake\")
    foreach(TARGET_FILENAME \${ALL_OCCT_TARGET_FILES})
      file (STRINGS \"\${TARGET_FILENAME}\" TARGET_FILE_CONTENT)
      file (REMOVE \"\${TARGET_FILENAME}\")
+diff --git adm/cmake/tbb.cmake adm/cmake/tbb.cmake
+index 4e5f724ac2..31c55a10ff 100644
+--- adm/cmake/tbb.cmake
++++ adm/cmake/tbb.cmake
+@@ -191,7 +191,7 @@ else ()
+     string(TOUPPER "${LIB}" LIB_UPPER)
+ 
+     # Achive *.so files and directory containing it.
+-    get_target_property (TBB_SO_FILE "TBB::${LIB_LOWER}" IMPORTED_LOCATION_RELEASE)
++    get_target_property (TBB_SO_FILE "TBB::${LIB_LOWER}" IMPORTED_LOCATION_MACPORTS)
+     # Reserve cache variable for *.so.
+     if (NOT DEFINED 3RDPARTY_${LIB_UPPER}_LIBRARY)
+       set (3RDPARTY_${LIB_UPPER}_LIBRARY "" CACHE FILEPATH "${LIB_UPPER} library (*.so)")

--- a/science/root6/Portfile
+++ b/science/root6/Portfile
@@ -14,7 +14,7 @@ PortGroup           legacysupport                 1.1
 # Please also check if Gate needs a revbump after root6 update
 github.setup        root-project root 6-26-10 v
 version             [string map {- .} ${github.version}]
-revision            0
+revision            1
 livecheck.version   ${github.version}
 
 # Use git commit
@@ -76,7 +76,7 @@ depends_lib-append  port:expat \
                     port:gl2ps \
                     port:lz4 \
                     port:vdt \
-                    port:tbb \
+                    port:onetbb \
                     port:xxhashlib \
                     port:z3 \
                     port:zstd \


### PR DESCRIPTION
#### Description

OneTBB is a new and supported version for Threading Building Blocks API.

Here I've switched a few ports from `tbb` to `onetbb`, some of them were also updated.

I've stop here with hope that GitHub CI timeout is enough to build all touched ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->