### PR TITLE
nanoflann: fix configure arg NANOFLANN_BUILD_EXAMPLES=OFF

### DIFF
--- a/math/nanoflann/Portfile
+++ b/math/nanoflann/Portfile
@@ -22,6 +22,6 @@ compiler.cxx_standard   2011
 
 supported_archs         noarch
 
-configure.args-append   -DBUILD_EXAMPLES=OFF
+configure.args-append   -DNANOFLANN_BUILD_EXAMPLES=OFF
 
-test.run            yes
+test.run                yes


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66602

#### Description

The port was set not to build examples, however correct arg for that is `-DNANOFLANN_BUILD_EXAMPLES=OFF`.

`-DBUILD_EXAMPLES=OFF` does not have an effect, and examples are being built (which requires then dependency on `eigen3` and some fixes to it – in case of PPC).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
