### PR TITLE
tiff: apply patch for CVE-2022-3970

### DIFF
--- a/graphics/tiff/Portfile
+++ b/graphics/tiff/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 
 name                tiff
 version             4.4.0
-revision            0
+revision            1
 checksums           rmd160  715752ebd2613d2e454b90d25f0c003bd8626ea4 \
                     sha256  917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed \
                     size    2841082
@@ -46,7 +46,8 @@ test.target         check
 compiler.c_standard 1999
 
 patchfiles          allow-opengl-without-x11.patch \
-                    dont-find-x11-opengl.patch
+                    dont-find-x11-opengl.patch \
+                    CVE-2022-3970.patch
 
 configure.args      --disable-jbig \
                     --disable-webp \

--- a/graphics/tiff/files/CVE-2022-3970.patch
+++ b/graphics/tiff/files/CVE-2022-3970.patch
@@ -1,0 +1,33 @@
+From 227500897dfb07fb7d27f7aa570050e62617e3be Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Tue, 8 Nov 2022 15:16:58 +0100
+Subject: [PATCH] TIFFReadRGBATileExt(): fix (unsigned) integer overflow on
+ strips/tiles > 2 GB
+
+Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53137
+---
+ libtiff/tif_getimage.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- libtiff/tif_getimage.c.orig
++++ libtiff/tif_getimage.c
+@@ -3058,15 +3058,15 @@ TIFFReadRGBATileExt(TIFF* tif, uint32_t
+         return( ok );
+ 
+     for( i_row = 0; i_row < read_ysize; i_row++ ) {
+-        memmove( raster + (tile_ysize - i_row - 1) * tile_xsize,
+-                 raster + (read_ysize - i_row - 1) * read_xsize,
++        memmove( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize,
++                 raster + (size_t)(read_ysize - i_row - 1) * read_xsize,
+                  read_xsize * sizeof(uint32_t) );
+-        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize+read_xsize,
++        _TIFFmemset( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize+read_xsize,
+                      0, sizeof(uint32_t) * (tile_xsize - read_xsize) );
+     }
+ 
+     for( i_row = read_ysize; i_row < tile_ysize; i_row++ ) {
+-        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize,
++        _TIFFmemset( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize,
+                      0, sizeof(uint32_t) * tile_xsize );
+     }
+ 


### PR DESCRIPTION
See

   * https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3970
   * https://launchpad.net/ubuntu/+source/tiff/4.3.0-6ubuntu0.3
   * http://launchpadlibrarian.net/636971190/tiff_4.3.0-6ubuntu0.2_4.3.0-6ubuntu0.3.diff.gz

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
