### PR TITLE
rapidjson-devel: fix build failure

### DIFF
--- a/devel/rapidjson-devel/Portfile
+++ b/devel/rapidjson-devel/Portfile
@@ -34,12 +34,12 @@ homepage                        http://rapidjson.org/
 # Disbled Valgrind because it's apparently failing not due to issues with RapidJSON but rather macOS itself.
 patchfiles                      patch-test-CmakeLists.txt.diff \
                                 patch-test-unittest.diff \
-                                patch-test-unittest-CmakeLists.txt.diff
+                                patch-test-unittest-CmakeLists.txt.diff \
+                                patch-CMakeLists-arch.diff
 
 depends_build-append            bin:doxygen:doxygen
 
 compiler.cxx_standard   2011
-compiler.fallback       macports-clang-15
 
 configure.args-append           -DRAPIDJSON_HAS_STDSTRING=ON \
                                 -DRAPIDJSON_HAS_CXX11_RVALUE_REFS=ON \

--- a/devel/rapidjson-devel/Portfile
+++ b/devel/rapidjson-devel/Portfile
@@ -22,6 +22,8 @@ platforms                       darwin
 # original by {@Lord-Kamina gmail.com:g.litenstein}
 maintainers                     nomaintainer
 
+conflicts                       rapidjson
+
 description                     A fast JSON parser/generator for C++ with both SAX/DOM style API.
 long_description                RapidJSON is a fast, unicode-friendly, self-contained \
                                 and header-only library without any dependencies for parsing JSON.
@@ -37,6 +39,7 @@ patchfiles                      patch-test-CmakeLists.txt.diff \
 depends_build-append            bin:doxygen:doxygen
 
 compiler.cxx_standard   2011
+compiler.fallback       macports-clang-15
 
 configure.args-append           -DRAPIDJSON_HAS_STDSTRING=ON \
                                 -DRAPIDJSON_HAS_CXX11_RVALUE_REFS=ON \

--- a/devel/rapidjson-devel/Portfile
+++ b/devel/rapidjson-devel/Portfile
@@ -8,6 +8,7 @@ PortGroup                       cmake 1.1
 # see https://github.com/macports/macports-ports/pull/1738
 github.setup                    Tencent rapidjson b32cd9421c5e3cbe183a99b6537ce11441e50656
 version                         20180424
+revision                        1
 name                            rapidjson-devel
 
 checksums                       rmd160  a0211ac1dc84270169b59c584894a0f49d0030a8 \

--- a/devel/rapidjson-devel/files/patch-CMakeLists-arch.diff
+++ b/devel/rapidjson-devel/files/patch-CMakeLists-arch.diff
@@ -1,0 +1,32 @@
+--- CMakeLists.orig.txt	2022-12-23 08:11:02.000000000 +0100
++++ CMakeLists.txt	2022-12-23 08:11:54.000000000 +0100
+@@ -56,14 +56,6 @@
+ endif(CCACHE_FOUND)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+-    if(RAPIDJSON_ENABLE_INSTRUMENTATION_OPT AND NOT CMAKE_CROSSCOMPILING)
+-        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "powerpc" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+-          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
+-        else()
+-          #FIXME: x86 is -march=native, but doesn't mean every arch is this option. To keep original project's compatibility, I leave this except POWER.
+-          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+-        endif()
+-    endif()
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
+     set(EXTRA_CXX_FLAGS -Weffc++ -Wswitch-default -Wfloat-equal -Wconversion -Wsign-conversion)
+     if (RAPIDJSON_BUILD_CXX11 AND CMAKE_VERSION VERSION_LESS 3.1)
+@@ -88,14 +80,6 @@
+         endif()
+     endif()
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    if(NOT CMAKE_CROSSCOMPILING)
+-      if(CMAKE_SYSTEM_PROCESSOR STREQUAL "powerpc" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
+-      else()
+-        #FIXME: x86 is -march=native, but doesn't mean every arch is this option. To keep original project's compatibility, I leave this except POWER.
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+-      endif()
+-    endif()
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-missing-field-initializers")
+     set(EXTRA_CXX_FLAGS -Weffc++ -Wswitch-default -Wfloat-equal -Wconversion -Wimplicit-fallthrough)
+     if (RAPIDJSON_BUILD_CXX11 AND CMAKE_VERSION VERSION_LESS 3.1)


### PR DESCRIPTION
#### Description

The rapidjson-devel port was failing to compile on my system (MacPorts 2.8.0, macOS 12.6.1, Apple Silicon).
The error was:
```
clang: error: the clang compiler does not support '-march=native'
```

Forcing MacPorts to use clang-15 fixes the issue. I also added a conflicts line because this port would not install if rapidjson port is active.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.1 21G217 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

The tests and universal variants do not build, but they were probably also already broken.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

