### PR TITLE
py-llvmlite: fix build on MacOS 13

### DIFF
--- a/python/py-llvmlite/Portfile
+++ b/python/py-llvmlite/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_wrapper 1.0
 
 github.setup        numba llvmlite 0.39.1 v
 name                py-llvmlite
-revision            0
+revision            1
 categories-append   devel science
 license             BSD
 
@@ -37,9 +37,15 @@ if {${name} ne ${subport}} {
             # https://trac.macports.org/ticket/61302
             reinplace "s|%%MP_EXTRA_LDFLAGS%%|-framework CoreFoundation|" \
                 ${worksrcpath}/ffi/Makefile.osx
+        } elseif {${os.major} >= 22} {
+            reinplace "s|%%MP_EXTRA_LDFLAGS%%|-lLLVM|" ${worksrcpath}/ffi/Makefile.osx
         } else {
             reinplace "s|%%MP_EXTRA_LDFLAGS%%||" ${worksrcpath}/ffi/Makefile.osx
         }
+    }
+
+    post-destroot {
+        system "/usr/bin/install_name_tool -change @rpath/libLLVM.dylib ${prefix}/libexec/llvm-${llvmver}/lib/libLLVM.dylib ${destroot}${python.pkgd}/llvmlite/binding/libllvmlite.dylib"
     }
 
     depends_build-append \


### PR DESCRIPTION
#### Description

This is equivalent to and closes #16640 . I don't delete the original branch to keep track of the two attempts done (there are two commits on that branch). Here I use `install_name_tool`, as suggested by @kencu . I guess this can be merged now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? **See #16640 **
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
