### PR TITLE
onetbb: fix +universal build on macOS 10.6

### DIFF
--- a/devel/onetbb/Portfile
+++ b/devel/onetbb/Portfile
@@ -34,4 +34,11 @@ depends_lib-append  port:hwloc
 
 compiler.cxx_standard  2011
 
+# OneTBB's build uses CMAKE_OSX_ARCHITECTURES to add -arch flags which may lead
+# to missed symbols from exported symbol list on universal build like:
+# Undefined symbols for architecture i386:
+#  "tbb::detail::r1::wait_bounded_queue_monitor(tbb::detail::r1::concurrent_monitor*, unsigned long, long, tbb::detail::d1::delegate_base&)", referenced from:
+#     -exported_symbol[s_list] command line option
+cmake.set_osx_architectures no
+
 configure.args-append  -DTBB_TEST=OFF

--- a/devel/onetbb/files/patch-onetbb-older-malloc.diff
+++ b/devel/onetbb/files/patch-onetbb-older-malloc.diff
@@ -1,6 +1,39 @@
+diff --git src/tbbmalloc_proxy/proxy_overload_osx.h src/tbbmalloc_proxy/proxy_overload_osx.h
+index 69582983..632d25e2 100644
 --- src/tbbmalloc_proxy/proxy_overload_osx.h
 +++ src/tbbmalloc_proxy/proxy_overload_osx.h
-@@ -135,9 +135,11 @@ struct DoMallocReplacement {
+@@ -81,6 +81,7 @@ static boolean_t zone_locked(malloc_zone_t *)
+     return false;
+ }
+ 
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+ static boolean_t impl_zone_enable_discharge_checking(malloc_zone_t *)
+ {
+     return false;
+@@ -88,6 +89,8 @@ static boolean_t impl_zone_enable_discharge_checking(malloc_zone_t *)
+ 
+ static void impl_zone_disable_discharge_checking(malloc_zone_t *) {}
+ static void impl_zone_discharge(malloc_zone_t *, void *) {}
++#endif
++
+ static void impl_zone_destroy(struct _malloc_zone_t *) {}
+ 
+ /* note: impl_malloc_usable_size() is called for each free() call, so it must be fast */
+@@ -111,11 +114,13 @@ static void impl_free_definite_size(struct _malloc_zone_t*, void *ptr, size_t si
+     __TBB_malloc_free_definite_size(ptr, size);
+ }
+ 
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+ /* Empty out caches in the face of memory pressure. */
+ static size_t impl_pressure_relief(struct _malloc_zone_t *, size_t  /* goal */)
+ {
+     return 0;
+ }
++#endif
+ 
+ static malloc_zone_t *system_zone = nullptr;
+ 
+@@ -135,9 +140,11 @@ struct DoMallocReplacement {
          introspect.force_unlock = &zone_force_unlock;
          introspect.statistics = zone_statistics;
          introspect.zone_locked = &zone_locked;
@@ -12,7 +45,7 @@
  
          zone.size = &impl_malloc_usable_size;
          zone.malloc = &impl_malloc;
-@@ -151,7 +153,9 @@ struct DoMallocReplacement {
+@@ -151,7 +158,9 @@ struct DoMallocReplacement {
          zone.version = 8;
          zone.memalign = impl_memalign;
          zone.free_definite_size = &impl_free_definite_size;


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/66379

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
