### PR TITLE
netgen: fix build on case sensetive FS

### DIFF
--- a/math/netgen/Portfile
+++ b/math/netgen/Portfile
@@ -49,6 +49,7 @@ patchfiles-append       patch-no-external.diff \
                         patch-link-agains-ffmpeg.diff \
                         patch-cmake-version.diff \
                         patch-MacPorts-rpath.diff \
+                        patch-MacPorts-togl.diff \
                         patch-propagate_c_compiler.diff
 
 depends_lib-append      port:zlib \
@@ -71,11 +72,6 @@ configure.args-append   -DUSE_NATIVE_ARCH=OFF \
 if {${os.platform} eq "darwin" && ${os.major} <= 15} {
     # No support for sized operator delete
     patchfiles-append   patch-sized-deallocation.diff
-}
-
-post-patch {
-    # use MacPorts Togl
-    reinplace {/add_subdirectory.Togl/s/^/#/g} ${worksrcpath}/ng/CMakeLists.txt
 }
 
 set pythonversions      {3.7 3.8 3.9}

--- a/math/netgen/files/patch-MacPorts-togl.diff
+++ b/math/netgen/files/patch-MacPorts-togl.diff
@@ -1,0 +1,25 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 0a05ebb1..6726480c 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -280,7 +280,7 @@ if (USE_GUI)
+        target_include_directories(netgen_gui INTERFACE ${TK_INCLUDE_PATH}/../xlib)
+     endif()
+ 
+-    target_link_libraries(nggui PUBLIC nglib togl PRIVATE "$<BUILD_INTERFACE:netgen_python>" )
++    target_link_libraries(nggui PUBLIC nglib Togl PRIVATE "$<BUILD_INTERFACE:netgen_python>" )
+ 
+     if(WIN32)
+       target_compile_definitions(netgen_gui INTERFACE -DTOGL_WGL)
+diff --git ng/CMakeLists.txt ng/CMakeLists.txt
+index 3ad3d8be..b14a3d1d 100644
+--- ng/CMakeLists.txt
++++ ng/CMakeLists.txt
+@@ -70,6 +70,6 @@ if(USE_GUI)
+         DESTINATION ${NG_INSTALL_DIR_BIN} COMPONENT netgen)
+   endif()
+ 
+-  add_subdirectory(Togl2.1)
++  # add_subdirectory(Togl2.1)
+ endif(USE_GUI)
+ 


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->