### PR TITLE
libfixmath: new port

### DIFF
--- a/math/libfixmath/Portfile
+++ b/math/libfixmath/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        PetteriAimonen libfixmath ddff910fc03c6e9581ed186268b508dc0f51f4b7
+version             2022.12.27
+revision            0
+categories          math
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Q16.16 format fixed point operations in C
+long_description    {*}${description}
+checksums           rmd160  d925a84dfa834b20cd57f4aad5cca1c89c7398b8 \
+                    sha256  5723d35280bd2cbf713ebab4f0aa97da93a17667a81bdf7031d15e8254ec018c \
+                    size    267530
+
+patch.pre_args      -p1
+patchfiles          0001-Fix-install-targets.patch
+
+compiler.cxx_standard 2011
+
+configure.args-append \
+                    -DBUILD_SHARED_LIBS=ON
+
+test.run            yes
+test.target         test

--- a/math/libfixmath/files/0001-Fix-install-targets.patch
+++ b/math/libfixmath/files/0001-Fix-install-targets.patch
@@ -1,0 +1,61 @@
+From 04168987218649d7ff0a6cff7f2c39cacb85c5b9 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 27 Dec 2022 16:12:36 +0700
+Subject: [PATCH 1/1] Fix install targets See:
+ https://github.com/NetBSD/pkgsrc/tree/trunk/math/libfixmath/patches
+
+In addition, duplicate liblib* has been fixed.
+
+---
+ CMakeLists.txt              | 11 ++++++++---
+ libfixmath/libfixmath.cmake |  9 ++++++---
+ 2 files changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dbcf5e3..865d096 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,14 +14,19 @@ include(libfixmath/libfixmath.cmake)
+ include(tests/tests.cmake)
+ 
+ file(GLOB fixsingen-srcs fixsingen/*.c)
+-file(GLOB fixtest-srcs fixtest/*.c fixtest/*.h)
++file(GLOB fixtest-srcs fixtest/*.c)
+ 
+ add_executable(fixtest ${fixtest-srcs})
+-target_link_libraries(fixtest PRIVATE libfixmath m)
++target_link_libraries(fixtest PRIVATE fixmath m)
+ target_include_directories(fixtest PRIVATE ${CMAKE_SOURCE_DIR})
+ 
+ add_executable(fixsingen ${fixsingen-srcs})
+-target_link_libraries(fixsingen PRIVATE libfixmath m)
++target_link_libraries(fixsingen PRIVATE fixmath m)
+ target_include_directories(fixsingen PRIVATE ${CMAKE_SOURCE_DIR})
+ 
++install(TARGETS fixmath
++    ARCHIVE DESTINATION lib
++    LIBRARY DESTINATION lib
++)
+ 
++install(FILES ${libfixmath-includes} DESTINATION include/libfixmath)
+diff --git a/libfixmath/libfixmath.cmake b/libfixmath/libfixmath.cmake
+index 138b1de..b92e677 100644
+--- a/libfixmath/libfixmath.cmake
++++ b/libfixmath/libfixmath.cmake
+@@ -1,6 +1,9 @@
+ file(GLOB libfixmath-srcs libfixmath/*.c)
++file(GLOB libfixmath-includes libfixmath/*.h libfixmath/*.hpp)
+ 
+-add_library(libfixmath STATIC ${libfixmath-srcs})
++add_library(fixmath ${libfixmath-srcs})
+ 
+-target_include_directories(libfixmath INTERFACE
+-  ${CMAKE_CURRENT_SOURCE_DIR})
+\ No newline at end of file
++target_include_directories(fixmath INTERFACE
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libfixmath>
++    $<INSTALL_INTERFACE:include>
++)
+-- 
+2.37.3
+


### PR DESCRIPTION
#### Description

New port: https://github.com/PetteriAimonen/libfixmath

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

All tests pass in Rosetta:
```
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_libfixmath/libfixmath/work/build
      Start  1: tests_ro64
 1/12 Test  #1: tests_ro64 .......................   Passed    0.02 sec
      Start  2: tests_no64
 2/12 Test  #2: tests_no64 .......................   Passed    0.02 sec
      Start  3: tests_rn64
 3/12 Test  #3: tests_rn64 .......................   Passed    0.02 sec
      Start  4: tests_nn64
 4/12 Test  #4: tests_nn64 .......................   Passed    0.02 sec
      Start  5: tests_ro32
 5/12 Test  #5: tests_ro32 .......................   Passed    0.02 sec
      Start  6: tests_no32
 6/12 Test  #6: tests_no32 .......................   Passed    0.02 sec
      Start  7: tests_rn32
 7/12 Test  #7: tests_rn32 .......................   Passed    0.02 sec
      Start  8: tests_nn32
 8/12 Test  #8: tests_nn32 .......................   Passed    0.02 sec
      Start  9: tests_ro08
 9/12 Test  #9: tests_ro08 .......................   Passed    0.03 sec
      Start 10: tests_no08
10/12 Test #10: tests_no08 .......................   Passed    0.02 sec
      Start 11: tests_rn08
11/12 Test #11: tests_rn08 .......................   Passed    0.02 sec
      Start 12: tests_nn08
12/12 Test #12: tests_nn08 .......................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 12
```
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
