### PR TITLE
py-mutagen: update to 1.46.0, add Python 3.11 subport

### DIFF
--- a/python/py-mutagen/Portfile
+++ b/python/py-mutagen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        quodlibet mutagen 1.45.1 release-
+github.setup        quodlibet mutagen 1.46.0 release-
 github.tarball_from releases
 name                py-mutagen
 revision            0
@@ -27,11 +27,11 @@ long_description \
 
 homepage            https://mutagen.readthedocs.io
 
-checksums           rmd160  e7294198f99abd384a42b94e91745eb01da6c19b \
-                    sha256  6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1 \
-                    size    1285455
+checksums           rmd160  da9f59948d03c0b477c464390ef983c9ab96b2d3 \
+                    sha256  6e5f8ba84836b99fe60be5fb27f84be4ad919bbb6b49caa6ae81e70584b55e58 \
+                    size    1268561
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${subport} ne ${name}} {
     if {${python.version} == 27} {
@@ -41,7 +41,14 @@ if {${subport} ne ${name}} {
         checksums       rmd160  fcac1fe459ef151c402ab48745a3336713da0a50 \
                         sha256  d873baeb7815311d3420aab0a1d83f050f628228cbc2d6045a14a16460411bc9 \
                         size    1151423
-        }
+    } elseif {${python.version} < 37} {
+        github.setup    quodlibet mutagen 1.45.1 release-
+        github.tarball_from releases
+        revision        0
+        checksums       rmd160  e7294198f99abd384a42b94e91745eb01da6c19b \
+                        sha256  6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1 \
+                        size    1285455
+    }
 
     depends_lib-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Addresses https://trac.macports.org/ticket/66554

Update py-mutagen to 1.46.0, added Python 3.11 subport. I've kept version 1.45.1 for Python 3.5 and 3.6, since [support was dropped in 1.46.0](https://github.com/quodlibet/mutagen/blob/941585251a34b0d46e8033e7535b39b611dbb0ce/NEWS#L3-L6).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?

I get the following, but it seems to be an existing problem.
```
--->  Verifying Portfile for py-mutagen
Error: Unknown platform: any
--->  1 errors and 0 warnings found.
```
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
`sudo port -vst install` reports that `py-mutagen is a stub port`. However, `port -vst install py311-mutagen` works.
- [x] tested basic functionality of all binary files?
The Portfile has no binary files.
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
The Portfile has no variants.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
