### PR TITLE
muniversal-1.1: Set --build when cross-compiling

### DIFF
--- a/_resources/port1.0/group/muniversal-1.1.tcl
+++ b/_resources/port1.0/group/muniversal-1.1.tcl
@@ -166,7 +166,7 @@ default triplet.add_host    {cross}
 
 # possible values: none, all, cross, or a list of architectures
 options triplet.add_build
-default triplet.add_build   {none}
+default triplet.add_build   {cross}
 
 foreach arch {arm64 x86_64 i386 ppc ppc64} {
     options triplet.cpu.${arch}


### PR DESCRIPTION
This is almost always required when building for x86_64 from Apple Silicon

Commonly configure based projects will be looking for ${triplet.cpu.${arch}}-${triplet.vendor}-${triplet.os}-${tool}

e.g. 
An x86_64 build from Apple silicon will be looking for x86_64-apple-darwin22-ar when --build is not set

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
