### PR TITLE
cmh: new port in math; pari (one of dependencies): fix target for Rosetta

### DIFF
--- a/math/cmh/Portfile
+++ b/math/cmh/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                cmh
+version             1.1.1
+categories          math
+license             GPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Compute Igusa class polynomials
+long_description    {*}${description}
+homepage            https://www.multiprecision.org/cmh/home.html
+master_sites        https://www.multiprecision.org/downloads/
+checksums           rmd160  0803d09ab2bca13cc852a7fded72aaae4a48890b \
+                    sha256  214d5d51fea4af54cda85ef9aee43eff8a711b725a527574d0f3b5581dde4d59 \
+                    size    511873
+
+use_autoreconf      yes
+
+depends_lib-append  port:fplll \
+                    port:gmp \
+                    port:libmpc \
+                    port:mpfr \
+                    port:mpfrcx \
+                    port:pari
+
+patchfiles          patch-test.diff
+
+configure.args-append \
+                    --enable-mpi=no
+
+platform darwin 10 powerpc {
+configure.args-append \
+                    --build=powerpc-apple-darwin${os.major}
+}
+
+test.run            yes
+test.dir            ${worksrcpath}/tests
+test.cmd            ./test.sh
+test.target

--- a/math/cmh/Portfile
+++ b/math/cmh/Portfile
@@ -24,7 +24,8 @@ depends_lib-append  port:fplll \
                     port:mpfrcx \
                     port:pari
 
-patchfiles          patch-test.diff
+patchfiles          patch-asprintf.diff \
+                    patch-test.diff
 
 configure.args-append \
                     --enable-mpi=no

--- a/math/cmh/files/patch-asprintf.diff
+++ b/math/cmh/files/patch-asprintf.diff
@@ -1,0 +1,17 @@
+# cm2.c: error: implicit declaration of function 'asprintf' is invalid in C99
+
+--- src/cm2.c.orig	2022-07-20 16:56:48.000000000 +0700
++++ src/cm2.c	2022-12-29 04:49:30.000000000 +0700
+@@ -19,8 +19,12 @@
+  */
+ 
+ /*{{{ includes, etc. */
++#ifdef __APPLE__
++#define _DARWIN_C_SOURCE
++#else
+ #define _POSIX_C_SOURCE 200112L
+ #define _GNU_SOURCE
++#endif
+ #include "config.h"
+ #include <stdio.h>
+ #include <stdlib.h>

--- a/math/cmh/files/patch-test.diff
+++ b/math/cmh/files/patch-test.diff
@@ -1,0 +1,18 @@
+--- tests/test.sh.orig	2021-02-06 00:21:58.000000000 +0700
++++ tests/test.sh	2022-12-29 04:15:06.000000000 +0700
+@@ -5,13 +5,13 @@
+ }
+ 
+ clean_up
+-$CMH_BINDIR/../scripts/cmh-classpol.sh -f -p -c 13 3
++../scripts/cmh-classpol.sh -f -p -c 13 3
+ if test $? -ne 0 ; then
+    echo "Error when executing the cmh-classpol.sh script."
+    exit 1
+ fi
+ 
+-cmp 157_13_3.pol $CMH_TESTDIR/example.pol
++cmp 157_13_3.pol ./example.pol
+ if test $? -ne 0 ; then
+    echo "Wrong polynomial computed by the cmh-classpol.sh script."
+    exit 1

--- a/math/pari/Portfile
+++ b/math/pari/Portfile
@@ -130,6 +130,12 @@ variant mt description {Build multithreaded} {
     configure.args-append --mt=pthread
 }
 
+platform darwin 10 powerpc {
+    # Without this settings get wrong in Rosetta:
+    # Building for: i386 running darwin (ix86/GMP kernel) 32-bit version
+    patchfiles-append patch-rosetta.diff
+}
+
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]
 livecheck.regex     ${name}-(\\d+\\.\\d+\\.\\d+)

--- a/math/pari/files/patch-rosetta.diff
+++ b/math/pari/files/patch-rosetta.diff
@@ -1,0 +1,8 @@
+--- config/arch-osname.orig	2011-09-23 03:02:11.000000000 +0700
++++ config/arch-osname	2022-12-29 03:54:58.000000000 +0700
+@@ -76,4 +76,4 @@
+             case $arch in powerpc) arch=ppc;;esac;;
+   esac
+ fi
+-echo $arch-$osname
++echo ppc-darwin


### PR DESCRIPTION
#### Description

Since `fplll` and `mpfrcx` are merged, here is their dependent: https://www.multiprecision.org/cmh/home.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
