### PR TITLE
gts: fix universal build on M1 Mac

### DIFF
--- a/math/gts/Portfile
+++ b/math/gts/Portfile
@@ -32,7 +32,6 @@ depends_build       port:pkgconfig
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libnetpbm
 
-
 test.run            yes
 test.target         check
 post-extract {

--- a/math/gts/Portfile
+++ b/math/gts/Portfile
@@ -32,6 +32,7 @@ depends_build       port:pkgconfig
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libnetpbm
 
+
 test.run            yes
 test.target         check
 post-extract {
@@ -71,6 +72,18 @@ if {${universal_possible} && [variant_isset universal]} {
                     ${worksrcpath}-${arch}/src/Makefile
             }
         }
+    }
+}
+
+platform darwin arm {
+    depends_build-append    port:automake
+
+    post-patch {
+        # Use newer config.guess and config.sub to support Apple Silicon.
+        set automake_dirs [glob -directory ${prefix}/share automake-*]
+        set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+        copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+            ${worksrcpath}
     }
 }
 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/66605

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
