### PR TITLE
stellarium: update to 1.2, update build Python versions

### DIFF
--- a/science/stellarium/Portfile
+++ b/science/stellarium/Portfile
@@ -19,11 +19,11 @@ long_description ${description} \
 homepage        https://stellarium.org/
 
 conflicts           stellarium-qt4
-github.setup        Stellarium stellarium 0.22.2 v
-checksums           rmd160  48db461198d032f18d770c0bc059d596491db75f \
-                    sha256  d207b0722d4dca6299d754916e172cae15ee75f1e5a077e0b608ca7c68d22bd9 \
-                    size    409233913
-revision            1
+github.setup        Stellarium stellarium 1.2 v
+checksums           rmd160  75d214229de3283553782d08fe831b8f5f275085 \
+                    sha256  84c8abcb4811b99ecff41d541dd96e327c5387e04f636a646d1f6589ee5a6e3a \
+                    size    439008077
+revision            0
 
 # builds as 64-bit only, according to its top-level CMakeLists.txt file
 universal_variant   no
@@ -65,9 +65,6 @@ configure.args-append \
 post-destroot {
     set appdir ${destroot}${applications_dir}/Stellarium.app/Contents
 
-    # move App parts around internally
-    move ${appdir}/share ${appdir}/Resources
-
     # copy other useful file(s)
     copy ${worksrcpath}/util/qt.conf ${appdir}/Resources/
 
@@ -87,7 +84,7 @@ if {[variant_isset RemoteControl]} {
     # specify the Python dependencies; these are checked for at configure,
     # then used for building, but not at runtime.
 
-    set pythons_versions_with_dot {2.7 3.5 3.6 3.7 3.8 3.9 3.10}
+    set pythons_versions_with_dot {3.7 3.8 3.9 3.10}
 
     set pythons_ports {}
     set pythons_versions_no_dot {}
@@ -104,8 +101,8 @@ if {[variant_isset RemoteControl]} {
         variant ${p} description "Build ${name} using Python ${v}" conflicts {*}${c} ""
     }
 
-    #default to Python 3.9
-    set selected_python_no_dot 39
+    #default to Python 3.10
+    set selected_python_no_dot 310
     foreach v ${pythons_versions_with_dot} {
         set s [string map {. {}} ${v}]
         if {[variant_isset python${s}]} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.2 21G320 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
-<!--  [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)? -->
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
