### PR TITLE
gdb: Fix x86_64 builds on Apple silicon a different way

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       muniversal 1.0
+PortGroup       muniversal 1.1
 PortGroup       compiler_blacklist_versions 1.0
 
 name            gdb
@@ -65,6 +65,8 @@ compiler.thread_local_storage \
 # compiler supports the standard - getting rid of old Apple GCC versions and the like?
 compiler.cxx_standard   2011
 
+triplet.add_build       cross
+
 configure.dir ${workpath}/build
 configure.cmd ${worksrcpath}/configure
 configure.args \
@@ -73,15 +75,6 @@ configure.args \
     --without-python \
     --program-prefix=g \
     --disable-werror
-
-platform darwin arm {
-    # build an x86_64 binary as gdb arm binaries are not yet supported.
-    configure.args-append --build=arm64-apple-${os.platform}${os.major} \
-                          --host=x86_64-apple-${os.platform}${os.major}
-
-    # prevent make[2]: x86_64-apple-darwin22-ar: No such file or directory
-    configure.env-append  AR=ar
-}
 
 pre-configure {
     file mkdir ${configure.dir}


### PR DESCRIPTION
#### Description

@kencu heres a much cleaner way to handle this.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
