### PR TITLE
webkit2-gtk: fix quartz build on Big Sur

### DIFF
--- a/www/webkit2-gtk/Portfile
+++ b/www/webkit2-gtk/Portfile
@@ -147,6 +147,9 @@ default_variants-append +minibrowser
 variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/gtk+-3.0.pc:gtk3 quartz
 
+    # TODO: restrict this patch to just Big Sur?
+    patchfiles-append patch-Source_WebKit_Platform_IPC_Connection.cpp.diff
+
     configure.args-append \
         -DENABLE_QUARTZ_TARGET=ON \
         -DENABLE_X11_TARGET=OFF \

--- a/www/webkit2-gtk/files/patch-Source_WebKit_Platform_IPC_Connection.cpp.diff
+++ b/www/webkit2-gtk/files/patch-Source_WebKit_Platform_IPC_Connection.cpp.diff
@@ -1,0 +1,20 @@
+--- /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_www_webkit2-gtk/webkit2-gtk/work/webkitgtk-2.28.2/Source/WebKit/Platform/IPC/Connection.cpp.bak	2021-05-08 09:24:06.000000000 -0400
++++ /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_www_webkit2-gtk/webkit2-gtk/work/webkitgtk-2.28.2/Source/WebKit/Platform/IPC/Connection.cpp	2021-05-08 10:04:20.000000000 -0400
+@@ -36,6 +36,8 @@
+ #include <wtf/text/WTFString.h>
+ #include <wtf/threads/BinarySemaphore.h>
+ 
++#include <unistd.h>
++
+ #if PLATFORM(COCOA)
+ #include "MachMessage.h"
+ #endif
+@@ -669,7 +671,7 @@
+     }
+ 
+ #if OS(DARWIN)
+-    RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Timed-out while waiting for reply for %{public}s::%{public}s from process %d, id = %" PRIu64, messageReceiverName.toString().data(), messageName.toString().data(), remoteProcessID(), syncRequestID);
++    RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Timed-out while waiting for reply for %{public}s::%{public}s from process %d, id = %" PRIu64, messageReceiverName.toString().data(), messageName.toString().data(), (int)getpid(), syncRequestID);
+ #else
+     RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Timed-out while waiting for reply for %s::%s, id = %" PRIu64, messageReceiverName.toString().data(), messageName.toString().data(), syncRequestID);
+ #endif

--- a/www/webkit2-gtk/files/patch-Source_WebKit_Platform_IPC_Connection.cpp.diff
+++ b/www/webkit2-gtk/files/patch-Source_WebKit_Platform_IPC_Connection.cpp.diff
@@ -1,5 +1,5 @@
---- /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_www_webkit2-gtk/webkit2-gtk/work/webkitgtk-2.28.2/Source/WebKit/Platform/IPC/Connection.cpp.bak	2021-05-08 09:24:06.000000000 -0400
-+++ /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_www_webkit2-gtk/webkit2-gtk/work/webkitgtk-2.28.2/Source/WebKit/Platform/IPC/Connection.cpp	2021-05-08 10:04:20.000000000 -0400
+--- Source/WebKit/Platform/IPC/Connection.cpp.bak	2021-05-08 09:24:06.000000000 -0400
++++ Source/WebKit/Platform/IPC/Connection.cpp	2021-05-08 10:04:20.000000000 -0400
 @@ -36,6 +36,8 @@
  #include <wtf/text/WTFString.h>
  #include <wtf/threads/BinarySemaphore.h>


### PR DESCRIPTION
possibly closes: https://trac.macports.org/ticket/62842 (untested)

#### Description
See Trac bug 62842

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.1 20G918 x86_64
Xcode 13.2.1 13C100
(testing still in progress)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`? (I had to remove the `-t` flag because trace mode blocked access to `ccache`, which a previous stage had used)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
