### PR TITLE
rspamd: fix build on macOS <10.15

### DIFF
--- a/mail/rspamd/Portfile
+++ b/mail/rspamd/Portfile
@@ -4,14 +4,19 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+# fatal error: 'variant' file not found
+# error: use of undeclared identifier 'have_monotonic'
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx                 yes
 
 github.setup        rspamd rspamd 3.4
-revision            0
+revision            1
 
 categories          mail
 license             BSD
 maintainers         nomaintainer
-platforms           darwin
 license             Apache-2
 homepage            https://rspamd.com
 
@@ -55,6 +60,7 @@ depends_lib-append  port:fann \
                     port:libsodium \
                     port:libstemmer \
                     port:libunwind \
+                    port:xxhashlib \
                     port:lua \
                     path:lib/libluajit-5.1.2.dylib:luajit \
                     path:lib/libopenblas.dylib:OpenBLAS \
@@ -101,6 +107,7 @@ configure.args-append \
                     -DENABLE_PCRE2=ON \
                     -DENABLE_SNOWBALL=ON \
                     -DENABLE_TORCH=ON \
+                    -DSYSTEM_XXHASH=ON \
                     -DINSTALL_EXAMPLES=ON \
                     -DLIBDIR=${prefix}/lib \
                     -DLOGDIR=${prefix}/var/log/${name} \


### PR DESCRIPTION
* remove platforms line

Closes: https://trac.macports.org/ticket/63785

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
