### PR TITLE
mint: update to 0.17.5

### DIFF
--- a/devel/mint/Portfile
+++ b/devel/mint/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               xcodeversion 1.0
 
-github.setup            yonaskolb Mint 0.17.4
+github.setup            yonaskolb Mint 0.17.5
 revision                0
 github.tarball_from     archive
 
@@ -17,9 +17,9 @@ maintainers             {kylelanchman.com:macports @klanchman} openmaintainer
 description             A package manager that installs and runs executable Swift packages
 long_description        {*}${description}
 
-checksums               rmd160  b94dfbce237e4911a126a9fd6d94d0e152674700 \
-                        sha256  1c4ccf124ab883a6f8c50d1d7cc5feba92c527cdc2dbcb4d2b1ae8960131aedf \
-                        size    23984
+checksums               rmd160  9a092c26b9aafb0b68f02e7d9c1333290c8c38a2 \
+                        sha256  f55350f7778c4ccd38311ed36f39287ff74bb63eb230f6d448e35e7f934c489c \
+                        size    24070
 
 minimum_xcodeversions-append {18 11}
 


### PR DESCRIPTION
#### Description

[Release notes](https://github.com/yonaskolb/Mint/releases/tag/0.17.5)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
