### PR TITLE
minetest: new maintainer & new Portfile

### DIFF
--- a/games/minetest/Portfile
+++ b/games/minetest/Portfile
@@ -8,9 +8,9 @@ compiler.cxx_standard   2011
 compiler.thread_local_storage   yes
 
 github.setup            minetest minetest 5.6.1
-revision                0
+revision                1
 
-# the game version could be different than the minetest version
+# the game version could be different from the minetest version
 set game_version        5.6.1
 
 # to add on more files to a github portgroup download
@@ -23,7 +23,7 @@ set game_mastersite     https://github.com/minetest/minetest_game/archive/
 
 distfiles               ${main_distfile}:main \
                         ${game_distfile}:game
-                        
+
 master_sites            ${github.master_sites}:main \
                         ${game_mastersite}:game
 
@@ -47,9 +47,12 @@ post-extract {
 license                 LGPL-2.1+
 categories              games
 platforms               darwin
-maintainers             nomaintainer
+maintainers             @Zweihorn openmaintainer
 description             open source infinite-world block sandbox game with survival and crafting
-long_description        ${description}.
+long_description        ${description} - \
+                        Find more MT mods at <https://content.minetest.net/> and have fun.
+
+homepage                https://www.minetest.net
 
 depends_build-append    path:bin/doxygen:doxygen \
                         port:mesa
@@ -61,10 +64,13 @@ depends_lib-append      port:irrlichtmt \
                         port:freetype \
                         port:gettext \
                         port:leveldb \
-                        port:hiredis \
-                        port:curl \
+                        port:sqlite3 \
+                        port:zstd \
                         path:lib/libluajit-5.1.2.dylib:luajit \
+                        port:gmp \
+                        port:curl \
                         port:jsoncpp \
+                        port:spatialindex \
                         port:xorg-libX11 \
                         port:xorg-libXxf86vm
 
@@ -85,20 +91,25 @@ patchfiles-append       003-patch-ignore-psn-option-mac-bundle.diff
 
 configure.args-append   -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_INSTALL_PREFIX:PATH=${applications_dir} \
-                        -DBUILD_CLIENT=1 \
-                        -DENABLE_SOUND=1 \
-                        -DENABLE_REDIS=1 \
-                        -DENABLE_POSTGRESQL:BOOL=OFF \
-                        -DENABLE_LEVELDB=1 \
-                        -DENABLE_FREETYPE=1 \
-                        -DENABLE_CURL=1 \
-                        -DENABLE_GETTEXT=1 \
-                        -DENABLE_SYSTEM_JSONCPP=1 \
-                        -DENABLE_UPDATE_CHECKER=0 \
+                        -DBUILD_UNITTESTS=OFF \
+                        -DENABLE_UPDATE_CHECKER=OFF \
+                        -DBUILD_CLIENT=ON \
+                        -DBUILD_SERVER=ON \
+                        -DENABLE_SOUND=ON \
+                        -DENABLE_REDIS=OFF \
+                        -DENABLE_POSTGRESQL=OFF \
+                        -DENABLE_LEVELDB=ON \
+                        -DENABLE_FREETYPE=ON \
+                        -DENABLE_CURL=ON \
+                        -DENABLE_GETTEXT=ON \
+                        -DENABLE_SPATIAL=ON \
+                        -DENABLE_SYSTEM_GMP=ON \
+                        -DENABLE_SYSTEM_JSONCPP=ON \
                         -DCURSES_INCLUDE_PATH:FILEPATH=${prefix}/include \
                         -DENABLE_LUAJIT=ON \
                         -DLUA_INCLUDE_DIR:PATH=${prefix}/include/luajit-2.1 \
-                        -DLUA_LIBRARY:FILEPATH=${prefix}/lib/libluajit-5.1.dylib
+                        -DLUA_LIBRARY:FILEPATH=${prefix}/lib/libluajit-5.1.dylib \
+                        -DVERSION_EXTRA=MacPorts-rev${revision}
 
 post-destroot {
     move ${workpath}/minetest_game-${game_version}   ${destroot}${applications_dir}/minetest.app/Contents/Resources/games/minetest_game


### PR DESCRIPTION
MT 5.6.1 _minetest_ **Revision "1"** (i.e. :one: ) with **improved Portfile** and **new maintainer** ready for review.

* Portfile derived from legacy Portfile, however heavily improved
* the b.m. GMP bugfix
* updates and improvements to 'depends_lib-append'
* updates and improvements to 'configure.args-append'
* new maintainer (Zweihorn & openmaintainer)
* keep all "path" requirements
* keep "-DLUA_" options for better specificity
* keep all diffs in `files` untouched

Closes: https://trac.macports.org/ticket/66408   - _(bugfix)_

Ref https://trac.macports.org/ticket/66562
Ref #17080

#### Description

MT 5.6.1 _minetest_ **Revision "1"** (i.e. :one: ) with new Portfile **greatly improving the overall performance** of the Minetest App and _continuing_ in **good compatibility** to other ports. 

### The technical details and the description of #17080 apply as amended by this PR.

Please refer to the conversation resolved in that a.m. PR and the resolve in this PR below.
That a.m. PR became obsolete and there is no need for an extra `minetest-devel` port.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.2 20G1020 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->

Ref #17080

For the **binary check and library bindings** see below at: 
- https://github.com/macports/macports-ports/pull/17077#issuecomment-1367523683

###### Examples of Minetest 5.6.1 GUI

**Example 1** of **Minetest 5.6.1 GUI** world view with [Ethereal NG](https://forum.minetest.net/viewtopic.php?f=11&t=14638) mod and [other MT mods](https://content.minetest.net/) added for a better MT Player user experience.  

![screenshot_20221220_100146](https://user-images.githubusercontent.com/4863737/209885239-6f84a964-2f6f-4ebd-b5ea-c179e705f098.png)

**Example 2** of **Minetest 5.6.1 GUI** with MT main menu:

![Bildschirmfoto 2022-12-29 MT](https://user-images.githubusercontent.com/4863737/209986126-deb7f4b2-bf30-4cd5-9db2-2aee562f08f0.png)

The example shows text in the German locale with "Hauptmenü" at the UI main menu. The text "MacPorts" and the MacPorts revision No. are concatenated to the MT version text at the top of the GUI window.

NOTE: Amended in the new Profile to show  "MT 5.6.1-MacPorts-rev1" for optical reasons.

###### Fascicle

More information on  @Zweihorn at:
- https://github.com/Zweihorn/Zweihorn_fascicle

MT rocks. Have fun.

🌻 🚀 📦 