### PR TITLE
xar: use path:lib/libssl.dylib:openssl for LibreSSL compatibility.

### DIFF
--- a/archivers/xar/Portfile
+++ b/archivers/xar/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           clang_dependency 1.0
 PortGroup           github 1.0
-PortGroup           openssl 1.0
 
 set apple_version   494
 github.setup        apple-oss-distributions xar ${apple_version} xar-
@@ -27,7 +26,8 @@ checksums           rmd160  360699d6bd11399b1d84b4e23be89c382d3bb026 \
 depends_build       port:pkgconfig \
                     port:automake
 
-depends_lib         port:bzip2 \
+depends_lib         path:lib/libssl.dylib:openssl \
+                    port:bzip2 \
                     port:libxml2 \
                     port:zlib
 


### PR DESCRIPTION

 * tested with libressl-devel and openssl3

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
