### PR TITLE
clingo: update to 5.6.2, clingcon: new port

### DIFF
--- a/math/clingcon/Portfile
+++ b/math/clingcon/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           muniversal 1.0
+
+github.setup        potassco clingcon 5.2.0 v
+categories          math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             MIT
+description         An Answer Set Programming system to ground and solve logic programs.
+long_description    Clingcon is an answer set solver for constraint logic programs, \
+                    building upon the answer set solver clingo. It extends the high-level \
+                    modeling language of ASP with constraint solving capacities. \
+                    Constraints over finite domain integer variables can be used \
+                    in logic programs. Clingcon adopts state-of-the-art techniques \
+                    from the area of SMT, like conflict-driven learning and theory propagation. \
+                    It uses lazy nogood and variable generation on the order encoding \
+                    and features several preprocessing techniques.
+homepage            https://potassco.org/clingcon
+github.tarball_from archive
+checksums           rmd160  2d10c0889c4cd987622119cfafdba4b282f83322 \
+                    sha256  4b568475066e34be34110f481f7028b466c2b008e9ba41686e24ecbb468a40f2 \
+                    size    333420
+
+depends_lib-append  port:clingo
+
+compiler.cxx_standard 2017
+
+configure.args-append \
+                    -DPYCLINGCON_ENABLE=OFF \
+                    -DCLINGCON_BUILD_TESTS=ON
+
+# ___atomic_load_8
+if {${build_arch} in [list i386 ppc] && [string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append -latomic
+}
+
+test.run            yes
+test.dir            ${build.dir}/bin
+test.cmd            ./test_clingcon
+test.target

--- a/math/clingo/Portfile
+++ b/math/clingo/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 9
 
 github.setup        potassco clingo 5.6.2 v
 categories          math
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         An Answer Set Programming system to ground and solve logic programs.
 long_description \

--- a/math/clingo/Portfile
+++ b/math/clingo/Portfile
@@ -39,9 +39,12 @@ configure.args-append \
                     -DCLINGO_BUILD_WITH_PYTHON=OFF \
                     -DCLINGO_BUILD_WITH_LUA=OFF
 
-if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64" } {
+if {${build_arch} in [list ppc ppc64]} {
     patchfiles-append patch-locale.diff
-    configure.cxxflags-append -latomic
+}
+
+if {${build_arch} in [list i386 ppc] && [string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append -latomic
 }
 
 post-destroot {

--- a/math/clingo/Portfile
+++ b/math/clingo/Portfile
@@ -8,7 +8,7 @@ PortGroup           muniversal 1.0
 PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 9
 
-github.setup        potassco clingo 5.5.2 v
+github.setup        potassco clingo 5.6.2 v
 categories          math
 maintainers         nomaintainer
 license             MIT
@@ -22,9 +22,9 @@ long_description \
 homepage            https://potassco.org/clingo/
 github.tarball_from archive
 
-checksums           rmd160  9392ae24672a7d302a6e74c016a9f9f71a03e8db \
-                    sha256  a2a0a590485e26dce18860ac002576232d70accc5bfcb11c0c22e66beb23baa6 \
-                    size    3136393
+checksums           rmd160  663e2df243efbf5ccca351ed5b55a82b2f1ce95c \
+                    sha256  81eb7b14977ac57c97c905bd570f30be2859eabc7fe534da3cdc65eaca44f5be \
+                    size    5079018
 
 # clingo installs its own version of clasp.
 # As of now, it's just the latest release version of clasp, but I guess in theory


### PR DESCRIPTION
#### Description

Update to `clingo`.
New port, dependent of it: https://github.com/potassco/clingcon

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

For `clingcon`, on 10.6.8 in Rosetta two tests fail out of 13: https://github.com/potassco/clingcon/issues/97
```
test cases:   13 |   11 passed | 2 failed
assertions: 2355 | 2351 passed | 4 failed
```