### PR TITLE
emacs{,-app}-devel: update to 20221231, add treesitter variant

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -103,31 +103,53 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     PortGroup       github 1.0
 
-    github.setup    emacs-mirror emacs 7939184f8e0370e7a3397d492812c6d202c2a193
+    github.setup    emacs-mirror emacs f59d012af7e607448fdb435fcb4becb6a6ebe665
     epoch           5
-    version         20221128
+    version         20221231
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  cb434a6d1ef8cd1f1e1baabcf1bf5a05aba8c098 \
-                    sha256  08fa8ae7e62fdb50ac8e49935db83b71987a454861d5b2cf6d2bb65a1eb8ca38 \
-                    size    46595420
+    checksums       rmd160  ddd42b2605c0865241762077da6ed96506ddae71 \
+                    sha256  9ce6855d06e31997fc9fa5d50d470420f463814ed36735bdb253d708aff03bb6 \
+                    size    46934030
 
     configure.args-append \
         --with-sqlite3 \
         --with-webp \
-        --with-tree-sitter
+        --without-tree-sitter
 
     depends_lib-append \
         port:sqlite3 \
-        port:webp \
-        port:tree-sitter
+        port:webp
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
     }
 
     livecheck.type none
+
+    variant treesitter description {Builds emacs with tree-sitter support} {
+        configure.args-delete   --without-tree-sitter
+        configure.args-append   --with-tree-sitter
+        depends_lib-append  port:tree-sitter
+        depends_run-append  port:tree-sitter-typescript \
+            port:tree-sitter-tsx \
+            port:tree-sitter-c \
+            port:tree-sitter-cpp \
+            port:tree-sitter-java \
+            port:tree-sitter-python \
+            port:tree-sitter-css \
+            port:tree-sitter-json \
+            port:tree-sitter-c-sharp \
+            port:tree-sitter-bash \
+            port:tree-sitter-dockerfile \
+            port:tree-sitter-cmake \
+            port:tree-sitter-toml \
+            port:tree-sitter-go \
+            port:tree-sitter-go-mod \
+            port:tree-sitter-yaml \
+            port:tree-sitter-rust
+    }
 } else {
     livecheck.type  regex
     livecheck.url   https://ftp.gnu.org/gnu/emacs/?C=M&O=D

--- a/editors/emacs/files/site-start.el
+++ b/editors/emacs/files/site-start.el
@@ -14,3 +14,7 @@
 ;; Use the OS X Emoji font for Emoticons
 (when (fboundp 'set-fontset-font)
   (set-fontset-font t 'emoji '("Apple Color Emoji" . "iso10646-1") nil 'prepend))
+
+;; Look in MacPorts ${prefix} for tree-sitter parser libraries
+(when (boundp 'treesit-extra-load-path)
+  (setq treesit-extra-load-path (cons "__PREFIX__/lib" treesit-extra-load-path)))


### PR DESCRIPTION
#### Description

This moves tree-sitter support to a variant that also pulls in all of the new tree-sitter-* ports for which a built-in mode (*-ts-mode) exists.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
