### PR TITLE
xorg-libxcb, xorg-xcb-proto: add python311 variants

### DIFF
--- a/x11/xorg-libxcb/Portfile
+++ b/x11/xorg-libxcb/Portfile
@@ -59,31 +59,37 @@ variant docs description "Install extra documentation" {
 #
 # [1] https://gitlab.freedesktop.org/xorg/lib/libxcb/blob/1.13.1/configure.ac#L85
 
-variant python37 conflicts python38 python39 python310 description {Use python 3.7} {
+variant python37 conflicts python38 python39 python310 python311 description {Use python 3.7} {
     depends_build-append    port:python37
     license_noconflict      python37
     configure.python        ${prefix}/bin/python3.7
 }
 
-variant python38 conflicts python37 python39 python310 description {Use python 3.8} {
+variant python38 conflicts python37 python39 python310 python311 description {Use python 3.8} {
     depends_build-append    port:python38
     license_noconflict      python38
     configure.python        ${prefix}/bin/python3.8
 }
 
-variant python39 conflicts python37 python38 python310 description {Use python 3.9} {
+variant python39 conflicts python37 python38 python310 python311 description {Use python 3.9} {
     depends_build-append    port:python39
     license_noconflict      python39
     configure.python        ${prefix}/bin/python3.9
 }
 
-variant python310 conflicts python37 python38 python39 description {Use python 3.10} {
+variant python310 conflicts python37 python38 python39 python311 description {Use python 3.10} {
     depends_build-append    port:python310
     license_noconflict      python310
     configure.python        ${prefix}/bin/python3.10
 }
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
+variant python311 conflicts python37 python38 python39 python310 description {Use python 3.11} {
+    depends_build-append    port:python311
+    license_noconflict      python311
+    configure.python        ${prefix}/bin/python3.11
+}
+
+if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python311]} {
     default_variants +python310
 }
 

--- a/x11/xorg-xcb-proto/Portfile
+++ b/x11/xorg-xcb-proto/Portfile
@@ -35,31 +35,37 @@ depends_run     port:libxml2
 #
 # [1] https://github.com/polybar/xpp
 
-variant python37 conflicts python38 python39 python310 description {Use python 3.7} {
+variant python37 conflicts python38 python39 python310 python311 description {Use python 3.7} {
     depends_build-append    port:python37
     configure.python        ${prefix}/bin/python3.7
     license_noconflict      python37
 }
 
-variant python38 conflicts python37 python39 python310 description {Use python 3.8} {
+variant python38 conflicts python37 python39 python310 python311 description {Use python 3.8} {
     depends_build-append    port:python38
     configure.python        ${prefix}/bin/python3.8
     license_noconflict      python38
 }
 
-variant python39 conflicts python37 python38 python310 description {Use python 3.9} {
+variant python39 conflicts python37 python38 python310 python311 description {Use python 3.9} {
     depends_build-append    port:python39
     configure.python        ${prefix}/bin/python3.9
     license_noconflict      python39
 }
 
-variant python310 conflicts python37 python38 python39 description {Use python 3.10} {
+variant python310 conflicts python37 python38 python39 python311 description {Use python 3.10} {
     depends_build-append    port:python310
     configure.python        ${prefix}/bin/python3.10
     license_noconflict      python310
 }
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
+variant python311 conflicts python37 python38 python39 python310 description {Use python 3.11} {
+    depends_build-append    port:python311
+    configure.python        ${prefix}/bin/python3.11
+    license_noconflict      python311
+}
+
+if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python311]} {
     default_variants +python310
 }
 


### PR DESCRIPTION
#### Description

This adds `python311` variants to `xorg-libxcb` and its dependency `xorg-xcb-proto`.

The `python310` variants are still the default, as it’s early days for Python 3.11 and, in particular, Python 3.11 in MacPorts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
