### PR TITLE
minetest rev2 - Portfile w/ variants

### DIFF
--- a/games/minetest/Portfile
+++ b/games/minetest/Portfile
@@ -8,7 +8,7 @@ compiler.cxx_standard   2011
 compiler.thread_local_storage   yes
 
 github.setup            minetest minetest 5.6.1
-revision                1
+revision                2
 
 # the game version could be different from the minetest version
 set game_version        5.6.1
@@ -46,7 +46,9 @@ post-extract {
 
 license                 LGPL-2.1+
 categories              games
+
 platforms               darwin
+
 maintainers             @Zweihorn openmaintainer
 description             open source infinite-world block sandbox game with survival and crafting
 long_description        ${description} - \
@@ -94,6 +96,7 @@ configure.args-append   -DCMAKE_BUILD_TYPE=Release \
                         -DBUILD_UNITTESTS=OFF \
                         -DENABLE_UPDATE_CHECKER=OFF \
                         -DBUILD_CLIENT=ON \
+                        -DENABLE_GLES=OFF \
                         -DBUILD_SERVER=ON \
                         -DENABLE_SOUND=ON \
                         -DENABLE_REDIS=OFF \
@@ -109,8 +112,133 @@ configure.args-append   -DCMAKE_BUILD_TYPE=Release \
                         -DENABLE_LUAJIT=ON \
                         -DLUA_INCLUDE_DIR:PATH=${prefix}/include/luajit-2.1 \
                         -DLUA_LIBRARY:FILEPATH=${prefix}/lib/libluajit-5.1.dylib \
+                        -USE_GPROF=FALSE \
                         -DVERSION_EXTRA=MacPorts-rev${revision}
 
+default_variants        +GLES
+
+
+# WIP - Tries (failed) platform arm64 for early adoptors and/or development
+variant arm64 conflicts server \
+        description {Try arm64 platform for early adoptors and/or development} {
+
+    platform darwin arm {
+
+        supported_archs         arm64
+
+        known_fail              yes
+
+    }
+
+notes "
+This variant is WIP and a stub. Should be tried on Mac ARM platforms only.
+"
+
+}
+
+
+# Benchmark should apply the MT options including UnitTests and Benchmarks
+variant benchmark conflicts debug \
+        description {Make a MT RelWithDebInfo build including UnitTests and Benchmarks} {
+
+    configure.args-delete    -DCMAKE_BUILD_TYPE=Release \
+                             -DBUILD_UNITTESTS=OFF
+
+    configure.args-append    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                             -DBUILD_UNITTESTS=ON \
+                             -DBUILD_BENCHMARKS=ON
+
+}
+
+
+# Debug should apply the MT options (but unsure if this collides with implicit debug?)
+variant debug conflicts benchmark \
+        description {Make a MT Debug build for development and/or test purposes} {
+
+    configure.args-delete    -DCMAKE_BUILD_TYPE=Release \
+                             -DBUILD_UNITTESTS=OFF
+
+    configure.args-append    -DCMAKE_BUILD_TYPE=Debug \
+                             -DBUILD_UNITTESTS=ON
+
+}
+
+
+# WIP - Awaiting upstream MT 5.7.0 (expected around Feb 2023)
+# -- TBD
+# Presumable minimum is a new subport "minetest-devel"
+# subport for MT 5.6.x ?
+# subport for MT 5.7.x ? - upstream MT 5.7.0 - Feb 2023 ETA
+
+
+# Optional GLES improvement for the MT client build (default variant)
+variant GLES conflicts noclient \
+        description {Extended MESA & GLES graphical support for the MT client build} {
+
+    configure.args-delete    -DENABLE_GLES=OFF
+
+    configure.args-append    -DENABLE_GLES=ON
+
+}
+
+
+# Optional GPROF profiler support - see: https://www.thegeekstuff.com/2012/08/gprof-tutorial/
+variant gprof \
+        description {Optional GPROF profiler support (needs GCC)} {
+
+    configure.compiler       macports-gcc-12
+
+    depends_build-append     port:gcc12
+
+    configure.args-delete    -USE_GPROF=FALSE
+
+    configure.args-append    -USE_GPROF=TRUE
+
+}
+
+
+# Optional improvement for a 24/7 MT server by dropping the MT client build
+variant noclient requires server conflicts GLES \
+        description {Drops the MT client for benefit of a lean CLI and stable MT server only} {
+
+    depends_build-delete     port:mesa
+
+    configure.args-delete    -DENABLE_CLIENT=ON
+
+    configure.args-append    -DENABLE_CLIENT=OFF
+
+# -- TBD
+# needs further investigation and improvement for dropping the complete MT App bundle
+
+}
+
+
+# PostgreSQL database support for dedicated `minetestserver` improved service
+# NOTE: "postgresql13-server" benefits from RAM storage and poor little psql-client cannot.
+variant psql description {PostgreSQL database for dedicated `minetestserver` improved service} {
+
+    depends_lib-append       port:postgresql13-server
+
+    configure.args-delete    -DENABLE_POSTGRESQL=OFF
+
+    configure.args-append    -DENABLE_POSTGRESQL=ON
+
+}
+
+
+# WIP - Improvements for a 24/7 MT server with dedicated `minetestserver` and system service
+variant server requires psql \
+        description {Dedicated stable `minetestserver` with improvements and system service} {
+
+# -- TBC
+# support for dedicated 'minetest' system user by adduser:username
+# support for "sudo port launch minetestserver"
+
+}
+
+
 post-destroot {
+# WIP - Move `minetestserver` to `/opt/local/bin` and find a new "good place" for related MT files or `ln -s` them
+#    move ${workpath}/minetest-${version}/bin/minetestserver ${destroot}${prefix}/bin  #-- have to look into Guide and think on the concept
     move ${workpath}/minetest_game-${game_version}   ${destroot}${applications_dir}/minetest.app/Contents/Resources/games/minetest_game
 }


### PR DESCRIPTION
This PR is **ready for REVIEW** _(rev2 - 2nd round)_

#### Description

1. **Update Profile** of MT 5.6.1 "minetest" rev2 with **new variants** and some **improvements**
3. **Introduce new variants:** [+]GLES, arm64, benchmark, debug, gprof, noclient, psql, server
2. Continue **legacy-os**: Mac OS X 10.6 Snow Leopard platform _(requires bugfix in update of "**irrlichtmt**")_

Ref https://trac.macports.org/ticket/66439
Ref https://trac.macports.org/ticket/66599
Ref https://trac.macports.org/ticket/66600

The b.m. Trac ticket should **not hinder** any review and is **an independent activity** by same maintainer:
- ref https://trac.macports.org/ticket/66610

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.2 20G1020 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

###### Future tasks:

- **Postpone** "irrlichtmt" update (upstream IrrLichtMT 1.9.0mt9; 2022-12-29) in hope of **legacy-os** support
- **Consider** feasibility of _sub-port "minetest-devel"_ only **after** MT 5.7.0 upstream.

Ref [​https://github.com/minetest/irrlicht/compare/1.9.0mt8...1.9.0mt9](https://github.com/minetest/irrlicht/compare/1.9.0mt8...1.9.0mt9)
~~Ref to a.m. MT forum topic with preliminary MT 5.7 schedule~~  _seems to be lost or deleted_

Hope this helps.

🌻 