### PR TITLE
taco: new port in math

### DIFF
--- a/math/taco/Portfile
+++ b/math/taco/Portfile
@@ -1,0 +1,68 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+github.setup        tensor-compiler taco 2b8ece4c230a5f0f0a74bc6f48e28edfb6c1c95e
+version             2022.08.02
+revision            0
+categories          math
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Tensor Algebra Compiler (taco): computes sparse tensor expressions on CPUs and GPUs
+long_description    The Tensor Algebra Compiler (taco) is a C++ library that computes tensor algebra \
+                    expressions on sparse and dense tensors. It uses novel compiler techniques \
+                    to get performance competitive with hand-optimized kernels in widely used libraries \
+                    for both sparse tensor algebra and sparse linear algebra.
+homepage            https://tensor-compiler.org
+
+# Fetch from git instead of distfile because it needs submodules
+fetch.type          git
+
+if {${os.major} < 14} {
+    depends_build-append    port:git
+    git.cmd                 ${prefix}/bin/git
+}
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+# https://github.com/tensor-compiler/taco/issues/541
+patchfiles          patch-no-narrowing.diff
+
+post-patch {
+    reinplace "s,@ARCHFLAGS@,[get_canonical_archflags cxx]," ${worksrcpath}/CMakeLists.txt
+    reinplace "s, -shared -fPIC, [get_canonical_archflags cc] -shared -fPIC," ${worksrcpath}/src/codegen/module.cpp
+}
+
+compiler.cxx_standard   2014
+compiler.openmp_version 3.0
+
+legacysupport.newest_darwin_requires_legacy 10
+legacysupport.redirect_bins taco taco-tensor_times_vector taco-test
+
+configure.args-append \
+                    -DTACO_SHARED_LIBRARY=on \
+                    -DOPENMP=on \
+                    -DCOVERAGE=off \
+                    -DCUDA=off \
+                    -DPYTHON=off \
+                    -DCTEST_PARALLEL_LEVEL=2
+
+if {[string match *clang* ${configure.compiler}]} {
+    configure.ldflags-append \
+                    -L${prefix}/lib/libomp \
+                    -lomp
+}
+
+pre-test {
+    system -W ${cmake.build_dir} "install_name_tool -change ${prefix}/lib/libtaco.dylib ${cmake.build_dir}/lib/libtaco.dylib ${cmake.build_dir}/bin/taco-test"
+}
+
+# Tests will fail on PPC: https://github.com/tensor-compiler/taco/issues/541
+test.run            yes
+test.cmd            ctest
+test.cmd-prepend    DYLD_LIBRARY_PATH=${cmake.build_dir}/lib

--- a/math/taco/files/patch-no-narrowing.diff
+++ b/math/taco/files/patch-no-narrowing.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2022-12-31 10:48:32.000000000 +0700
++++ CMakeLists.txt	2022-12-31 11:00:28.000000000 +0700
+@@ -83,7 +83,7 @@
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+ 
+ set(OPTIMIZE "-O3" CACHE STRING "Optimization level")
+-set(C_CXX_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wmissing-declarations -Woverloaded-virtual -pedantic-errors -Wno-deprecated")
++set(C_CXX_FLAGS "@ARCHFLAGS@ -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wmissing-declarations -Woverloaded-virtual -Wno-deprecated -Wno-narrowing -pedantic-errors")
+ if(OPENMP)
+   set(C_CXX_FLAGS "-fopenmp ${C_CXX_FLAGS}")
+ endif(OPENMP)


### PR DESCRIPTION
#### Description

New port: https://github.com/tensor-compiler/taco

Tests mostly pass on 10.6.8 `x86_64`:
```
99% tests passed, 2 tests failed out of 231

Total Test time (real) = 294.20 sec

The following tests did not run:
	 43 - expr.accumulate (Disabled)
	 55 - format.mm_permute_formats (Disabled)
	101 - qcd.mul3 (Disabled)
	127 - generate_evaluation_files.cpu (Disabled)
	128 - generate_evaluation_files.gpu (Disabled)
	129 - generate_figures.cpu (Disabled)
	130 - scheduling_eval.bfsPullScheduled (Disabled)
	193 - tensor_types.complex_mul_scalar (Disabled)
	198 - tensor_types.coordinate_types (Disabled)
	204 - lower.transpose (Disabled)
	205 - lower.transpose2 (Disabled)
	206 - lower.transpose3 (Disabled)

The following tests FAILED:
	 99 - qcd.mul1 (Failed)
	243 - taco-cli-test (Failed)
Errors while running CTest
```

PPC does not work presently: https://github.com/tensor-compiler/taco/issues/541 (`malloc` errors, and adding `DYDL_LIBRARY_PATH` to `test.env` fails to help, whether directly or via `legacysupport` PG).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
