### PR TITLE
pcre2: update to 10.42

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -10,7 +10,7 @@ if {${subport} eq ${name}} {
 subport pcre2 {
     PortGroup       github 1.0
 
-    github.setup    PCRE2Project pcre2 10.40 pcre2-
+    github.setup    PCRE2Project pcre2 10.42 pcre2-
     github.tarball_from releases
     revision        0
 
@@ -44,9 +44,9 @@ use_bzip2           yes
 set rmd160(pcre)    9792fbed380a39be36674e74839b9a2a6a4ce65a
 set sha256(pcre)    4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8
 set size(pcre)      1578809
-set rmd160(pcre2)   9728e170b4da3ed594e18934b403e97fe4b72291
-set sha256(pcre2)   14e4b83c4783933dc17e964318e6324f7cae1bc75d8f3c79bc6969f00c159d68
-set size(pcre2)     1765440
+set rmd160(pcre2)   02a53836b3371918a3942d5dcd6f4c9321d98462
+set sha256(pcre2)   8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840
+set size(pcre2)     1799866
 checksums           rmd160  $rmd160(${subport}) \
                     sha256  $sha256(${subport}) \
                     size    $size(${subport})
@@ -66,6 +66,7 @@ configure.args-append --enable-jit
 
 subport pcre {
     PortGroup clang_dependency 1.0
+
     configure.args-append --enable-unicode-properties
 }
 


### PR DESCRIPTION
#### Description

Tested with some pcre2grep

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
