### PR TITLE
crystal: update to 1.6.2

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 1.6.0
+github.setup        crystal-lang crystal 1.6.2
 github.tarball_from archive
 revision            0
 categories          lang
@@ -40,13 +40,13 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  29bef9e811f02ac3e6172c68fbafd213318b8739 \
-                    sha256  8119bc099d898be0d2e5055f783d41325a10e4b7824240272eb6ecb30c8c9a2e \
-                    size    3058366 \
+                    rmd160  5adf94f3d7bc7c8662b16802a96701ecbe5e1a4e \
+                    sha256  fbbff8f975a2627ac3f42208362365668fb08a33637f424e0c2c0e51b1f37cfa \
+                    size    3060644 \
                     ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix} \
-                    rmd160  d24c2e7a5277fc08569a0225ab05f3483db1851e \
-                    sha256  6e597788260a68d70e2c71ff4a8c4d611537de49eb0dbfd2e73405ec2a368f71 \
-                    size    46743537
+                    rmd160  dedfea59e630496a6f8c6fd4204990240586181c \
+                    sha256  488af204cbcf4c90b9445426fd80ea68c85170036be0065f0647929c5dd92814 \
+                    size    46768092
 
 patchfiles          patch-static.diff
 
@@ -64,7 +64,7 @@ set llvm_config     LLVM_CONFIG=llvm-config-mp-${llvm_version}
 
 compiler.cxx_standard  2014
 
-build.args          release=1 FLAGS=--no-debug \
+build.args          release=1 interpreter=1 FLAGS=--no-debug \
                     CRYSTAL_CONFIG_LIBRARY_PATH=${prefix}/lib
 
 build.env           ${llvm_config} \


### PR DESCRIPTION
###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?