### PR TITLE
istioctl: update to 1.16.1

### DIFF
--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 name                istioctl
 revision            0
 
-go.setup            github.com/istio/istio 1.16.0
+go.setup            github.com/istio/istio 1.16.1
 categories          sysutils
 supported_archs     x86_64 arm64
 license             Apache-2
@@ -30,9 +30,9 @@ github.livecheck.regex \
 
 go.package          istio.io/istio
 
-checksums           rmd160  8987d71e613e653687b7cf26aa0585e2d48d47c3 \
-                    sha256  1ad846b48928de57c58798c73b3f773c7362c5277d71121aa7d75c5d1250b645 \
-                    size    4907538
+checksums           rmd160  bdd68fc9e19227b0d2b77115aeefa7b09cee5638 \
+                    sha256  357b147578a00b0da5148a53963d1a086c79cbda345b4607f9cbe8d9f4b50220 \
+                    size    4909940
 
 build.cmd           make
 build.target        ${name}


### PR DESCRIPTION
#### Description
istioctl: update to 1.16.1
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.0.1 22A400 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
