### PR TITLE
MoltenVK: Add universal variant and strip arch when not universal

### DIFF
--- a/graphics/MoltenVK/Portfile
+++ b/graphics/MoltenVK/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 
 github.setup        KhronosGroup MoltenVK 1.1.9 v
 epoch               1
+revision            1
 
 set sdkversion      1.3.211.0
 categories          graphics
@@ -34,6 +35,7 @@ checksums           sha256  bfe654af00030b6e65521f834f0830f15e18c828594226865f15
 depends_build       port:p7zip
 depends_skip_archcheck p7zip
 
+variant universal   {}
 use_configure       no
 
 build {
@@ -57,6 +59,10 @@ destroot {
 
     # vulkan and vk_video are provided via vulkan-headers
     file copy ${output_dir}/MoltenVK/include/MoltenVK ${destroot}${prefix}/include
+
+    if {(![variant_isset universal])} {
+        system -W ${destroot}${prefix}/lib "lipo -thin ${configure.build_arch} libMoltenVK.dylib -o libMoltenVK.dylib 2> /dev/null"
+    }
 }
 
 platform darwin {


### PR DESCRIPTION
closes https://trac.macports.org/ticket/66532

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
