### PR TITLE
botan: fix cross-arch universal building

### DIFF
--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -112,14 +112,24 @@ variant native description {Enable all intrinsics} {
 
 # botan way of setting cpu type in build phase
 array set merger_configure_args {
-    ppc     --cpu=ppc
-    i386    --cpu=ia32
-    ppc64   --cpu=ppc64
-    x86_64  --cpu=amd64
+    ppc     "--cpu=ppc   --cc-abi-flags='-arch ppc'"
+    i386    "--cpu=ia32  --cc-abi-flags='-arch i386'"
+    ppc64   "--cpu=ppc64 --cc-abi-flags='-arch ppc64'"
+    x86_64  "--cpu=amd64 --cc-abi-flags='-arch x86_64'"
+    arm64   "--cpu=arm64 --cc-abi-flags='-arch arm64'"
 }
 
 if {(!${universal_possible} || ![variant_isset universal]) && [info exists merger_configure_args(${build_arch})]} {
     configure.args-append $merger_configure_args(${build_arch})
+}
+
+if {${universal_possible} && [variant_isset universal]} {
+    foreach my_arch ${configure.universal_archs} {
+        # configure.py rejects this argument
+        # strip the automatic setting of host
+        ui_info "removing ${my_arch} from hosts"
+        set merger_host(${my_arch}) ""
+    }
 }
 
 # configure.py rejects this argument


### PR DESCRIPTION
allows universal arm64/x86_64 and others
closes: https://trac.macports.org/ticket/59945

this is admittedly a little messy -- look forward to anyone with a cleaner plan

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

```
% port -v installed botan
The following ports are currently installed:
  botan @2.19.3_0+universal (active) requested_variants='+universal' platform='darwin 22' archs='arm64 x86_64' date='2022-12-30T13:12:38-0800'

% file /opt/local/lib/libbotan-2.19.19.3.dylib                         
/opt/local/lib/libbotan-2.19.19.3.dylib: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64]
/opt/local/lib/libbotan-2.19.19.3.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
/opt/local/lib/libbotan-2.19.19.3.dylib (for architecture arm64):	Mach-O 64-bit dynamically linked shared library arm64
```


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
