### PR TITLE
gitlab portgroup: adopt extract.rename

### DIFF
--- a/_resources/port1.0/group/gitlab-1.0.tcl
+++ b/_resources/port1.0/group/gitlab-1.0.tcl
@@ -48,6 +48,11 @@ proc gitlab.setup {gl_author gl_project gl_version {gl_tag_prefix ""} {gl_tag_su
     default master_sites    {${gitlab.master_sites}}
     distname                ${gitlab.project}-${gitlab.version}
     use_bzip2               yes
+    # https://trac.macports.org/ticket/66415
+    # remove the 'if' clause with the next 'port' release
+    if {[exists extract.rename]} {
+        extract.rename      yes
+    }
 
 # I don't _think_ we need this bit from the github portgroup, but keeping
 # around until we have more use cases...


### PR DESCRIPTION
#### Description

This fixes the build for these ports on MacPorts HEAD.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D5027d
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
