### PR TITLE
google-cloud-sdk: update to 412.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             411.0.0
+version             412.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  78e5356f24c913bdb344089b6a7b39056bd9f971 \
-                    sha256  f2483dd4723c568692e521881b2b000781b55e70a43316f6395855763683c000 \
-                    size    110371474
+    checksums       rmd160  84cdfec6f1887a92db6eb61cc7e6d744285b33b0 \
+                    sha256  226e0adb212eb69070ad1c482af0f6583e8c1a8ef14c30238a0bb56eec01d109 \
+                    size    110533786
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ab4bc86dfa0481978e23c01467afe3db36c58543 \
-                    sha256  55fa02e3dfe291500b47a5cabe2cb6b6a5dcd7d53f78ff8a281495bc1f508629 \
-                    size    99341829
+    checksums       rmd160  2379b84d826d93430a7041589d45c113e4b1c115 \
+                    sha256  233aecd0ef927ee1aad285d2a8b4cb029df6d9143c91354c3f7a4ac800e5f29c \
+                    size    99504027
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  2939d16b73d0881749d99f55406910acf343a674 \
-                    sha256  4677875857c9348285fd206c3bd233415b063c8f80dfc8e823387584944af3e4 \
-                    size    97747502
+    checksums       rmd160  976f50c9ef93355a43586d163a301ca15c98ab7a \
+                    sha256  509f7fd522ef2ea36a3742e46e9586b86cbe7793f4b9467e3c967e71bdd36223 \
+                    size    97911731
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 412.0.0.

###### Tested on

macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?