### PR TITLE
botan: fix cross-arch universal building (alternative)

### DIFF
--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           muniversal 1.0
+PortGroup           muniversal 1.1
 PortGroup           openssl 1.0
 PortGroup           legacysupport 1.1
 
@@ -110,20 +110,14 @@ variant native description {Enable all intrinsics} {
     }
 }
 
-# botan way of setting cpu type in build phase
-array set merger_configure_args {
-    ppc     --cpu=ppc
-    i386    --cpu=ia32
-    ppc64   --cpu=ppc64
-    x86_64  --cpu=amd64
-}
+configure.args.ppc     "--cpu=ppc   --cc-abi-flags='-arch ppc'"
+configure.args.i386    "--cpu=ia32  --cc-abi-flags='-arch i386'"
+configure.args.ppc64   "--cpu=ppc64 --cc-abi-flags='-arch ppc64'"
+configure.args.x86_64  "--cpu=amd64 --cc-abi-flags='-arch x86_64'"
+configure.args.arm64   "--cpu=arm64 --cc-abi-flags='-arch arm64'"
 
-if {(!${universal_possible} || ![variant_isset universal]) && [info exists merger_configure_args(${build_arch})]} {
-    configure.args-append $merger_configure_args(${build_arch})
-}
-
-# configure.py rejects this argument
-configure.universal_args-delete --disable-dependency-tracking
+# configure.py rejects --host
+triplet.add_host    {none}
 
 livecheck.regex     Botan-(${branch}\\.\[0-9.\]+)${extract.suffix}
 


### PR DESCRIPTION
allows universal arm64/x86_64 and others
closes: https://trac.macports.org/ticket/59945

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
