### PR TITLE
lapack: update to 3.11.0

### DIFF
--- a/math/lapack/Portfile
+++ b/math/lapack/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Reference-LAPACK lapack 3.10.1 v
+github.setup        Reference-LAPACK lapack 3.11.0 v
 if {${subport} eq ${name}} {
     PortGroup           compilers 1.0
     compilers.choose    cc fc f77 f90
@@ -24,9 +24,9 @@ long_description \
     eigenvalue problems, and singular value problems.
 homepage            http://www.netlib.org/${name}/
 
-checksums           rmd160  bfae414d56c156ef9399dce073fd14e1c674e9af \
-                    sha256  62ca09e81aefc1cae06861773aca26e143cb5226aefc4d2470c6c42b3598981e \
-                    size    7633700
+checksums           rmd160  1ee85d3ea0a902e6f05dacfdebaddb157ab8e86e \
+                    sha256  10315e94d6428ecf77b5a741b5065ca8643aaf9687c9a734c0e1bb7f0d4b6090 \
+                    size    7724854
 
 configure.cppflags-append \
                     -DADD_


### PR DESCRIPTION
#### Description

update lapack to 3.11.0 ; just the basics!

cmake files are now installed into `$prefix/share/cmake`, which is where most other cmake-based ports install their cmake scripts.

Closes: https://trac.macports.org/ticket/64379

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.3 20G1102 x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
