### PR TITLE
x86_64-elf-gcc: Update to 12.2.0

### DIFF
--- a/cross/i386-elf-gcc/Portfile
+++ b/cross/i386-elf-gcc/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           crossgcc 1.0
 
-crossgcc.setup      i386-elf 9.2.0
+crossgcc.setup      i386-elf 12.2.0
 crossgcc.setup_libc newlib 3.1.0
-revision            2
+revision            0
 
 maintainers         nomaintainer

--- a/cross/x86_64-elf-gcc/Portfile
+++ b/cross/x86_64-elf-gcc/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           crossgcc 1.0
 
-crossgcc.setup      x86_64-elf 9.2.0
+crossgcc.setup      x86_64-elf 12.2.0
 crossgcc.setup_libc newlib 3.1.0
-revision            2
+revision            0
 
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description

I wanted to use a newer x86_64-elf-gcc, as the existing one hadn't been updated in some time.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.1 21G217 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
