### PR TITLE
py-subprocess-tee: Add patch for update deps

### DIFF
--- a/python/py-subprocess-tee/Portfile
+++ b/python/py-subprocess-tee/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-subprocess-tee
 version             0.4.0
-revision            1
+revision            2
 
 categories          python
 supported_archs     noarch
@@ -25,13 +25,13 @@ checksums           rmd160  398bf9c0fbaa5695557367972321c8166ca3b732 \
 python.versions     39 310 311
 python.pep517       yes
 
+# Remove in next update
+patchfiles          patch-update-deps.diff
+
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-pip \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-setuptools_scm \
-                        port:py${python.version}-setuptools_scm_git_archive \
-                        port:py${python.version}-wheel
 
     livecheck.type      none
 }

--- a/python/py-subprocess-tee/files/patch-update-deps.diff
+++ b/python/py-subprocess-tee/files/patch-update-deps.diff
@@ -1,0 +1,100 @@
+From be90d1649ac258986f1ae72630419f8a925a5280 Mon Sep 17 00:00:00 2001
+From: Sorin Sbarnea <ssbarnea@redhat.com>
+Date: Fri, 25 Nov 2022 23:59:38 +0000
+Subject: [PATCH] Clear build dependencies (#80)
+
+Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+
+From 50ddd62386597481b34235fb97de9c2a9764a173 Mon Sep 17 00:00:00 2001
+From: Maxwell G <gotmax@e.email>
+Date: Sun, 27 Nov 2022 12:55:15 -0600
+Subject: [PATCH] Add "setuptools >= 61.0" to build system requires (#82)
+---
+ .pre-commit-config.yaml        | 1 -
+ pyproject.toml                 | 9 +--------
+ src/subprocess_tee/__init__.py | 8 ++++++++
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
+index 382c686..e9a4da2 100644
+--- .pre-commit-config.yaml.Orig
++++ .pre-commit-config.yaml
+@@ -51,7 +51,6 @@ repos:
+         pass_filenames: false
+         additional_dependencies:
+           - pytest>=6.1.2
+-          - packaging
+           - enrich>=1.2.5
+   - repo: https://github.com/PyCQA/pylint
+     rev: v2.15.6
+diff --git a/pyproject.toml b/pyproject.toml
+index 30f7e81..1f73bc5 100644
+--- pyproject.toml.Orig
++++ pyproject.toml
+@@ -1,10 +1,6 @@
+ [build-system]
+ requires = [
+-  "pip >= 19.3.1",
+-  "setuptools >= 42",
+-  "setuptools_scm[toml] >= 3.5.0",
+-  "setuptools_scm_git_archive >= 1.1",
+-  "wheel >= 0.33.6",
++  "setuptools_scm[toml] >= 7.0.0",
+ ]
+ build-backend = "setuptools.build_meta"
+ 
+@@ -59,9 +55,6 @@ test =[
+     "pytest>=6.2.5",
+ ]
+ 
+-[tool.black]
+-skip-string-normalization = false
+-
+ [tool.isort]
+ profile = "black"
+ known_first_party = "subprocess_tee"
+diff --git a/src/subprocess_tee/__init__.py b/src/subprocess_tee/__init__.py
+index dad299e..cc3b814 100644
+--- src/subprocess_tee/__init__.py.Orig
++++ src/subprocess_tee/__init__.py
+@@ -5,8 +5,16 @@
+ import subprocess
+ import sys
+ from asyncio import StreamReader
++from importlib.metadata import PackageNotFoundError, version  # type: ignore
+ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+ 
++try:
++    __version__ = version("subprocess-tee")
++except PackageNotFoundError:  # pragma: no branch
++    __version__ = "0.1.dev1"
++
++__all__ = ["run", "CompletedProcess", "__version__"]
++
+ if TYPE_CHECKING:
+     CompletedProcess = subprocess.CompletedProcess[Any]  # pylint: disable=E1136
+ else:
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 1f73bc5..a1b9e17 100644
+--- pyproject.toml.Orig
++++ pyproject.toml
+@@ -1,5 +1,7 @@
+ [build-system]
+ requires = [
++  # Needed for PEP 621 support
++  "setuptools >= 61.0",
+   "setuptools_scm[toml] >= 7.0.0",
+ ]
+ build-backend = "setuptools.build_meta"
+diff --git a/tox.ini b/tox.ini
+index f4bae76..d6407e8 100644
+--- tox.ini.Orig
++++ tox.ini
+@@ -9,7 +9,6 @@ envlist =
+ isolated_build = True
+ 
+ requires =
+-    setuptools >= 41.4.0
+     # 2020-resolver
+     pip >= 2.20.3


### PR DESCRIPTION
See https://github.com/macports/macports-ports/commit/4431e1daa68df015c621a0d4f9f0c2e0205bb49f

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
