### PR TITLE
mpfrcx: new port in math

### DIFF
--- a/math/mpfrcx/Portfile
+++ b/math/mpfrcx/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mpfrcx
+version             0.6.3
+categories          math
+license             LGPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Arbitrary precision library for arithmetic of univariate polynomials
+long_description    {*}${description}
+homepage            https://www.multiprecision.org/mpfrcx/home.html
+master_sites        https://www.multiprecision.org/downloads/
+checksums           rmd160  3414e6d2d79b4ab450207b6d7d3aada4c587eb97 \
+                    sha256  9da9b3614c0a3e00e6ed2b82fc935d1c838d97074dc59cb388f8fafbe3db8594 \
+                    size    687823
+
+depends_build-append \
+                    port:libtool
+depends_lib-append  port:gmp \
+                    port:libmpc \
+                    port:mpfr
+
+test.run            yes
+test.target         check


### PR DESCRIPTION
#### Description

New port in math: https://www.multiprecision.org/mpfrcx/home.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass on 10.6.8:
```
/usr/bin/make  check-TESTS
PASS: tc_neg
PASS: tc_add
PASS: tc_sub
PASS: tc_mul
PASS: tc_swap
PASS: tc_derive
PASS: tc_tree
PASS: tf_neg
PASS: tf_add
PASS: tf_sub
PASS: tf_mul
PASS: tf_swap
PASS: tf_derive
PASS: tf_tree
PASS: tc_eval
PASS: tf_eval
PASS: tc_tower
PASS: tf_tower
PASS: tget_version
============================================================================
Testsuite summary for mpfrcx 0.6.3
============================================================================
# TOTAL: 19
# PASS:  19
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```