### PR TITLE
ginkgo: new port in math

### DIFF
--- a/math/ginkgo/Portfile
+++ b/math/ginkgo/Portfile
@@ -1,0 +1,75 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           mpi 1.0
+
+github.setup        ginkgo-project ginkgo 1.5.0 v
+revision            0
+categories          math
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Numerical linear algebra software package
+long_description    A numerical linear algebra library targeting many-core architectures.
+homepage            https://ginkgo-project.github.io
+checksums           rmd160  44582d50b1dcb0108438a52d240eb37be1d936a6 \
+                    sha256  3a6bfdbf3d343bdf30c05a1a7ea913d36e15e484cea8afbc509238718ad2076b \
+                    size    9508712
+
+# Needed for tests:
+cmake.out_of_source no
+
+if {${os.platform} eq "darwin" && ${os.arch} eq "powerpc"} {
+    mpi.setup       require require_fortran \
+                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 -gcc6 \
+                    -clang -fortran
+} else {
+    mpi.setup       require require_fortran \
+                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 -gcc6
+}
+
+compiler.openmp_version 3.0
+
+configure.args-append \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DGINKGO_MIXED_PRECISION=ON \
+                    -DGINKGO_BUILD_MPI=ON \
+                    -DGINKGO_BUILD_REFERENCE=ON \
+                    -DGINKGO_BUILD_TESTS=ON \
+                    -DGINKGO_BUILD_BENCHMARKS=OFF \
+                    -DGINKGO_BUILD_CUDA=OFF \
+                    -DGINKGO_BUILD_DPCPP=OFF \
+                    -DGINKGO_BUILD_HIP=OFF \
+                    -DGINKGO_BUILD_DOC=OFF \
+                    -DGINKGO_BUILD_EXAMPLES=OFF \
+                    -DGINKGO_BUILD_HWLOC=OFF \
+                    -DGINKGO_BUILD_OMP=OFF \
+                    -DGINKGO_DEVEL_TOOLS=OFF \
+                    -DGINKGO_DOC_GENERATE_EXAMPLES=OFF \
+                    -DGINKGO_DOC_GENERATE_PDF=OFF \
+                    -DGINKGO_JACOBI_FULL_OPTIMIZATIONS=OFF \
+                    -DGINKGO_WITH_CCACHE=OFF \
+                    -DGTEST_SRC_DIR=${prefix}/src/googletest/
+
+# Even though compilation succeeds, OMP module does not build correctly on PPC.
+if {${build_arch} ni [list ppc ppc64]} {
+    configure.args-replace \
+                    -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_OMP=ON
+}
+
+if {[string match *clang* ${configure.compiler}]} {
+    configure.ldflags-append \
+                    -L${prefix}/lib/libomp \
+                    -lomp
+}
+
+# ___atomic_compare_exchange_8
+if {${build_arch} in [list i386 ppc] && [string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append -latomic
+}
+
+depends_test-append port:gtest
+
+test.run            yes
+test.cmd            ctest


### PR DESCRIPTION
#### Description

New port in math: https://github.com/ginkgo-project/ginkgo

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

**PPC status:** Aside of OpenMPI-related ones and few FP-related, tests pass in Rosetta:
```
71% tests passed, 66 tests failed out of 229

Total Test time (real) = 584.03 sec

The following tests FAILED:
	 71 - omp/test/base/index_set (Failed)
	 72 - omp/test/matrix/fbcsr_kernels (Failed)
	 73 - omp/test/reorder/rcm_kernels (Failed)
	 93 - core/test/base/extended_float (Failed)
	 94 - core/test/base/executor (Failed)
	110 - core/test/mpi/base/communicator (Failed)
	111 - core/test/mpi/base/exception_helpers (Failed)
	112 - core/test/mpi/base/bindings (Failed)
	113 - core/test/mpi/base/polymorphic_object (Failed)
	114 - core/test/mpi/base/rank_mapping (Failed)
	115 - core/test/mpi/distributed/helpers (Failed)
	116 - core/test/mpi/distributed/matrix (Failed)
	175 - test/base/device_matrix_data_kernels_omp (Failed)
	177 - test/base/kernel_launch_generic_omp (Failed)
	178 - test/components/absolute_array_kernels_omp (Failed)
	179 - test/components/fill_array_kernels_omp (Failed)
	180 - test/components/format_conversion_kernels_omp (Failed)
	181 - test/components/precision_conversion_kernels_omp (Failed)
	182 - test/components/prefix_sum_kernels_omp (Failed)
	183 - test/components/reduce_array_kernels_omp (Failed)
	184 - test/distributed/matrix_kernels_omp (Failed)
	185 - test/distributed/partition_kernels_omp (Failed)
	186 - test/distributed/vector_kernels_omp (Failed)
	187 - test/factorization/cholesky_kernels_omp (Failed)
	188 - test/factorization/lu_kernels_omp (Failed)
	189 - test/factorization/par_ic_kernels_omp (Failed)
	190 - test/factorization/par_ict_kernels_omp (Failed)
	191 - test/factorization/par_ilu_kernels_omp (Failed)
	192 - test/factorization/par_ilut_kernels_omp (Failed)
	193 - test/matrix/csr_kernels_omp (Failed)
	194 - test/matrix/csr_kernels2_omp (Failed)
	195 - test/matrix/coo_kernels_omp (Failed)
	196 - test/matrix/dense_kernels_omp (Subprocess aborted)
	197 - test/matrix/diagonal_kernels_omp (Failed)
	198 - test/matrix/ell_kernels_omp (Failed)
	199 - test/matrix/fbcsr_kernels_omp (Failed)
	200 - test/matrix/fft_kernels_omp (Subprocess aborted)
	201 - test/matrix/hybrid_kernels_omp (Failed)
	202 - test/matrix/matrix_omp (Failed)
	203 - test/matrix/sellp_kernels_omp (Failed)
	204 - test/mpi/distributed/matrix_omp (Failed)
	205 - test/mpi/distributed/matrix_reference (Failed)
	206 - test/mpi/distributed/vector_omp (Failed)
	207 - test/mpi/distributed/vector_reference (Failed)
	208 - test/mpi/solver/solver_omp (Failed)
	209 - test/mpi/solver/solver_reference (Failed)
	210 - test/multigrid/pgm_kernels_omp (Failed)
	211 - test/multigrid/fixed_coarsening_kernels_omp (Failed)
	212 - test/preconditioner/jacobi_kernels_omp (Failed)
	213 - test/preconditioner/isai_kernels_omp (Failed)
	214 - test/solver/bicg_kernels_omp (Failed)
	215 - test/solver/bicgstab_kernels_omp (Failed)
	216 - test/solver/cb_gmres_kernels_omp (Failed)
	217 - test/solver/cg_kernels_omp (Failed)
	218 - test/solver/cgs_kernels_omp (Failed)
	219 - test/solver/direct_omp (Failed)
	220 - test/solver/fcg_kernels_omp (Failed)
	221 - test/solver/gmres_kernels_omp (Failed)
	222 - test/solver/idr_kernels_omp (Failed)
	223 - test/solver/ir_kernels_omp (Failed)
	224 - test/solver/lower_trs_kernels_omp (Failed)
	225 - test/solver/multigrid_kernels_omp (Failed)
	226 - test/solver/solver_omp (Failed)
	227 - test/solver/upper_trs_kernels_omp (Failed)
	228 - test/stop/criterion_kernels_omp (Failed)
	229 - test/stop/residual_norm_kernels_omp (Failed)
```
OpenMP-related tests fail due to a missing module, like this:
```
[ RUN      ] Matrix/2.BuildsLocalWithColPartitionIsEquivalentToRef
unknown file: Failure
C++ exception with description "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_ginkgo/ginkgo/work/ginkgo-1.5.0/core/device_hooks/common_kernels.inc.cpp:245: feature count_ranges is part of the omp module, which is not compiled on this system" thrown in the test body.
[  FAILED  ] Matrix/2.BuildsLocalWithColPartitionIsEquivalentToRef, where TypeParam = std::tuple<float, long long, long long> (3 ms)
[----------] 6 tests from Matrix/2 (17 ms total)
```
For this reason, I disable OpenMP on PPC, even though compilation succeeds with `-DGINKGO_BUILD_OMP=ON`.