### PR TITLE
qt6: remove useless & confusing cmake symlinks

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -113,7 +113,7 @@ array set modules {
         {"Qt 3D"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qt5compat {
@@ -128,7 +128,7 @@ array set modules {
         {"Qt5 Compatibility"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtbase {
@@ -149,7 +149,7 @@ array set modules {
          "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtcharts {
@@ -164,7 +164,7 @@ array set modules {
         {"Qt Charts"}
         "GPLv3 license only"
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: GPL-3"
     }
     qtconnectivity {
@@ -179,7 +179,7 @@ array set modules {
         {"Qt Bluetooth" "Qt NFC"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtdeclarative {
@@ -194,7 +194,7 @@ array set modules {
         {"Qt QML" "Qt Quick" "Qt Quick Layouts" "Qt Quick Widgets"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtimageformats {
@@ -209,7 +209,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtmultimedia {
@@ -224,7 +224,7 @@ array set modules {
         {"Qt Multimedia" "Qt Multimedia Widgets"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtnetworkauth {
@@ -239,7 +239,7 @@ array set modules {
         {"Qt Network Authorization"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtpositioning {
@@ -254,7 +254,7 @@ array set modules {
         {"Provides the ability to determine a position by using a variety of possible sources"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: {GPL-3}"
     }
     qtremoteobjects {
@@ -269,7 +269,7 @@ array set modules {
        {"Qt Remote Objects"}
        ""
        "variant overrides: "
-       "revision 2"
+       "revision 3"
        "License: "
     }
     qtsensors {
@@ -284,7 +284,7 @@ array set modules {
         {"Qt Sensors"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtserialbus {
@@ -299,7 +299,7 @@ array set modules {
         {"Qt Serial Bus"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtserialport {
@@ -314,7 +314,7 @@ array set modules {
         {"Qt Serial Port"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtshadertools {
@@ -329,7 +329,7 @@ array set modules {
         {"Qt ShaderTools"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtsvg {
@@ -344,7 +344,7 @@ array set modules {
         {"Qt SVG"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qttools {
@@ -359,7 +359,7 @@ array set modules {
         {"Qt Designer" "Qt Help" "Qt UI Tools"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qttranslations {
@@ -374,7 +374,7 @@ array set modules {
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests noarch ~docs"
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtwebchannel {
@@ -389,7 +389,7 @@ array set modules {
         {"Qt WebChannel"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtwebsockets {
@@ -404,7 +404,7 @@ array set modules {
         {"Qt WebSockets"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
 }
@@ -1296,22 +1296,6 @@ post-destroot {
         xinstall -d -m 0755 ${destroot}${mp_prefix}/lib/pkgconfig
         foreach pcfile [glob -nocomplain -tails -directory ${destroot}${qt_libs_dir}/pkgconfig *.pc] {
             ln -s ${qt_libs_dir}/pkgconfig/${pcfile} ${destroot}${mp_prefix}/lib/pkgconfig
-        }
-
-        # put link to cmake files in place where cmake will find it
-        # most Qt 6 cmake directories begin with Qt6, so link should not conflict with any other Qt installations
-        xinstall -d -m 0755 ${destroot}${mp_prefix}/lib/cmake
-        foreach cmakedir [glob -type d -nocomplain -tails -directory ${destroot}${qt_libs_dir}/cmake *] {
-            # only symlink the top folder, checking to see if the symlink already exists
-            if { ![ file exists ${mp_prefix}/lib/cmake/${cmakedir} ] } {
-                ln -s ${qt_libs_dir}/cmake/${cmakedir} ${destroot}${mp_prefix}/lib/cmake/${cmakedir}
-            }
-        }
-        # grab the cmake files in qt_bins_dir too
-        foreach cmakefile [glob -type f -nocomplain -tails -directory ${destroot}${qt_bins_dir}/ *.cmake] {
-            if { ![ file exists ${mp_prefix}/lib/cmake/${cmakefile} ] } {
-                ln -s ${qt_bins_dir}/${cmakefile} ${destroot}${mp_prefix}/lib/cmake/${cmakefile}
-            }
         }
     }
 }


### PR DESCRIPTION
These symlinks are not useful IMO.

- qmake shall find the qt6 installation it belongs to correctly
- when building a Qt application with cmake, one should actually use
  qt-cmake which will also find the qt6 installation it belongs to.

The important thing is to call the qmake & qt-cmake executable from their
installation location. Eg /opt/local/libexec/qt6/bin

especially, qt-cmake shouldn't be called through a symlink

If these symlinks are present and configuration is made with cmake (and not
qt-cmake) one may have errors reported at configure time saying that some Qt
components/tools are not installed. Actually, this is due to heavy use by Qt
of CMAKE_CURRENT_LIST_DIR in the cmake files. Changing this will mess the Qt6
installation. It doesn't resolve to the realpath but to the path to the
symlink.

Configuration should be made with qt-cmake (or if one wants to use cmake, one
has to add additional parameters to the cmake call) or qmake.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
CI

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
