### PR TITLE
kerberos5: Restore compatibility with libressl

### DIFF
--- a/net/kerberos5/Portfile
+++ b/net/kerberos5/Portfile
@@ -5,7 +5,7 @@ PortGroup                   compiler_blacklist_versions 1.0
 
 name                        kerberos5
 version                     1.20.1
-revision                    0
+revision                    1
 checksums                   rmd160  fc9dcb34199c566bc650876266cb06cbef5315cc \
                             sha256  704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851 \
                             size    8661660
@@ -46,6 +46,7 @@ worksrcdir                  ${worksrcdir}/src
 patchfiles                  patch-util__verto__Makefile.in-use-nonzero-compat-version.diff \
                             patch-config__shlib.conf-do-not-pass-dylib-file-ldflags.diff \
                             patch-lib_rpc_Makefile.in-explicitly-link-krb5support.diff \
+                            patch-libressl-compat.diff \
                             no-Werror.patch
 
 use_autoreconf              yes

--- a/net/kerberos5/files/patch-libressl-compat.diff
+++ b/net/kerberos5/files/patch-libressl-compat.diff
@@ -1,0 +1,48 @@
+# This patch file copied verbatim from FreeBSD Ports [1] and renamed
+# to match MacPorts guidelines.
+#
+# [1] https://github.com/freebsd/freebsd-ports/blob/main/security/krb5-120/files/patch-plugins_preauth_pkinit_pkinit__crypto__openssl.c
+#
+--- plugins/preauth/pkinit/pkinit_crypto_openssl.c.orig	2022-10-17 09:52:43 UTC
++++ plugins/preauth/pkinit/pkinit_crypto_openssl.c
+@@ -184,6 +184,17 @@ pkcs11err(int err);
+     (*_x509_pp) = PKCS7_cert_from_signer_info(_p7,_si)
+ #endif
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++
++/*
++ * 1.1 adds DHX support, which uses the RFC 3279 DomainParameters encoding we
++ * need for PKINIT.  For 1.0 we must use the original DH type when creating
++ * EVP_PKEY objects.
++ */
++#define EVP_PKEY_DHX EVP_PKEY_DH
++#define d2i_DHxparams d2i_DHparams
++#endif
++
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 
+ /* 1.1 standardizes constructor and destructor names, renaming
+@@ -193,13 +204,6 @@ pkcs11err(int err);
+ #define EVP_MD_CTX_free EVP_MD_CTX_destroy
+ #define ASN1_STRING_get0_data ASN1_STRING_data
+ 
+-/*
+- * 1.1 adds DHX support, which uses the RFC 3279 DomainParameters encoding we
+- * need for PKINIT.  For 1.0 we must use the original DH type when creating
+- * EVP_PKEY objects.
+- */
+-#define EVP_PKEY_DHX EVP_PKEY_DH
+-
+ /* 1.1 makes many handle types opaque and adds accessors.  Add compatibility
+  * versions of the new accessors we use for pre-1.1. */
+ 
+@@ -588,7 +592,7 @@ set_padded_derivation(EVP_PKEY_CTX *ctx)
+ {
+     EVP_PKEY_CTX_set_dh_pad(ctx, 1);
+ }
+-#elif OPENSSL_VERSION_NUMBER >= 0x10100000L
++#elif OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ static void
+ set_padded_derivation(EVP_PKEY_CTX *ctx)
+ {


### PR DESCRIPTION
FreeBSD maintains patches for kerberos, including compatibility with
libressl.  The patch file included here is based on FreeBSD's patch
file, was simplified, and added another code patch.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
The kerberos developers are not against libressl, but they do not
spend effort towards compatibility with libressl.  However, FreeBSD's
ports project maintains a kerberos port which includes a patch for
libressl compatibility.  I had to make two adjustments to the patch
file in order to build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.9.5 13F1911 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
