### PR TITLE
nheko: Depend on mtxclient, cmark, olm at runtime

### DIFF
--- a/net/nheko/Portfile
+++ b/net/nheko/Portfile
@@ -7,7 +7,7 @@ PortGroup           qt5 1.0
 PortGroup           boost 1.0
 
 github.setup        nheko-reborn nheko 0.10.2 v
-revision            0
+revision            1
 categories          net chat
 platforms           darwin
 license             GPL-3
@@ -35,19 +35,21 @@ if {(${os.major} < 16)} {
 configure.cppflags-append -I${prefix}/include/lmdbxx-cxx17
 configure.cxxflags-append -fno-sized-deallocation
 
-depends_build-append port:cmark \
+depends_build-append \
                     port:lmdbxx-cxx17 \
-                    port:mtxclient \
-                    port:olm \
                     port:tweeny
 
-depends_lib-append  port:coeurl \
+depends_lib-append  \
+                    port:cmark \
+                    port:coeurl \
                     port:fontconfig \
                     port:libsodium \
                     port:lmdb \
+                    port:mtxclient \
                     port:nlohmann-json \
-                    port:spdlog \
-                    port:qtkeychain-qt5
+                    port:olm \
+                    port:qtkeychain-qt5 \
+                    port:spdlog
 
 qt5.depends_component \
                     qtmacextras \


### PR DESCRIPTION
#### Description

nheko links against libmatrix_cilent, libcmark and libolm, so it needs library dependencies on those, or nheko will fail to start after uninstalling leaves.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
