### PR TITLE
minetest-devel: new port in games

### DIFF
--- a/games/minetest-devel/Portfile
+++ b/games/minetest-devel/Portfile
@@ -1,0 +1,127 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake 1.1
+
+compiler.cxx_standard   2011
+compiler.thread_local_storage   yes
+
+name                    minetest-devel
+github.setup            minetest minetest 5.6.1
+revision                0
+
+# the game version could be different to the minetest version
+set game_version        5.6.1
+
+# to add on more files to a github portgroup download
+# have to cache the preset distfiles from the github PG
+set main_distfile       ${distfiles}
+
+# then add another distfile, with a direct URL as can't use the github PG again
+set game_distfile       ${game_version}${extract.suffix}
+set game_mastersite     https://github.com/minetest/minetest_game/archive/
+
+distfiles               ${main_distfile}:main \
+                        ${game_distfile}:game
+
+master_sites            ${github.master_sites}:main \
+                        ${game_mastersite}:game
+
+checksums               ${main_distfile} \
+                        rmd160  7b32331e0007f29003107592522d1c906935e44d \
+                        sha256  425d8e9363212dcb5bc7986dd12460c9c3784aca22eb1b90dad6a7fc2c6ef546 \
+                        size    9925064 \
+                        ${game_distfile} \
+                        rmd160  73d35423b856d141cebfa16396fe5dcf834dcf89 \
+                        sha256  5dc857003d24bb489f126865fcd6bf0d9c0cb146ca4c1c733570699d15abd0e3 \
+                        size    2590582
+
+# rename directory - from github portgroup
+post-extract {
+    if {[file exists [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]] && \
+        [file isdirectory [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]]} {
+        move [glob ${workpath}/${github.author}-${github.project}-*] ${workpath}/${distname}
+    }
+}
+
+license                 EUPL-1.2
+categories              games
+platforms               darwin
+maintainers             {macports.org:Zweihorn @Zweihorn}
+description             open source infinite-world block sandbox game with survival and crafting
+long_description        - ${description} - \
+                         \
+                        Minetest (usually abbreviated as MT) is an open source voxel game \
+                        engine. Play one of our many games, mod a game to your liking, make your \
+                        own game, or play on a multiplayer server. \
+                         \
+                        Available for Windows, macOS, GNU/Linux, FreeBSD, OpenBSD, DragonFly \
+                        BSD, and Android. \
+                         \
+                        * More information at <https://www.minetest.net> \
+                        * More MT mod expansions at <https://content.minetest.net/> \
+                        * More on MT DB Backends at <https://wiki.minetest.net/Database_backends> \
+                         \
+                        This ${name} port provides a cutting edge Minetest (stable).
+
+homepage                https://www.minetest.net
+
+conflicts               minetest
+
+depends_build-append    port:doxygen
+
+depends_lib-append      port:irrlichtmt \
+                        port:libjpeg-turbo \
+                        port:libogg \
+                        port:libvorbis \
+                        port:freetype \
+                        port:gettext \
+                        port:leveldb \
+                        port:sqlite3 \
+                        port:zstd \
+                        port:luajit \
+                        port:gmp \
+                        port:curl \
+                        port:jsoncpp \
+                        port:spatialindex \
+                        port:xorg-libX11 \
+                        port:xorg-libXxf86vm
+
+# see https://trac.macports.org/ticket/58315 - possibly fixable?
+universal_variant       no
+supported_archs         x86_64
+
+# 001. the original build calls fixup_bundle to move all the deps into the app bundle.
+#    this doesn't work correctly with macports destrooting, and isn't necessary for a macports install so deleted it
+patchfiles-append       001-patch-src-CMakeLists-disable-bundlefixup.diff
+
+# 002. patch to get the luajit include headers ahead of the system includes, or the build finds the
+#    wrong lua headers if you have a newer version of lua installed
+patchfiles-append       002-patch-cmake-Modules-FindLua-include-LUADIR-before-system.diff
+
+# 003. patch main.cpp to not barf on the unrecognized command-line option -psn from Apple launch
+patchfiles-append       003-patch-ignore-psn-option-mac-bundle.diff
+
+configure.args-append   -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_INSTALL_PREFIX:PATH=${applications_dir} \
+                        -DBUILD_UNITTESTS=OFF \
+                        -DBUILD_CLIENT=ON \
+                        -DBUILD_SERVER=ON \
+                        -DENABLE_SOUND=ON \
+                        -DENABLE_REDIS=OFF \
+                        -DENABLE_POSTGRESQL=OFF \
+                        -DENABLE_LEVELDB=ON \
+                        -DENABLE_FREETYPE=ON \
+                        -DENABLE_CURL=ON \
+                        -DENABLE_GETTEXT=ON \
+                        -DENABLE_SPATIAL=ON \
+                        -DENABLE_SYSTEM_GMP=ON \
+                        -DENABLE_SYSTEM_JSONCPP=ON \
+                        -DCURSES_INCLUDE_PATH:FILEPATH=${prefix}/include \
+                        -DENABLE_LUAJIT=ON \
+                        -DVERSION_EXTRA=MacPorts
+
+post-destroot {
+    move ${workpath}/minetest_game-${game_version}   ${destroot}${applications_dir}/minetest.app/Contents/Resources/games/minetest_game
+}

--- a/games/minetest-devel/Portfile
+++ b/games/minetest-devel/Portfile
@@ -45,10 +45,10 @@ post-extract {
     }
 }
 
-license                 EUPL-1.2
+license                 LGPL
 categories              games
 platforms               darwin
-maintainers             {macports.org:Zweihorn @Zweihorn}
+maintainers             @Zweihorn
 description             open source infinite-world block sandbox game with survival and crafting
 long_description        - ${description} - \
                          \

--- a/games/minetest-devel/files/001-patch-src-CMakeLists-disable-bundlefixup.diff
+++ b/games/minetest-devel/files/001-patch-src-CMakeLists-disable-bundlefixup.diff
@@ -1,0 +1,16 @@
+--- ./src/CMakeLists.txt.orig	2016-12-18 11:32:01.000000000 -0800
++++ ./src/CMakeLists.txt	2016-12-18 11:32:13.000000000 -0800
+@@ -818,13 +818,6 @@
+ 		BUNDLE DESTINATION .
+ 	)
+ 
+-	if(APPLE)
+-		install(CODE "
+-			set(BU_CHMOD_BUNDLE_ITEMS ON)
+-			include(BundleUtilities)
+-			fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${BUNDLE_PATH}\" \"\" \"\${CMAKE_INSTALL_PREFIX}/${BINDIR}\")
+-		" COMPONENT Runtime)
+-	endif()
+ 
+ 	if(USE_GETTEXT)
+ 		foreach(LOCALE ${GETTEXT_AVAILABLE_LOCALES})

--- a/games/minetest-devel/files/002-patch-cmake-Modules-FindLua-include-LUADIR-before-system.diff
+++ b/games/minetest-devel/files/002-patch-cmake-Modules-FindLua-include-LUADIR-before-system.diff
@@ -1,0 +1,10 @@
+--- cmake/Modules.FindLua.cmake.orig	2017-12-08 11:49:52.000000000 -0800
++++ cmake/Modules/FindLua.cmake	2017-12-08 11:50:05.000000000 -0800
+@@ -11,6 +11,7 @@
+ 	find_package(LuaJIT)
+ 	if(LUAJIT_FOUND)
+ 		set(USE_LUAJIT TRUE)
++		include_directories(BEFORE ${LUA_INCLUDE_DIR})
+ 		message (STATUS "Using LuaJIT provided by system.")
+ 	elseif(REQUIRE_LUAJIT)
+ 		message(FATAL_ERROR "LuaJIT not found whereas REQUIRE_LUAJIT=\"TRUE\" is used.\n"

--- a/games/minetest-devel/files/003-patch-ignore-psn-option-mac-bundle.diff
+++ b/games/minetest-devel/files/003-patch-ignore-psn-option-mac-bundle.diff
@@ -1,0 +1,11 @@
+--- ./src/main.cpp.orig	2016-12-18 15:49:42.000000000 -0800
++++ ./src/main.cpp	2016-12-18 15:50:13.000000000 -0800
+@@ -126,7 +126,7 @@
+ 			|| cmd_args.getFlag("help")
+ 			|| cmd_args.exists("nonopt1")) {
+ 		print_help(allowed_options);
+-		return cmd_args_ok ? 0 : 1;
++//		return cmd_args_ok ? 0 : 1;
+ 	}
+ 
+ 	if (cmd_args.getFlag("version")) {


### PR DESCRIPTION
MT 5.6.1 **minetest-devel** derived from minetest

* Portfile derived from minetest port
* updates and additions to 'depends_lib-append'
* updates and additions to 'configure.args-append'
* includes all diffs from minetest _(i.e. the original files without any changes)_
* adds new maintainer (Zweihorn)
* license `EUPL-1.2` _<--- changed back to `LGPL` to resolve conversation_
* adds 'conflicts minetest'

Ref https://trac.macports.org/ticket/66562

#### Description

MT 5.6.1 _minetest-devel_ provides **better compatibility** with other ports and **greatly improves the internal performance** of the Minetest App by providing particular options to the build of the port.

The Portfile **Depends.Lib** were improved for compatibility in general. The two more particular additions were:
```
port:sqlite3 		<-- # better compatibility, ensures for 'state of the art' SQLite3 by MacPorts

port:zstd  		<-- # better compatibility, ensures for fast lossless compression by MacPorts zstd
```
SQLite3 was made the default database back-end by the MT project since 0.4.17 or earlier. Accordingly, the a.m. dependency avoids a default at the legacy sqlite3 from the OS by Apple.

The Portfile **Config.Args** were improved on particular CMake options for the MT build:
```
ENABLE_SPATIAL=ON          - Build with LibSpatial; Speeds up AreaStores

ENABLE_SYSTEM_GMP=ON       - Use GMP from system (much faster than bundled mini-gmp)

VERSION_EXTRA=             - Text to append to version (e.g. VERSION_EXTRA=MacPorts -> Minetest 5.6.1-MacPorts)
```
Apparently, these options were missed in establishing the legacy _minetest_ port definitions in the past.

Further **Improvements to the Portfile** and the Verification output can be found in the _Addendum_ below.

1. This PR makes to former draft PR #17061 **obsolete**.
2. My additional application as **new maintainer** to the _minetest_ port at: #17077

However, I decline to publicly distributing my personal email address.
Needs further application on [7.6. MacPorts Membership](https://guide.macports.org/#project.membership) for my `macports.org:Zweihorn` email by your kind approval.

Please be aware, my work and/or contribution to Open Source Endeavour is always published under the **EUPL-1.2** license. This fits my legal requirement as an European citizen thus outside U.S. jurisdiction. Furthermore, the Open Source Initiative (OSI) **approves** of EUPL-1.2 and agrees, that **public domain doesn't exist in Europe**.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.2 20G1020 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
We have **successfully verified** as follows:

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`? - _for output see below_
- [x] tried existing tests with `sudo port test`? - _for output see below_
- [x] tried a full install with `sudo port -vst install`? - _for output see below_
- [x] tested basic functionality of all binary files? - 

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

#### Addendum

Minetest 5.6.1 minetest-devel results and improvements to Portfile

##### Portfile check

Acceptable results.

```
% port lint --nitpick
--->  Verifying Portfile for minetest-devel
Warning: Line 15 seems to hardcode the version number, consider using ${version} instead
--->  0 errors and 1 warnings found.
```
The warning derives from the `set game_version        5.6.1` which cannot be avoided due to technical reasons.
There is the need to give both the MT core and the MT game a version number each respectively as these may differ.

##### NO existing tests

There were **no tests turned on**.

```
% sudo port test

. . .
--->  Attempting to fetch 5.6.1.tar.gz from https://github.com/minetest/minetest_game/archive/
--->  Verifying checksums for minetest-devel
--->  Extracting minetest-devel
--->  Applying patches to minetest-devel
--->  Configuring minetest-devel
--->  Building minetest-devel                            
--->  Testing minetest-devel                             
Error: Failed to test minetest-devel: minetest-devel has no tests turned on. see 'test.run' in portfile(7)
Error: See /opt/local/var/macports/logs/_usr_local_macports_ports_games_minetest-devel/minetest-devel/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets if you believe there is a bug.

```
IMO the errors can be neglected due to tests turned off obviously. No bug.

##### Full install

```
% sudo port -vst install

. . .
x ./Applications/MacPorts/minetest.app/Contents/Resources/textures/base/pack/minimap_overlay_square.png
x ./Applications/MacPorts/minetest.app/Contents/MacOS/minetestserver
x ./Applications/MacPorts/minetest.app/Contents/MacOS/minetest
--->  Cleaning minetest-devel
--->  Removing work directory for minetest-devel
--->  Scanning binaries for linking errors
--->  No broken files found.
--->  No broken ports found.
```

##### Tested basic functionality

Minetest 5.6.1 minetest-devel was started via the MT App from the LaunchPad successfully.

- App starts and presenting the MT GUI by Irrlicht as expected.
- Setup accordingly to MT Get Started was functioning.
- World Map builds and player is spawned, world view is as expected. 
- No errors in 'debug.txt' log found.

```
% tail debug.txt

2022-12-27 18:17:17: [Main]: Automatically selecting world at [/Users/XXX/Library/Application Support/minetest/worlds/test561]
2022-12-27 18:17:35: ACTION[Main]: World at [/Users/XXX/Library/Application Support/minetest/worlds/test561]
2022-12-27 18:17:35: ACTION[Main]: Server for gameid="minetest" listening on 0.0.0.0:56218.
2022-12-27 18:17:36: ACTION[Server]: singleplayer [127.0.0.1] joins game. List of players: singleplayer
2022-12-27 18:18:27: ACTION[Main]: Server: Shutting down

```

Minetest 5.6.1 minetest-devel was started and uses SQLite3 as default Database Back-end.

- All files needed as default to a MT World folder were found.
- SQLite3 Database Back-ends for
  + Authentication
  + World Map
  + MT Mod Storage
  + Players Inventory
- MT GUI Setup stores configuration in World.MT as expected.

```
% ls -1 /Users/XXX/Library/Application\ Support/minetest/worlds/test561 
auth.sqlite
env_meta.txt
force_loaded.txt
ipban.txt
map.sqlite
map_meta.txt
mod_storage.sqlite
players.sqlite
world.mt
```

NOTE: For the **MT graphical world view** see the PNG in the **attach**.

##### Improvements to the Portfile

This is a **Diff-file** amended by inline **commentary** for explanations.

Particular  POIs are marked with `<-- # better compatibility` or similar comment inline.

```
--- ../GitHub/macports-ports/games/minetest/Portfile	2022-12-26 11:21:24.000000000 +0100
+++ ../GitHub/macports-ports/games/minetest-devel/Portfile	2022-12-27 18:50:08.000000000 +0100
@@ -7,10 +7,11 @@
 compiler.cxx_standard   2011
 compiler.thread_local_storage   yes
 
+name                    minetest-devel
 github.setup            minetest minetest 5.6.1
 revision                0
 
-# the game version could be different than the minetest version
+# the game version could be different to the minetest version
 set game_version        5.6.1
 
 # to add on more files to a github portgroup download
@@ -23,7 +24,7 @@
 
 distfiles               ${main_distfile}:main \
                         ${game_distfile}:game
-                        
+
 master_sites            ${github.master_sites}:main \
                         ${game_mastersite}:game
 
@@ -44,27 +45,46 @@
     }
 }
 
-license                 LGPL-2.1+
+license                 EUPL-1.2
 categories              games
 platforms               darwin
-maintainers             nomaintainer
+maintainers             {macports.org:Zweihorn @Zweihorn}
 description             open source infinite-world block sandbox game with survival and crafting
-long_description        ${description}.
+long_description        - ${description} - \
+                         \
+                        Minetest (usually abbreviated as MT) is an open source voxel game \
+                        engine. Play one of our many games, mod a game to your liking, make your \
+                        own game, or play on a multiplayer server. \
+                         \
+                        Available for Windows, macOS, GNU/Linux, FreeBSD, OpenBSD, DragonFly \
+                        BSD, and Android. \
+                         \
+                        * More information at <https://www.minetest.net> \
+                        * More MT mod expansions at <https://content.minetest.net/> \
+                        * More on MT DB Backends at <https://wiki.minetest.net/Database_backends> \
+                         \
+                        This ${name} port provides a cutting edge Minetest (stable).
+
+homepage                https://www.minetest.net
+
+conflicts               minetest			<-- # conflicts w/ port
 
-depends_build-append    path:bin/doxygen:doxygen \
-                        port:mesa
+depends_build-append    port:doxygen
 
 depends_lib-append      port:irrlichtmt \
-                        path:include/turbojpeg.h:libjpeg-turbo \
+                        port:libjpeg-turbo \	<-- # better compatibility
                         port:libogg \
                         port:libvorbis \
                         port:freetype \
                         port:gettext \
                         port:leveldb \
-                        port:hiredis \		<-- # was exotic / not used
+                        port:sqlite3 \		<-- # better compatibility
+                        port:zstd \		<-- # improved performance
+                        port:luajit \		<-- # better compatibility
+                        port:gmp \		<-- # improved performance
                         port:curl \
-                        path:lib/libluajit-5.1.2.dylib:luajit \
                         port:jsoncpp \
+                        port:spatialindex \	<-- # improved performance
                         port:xorg-libX11 \
                         port:xorg-libXxf86vm
 
@@ -85,20 +105,22 @@
 
 configure.args-append   -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_INSTALL_PREFIX:PATH=${applications_dir} \
-                        -DBUILD_CLIENT=1 \
-                        -DENABLE_SOUND=1 \
-                        -DENABLE_REDIS=1 \
-                        -DENABLE_POSTGRESQL:BOOL=OFF \
-                        -DENABLE_LEVELDB=1 \
-                        -DENABLE_FREETYPE=1 \
-                        -DENABLE_CURL=1 \
-                        -DENABLE_GETTEXT=1 \
-                        -DENABLE_SYSTEM_JSONCPP=1 \
-                        -DENABLE_UPDATE_CHECKER=0 \
+                        -DBUILD_UNITTESTS=OFF \
+                        -DBUILD_CLIENT=ON \		<-- # consistant to MT install
+                        -DBUILD_SERVER=ON \		<-- # consistant to MT install
+                        -DENABLE_SOUND=ON \
+                        -DENABLE_REDIS=OFF \		<-- # was exotic / not used
+                        -DENABLE_POSTGRESQL=OFF \	<-- # ON for dedicated MT server (future?)
+                        -DENABLE_LEVELDB=ON \
+                        -DENABLE_FREETYPE=ON \
+                        -DENABLE_CURL=ON \
+                        -DENABLE_GETTEXT=ON \
+                        -DENABLE_SPATIAL=ON \		<-- # improves performance
+                        -DENABLE_SYSTEM_GMP=ON \	<-- # improves performance
+                        -DENABLE_SYSTEM_JSONCPP=ON \
                         -DCURSES_INCLUDE_PATH:FILEPATH=${prefix}/include \
                         -DENABLE_LUAJIT=ON \		<-- # better compatibility
-                        -DLUA_INCLUDE_DIR:PATH=${prefix}/include/luajit-2.1 \
-                        -DLUA_LIBRARY:FILEPATH=${prefix}/lib/libluajit-5.1.dylib
+                        -DVERSION_EXTRA=MacPorts	<-- # adds advertising to GUI
 
 post-destroot {
     move ${workpath}/minetest_game-${game_version}   ${destroot}${applications_dir}/minetest.app/Contents/Resources/games/minetest_game

```

Last not least this Portfile was implemented as a local port definition on may Mac for years and greatly improving my user experience as a MT player together with the MT server even for several Multi-Player events. The code build can be called stable, I presume.

Hope this helps.

##### Licence

@Zweihorn - 2022-12-27
This work is derived from work under the LGPL-1.2+ from 'minetest' on MacPorts ports.

Licensed under the EUPL-1.2-or-later

The text of the European Union Public Licence (EUPL) version 1.2,
published in Official Journal of 19 May 2017 and available in 23
official languages of the European Union (SPDX identifier EUPL-1.2),
is to be found at:

  * <https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12>

The a.m. page contains all the official versions of the European Union
Public Licence (EUPL-1.2).  The preamble written for v 1.0, explaining
the purpose of this Free/Open Source Software Licence, together with
links to further information on the licence is valid for later versions.

The Joinup Licensing Assistant (JLA) may be worth a visit to find and
compare software licenses with:

  * <https://joinup.ec.europa.eu/collection/eupl/solution/joinup-licensing-assistant/jla-find-and-compare-software-licenses>

The JLA is linked to SPDX (for Software Package Data Exchange), an
initiative of the LINUX foundation that attempts to standardize the way
in which organizations refer to software licenses: each licence is
identified by a full name, such as "European Union Public Licence 1.2"
and a shorter identifier, here "EUPL-1.2".

##### MT graphical world view

![screenshot_20221227_181754](https://user-images.githubusercontent.com/4863737/209727029-e21cfbc8-8644-469e-98e0-e5754bc52cd4.png)
