### PR TITLE
qt6: bump qtbase revision

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -113,7 +113,7 @@ array set modules {
         {"Qt 3D"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qt5compat {
@@ -128,7 +128,7 @@ array set modules {
         {"Qt5 Compatibility"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtbase {
@@ -149,7 +149,7 @@ array set modules {
          "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtcharts {
@@ -164,7 +164,7 @@ array set modules {
         {"Qt Charts"}
         "GPLv3 license only"
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: GPL-3"
     }
     qtconnectivity {
@@ -179,7 +179,7 @@ array set modules {
         {"Qt Bluetooth" "Qt NFC"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtdeclarative {
@@ -194,7 +194,7 @@ array set modules {
         {"Qt QML" "Qt Quick" "Qt Quick Layouts" "Qt Quick Widgets"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtimageformats {
@@ -209,7 +209,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtmultimedia {
@@ -224,7 +224,7 @@ array set modules {
         {"Qt Multimedia" "Qt Multimedia Widgets"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtnetworkauth {
@@ -239,7 +239,7 @@ array set modules {
         {"Qt Network Authorization"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtpositioning {
@@ -254,7 +254,7 @@ array set modules {
         {"Provides the ability to determine a position by using a variety of possible sources"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: {GPL-3}"
     }
     qtremoteobjects {
@@ -269,7 +269,7 @@ array set modules {
        {"Qt Remote Objects"}
        ""
        "variant overrides: "
-       "revision 1"
+       "revision 2"
        "License: "
     }
     qtsensors {
@@ -284,7 +284,7 @@ array set modules {
         {"Qt Sensors"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtserialbus {
@@ -299,7 +299,7 @@ array set modules {
         {"Qt Serial Bus"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtserialport {
@@ -314,7 +314,7 @@ array set modules {
         {"Qt Serial Port"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtshadertools {
@@ -329,7 +329,7 @@ array set modules {
         {"Qt ShaderTools"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtsvg {
@@ -344,7 +344,7 @@ array set modules {
         {"Qt SVG"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qttools {
@@ -359,7 +359,7 @@ array set modules {
         {"Qt Designer" "Qt Help" "Qt UI Tools"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qttranslations {
@@ -374,7 +374,7 @@ array set modules {
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtwebchannel {
@@ -389,7 +389,7 @@ array set modules {
         {"Qt WebChannel"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtwebsockets {
@@ -404,7 +404,7 @@ array set modules {
         {"Qt WebSockets"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
 }


### PR DESCRIPTION
The PR https://github.com/macports/macports-ports/pull/16831 bumped qtbase revision from 0 to 1
but because of https://github.com/macports/macports-ports/commit/41000ab0296c57c01f3aba71bcdf5aa52b68ceb3 which was merged before,
the revision was not bumped and hence, qtbase was not rebuilt with the changes
of https://github.com/macports/macports-ports/pull/16831.

So bump it to revision 2 (and dependants also). This should fix build failure
https://build.macports.org/builders/ports-13_x86_64-watcher/builds/1010

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
CI only

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
