### PR TITLE
py-{botocore,boto3,awscli}: Update to latest versions, add Python 3.11 and remove Python 3.8-3.9

### DIFF
--- a/python/py-allennlp/Portfile
+++ b/python/py-allennlp/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  acd8338381723cdddcb52136a5e70713529ea230 \
                     sha256  3fbd02e6261d04fe2221e44c48cc936dbcefc11704c37b746ef7b96b705c9caa \
                     size    2714266
 
-python.versions     38 39
+python.versions     39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-aws-sam-translator/Portfile
+++ b/python/py-aws-sam-translator/Portfile
@@ -21,7 +21,7 @@ checksums           sha256  e1d53fa663599ccdb0667e25f6f6fe38ea6aee077a2db1d91a24
                     rmd160  d487d37cf04292761f8cd2d33653174d62163411 \
                     size    1006734
 
-python.versions     37 38 39 310
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-awscli-plugin-endpoint/Portfile
+++ b/python/py-awscli-plugin-endpoint/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  a322d2a4faff6677d248443a76a7cb6b53ec64d5 \
                     sha256  9096f01f637f17e7b0c28788a64276acc40c0165f1655a6dc45fec39b96bafd0 \
                     size    3680
 
-python.versions     37 38 39 310
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-awscli
-version             1.27.27
+version             1.27.29
 revision            0
 
 categories          python devel
@@ -19,11 +19,11 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  b970df26e69f47ec5f14b648acb9a875e4e5d388 \
-                    sha256  4f1781f6ef104df57549c41ed58620f34f821a29d7d36d35b3a62fc25fc9831f \
-                    size    1609022
+checksums           rmd160  e36dae4f9125eeb1d6278f3593635e1ab1b87305 \
+                    sha256  041c595c358988915988d65aa0bcc7fccb0f5f9f2c0a85dd99ebc750326d8c90 \
+                    size    1612756
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     conflicts           py${python.version}-awscli2
@@ -61,7 +61,7 @@ if {${name} ne ${subport}} {
         xinstall -d ${destroot}${bash_compl_path}
         xinstall -m 0644 ${worksrcpath}/bin/aws_bash_completer \
             ${destroot}${bash_compl_path}/aws-${python.branch}
- 
+
         set zsh_compl_path ${prefix}/share/zsh/site-functions
         xinstall -d ${destroot}${zsh_compl_path}
         xinstall -m 0644 ${worksrcpath}/bin/aws_zsh_completer.sh \

--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  e36dae4f9125eeb1d6278f3593635e1ab1b87305 \
                     sha256  041c595c358988915988d65aa0bcc7fccb0f5f9f2c0a85dd99ebc750326d8c90 \
                     size    1612756
 
-python.versions     37 38 39 310 311
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     conflicts           py${python.version}-awscli2

--- a/python/py-boto3/Portfile
+++ b/python/py-boto3/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  6d98bbdbce3e57c3c029cca30d1361dac0a23382 \
                     sha256  4fb4a0ce2679e5dc1719441192b45687654201d5de76224f2c376b689c9ed4aa \
                     size    104194
 
-python.versions     37 38 39 310 311
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-boto3/Portfile
+++ b/python/py-boto3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-boto3
-version             1.26.27
+version             1.26.29
 revision            0
 
 supported_archs     noarch
@@ -21,11 +21,11 @@ long_description    Boto3 is the Amazon Web Services (AWS) Software \
 
 homepage            https://github.com/boto/boto3
 
-checksums           rmd160  88d59d6167162a0612e2e0fe9a7316ddfb4868ad \
-                    sha256  255a7565226c21c5d500f69aabb977e1ac07dbaf576f4428d00558e8e508a23b \
-                    size    104148
+checksums           rmd160  6d98bbdbce3e57c3c029cca30d1361dac0a23382 \
+                    sha256  4fb4a0ce2679e5dc1719441192b45687654201d5de76224f2c376b689c9ed4aa \
+                    size    104194
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-botocore
-version             1.29.27
+version             1.29.29
 revision            0
 
 supported_archs     noarch
@@ -20,11 +20,11 @@ long_description    A low-level interface to a growing number of Amazon Web \
 
 homepage            https://github.com/boto/botocore
 
-checksums           rmd160  66de5be0636e1471222b9fd3029113b330659d1f \
-                    sha256  0932b22d8737b11037adf7e734f9b90425b575d0757e4c1a035e99f382955221 \
-                    size    10683910
+checksums           rmd160  a27bab9d91f43dab0948ebb44c77634b4b457cea \
+                    sha256  97a6d059e688ff9caa7c0a4e30cc58fa27be8bf3347578ce7c62fb808380fb55 \
+                    size    10687811
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-cfn-lint/Portfile
+++ b/python/py-cfn-lint/Portfile
@@ -5,22 +5,22 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 name                py-cfn-lint
-github.setup        aws-cloudformation cfn-python-lint 0.29.0 v
+github.setup        aws-cloudformation cfn-python-lint 0.72.2 v
 revision            0
 
 platforms           {darwin any}
 supported_archs     noarch
 license             MIT
-maintainers         nomaintainer
+maintainers         {judaew @judaew} openmaintainer
 
 description         Checks cloudformation for practices and behaviour that could potentially be improved
 long_description    ${description}
 
-checksums           sha256  30597e0191ec3893f507e70e2d8d179f4c114321280298e6b145c5a3d3e15e06 \
-                    rmd160  ea75c05578d7c4bbfdb7fcd1db38b9a5a920c1b1 \
-                    size    3860511
+checksums           sha256  a7bb1576d19e8f179e0f6bd4047e0789c7861068d0ae971773c526a7dfda8f80 \
+                    rmd160  df8209f8ba6bbd5bbd38274c7c1ee10cd6105472 \
+                    size    3114492
 
-python.versions     37 38
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     post-patch {
@@ -31,13 +31,16 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-setuptools
 
+    # These are in setup.py order
     depends_run-append \
+                    port:py${python.version}-yaml \
                     port:py${python.version}-aws-sam-translator \
                     port:py${python.version}-jsonpatch \
                     port:py${python.version}-jsonschema \
-                    port:py${python.version}-yaml \
-                    port:py${python.version}-requests \
-                    port:py${python.version}-six
+                    port:py${python.version}-networkx \
+                    port:py${python.version}-junit-xml \
+                    port:py${python.version}-jschema_to_python \
+                    port:py${python.version}-sarif-om
 
     depends_test-append \
                     port:py${python.version}-mock \

--- a/python/py-jmespath/Portfile
+++ b/python/py-jmespath/Portfile
@@ -11,7 +11,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jschema_to_python/Portfile
+++ b/python/py-jschema_to_python/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jschema_to_python
+version             1.2.3
+revision            0
+
+categories          python
+supported_archs     noarch
+license             MIT
+maintainers         {judaew @judaew} openmaintainer
+
+description         Generate source code for Python classes from a JSON schema.
+long_description    {*}${description}
+homepage            https://github.com/microsoft/jschema-to-python
+
+checksums           rmd160  1c686e44546e5ad515d6268206603f7073f5eeca \
+                    sha256  76ff14fe5d304708ccad1284e4b11f96a658949a31ee7faed9e0995279549b91 \
+                    size    10061
+
+python.versions     39 310 311
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+    depends_lib-append  port:py${python.version}-pbr
+    depends_test-append port:py${python.version}-pytest \
+                        port:py${python.version}-jsonpickle
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env-append PYTHONPATH=build/lib
+
+    livecheck.type      none
+}

--- a/python/py-jsonpatch/Portfile
+++ b/python/py-jsonpatch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jsonpatch
-version             1.26
+version             1.32
 revision            0
 
 supported_archs     noarch
@@ -17,11 +17,11 @@ long_description    {*}${description}
 
 homepage            https://github.com/stefankoegl/python-json-patch
 
-checksums           sha256  e45df18b0ab7df1925f20671bbc3f6bd0b4b556fb4b9c5d97684b0a7eac01744 \
-                    rmd160  82cf1761dba6d8f319b91b6eb24cdbe3fce09af4 \
-                    size    18641
+checksums           sha256  b6ddfe6c3db30d81a96aaeceb6baf916094ffa23d7dd5fa2c13e13f8b6e600c2 \
+                    rmd160  3137643732c70ab053c707b14344c43d67b624d8 \
+                    size    20853
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-jsonpickle/Portfile
+++ b/python/py-jsonpickle/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  4cc18c6911ef2691e993317f165c10f63df8fb54 \
                     sha256  84684cfc5338a534173c8dd69809e40f2865d0be1f8a2b7af8465e5b968dcfa9 \
                     size    186799
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-jsonpointer/Portfile
+++ b/python/py-jsonpointer/Portfile
@@ -21,7 +21,7 @@ checksums           sha256  97cba51526c829282218feb99dab1b1e6bdf8efd1c43dc9d57be
                     rmd160  76a846b62bab4adf17d1c1a845bc0baa9989fe3f \
                     size    9295
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-jsonschema/Portfile
+++ b/python/py-jsonschema/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jsonschema
-version             4.16.0
+version             4.17.3
 revision            0
 categories-append   devel
 license             MIT
@@ -22,9 +22,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/python-jsonschema/jsonschema
 
-checksums           rmd160  9a89203368928752a3d2f4a6e8ef91ad614c41c5 \
-                    sha256  165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23 \
-                    size    292399
+checksums           rmd160  86637e335ef60176700311eb93e0d5dbbcb8d457 \
+                    sha256  0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d \
+                    size    297785
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-junit-xml/Portfile
+++ b/python/py-junit-xml/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        kyrus python-junit-xml 1.9 v
+name                py-junit-xml
+revision            0
+
+categories          python
+supported_archs     noarch
+license             MIT
+maintainers         {judaew @judaew} openmaintainer
+
+description         Creates JUnit XML test result documents that can be read \
+                    by tools such as Jenkins
+long_description    {*}${description}
+
+checksums           rmd160  be2cacd2138b735d7f15db949a7caf3f016f64c2 \
+                    sha256  fc3c243666574ce2db66a8502793d3d420556b7ff5123b63a63a199287d753d8 \
+                    size    11111
+
+python.versions     39 310 311
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+    depends_lib-append  port:py${python.version}-six
+    depends_test-append port:py${python.version}-pytest
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env-append PYTHONPATH=build/lib
+
+    livecheck.type      none
+}

--- a/python/py-photomosaic/Portfile
+++ b/python/py-photomosaic/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  3c4ba6aa62d34befeac9a29349d9f70292cb284b \
                     sha256  a535bd251ba7a0a58ffbc54267dd3d216039444c27fe699a3780962c3b74854d \
                     size    206597225
 
-python.versions     37 38 39 310
+python.versions     39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pyrsistent/Portfile
+++ b/python/py-pyrsistent/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pyrsistent
-version             0.18.1
+version             0.19.2
 revision            0
 categories-append   devel
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            http://github.com/tobgu/pyrsistent/
 
-checksums           rmd160  79dcbde5c8400c6feb6a64c2092c650e9e40d729 \
-                    sha256  d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96 \
-                    size    100522
+checksums           rmd160  4ee00c2fe3eb090defa755cc74f9d0bdd059b0ac \
+                    sha256  bfa0351be89c9fcbcb8c9879b826f4353be10f58f8a677efab0c017bf7137ec2 \
+                    size    102438
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-rsa/Portfile
+++ b/python/py-rsa/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-rsa
 version             4.9
+revision            1
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer
 
@@ -22,11 +23,11 @@ checksums           rmd160  882305d1cf9b736a3e06b33f77d6e88899453f9f \
                     sha256  e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21 \
                     size    29711
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend poetry
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-asn1
     depends_test-append port:py${python.version}-mypy
 

--- a/python/py-s3transfer/Portfile
+++ b/python/py-s3transfer/Portfile
@@ -20,7 +20,7 @@ long_description    ${description}
 
 homepage            https://github.com/boto/${python.rootname}
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sarif-om/Portfile
+++ b/python/py-sarif-om/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sarif-om
+version             1.0.4
+revision            0
+
+categories          python
+supported_archs     noarch
+license             MIT
+maintainers         {judaew @judaew} openmaintainer
+
+description         Classes implementing the SARIF 2.1.0 object model.
+long_description    {*}${description}
+homepage            https://github.com/microsoft/sarif-python-om
+
+distname            sarif_om-${version}
+
+checksums           rmd160  2040375edf41e8fe6ee793e7bfc6afda91192fb6 \
+                    sha256  cd5f416b3083e00d402a92e449a7ff67af46f11241073eea0461802a3b5aef98 \
+                    size    28847
+
+python.versions     39 310 311
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+    depends_lib-append  port:py${python.version}-pbr
+
+    livecheck.type      none
+}

--- a/python/py-sentencepiece/Portfile
+++ b/python/py-sentencepiece/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        google sentencepiece 0.1.93 v
+github.setup        google sentencepiece 0.1.97 v
 revision            0
 name                py-${github.project}
 
@@ -26,9 +26,9 @@ long_description    SentencePiece is an unsupervised text tokenizer \
                     purely end-to-end system that does not depend on \
                     language-specific pre/postprocessing.
 
-checksums           rmd160  76b1e1ae6e5b297ed07c749d7ff35f12e4852322 \
-                    sha256  9a146e83dc6a403e431ae444dcc0c28203be81436566acc628edae42fc8901ec \
-                    size    11684466
+checksums           rmd160  de3ed2ed6103ae71339d99a399223a9b94c0ea3c \
+                    sha256  aeb50103249d07018545db3ed8580427aa5a73d6af92b94577dc40626c071beb \
+                    size    11945683
 
 python.versions     37 38 39
 

--- a/textproc/sentencepiece/Portfile
+++ b/textproc/sentencepiece/Portfile
@@ -4,6 +4,8 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
+# If you update this port, also update the py-sentencepiece to latest version.
+# `py-sentencepiece` is closely coupled to `sentencepiece`.
 github.setup        google sentencepiece 0.1.97 v
 revision            0
 categories          textproc


### PR DESCRIPTION
#### Description

The motivation for this PR is to update py-botocore, py-boto3, py-awscli to the latest versions and add Python3.11 support. Also remove subports for Python 3.8-3.9 and their dependencies because I want to support the last three versions of Python.

TO-DO in next PR:
- py-botocore: Remove Python 3.7-3.8

Commits in this PR:
- py-jmespath: Add Python 3.11
- py-botocore: Update to 1.29.29 and add py311
- py-asn1: Add Python 3.11
- py-rsa: Add Python 3.11 and use PEP517
- py-s3transfer: Add Python 3.11
- py-awscli: Update to 1.27.29, add Python 3.11
- py-boto3: Update to 1.26.29, add Python 3.11
- py-awscli{,-plugin-endpoint}: Remove py37, py38 & add py311
- py-aws-sam-translator: Add py311, remove py37, py38
- py-jsonpickle: Add Python 3.11
- py-jschema_to_python: New port (for py-cfn-lint)
- py-junit-xml: New port (for py-cfn-lint)
- py-sarif-om: New port (for py-cfn-lint)
- py-pyrsistent: Update to 0.19.2, add Python 3.11
- py-jsonschema: Update to 4.17.3, add Python 3.11
- py-jsonpointer: Add Python 3.11
- py-jsonpatch: Update to 1.32, add Python 3.11
- py-cfn-lint: Update to 0.72.2, add py39-311
- py-allennlp: Remove Python 3.8
- py-photomosaic: Remove Python 3.7-3.8
- py-boto3: Remove Python 3.7-3.8
- py-sentencepiece: Update to 0.1.97 for fix build
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
