### PR TITLE
terragrunt: upgrade to 0.42.2

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -15,7 +15,34 @@ maintainers         {mjrc.nl:macports @mjrc} openmaintainer
 
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       terragrunt-0.39
+set latestVersion       terragrunt-0.42
+
+subport terragrunt-0.42 {
+    set dependsOn       1.2
+    set patchNumber     2
+
+    checksums           rmd160  7040741e7d9ed49ccdc2d7efe24c642127f764d9 \
+                        sha256  3cb65b86ecf72781a98f5aa2dd7b55ad773692f6e1d0d84182a17b5542ce8448 \
+                        size    2308445
+}
+
+subport terragrunt-0.41 {
+    set dependsOn       1.2
+    set patchNumber     0
+
+    checksums           rmd160  9e1104bcea6754c4f6ac2ada3cce99465cb8c4b2 \
+                        sha256  679f6cbb943bdbd4aa45fca499e685e68aa8e5bdf4c9ae8aee1831afd9dd631c \
+                        size    2307873
+}
+
+subport terragrunt-0.40 {
+    set dependsOn       1.2
+    set patchNumber     2
+
+    checksums           rmd160  355f4c2461e06d21e55fbaf6a959246a5ac86148 \
+                        sha256  dcc89a20e348f3d966d0c9977417b5d7e0de697dbd9fef1ac6b5663e9671c659 \
+                        size    2310897
+}
 
 subport terragrunt-0.39 {
     set dependsOn       1.2


### PR DESCRIPTION
#### Description
terragrunt: upgrade to 0.42.2
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
