### PR TITLE
gopass-summon-provider: update to 1.14.11

### DIFF
--- a/devel/gopass-summon-provider/Portfile
+++ b/devel/gopass-summon-provider/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-summon-provider 1.14.9 v
+go.setup            github.com/gopasspw/gopass-summon-provider 1.14.11 v
+revision            0
 categories          devel
 maintainers         {@0x1DA117 danieltrautmann.com:me} openmaintainer
 license             MIT
@@ -32,9 +33,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  628a45dea2e27e16db5ae14711f3b6d6458c3591 \
-                        sha256  9c392344aea9fa09da33f34969095abc4ec513e892a6860ce488d462fcf41a51 \
-                        size    17440
+                        rmd160  2ee643a62e164b44c1e136e8c384f592fd8bf767 \
+                        sha256  955958dec7334571d4a3550e40308194e9a1978f365452f544ffeed9126376da \
+                        size    17479
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -53,30 +54,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    7a66f970e087 \
-                        rmd160  41c0ec1933a371ad67cb43763a5f056beb4f4863 \
-                        sha256  eb75717073f7fa08879333df6cc9ddcefd6dff51fdcd68769a144f480b754d89 \
-                        size    14836 \
+                        lock    v0.2.0 \
+                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
+                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
+                        size    14797 \
                     golang.org/x/sys \
-                        lock    f11e5e49a4ec \
-                        rmd160  9a3d80028b63286705afae2e0ac56db4ead87393 \
-                        sha256  0d9b8a224175ae48e956e9819f3956ab99e424d972392dc14f2767f7ed5cc08e \
-                        size    1358598 \
+                        lock    v0.2.0 \
+                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
+                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
+                        size    1411246 \
                     golang.org/x/net \
-                        lock    f486391704dc \
-                        rmd160  ad3567fe403e6f60af35e23a16148a64ba897ada \
-                        sha256  552e03ea9ace20d5dc0d2a8e38a70b46fb129a949ff5ede12647ff7f1cb0db63 \
-                        size    1228309 \
+                        lock    v0.2.0 \
+                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
+                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
+                        size    1243767 \
                     golang.org/x/exp \
-                        lock    c76eaa363f9d \
-                        rmd160  6a5edb9a872e69af22259e1788a4232e5de90a4e \
-                        sha256  45bd97165cabf719fa62fb6ab9a6e76244485d948814b09e59b1b05615678083 \
-                        size    1581437 \
+                        lock    850992195362 \
+                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
+                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
+                        size    1605708 \
                     golang.org/x/crypto \
-                        lock    eccd6366d1be \
-                        rmd160  ab1c320cdf6095b7b631d84be10a670bf1fb93ef \
-                        sha256  b521c71cb061835f7613fa91303a40cf3453ba09727f952a2363b6e403f3bde2 \
-                        size    1631515 \
+                        lock    v0.3.0 \
+                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
+                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
+                        size    1633434 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -100,25 +101,25 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.16.3 \
-                        rmd160  adb83ade0b2179e2e317399b92b0847400e50657 \
-                        sha256  99806c3033219a905b006c8cae96c8ba4cd08a94ce966886b0f3855b36440850 \
-                        size    3469448 \
+                        lock    v2.23.5 \
+                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
+                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
+                        size    3478097 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
                         sha256  24ed1834717a15fd2bbb7881e8c9e84948a6a3696ef5faba54c8b58b565932ba \
                         size    11986 \
                     github.com/stretchr/testify \
-                        lock    v1.8.0 \
-                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
-                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
-                        size    97622 \
+                        lock    v1.8.1 \
+                        rmd160  4d80635834e01b3ddb67babdd8de2eac2c5a7587 \
+                        sha256  9848272e238f98fc0555b514c4522e70c4df25331b4ee3f9cb9244a04935934e \
+                        size    97722 \
                     github.com/stretchr/objx \
-                        lock    v0.4.0 \
-                        rmd160  7c15794276cc01606b1af8f7c1464f3c6267d669 \
-                        sha256  2e19a33cf951b8d9d19ce9ac9ddbdf7bf866e8ee5a730a08020e612418ef3f3a \
-                        size    163135 \
+                        lock    v0.5.0 \
+                        rmd160  9ff3c4d1d122c7e389f2d8b0b0c5503fd1c15e0a \
+                        sha256  21b1f19a64c553c9ee77ab25f498ceafe839a84aa9380f04154ea28217c60974 \
+                        size    165551 \
                     github.com/skip2/go-qrcode \
                         lock    da1b6568686e \
                         rmd160  bbb9e2167ddfc72dd22da6df324b41792e70a627 \
@@ -235,10 +236,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.9 \
-                        rmd160  461fa3f1f7214d6a62be3a30cf33900f9aae5e75 \
-                        sha256  6ec5ba719ea87e5a86f58925b60eacef55cb76f291eff7ca5d6003714caf1f54 \
-                        size    2252771 \
+                        lock    v1.14.11 \
+                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
+                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
+                        size    2255917 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -290,10 +291,10 @@ go.vendors          gotest.tools \
                         sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
                         size    64382 \
                     github.com/cloudflare/circl \
-                        lock    v1.2.0 \
-                        rmd160  57ecd1876b3db3338e04ee26399ba504d67e15af \
-                        sha256  2d9d0e87698fceae275c06f5641c4dacf1e505217a981a21bac72438d0972ab7 \
-                        size    4702712 \
+                        lock    v1.3.0 \
+                        rmd160  0a2756e43e5d01217e3ac910831ce324cb028db4 \
+                        sha256  c6ed975caf7d6eccb95bfe8d192ff3946a6261a31a218106616510109459992c \
+                        size    4764393 \
                     github.com/chzyer/readline \
                         lock    v1.5.1 \
                         rmd160  cea52b55bd592a89cb49da082f5f0f3b6e8ad48a \
@@ -330,10 +331,10 @@ go.vendors          gotest.tools \
                         sha256  ab26daceb19d4973dd1bf37105473f8d27697b5a04b124d790fd45124450b9a2 \
                         size    7552 \
                     github.com/ProtonMail/go-crypto \
-                        lock    4b6e5c587895 \
-                        rmd160  d4b9fbd23c062647ad52781906cb8a7bf94fee3d \
-                        sha256  83ff491e152d6c47a8a8c7813a782581c4782f94c8b2573a47ada6b08449d917 \
-                        size    329665 \
+                        lock    cf6655e29de4 \
+                        rmd160  0c878f2d4a5a2e8869df40d99ee219bdff7503de \
+                        sha256  5b94489154983036fbaf619202a3f92700817fd57b3a1010f0a39bf2e2432665 \
+                        size    330467 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
                         lock    v1.0.0 \


### PR DESCRIPTION
#### Description
https://github.com/macports/macports-ports/pull/16815

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
