### PR TITLE
openssl3: Backport patch for CVE-2022-3996

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 8
 set major_v         3
 name                openssl$major_v
 version             ${major_v}.0.7
-revision            0
+revision            1
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)
@@ -59,6 +59,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 
 set my_name         openssl-${major_v}
 set my_prefix       ${prefix}/libexec/${name}
+
+patchfiles          7725e7bfe6f2ce8146b6552b44e0d226be7638e7.patch
 
 #-----------------------------------------------------------------------------------------
 # Fix compilation errors related to AVX-512 instruction set, occurring with Xcode Clang.

--- a/devel/openssl3/files/7725e7bfe6f2ce8146b6552b44e0d226be7638e7.patch
+++ b/devel/openssl3/files/7725e7bfe6f2ce8146b6552b44e0d226be7638e7.patch
@@ -1,0 +1,36 @@
+From 7725e7bfe6f2ce8146b6552b44e0d226be7638e7 Mon Sep 17 00:00:00 2001
+From: Pauli <pauli@openssl.org>
+Date: Fri, 11 Nov 2022 09:40:19 +1100
+Subject: [PATCH] x509: fix double locking problem
+
+This reverts commit 9aa4be691f5c73eb3c68606d824c104550c053f7 and removed the
+redundant flag setting.
+
+Fixes #19643
+
+Fixes LOW CVE-2022-3996
+
+Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/19652)
+
+(cherry picked from commit 4d0340a6d2f327700a059f0b8f954d6160f8eef5)
+---
+ crypto/x509/pcy_map.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/crypto/x509/pcy_map.c b/crypto/x509/pcy_map.c
+index 05406c6493fc..60dfd1e3203b 100644
+--- ./crypto/x509/pcy_map.c
++++ ./crypto/x509/pcy_map.c
+@@ -73,10 +73,6 @@ int ossl_policy_cache_set_mapping(X509 *x, POLICY_MAPPINGS *maps)
+ 
+     ret = 1;
+  bad_mapping:
+-    if (ret == -1 && CRYPTO_THREAD_write_lock(x->lock)) {
+-        x->ex_flags |= EXFLAG_INVALID_POLICY;
+-        CRYPTO_THREAD_unlock(x->lock);
+-    }
+     sk_POLICY_MAPPING_pop_free(maps, POLICY_MAPPING_free);
+     return ret;
+ 


### PR DESCRIPTION
#### Description

This is a low severity CVE. The advisory is available at:

  https://www.openssl.org/news/secadv/20221213.txt

CVE: CVE-2022-3996

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
