### PR TITLE
py-igraph: re-add test dependencies for py311 subport

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -78,18 +78,13 @@ if {${name} ne ${subport}} {
 
     # python-igraph optionally makes use of these, and some tests depend on them.
     # If they are not installed, the corresponding tests will simply be skipped.
-    if {${subport} eq "py311-igraph"} {
-        # Temporary workaround:
-        # Skip test dependencies not yet available as py311 ports.
-        depends_test-append     port:py${python.version}-networkx \
-                                port:py${python.version}-numpy
-    } else {
-        depends_test-append     port:py${python.version}-matplotlib \
-                                port:py${python.version}-networkx \
-                                port:py${python.version}-numpy \
-                                port:py${python.version}-pandas \
-                                port:py${python.version}-scipy
-    }
+    # python-igraph optionally makes use of these, and some tests depend on them.
+    # If they are not installed, the corresponding tests will simply be skipped.
+    depends_test-append     port:py${python.version}-matplotlib \
+                            port:py${python.version}-networkx \
+                            port:py${python.version}-numpy \
+                            port:py${python.version}-pandas \
+                            port:py${python.version}-scipy
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]


### PR DESCRIPTION
#### Description

This PR re-adds some test dependencies for the py311 subport. When py311 support was originally added for py-igraph, these packages were not yet available for py311.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
