### PR TITLE
ntpsec: Fix build failure with clang 14.

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 name                ntpsec
 version             1.2.1
-revision            3
+revision            4
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -72,6 +72,7 @@ configure.args      --alltests \
                     --disable-manpage \
                     --python=${python.bin} \
                     --enable-pylib=ext \
+                    --pyshebang=${python.bin} \
                     --pythondir=${python.pkgd} \
                     --pythonarchdir=${python.pkgd}
 # Make sure we use waf, not setup.py for build

--- a/sysutils/ntpsec/files/patch-allfixes.diff
+++ b/sysutils/ntpsec/files/patch-allfixes.diff
@@ -1,5 +1,5 @@
---- ./attic/backwards.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/backwards.c	2021-11-20 13:51:42.000000000 -0800
+--- attic/backwards.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ attic/backwards.c	2022-11-28 16:18:24.000000000 -0800
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -9,8 +9,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- ./attic/clocks.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/clocks.c	2021-11-20 13:51:42.000000000 -0800
+--- attic/clocks.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ attic/clocks.c	2022-11-28 16:18:24.000000000 -0800
 @@ -9,6 +9,8 @@
  #include <unistd.h>
  
@@ -20,8 +20,8 @@
  struct table {
    const int type;
    const char* name;
---- ./attic/cmac-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/cmac-timing.c	2021-11-20 13:51:42.000000000 -0800
+--- attic/cmac-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ attic/cmac-timing.c	2022-11-28 16:18:24.000000000 -0800
 @@ -35,6 +35,8 @@
  #include <openssl/params.h> 
  #endif
@@ -31,8 +31,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  
---- ./attic/digest-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/digest-timing.c	2021-11-20 13:51:42.000000000 -0800
+--- attic/digest-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ attic/digest-timing.c	2022-11-28 16:18:24.000000000 -0800
 @@ -33,6 +33,8 @@
  #include <openssl/ssl.h>
  #endif
@@ -42,8 +42,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
---- ./attic/random.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./attic/random.c	2021-11-20 13:51:42.000000000 -0800
+--- attic/random.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ attic/random.c	2022-11-28 16:18:24.000000000 -0800
 @@ -10,6 +10,8 @@
  #include <openssl/opensslv.h>    /* for OPENSSL_VERSION_NUMBER */
  #include <openssl/rand.h>
@@ -53,8 +53,21 @@
  #define BATCHSIZE 1000000
  #define BILLION 1000000000
  #define HISTSIZE 2500
---- ./include/ntp_machine.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./include/ntp_machine.h	2021-11-20 13:51:42.000000000 -0800
+--- include/ntp_fp.h.orig	2021-06-06 21:03:11.000000000 -0700
++++ include/ntp_fp.h	2022-11-28 16:18:24.000000000 -0800
+@@ -112,8 +112,9 @@ typedef struct {
+  * Operations on the long fp format.  The only reason these aren't
+  * native operations is to be independent of whether the l_fp
+  * type is signed or unsigned.
++ * Can l_fp ever be signed??
+  */
+-#define	L_NEG(v)	(v) = (l_fp)(-(int64_t)(v))
++#define	L_NEG(v)	(v) = -(v)
+ #define	L_ISNEG(v)	M_ISNEG(lfpuint(v))
+ #define	L_ISGT(a, b)	((int64_t)(a) > (int64_t)(b))
+ #define	L_ISGTU(a, b)	((a) > (b))
+--- include/ntp_machine.h.orig	2021-06-06 21:03:11.000000000 -0700
++++ include/ntp_machine.h	2022-11-28 16:18:24.000000000 -0800
 @@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
@@ -207,8 +220,8 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- ./include/ntp_stdlib.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./include/ntp_stdlib.h	2021-11-20 13:51:42.000000000 -0800
+--- include/ntp_stdlib.h.orig	2021-06-06 21:03:11.000000000 -0700
++++ include/ntp_stdlib.h	2022-11-28 16:18:24.000000000 -0800
 @@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -219,8 +232,8 @@
  extern	char *	statustoa	(int, int);
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
---- ./include/ntp_syscall.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./include/ntp_syscall.h	2021-11-20 13:51:42.000000000 -0800
+--- include/ntp_syscall.h.orig	2021-06-06 21:03:11.000000000 -0700
++++ include/ntp_syscall.h	2022-11-28 16:18:24.000000000 -0800
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -233,8 +246,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- ./libntp/clockwork.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./libntp/clockwork.c	2021-11-20 13:51:42.000000000 -0800
+--- libntp/clockwork.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ libntp/clockwork.c	2022-11-28 16:18:24.000000000 -0800
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -248,8 +261,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- ./libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./libntp/statestr.c	2021-11-20 13:51:42.000000000 -0800
+--- libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ libntp/statestr.c	2022-11-28 16:18:24.000000000 -0800
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -350,8 +363,8 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ./ntpd/ntp_control.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpd/ntp_control.c	2021-11-20 13:51:42.000000000 -0800
+--- ntpd/ntp_control.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ntpd/ntp_control.c	2022-11-28 16:18:24.000000000 -0800
 @@ -1361,6 +1361,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
@@ -475,8 +488,8 @@
  
  	case CS_K_PPS_FREQ:
  		CTL_IF_KERNPPS(
---- ./ntpd/ntp_loopfilter.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2021-11-20 13:51:42.000000000 -0800
+--- ntpd/ntp_loopfilter.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ntpd/ntp_loopfilter.c	2022-11-28 16:18:24.000000000 -0800
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -698,8 +711,8 @@
  	}
  }
 -
---- ./ntpd/ntp_timer.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2021-11-20 13:51:42.000000000 -0800
+--- ntpd/ntp_timer.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ntpd/ntp_timer.c	2022-11-28 16:18:24.000000000 -0800
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -722,8 +735,8 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ./ntpd/refclock_local.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpd/refclock_local.c	2021-11-20 13:51:42.000000000 -0800
+--- ntpd/refclock_local.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ntpd/refclock_local.c	2022-11-28 16:18:24.000000000 -0800
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -746,8 +759,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ./ntpfrob/precision.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./ntpfrob/precision.c	2021-11-20 13:51:42.000000000 -0800
+--- ntpfrob/precision.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ ntpfrob/precision.c	2022-11-28 16:18:24.000000000 -0800
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -756,8 +769,8 @@
  
  #define	DEFAULT_SYS_PRECISION	-99
  
---- ./tests/libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./tests/libntp/statestr.c	2021-11-20 13:51:42.000000000 -0800
+--- tests/libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
++++ tests/libntp/statestr.c	2022-11-28 16:18:24.000000000 -0800
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -778,8 +791,8 @@
  }
  
  // statustoa
---- ./wafhelpers/bin_test.py.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./wafhelpers/bin_test.py	2021-11-20 13:51:42.000000000 -0800
+--- wafhelpers/bin_test.py.orig	2021-06-06 21:03:11.000000000 -0700
++++ wafhelpers/bin_test.py	2022-11-28 16:18:24.000000000 -0800
 @@ -103,6 +103,12 @@ def cmd_bin_test(ctx):
      if ctx.env['PYTHON_CURSES']:
          cmd_map_python.update(cmd_map_python_curses)
@@ -793,8 +806,8 @@
      for cmd in sorted(cmd_map):
          if not run(cmd, cmd_map[cmd] % version):
              fails += 1
---- ./wafhelpers/options.py.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./wafhelpers/options.py	2021-11-20 13:51:42.000000000 -0800
+--- wafhelpers/options.py.orig	2021-06-06 21:03:11.000000000 -0700
++++ wafhelpers/options.py	2022-11-28 16:18:24.000000000 -0800
 @@ -21,6 +21,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -804,8 +817,8 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- ./wscript.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ./wscript	2021-11-20 13:51:42.000000000 -0800
+--- wscript.orig	2021-06-06 21:03:11.000000000 -0700
++++ wscript	2022-11-28 16:18:24.000000000 -0800
 @@ -562,7 +562,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),


### PR DESCRIPTION
This was actually just a test failure in a corner case, but since the tests are run as part of the build, the build was failing.  The build originally worked on 12.x Monterey, but failed after upgrading to Xcode 14, and building on 13.x Ventura never worked.

There was already a one-line upstream fix for this, which is backported here.

Also, the Python programs lacked a versioned shebang line, causing them to fail whenever the default Python wasn't python27.  This also now fixed.

Since installed content is changed, this includes a revbump.

This doesn't bother to fix the minor lint warning about a duplicate pkgconfig dependency.

As usual, the patchfile is derived from a GitLab fork, and the overall diffs can be seen at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports_1_2_1r4

TESTED:
Tested (including building the usual set of variant combinations) on 10.4-10.5 ppc, 10.4-10.6 i386, 10.6-10.15 x86_64, and 11.x-13.x arm64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e
macOS 11.7.1 20G918, arm64, Xcode 13.2.1 13C100
macOS 12.6.1 21G217, arm64, Xcode 14.1 14B47b
macOS 13.0.1 22A400, arm64, Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- N/A referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- N/A tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
