### PR TITLE
bsdmake: Update checksums after Apple redirect to github

### DIFF
--- a/devel/bsdmake/Portfile
+++ b/devel/bsdmake/Portfile
@@ -5,6 +5,8 @@ PortSystem     1.0
 name           bsdmake
 version        24
 revision       1
+# stealth upgraded from Apple-hosted to github-hosted
+dist_subdir    ${name}/${version}_1
 categories     devel
 platforms      darwin
 license        BSD
@@ -22,8 +24,10 @@ homepage       http://opensource.apple.com/
                # see also http://www.freebsd.org/cgi/cvsweb.cgi/src/usr.bin/make/
 master_sites   http://opensource.apple.com/tarballs/${name}
 
-checksums      rmd160  ff6d946a8b742b20948f9a48c9cdaa95e9dee2bd \
-               sha256  82a948b80c2abfc61c4aa5c1da775986418a8e8eb3dd896288cfadf2e19c4985
+checksums      rmd160  1f08d49704391725cc304c455ead7e48103fd8cf \
+               sha256  096f333f94193215931a9fab86b9bca0713fbd22ec465bf55510067b53940e62 \
+               size    238536
+
 
 patchfiles     patch-Makefile.diff \
                patch-mk.diff \


### PR DESCRIPTION
Apple's redirect to github gives a different top-level dir in tar; no diffs

Fixes: https://trac.macports.org/ticket/66404

#### Description

As documented in 66404, Apple seems to have moved tar.gz hosting from in-house to github.  The github link appears to generate a tarball from the repo for a tag by creating a tar with a root dir "REPO-TAG".  The tag in bsdmake is "bsdmake-24", so the top-level dir in the new file is "bsdmake-bsdmake-24", while the old was "bsdmake-24".

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix (fix sha error)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?  No tests for bsdmake
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
