### PR TITLE
skaffold: fix checksums

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -4,7 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        GoogleContainerTools skaffold 2.0.4 v
-revision            0
+
+# Stealth update: https://github.com/macports/macports-ports/pull/17184
+revision            1
+dist_subdir         ${name}/${version}_1
 
 categories          devel
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -22,9 +25,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  910bf4dd3f6de5367ca03bc44cd1d0747de1648e \
-                    sha256  c86efc08e3687eb1b0f952e99823c8247c74caab0cba8ef673cef1c311cc3da3 \
-                    size    41605601
+checksums           rmd160  e70c9d39927b939a6e3fc7fbe32d15d0a45abc34 \
+                    sha256  ea8d3ed08193eced46e3411e745c20018c2806cee379dbad2e2b4070f6507f44 \
+                    size    41605904
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Fix the skaffold checksums.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?