### PR TITLE
cppcheck: use newer gmake on Tiger, fix CXXFLAGS

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -61,6 +61,12 @@ build.args                  CXX="${configure.cxx} [get_canonical_archflags cxx]"
                             PREFIX=${prefix} \
                             PYTHON_INTERPRETER=${python_bin}
 
+# https://trac.macports.org/ticket/66418
+platform darwin 8 {
+    depends_build-append    port:gmake-apple
+    build.cmd               gmake-apple
+}
+
 test.run                    yes
 test.target                 test
 test.args                   {*}${build.args}

--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 
 github.setup                danmar cppcheck 2.9.3
-revision                    0
+revision                    1
 
 categories                  devel
 license                     GPL-3

--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -38,9 +38,7 @@ depends_lib                 port:pcre \
                             port:py${python_version}-pygments
 
 post-patch {
-    reinplace -W ${worksrcpath} "/CXXFLAGS/s/-O2/${configure.cxxflags}/" Makefile
     reinplace -W ${worksrcpath} "s|#!/usr/bin/env python|#!${python_bin}|" htmlreport/cppcheck-htmlreport
-
 }
 
 compiler.cxx_standard       2011
@@ -53,7 +51,7 @@ variant universal {}
 set sharedir                ${prefix}/share/${name}
 
 build.target                all man
-build.args                  CXX="${configure.cxx} [get_canonical_archflags cxx]" \
+build.args                  CXX="${configure.cxx} [get_canonical_archflags cxx] ${configure.cxxflags}" \
                             DB2MAN=${prefix}/share/xsl/docbook-xsl-nons/manpages/docbook.xsl \
                             FILESDIR=${sharedir} \
                             HAVE_RULES=yes \


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/66418

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
