### PR TITLE
lighttpd: Update to 1.4.68

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -4,11 +4,11 @@ PortSystem                  1.0
 PortGroup                   legacysupport 1.0
 
 name                        lighttpd
-version                     1.4.67
+version                     1.4.68
 revision                    0
-checksums                   rmd160  e710c084bfa45d6e9bce549198372538130aa2da \
-                            sha256  7e04d767f51a8d824b32e2483ef2950982920d427d1272ef4667f49d6f89f358 \
-                            size    1039872
+checksums                   rmd160  6a273cab0c862f04fc62f639555bbbd757209943 \
+                            sha256  e56f37ae52b63e1ada4d76ce78005affb6e56eea2f6bdb0ce17d6d36e9583384 \
+                            size    1030612
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  www


### PR DESCRIPTION
#### Description

lighttpd: Update to 1.4.68

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?