### PR TITLE
ntpsec: update to 1.2.2

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -6,8 +6,8 @@ PortGroup           python 1.0
 PortGroup           openssl 1.0
 
 name                ntpsec
-version             1.2.1
-revision            4
+version             1.2.2
+revision            0
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -20,9 +20,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  ca5d758bf6572b460ba8e8c8e70f09b8a7417fd0 \
-                    sha256  f2684835116c80b8f21782a5959a805ba3c44e3a681dd6c17c7cb00cc242c27a \
-                    size    2681237
+checksums           rmd160  60b8c64a75d27d8e34db51c17050ccecc182f972 \
+                    sha256  2f2848760b915dfe185b9217f777738b36ceeb78a7fc208b7e74e039dec22df5 \
+                    size    2710329
 
 # 10.5 x86_64 builds successfully and passes all build tests, but doesn't
 # actually work.  This has apparently been true forever, but until recently,
@@ -30,6 +30,8 @@ checksums           rmd160  ca5d758bf6572b460ba8e8c8e70f09b8a7417fd0 \
 # and not really a regression, we simply disallow it for now.  It's unknown
 # whether 10.4 x86_64 has the same issue, but we also disallow that out of
 # conservatism.  This should be removed once the code is fixed.
+#
+# This bug has been verified as still present as of 1.2.2.
 if { ${os.platform} eq "darwin" && ${os.major} < 10 } {
     supported_archs     i386 ppc
 }
@@ -47,16 +49,7 @@ python.versions     27
 # Also note that the new ffi-based Python client library doesn't work properly
 # on the Mac, so we use the old extension-based version.
 
-# The installed ntpsec code builds correctly with openssl3, though one of
-# the "attic" programs included (erroneously) in the default build does not.
-# Although this is easily fixed, openssl3 itself currently fails to build
-# in certain cases, so we keep this on openssl11 for now.
-#
-# Since OpenSSL 1.1 is still fully supported, adequate for ntpsec, and has no
-# licensing issues for ntpsec, there's no rush to move to OpenSSL 3, which might
-# as well wait for the next ntpsec release (or later, if openssl3 isn't fully
-# fixed by then).
-openssl.branch      1.1
+openssl.branch      3
 # NOTE: doesn't work with libressl
 
 depends_build-append port:bison port:pkgconfig
@@ -82,6 +75,8 @@ destroot.cmd        ${build.cmd}
 # Although the normal build procedure includes the tests, we also allow
 # them separately so that "port test" works.
 test.run            yes
+# Override the python portgroup's inappropriate test.cmd
+test.cmd            ${build.cmd}
 test.target         check
 
 default_variants    +doc

--- a/sysutils/ntpsec/files/patch-allfixes.diff
+++ b/sysutils/ntpsec/files/patch-allfixes.diff
@@ -1,5 +1,5 @@
---- attic/backwards.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ attic/backwards.c	2022-11-28 16:18:24.000000000 -0800
+--- attic/backwards.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ attic/backwards.c	2022-12-30 00:59:15.000000000 -0800
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -9,8 +9,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- attic/clocks.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ attic/clocks.c	2022-11-28 16:18:24.000000000 -0800
+--- attic/clocks.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ attic/clocks.c	2022-12-30 00:59:15.000000000 -0800
 @@ -9,6 +9,8 @@
  #include <unistd.h>
  
@@ -20,8 +20,8 @@
  struct table {
    const int type;
    const char* name;
---- attic/cmac-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ attic/cmac-timing.c	2022-11-28 16:18:24.000000000 -0800
+--- attic/cmac-timing.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ attic/cmac-timing.c	2022-12-30 00:59:15.000000000 -0800
 @@ -35,6 +35,8 @@
  #include <openssl/params.h> 
  #endif
@@ -31,8 +31,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  
---- attic/digest-timing.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ attic/digest-timing.c	2022-11-28 16:18:24.000000000 -0800
+--- attic/digest-timing.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ attic/digest-timing.c	2022-12-30 00:59:15.000000000 -0800
 @@ -33,6 +33,8 @@
  #include <openssl/ssl.h>
  #endif
@@ -42,8 +42,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
---- attic/random.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ attic/random.c	2022-11-28 16:18:24.000000000 -0800
+--- attic/random.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ attic/random.c	2022-12-30 00:59:15.000000000 -0800
 @@ -10,6 +10,8 @@
  #include <openssl/opensslv.h>    /* for OPENSSL_VERSION_NUMBER */
  #include <openssl/rand.h>
@@ -53,21 +53,8 @@
  #define BATCHSIZE 1000000
  #define BILLION 1000000000
  #define HISTSIZE 2500
---- include/ntp_fp.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ include/ntp_fp.h	2022-11-28 16:18:24.000000000 -0800
-@@ -112,8 +112,9 @@ typedef struct {
-  * Operations on the long fp format.  The only reason these aren't
-  * native operations is to be independent of whether the l_fp
-  * type is signed or unsigned.
-+ * Can l_fp ever be signed??
-  */
--#define	L_NEG(v)	(v) = (l_fp)(-(int64_t)(v))
-+#define	L_NEG(v)	(v) = -(v)
- #define	L_ISNEG(v)	M_ISNEG(lfpuint(v))
- #define	L_ISGT(a, b)	((int64_t)(a) > (int64_t)(b))
- #define	L_ISGTU(a, b)	((a) > (b))
---- include/ntp_machine.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ include/ntp_machine.h	2022-11-28 16:18:24.000000000 -0800
+--- include/ntp_machine.h.orig	2022-12-22 22:08:52.000000000 -0800
++++ include/ntp_machine.h	2022-12-30 00:59:15.000000000 -0800
 @@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
@@ -220,8 +207,8 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- include/ntp_stdlib.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ include/ntp_stdlib.h	2022-11-28 16:18:24.000000000 -0800
+--- include/ntp_stdlib.h.orig	2022-12-22 22:08:52.000000000 -0800
++++ include/ntp_stdlib.h	2022-12-30 00:59:15.000000000 -0800
 @@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -232,8 +219,8 @@
  extern	char *	statustoa	(int, int);
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
---- include/ntp_syscall.h.orig	2021-06-06 21:03:11.000000000 -0700
-+++ include/ntp_syscall.h	2022-11-28 16:18:24.000000000 -0800
+--- include/ntp_syscall.h.orig	2022-12-22 22:08:52.000000000 -0800
++++ include/ntp_syscall.h	2022-12-30 00:59:15.000000000 -0800
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -246,8 +233,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- libntp/clockwork.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ libntp/clockwork.c	2022-11-28 16:18:24.000000000 -0800
+--- libntp/clockwork.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ libntp/clockwork.c	2022-12-30 00:59:15.000000000 -0800
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -261,8 +248,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ libntp/statestr.c	2022-11-28 16:18:24.000000000 -0800
+--- libntp/statestr.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ libntp/statestr.c	2022-12-30 00:59:15.000000000 -0800
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -363,9 +350,9 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ntpd/ntp_control.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ntpd/ntp_control.c	2022-11-28 16:18:24.000000000 -0800
-@@ -1361,6 +1361,7 @@ ctl_putsys(
+--- ntpd/ntp_control.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ ntpd/ntp_control.c	2022-12-30 00:59:15.000000000 -0800
+@@ -1388,6 +1388,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
  	const char *ss;
@@ -373,7 +360,7 @@
  	static struct timex ntx;
  	static unsigned long ntp_adjtime_time;
  
-@@ -1376,6 +1377,7 @@ ctl_putsys(
+@@ -1403,6 +1404,7 @@ ctl_putsys(
  		else
                      ntp_adjtime_time = current_time;
  	}
@@ -381,7 +368,7 @@
  
  	switch (varid) {
  
-@@ -1666,45 +1668,94 @@ ctl_putsys(
+@@ -1703,45 +1705,94 @@ ctl_putsys(
  	CASE_UINT(CS_AUTHRESET, current_time - auth_timereset);
  
  		/*
@@ -488,8 +475,8 @@
  
  	case CS_K_PPS_FREQ:
  		CTL_IF_KERNPPS(
---- ntpd/ntp_loopfilter.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ntpd/ntp_loopfilter.c	2022-11-28 16:18:24.000000000 -0800
+--- ntpd/ntp_loopfilter.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ ntpd/ntp_loopfilter.c	2022-12-30 00:59:15.000000000 -0800
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -711,8 +698,8 @@
  	}
  }
 -
---- ntpd/ntp_timer.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ntpd/ntp_timer.c	2022-11-28 16:18:24.000000000 -0800
+--- ntpd/ntp_timer.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ ntpd/ntp_timer.c	2022-12-30 00:59:15.000000000 -0800
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -735,8 +722,8 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ntpd/refclock_local.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ntpd/refclock_local.c	2022-11-28 16:18:24.000000000 -0800
+--- ntpd/refclock_local.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ ntpd/refclock_local.c	2022-12-30 00:59:15.000000000 -0800
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -759,8 +746,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ntpfrob/precision.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ ntpfrob/precision.c	2022-11-28 16:18:24.000000000 -0800
+--- ntpfrob/precision.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ ntpfrob/precision.c	2022-12-30 00:59:15.000000000 -0800
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -769,8 +756,8 @@
  
  #define	DEFAULT_SYS_PRECISION	-99
  
---- tests/libntp/statestr.c.orig	2021-06-06 21:03:11.000000000 -0700
-+++ tests/libntp/statestr.c	2022-11-28 16:18:24.000000000 -0800
+--- tests/libntp/statestr.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ tests/libntp/statestr.c	2022-12-30 00:59:15.000000000 -0800
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -791,8 +778,8 @@
  }
  
  // statustoa
---- wafhelpers/bin_test.py.orig	2021-06-06 21:03:11.000000000 -0700
-+++ wafhelpers/bin_test.py	2022-11-28 16:18:24.000000000 -0800
+--- wafhelpers/bin_test.py.orig	2022-12-22 22:08:52.000000000 -0800
++++ wafhelpers/bin_test.py	2022-12-30 00:59:15.000000000 -0800
 @@ -103,6 +103,12 @@ def cmd_bin_test(ctx):
      if ctx.env['PYTHON_CURSES']:
          cmd_map_python.update(cmd_map_python_curses)
@@ -806,9 +793,9 @@
      for cmd in sorted(cmd_map):
          if not run(cmd, cmd_map[cmd] % version):
              fails += 1
---- wafhelpers/options.py.orig	2021-06-06 21:03:11.000000000 -0700
-+++ wafhelpers/options.py	2022-11-28 16:18:24.000000000 -0800
-@@ -21,6 +21,8 @@ def options_cmd(ctx, config):
+--- wafhelpers/options.py.orig	2022-12-22 22:08:52.000000000 -0800
++++ wafhelpers/options.py	2022-12-30 00:59:15.000000000 -0800
+@@ -23,6 +23,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
                     default=False, help="Enable seccomp (restricts syscalls).")
@@ -817,9 +804,9 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- wscript.orig	2021-06-06 21:03:11.000000000 -0700
-+++ wscript	2022-11-28 16:18:24.000000000 -0800
-@@ -562,7 +562,7 @@ int main(int argc, char **argv) {
+--- wscript.orig	2022-12-22 22:08:52.000000000 -0800
++++ wscript	2022-12-30 00:59:15.000000000 -0800
+@@ -585,7 +585,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
          ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
@@ -828,19 +815,7 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -619,6 +619,11 @@ int main(int argc, char **argv) {
-         ctx.check_cc(msg="Checking for OpenSSL's crypto library",
-                      lib="crypto", mandatory=True)
- 
-+    # KLUDGE: Make sure selected SSL version is seen before system's.
-+    # Assumes that CRYPTO and SSL paths are the same.
-+    ctx.env.INCLUDES = ctx.env.INCLUDES_CRYPTO + ctx.env.INCLUDES
-+    ctx.env.LIBPATH = ctx.env.LIBPATH_CRYPTO + ctx.env.LIBPATH
-+
-     # Optional functions.  Do all function checks here, otherwise
-     # we're likely to duplicate them.
-     optional_functions = (
-@@ -776,6 +781,21 @@ int main(int argc, char **argv) {
+@@ -808,6 +808,21 @@ int main(int argc, char **argv) {
          ctx.define("ENABLE_FUZZ", 1,
                     comment="Enable fuzzing low bits of time")
  


### PR DESCRIPTION
Moves to OpenSSL 3, now that in can build correctly with it.

This includes the patches for compatibility with macOS<10.13, which can also be seen (more readably) at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports_1_2_2

Note that 10.5 x86_64 remains broken and is disabled.

TESTED:
Built and ran tests on 10.4-10.5 ppc, 10.4-10.6 i386, 10.6-10.15 x86_64, and 11.x-13.x arm64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e
macOS 11.7.2 20G1020, arm64, Xcode 13.2.1 13C100
macOS 12.6.2 21G320, arm64, Xcode 14.2 14C18
macOS 13.1 22C65, arm64, Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
