### PR TITLE
lerc: update to 4.0.0

### DIFF
--- a/gis/lerc/Portfile
+++ b/gis/lerc/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cmake   1.1
 
-github.setup        Esri lerc 3.0 v
+github.setup        Esri lerc 4.0.0 v
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  9ec098024ef752bc2b39569fa18cde12a0cd1464 \
-                    sha256  8c0148f5c22d823eff7b2c999b0781f8095e49a7d3195f13c68c5541dd5740a1 \
-                    size    4357957
+checksums           rmd160  4db543ea71fe126c94bce3ae8559107b483a4668 \
+                    sha256  91431c2b16d0e3de6cbaea188603359f87caed08259a645fd5a3805784ee30a0 \
+                    size    4710408
 
 categories          gis
 platforms           darwin


### PR DESCRIPTION
#### Description

Note the library is now shipping a libLerc.4.dylib in addition to libLerc.dylib. There was never a libLerc.3.dylib. I rebuilt tiff against lerc 4 and it is now directly linking against that libLerc.4.dylib. I think this PR is safe to release without any revbumps - no ABI breakage, only some new functions added - but future major releases may need to revbump dependencies.

The actual C API is simple and meant to support multiple versions of the underlying LERC encoding at once, so it'll be pretty stable.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
