### PR TITLE
Move Leopard to libgcc12, fix GCC targets for PPC

### DIFF
--- a/_resources/port1.0/compilers/gcc_compilers.tcl
+++ b/_resources/port1.0/compilers/gcc_compilers.tcl
@@ -6,19 +6,19 @@
 global os.major os.arch os.platform
 
 #3 GCC 10 and above on OSX10.6+
-if {${os.major} >= 10 || ${os.platform} ne "darwin"} {
+if {${os.major} >= 9 || ${os.platform} ne "darwin"} {
     lappend compilers macports-gcc-13 macports-gcc-12 macports-gcc-11 macports-gcc-10
 }
 
 # GCC 9 and older only on OSX10.10 and older
 # https://trac.macports.org/ticket/65472
 if { ${os.major} < 15 } {
-    if { ${os.major} >= 10 } {
+    if { ${os.major} >= 9 } {
         lappend compilers macports-gcc-9 macports-gcc-8
     }
     lappend compilers macports-gcc-7 macports-gcc-6 macports-gcc-5
 }
 
-if { ${os.major} >= 10 } {
+if { ${os.major} >= 9 } {
     lappend compilers macports-gcc-devel
 }

--- a/_resources/port1.0/compilers/gcc_dependencies.tcl
+++ b/_resources/port1.0/compilers/gcc_dependencies.tcl
@@ -4,7 +4,7 @@ global os.major os.platform
 
 # GCC version providing the primary runtime
 # Note settings here *must* match those in the lang/libgcc port and compilers PG
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
+if {${os.platform} eq "darwin" && ${os.major} < 9} {
     set gcc_main_version 7
 } else {
     set gcc_main_version 13

--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -77,7 +77,7 @@ options compilers.allow_arguments_mismatch
 default compilers.allow_arguments_mismatch no
 
 # Set a default gcc version
-if {${os.major} < 10 && ${os.platform} eq "darwin" } {
+if {${os.major} < 9 && ${os.platform} eq "darwin" } {
     # see https://trac.macports.org/ticket/57135
     set compilers.gcc_default gcc7
 } else {
@@ -95,13 +95,13 @@ if { ${os.arch} eq "arm" || ${os.platform} ne "darwin" } {
     if { ${os.major} < 15 } {
         lappend gcc_versions 5 6 7 8 9
     }
-    if { ${os.major} >= 10 } {
+    if { ${os.major} >= 9 } {
         lappend gcc_versions 10 11 12 13 devel
     }
 }
 # GCC version providing the primary runtime
 # Note settings here *must* match those in the lang/libgcc port.
-if { ${os.major} < 10 && ${os.platform} eq "darwin" } {
+if { ${os.major} < 9 && ${os.platform} eq "darwin" } {
     set gcc_main_version 7
 } else {
     set gcc_main_version 13

--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -73,6 +73,8 @@ depends_run-append  port:gcc_select \
 
 platform darwin {
     if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        configure.compiler.add_deps \
+                        no
         depends_build-append \
                         port:gcc10-bootstrap
         configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc

--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -11,7 +11,7 @@ name                gcc-devel
 
 homepage            https://gcc.gnu.org/
 
-platforms           {darwin >= 10}
+platforms           {darwin >= 9}
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -71,6 +71,15 @@ depends_lib-append  port:cctools \
 depends_run-append  port:gcc_select \
                     port:libgcc-devel
 
+platform darwin {
+    if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        depends_build-append \
+                        port:gcc10-bootstrap
+        configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc
+        configure.cxx   ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    }
+}
+
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
 

--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -80,7 +80,13 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 set major           devel
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -89,6 +89,8 @@ depends_run-append  port:gcc_select \
 
 platform darwin {
     if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        configure.compiler.add_deps \
+                        no
         depends_build-append \
                         port:gcc10-bootstrap
         configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -12,7 +12,7 @@ name                gcc10
 version             10.4.0
 revision            4
 
-platforms           {darwin >= 10 < 22}
+platforms           {darwin >= 9 < 22}
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -93,7 +93,13 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -87,6 +87,15 @@ depends_lib-append  port:cctools \
 depends_run-append  port:gcc_select \
                     port:libgcc10
 
+platform darwin {
+    if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        depends_build-append \
+                        port:gcc10-bootstrap
+        configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc
+        configure.cxx   ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    }
+}
+
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
 

--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -13,7 +13,7 @@ name                gcc11
 version             11.4.0
 revision            0
 
-platforms           {darwin >= 10 < 22}
+platforms           {darwin >= 9 < 22}
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -100,7 +100,13 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}

--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -94,6 +94,15 @@ depends_lib-append  port:cctools \
 depends_run-append  port:gcc_select \
                     port:libgcc11
 
+platform darwin {
+    if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        depends_build-append \
+                        port:gcc10-bootstrap
+        configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc
+        configure.cxx   ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    }
+}
+
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
 

--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -96,6 +96,8 @@ depends_run-append  port:gcc_select \
 
 platform darwin {
     if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        configure.compiler.add_deps \
+                        no
         depends_build-append \
                         port:gcc10-bootstrap
         configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc

--- a/lang/gcc12/Portfile
+++ b/lang/gcc12/Portfile
@@ -66,6 +66,8 @@ depends_run-append  port:gcc_select \
 
 platform darwin {
     if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        configure.compiler.add_deps \
+                        no
         depends_build-append \
                         port:gcc10-bootstrap
         configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc

--- a/lang/gcc12/Portfile
+++ b/lang/gcc12/Portfile
@@ -11,7 +11,7 @@ name                gcc12
 
 homepage            https://gcc.gnu.org/
 
-platforms           {darwin >= 10}
+platforms           {darwin >= 9}
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc12/Portfile
+++ b/lang/gcc12/Portfile
@@ -70,7 +70,13 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}

--- a/lang/gcc12/Portfile
+++ b/lang/gcc12/Portfile
@@ -64,6 +64,15 @@ depends_lib-append  port:cctools \
 depends_run-append  port:gcc_select \
                     port:libgcc12
 
+platform darwin {
+    if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        depends_build-append \
+                        port:gcc10-bootstrap
+        configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc
+        configure.cxx   ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    }
+}
+
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
 

--- a/lang/gcc13/Portfile
+++ b/lang/gcc13/Portfile
@@ -66,6 +66,8 @@ depends_run-append  port:gcc_select \
 
 platform darwin {
     if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        configure.compiler.add_deps \
+                        no
         depends_build-append \
                         port:gcc10-bootstrap
         configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc

--- a/lang/gcc13/Portfile
+++ b/lang/gcc13/Portfile
@@ -64,6 +64,15 @@ depends_lib-append  port:cctools \
 depends_run-append  port:gcc_select \
                     path:share/doc/libgcc/README:libgcc
 
+platform darwin {
+    if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        depends_build-append \
+                        port:gcc10-bootstrap
+        configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc
+        configure.cxx   ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    }
+}
+
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
 

--- a/lang/gcc13/Portfile
+++ b/lang/gcc13/Portfile
@@ -11,7 +11,7 @@ name                gcc13
 
 homepage            https://gcc.gnu.org/
 
-platforms           {darwin >= 10}
+platforms           {darwin >= 9}
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc13/Portfile
+++ b/lang/gcc13/Portfile
@@ -70,7 +70,13 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}

--- a/lang/gcc13/Portfile
+++ b/lang/gcc13/Portfile
@@ -295,11 +295,23 @@ if { ${subport} ne ${libcxxname} } {
 # https://trac.macports.org/ticket/29104
 # https://trac.macports.org/ticket/47996
 # https://trac.macports.org/ticket/58493
-compiler.blacklist-append {clang < 800} gcc-4.0 *gcc-4.2 {llvm-gcc-4.2 < 2336.1} {macports-clang-3.[4-7]}
-
 # https://build.macports.org/builders/ports-10.13_x86_64-builder/builds/105513/steps/install-port/logs/stdio
 # c++/v1/functional:1408:2: error: no member named 'fancy_abort' in namespace 'std::__1'; did you mean simply 'fancy_abort'?
-compiler.blacklist-append {clang < 1001}
+compiler.blacklist-append {clang < 1001} gcc-4.0 {llvm-gcc-4.2 < 2336.1} {macports-clang-3.[4-7]}
+
+# For some reason Macports creates a circular dependency, if all Xcode gccs are blacklisted:
+# port deps gcc13
+# Full Name: gcc13 @13.2.0_3
+# Extract Dependencies: xz
+# Build Dependencies:   texinfo, gcc10-bootstrap, gcc13
+# Library Dependencies: cctools, gmp, isl, ld64, libiconv, libmpc, mpfr, zlib, zstd, libgcc
+# Runtime Dependencies: gcc_select, libgcc
+# The condition below mirrors the one above for gcc10-bootstrap.
+platform darwin {
+    if {(${configure.build_arch} ni [list ppc ppc64]) && ${os.major} > 9} {
+        compiler.blacklist-append *gcc-4.2
+    }
+}
 
 platform darwin {
     # gcc can't be built by Xcode Clang 14.0.x

--- a/lang/gcc43/Portfile
+++ b/lang/gcc43/Portfile
@@ -6,7 +6,7 @@ PortGroup compiler_blacklist_versions 1.0
 
 name                gcc43
 version             4.3.6
-revision            16
+revision            17
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -107,7 +107,13 @@ set major           [join [lrange [split ${version} .-] 0 1] .]
 worksrcdir          gcc-${version}
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 configure.dir       ${workpath}/build

--- a/lang/gcc44/Portfile
+++ b/lang/gcc44/Portfile
@@ -7,7 +7,7 @@ PortGroup compiler_blacklist_versions 1.0
 name                gcc44
 epoch               1
 version             4.4.7
-revision            15
+revision            16
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -101,7 +101,13 @@ set major           [join [lrange [split ${version} .-] 0 1] .]
 worksrcdir          gcc-${version}
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 configure.dir       ${workpath}/build

--- a/lang/gcc45/Portfile
+++ b/lang/gcc45/Portfile
@@ -8,7 +8,7 @@ name                gcc45
 # Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.5
 epoch               1
 version             4.5.4
-revision            17
+revision            18
 subport             libgcc45 { revision 16 }
 platforms           darwin
 categories          lang
@@ -120,7 +120,13 @@ post-extract {
 }
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 configure.dir       ${workpath}/build

--- a/lang/gcc46/Portfile
+++ b/lang/gcc46/Portfile
@@ -8,7 +8,7 @@ name                gcc46
 # Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.6
 epoch               1
 version             4.6.4
-revision            15
+revision            16
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -104,7 +104,13 @@ post-extract {
 }
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 configure.dir       ${workpath}/build

--- a/lang/gcc47/Portfile
+++ b/lang/gcc47/Portfile
@@ -8,7 +8,7 @@ name                gcc47
 # Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.7
 epoch               1
 version             4.7.4
-revision            12
+revision            13
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -102,7 +102,13 @@ post-extract {
 }
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 configure.dir       ${workpath}/build

--- a/lang/gcc48/Portfile
+++ b/lang/gcc48/Portfile
@@ -8,7 +8,7 @@ name                gcc48
 # Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.8
 epoch               2
 version             4.8.5
-revision            6
+revision            7
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -85,7 +85,13 @@ post-extract {
 set major           [join [lrange [split ${version} .-] 0 1] .]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 configure.dir       ${workpath}/build

--- a/lang/gcc49/Portfile
+++ b/lang/gcc49/Portfile
@@ -7,7 +7,7 @@ PortGroup compiler_blacklist_versions 1.0
 name                gcc49
 epoch               2
 version             4.9.4
-revision            6
+revision            7
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -80,7 +80,13 @@ post-extract {
 set major           [join [lrange [split ${version} .-] 0 1] .]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 configure.dir       ${workpath}/build

--- a/lang/gcc5/Portfile
+++ b/lang/gcc5/Portfile
@@ -10,7 +10,7 @@ PortGroup xcode_workaround            1.0
 name                gcc5
 epoch               2
 version             5.5.0
-revision            6
+revision            7
 platforms           {darwin >= 10 < 15}
 categories          lang
 maintainers         nomaintainer
@@ -120,7 +120,14 @@ platform darwin {
         # alignment to 2
         patchfiles-append   boehm-gc-darwin15-hack.patch
     }
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 platform darwin 11 {

--- a/lang/gcc5/Portfile
+++ b/lang/gcc5/Portfile
@@ -11,7 +11,7 @@ name                gcc5
 epoch               2
 version             5.5.0
 revision            7
-platforms           {darwin >= 10 < 15}
+platforms           {darwin >= 9 < 15}
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc6/Portfile
+++ b/lang/gcc6/Portfile
@@ -10,8 +10,8 @@ PortGroup xcode_workaround            1.0
 name                gcc6
 epoch               3
 version             6.5.0
-revision            7
-subport             libgcc6 { revision 4 }
+revision            8
+subport             libgcc6 { revision 5 }
 platforms           {darwin < 15}
 categories          lang
 maintainers         nomaintainer
@@ -86,7 +86,13 @@ if {[vercmp ${xcodeversion} 10.2] >= 0} {
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 
     # see https://gcc.gnu.org/ml/gcc-patches/2012-05/msg00672.html
     patchfiles-append         patch-float128.diff

--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -10,8 +10,8 @@ PortGroup xcode_workaround             1.0
 name                gcc7
 epoch               3
 version             7.5.0
-revision            3
-subport             libgcc7 { revision 1 }
+revision            4
+subport             libgcc7 { revision 2 }
 platforms           {darwin < 15}
 categories          lang
 maintainers         nomaintainer
@@ -41,7 +41,7 @@ checksums           rmd160  91d46ec088badec75f41a2ad2a0ba228a6715107 \
 # If it is, libgcc7 installs a full runtime, otherwise it only installs
 # what is missing from newer libgccX builds.
 # NOTE : The logic here must match that in the libgcc port.
-set isLastSupported [ expr ${os.major} < 10 ]
+set isLastSupported [ expr ${os.major} < 9 ]
 
 if { ${configure.build_arch} eq "i386" && ${os.major} >= 10 } {
 

--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -89,7 +89,13 @@ patchfiles-append   notparallel-install-headers.patch
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 platform darwin 8 i386 {

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -90,6 +90,16 @@ depends_lib         port:cctools \
                     port:mpfr \
                     port:zlib
 depends_run         port:gcc_select
+
+platform darwin {
+    if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        depends_build-append \
+                        port:gcc10-bootstrap
+        configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc
+        configure.cxx   ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    }
+}
+
 if { ${isLastSupported} } {
     depends_run-append  path:share/doc/libgcc/README:libgcc
 } else {

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -12,7 +12,7 @@ name                gcc8
 version             8.5.0
 revision            1
 subport             libgcc8 { revision 1 }
-platforms           {darwin >= 10 < 15}
+platforms           {darwin >= 9 < 15}
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -93,6 +93,8 @@ depends_run         port:gcc_select
 
 platform darwin {
     if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        configure.compiler.add_deps \
+                        no
         depends_build-append \
                         port:gcc10-bootstrap
         configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -102,7 +102,13 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -12,7 +12,7 @@ name                gcc9
 version             9.5.0
 revision            0
 subport             libgcc9 { revision 2 }
-platforms           {darwin >= 10 < 15}
+platforms           {darwin >= 9 < 15}
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -81,6 +81,8 @@ depends_run         port:gcc_select \
 
 platform darwin {
     if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        configure.compiler.add_deps \
+                        no
         depends_build-append \
                         port:gcc10-bootstrap
         configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -79,6 +79,15 @@ depends_lib         port:cctools \
 depends_run         port:gcc_select \
                     port:libgcc9
 
+platform darwin {
+    if {(${configure.build_arch} in [list ppc ppc64]) || ${os.major} < 10} {
+        depends_build-append \
+                        port:gcc10-bootstrap
+        configure.cc    ${prefix}/libexec/gcc10-bootstrap/bin/gcc
+        configure.cxx   ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    }
+}
+
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
 

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -85,7 +85,13 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    if {${configure.build_arch} eq "ppc"} {
+        configure.pre_args-append --build=powerpc-apple-darwin${os.major}
+    } elseif {${configure.build_arch} eq "ppc64"} {
+        configure.pre_args-append --build=powerpc64-apple-darwin${os.major}
+    } else {
+        configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    }
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}

--- a/lang/libgcc/Portfile
+++ b/lang/libgcc/Portfile
@@ -6,7 +6,7 @@ PortGroup select    1.0
 epoch               3
 name                libgcc
 version             7.0
-revision            0
+revision            1
 
 conflicts           libgcc-devel
 
@@ -30,7 +30,7 @@ variant universal   { }
 # Pick the gcc version that provides the primary runtime.
 # NOTE : The logic here must match that in the gccX ports *and*
 # that in _resources/port1.0/group/compilers-1.0.tcl
-if { ${os.major} < 10 } {
+if { ${os.major} < 9 } {
     set gcc_version 7
 } else {
     set gcc_version 13


### PR DESCRIPTION
#### Description

This PR aims to finally move 10.5 to using the latest `libgcc` and `gcc`, like it is the case with 10.6. Aside of changing relevant settings, it uses `gcc10-bootstrap` to build `gcc8` and up on PPC.
It also fixes wrong target names for PPC: it should be `powerpc*-` and not `ppc*-`.

At the moment is **does not address** building GCC as `+universal`. It is certainly desirable to have universal GCC on Leopard, but here I need help of @catap and @kencu to get it done. This is a bigger problem, perhaps, since currently “universal” GCCs in Macports are fake universal, AFAIU.

A question: do we need to use `gcc10-bootstrap` on 10.5 Intel? I have no idea and cannot test it. @kencu I think you know this, should I use `if {${os.major} < 10 || ({os.major} == 10 && ${build_arch} eq "ppc")}` instead of PPC-only condition?

@catap I followed your clang-11-bootstrap here in setting `depends_build` instead of `depends_lib` for `gcc10-bootstrap`. I have used `depends_lib` earlier and that worked fine, but I guess we only need build dependency?

Relevant Trac ticket: https://trac.macports.org/ticket/64694
Not closing it, since Tiger remains on `libgcc7`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

macOS 10A190
Xcode 3.2

macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
