### PR TITLE
pffft: new port in math

### DIFF
--- a/math/pffft/Portfile
+++ b/math/pffft/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        marton78 pffft e0bf595c98ded55cc457a371c1b29c8cab552628
+version             2022.12.19
+revision            0
+categories          math
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Pretty Fast FFT (PFFFT) library
+long_description    A fork of Julien Pommier’s Pretty Fast FFT (PFFFT) library with several additions.
+checksums           rmd160  bbfeac4fa8fdd2475c920ecfae8dff7813fbf6f4 \
+                    sha256  1a50d6b4cf030f9b081b2d91c48a56749c7b0cf381dcf13824a767ffd3017f7e \
+                    size    158826
+
+compiler.cxx_standard 2011
+
+platform powerpc {
+    # https://github.com/marton78/pffft/issues/55
+    configure.args-append \
+                    -DPFFFT_USE_SIMD:BOOL=OFF
+}
+
+platform darwin 10 powerpc {
+    # Fix arch detection in Rosetta:
+    post-patch {
+        reinplace "s|CMAKE_SYSTEM_PROCESSOR|CMAKE_OSX_ARCHITECTURES|g" ${worksrcpath}/CmakeLists.txt
+    }
+}
+
+test.run            yes
+test.cmd            ctest


### PR DESCRIPTION
#### Description

New port in math: https://github.com/marton78/pffft

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing pffft
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_pffft/pffft/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_pffft/pffft/work/build
    Start 1: test_fft_factors
1/9 Test #1: test_fft_factors .................   Passed    0.04 sec
    Start 2: test_fftpack_float
2/9 Test #2: test_fftpack_float ...............   Passed    0.06 sec
    Start 3: test_fftpack_double
3/9 Test #3: test_fftpack_double ..............   Passed    0.06 sec
    Start 4: bench_pffft_pow2
4/9 Test #4: bench_pffft_pow2 .................   Passed    4.25 sec
    Start 5: bench_pffft_non2
5/9 Test #5: bench_pffft_non2 .................   Passed    2.74 sec
    Start 6: test_pfconv_lens_symetric
6/9 Test #6: test_pfconv_lens_symetric ........   Passed    1.81 sec
    Start 7: test_pfconv_lens_non_sym
7/9 Test #7: test_pfconv_lens_non_sym .........   Passed   19.55 sec
    Start 8: bench_pfconv_symetric
8/9 Test #8: bench_pfconv_symetric ............   Passed    8.40 sec
    Start 9: bench_pfconv_non_sym
9/9 Test #9: bench_pfconv_non_sym .............   Passed    8.42 sec

100% tests passed, 0 tests failed out of 9

Total Test time (real) =  45.37 sec
```