### PR TITLE
emacs{-app,}-devel: update to 20221128

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -103,23 +103,25 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     PortGroup       github 1.0
 
-    github.setup    emacs-mirror emacs 802671493d7c18569dac47ca91a4b7d6e693aff6
+    github.setup    emacs-mirror emacs 7939184f8e0370e7a3397d492812c6d202c2a193
     epoch           5
-    version         20221107
+    version         20221128
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  cea40725dd2593dcb375210c95f1c0aca4961df7 \
-                    sha256  a318cc46ea0b143136693e539d3f031039e03a3361ced1877963eab8ae5aa59f \
-                    size    46262466
+    checksums       rmd160  cb434a6d1ef8cd1f1e1baabcf1bf5a05aba8c098 \
+                    sha256  08fa8ae7e62fdb50ac8e49935db83b71987a454861d5b2cf6d2bb65a1eb8ca38 \
+                    size    46595420
 
     configure.args-append \
         --with-sqlite3 \
-        --with-webp
+        --with-webp \
+        --with-tree-sitter
 
     depends_lib-append \
         port:sqlite3 \
-        port:webp
+        port:webp \
+        port:tree-sitter
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"


### PR DESCRIPTION
#### Description

- Version bumped to 30.0.50
- Includes tree-sitter integration
  - Language modules are *not* included; it's not currently clear how MacPorts can or should make these available

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
