### PR TITLE
boost181: enable context/coroutine on PPC32

### DIFF
--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -106,6 +106,11 @@ patchfiles-append patch-export_serialization_explicit_template_instantiations.di
 # p64, p32).
 patchfiles-append patch-revert-lib-name-tagged.diff
 
+# Fix the context-switching code on PPC32. 10.4 and 10.5 lack makecontext/
+# swapcontext (provided by ucontext.h), so they require functioning ASM code.
+# https://github.com/boostorg/context/pull/215
+patchfiles-append patch-boost-context-asm.diff
+
 # Availability.h -> AvailabilityMacros.h on Tiger
 # The attempted fix:
 # https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
@@ -166,12 +171,16 @@ if {[string match *gcc* ${configure.compiler}]} {
     configure.args-append --with-toolset=gcc
 }
 
-# makecontext/swapcontext introduced in 10.6
-# In 10.6.x Rosetta they do not work: https://trac.macports.org/ticket/64978
+# Boost's PPC32 ASM code in the context module was only recently fixed (see
+# patch above). PPC64 is still broken, and the Fiber module won't compile with
+# GCC7. Conditionally disable pending further investigation.
 platform darwin {
-    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+    if {${build_arch} eq "ppc64"} {
         configure.args-append   --without-libraries=context \
                                 --without-libraries=coroutine
+    }
+    if {${build_arch} eq "ppc"} {
+        configure.args-append   --without-libraries=fiber
     }
 }
 
@@ -359,7 +368,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 3
+    revision 4
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost181/files/patch-boost-context-asm.diff
+++ b/devel/boost181/files/patch-boost-context-asm.diff
@@ -1,0 +1,120 @@
+Fix some call convention bugs on PPC32
+
+Upstream PR: https://github.com/boostorg/context/pull/215
+
+--- libs/context/build/Jamfile.v2.orig
++++ libs/context/build/Jamfile.v2
+@@ -331,6 +331,7 @@
+    : asm/make_ppc32_sysv_macho_gas.S
+      asm/jump_ppc32_sysv_macho_gas.S
+      asm/ontop_ppc32_sysv_macho_gas.S
++     asm/tail_ppc32_sysv_elf_gas.cpp
+    : <abi>sysv
+      <address-model>32
+      <architecture>power
+--- libs/context/src/asm/make_ppc32_sysv_macho_gas.S.orig
++++ libs/context/src/asm/make_ppc32_sysv_macho_gas.S
+@@ -85,11 +85,12 @@
+     clrrwi  r3, r3, 4
+ 
+     ; reserve space for context-data on context-stack
+-    ; including 64 byte of linkage + parameter area (R1  16 == 0)
++    ; including 64 byte of linkage + parameter area (R1 % 16 == 0)
+     subi  r3, r3, 336
+ 
+     ; third arg of make_fcontext() == address of context-function
+-    stw  r5, 240(r3)
++    ; store as trampoline's R31
++    stw  r5, 224(r3)
+ 
+     ; set back-chain to zero
+     li   r0, 0
+@@ -106,12 +107,15 @@
+     ; load LR
+     mflr  r0
+     ; jump to label 1
+-    bl  l1
+-l1:
++    bcl  20, 31, L1
++L1:
+     ; load LR into R4
+     mflr  r4
++    ; compute abs address of trampoline, use as PC
++    addi  r5, r4, lo16(Ltrampoline - L1)
++    stw  r5, 240(r3)
+     ; compute abs address of label finish
+-    addi  r4, r4, lo16((finish - .) + 4)
++    addi  r4, r4, lo16(Lfinish - L1)
+     ; restore LR
+     mtlr  r0
+     ; save address of finish as return-address for context-function
+@@ -123,15 +127,28 @@ l1:
+ 
+     blr  ; return pointer to context-data
+ 
+-finish:
+-    ; save return address into R0
+-    mflr  r0
+-    ; save return address on stack, set up stack frame
+-    stw  r0, 4(r1)
+-    ; allocate stack space, R1  16 == 0
+-    stwu  r1, -16(r1)
++Ltrampoline:
++    ; We get R31 = context-function, R3 = address of transfer_t,
++    ; but we need to pass R3:R4 = transfer_t.
++    mtctr  r31
++    lwz  r4, 4(r3)
++    lwz  r3, 0(r3)
++    bctr
+ 
++Lfinish:
++    ; load address of _exit into CTR
++    bcl  20, 31, L2
++L2:
++    mflr  r4
++    addis  r4, r4, ha16(Lexitp - L2)
++    lwz  r4, lo16(Lexitp - L2)(r4)
++    mtctr  r4
+     ; exit code is zero
+     li  r3, 0
+     ; exit application
+-    bl  _exit
++    bctr
++
++.const_data
++.align 2
++Lexitp:
++    .long  __exit
+--- libs/context/src/asm/ontop_ppc32_sysv_macho_gas.S.orig
++++ libs/context/src/asm/ontop_ppc32_sysv_macho_gas.S
+@@ -177,7 +177,7 @@
+     lwz  r29, 216(r1)  ; restore R29
+     lwz  r30, 220(r1)  ; restore R30
+     lwz  r31, 224(r1)  ; restore R31
+-    lwz  r4,  228(r1)  ; restore hidden
++    lwz  r3,  228(r1)  ; restore hidden
+ 
+     ; restore CR
+     lwz   r0, 232(r1)
+@@ -190,12 +190,12 @@
+     ; adjust stack
+     addi  r1, r1, 244
+ 
+-    ; return transfer_t 
+-    stw  r7, 0(r4)
+-    stw  r5, 4(r4)
+-
+-    ; restore CTR
+-    mtctr r6
+-
+-    ; jump to ontop-function
+-    bctr
++    ; Need to pass ontop_fcontext_tail(
++    ;   hidden R3, 
++    ;   R4 = ignore,
++    ;   R5 = data,
++    ;   R6 = ontop-function,
++    ;   R7 = fcontext_t
++    ; )
++    ; All of these registers are correctly set at this point
++    b _ontop_fcontext_tail


### PR DESCRIPTION
#### Description

Boost's PPC32 assembler code is now fixed [upstream](https://github.com/boostorg/context/pull/215), let's back-port it into MacPorts and enable the context and coroutine modules on PPC. Related discussion in #16407 but that patch was incomplete. Leaving context/coroutine disabled on PPC64 as that ASM code is still broken, and also leaving fiber disabled since it's not compiling with our standard C++11 compiler (GCC7). Fiber depends on the context module, so disabling it pending further research isn't removing anything for anyone.

Feel free to combine with #17064 to skip the revbump.

Closes: https://trac.macports.org/ticket/64978

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
