### PR TITLE
py-pymongoengine: Update to 0.24.2, add modern python, drop old python

### DIFF
--- a/python/py-mongoengine/Portfile
+++ b/python/py-mongoengine/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        MongoEngine mongoengine 0.18.2 v
+github.setup        MongoEngine mongoengine 0.24.2 v
 name                py-mongoengine
 revision            0
 
 license             MIT
-maintainers         {cal @neverpanic} openmaintainer
+maintainers         nomaintainer
 platforms           {darwin any}
 supported_archs     noarch
 
@@ -21,11 +21,12 @@ long_description    \
 
 homepage            http://mongoengine.org/
 
-checksums           rmd160  3d6c8844be5b295611d1c29849f78f2e86bb4df8 \
-                    sha256  db23d3f1242de90ee637f8aac4463a62b1afc0922e5428490e51b8a5eb0d8ead \
-                    size    306001
+checksums           rmd160  3d2d801ead380fa52a5ebfe1d6483b1de1f6825f \
+                    sha256  39f9f069964b9e51bf0041fc02e541cdc60ec9b82f3a528a08a1956cf22d9daf \
+                    size    328277
 
-python.versions     27 35 36
+python.versions     37 38 39 310 311
+python.pep517       yes
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Also drop maintainership, I no longer use this.

Closes: https://trac.macports.org/ticket/66445

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 arm64
Xcode 13.4.1 13F100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
