### PR TITLE
dmarc-report-converter: new port

### DIFF
--- a/mail/dmarc-report-converter/Portfile
+++ b/mail/dmarc-report-converter/Portfile
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/tierpod/dmarc-report-converter 0.6.5 v
+categories          mail
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+license             MIT
+
+description         Convert dmarc reports from xml to human-readable formats.
+long_description    {*}${description} Files can be located on a local filesystem or on an IMAP server.
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  90115ad43785476ea0f6b2ed331a799467946141 \
+                        sha256  3db27ecd9caba5e547b9ab93f256e4202832ab19cdcc18eb995556c84afbe912 \
+                        size    1021558
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.1 \
+                        rmd160  56eb283b31feac8db4ede3e24768e0f9999913d2 \
+                        sha256  34dc73c7798abfa3bb96c46c25002ccc5b92543dc3e008a31e0ae94c2528e52b \
+                        size    70231 \
+                    golang.org/x/text \
+                        lock    7922cc490dd5 \
+                        rmd160  aa9d82c8de834c5857901076230e457789487a00 \
+                        sha256  5e6521857009c9fe6267e71448b45296049161d7c80fc1060f8b2e1f03683128 \
+                        size    6566859 \
+                    github.com/hashicorp/logutils \
+                        lock    0dc08b1671f3 \
+                        rmd160  942a35fd0913abee504af858be320327da0e5157 \
+                        sha256  45b0cb934db8649767a757b47d7d7941e2ea1ee4a31c87b282065c66dc653e96 \
+                        size    7711 \
+                    github.com/emersion/go-textwrapper \
+                        lock    d0e65e56babe \
+                        rmd160  ef26d9541c9c955095a1226ea84e2c07a4556d94 \
+                        sha256  66bda58d5b25c55bc1f46d0441140959f4a7ef18f2dc1b7f952dfea4519aa2be \
+                        size    2173 \
+                    github.com/emersion/go-sasl \
+                        lock    7e096a0a6197 \
+                        rmd160  97a794cf5884c1e37ccb5d0705b2972d44751fe4 \
+                        sha256  08d79072650677165739eceb82af47ca4bcd3d312cd8454587b1df0f086c9ccd \
+                        size    4451 \
+                    github.com/emersion/go-message \
+                        lock    51445bfdc558 \
+                        rmd160  b33f51ebeb108a77db62b21bd9673a2023b824b6 \
+                        sha256  afefe559f6d44a0addfacc94e4229da6a1cc60fd70cabd0fb285f0abb1fc29c5 \
+                        size    15278 \
+                    github.com/emersion/go-imap \
+                        lock    b63c7c7011cb \
+                        rmd160  b31f0d149601927d350e5c1f01718db46c9fbedd \
+                        sha256  fc8cf5d850cf39953f2ee3d9c3f17c180029f972b13a7b078cb25ab6f46fe408 \
+                        size    87012
+
+build.args          ./cmd/${name}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+    xinstall -m 0644 -d ${destroot}${prefix}/share/${name}/assets/css
+    xinstall -m 0644 -d ${destroot}${prefix}/share/${name}/assets/js
+    xinstall -m 0644 {*}[glob ${worksrcpath}/assets/css/*] ${destroot}${prefix}/share/${name}/assets/css
+    xinstall -m 0644 {*}[glob ${worksrcpath}/assets/js/*] ${destroot}${prefix}/share/${name}/assets/js
+    xinstall -m 0644 ${worksrcpath}/config/config.dist.yaml ${destroot}${prefix}/share/${name}/config.example.yaml
+}


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
