### PR TITLE
rust: fix arm64/x86_64 build & remove jemalloc dep

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -8,7 +8,7 @@ name                        rust
 
 # keep in mind that you also need to update cargo.crates at the end of this file
 version                     1.66.0
-revision                    0
+revision                    1
 
 categories                  lang devel
 license                     {MIT Apache-2} BSD zlib NCSA Permissive
@@ -39,9 +39,6 @@ depends_build-append        path:bin/cmake:cmake \
 if { ${configure.ccache} } {
     depends_build-append    port:ccache
 }
-if { ${os.platform} eq "darwin" && ${os.major} > 14 } {
-    depends_lib-append      port:jemalloc
-}
 depends_lib-append          port:curl \
                             port:libiconv \
                             port:libgit2 \
@@ -56,9 +53,16 @@ depends_skip_archcheck      cmake \
 
 dist_subdir                 rust
 
+# the downloaded Rust compiler must run on the machine
+# since binaries must run anyway, simplify build by using Rosetta and not worry about cross-compiling
 muniversal.run_binaries     yes
 triplet.add_host            all
 triplet.add_build           all
+foreach arch {arm64 x86_64 i386 ppc ppc64} {
+    if { [option muniversal.can_run.${arch}] && [option muniversal.is_cross.${arch}] } {
+        muniversal.is_cross.${arch} no
+    }
+}
 
 distname                    rustc-${version}-src
 distfiles                   ${distname}${extract.suffix}:apple_vendor
@@ -135,6 +139,12 @@ if { ${os.platform} eq "darwin" && ${os.major} < 9 } {
 }
 if { ${os.platform} eq "darwin" && ${os.major} > 14 } {
     configure.args-append   --set=rust.jemalloc
+    if { ${os.arch} eq "arm" } {
+        # specify the number of significant virtual address bits in jmalloc
+        # the configure script calls cpuid, but it does not work properly on Rosetta 2
+        # see https://github.com/jemalloc/jemalloc/issues/1997#issuecomment-1041589117
+        build.env.x86_64-append JEMALLOC_SYS_WITH_LG_VADDR=48
+    }
 }
 
 foreach arch ${muniversal.architectures} {
@@ -168,6 +178,10 @@ test.target                 check
 
 rust::append_envs           RUST_BACKTRACE=1
 
+# lists of installed files, so they should include files from all architectures
+muniversal.combine          ${prefix}/lib/rustlib/components \
+                            ${prefix}/lib/rustlib/manifest-rustc
+
 post-destroot {
     if {${subport} eq "rust-src"} return
     delete                  ${destroot}${prefix}/lib/rustlib/install.log
@@ -175,6 +189,10 @@ post-destroot {
     xinstall -d -m 0755     ${destroot}${prefix}/share/${name}
     xinstall    -m 0644     ${worksrcpath}/src/etc/ctags.rust \
                             ${destroot}${prefix}/share/${name}
+    reinplace               "s|${destroot}||g" \
+                            ${destroot}${prefix}/lib/rustlib/manifest-rustc \
+                            ${destroot}${prefix}/lib/rustlib/manifest-rustfmt-preview \
+                            ${destroot}${prefix}/lib/rustlib/manifest-clippy-preview
 }
 
 subport rust-src {


### PR DESCRIPTION
Rust builds its own copy of jemalloc
Removing it as a dependency as part of this commit minimizes rebuilds

Fixes https://trac.macports.org/ticket/66591

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
