### PR TITLE
libpcap: add remote capture variant

### DIFF
--- a/net/libpcap/Portfile
+++ b/net/libpcap/Portfile
@@ -29,6 +29,10 @@ configure.args      --disable-bluetooth \
 depends_build       port:bison \
                     port:flex
 
+variant remote description {Enable remote packet capture} {
+    configure.args-append   --enable-remote
+}
+
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}
     xinstall -d ${docdir}


### PR DESCRIPTION
#### Description

Variant for building libpcap with remote packet capture (rpcap) support along with rpcapd binary. Building wireshark against this variant enables remote capture support for it.

Not enabled by default.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? (none exist)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
