### PR TITLE
gjs-devel: update to 1.74.1

### DIFF
--- a/gnome/gjs-devel/Portfile
+++ b/gnome/gjs-devel/Portfile
@@ -8,8 +8,8 @@ name                gjs-devel
 conflicts           gjs
 set my_name         gjs
 
-version             1.72.2
-revision            2
+version             1.74.1
+revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
@@ -26,18 +26,21 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  3b03b8b41f50088bd4182cb015585c10809e034c \
-                    sha256  ddee379bdc5a7d303a5d894be2b281beb8ac54508604e7d3f20781a869da3977 \
-                    size    620380
+checksums           rmd160  1dc4e4d1b5ad9721b108040fcf6073f09f20451f \
+                    sha256  f21f9cd3337a672a44c7e64bf9a8d8ad77c1b88b952b2b6184c7af9b1f3ef459 \
+                    size    638536
 
 depends_build       port:pkgconfig \
                     port:python310
 
+# Currently requires gobject-introspection-devel and
+# glib2-upstream (or glib2-devel) for GBindingGroup
 depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
-                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    port:glib2-upstream \
+                    port:dbus \
                     port:libffi \
                     path:lib/pkgconfig/cairo.pc:cairo \
-                    port:mozjs91 \
+                    port:mozjs102 \
                     port:readline
 
 compiler.cxx_standard \


### PR DESCRIPTION
#### Description

Builds fine, ran the test suite. The Cairo module tests are failing, but everything else is passing.

CI is failing because the build needs glib2-devel and gobject-introspection-devel.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
