### PR TITLE
zsh-history-substring-search: new port

### DIFF
--- a/sysutils/zsh-history-substring-search/Portfile
+++ b/sysutils/zsh-history-substring-search/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        zsh-users zsh-history-substring-search 1.0.2 v
+github.tarball_from archive
+
+categories          sysutils shells
+
+maintainers         {@bashu gmail.com:bashu.was.here} openmaintainer
+
+description         Zsh port of Fish shell's history search.
+
+long_description    This is a clean-room implementation of the Fish shell's \
+                    history search feature, where you can type in any part of \
+                    any command from history and then press chosen keys, such \
+                    as the UP and DOWN arrows, to cycle through matches. \
+                    \
+                    Please note that you must load zsh-history-substring-search \
+                    after all other custom widgets, at the end of your .zshrc \
+                    file.
+
+license             BSD
+
+supported_archs     noarch
+
+checksums           sha256  c1bb21490bd31273fb511b23000fb7caf49c258a79c4b8842f3e1f2ff76fd84c \
+                    rmd160  637c943ecb719780209e61fd861883e48d3ac624 \
+                    size    9074
+
+depends_run         path:bin/zsh:zsh
+
+use_configure       no
+
+build { }
+
+destroot {
+    set dest_dir ${destroot}${prefix}/share/zsh-history-substring-search
+    xinstall -d ${dest_dir}
+    xinstall -m 0644 ${worksrcpath}/zsh-history-substring-search.zsh ${dest_dir}
+}
+
+github.livecheck.regex {([^"-]+)}


### PR DESCRIPTION
#### Description

Zsh port of Fish shell's history search.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
