### PR TITLE
py-awscli2: update to 2.9.10

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,8 +6,8 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.9.6
-revision            1
+github.setup        aws aws-cli 2.9.10
+revision            0
 
 categories          python devel
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  76433ac984a49ee27539a124fa13a618085db184 \
-                    sha256  2f480d103c38b19683d123655b697d782fc6aa65436712cd287adfc6955d2164 \
-                    size    12673244
+checksums           rmd160  1d9cfbf3e22a99f499e582f02a328a4149c345d6 \
+                    sha256  d89787e4abcf162c5e1727b62bc2cb15f11ae398f175c2b2f7ad6a913f1446ae \
+                    size    12747897
 
 python.versions     38 39 310
 python.pep517       yes

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,10 +1,8 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-N.B. unpinned awscrt to fix #66141.
-
---- aws-cli-2.9.6-orig/pyproject.toml	2022-12-11 17:14:55.655896748 -0500
-+++ aws-cli-2.9.6/pyproject.toml	2022-12-11 17:16:25.306058469 -0500
+--- aws-cli-2.9.10-orig/pyproject.toml	2022-12-23 12:46:49.000000000 -0500
++++ aws-cli-2.9.10/pyproject.toml	2022-12-27 10:16:24.454080406 -0500
 @@ -1,6 +1,6 @@
  [build-system]
  requires = [
@@ -19,11 +17,11 @@ N.B. unpinned awscrt to fix #66141.
  dependencies = [
 -    "colorama>=0.2.5,<0.4.4",
 -    "docutils>=0.10,<0.20",
--    "cryptography>=3.3.2,<=38.0.1",
+-    "cryptography>=3.3.2,<38.0.5",
 -    "ruamel.yaml>=0.15.0,<=0.17.21",
 -    "prompt-toolkit>=3.0.24,<3.0.29",
 -    "distro>=1.5.0,<1.6.0",
--    "awscrt>=0.12.4,<=0.14.0",
+-    "awscrt>=0.12.4,<0.17.0",
 -    "python-dateutil>=2.1,<3.0.0",
 -    "jmespath>=0.7.1,<1.1.0",
 -    "urllib3>=1.25.4,<1.27",

--- a/python/py-awscrt/Portfile
+++ b/python/py-awscrt/Portfile
@@ -6,8 +6,7 @@ PortGroup           python 1.0
 name                py-awscrt
 # This is only used by awscli2. Bump when Amazon bumps
 # their pinned version in awscli2's setup.cfg.
-# N.B. bumped to fix #66141
-version             0.16.1
+version             0.16.3
 revision            0
 
 categories-append   devel
@@ -20,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  0cb35f74d6baebd11b906e4141d00bc250395f65 \
-                    sha256  8fdfbe7aec52b2f7fa64b91526dc867653b1e965ab01710e733ab0ca96199170 \
-                    size    21811901
+checksums           rmd160  e36b54a12c20909804a9dbb53c09067d9bc44eae \
+                    sha256  c37f50b74e3a7560f36ede35b7d2d530224d336b863aff554d97f7c9f59494d3 \
+                    size    21848392
 
 python.versions     38 39 310
 


### PR DESCRIPTION
#### Description

Also minor update for py-awscrt that is in bounds for py-awscli2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
