### PR TITLE
absent: new port in devel

### DIFF
--- a/devel/absent/Portfile
+++ b/devel/absent/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        rvarago absent 432fb82052dd066cf72b85dd740a83d59579348c
+version             2020.10.28
+revision            0
+categories          devel
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Small C++17 library meant to simplify the composition of nullable types \
+                    in a generic, type-safe and declarative way.
+long_description    {*}${description}
+checksums           rmd160  b0561e2edcdf65d0819b3e24850c6ee7b8541c09 \
+                    sha256  93373d0892ad13bb3f0c6635a468095c3ad7ab5b3fd09de49bd304462d05c59d \
+                    size    13972
+
+patch.pre_args      -p1
+patchfiles          0001-Fix-catch2-includes.patch \
+                    0002-tests-CMakeLists.txt-require-C-17.patch \
+                    0003-Fix-missing-_main-on-macOS.patch
+
+compiler.cxx_standard   2017
+
+configure.args-append \
+                    -DBUILD_TESTS=ON
+
+# While absent is header-only library, building and running tests depend on catch2:
+depends_build-append \
+                    port:catch2
+depends_test-append port:catch2
+
+test.run            yes
+test.cmd            ctest

--- a/devel/absent/files/0001-Fix-catch2-includes.patch
+++ b/devel/absent/files/0001-Fix-catch2-includes.patch
@@ -1,0 +1,190 @@
+From 56e27ea4aa59ce9e3c42932e832ef5ab49ed8ea7 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 4 Jan 2023 22:25:18 +0700
+Subject: [PATCH 1/3] Fix catch2 includes
+
+---
+ tests/and_then_test.cpp         | 2 +-
+ tests/attempt_test.cpp          | 2 +-
+ tests/either/and_then_test.cpp  | 2 +-
+ tests/either/attempt_test.cpp   | 2 +-
+ tests/either/eval_test.cpp      | 2 +-
+ tests/either/for_each_test.cpp  | 2 +-
+ tests/either/transform_test.cpp | 2 +-
+ tests/eval_test.cpp             | 2 +-
+ tests/execution_status_test.cpp | 2 +-
+ tests/for_each_test.cpp         | 2 +-
+ tests/from_variant_test.cpp     | 2 +-
+ tests/main.cpp                  | 2 +-
+ tests/transform_test.cpp        | 2 +-
+ 13 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/tests/and_then_test.cpp b/tests/and_then_test.cpp
+index 9be1d87..8cc0a3f 100644
+--- a/tests/and_then_test.cpp
++++ b/tests/and_then_test.cpp
+@@ -3,7 +3,7 @@
+ #include <optional>
+ #include <string>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent;
+ 
+diff --git a/tests/attempt_test.cpp b/tests/attempt_test.cpp
+index 9f5803c..946bb5a 100644
+--- a/tests/attempt_test.cpp
++++ b/tests/attempt_test.cpp
+@@ -3,7 +3,7 @@
+ #include <optional>
+ #include <stdexcept>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent;
+ 
+diff --git a/tests/either/and_then_test.cpp b/tests/either/and_then_test.cpp
+index 4f8ca9f..0110030 100644
+--- a/tests/either/and_then_test.cpp
++++ b/tests/either/and_then_test.cpp
+@@ -2,7 +2,7 @@
+ 
+ #include <string>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent::adapters::either;
+ using rvarago::absent::adapters::types::either;
+diff --git a/tests/either/attempt_test.cpp b/tests/either/attempt_test.cpp
+index d7050a2..9e2f0ed 100644
+--- a/tests/either/attempt_test.cpp
++++ b/tests/either/attempt_test.cpp
+@@ -2,7 +2,7 @@
+ 
+ #include <stdexcept>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent::adapters::either;
+ using rvarago::absent::adapters::types::either;
+diff --git a/tests/either/eval_test.cpp b/tests/either/eval_test.cpp
+index 16b933e..2eac882 100644
+--- a/tests/either/eval_test.cpp
++++ b/tests/either/eval_test.cpp
+@@ -2,7 +2,7 @@
+ 
+ #include <optional>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent::adapters::either;
+ using rvarago::absent::adapters::types::either;
+diff --git a/tests/either/for_each_test.cpp b/tests/either/for_each_test.cpp
+index d792b67..7ec8be1 100644
+--- a/tests/either/for_each_test.cpp
++++ b/tests/either/for_each_test.cpp
+@@ -2,7 +2,7 @@
+ 
+ #include <optional>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent::adapters::either;
+ using rvarago::absent::adapters::types::either;
+diff --git a/tests/either/transform_test.cpp b/tests/either/transform_test.cpp
+index f6fd8d2..c14325f 100644
+--- a/tests/either/transform_test.cpp
++++ b/tests/either/transform_test.cpp
+@@ -3,7 +3,7 @@
+ #include <string>
+ #include <utility>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent::adapters::either;
+ using rvarago::absent::adapters::types::either;
+diff --git a/tests/eval_test.cpp b/tests/eval_test.cpp
+index 420d84c..fcf95eb 100644
+--- a/tests/eval_test.cpp
++++ b/tests/eval_test.cpp
+@@ -2,7 +2,7 @@
+ 
+ #include <optional>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent;
+ 
+diff --git a/tests/execution_status_test.cpp b/tests/execution_status_test.cpp
+index 87ca610..8a47014 100644
+--- a/tests/execution_status_test.cpp
++++ b/tests/execution_status_test.cpp
+@@ -3,7 +3,7 @@
+ 
+ #include <string>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent;
+ 
+diff --git a/tests/for_each_test.cpp b/tests/for_each_test.cpp
+index 560cd0e..ed6c70d 100644
+--- a/tests/for_each_test.cpp
++++ b/tests/for_each_test.cpp
+@@ -2,7 +2,7 @@
+ 
+ #include <optional>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent;
+ 
+diff --git a/tests/from_variant_test.cpp b/tests/from_variant_test.cpp
+index 47725ea..2460383 100644
+--- a/tests/from_variant_test.cpp
++++ b/tests/from_variant_test.cpp
+@@ -2,7 +2,7 @@
+ 
+ #include <string>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent;
+ 
+diff --git a/tests/main.cpp b/tests/main.cpp
+index 2380d6b..cbcca02 100644
+--- a/tests/main.cpp
++++ b/tests/main.cpp
+@@ -1,2 +1,2 @@
+ #define CATCH_CONFIG_MAIN
+-#include <catch2/catch.hpp>
+\ No newline at end of file
++#include <catch2/catch_all.hpp>
+\ No newline at end of file
+diff --git a/tests/transform_test.cpp b/tests/transform_test.cpp
+index 08abd3b..4e2a39d 100644
+--- a/tests/transform_test.cpp
++++ b/tests/transform_test.cpp
+@@ -3,7 +3,7 @@
+ #include <optional>
+ #include <string>
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ using namespace rvarago::absent;
+ 
+-- 
+2.39.0
+

--- a/devel/absent/files/0002-tests-CMakeLists.txt-require-C-17.patch
+++ b/devel/absent/files/0002-tests-CMakeLists.txt-require-C-17.patch
@@ -1,0 +1,46 @@
+From 9f4e2cce920e915ea3d80da243ad6db26028b5d7 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 4 Jan 2023 22:40:59 +0700
+Subject: [PATCH 2/3] tests/CMakeLists.txt: require C++17
+
+---
+ tests/CMakeLists.txt | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index baf1200..007d586 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -21,13 +21,28 @@ add_executable(${PROJECT_NAME}
+         main.cpp
+ )
+ 
++set(CMAKE_CXX_STANDARD 17)
++set(CMAKE_CXX_STANDARD_REQUIRED ON)
++
+ target_compile_features(${PROJECT_NAME}
+         PRIVATE
+             cxx_std_17
+ )
+ 
+-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
++if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
++    target_compile_options(${PROJECT_NAME}
++            PRIVATE
++                -std=gnu++17
++    )
++else()
+     target_compile_options(${PROJECT_NAME}
++            PRIVATE
++                -std=c++17
++    )
++endif()
++
++if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
++    add_compile_options(${PROJECT_NAME}
+             PRIVATE
+                 -Wall -Wextra -Werror -ansi -pedantic
+     )
+-- 
+2.39.0
+

--- a/devel/absent/files/0003-Fix-missing-_main-on-macOS.patch
+++ b/devel/absent/files/0003-Fix-missing-_main-on-macOS.patch
@@ -1,0 +1,23 @@
+From c93f033d38e59473edd17fc9c4b7e1894fbdc453 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 4 Jan 2023 23:15:47 +0700
+Subject: [PATCH 3/3] Fix missing _main on macOS
+
+---
+ tests/main.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tests/main.cpp b/tests/main.cpp
+index cbcca02..b8686e2 100644
+--- a/tests/main.cpp
++++ b/tests/main.cpp
+@@ -1,2 +1,4 @@
+ #define CATCH_CONFIG_MAIN
+-#include <catch2/catch_all.hpp>
+\ No newline at end of file
++#include <catch2/catch_all.hpp>
++
++int main() { return 0; }
+-- 
+2.39.0
+


### PR DESCRIPTION
#### Description

New port: https://github.com/rvarago/absent

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Test passes on Rosetta:
```
--->  Testing absent
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_absent/absent/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_absent/absent/work/build
    Start 1: absent_tests
1/1 Test #1: absent_tests .....................   Passed    0.03 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.05 sec
```