### PR TITLE
Update lenstool port to new version 8.0.4

### DIFF
--- a/science/lenstool/Portfile
+++ b/science/lenstool/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport   1.0
 
 name                lenstool
 version             8.0.4
-revision            1
+revision            0
 categories          science
 license             GPL-3+
 platforms           darwin

--- a/science/lenstool/Portfile
+++ b/science/lenstool/Portfile
@@ -28,7 +28,7 @@ long_description    LENSTOOL package contains a C library and several \
                     by several additional executables provided in the package.
 
 homepage            https://projets.lam.fr/projects/lenstool
-master_sites        https://git-cral.univ-lyon1.fr/lenstool/lenstool/-/archive/8.0.4/lenstool-8.0.4.tar.gz
+master_sites        https://git-cral.univ-lyon1.fr/lenstool/lenstool/-/archive/8.0.4/
 
 checksums           sha256 f14fb546a78ebbae3604739fe70089a98ca22668a85ba0d537fd9d63fc1c0786 \
                     rmd160 9dd3aee11b46356ac75e3277de38984a2a0f9e53 \

--- a/science/lenstool/Portfile
+++ b/science/lenstool/Portfile
@@ -4,8 +4,8 @@ PortSystem                          1.0
 PortGroup           legacysupport   1.0
 
 name                lenstool
-version             7.1.1
-revision            2
+version             8.0.4
+revision            1
 categories          science
 license             GPL-3+
 platforms           darwin
@@ -28,11 +28,11 @@ long_description    LENSTOOL package contains a C library and several \
                     by several additional executables provided in the package.
 
 homepage            https://projets.lam.fr/projects/lenstool
-master_sites        https://projets.lam.fr/attachments/download/5851
+master_sites        https://git-cral.univ-lyon1.fr/lenstool/lenstool/-/archive/8.0.4/lenstool-8.0.4.tar.gz
 
-checksums           sha256 272aed5e5964b8b941c916be98f13a7f134f3a785681c5b6199ab0438114f5ac \
-                    rmd160 bbffc88c8ca5d02fd293eb8db5a5f9d0f983f065 \
-                    size   5709212
+checksums           sha256 f14fb546a78ebbae3604739fe70089a98ca22668a85ba0d537fd9d63fc1c0786 \
+                    rmd160 9dd3aee11b46356ac75e3277de38984a2a0f9e53 \
+                    size   15830584
 
 depends_lib-append  port:cfitsio \
                     port:gsl \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.

-->
macOS 12.6.1 21G217 x86_64
Command Line Tools 14.1.0.0.1.1666437224

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
