### PR TITLE
skaffold: update to 2.0.4

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.0.3 v
+github.setup        GoogleContainerTools skaffold 2.0.4 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  e30c178b755695146903a024568de052732be651 \
-                    sha256  8153ae02bf89f3fc90976d844762193aee27b81e823eb1616f35937130002a1b \
-                    size    71690278
+checksums           rmd160  910bf4dd3f6de5367ca03bc44cd1d0747de1648e \
+                    sha256  c86efc08e3687eb1b0f952e99823c8247c74caab0cba8ef673cef1c311cc3da3 \
+                    size    41605601
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to skaffold 2.0.4.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?