### PR TITLE
lab: update to version 0.25.1

### DIFF
--- a/devel/lab/Portfile
+++ b/devel/lab/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/zaquestion/lab 0.22.0 v
+go.setup            github.com/zaquestion/lab 0.25.1 v
 revision            0
 categories          devel
 platforms           darwin
@@ -18,9 +18,9 @@ long_description    \
 
 homepage            https://zaquestion.github.io/lab
 
-checksums           rmd160  5edd81ad2493f2efc74a566a7c3548c3b454b070 \
-                    sha256  ff5b184db71818d0c342788fd5b38ab7c7af8d8561c683b5d08ffd4075116a0d \
-                    size    161507
+checksums           rmd160  bc2a30535ce385500f56eb2c2288acb5bc64ec24 \
+                    sha256  f8cccdfbf1ca5a2c76f894321a961dfe0dc7a781d95baff5181eafd155707d79 \
+                    size    180159
 
 github.tarball_from archive
 


### PR DESCRIPTION
#### Description

Lab is updated to version 0.25.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1
Xcode 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
