### PR TITLE
Update minetest rev2 (draft) 01

### DIFF
--- a/games/minetest/Portfile
+++ b/games/minetest/Portfile
@@ -8,7 +8,7 @@ compiler.cxx_standard   2011
 compiler.thread_local_storage   yes
 
 github.setup            minetest minetest 5.6.1
-revision                1
+revision                2
 
 # the game version could be different from the minetest version
 set game_version        5.6.1
@@ -54,8 +54,7 @@ long_description        ${description} - \
 
 homepage                https://www.minetest.net
 
-depends_build-append    path:bin/doxygen:doxygen \
-                        port:mesa
+depends_build-append    path:bin/doxygen:doxygen
 
 depends_lib-append      port:irrlichtmt \
                         path:include/turbojpeg.h:libjpeg-turbo \
@@ -76,7 +75,7 @@ depends_lib-append      port:irrlichtmt \
 
 # see https://trac.macports.org/ticket/58315 - possibly fixable?
 universal_variant       no
-supported_archs         x86_64
+supported_archs         x86_64 arm64
 
 # 001. the original build calls fixup_bundle to move all the deps into the app bundle.
 #    this doesn't work correctly with macports destrooting, and isn't necessary for a macports install so deleted it


### PR DESCRIPTION
This PR is _WIP_ and a **DRAFT**

* drop "port:mesa"
* add arch "arm64"
* preliminary revision 2
* note "irrlichtmt" supports arm64

Ref https://trac.macports.org/ticket/66599 _(preliminary status)_

#### Description

1. Update MT 5.6.1 "minetest" rev2 (draft) step 01

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.2 20G1020 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
