### PR TITLE
boost*: add python311 variant

### DIFF
--- a/devel/boost171/Portfile
+++ b/devel/boost171/Portfile
@@ -223,7 +223,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10}
+set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {

--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -251,7 +251,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10}
+set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {

--- a/devel/boost177/Portfile
+++ b/devel/boost177/Portfile
@@ -252,7 +252,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10}
+set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {

--- a/devel/boost178/Portfile
+++ b/devel/boost178/Portfile
@@ -252,7 +252,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10}
+set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {

--- a/devel/boost179/Portfile
+++ b/devel/boost179/Portfile
@@ -252,7 +252,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10}
+set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {

--- a/devel/boost180/Portfile
+++ b/devel/boost180/Portfile
@@ -252,7 +252,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10}
+set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {


### PR DESCRIPTION
The `python310` variants are still the default, as it’s early days for Python 3.11 and, in particular, Python 3.11 in MacPorts.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
