### PR TITLE
josm: update to 18621

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18583
+version             18621
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  6d314bc612b5f88a15379a3250c56df3f0f3c1e4 \
-                    sha256  dd71284825c4a5ea998f5cb89e7b39fb4251d5220d604d6bb264387cc7e5c514 \
-                    size    78073192
+checksums           rmd160  8d99653904c265790d994bde7dc64de41408e39f \
+                    sha256  49fe668315a3ab6e34535b54072052e8515bd13a63fd03fbc8797ec2f4c87e78 \
+                    size    78113616
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2023-01-01: Stable release 18621](https://josm.openstreetmap.de/wiki/Changelog#a2023-01-01:Stablerelease1862122.12)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
