### PR TITLE
python27-bootstrap: fix missing expat/libffi on Tiger

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -71,6 +71,12 @@ if {${subport} eq ${name}} {
     openssl.branch  1.1
 }
 
+configure.args-append \
+                    --enable-framework=${frameworks_dir} \
+                    --enable-ipv6 \
+                    --with-system-expat \
+                    --with-system-ffi
+
 # This port is used by clang-3.4 to bootstrap libcxx
 subport ${name}-bootstrap {
     depends_extract         port:xz-bootstrap
@@ -98,17 +104,20 @@ subport ${name}-bootstrap {
     # sterilize PATH
     configure.env-append    PATH=/usr/bin:/bin:/usr/sbin:/sbin
     build.env-append        PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+    if {${os.platform} eq "darwin" && ${os.major} < 9} {
+        # Tiger has no system libexpat or libffi, so we can't use them for the bootstrap port
+        configure.args-delete --with-system-expat \
+                              --with-system-ffi
+        notes-append    "${name}-bootstrap on Tiger cannot build these modules, which can be\
+                        built by the full ${name} port: gdbm, hashlib, locale, sqlite3, ssl"
+    }
 }
+
 # Also needed by later clangs.
 if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
     clang_dependency.extra_versions 3.7
 }
-
-configure.args-append \
-                    --enable-framework=${frameworks_dir} \
-                    --enable-ipv6 \
-                    --with-system-expat \
-                    --with-system-ffi
 
 if {${subport} eq ${name}} {
     configure.cppflags-append -I${prefix}/include/db48


### PR DESCRIPTION
python27-bootstrap can't use system expat and libffi as
    they don't exist on Tiger
closes: https://trac.macports.org/ticket/65177 

Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4, Intel and PPC

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
