### PR TITLE
hstr: update to 2.6.0

### DIFF
--- a/shells/hstr/Portfile
+++ b/shells/hstr/Portfile
@@ -3,19 +3,20 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dvorka hstr 2.5
+github.setup        dvorka hstr 2.6
 while {[llength [split ${version} .]] < 3} {
     version         ${version}.0
 }
 revision            0
-checksums           rmd160  2e69f6d080e6b89b4ec258774a972428c1b507b2 \
-                    sha256  44bb6d93ef064536218f8ae5464772861bfccfe364a436397d9f770207cd306d \
-                    size    179948
+checksums           rmd160  144b2f5ebdcc50e3aaa3ecac39c9b12ee062cff5 \
+                    sha256  91100b00132a5f5f535141f117c18bfd7d6c95b3a161bf10c13c1195cf81cd1d \
+                    size    178263
 
 categories          shells
-platforms           darwin
 license             Apache-2
-maintainers         {ryandesign @ryandesign} openmaintainer
+maintainers         {ryandesign @ryandesign} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         Bash and Zsh shell history suggest box
 


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
