### PR TITLE
gopass: update to 1.15.0

### DIFF
--- a/devel/gopass-summon-provider/Portfile
+++ b/devel/gopass-summon-provider/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-summon-provider 1.14.11 v
+go.setup            github.com/gopasspw/gopass-summon-provider 1.15.0 v
 revision            0
 categories          devel
 maintainers         {@0x1DA117 danieltrautmann.com:me} openmaintainer
@@ -33,9 +33,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  2ee643a62e164b44c1e136e8c384f592fd8bf767 \
-                        sha256  955958dec7334571d4a3550e40308194e9a1978f365452f544ffeed9126376da \
-                        size    17479
+                        rmd160  a00e55a61eab806652afb8ec29ab218774ada156 \
+                        sha256  edf1a9a74b3ccb6e958922225c6999a31f2dddff52e18b1fe0be1b051e08c54d \
+                        size    17556
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -69,10 +69,10 @@ go.vendors          gotest.tools \
                         sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
                         size    1243767 \
                     golang.org/x/exp \
-                        lock    850992195362 \
-                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
-                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
-                        size    1605708 \
+                        lock    6ab00d035af9 \
+                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
+                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
+                        size    1606053 \
                     golang.org/x/crypto \
                         lock    v0.3.0 \
                         rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
@@ -236,10 +236,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.11 \
-                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
-                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
-                        size    2255917 \
+                        lock    v1.15.0 \
+                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
+                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
+                        size    2270837 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \

--- a/security/git-credential-gopass/Portfile
+++ b/security/git-credential-gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/git-credential-gopass 1.14.11 v
+go.setup            github.com/gopasspw/git-credential-gopass 1.15.0 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  7e783b0eb859b8f50bcc78e66c0b24335169c644 \
-                        sha256  9f8d897b25f9c61fb1c62366efc486fc5a48e31c88faed223d3cad69ff01681c \
-                        size    20716
+                        rmd160  5774d2cc8cd360cbf70a8862200687e20dc2d5a1 \
+                        sha256  f532f792c70d5ee3e8bbb380dd123c7ba146fd5a18102658a3e231a48682be54 \
+                        size    20790
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -50,10 +50,10 @@ go.vendors          gotest.tools \
                         sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
                         size    1243767 \
                     golang.org/x/exp \
-                        lock    850992195362 \
-                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
-                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
-                        size    1605708 \
+                        lock    6ab00d035af9 \
+                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
+                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
+                        size    1606053 \
                     golang.org/x/crypto \
                         lock    v0.3.0 \
                         rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
@@ -217,10 +217,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.11 \
-                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
-                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
-                        size    2255917 \
+                        lock    v1.15.0 \
+                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
+                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
+                        size    2270837 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \

--- a/security/gopass-hibp/Portfile
+++ b/security/gopass-hibp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-hibp 1.14.11 v
+go.setup            github.com/gopasspw/gopass-hibp 1.15.0 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    ${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  45ee724b0ac24554e1362731d497324699c0836f \
-                        sha256  23d8553e50dacfdf2da4ecdf1f20d76cc1c7aebef3ae39db8781332899912e25 \
-                        size    23296
+                        rmd160  f198adddc939a83da9551985ec25cc8984b5e26a \
+                        sha256  de72f49cba331ddc0107326e356ee9e4704247420f86e33cfc5bb60a9b630a78 \
+                        size    23398
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -50,10 +50,10 @@ go.vendors          gotest.tools \
                         sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
                         size    1243767 \
                     golang.org/x/exp \
-                        lock    850992195362 \
-                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
-                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
-                        size    1605708 \
+                        lock    6ab00d035af9 \
+                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
+                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
+                        size    1606053 \
                     golang.org/x/crypto \
                         lock    v0.3.0 \
                         rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
@@ -222,10 +222,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.11 \
-                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
-                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
-                        size    2255917 \
+                        lock    v1.15.0 \
+                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
+                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
+                        size    2270837 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \

--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.14.11 v
+go.setup            github.com/gopasspw/gopass-jsonapi 1.15.0 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  920c02f351267df2761f86842fa8f32bdb51829d \
-                        sha256  c158c2a5bcc939bd8f2b4b27bc66c729e484cbe5e1279c1b39c443e9011a34fc \
-                        size    31592
+                        rmd160  d22583885272e60ee6cb6bc58bb7d3befbae108c \
+                        sha256  0853005ac1d43299e74288ee78f2f1f0ac456ff7df412ccb42acbcbb11ca11c2 \
+                        size    31737
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -50,10 +50,10 @@ go.vendors          gotest.tools \
                         sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
                         size    1243767 \
                     golang.org/x/exp \
-                        lock    850992195362 \
-                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
-                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
-                        size    1605708 \
+                        lock    6ab00d035af9 \
+                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
+                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
+                        size    1606053 \
                     golang.org/x/crypto \
                         lock    v0.3.0 \
                         rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
@@ -217,10 +217,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.14.11 \
-                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
-                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
-                        size    2255917 \
+                        lock    v1.15.0 \
+                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
+                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
+                        size    2270837 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \

--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.14.11 v
+go.setup            github.com/gopasspw/gopass 1.15.0 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  657f3cb1a47e21e5b29081e52646b346ee76be65 \
-                        sha256  62ce1058090bd1b1b1ccfc1c0f5f43de55cffbe5ecb283d4b058f76add557643 \
-                        size    2255917
+                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
+                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
+                        size    2270837
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -75,10 +75,10 @@ go.vendors          rsc.io/qr \
                         sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
                         size    1243767 \
                     golang.org/x/exp \
-                        lock    850992195362 \
-                        rmd160  57bf877946a29419867f43b26288ed9e0eead179 \
-                        sha256  7d63d1407b80dd41dd69ab033b54cc9150e836f217a04f4fde8beddac04fbc8d \
-                        size    1605708 \
+                        lock    6ab00d035af9 \
+                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
+                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
+                        size    1606053 \
                     golang.org/x/crypto \
                         lock    v0.3.0 \
                         rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
@@ -181,11 +181,6 @@ go.vendors          rsc.io/qr \
                         rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
                         sha256  8e158a59a9b7e407b27a4cf6100f33648b7c8bffb4ac07bd074f43d4796afa87 \
                         size    7631 \
-                    github.com/mitchellh/go-homedir \
-                        lock    v1.1.0 \
-                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
-                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
-                        size    3366 \
                     github.com/mattn/go-tty \
                         lock    v0.0.4 \
                         rmd160  aeef24ae0b469f8a83cd43f40843ba3dc58f057d \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.4
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
