### PR TITLE
nethack: fix build on Ventura

### DIFF
--- a/games/nethack/Portfile
+++ b/games/nethack/Portfile
@@ -33,6 +33,9 @@ worksrcdir         ${name}-${version}
 patch.pre_args     -p1
 patchfiles         patch-gamestate-dir.diff \
                    patch-manpage-dir.diff
+                   
+patchfiles-append  patch-nethack-warn-unused-result.diff
+
 post-patch {
     if {${subport} eq "nethack"} {
         reinplace "s|__PREFIX__|${prefix}|" \

--- a/games/nethack/files/patch-nethack-warn-unused-result.diff
+++ b/games/nethack/files/patch-nethack-warn-unused-result.diff
@@ -1,0 +1,16 @@
+https://trac.macports.org/ticket/66092
+
+--- a/include/tradstdc.h.orig	2022-12-27 17:46:35
++++ b/include/tradstdc.h	2022-12-27 17:48:14
+@@ -431,8 +431,11 @@
+ #define NORETURN __attribute__((noreturn))
+ /* disable gcc's __attribute__((__warn_unused_result__)) since explicitly
+    discarding the result by casting to (void) is not accepted as a 'use' */
++#ifndef __clang__
+ #define __warn_unused_result__ /*empty*/
+ #define warn_unused_result /*empty*/
++#endif
++
+ #endif
+ #endif
+ 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/66092

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
```
 % port -v installed nethack
The following ports are currently installed:
  nethack @3.6.6_0 (active) requested_variants='' platform='darwin 22' archs='arm64' date='2022-12-27T17:58:45-0800'
```