### PR TITLE
vile: Update to 9.8x

### DIFF
--- a/editors/vile/Portfile
+++ b/editors/vile/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                vile
-version             9.8w
+version             9.8x
 revision            0
-checksums           rmd160  b9f4a2106ab5218c3fc3e882799829cf1cc7d60c \
-                    sha256  78253ec3f7ae5f4f9d4799a3c8bc35b85b47d456f2ac172810008a48e4609815 \
-                    size    2407322
+checksums           rmd160  e584dabaa84e0ad6b0e32478b09c8ce1523826e6 \
+                    sha256  8fe0dfa60179d4b7dd2750f116cd4396d4cd3e07d8a54d142a36c84f4a82feef \
+                    size    2476108
 
 categories          editors
 platforms           darwin


### PR DESCRIPTION
#### Description

Update to current stable release

###### Type(s)

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
