### PR TITLE
swi-prolog-devel: Updated to version 9.1.2

### DIFF
--- a/lang/swi-prolog-devel/Portfile
+++ b/lang/swi-prolog-devel/Portfile
@@ -2,12 +2,11 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           compiler_blacklist_versions 1.0
 
 name                swi-prolog-devel
 conflicts           swi-prolog
 epoch               20051223
-version             9.1.1
+version             9.1.2
 revision            0
 
 categories          lang
@@ -32,12 +31,9 @@ master_sites        https://www.swi-prolog.org/download/devel/src/
 distname            swipl-${version}
 dist_subdir         swi-prolog
 
-checksums           rmd160  8e501ba91c330b289d2c4a326f24282da5bbec42 \
-                    sha256  66cbe9652528c831d26fa9999f3a088ab5b9126115d33f48442ac0e52d4d2be2 \
-                    size    11818020
-
-# to avoid the following problem: fatal error: 'threads.h' file not found
-compiler.blacklist-append {clang < 900}
+checksums           rmd160  2ad5e655ca6862510a7b7a08a76f64ea60113b02 \
+                    sha256  3712f85a6b48531d40f0fa402f40bf99fdfab5e4e303083c4a2cece8629b74b0 \
+                    size    11827220
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
Removed compiler_blacklist_versions.  This dealt with existence of threads.h. Current versions deal with that using a CMake test.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.0.1 22A400 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
