### PR TITLE
the new minetest-devel port delivering a cutting edge Minetest to MacPorts

### DIFF
--- a/games/minetest-devel/Portfile
+++ b/games/minetest-devel/Portfile
@@ -45,7 +45,7 @@ post-extract {
     }
 }
 
-license                 LGPL-2.1+
+license                 EUPL-1.2
 categories              games
 platforms               darwin
 maintainers             nomaintainer

--- a/games/minetest-devel/Portfile
+++ b/games/minetest-devel/Portfile
@@ -1,0 +1,122 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake 1.1
+
+compiler.cxx_standard   2011
+compiler.thread_local_storage   yes
+
+name                    minetest-devel
+github.setup            minetest minetest 5.6.1
+revision                0
+
+# the game version could be different to the minetest version
+set game_version        5.6.1
+
+# to add on more files to a github portgroup download
+# have to cache the preset distfiles from the github PG
+set main_distfile       ${distfiles}
+
+# then add another distfile, with a direct URL as can't use the github PG again
+set game_distfile       ${game_version}${extract.suffix}
+set game_mastersite     https://github.com/minetest/minetest_game/archive/
+
+distfiles               ${main_distfile}:main \
+                        ${game_distfile}:game
+
+master_sites            ${github.master_sites}:main \
+                        ${game_mastersite}:game
+
+checksums               ${main_distfile} \
+                        rmd160  7b32331e0007f29003107592522d1c906935e44d \
+                        sha256  425d8e9363212dcb5bc7986dd12460c9c3784aca22eb1b90dad6a7fc2c6ef546 \
+                        size    9925064 \
+                        ${game_distfile} \
+                        rmd160  73d35423b856d141cebfa16396fe5dcf834dcf89 \
+                        sha256  5dc857003d24bb489f126865fcd6bf0d9c0cb146ca4c1c733570699d15abd0e3 \
+                        size    2590582
+
+# rename directory - from github portgroup
+post-extract {
+    if {[file exists [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]] && \
+        [file isdirectory [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]]} {
+        move [glob ${workpath}/${github.author}-${github.project}-*] ${workpath}/${distname}
+    }
+}
+
+license                 LGPL-2.1+
+categories              games
+platforms               darwin
+maintainers             nomaintainer
+description             open source infinite-world block sandbox game with survival and crafting
+long_description        - ${description} - \
+                         \
+                        Minetest (usually abbreviated as MT) is an open source voxel game \
+                        engine. Play one of our many games, mod a game to your liking, make your \
+                        own game, or play on a multiplayer server. \
+                         \
+                        Available for Windows, macOS, GNU/Linux, FreeBSD, OpenBSD, DragonFly \
+                        BSD, and Android. \
+                         \
+                        * More information at <https://www.minetest.net> \
+                        * More MT mod expansions at <https://content.minetest.net/> \
+                         \
+                        This is the ${name} port delivering a cutting edge Minetest to macOS.
+
+depends_build-append    port:doxygen
+
+depends_lib-append      port:irrlichtmt \
+                        port:libjpeg-turbo \
+                        port:libogg \
+                        port:libvorbis \
+                        port:freetype \
+                        port:gettext \
+                        port:leveldb \
+                        port:sqlite3 \
+                        port:zstd \
+                        port:luajit \
+                        port:gmp \
+                        port:curl \
+                        port:jsoncpp \
+                        port:spatialindex \
+                        port:xorg-libX11 \
+                        port:xorg-libXxf86vm
+
+# see https://trac.macports.org/ticket/58315 - possibly fixable?
+universal_variant       no
+supported_archs         x86_64
+
+# 001. the original build calls fixup_bundle to move all the deps into the app bundle.
+#    this doesn't work correctly with macports destrooting, and isn't necessary for a macports install so deleted it
+patchfiles-append       001-patch-src-CMakeLists-disable-bundlefixup.diff
+
+# 002. patch to get the luajit include headers ahead of the system includes, or the build finds the
+#    wrong lua headers if you have a newer version of lua installed
+patchfiles-append       002-patch-cmake-Modules-FindLua-include-LUADIR-before-system.diff
+
+# 003. patch main.cpp to not barf on the unrecognized command-line option -psn from Apple launch
+patchfiles-append       003-patch-ignore-psn-option-mac-bundle.diff
+
+configure.args-append   -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_INSTALL_PREFIX:PATH=${applications_dir} \
+                        -DBUILD_UNITTESTS=OFF \
+                        -DBUILD_CLIENT=ON \
+                        -DBUILD_SERVER=ON \
+                        -DENABLE_SOUND=ON \
+                        -DENABLE_REDIS=OFF \
+                        -DENABLE_POSTGRESQL=OFF \
+                        -DENABLE_LEVELDB=ON \
+                        -DENABLE_FREETYPE=ON \
+                        -DENABLE_CURL=ON \
+                        -DENABLE_GETTEXT=ON \
+                        -DENABLE_SPATIAL=ON \
+                        -DENABLE_SYSTEM_GMP=ON \
+                        -DENABLE_SYSTEM_JSONCPP=ON \
+                        -DCURSES_INCLUDE_PATH:FILEPATH=${prefix}/include \
+                        -DENABLE_LUAJIT=ON \
+                        -DVERSION_EXTRA=MacPorts
+
+post-destroot {
+    move ${workpath}/minetest_game-${game_version}   ${destroot}${applications_dir}/minetest.app/Contents/Resources/games/minetest_game
+}

--- a/games/minetest-devel/files/001-patch-src-CMakeLists-disable-bundlefixup.diff
+++ b/games/minetest-devel/files/001-patch-src-CMakeLists-disable-bundlefixup.diff
@@ -1,0 +1,16 @@
+--- ./src/CMakeLists.txt.orig	2016-12-18 11:32:01.000000000 -0800
++++ ./src/CMakeLists.txt	2016-12-18 11:32:13.000000000 -0800
+@@ -818,13 +818,6 @@
+ 		BUNDLE DESTINATION .
+ 	)
+ 
+-	if(APPLE)
+-		install(CODE "
+-			set(BU_CHMOD_BUNDLE_ITEMS ON)
+-			include(BundleUtilities)
+-			fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${BUNDLE_PATH}\" \"\" \"\${CMAKE_INSTALL_PREFIX}/${BINDIR}\")
+-		" COMPONENT Runtime)
+-	endif()
+ 
+ 	if(USE_GETTEXT)
+ 		foreach(LOCALE ${GETTEXT_AVAILABLE_LOCALES})

--- a/games/minetest-devel/files/002-patch-cmake-Modules-FindLua-include-LUADIR-before-system.diff
+++ b/games/minetest-devel/files/002-patch-cmake-Modules-FindLua-include-LUADIR-before-system.diff
@@ -1,0 +1,10 @@
+--- cmake/Modules.FindLua.cmake.orig	2017-12-08 11:49:52.000000000 -0800
++++ cmake/Modules/FindLua.cmake	2017-12-08 11:50:05.000000000 -0800
+@@ -11,6 +11,7 @@
+ 	find_package(LuaJIT)
+ 	if(LUAJIT_FOUND)
+ 		set(USE_LUAJIT TRUE)
++		include_directories(BEFORE ${LUA_INCLUDE_DIR})
+ 		message (STATUS "Using LuaJIT provided by system.")
+ 	elseif(REQUIRE_LUAJIT)
+ 		message(FATAL_ERROR "LuaJIT not found whereas REQUIRE_LUAJIT=\"TRUE\" is used.\n"

--- a/games/minetest-devel/files/003-patch-ignore-psn-option-mac-bundle.diff
+++ b/games/minetest-devel/files/003-patch-ignore-psn-option-mac-bundle.diff
@@ -1,0 +1,11 @@
+--- ./src/main.cpp.orig	2016-12-18 15:49:42.000000000 -0800
++++ ./src/main.cpp	2016-12-18 15:50:13.000000000 -0800
+@@ -126,7 +126,7 @@
+ 			|| cmd_args.getFlag("help")
+ 			|| cmd_args.exists("nonopt1")) {
+ 		print_help(allowed_options);
+-		return cmd_args_ok ? 0 : 1;
++//		return cmd_args_ok ? 0 : 1;
+ 	}
+ 
+ 	if (cmd_args.getFlag("version")) {


### PR DESCRIPTION
This PR is a DRAFT and **WIP** until further notice.

The _minetest_ port is at MT 5.6.1 current level, however the build is **not optimal** IMO. 

#### Description

This is the new **minetest-devel** port, delivering a cutting edge **Minetest** to macOS by help of MacPorts.

The contribution and core commit is the **improved Portfile** derived from the legacy Portfile.

This PR addresses the Ticket at <https://trac.macports.org/ticket/66562>
Please take the time to thoroughly read the complete Description text of this Ticket.

TO DO: Please note Test and Verification shall be accomplished in due time.

Please be aware, my work and/or contribution to Open Source Endeavour is always published under the **EUPL-1.2** license. This fits my legal requirement as an European citizen thus outside U.S. jurisdiction. Furthermore, the Open Source Initiative (OSI) approves of EUPL-1.2 and agrees, that **public domain doesn't exist in Europe**.

  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12

More information in section _License_ added below.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.2 20G1020 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->

Have you - **Stay tuned.** 

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`? - see below
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
<!--  - [ ] tested basic functionality of all binary files?  -->
<!--  - [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?  -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

#### Addendum
##### Portfile check

```
$ port lint --nitpick -F Portfile
--->  Verifying Portfile for minetest-devel
Warning: Line 15 seems to hardcode the version number, consider using ${version} instead
--->  0 errors and 1 warnings found.
Error: Unrecognized action "port PortSystem"
```

##### Licence

@Zweihorn - 2022-12-26
This work is derived from work under the LGPL-1.2+ on MacPorts ports.

Licensed under the EUPL-1.2-or-later

The text of the European Union Public Licence (EUPL) version 1.2, 
published in Official Journal of 19 May 2017 and available in 23
official languages of the European Union (SPDX identifier EUPL-1.2), is
found at:

  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12

The a.m. page contains all the official versions of the European Union
Public Licence (EUPL-1.2).  The preamble written for v 1.0, explaining
the purpose of this Free/Open Source Software Licence, together with
links to further information on the licence is valid for later versions.

The Joinup Licensing Assistant (JLA) may be worth a visit to find and
compare software licenses with:

  * https://joinup.ec.europa.eu/collection/eupl/solution/joinup-licensing-assistant/jla-find-and-compare-software-licenses

The JLA is linked to SPDX (for Software Package Data Exchange), an
initiative of the LINUX foundation that attempts to standardize the way
in which organizations refer to software licenses: each licence is
identified by a full name, such as "European Union Public Licence 1.2"
and a shorter identifier, here "EUPL-1.2".
