### PR TITLE
haproxy: fix build on 10.6.x

### DIFF
--- a/net/haproxy/files/patch-older_systems.diff
+++ b/net/haproxy/files/patch-older_systems.diff
@@ -20,3 +20,31 @@
  
  /* Max number of file descriptors we send in one sendmsg(). Linux seems to be
   * able to send 253 fds per sendmsg(), however musl is limited to 252, not sure
+
+# https://trac.macports.org/ticket/66621
+--- include/haproxy/openssl-compat.h.orig	2022-12-19 22:46:54.000000000 +0700
++++ include/haproxy/openssl-compat.h	2023-01-04 20:31:17.000000000 +0700
+@@ -91,6 +91,9 @@
+ #define HAVE_SSL_KEYLOG
+ #endif
+ 
++#if !defined(__cplusplus)
++#define static_assert _Static_assert
++#endif
+ 
+ #if (HA_OPENSSL_VERSION_NUMBER >= 0x3000000fL)
+ #define HAVE_OSSL_PARAM
+
+--- include/import/xxhash.h.orig	2022-12-19 22:46:54.000000000 +0700
++++ include/import/xxhash.h	2023-01-04 21:22:05.000000000 +0700
+@@ -76,6 +76,10 @@
+ XXH32        6.8 GB/s            6.0 GB/s
+ */
+ 
++#if !defined(__cplusplus)
++#define static_assert _Static_assert
++#endif
++
+ #if defined (__cplusplus)
+ extern "C" {
+ #endif


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66621

#### Description

Currently `haproxy` fails on 10.6.8, both Intel and Rosetta (I cannot check native PPC right now), see the ticket.
PR adds the fix to missing symbol, borrowed from: https://github.com/apache/mynewt-core/pull/2417/commits/d5bde910215a57d9d86a0332ecb6e281207427f2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
