### PR TITLE
py-tmuxp: Update to 1.19.1, add Python 3.11, remove Python 3.7-3.8

### DIFF
--- a/python/py-kaptan/Portfile
+++ b/python/py-kaptan/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  f815b558ccb87e79a9240f40ba65a23313a6e25b \
                     sha256  1abd1f56731422fce5af1acc28801677a51e56f5d3c3e8636db761ed143c3dd2 \
                     size    10539
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-libtmux/Portfile
+++ b/python/py-libtmux/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-libtmux
-version             0.15.10
+version             0.16.1
 revision            0
 
 categories-append   devel
@@ -21,13 +21,16 @@ homepage            https://github.com/tmux-python/libtmux
 master_sites        pypi:l/${python.rootname}/
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  21ddb0b6e1723d9a82f4775c5bdf0ec6b5ba2337 \
-                    sha256  c40959c5ae9e7add705a3c4e60365667e65ab45835a9e663692e428e1d7e42e2 \
-                    size    213329
+checksums           rmd160  742bec192b8463fd00ddd8071467494db07927ee \
+                    sha256  4b5b74e70e0edf2e7a5c1a841fffcd78e1f203205ced9c9b0dd325a6d903d0ed \
+                    size    220027
 
-python.versions     37 38 39 310
+python.versions     39 310 311
+python.pep517       yes
+python.pep517_backend poetry
 
 if {${name} ne ${subport}} {
+    # py-setuptools required by pyproject.toml
     depends_build-append \
                     port:py${python.version}-setuptools
 

--- a/python/py-tmuxp/Portfile
+++ b/python/py-tmuxp/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-github.setup        tmux-python tmuxp 1.18.2 v
+github.setup        tmux-python tmuxp 1.19.1 v
 name                py-tmuxp
 revision            0
 
@@ -20,14 +20,11 @@ maintainers         {@egorenar posteo.net:egorenar-dev} \
 description         tmux session manager.
 long_description    {*}${description}
 
-python.versions     37 38 39 310
+python.versions     39 310 311
 python.pep517       yes
+python.pep517_backend poetry
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools \
-                    port:py${python.version}-poetry-core
-
     depends_lib-append \
                     port:py${python.version}-click \
                     port:py${python.version}-colorama \
@@ -37,9 +34,9 @@ if {${name} ne ${subport}} {
     depends_run-append \
                     port:tmuxp_select
 
-    checksums       rmd160  8b006c67b4bf7e0c23b50ed0df94e75fa9c4068c \
-                    sha256  26e3df7f46e6dfb09d2f021e912e953cc5a22903ad9c86427ae762f83cf91ba3 \
-                    size    853216
+    checksums       rmd160  a6d07beb01c77d1bdee9e5d7b59708d1faaa94b5 \
+                    sha256  b7a235fc4892fdd17ab34ed67d8948e14a6b2d88e94b8cdd853d3008f9083110 \
+                    size    853768
 
     select.group    tmuxp
     select.file     ${worksrcpath}/py${python.version}-tmuxp


### PR DESCRIPTION
#### Description

- py-kaptan: Add Python to 3.11
- py-libtmux: Update to 0.16.1, add py311, remove py37-38
- py-tmuxp: Update to 1.19.1, add py311, remove py37-38


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
