### PR TITLE
boost181: fix build on 10.4/10.5

### DIFF
--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -115,6 +115,13 @@ platform darwin 8 {
     patchfiles-append patch-tiger-availability.diff
 }
 
+# posix_memalign introduced in 10.6
+platform darwin {
+    if {${os.major} < 10} {
+        patchfiles-append patch-boost-aligned-alloc.diff
+    }
+}
+
 # see https://trac.macports.org/wiki/UsingTheRightCompiler
 patchfiles-append patch-compiler.diff
 post-patch {

--- a/devel/boost181/files/patch-boost-aligned-alloc.diff
+++ b/devel/boost181/files/patch-boost-aligned-alloc.diff
@@ -1,0 +1,17 @@
+posix_memalign introduced in 10.6
+
+--- ./boost/align/detail/aligned_alloc_posix.hpp.orig
++++ ./boost/align/detail/aligned_alloc_posix.hpp
+@@ -23,8 +23,10 @@
+         alignment = sizeof(void*);
+     }
+     void* p;
+-    if (::posix_memalign(&p, alignment, size) != 0) {
+-        p = 0;
++    if (alignment <= 16) {
++        p = ::malloc(size);
++    } else {
++        p = ::valloc(size);
+     }
+     return p;
+ }


### PR DESCRIPTION
#### Description

Mimic the `posix_memalign` emulation logic in LegacySupport without bringing in the dependency. Tested through build on 10.4.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
