### PR TITLE
ecgen: fix build on old macOS

### DIFF
--- a/math/ecgen/files/old-macos.patch
+++ b/math/ecgen/files/old-macos.patch
@@ -1,18 +1,16 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index 04d8f36..45fb667 100644
+index 04d8f36..3ab997e 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -23,7 +23,12 @@ if (APPLE)
+@@ -21,9 +21,10 @@ set(PLATFORM_SPECIFIC_LIBS)
+ if (APPLE)
+   find_library(LIB_ARGP argp)
  
++  find_library(LIB_POSIX_MACOS_TIME posix-macos-time)
    find_library(LIB_POSIX_MACOS_TIMER posix-macos-timer)
  
 -  set(PLATFORM_SPECIFIC_LIBS ${LIB_ARGP} ${LIB_POSIX_MACOS_TIMER})
-+  set(PLATFORM_SPECIFIC_LIBS ${LIB_ARGP} ${LIB_POSIX_MACOS_TIME})
-+
-+  if(APPLE AND (CMAKE_OSX_DEPLOYMENT_TARGET GREATER_EQUAL 10.7))
-+    find_library(LIB_POSIX_MACOS_TIME posix-macos-time)
-+    set(PLATFORM_SPECIFIC_LIBS ${PLATFORM_SPECIFIC_LIBS} ${LIB_POSIX_MACOS_TIMER})
-+  endif()
++  set(PLATFORM_SPECIFIC_LIBS ${LIB_ARGP} ${LIB_POSIX_MACOS_TIME} ${LIB_POSIX_MACOS_TIMER})
  else ()
    set(PLATFORM_SPECIFIC_LIBS rt)
  endif()


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->