### PR TITLE
ruby-build: update to 20221225

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20220713 v
+github.setup        rbenv ruby-build 20221225 v
 categories          ruby
 license             MIT
 platforms           any
@@ -14,9 +14,9 @@ maintainers         {mojca @mojca} openmaintainer
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  e5bf4b10aaa54bb06499a55d46da991eb8cacada \
-                    sha256  b2d71482445d2b6684532580fbc63aceb5e0a84cb533b00fac574f5c6d4e46ed \
-                    size    76846
+checksums           rmd160  d6b29467efcbfbc3cb289bf2b5e24c0b3fd51074 \
+                    sha256  18cf31c9081a90f00d8810a48db8caf6f190926f9a9736130f1e90c9f483f49e \
+                    size    79455
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Has Ruby 3.2.0, etc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
