### PR TITLE
python27-bootstrap: fix missing expat/libffi on Tiger

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -98,6 +98,11 @@ subport ${name}-bootstrap {
     # sterilize PATH
     configure.env-append    PATH=/usr/bin:/bin:/usr/sbin:/sbin
     build.env-append        PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+    if {${os.platform} eq "darwin" && ${os.major} < 9} {
+        notes-append    "${name}-bootstrap on Tiger cannot build these modules, which can be\
+                        built by the full ${name} port: gdbm, hashlib, locale, sqlite3, ssl"
+    }
 }
 # Also needed by later clangs.
 if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
@@ -106,9 +111,13 @@ if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"}
 
 configure.args-append \
                     --enable-framework=${frameworks_dir} \
-                    --enable-ipv6 \
+                    --enable-ipv6
+if {${subport} eq ${name} || (${os.platform} eq "darwin" && ${os.major} >= 9)} {
+    # Tiger has no system libexpat or libffi, so we can't use them for the bootstrap port
+    configure.args-append \
                     --with-system-expat \
                     --with-system-ffi
+}
 
 if {${subport} eq ${name}} {
     configure.cppflags-append -I${prefix}/include/db48


### PR DESCRIPTION
Can't use system expat and libffi as they don't exist on Tiger. Closes: https://trac.macports.org/ticket/65177

Add notes about Tiger modules--because it builds from system roots, the python27-bootstrap port cannot build as many modules as the full python27 port.
