### PR TITLE
mimalloc: new port

### DIFF
--- a/devel/mimalloc/Portfile
+++ b/devel/mimalloc/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        microsoft mimalloc 2.0.9 v
+github.tarball_from archive
+
+revision            0
+categories          devel
+license             MIT
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         mimalloc is a compact general purpose allocator with \
+                    excellent performance
+
+long_description    mimalloc is a general purpose allocator with excellent \
+                    performance characteristics.
+
+checksums           rmd160  984b43fc094751aa8c5ec52e91ac816d9c5d9c52 \
+                    sha256  4a29edae32a914a706715e2ac8e7e4109e25353212edeed0888f4e3e15db5850 \
+                    size    1143452
+
+patchfiles          patch-cmake.diff

--- a/devel/mimalloc/files/patch-cmake.diff
+++ b/devel/mimalloc/files/patch-cmake.diff
@@ -1,0 +1,12 @@
+--- CMakeLists.txt.orig	2022-12-24 01:31:56.000000000 +0400
++++ CMakeLists.txt	2022-12-30 16:02:05.000000000 +0400
+@@ -321,9 +321,6 @@
+   set(mi_basename "${mi_basename}-asan")
+ endif()
+ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LC)
+-if(NOT(CMAKE_BUILD_TYPE_LC MATCHES "^(release|relwithdebinfo|minsizerel|none)$"))
+-  set(mi_basename "${mi_basename}-${CMAKE_BUILD_TYPE_LC}") #append build type (e.g. -debug) if not a release version
+-endif()
+ 
+ if(MI_BUILD_SHARED)
+   list(APPEND mi_build_targets "shared")


### PR DESCRIPTION
#### Description

[mimalloc](https://github.com/microsoft/mimalloc) is a compact general purpose allocator with excellent performance.

###### Tested on
macOS 12.6.2 21G320 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?