### PR TITLE
sbcl: update to 2.2.11

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -8,7 +8,7 @@ name            sbcl
 #
 # Please bump the revision of math/maxima (and when it exists
 # math/maxima-devel) when this port changes.
-version         2.2.10
+version         2.2.11
 revision        0
 
 categories      lang
@@ -41,9 +41,9 @@ distfiles       ${name}-${version}-source${extract.suffix}:sbcl
 worksrcdir      ${name}-${version}
 
 checksums       ${name}-${version}-source${extract.suffix} \
-    rmd160  2d47809e97b137cba637b25e0bfe2c1aca0683e7 \
-    sha256  8cc3c3a8761223adef144a88730b2675083a3b26fa155d70cf91abb935e90833 \
-    size    7269005
+    rmd160  1b253ec468addb64e19872cfee08bb297289ea69 \
+    sha256  3607d68016731880845ced5d5d55c6054cc49f19121a15027e6c5607ae8496df \
+    size    7290281
 
 # Since SBCL is written in lisp, it requires a running lisp binary to
 # bootstrap from.

--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fricas
 version             1.3.8
-revision            3
+revision            4
 categories          math
 maintainers         {@pietvo vanoostrum.org:pieter} openmaintainer
 platforms           darwin

--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -39,7 +39,7 @@ subport maxima-devel {
     # Date:  Sat Oct 29 16:24:21 2022 +0000
     # commit 5b42cccfd9eee54d0458d8f4e63e6b44c55d48a1
     version     5.46-dev-20221029
-    revision    1
+    revision    2
     fetch.type  git
     git.url     https://git.code.sf.net/p/maxima/code
     git.branch  5b42cccfd9eee54d0458d8f4e63e6b44c55d48a1
@@ -53,7 +53,7 @@ if {${subport} eq ${name}} {
     conflicts   maxima-devel
 
     version     5.46.0
-    revision    1
+    revision    2
     # get the source tarball from sourceforge.
     master_sites    sourceforge:project/maxima/Maxima-source/${version}-source
 


### PR DESCRIPTION
#### Description

Update SBCL to the latest version. We also revbump the following dependencies, as they rely on binary compatibility of SBCL core files:

- fricas
- maxima

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
