### PR TITLE
libgcrypt: allow cross-arch universal building

### DIFF
--- a/devel/libgcrypt/Portfile
+++ b/devel/libgcrypt/Portfile
@@ -7,7 +7,7 @@ PortGroup       muniversal 1.0
 
 name            libgcrypt
 version         1.10.1
-revision        0
+revision        1
 categories      devel security
 # libs are LGPL, executables and docs are GPL
 license         {GPL-2+ LGPL-2.1+}
@@ -69,6 +69,24 @@ use_parallel_build  yes
 post-patch {
     if {[variant_exists universal] && [variant_isset universal]} {
         reinplace "s/@LIBGCRYPT_CONFIG_HOST@/${os.arch}-apple-darwin${os.major}/" ${worksrcpath}/src/libgcrypt-config.in
+    }
+}
+
+# strip host= from pkgconfig file https://trac.macports.org/ticket/63635
+# could be added to muniversal PG but Ryan asked that it remain in each Port needing it
+# so that upstream could be notified and fix it properly
+post-build {
+    if {[variant_exists universal] && [variant_isset universal]} {
+        set dirs {}
+        foreach arch ${universal_archs_to_use} {
+            lappend dirs ${worksrcpath}-${arch}
+        }
+    } else {
+        set dirs ${worksrcpath}
+    }
+    foreach dir ${dirs} {
+        # Remove architecture-specific differences to allow merging.
+        reinplace -E {s|host=[^ ]+||g}               ${dir}/src/libgcrypt.pc
     }
 }
 


### PR DESCRIPTION
strip host= from pc file
closes: https://trac.macports.org/ticket/63635

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

```
% port -v installed libgcrypt
The following ports are currently installed:
  libgcrypt @1.10.1_1+universal (active) requested_variants='+universal' platform='darwin 22' archs='arm64 x86_64' date='2022-12-30T13:59:49-0800'

% file /opt/local/lib/libgcrypt.20.dylib                                      
/opt/local/lib/libgcrypt.20.dylib: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64:Mach-O 64-bit dynamically linked shared library arm64]
/opt/local/lib/libgcrypt.20.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
/opt/local/lib/libgcrypt.20.dylib (for architecture arm64):	Mach-O 64-bit dynamically linked shared library arm64

```


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
