### PR TITLE
py-serial: Add py311 subport, + additional fixes.

### DIFF
--- a/python/py-serial/Portfile
+++ b/python/py-serial/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        pyserial pyserial 3.5 v
-revision            0
+revision            1
 name                py-serial
 
 categories-append   comms
@@ -16,19 +16,21 @@ maintainers         {fwright.net:fw @fhgwright} openmaintainer
 
 description         Python Serial Port Extension
 long_description    This module encapsulates the access for the serial port. \
-                    It provides backends for standard Python running on Windows, \
-                    Linux, BSD (possibly any POSIX compliant system) and Jython. \
-                    The module named "serial" automatically selects the appropriate \
-                    backend.
+                    It provides backends for standard Python running on \
+                    Windows, Linux, BSD (possibly any POSIX compliant system) \
+                    and Jython. The module named "serial" automatically \
+                    selects the appropriate backend.
 
 checksums           rmd160  ee56e22c15af484b72b65d445a4fe8a2aeee0cd0 \
                     sha256  80125f950a620bd0a31cfa18f5eda0df77e0bed2accc2bb7a76ab650ff63afa9 \
                     size    155864
 
-python.versions     27 37 38 39 310
+python.versions     27 34 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
-    depends_build-append \
+    # py*-setuptools is needed at runtime for the included programs,
+    # as well as at build time, so it's a library dependency.
+    depends_lib-append \
                     port:py${python.version}-setuptools
 
     post-destroot {


### PR DESCRIPTION
Also corrects the py-setuptools dependency, which is needed at runtime for the included programs.  Because this affects the runtime dependency, it includes a revbump.

Also restores the py34-py36 subports, which were removed without maintainer approval.  The upstream code supports 2.7 and 3.4+.  These subports are a known_fail on arm (handled externally), but OK where python34-36 exists.

Also cleans up long Portfile lines in the long description.

NOTE:
Testing turned up bugs in python36 on 10.4 ppc, and python37 on 10.4-10.5 ppc, 10.5 i386, and 10.5 x86_64.  There also seem to be bugs in setuptools in certain cases which cause trace-mode builds to fail. None of these issues is believed to be a problem in this port itself.

TESTED:
Tested the included programs for all available Python versions on 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-10.15 x86_64, and 11.x-13.x arm64. Tested actual serial communication in a subset of cases.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e
macOS 11.7.2 20G1020, arm64, Xcode 13.2.1 13C100
macOS 12.6.2 21G320, arm64, Xcode 14.2 14C18
macOS 13.1 22C65, arm64, Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [FAIL] checked your Portfile with `port lint --nitpick`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [N/A] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

NOTE:  port lint fails due to not recognizing 'any' in 'platforms' (46ab9a2e798).

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
