### PR TITLE
gopass: update to 1.15.1

### DIFF
--- a/devel/gopass-summon-provider/Portfile
+++ b/devel/gopass-summon-provider/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-summon-provider 1.15.0 v
+go.setup            github.com/gopasspw/gopass-summon-provider 1.15.1 v
 revision            0
 categories          devel
 maintainers         {@0x1DA117 danieltrautmann.com:me} openmaintainer
@@ -33,9 +33,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  a00e55a61eab806652afb8ec29ab218774ada156 \
-                        sha256  edf1a9a74b3ccb6e958922225c6999a31f2dddff52e18b1fe0be1b051e08c54d \
-                        size    17556
+                        rmd160  d62b2b651d4facc6a9808ab8765549fd1f4fbac2 \
+                        sha256  1cc77c938b46657d70e2417e4fbb5c3aafb8206f7097c219d3f2cf8b3f084c5b \
+                        size    17264
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -54,30 +54,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    v0.2.0 \
-                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
-                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
-                        size    14797 \
-                    golang.org/x/sys \
-                        lock    v0.2.0 \
-                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
-                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
-                        size    1411246 \
-                    golang.org/x/net \
-                        lock    v0.2.0 \
-                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
-                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
-                        size    1243767 \
-                    golang.org/x/exp \
-                        lock    6ab00d035af9 \
-                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
-                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
-                        size    1606053 \
-                    golang.org/x/crypto \
                         lock    v0.3.0 \
-                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
-                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
-                        size    1633434 \
+                        rmd160  14a60f913597d05ed7df0b6d6fbca50ca672b594 \
+                        sha256  c5e084b265e4c0dfb37ef0a0e7aa5b5ff4f9afe55c71452d13789a85abcd46c9 \
+                        size    14800 \
+                    golang.org/x/sys \
+                        lock    v0.3.0 \
+                        rmd160  17c78e6210a6f938db21fa772584ab8c7d4e06c1 \
+                        sha256  b04ddf676ead57e0d3e367e9aa17db1b11fc20af719e479d1ca56873a2bdf06b \
+                        size    1411264 \
+                    golang.org/x/net \
+                        lock    v0.4.0 \
+                        rmd160  c003f74a2dd1696a79f5fa52e78d12d95e58a3a2 \
+                        sha256  22ce878356e58045cc8509555dab771ac53d6a0541448d3d58fc24d9ba462cd9 \
+                        size    1237072 \
+                    golang.org/x/exp \
+                        lock    ad323defaf05 \
+                        rmd160  bc9e2228979d2dcaf61905c09ad2f9fb252257c0 \
+                        sha256  9c0e907e60e1dcffbedcf38ba11ca4581b082fb6a44bd23cd073fbfa246f2c8d \
+                        size    1608821 \
+                    golang.org/x/crypto \
+                        lock    v0.4.0 \
+                        rmd160  5669817509812aad1d04b5dc12d2217d28d954d8 \
+                        sha256  d2340a6bb7fa26df5f5e309cada4e2666652e721307fa512923f352a17b7a14e \
+                        size    1633555 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -101,10 +101,10 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.23.5 \
-                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
-                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
-                        size    3478097 \
+                        lock    v2.23.7 \
+                        rmd160  24267bc404311ebe68041f20ff5a7319a2fb4a41 \
+                        sha256  79e7cb8a8370eebf06ee097fa983615701d788d76bad63eb24654e3ae1a4c930 \
+                        size    3478311 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -175,11 +175,6 @@ go.vendors          gotest.tools \
                         rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
                         sha256  8e158a59a9b7e407b27a4cf6100f33648b7c8bffb4ac07bd074f43d4796afa87 \
                         size    7631 \
-                    github.com/mitchellh/go-homedir \
-                        lock    v1.1.0 \
-                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
-                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
-                        size    3366 \
                     github.com/mattn/go-tty \
                         lock    v0.0.4 \
                         rmd160  aeef24ae0b469f8a83cd43f40843ba3dc58f057d \
@@ -196,10 +191,10 @@ go.vendors          gotest.tools \
                         sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
                         size    9778 \
                     github.com/martinhoefling/goxkcdpwgen \
-                        lock    v0.1.1 \
-                        rmd160  56164d6a8b2620f53897f85abe3ff7659e0aa0c5 \
-                        sha256  0ee21438461014724b2a3afe08e6db51649748ff23f7f90705b2617d80e568a6 \
-                        size    89925 \
+                        lock    737661b92a0e \
+                        rmd160  a9ff7472b7e85aa183c6e22ab80a0796aa527769 \
+                        sha256  60ea3c457e03c7a186caa391955ade2fb169325d77f351d73b97e80a30e9607b \
+                        size    180699 \
                     github.com/kr/text \
                         lock    v0.2.0 \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
@@ -236,10 +231,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.15.0 \
-                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
-                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
-                        size    2270837 \
+                        lock    v1.15.1 \
+                        rmd160  5f8ff7cde5df868d8a6369a1d09ec3477ba54f9a \
+                        sha256  f203b9a4171a426d76b7661a5bdd5188db5c3202988a1150a07ea513351185d4 \
+                        size    2280755 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -346,9 +341,4 @@ go.vendors          gotest.tools \
                         lock    v1.0.0 \
                         rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
                         sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
-                        size    59693 \
-                    bitbucket.org/creachadair/stringset \
-                        lock    v0.0.10 \
-                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
-                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
-                        size    19241
+                        size    59693

--- a/security/git-credential-gopass/Portfile
+++ b/security/git-credential-gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/git-credential-gopass 1.15.0 v
+go.setup            github.com/gopasspw/git-credential-gopass 1.15.1 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  5774d2cc8cd360cbf70a8862200687e20dc2d5a1 \
-                        sha256  f532f792c70d5ee3e8bbb380dd123c7ba146fd5a18102658a3e231a48682be54 \
-                        size    20790
+                        rmd160  b5777717cc4fb9bbd1cf21a248559925ed1615e8 \
+                        sha256  b85ea8c7c55584fec8f39b21c5306609a8f50d92fa48821cff0137cc207433c6 \
+                        size    20390
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -35,30 +35,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    v0.2.0 \
-                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
-                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
-                        size    14797 \
-                    golang.org/x/sys \
-                        lock    v0.2.0 \
-                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
-                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
-                        size    1411246 \
-                    golang.org/x/net \
-                        lock    v0.2.0 \
-                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
-                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
-                        size    1243767 \
-                    golang.org/x/exp \
-                        lock    6ab00d035af9 \
-                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
-                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
-                        size    1606053 \
-                    golang.org/x/crypto \
                         lock    v0.3.0 \
-                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
-                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
-                        size    1633434 \
+                        rmd160  14a60f913597d05ed7df0b6d6fbca50ca672b594 \
+                        sha256  c5e084b265e4c0dfb37ef0a0e7aa5b5ff4f9afe55c71452d13789a85abcd46c9 \
+                        size    14800 \
+                    golang.org/x/sys \
+                        lock    v0.3.0 \
+                        rmd160  17c78e6210a6f938db21fa772584ab8c7d4e06c1 \
+                        sha256  b04ddf676ead57e0d3e367e9aa17db1b11fc20af719e479d1ca56873a2bdf06b \
+                        size    1411264 \
+                    golang.org/x/net \
+                        lock    v0.4.0 \
+                        rmd160  c003f74a2dd1696a79f5fa52e78d12d95e58a3a2 \
+                        sha256  22ce878356e58045cc8509555dab771ac53d6a0541448d3d58fc24d9ba462cd9 \
+                        size    1237072 \
+                    golang.org/x/exp \
+                        lock    ad323defaf05 \
+                        rmd160  bc9e2228979d2dcaf61905c09ad2f9fb252257c0 \
+                        sha256  9c0e907e60e1dcffbedcf38ba11ca4581b082fb6a44bd23cd073fbfa246f2c8d \
+                        size    1608821 \
+                    golang.org/x/crypto \
+                        lock    v0.4.0 \
+                        rmd160  5669817509812aad1d04b5dc12d2217d28d954d8 \
+                        sha256  d2340a6bb7fa26df5f5e309cada4e2666652e721307fa512923f352a17b7a14e \
+                        size    1633555 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -82,10 +82,10 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.23.5 \
-                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
-                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
-                        size    3478097 \
+                        lock    v2.23.7 \
+                        rmd160  24267bc404311ebe68041f20ff5a7319a2fb4a41 \
+                        sha256  79e7cb8a8370eebf06ee097fa983615701d788d76bad63eb24654e3ae1a4c930 \
+                        size    3478311 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -156,11 +156,6 @@ go.vendors          gotest.tools \
                         rmd160  230cfe4a0b10fceb33f1826b75ad5a36de0aa241 \
                         sha256  8e158a59a9b7e407b27a4cf6100f33648b7c8bffb4ac07bd074f43d4796afa87 \
                         size    7631 \
-                    github.com/mitchellh/go-homedir \
-                        lock    v1.1.0 \
-                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
-                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
-                        size    3366 \
                     github.com/mattn/go-tty \
                         lock    v0.0.4 \
                         rmd160  aeef24ae0b469f8a83cd43f40843ba3dc58f057d \
@@ -177,10 +172,10 @@ go.vendors          gotest.tools \
                         sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
                         size    9778 \
                     github.com/martinhoefling/goxkcdpwgen \
-                        lock    v0.1.1 \
-                        rmd160  56164d6a8b2620f53897f85abe3ff7659e0aa0c5 \
-                        sha256  0ee21438461014724b2a3afe08e6db51649748ff23f7f90705b2617d80e568a6 \
-                        size    89925 \
+                        lock    737661b92a0e \
+                        rmd160  a9ff7472b7e85aa183c6e22ab80a0796aa527769 \
+                        sha256  60ea3c457e03c7a186caa391955ade2fb169325d77f351d73b97e80a30e9607b \
+                        size    180699 \
                     github.com/kr/text \
                         lock    v0.2.0 \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
@@ -217,10 +212,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.15.0 \
-                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
-                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
-                        size    2270837 \
+                        lock    v1.15.1 \
+                        rmd160  5f8ff7cde5df868d8a6369a1d09ec3477ba54f9a \
+                        sha256  f203b9a4171a426d76b7661a5bdd5188db5c3202988a1150a07ea513351185d4 \
+                        size    2280755 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -327,12 +322,7 @@ go.vendors          gotest.tools \
                         lock    v1.0.0 \
                         rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
                         sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
-                        size    59693 \
-                    bitbucket.org/creachadair/stringset \
-                        lock    v0.0.10 \
-                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
-                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
-                        size    19241
+                        size    59693
 
 build.args          -ldflags '-X main.version=${version}'
 

--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.15.0 v
+go.setup            github.com/gopasspw/gopass-jsonapi 1.15.1 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -14,9 +14,9 @@ long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  d22583885272e60ee6cb6bc58bb7d3befbae108c \
-                        sha256  0853005ac1d43299e74288ee78f2f1f0ac456ff7df412ccb42acbcbb11ca11c2 \
-                        size    31737
+                        rmd160  157ca0eaf1628ded298b554e419e388cc8422325 \
+                        sha256  de70f4c428f09814321a0568a866483106b6ef0bbc89f4ddac908c1792d537f3 \
+                        size    31546
 
 go.vendors          gotest.tools \
                         repo    github.com/gotestyourself/gotest.tools \
@@ -35,30 +35,30 @@ go.vendors          gotest.tools \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/term \
-                        lock    v0.2.0 \
-                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
-                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
-                        size    14797 \
-                    golang.org/x/sys \
-                        lock    v0.2.0 \
-                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
-                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
-                        size    1411246 \
-                    golang.org/x/net \
-                        lock    v0.2.0 \
-                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
-                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
-                        size    1243767 \
-                    golang.org/x/exp \
-                        lock    6ab00d035af9 \
-                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
-                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
-                        size    1606053 \
-                    golang.org/x/crypto \
                         lock    v0.3.0 \
-                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
-                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
-                        size    1633434 \
+                        rmd160  14a60f913597d05ed7df0b6d6fbca50ca672b594 \
+                        sha256  c5e084b265e4c0dfb37ef0a0e7aa5b5ff4f9afe55c71452d13789a85abcd46c9 \
+                        size    14800 \
+                    golang.org/x/sys \
+                        lock    v0.3.0 \
+                        rmd160  17c78e6210a6f938db21fa772584ab8c7d4e06c1 \
+                        sha256  b04ddf676ead57e0d3e367e9aa17db1b11fc20af719e479d1ca56873a2bdf06b \
+                        size    1411264 \
+                    golang.org/x/net \
+                        lock    v0.4.0 \
+                        rmd160  c003f74a2dd1696a79f5fa52e78d12d95e58a3a2 \
+                        sha256  22ce878356e58045cc8509555dab771ac53d6a0541448d3d58fc24d9ba462cd9 \
+                        size    1237072 \
+                    golang.org/x/exp \
+                        lock    ad323defaf05 \
+                        rmd160  bc9e2228979d2dcaf61905c09ad2f9fb252257c0 \
+                        sha256  9c0e907e60e1dcffbedcf38ba11ca4581b082fb6a44bd23cd073fbfa246f2c8d \
+                        size    1608821 \
+                    golang.org/x/crypto \
+                        lock    v0.4.0 \
+                        rmd160  5669817509812aad1d04b5dc12d2217d28d954d8 \
+                        sha256  d2340a6bb7fa26df5f5e309cada4e2666652e721307fa512923f352a17b7a14e \
+                        size    1633555 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -82,10 +82,10 @@ go.vendors          gotest.tools \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.23.5 \
-                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
-                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
-                        size    3478097 \
+                        lock    v2.23.7 \
+                        rmd160  24267bc404311ebe68041f20ff5a7319a2fb4a41 \
+                        sha256  79e7cb8a8370eebf06ee097fa983615701d788d76bad63eb24654e3ae1a4c930 \
+                        size    3478311 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -177,10 +177,10 @@ go.vendors          gotest.tools \
                         sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
                         size    9778 \
                     github.com/martinhoefling/goxkcdpwgen \
-                        lock    v0.1.1 \
-                        rmd160  56164d6a8b2620f53897f85abe3ff7659e0aa0c5 \
-                        sha256  0ee21438461014724b2a3afe08e6db51649748ff23f7f90705b2617d80e568a6 \
-                        size    89925 \
+                        lock    737661b92a0e \
+                        rmd160  a9ff7472b7e85aa183c6e22ab80a0796aa527769 \
+                        sha256  60ea3c457e03c7a186caa391955ade2fb169325d77f351d73b97e80a30e9607b \
+                        size    180699 \
                     github.com/kr/text \
                         lock    v0.2.0 \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
@@ -217,10 +217,10 @@ go.vendors          gotest.tools \
                         sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
                         size    8586 \
                     github.com/gopasspw/gopass \
-                        lock    v1.15.0 \
-                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
-                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
-                        size    2270837 \
+                        lock    v1.15.1 \
+                        rmd160  5f8ff7cde5df868d8a6369a1d09ec3477ba54f9a \
+                        sha256  f203b9a4171a426d76b7661a5bdd5188db5c3202988a1150a07ea513351185d4 \
+                        size    2280755 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -327,12 +327,7 @@ go.vendors          gotest.tools \
                         lock    v1.0.0 \
                         rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
                         sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
-                        size    59693 \
-                    bitbucket.org/creachadair/stringset \
-                        lock    v0.0.10 \
-                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
-                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
-                        size    19241
+                        size    59693
 
 build.args          -ldflags '-X main.version=${version}'
 

--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.15.0 v
+go.setup            github.com/gopasspw/gopass 1.15.1 v
 revision            0
 categories          security
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 depends_lib-append  port:gnupg2
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  bd8b121335fd46ad5a6ea32abaa8a00a8c76eb27 \
-                        sha256  a302da1c268d01da6ad7d8878d270c7a0a57391d2a6d0b240d45ee2e84ead86a \
-                        size    2270837
+                        rmd160  5f8ff7cde5df868d8a6369a1d09ec3477ba54f9a \
+                        sha256  f203b9a4171a426d76b7661a5bdd5188db5c3202988a1150a07ea513351185d4 \
+                        size    2280755
 
 go.vendors          rsc.io/qr \
                         repo    github.com/rsc/qr \
@@ -55,35 +55,35 @@ go.vendors          rsc.io/qr \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/term \
-                        lock    v0.2.0 \
-                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
-                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
-                        size    14797 \
-                    golang.org/x/sys \
-                        lock    v0.2.0 \
-                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
-                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
-                        size    1411246 \
-                    golang.org/x/oauth2 \
-                        lock    v0.2.0 \
-                        rmd160  48360c3782cbcbf4bee62b295f25e78dd1a2b232 \
-                        sha256  f9d6706b090000deeaff12aec7bba2bfff89968f0740650297677de1f30467f4 \
-                        size    85700 \
-                    golang.org/x/net \
-                        lock    v0.2.0 \
-                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
-                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
-                        size    1243767 \
-                    golang.org/x/exp \
-                        lock    6ab00d035af9 \
-                        rmd160  0bc7d20e28588ebd6a442a737309887fe2e1593d \
-                        sha256  9b411f5ca3899a140f4afd0d6640eb2ca4b75371a04973490d805682e1965654 \
-                        size    1606053 \
-                    golang.org/x/crypto \
                         lock    v0.3.0 \
-                        rmd160  9fb8270d9c452cb03823b9d7727e198e91c6650e \
-                        sha256  f55f5e89d35b1c17e071d08a4b89fe5bf3cbf5214fb6ec87097de8751dbe69c3 \
-                        size    1633434 \
+                        rmd160  14a60f913597d05ed7df0b6d6fbca50ca672b594 \
+                        sha256  c5e084b265e4c0dfb37ef0a0e7aa5b5ff4f9afe55c71452d13789a85abcd46c9 \
+                        size    14800 \
+                    golang.org/x/sys \
+                        lock    v0.3.0 \
+                        rmd160  17c78e6210a6f938db21fa772584ab8c7d4e06c1 \
+                        sha256  b04ddf676ead57e0d3e367e9aa17db1b11fc20af719e479d1ca56873a2bdf06b \
+                        size    1411264 \
+                    golang.org/x/oauth2 \
+                        lock    v0.3.0 \
+                        rmd160  9feed440ae9739cf5f54b84c5a2d5d68ebe3ed92 \
+                        sha256  60061bd7d2c4b0e7744e581eea0974ae5172c506c8b087301f63a4e4c21cca36 \
+                        size    87101 \
+                    golang.org/x/net \
+                        lock    v0.4.0 \
+                        rmd160  c003f74a2dd1696a79f5fa52e78d12d95e58a3a2 \
+                        sha256  22ce878356e58045cc8509555dab771ac53d6a0541448d3d58fc24d9ba462cd9 \
+                        size    1237072 \
+                    golang.org/x/exp \
+                        lock    ad323defaf05 \
+                        rmd160  bc9e2228979d2dcaf61905c09ad2f9fb252257c0 \
+                        sha256  9c0e907e60e1dcffbedcf38ba11ca4581b082fb6a44bd23cd073fbfa246f2c8d \
+                        size    1608821 \
+                    golang.org/x/crypto \
+                        lock    v0.4.0 \
+                        rmd160  5669817509812aad1d04b5dc12d2217d28d954d8 \
+                        sha256  d2340a6bb7fa26df5f5e309cada4e2666652e721307fa512923f352a17b7a14e \
+                        size    1633555 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.8.0 \
@@ -107,10 +107,10 @@ go.vendors          rsc.io/qr \
                         sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
                         size    1823438 \
                     github.com/urfave/cli \
-                        lock    v2.23.5 \
-                        rmd160  d8938c21c70b60fe854dd8e097437583b4796312 \
-                        sha256  2ce7e9537407479ff0af3c61a71313319d91fe6fc10d19b4cda00ccad0e8e164 \
-                        size    3478097 \
+                        lock    v2.23.7 \
+                        rmd160  24267bc404311ebe68041f20ff5a7319a2fb4a41 \
+                        sha256  79e7cb8a8370eebf06ee097fa983615701d788d76bad63eb24654e3ae1a4c930 \
+                        size    3478311 \
                     github.com/twpayne/go-pinentry \
                         lock    v0.2.0 \
                         rmd160  88299f5352fe0c52d1c25ed05e568cc5a776aaab \
@@ -197,10 +197,10 @@ go.vendors          rsc.io/qr \
                         sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
                         size    9778 \
                     github.com/martinhoefling/goxkcdpwgen \
-                        lock    v0.1.1 \
-                        rmd160  56164d6a8b2620f53897f85abe3ff7659e0aa0c5 \
-                        sha256  0ee21438461014724b2a3afe08e6db51649748ff23f7f90705b2617d80e568a6 \
-                        size    89925 \
+                        lock    737661b92a0e \
+                        rmd160  a9ff7472b7e85aa183c6e22ab80a0796aa527769 \
+                        sha256  60ea3c457e03c7a186caa391955ade2fb169325d77f351d73b97e80a30e9607b \
+                        size    180699 \
                     github.com/kr/text \
                         lock    v0.2.0 \
                         rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
@@ -362,12 +362,7 @@ go.vendors          rsc.io/qr \
                         lock    v1.0.0 \
                         rmd160  3a01840612afa65c6dc7fa897b2dc573ed869da6 \
                         sha256  30d2ab91b9f13ca4aa2c079ca688013658965e827557aa461296932d633c4055 \
-                        size    59693 \
-                    bitbucket.org/creachadair/stringset \
-                        lock    v0.0.10 \
-                        rmd160  7db147228f81a1604d50f8b8754db17f0abdda9b \
-                        sha256  804f3c816450747166e4c006aa0bef7e5e06d94ea23d200db4e128bba2d99cc2 \
-                        size    19241
+                        size    59693
 
 set go_ldflags      "-s -w -X main.version=${version}"
 build.args          -ldflags \"${go_ldflags}\"


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
