### PR TITLE
serf1: fix build for Rosetta

### DIFF
--- a/www/serf1/Portfile
+++ b/www/serf1/Portfile
@@ -50,6 +50,15 @@ variant universal {}
 build.cmd       ${prefix}/bin/scons
 
 platform darwin {
+    # Build system fails to pass Macports archflags.
+    if {${os.major} == 10 && ${configure.build_arch} eq "ppc"} {
+        # This is a fix for Rosetta build, where a physical CPU is Intel.
+        patchfiles-replace \
+            patch-SConstruct.diff patch-SConstruct-Rosetta.diff
+        post-patch {
+            reinplace "s|@ARCH@|${configure.build_arch}|" ${worksrcpath}/SConstruct
+        }
+    }
     # Workaround scons buggy lack of MACOSX_DEPLOYMENT_TARGET propagation:
     build.args-append   CC="MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target} ${configure.cc}"
 }

--- a/www/serf1/files/patch-SConstruct-Rosetta.diff
+++ b/www/serf1/files/patch-SConstruct-Rosetta.diff
@@ -1,0 +1,54 @@
+--- SConstruct.orig	2015-09-17 07:46:24.000000000 -0500
++++ SConstruct	2017-09-27 14:56:41.000000000 -0500
+@@ -152,7 +152,8 @@
+                  True),
+     )
+ 
+-env = Environment(variables=opts,
++env = Environment(ENV = {'PATH' : os.environ['PATH']},
++                  variables=opts,
+                   tools=('default', 'textfile',),
+                   CPPPATH=['.', ],
+                   )
+@@ -216,7 +217,8 @@
+ # from current_version, so don't use the PATCH level to avoid that build and
+ # runtime patch levels have to be identical.
+ if sys.platform != 'sunos5':
+-  env['SHLIBVERSION'] = '%d.%d.%d' % (MAJOR, MINOR, 0)
++  # MacPorts: change PATCH to 0 when MINOR goes from 3 to 4.
++  env['SHLIBVERSION'] = '%d.%d.%d' % (MAJOR, MINOR, PATCH)
+ 
+ LIBNAME = 'libserf-%d' % (MAJOR,)
+ if sys.platform != 'win32':
+@@ -229,7 +231,8 @@
+ 
+ if sys.platform == 'darwin':
+ #  linkflags.append('-Wl,-install_name,@executable_path/%s.dylib' % (LIBNAME,))
+-  env.Append(LINKFLAGS=['-Wl,-install_name,%s/%s.dylib' % (thisdir, LIBNAME,)])
++  env.Append(LINKFLAGS=['-arch', '@ARCH@',
++                        '-Wl,-install_name,%s/%s.dylib' % (libdir, LIBNAME,)])
+ 
+ if sys.platform != 'win32':
+   def CheckGnuCC(context):
+@@ -419,21 +422,6 @@
+ install_static = env.Install(libdir, lib_static)
+ install_shared = env.InstallVersionedLib(libdir, lib_shared)
+ 
+-if sys.platform == 'darwin':
+-  # Change the shared library install name (id) to its final name and location.
+-  # Notes:
+-  # If --install-sandbox=<path> is specified, install_shared_path will point
+-  # to a path in the sandbox. We can't use that path because the sandbox is
+-  # only a temporary location. The id should be the final target path.
+-  # Also, we shouldn't use the complete version number for id, as that'll
+-  # make applications depend on the exact major.minor.patch version of serf.
+-
+-  install_shared_path = install_shared[0].abspath
+-  target_install_shared_path = os.path.join(libdir, '%s.dylib' % LIBNAME)
+-  env.AddPostAction(install_shared, ('install_name_tool -id %s %s'
+-                                     % (target_install_shared_path,
+-                                        install_shared_path)))
+-
+ env.Alias('install-lib', [install_static, install_shared,
+                           ])
+ env.Alias('install-inc', env.Install(incdir, HEADER_FILES))


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66366

#### Description

`serf1` fails to build on Rosetta because Macports archflags are not passed. Fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
