### PR TITLE
qt5-qtwebkit: Flag conflicting ports on case insensitive filesystems

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1609,7 +1609,19 @@ foreach {module module_info} [array get modules] {
 
             # special case
             if { ${module} eq "qtwebkit" } {
+                PortGroup conflicts_build     1.0
 
+                # Compile fails on case insensitve filesystems due to similar header files from other
+                # macports headers found on the include search path.  In particular event.h and archive.h
+                if {[file exists ${prefix}/include/event.h]} {
+                    conflicts_build-append libevent 
+                }
+                # Ruby 30/31 also adds an event.h header
+                    conflicts_build-append ruby30
+                    conflicts_build-append ruby31
+                if {[file exists ${prefix}/include/archive.h]} {
+                    conflicts_build-append libarchive
+                }
                 # use MacPorts icu
                 #
                 # qmake uses pkgconfig to look for icu


### PR DESCRIPTION
  On  some builds, the include search path picks up header files from macports
  and occasionally the system before the local header files causing an error.
  This modification places the qt5-qtwebkit header files first on the search path.

Closes: https://trac.macports.org/ticket/63877
Closes: https://trac.macports.org/ticket/62027
Closes: https://trac.macports.org/ticket/66177
Closes: https://trac.macports.org/ticket/63566

[skip ci]

Tested and verified to work with Test Application

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
