### PR TITLE
gcc10-bootstrap: backport preliminary support of Ventura

### DIFF
--- a/lang/gcc10-bootstrap/Portfile
+++ b/lang/gcc10-bootstrap/Portfile
@@ -110,6 +110,9 @@ patchfiles-append patch-xcode12-fix.diff
 # Backport additional patches for support darwin8
 patchfiles-append patch-darwin8.diff
 
+# Backport preliminary Darwin 22 support to GCC 10
+patchfiles-append patch-darwin22.diff
+
 # Skip bootstrap comparison entirely
 post-patch {
     reinplace {s|^do-compare =|do-compare = /usr/bin/true|g} \

--- a/lang/gcc10-bootstrap/files/patch-darwin22.diff
+++ b/lang/gcc10-bootstrap/files/patch-darwin22.diff
@@ -1,0 +1,365 @@
+From 90f9ae82ae5b948b2bb12296181c84d575252a0f Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Fri, 10 Jun 2022 15:56:42 +0100
+Subject: [PATCH 1/3] Darwin: Future-proof -mmacosx-version-min
+
+f18cbc1ee1f4 (2021-12-18) updated various parts of gcc to not impose a
+Darwin or macOS version maximum of the current known release. Different
+parts of gcc accept, variously, Darwin version numbers matching
+darwin2*, and macOS major version numbers up to 99. The current released
+version is Darwin 21 and macOS 12, with Darwin 22 and macOS 13 expected
+for public release later this year. With one major OS release per year,
+this strategy is expected to provide another 8 years of headroom.
+
+However, f18cbc1ee1f4 missed config/darwin-c.c (now .cc), which
+continued to impose a maximum of macOS 12 on the -mmacosx-version-min
+compiler driver argument. This was last updated from 11 to 12 in
+11b967577483 (2021-10-27), but kicking the can down the road one year at
+a time is not a viable strategy, and is not in line with the more recent
+technique from f18cbc1ee1f4.
+
+Prior to 556ab5125912 (2020-11-06), config/darwin-c.c did not impose a
+maximum that needed annual maintenance, as at that point, all macOS
+releases had used a major version of 10. The stricter approach imposed
+since then was valuable for a time until the particulars of the new
+versioning scheme were established and understood, but now that they
+are, it's prudent to restore a more permissive approach.
+
+gcc/ChangeLog:
+
+	* config/darwin-c.cc: Make -mmacosx-version-min more future-proof.
+
+Signed-off-by: Mark Mentovai <mark@mentovai.com>
+(cherry picked from commit 6725f186cb70d48338f69456864bf469a12ee5be)
+---
+ gcc/config/darwin-c.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git gcc/config/darwin-c.c gcc/config/darwin-c.c
+index 3c2afe56522..0f746e933c1 100644
+--- gcc/config/darwin-c.c
++++ gcc/config/darwin-c.c
+@@ -691,7 +691,8 @@ macosx_version_as_macro (void)
+   if (!version_array)
+     goto fail;
+ 
+-  if (version_array[MAJOR] < 10 || version_array[MAJOR] > 12)
++  /* System tools accept up to 99 as a major version.  */
++  if (version_array[MAJOR] < 10 || version_array[MAJOR] > 99)
+     goto fail;
+ 
+   if (version_array[MAJOR] == 10 && version_array[MINOR] < 10)
+-- 
+2.38.2
+
+
+From 4595a90aa7ab440c5ff7434dde34929713e2d4a1 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Mon, 13 Jun 2022 16:40:19 +0100
+Subject: [PATCH 2/3] libstdc++: Rename __null_terminated to avoid collision
+ with Apple SDK
+
+The macOS 13 SDK (and equivalent-version iOS and other Apple OS SDKs)
+contain this definition in <sys/cdefs.h>:
+
+863  #define __null_terminated
+
+This collides with the use of __null_terminated in libstdc++'s
+experimental fs_path.h.
+
+As libstdc++'s use of this token is entirely internal to fs_path.h, the
+simplest workaround, renaming it, is most appropriate. Here, it's
+renamed to __nul_terminated, referencing the NUL ('\0') value that is
+used to terminate the strings in the context in which this tag structure
+is used.
+
+libstdc++-v3/ChangeLog:
+
+	* include/experimental/bits/fs_path.h (__detail::__null_terminated):
+	Rename to __nul_terminated to avoid colliding with a macro in
+	Apple's SDK.
+
+Signed-off-by: Mark Mentovai <mark@mentovai.com>
+(cherry picked from commit 254e88b3d7e8abcc236be3451609834371cf4d5d)
+---
+ libstdc++-v3/include/bits/fs_path.h              | 12 ++++++------
+ libstdc++-v3/include/experimental/bits/fs_path.h | 12 ++++++------
+ 2 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git libstdc++-v3/include/bits/fs_path.h libstdc++-v3/include/bits/fs_path.h
+index 0b9911e638a..83e944b0a30 100644
+--- libstdc++-v3/include/bits/fs_path.h
++++ libstdc++-v3/include/bits/fs_path.h
+@@ -130,10 +130,10 @@ namespace __detail
+     _Source
+     _S_range_begin(_Source __begin) { return __begin; }
+ 
+-  struct __null_terminated { };
++  struct __nul_terminated { };
+ 
+   template<typename _Source>
+-    __null_terminated
++    __nul_terminated
+     _S_range_end(_Source) { return {}; }
+ 
+   template<typename _CharT, typename _Traits, typename _Alloc>
+@@ -533,11 +533,11 @@ namespace __detail
+       struct _Cvt;
+ 
+     static basic_string_view<value_type>
+-    _S_convert(value_type* __src, __detail::__null_terminated)
++    _S_convert(value_type* __src, __detail::__nul_terminated)
+     { return __src; }
+ 
+     static basic_string_view<value_type>
+-    _S_convert(const value_type* __src, __detail::__null_terminated)
++    _S_convert(const value_type* __src, __detail::__nul_terminated)
+     { return __src; }
+ 
+     static basic_string_view<value_type>
+@@ -559,7 +559,7 @@ namespace __detail
+ 
+     template<typename _InputIterator>
+       static string_type
+-      _S_convert(_InputIterator __src, __detail::__null_terminated)
++      _S_convert(_InputIterator __src, __detail::__nul_terminated)
+       {
+ 	// Read from iterator into basic_string until a null value is seen:
+ 	auto __s = _S_string_from_iter(__src);
+@@ -581,7 +581,7 @@ namespace __detail
+ 
+     template<typename _InputIterator>
+       static string_type
+-      _S_convert_loc(_InputIterator __src, __detail::__null_terminated,
++      _S_convert_loc(_InputIterator __src, __detail::__nul_terminated,
+ 		     const std::locale& __loc)
+       {
+ 	const std::string __s = _S_string_from_iter(__src);
+diff --git libstdc++-v3/include/experimental/bits/fs_path.h libstdc++-v3/include/experimental/bits/fs_path.h
+index 69b823a3466..7c1bb239e66 100644
+--- libstdc++-v3/include/experimental/bits/fs_path.h
++++ libstdc++-v3/include/experimental/bits/fs_path.h
+@@ -140,10 +140,10 @@ namespace __detail
+     inline _Source
+     _S_range_begin(_Source __begin) { return __begin; }
+ 
+-  struct __null_terminated { };
++  struct __nul_terminated { };
+ 
+   template<typename _Source>
+-    inline __null_terminated
++    inline __nul_terminated
+     _S_range_end(_Source) { return {}; }
+ 
+   template<typename _CharT, typename _Traits, typename _Alloc>
+@@ -467,11 +467,11 @@ namespace __detail
+       struct _Cvt;
+ 
+     static string_type
+-    _S_convert(value_type* __src, __detail::__null_terminated)
++    _S_convert(value_type* __src, __detail::__nul_terminated)
+     { return string_type(__src); }
+ 
+     static string_type
+-    _S_convert(const value_type* __src, __detail::__null_terminated)
++    _S_convert(const value_type* __src, __detail::__nul_terminated)
+     { return string_type(__src); }
+ 
+     template<typename _Iter>
+@@ -485,7 +485,7 @@ namespace __detail
+ 
+     template<typename _InputIterator>
+       static string_type
+-      _S_convert(_InputIterator __src, __detail::__null_terminated)
++      _S_convert(_InputIterator __src, __detail::__nul_terminated)
+       {
+ 	auto __s = _S_string_from_iter(__src);
+ 	return _S_convert(__s.c_str(), __s.c_str() + __s.size());
+@@ -505,7 +505,7 @@ namespace __detail
+ 
+     template<typename _InputIterator>
+       static string_type
+-      _S_convert_loc(_InputIterator __src, __detail::__null_terminated,
++      _S_convert_loc(_InputIterator __src, __detail::__nul_terminated,
+ 		     const std::locale& __loc)
+       {
+ 	const std::string __s = _S_string_from_iter(__src);
+-- 
+2.38.2
+
+
+From e3b0f417b5dbcf5fb3696f5f37fc756528cfa99c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fran=C3=A7ois-Xavier=20Coudert?= <fxcoudert@gcc.gnu.org>
+Date: Fri, 17 Dec 2021 19:30:36 +0100
+Subject: [PATCH 3/3] Darwin: Future-proof and homogeneize detection of darwin
+ versions
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The current GCC branch will become 12.1.0, which will be the stable
+version of GCC when the next macOS version is released. There are some
+places in GCC that don’t handle darwin22 as a version, so we need to
+future-proof it (gcc/config.gcc and gcc/config/darwin-driver.c). We
+align that code with what Apple clang does, i.e. accept all potential
+major macOS versions until 99.
+
+This patch also homogenises the handling of darwin version numbers,
+where the majority of places use darwin2*, but some used darwin2[0-9]*.
+Since there never was a darwin2.x version, the two are equivalent, and
+we prefer the simpler darwin2*
+
+gcc/ChangeLog:
+
+	* config/darwin-driver.c: Make version code more future-proof.
+	* config.gcc: Homogeneize darwin versions.
+	* configure.ac: Homogeneize darwin versions.
+	* configure: Regenerate.
+
+gcc/testsuite/ChangeLog:
+
+	* gcc.dg/darwin-minversion-link.c: Test darwin21.
+	* obj-c++.dg/cxx-ivars-3.mm: Homogeneize darwin versions.
+	* obj-c++.dg/objc-gc-3.mm: Homogeneize darwin versions.
+	* objc.dg/objc-gc-4.m: Homogeneize darwin versions.
+
+(cherry picked from commit f18cbc1ee1f421a0dd79dc389bef9a23dd4a761d)
+---
+ gcc/config.gcc                                | 4 ++--
+ gcc/config/darwin-driver.c                    | 6 +++---
+ gcc/configure                                 | 2 +-
+ gcc/configure.ac                              | 2 +-
+ gcc/testsuite/gcc.dg/darwin-minversion-link.c | 3 ++-
+ gcc/testsuite/obj-c++.dg/cxx-ivars-3.mm       | 2 +-
+ gcc/testsuite/obj-c++.dg/objc-gc-3.mm         | 2 +-
+ gcc/testsuite/objc.dg/objc-gc-4.m             | 2 +-
+ 8 files changed, 12 insertions(+), 11 deletions(-)
+
+diff --git gcc/config.gcc gcc/config.gcc
+index 853ce7cc663..d5155c9d952 100644
+--- gcc/config.gcc
++++ gcc/config.gcc
+@@ -1874,7 +1874,7 @@ hppa[12]*-*-hpux11*)
+ 		dwarf2=no
+ 	fi
+ 	;;
+-i[34567]86-*-darwin1[89]*)
++i[34567]86-*-darwin1[89]* | i[34567]86-*-darwin2*)
+ 	echo "Error: 32bit target is not supported after Darwin17" 1>&2
+ 	;;
+ i[34567]86-*-darwin*)
+@@ -1884,7 +1884,7 @@ i[34567]86-*-darwin*)
+ 	tmake_file="${tmake_file} ${cpu_type}/t-darwin32-biarch t-slibgcc"
+ 	tm_file="${tm_file} ${cpu_type}/darwin32-biarch.h"
+ 	;;
+-x86_64-*-darwin1[89]* | x86_64-*-darwin2[01]*)
++x86_64-*-darwin1[89]* | x86_64-*-darwin2*)
+ 	# Only 64b from now
+ 	with_cpu=${with_cpu:-core2}
+ 	tmake_file="${tmake_file} t-slibgcc"
+diff --git gcc/config/darwin-driver.c gcc/config/darwin-driver.c
+index 8876be6e0dc..8455287c162 100644
+--- gcc/config/darwin-driver.c
++++ gcc/config/darwin-driver.c
+@@ -64,7 +64,8 @@ validate_macosx_version_min (const char *version_str)
+ 
+   major = strtoul (version_str, &end, 10);
+ 
+-  if (major < 10 || major > 12 ) /* macOS 10, 11, and 12 are known. */
++  /* macOS 10, 11, and 12 are known. clang accepts up to 99.  */
++  if (major < 10 || major > 99)
+     return NULL;
+ 
+   /* Skip a separating period, if there's one.  */
+@@ -160,8 +161,7 @@ darwin_find_version_from_kernel (void)
+ 
+   /* Darwin20 sees a transition to macOS 11.  In this, it seems that the
+      mapping to macOS minor version is now shifted to the kernel minor
+-     version - 1 (at least for the initial releases).  At this stage, we
+-     don't know what macOS version will correspond to Darwin21.  */
++     version - 1 (at least for the initial releases).  */
+   if (major_vers >= 20)
+     {
+       int minor_vers = *version_p++ - '0';
+diff --git gcc/configure gcc/configure
+index 82850dd7a53..0a0fa9e3a2c 100755
+--- gcc/configure
++++ gcc/configure
+@@ -26700,7 +26700,7 @@ $as_echo "$as_me: WARNING: LTO for $target requires binutils >= 2.20.1, but vers
+ 	;;
+     esac
+     case $target_os in
+-       darwin2[0-9]* | darwin19*)
++       darwin2* | darwin19*)
+         { $as_echo "$as_me:${as_lineno-$LINENO}: checking assembler for llvm assembler x86-pad-for-align option" >&5
+ $as_echo_n "checking assembler for llvm assembler x86-pad-for-align option... " >&6; }
+ if ${gcc_cv_as_mllvm_x86_pad_for_align+:} false; then :
+diff --git gcc/configure.ac gcc/configure.ac
+index 5bea862a70a..f39d8de7da1 100644
+--- gcc/configure.ac
++++ gcc/configure.ac
+@@ -4623,7 +4623,7 @@ foo:	nop
+ 	;;
+     esac
+     case $target_os in
+-       darwin2[[0-9]]* | darwin19*)
++       darwin2* | darwin19*)
+         gcc_GAS_CHECK_FEATURE([llvm assembler x86-pad-for-align option],
+           gcc_cv_as_mllvm_x86_pad_for_align,,
+           [-mllvm -x86-pad-for-align=false], [.text],,
+diff --git gcc/testsuite/gcc.dg/darwin-minversion-link.c gcc/testsuite/gcc.dg/darwin-minversion-link.c
+index 765fb799a91..b6ede31c985 100644
+--- gcc/testsuite/gcc.dg/darwin-minversion-link.c
++++ gcc/testsuite/gcc.dg/darwin-minversion-link.c
+@@ -15,7 +15,8 @@
+ /* { dg-additional-options "-mmacosx-version-min=010.013.06 -DCHECK=101306" { target *-*-darwin17* } } */
+ /* { dg-additional-options "-mmacosx-version-min=010.014.05 -DCHECK=101405" { target *-*-darwin18* } } */
+ /* { dg-additional-options "-mmacosx-version-min=010.015.06 -DCHECK=101506" { target *-*-darwin19* } } */
+-/* { dg-additional-options "-mmacosx-version-min=011.000.00 -DCHECK=110000" { target *-*-darwin20 } } */
++/* { dg-additional-options "-mmacosx-version-min=011.000.00 -DCHECK=110000" { target *-*-darwin20* } } */
++/* { dg-additional-options "-mmacosx-version-min=012.000.00 -DCHECK=120000" { target *-*-darwin21* } } */
+ 
+ int
+ main ()
+diff --git gcc/testsuite/obj-c++.dg/cxx-ivars-3.mm gcc/testsuite/obj-c++.dg/cxx-ivars-3.mm
+index 07123559d72..27bae630ce8 100644
+--- gcc/testsuite/obj-c++.dg/cxx-ivars-3.mm
++++ gcc/testsuite/obj-c++.dg/cxx-ivars-3.mm
+@@ -2,7 +2,7 @@
+ 
+ // { dg-do run { target *-*-darwin* } }
+ // { dg-skip-if "" { *-*-* } { "-fgnu-runtime" } { "" } }
+-// { dg-skip-if "Headers incompatible with 10.4 APIs" { *-*-darwin1[1-9]* *-*-darwin2[0-9]* } { "-fnext-runtime" } { "" } }
++// { dg-skip-if "Headers incompatible with 10.4 APIs" { *-*-darwin1[1-9]* *-*-darwin2* } { "-fnext-runtime" } { "" } }
+ // { dg-additional-options "-fobjc-call-cxx-cdtors -mmacosx-version-min=10.4 -framework Foundation" }
+ // This test has no equivalent or meaning for m64/ABI V2
+ // { dg-xfail-run-if "No Test Avail" {  *-*-darwin* && lp64 } { "-fnext-runtime" } { "" } }
+diff --git gcc/testsuite/obj-c++.dg/objc-gc-3.mm gcc/testsuite/obj-c++.dg/objc-gc-3.mm
+index 45ffbc5553d..18f2cbe8869 100644
+--- gcc/testsuite/obj-c++.dg/objc-gc-3.mm
++++ gcc/testsuite/obj-c++.dg/objc-gc-3.mm
+@@ -3,7 +3,7 @@
+ /* Contributed by Ziemowit Laski <zlaski@apple.com>  */
+ 
+ /* { dg-do compile } */
+-/* { dg-skip-if "GC API is an error from Darwin16." { *-*-darwin1[6-9]* *-*-darwin2[0-9]* } { "-fnext-runtime" } { "" } } */
++/* { dg-skip-if "GC API is an error from Darwin16." { *-*-darwin1[6-9]* *-*-darwin2* } { "-fnext-runtime" } { "" } } */
+ /* { dg-options "-fobjc-gc" } */
+ /* { dg-prune-output "cc1objplus: warning: '-fobjc-gc' is ignored for '-fgnu-runtime'" } */
+ 
+diff --git gcc/testsuite/objc.dg/objc-gc-4.m gcc/testsuite/objc.dg/objc-gc-4.m
+index 8102a5a532f..1b2d9674969 100644
+--- gcc/testsuite/objc.dg/objc-gc-4.m
++++ gcc/testsuite/objc.dg/objc-gc-4.m
+@@ -3,7 +3,7 @@
+ /* Contributed by Ziemowit Laski <zlaski@apple.com>  */
+ 
+ /* { dg-do compile } */
+-/* { dg-skip-if "GC API is an error from Darwin16." { *-*-darwin1[6-9]* *-*-darwin2[0-9]* } { "-fnext-runtime" } { "" } } */
++/* { dg-skip-if "GC API is an error from Darwin16." { *-*-darwin1[6-9]* *-*-darwin2* } { "-fnext-runtime" } { "" } } */
+ /* { dg-options "-fobjc-gc" } */
+ /* { dg-prune-output "cc1obj: warning: '-fobjc-gc' is ignored for '-fgnu-runtime'" } */
+ 
+-- 
+2.38.2
+


### PR DESCRIPTION
#### Description

This fixes build of gcc10-bootstrap on Ventura. Near the same patch is required for gcc10: https://github.com/catap/macports-ports/commit/ae2f6b1e0c3f3f2c4133f2fb99d57518d786fc98 , but libgcc12 is failed on Ventura on both arm64 and x86_64 => I can't test it.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 x86_64
Xcode 14.1 14B47b

macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->