### PR TITLE
kotlin: update to 1.7.22

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.7.21 v
+github.setup        JetBrains kotlin 1.7.22 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  191b7449a84ec6563c5047b7572ab94939a643de \
-                    sha256  8412b31b808755f0c0d336dbb8c8443fa239bf32ddb3cdb81b305b25f0ad279e \
-                    size    78964847
+checksums           rmd160  b97fdf74f589570cdcf0c7f8700f37946d52a423 \
+                    sha256  9db4b467743c1aea8a21c08e1c286bc2aeb93f14c7ba2037dbd8f48adc357d83 \
+                    size    78964839
 
 java.version        1.8+
 java.fallback       openjdk17


### PR DESCRIPTION
#### Description

Update to Kotlin 1.7.22.

###### Tested on

macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?