### PR TITLE
LaTeXML: update to upstream version 0.8.7

### DIFF
--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                LaTeXML
-version             0.8.6
-revision            2
-checksums           rmd160  3f71105b7da576ab73e714430626888080716602 \
-                    sha256  9529c651b67f5e8ddef1fd1852f974e756a17b711c46d4118f0677ad0e6e9bb1 \
-                    size    13776498
+version             0.8.7
+revision            0
+checksums           rmd160  1bd87b8f5057de6db1c6a76c95a9dae227bd2559 \
+                    sha256  25da9d9440779dec0dadd4cc2d4227e8eab87437c0719877274dcfb906a4cc79 \
+                    size    14339344
 license             public-domain
 maintainers         {nist.gov:bruce.miller @brucemiller}
 description         LaTeXML converts TeX to XML/HTML/MathML


### PR DESCRIPTION
#### Description

Updates LaTeXML to version 0.8.7

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6.1 21G217 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
