### PR TITLE
x265: enable HDR10+ parsing

### DIFF
--- a/multimedia/x265/Portfile
+++ b/multimedia/x265/Portfile
@@ -52,6 +52,7 @@ platform darwin 10 {
     # Rosetta build has to override CMAKE_SYSTEM_PROCESSOR: https://trac.macports.org/ticket/64528
     if {${build_arch} eq "ppc"} {
         configure.args-append -DOVERRIDE_SYSTEM_PROCESSOR="ppc"
+        configure.args-append -DENABLE_HDR10_PLUS=On
     }
 }
 
@@ -99,15 +100,15 @@ variant highdepth conflicts universal description {Enable 10-bit and 12-bit enco
     configure {
 
         set configure.dir ${workpath}/10bit
-        configure.args -DHIGH_BIT_DEPTH=ON -DEXPORT_C_API=OFF -DENABLE_SHARED=OFF -DENABLE_CLI=OFF
+        configure.args -DENABLE_HDR10_PLUS=ON -DHIGH_BIT_DEPTH=ON -DEXPORT_C_API=OFF -DENABLE_SHARED=OFF -DENABLE_CLI=OFF
         portconfigure::configure_main
 
         set configure.dir ${workpath}/12bit
-        configure.args -DHIGH_BIT_DEPTH=ON -DEXPORT_C_API=OFF -DENABLE_SHARED=OFF -DENABLE_CLI=OFF -DMAIN12=ON
+        configure.args -DENABLE_HDR10_PLUS=ON -DHIGH_BIT_DEPTH=ON -DEXPORT_C_API=OFF -DENABLE_SHARED=OFF -DENABLE_CLI=OFF -DMAIN12=ON
         portconfigure::configure_main
 
         set configure.dir ${workpath}/build
-        configure.args -DEXTRA_LIB="x265_main10.a\;x265_main12.a" -DEXTRA_LINK_FLAGS=-L. -DLINKED_10BIT=ON -DLINKED_12BIT=ON
+        configure.args -DENABLE_HDR10_PLUS=ON -DEXTRA_LIB="x265_main10.a\;x265_main12.a" -DEXTRA_LINK_FLAGS=-L. -DLINKED_10BIT=ON -DLINKED_12BIT=ON
         portconfigure::configure_main
 
     }

--- a/multimedia/x265/Portfile
+++ b/multimedia/x265/Portfile
@@ -52,7 +52,6 @@ platform darwin 10 {
     # Rosetta build has to override CMAKE_SYSTEM_PROCESSOR: https://trac.macports.org/ticket/64528
     if {${build_arch} eq "ppc"} {
         configure.args-append -DOVERRIDE_SYSTEM_PROCESSOR="ppc"
-        configure.args-append -DENABLE_HDR10_PLUS=On
     }
 }
 

--- a/multimedia/x265/Portfile
+++ b/multimedia/x265/Portfile
@@ -13,7 +13,7 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 9
 
 github.setup        videolan x265 3.4
-revision            0
+revision            1
 
 checksums           rmd160  e614c4a03134a67e79efe8d3dd64d54c3990b99a \
                     sha256  544d147bf146f8994a7bf8521ed878c93067ea1c7c6e93ab602389be3117eaaf \


### PR DESCRIPTION
x265: enable HDR10+

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Allow HDR10+ parsing and usage of json files

Handle request from ticket:
https://trac.macports.org/ticket/66455

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
