### PR TITLE
kitten: new port in devel

### DIFF
--- a/devel/kitten/Portfile
+++ b/devel/kitten/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        rvarago kitten f45705bc3026551c702b05281cee940b51511dc1
+version             2020.04.05
+revision            0
+categories          devel
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         A small C++17 library inspired by Category Theory.
+long_description    This is a small header-only library with some machinery \
+                    meant to extend the already great STL with some concepts \
+                    obtained from Category Theory, such as functors and monads, \
+                    in order to make the composition of some C++ type constructors \
+                    even simpler.
+checksums           rmd160  b20d043f1ef2200ba31b8d24c4419b09e4e29136 \
+                    sha256  bb0c6a3d6fb45c6c8260a2f2ce90beae0749c9cdd428cc6f48fe9e4cfb8e0f4a \
+                    size    14289
+
+patch.pre_args      -p1
+patchfiles          0001-Fix-catch2-includes.patch \
+                    0002-Fix-for-missing-_main-on-macOS.patch \
+                    0003-tests-CMakeLists.txt-use-C-17.patch
+
+compiler.cxx_standard   2017
+
+configure.args-append \
+                    -DBUILD_TESTS=OFF
+
+variant test description "Build tests" {
+    depends_build-append \
+                    port:catch2
+    depends_test-append \
+                    port:catch2
+
+    configure.args-replace \
+                    -DBUILD_TESTS=OFF -DBUILD_TESTS=ON
+
+    test.run        yes
+    test.cmd        ctest
+}
+
+if {![string match *clang* ${configure.compiler}]} {
+    # Tests do not build with Clang at the moment.
+    # https://github.com/rvarago/kitten/issues/34
+    default variants +test
+} else {
+    supported_archs noarch
+}

--- a/devel/kitten/files/0001-Fix-catch2-includes.patch
+++ b/devel/kitten/files/0001-Fix-catch2-includes.patch
@@ -1,0 +1,65 @@
+From 27161be68648f9056342c4c34aaa75dc8100ab5d Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 5 Jan 2023 00:09:15 +0700
+Subject: [PATCH 1/3] Fix catch2 includes
+
+---
+ tests/function_test.cpp           | 2 +-
+ tests/main.cpp                    | 2 +-
+ tests/optional_test.cpp           | 2 +-
+ tests/sequence_container_test.cpp | 2 +-
+ tests/variant_test.cpp            | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/tests/function_test.cpp b/tests/function_test.cpp
+index 4078766..9d46f2d 100644
+--- a/tests/function_test.cpp
++++ b/tests/function_test.cpp
+@@ -1,4 +1,4 @@
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ #include <kitten/instances/function.h>
+ #include <string>
+diff --git a/tests/main.cpp b/tests/main.cpp
+index f481b16..13928b9 100644
+--- a/tests/main.cpp
++++ b/tests/main.cpp
+@@ -1,3 +1,3 @@
+ #define CATCH_CONFIG_MAIN
+ 
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+diff --git a/tests/optional_test.cpp b/tests/optional_test.cpp
+index 54dff11..5ccd5dd 100644
+--- a/tests/optional_test.cpp
++++ b/tests/optional_test.cpp
+@@ -1,4 +1,4 @@
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ #include <kitten/instances/optional.h>
+ #include <string>
+diff --git a/tests/sequence_container_test.cpp b/tests/sequence_container_test.cpp
+index 3c173f3..c0ac823 100644
+--- a/tests/sequence_container_test.cpp
++++ b/tests/sequence_container_test.cpp
+@@ -1,4 +1,4 @@
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ #include "utils.h"
+ #include <functional>
+diff --git a/tests/variant_test.cpp b/tests/variant_test.cpp
+index 9c9ee18..4e7e626 100644
+--- a/tests/variant_test.cpp
++++ b/tests/variant_test.cpp
+@@ -1,4 +1,4 @@
+-#include <catch2/catch.hpp>
++#include <catch2/catch_all.hpp>
+ 
+ #include <optional>
+ #include <string>
+-- 
+2.39.0
+

--- a/devel/kitten/files/0002-Fix-for-missing-_main-on-macOS.patch
+++ b/devel/kitten/files/0002-Fix-for-missing-_main-on-macOS.patch
@@ -1,0 +1,22 @@
+From e70e8a62b28e2c79cc7229f4b3daa464c61b5814 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 5 Jan 2023 00:12:48 +0700
+Subject: [PATCH 2/3] Fix for missing _main on macOS
+
+---
+ tests/main.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tests/main.cpp b/tests/main.cpp
+index 13928b9..2bd3007 100644
+--- a/tests/main.cpp
++++ b/tests/main.cpp
+@@ -1,3 +1,5 @@
+ #define CATCH_CONFIG_MAIN
+ 
+ #include <catch2/catch_all.hpp>
++
++int main() { return 0; }
+-- 
+2.39.0
+

--- a/devel/kitten/files/0003-tests-CMakeLists.txt-use-C-17.patch
+++ b/devel/kitten/files/0003-tests-CMakeLists.txt-use-C-17.patch
@@ -1,0 +1,41 @@
+From 11d0a509f4f16fa4b5a99dc988a37ba60de43e57 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 5 Jan 2023 00:16:26 +0700
+Subject: [PATCH 3/3] tests/CMakeLists.txt: use C++17
+
+---
+ tests/CMakeLists.txt | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index b788444..45ba1ba 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -10,8 +10,23 @@ add_executable(${PROJECT_NAME}
+         variant_test.cpp
+ )
+ 
+-if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
++set(CMAKE_CXX_STANDARD 17)
++set(CMAKE_CXX_STANDARD_REQUIRED ON)
++
++if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
++    target_compile_options(${PROJECT_NAME}
++            PRIVATE
++                -std=gnu++17
++    )
++else()
+     target_compile_options(${PROJECT_NAME}
++            PRIVATE
++                -std=c++17
++    )
++endif()
++
++if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
++    add_compile_options(${PROJECT_NAME}
+             PRIVATE
+                 -Wall -Wextra -Werror -ansi -pedantic
+     )
+-- 
+2.39.0
+


### PR DESCRIPTION
#### Description

New port: https://github.com/rvarago/kitten

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Test passes on Rosetta:
```
--->  Testing kitten
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_kitten/kitten/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_kitten/kitten/work/build
    Start 1: kitten_tests
1/1 Test #1: kitten_tests .....................   Passed    0.03 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.05 sec
```