### PR TITLE
gemmlowp: new port in math

### DIFF
--- a/math/gemmlowp/Portfile
+++ b/math/gemmlowp/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        google gemmlowp 08e4bb339e34017a0835269d4a37c4ea04d15a69
+version             2022.09.14
+categories          math
+license             Apache-2
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Low-precision matrix multiplication
+long_description    This is not a full linear algebra library, only a GEMM library: \
+                    it only does general matrix multiplication.
+checksums           rmd160  90cfab0e317d229edeb74301beb255e50cf8b703 \
+                    sha256  487b69241c7e0b77a7974aa6a71112610443205e5485c34d7bec0aa3e142b759 \
+                    size    842002
+# This is a header-only library:
+supported_archs     noarch
+installs_libs       no
+
+use_configure       no
+build               {}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/include/${name}
+    foreach dir {public fixedpoint eight_bit_int_gemm internal profiling meta} {
+        file copy ${worksrcpath}/${dir} ${destroot}${prefix}/include/${name}/
+    }
+}
+
+post-destroot {
+    fs-traverse f ${destroot}${prefix}/include/${name} {
+        if {[file isfile ${f}]} {
+            if {[file extension ${f}] == ".cc"} {
+                delete ${f}
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description

New port in math (header-only library): https://github.com/google/gemmlowp
https://github.com/freebsd/freebsd-ports/blob/main/math/gemmlowp

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
