### PR TITLE
python311: fix build on G3 processors

### DIFF
--- a/lang/python311/Portfile
+++ b/lang/python311/Portfile
@@ -42,6 +42,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
 if {${configure.build_arch} in "ppc ppc64"} {
     # https://trac.macports.org/ticket/66483
     configure.ldflags-append -Wl,-read_only_relocs,suppress
+    # G3 builds fail without this flag, as converting a static library
+    # to dynamic using -all_load inadvertently sets the arch to ppc7400
+    configure.ldflags-append -Wl,-force_cpusubtype_ALL
 }
 
 depends_build       port:pkgconfig


### PR DESCRIPTION
#### Description

There seems to be a bug in the GCC7 linker on 10.4 that causes `-all_load` to bundle up regular `ppc` (non-Altivec) functions and report the collection as `ppc7400` (Altivec), resulting in a failed build on non-Altivec machines. Adding `-Wl,-force_cpusubtype_ALL` works around this behavior. I don't *think* this change will have untoward consequences for the Altivec crowd, but it does let me build Python 3.11 on a G3.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
