### PR TITLE
libpetanque: new port in math

### DIFF
--- a/math/libpetanque/Portfile
+++ b/math/libpetanque/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        quarkslab arybo 1.1.0 release-
+name                libpetanque
+revision            0
+categories          math
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Library that helps manipulate symbolic boolean expressions
+long_description    Manipulation, canonicalization and identification \
+                    of mixed boolean-arithmetic symbolic expressions.
+checksums           rmd160  61fdd1497b0f01613d2ad6a003ddaf09083c86ff \
+                    sha256  8a3d5ac2c7f595848404480732e57cf0228cedc60f481cbf080fa6c0745c171a \
+                    size    941087
+
+compiler.cxx_standard 2014
+
+cmake.source_dir    ${worksrcpath}/petanque
+
+# pybind11.h: error: invalid use of incomplete type 'PyFrameObject' {aka 'struct _frame'}
+# Passing -DPYTHON_BINDINGS_ENABLED=OFF to configure gets ignored, therefore using a patch:
+patchfiles          patch-no-bindings.diff
+
+test.run            yes
+test.cmd            ctest

--- a/math/libpetanque/files/patch-no-bindings.diff
+++ b/math/libpetanque/files/patch-no-bindings.diff
@@ -1,0 +1,11 @@
+--- petanque/CMakeLists.txt.orig	2020-03-29 01:16:21.000000000 +0700
++++ petanque/CMakeLists.txt	2022-12-29 03:25:38.000000000 +0700
+@@ -16,7 +16,7 @@
+ include_directories(${CMAKE_SOURCE_DIR}/third-party)
+ 
+ add_subdirectory(src)
+-add_subdirectory(bindings)
++
+ if (NOT (DEFINED NO_TESTS OR NO_TESTS))
+ 	add_subdirectory(tests)
+ endif()


### PR DESCRIPTION
#### Description

New port in math, standalone library from: https://github.com/quarkslab/arybo

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing libpetanque
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_libpetanque/libpetanque/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_libpetanque/libpetanque/work/build
      Start  1: op_add
 1/30 Test  #1: op_add ...........................   Passed    0.03 sec
      Start  2: op_or
 2/30 Test  #2: op_or ............................   Passed    0.03 sec
      Start  3: op_mul
 3/30 Test  #3: op_mul ...........................   Passed    0.03 sec
      Start  4: op_complex
 4/30 Test  #4: op_complex .......................   Passed    0.03 sec
      Start  5: op_esf
 5/30 Test  #5: op_esf ...........................   Passed    0.03 sec
      Start  6: op_names
 6/30 Test  #6: op_names .........................   Passed    0.03 sec
      Start  7: simp_constants_prop
 7/30 Test  #7: simp_constants_prop ..............   Passed    0.02 sec
      Start  8: simp_flatten_no_rec
 8/30 Test  #8: simp_flatten_no_rec ..............   Passed    0.03 sec
      Start  9: simp_flatten
 9/30 Test  #9: simp_flatten .....................   Passed    0.03 sec
      Start 10: simp_remove_dead_ops
10/30 Test #10: simp_remove_dead_ops .............   Passed    0.03 sec
      Start 11: simp_expand_no_rec
11/30 Test #11: simp_expand_no_rec ...............   Passed    0.03 sec
      Start 12: simp_expand
12/30 Test #12: simp_expand ......................   Passed    0.03 sec
      Start 13: simp
13/30 Test #13: simp .............................   Passed    0.03 sec
      Start 14: algos
14/30 Test #14: algos ............................   Passed    0.03 sec
      Start 15: vector
15/30 Test #15: vector ...........................   Passed    0.03 sec
      Start 16: matrix
16/30 Test #16: matrix ...........................   Passed    0.03 sec
      Start 17: subs
17/30 Test #17: subs .............................   Passed    0.03 sec
      Start 18: vec_int
18/30 Test #18: vec_int ..........................   Passed    0.03 sec
      Start 19: random_simplify
19/30 Test #19: random_simplify ..................   Passed    0.09 sec
      Start 20: sort
20/30 Test #20: sort .............................   Passed    0.03 sec
      Start 21: sort2
21/30 Test #21: sort2 ............................   Passed    0.03 sec
      Start 22: vectorial_decomp
22/30 Test #22: vectorial_decomp .................   Passed    0.03 sec
      Start 23: prettyprinter
23/30 Test #23: prettyprinter ....................   Passed    0.03 sec
      Start 24: exprs
24/30 Test #24: exprs ............................   Passed    0.03 sec
      Start 25: app
25/30 Test #25: app ..............................   Passed    0.03 sec
      Start 26: or_to_esf
26/30 Test #26: or_to_esf ........................   Passed    0.03 sec
      Start 27: identify_ors_no_rec
27/30 Test #27: identify_ors_no_rec ..............   Passed    0.04 sec
      Start 28: syms_set
28/30 Test #28: syms_set .........................   Passed    0.03 sec
      Start 29: visitors
29/30 Test #29: visitors .........................   Passed    0.03 sec
      Start 30: sorted_vector
30/30 Test #30: sorted_vector ....................   Passed    0.03 sec

100% tests passed, 0 tests failed out of 30

Total Test time (real) =   1.05 sec
```