### PR TITLE
glab: update to 1.24.1

### DIFF
--- a/devel/glab/Portfile
+++ b/devel/glab/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/cli 1.23.1 v
+go.setup            gitlab.com/gitlab-org/cli 1.24.1 v
 name                glab
 revision            0
 categories          devel
@@ -16,9 +16,9 @@ long_description    ${name} is an open source GitLab CLI tool \
                     you are already working with git and your code.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  73374c19320c259ef2dead914d83673f33e6c31c \
-                        sha256  251f457f4e9990be4d2c991fa9fc427802695f463a8d5883b9b22f9adeca8438 \
-                        size    16627859
+                        rmd160  6d157932c8c98101a38c8ec7f114b2ed91dced50 \
+                        sha256  219461c1583f7ee7ecc30537e2b8e79e289de5c4d484c21fe8b268e3352b702b \
+                        size    16630772
 
 # If not set, it states that it's a developer build
 # Suppress build date for reproducible builds


### PR DESCRIPTION
Updating glab release to v1.24.0

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C5059b arm64
Command Line Tools 14.1.0.0.1.1666437224

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
