### PR TITLE
gdk-pixbuf2: stop malloc errors on older systems

### DIFF
--- a/graphics/gdk-pixbuf2/Portfile
+++ b/graphics/gdk-pixbuf2/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup           meson 1.0
+PortGroup           legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 10
+legacysupport.redirect_bins gdk-pixbuf-csource gdk-pixbuf-pixdata gdk-pixbuf-query-loaders gdk-pixbuf-thumbnailer
 
 name                gdk-pixbuf2
 conflicts           gdk-pixbuf2-devel
@@ -11,7 +15,7 @@ set my_name         gdk-pixbuf2
 set gname           gdk-pixbuf
 
 version             2.42.9
-revision            0
+revision            1
 epoch               2
 
 categories          graphics
@@ -64,6 +68,9 @@ post-patch {
 
 compiler.c_standard \
                     1999
+
+# this is needed to allow legacysupport's binwrapping to work
+compiler.cxx_standard 2011
 
 configure.ldflags-append \
                     -lintl


### PR DESCRIPTION
need to binwrap these bins, but to do that, need to set compiler.cxx_standard to 2011 due to legacysupport PG

closes: https://trac.macports.org/ticket/66159

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of SOME binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
