### PR TITLE
cminpack: new port in math

### DIFF
--- a/math/cminpack/Portfile
+++ b/math/cminpack/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        devernay cminpack 1.3.8 v
+categories          math
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Solving nonlinear equations and nonlinear least squares problems
+long_description    A C/C++ rewrite of the MINPACK software (originally in Fortran) \
+                    for solving nonlinear equations and nonlinear least squares problems.
+checksums           rmd160  3a8952788c7e5f18f79c2e1b001bd7ec3eb7ff1a \
+                    sha256  d904156dc6677f34d93edd326d54906d447534eaab907f8f345f3d14e4a3ed8d \
+                    size    341454
+
+configure.args-append \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DUSE_BLAS=OFF
+
+notes "
+This product includes software developed by the University
+of Chicago, as Operator of Argonne National Laboratory.
+"
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/${name}
+    xinstall -m 0644 -W ${worksrcpath} CopyrightMINPACK.txt ${destroot}${prefix}/share/${name}
+}
+
+test.run            yes
+test.cmd            ctest


### PR DESCRIPTION
#### Description

New port: https://github.com/devernay/cminpack

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass on 10.6.8:
```
--->  Testing cminpack
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_cminpack/cminpack/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_cminpack/cminpack/work/build
      Start  1: tchkder_
 1/24 Test  #1: tchkder_ .........................   Passed    0.33 sec
      Start  2: tchkderc
 2/24 Test  #2: tchkderc .........................   Passed    0.36 sec
      Start  3: thybrd_
 3/24 Test  #3: thybrd_ ..........................   Passed    0.36 sec
      Start  4: thybrdc
 4/24 Test  #4: thybrdc ..........................   Passed    0.35 sec
      Start  5: thybrd1_
 5/24 Test  #5: thybrd1_ .........................   Passed    0.34 sec
      Start  6: thybrd1c
 6/24 Test  #6: thybrd1c .........................   Passed    0.33 sec
      Start  7: thybrj_
 7/24 Test  #7: thybrj_ ..........................   Passed    0.36 sec
      Start  8: thybrjc
 8/24 Test  #8: thybrjc ..........................   Passed    0.36 sec
      Start  9: thybrj1_
 9/24 Test  #9: thybrj1_ .........................   Passed    0.34 sec
      Start 10: thybrj1c
10/24 Test #10: thybrj1c .........................   Passed    0.35 sec
      Start 11: tlmder_
11/24 Test #11: tlmder_ ..........................   Passed    0.33 sec
      Start 12: tlmderc
12/24 Test #12: tlmderc ..........................   Passed    0.33 sec
      Start 13: tlmder1_
13/24 Test #13: tlmder1_ .........................   Passed    0.34 sec
      Start 14: tlmder1c
14/24 Test #14: tlmder1c .........................   Passed    0.34 sec
      Start 15: tlmdif_
15/24 Test #15: tlmdif_ ..........................   Passed    0.35 sec
      Start 16: tlmdifc
16/24 Test #16: tlmdifc ..........................   Passed    0.34 sec
      Start 17: tlmdif1_
17/24 Test #17: tlmdif1_ .........................   Passed    0.34 sec
      Start 18: tlmdif1c
18/24 Test #18: tlmdif1c .........................   Passed    0.38 sec
      Start 19: tlmstr_
19/24 Test #19: tlmstr_ ..........................   Passed    0.34 sec
      Start 20: tlmstrc
20/24 Test #20: tlmstrc ..........................   Passed    0.34 sec
      Start 21: tlmstr1_
21/24 Test #21: tlmstr1_ .........................   Passed    0.33 sec
      Start 22: tlmstr1c
22/24 Test #22: tlmstr1c .........................   Passed    0.33 sec
      Start 23: tfdjac2_
23/24 Test #23: tfdjac2_ .........................   Passed    0.35 sec
      Start 24: tfdjac2c
24/24 Test #24: tfdjac2c .........................   Passed    0.34 sec

100% tests passed, 0 tests failed out of 24

Total Test time (real) =   8.36 sec
```