### PR TITLE
calendar-contacts-server: Use xml-file-based auth; migrate away from discontinued macOS Server/OpenDirectory

### DIFF
--- a/net/calendar-contacts-server/Portfile
+++ b/net/calendar-contacts-server/Portfile
@@ -10,7 +10,7 @@ name                calendar-contacts-server
 # version from https://github.com/apple/ccs-calendarserver/blob/master/setup.py
 # with date of git commit appended
 version             9.3.20200212
-revision            2
+revision            3
 categories          net mail
 platforms           darwin
 supported_archs     noarch
@@ -19,14 +19,14 @@ license             Apache-2
 
 description         Apple Calendar and Contacts Server configuration
 
-long_description    ccs-calendarserver is a standards-compliant server\
-                    implementing the CalDAV and CardDAV protocols,\
-                    including iMIP and APNS. It provides a shared\
-                    location on the network allowing multiple users to\
-                    store and edit calendaring and contact\
-                    information. This port provides a basic, working,\
-                    easily modifiable configuration, previously used\
-                    in macOS Server.app, and an nginx reverse proxy to\
+long_description    ccs-calendarserver is a standards-compliant server \
+                    implementing the CalDAV and CardDAV protocols, \
+                    including iMIP and APNS. It provides a shared \
+                    location on the network allowing multiple users to \
+                    store and edit calendaring and contact \
+                    information. This port provides a basic, working, \
+                    easily modifiable configuration, previously used \
+                    in macOS Server.app, and an nginx reverse proxy to \
                     handle modern crypto and isolate the backend server.
 
 homepage            https://www.calendarserver.org
@@ -44,6 +44,9 @@ set python2_branch [string index ${python2_version} 0].[string range ${python2_v
 set postgresql9_version 96
 set postgresql9_branch [string index ${postgresql9_version} 0].[string range ${postgresql9_version} 1 end]
 
+depends_build-append \
+                    port:py${python2_version}-setuptools
+
 depends_lib-append  port:cyrus-sasl2 \
                     port:libffi \
                     port:mail-server \
@@ -52,8 +55,25 @@ depends_lib-append  port:cyrus-sasl2 \
                     port:openssl \
                     port:postgresql${postgresql9_version}-server \
                     port:python${python2_version} \
+                    port:py${python2_version}-asn1 \
+                    port:py${python2_version}-asn1-modules \
+                    port:py${python2_version}-cffi \
+                    port:py${python2_version}-constantly \
+                    port:py${python2_version}-cryptography \
+                    port:py${python2_version}-dateutil \
+                    port:py${python2_version}-enum34 \
+                    port:py${python2_version}-incremental \
+                    port:py${python2_version}-ldap \
+                    port:py${python2_version}-mock \
+                    port:py${python2_version}-openssl \
                     port:py${python2_version}-pip \
-                    port:py${python2_version}-pyobjc-cocoa
+                    port:py${python2_version}-psutil \
+                    port:py${python2_version}-pycparser \
+                    port:py${python2_version}-pyobjc-cocoa \
+                    port:py${python2_version}-service_identity \
+                    port:py${python2_version}-six \
+                    port:py${python2_version}-virtualenv \
+                    port:py${python2_version}-zopeinterface \
 
 depends_run-append  port:pip_select \
                     port:postgresql_select
@@ -132,6 +152,7 @@ destroot {
         ${destroot}${calendarserverdir}/Library/CalendarServer \
         ${destroot}${calendarserverpackage}
     foreach d {
+        Library/CalendarServer/auth
         Library/CalendarServer/Config
         Library/CalendarServer/Config/Certificates
         Library/CalendarServer/etc
@@ -146,6 +167,9 @@ destroot {
         destroot.keepdirs-append \
             ${destroot}${calendarserverdir}/${d}
     }
+    file attributes \
+        ${destroot}${calendarserverdir}/Library/CalendarServer/auth \
+        -permissions 0770
     file attributes \
         ${destroot}${calendarserverdir}/Library/CalendarServer/etc/nginx_root \
         -permissions 0755
@@ -174,6 +198,11 @@ destroot {
     xinstall -m 0600 -o ${calendarserverUser} -g _calendar \
         ${filespath}/calendarserver.plist \
         ${destroot}${calendarserverdir}/Library/CalendarServer/Config/calendarserver.plist.macports
+
+    # Directory Service
+    xinstall -m 0660 -o ${calendarserverUser} -g _calendar \
+        ${worksrcpath}/conf/test/accounts.xml \
+        ${destroot}${calendarserverdir}/Library/CalendarServer/auth/accounts.xml.macports
 
     # nginx reverse proxy
     xinstall -m 0640 -o ${calendarserverUser} -g _calendar \
@@ -342,6 +371,7 @@ PACKAGE_CALENDARSERVER
 
     # calenderserver configuration and nginx reverse proxy
     foreach f_or_d {
+        auth/accounts.xml
         Config/calendarserver.plist
         etc/nginx.conf
     } {
@@ -351,6 +381,7 @@ PACKAGE_CALENDARSERVER
 
     # configure all template files with local settings
     foreach d_or_f {
+        auth
         Config
         etc
         } {
@@ -518,6 +549,25 @@ These are the locations and network settings for the default configuration:
 
     Personal data (note, outside ${prefix}):
         /var/calendarserver/Library/CalendarServer/Data
+
+Account and principal information is configurable in the file:
+        ${prefix}/var/calendarserver/Library/CalendarServer/auth/accounts.xml
+
+with baseline account records of the form:
+
+  <record>
+    <uid>7E1DE44E-F1E5-4656-93EF-1714B37877A5</uid>
+    <short-name>username</short-name>
+    <full-name>User Name</full-name>
+    <password>strong-password</password>
+    <email>username@example.com</email>
+  </record>
+
+uid's can must be unique; on macOS two ways of generating uid's are\
+the command `uuidgen`, or for local accounts and especially when migrating\
+from an OpenDirectory-based server:
+
+        dscl . -read /Users/username GeneratedUID
 
 A working Calendar and Contacts Server will allow local account\
 authentication at these web pages (ports 8008 and 8800 are\

--- a/net/calendar-contacts-server/files/calendarserver.plist
+++ b/net/calendar-contacts-server/files/calendarserver.plist
@@ -237,7 +237,24 @@
         A variety of directory services are available for use.
       -->
 
+    <!-- https://www.calendarserver.org/QuickStart.html:
+	 XML, LDAP, OpenDirectory -->
+    
+    <!-- XML File Directory Service -->
+    <key>DirectoryService</key>
+    <dict>
+      <key>type</key>
+      <string>xml</string>
+        
+      <key>params</key> 
+      <dict>
+        <key>xmlFile</key>
+        <string>@PREFIX@/var/calendarserver/Library/CalendarServer/auth/accounts.xml</string>
+      </dict>
+    </dict>
+
     <!-- Open Directory Service (Mac OS X) -->
+    <!--
     <key>DirectoryService</key>
     <dict>
         <key>type</key>
@@ -254,6 +271,7 @@
             </array>
         </dict>
     </dict>
+    -->
 
     <!-- XML File Augment Service -->
     <key>AugmentService</key>


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
