### PR TITLE
lzma: use CXXFLAGS during link

### DIFF
--- a/archivers/lzma/Portfile
+++ b/archivers/lzma/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 name            lzma
 version         22.01
-revision        1
+revision        2
 categories      archivers
 license         public-domain
 platforms       darwin
@@ -59,9 +59,9 @@ post-patch {
     ${worksrcpath}/C/7zip_gcc_c.mak \
     ${worksrcpath}/CPP/7zip/7zip_gcc.mak
 
-    reinplace "s|@CCFLAGS@|${configure.cflags} [get_canonical_archflags cc]|" \
+    reinplace "s|@CFLAGS@|${configure.cflags} [get_canonical_archflags cc]|g" \
         ${worksrcpath}/CPP/7zip/7zip_gcc.mak
-    reinplace "s|@CXXFLAGS@|${configure.cxxflags} [get_canonical_archflags cxx]|" \
+    reinplace "s|@CXXFLAGS@|${configure.cxxflags} [get_canonical_archflags cxx]|g" \
         ${worksrcpath}/CPP/7zip/7zip_gcc.mak
 
 }

--- a/archivers/lzma/files/patch-7zip_gcc_mak.diff
+++ b/archivers/lzma/files/patch-7zip_gcc_mak.diff
@@ -1,6 +1,8 @@
---- CPP/7zip/7zip_gcc.mak.orig	2022-04-02 21:21:09.000000000 -0700
-+++ CPP/7zip/7zip_gcc.mak	2022-04-02 21:21:39.000000000 -0700
-@@ -18,7 +18,7 @@
+diff --git CPP/7zip/7zip_gcc.mak.orig CPP/7zip/7zip_gcc.mak
+index 2a24e06..098bb95 100644
+--- CPP/7zip/7zip_gcc.mak.orig
++++ CPP/7zip/7zip_gcc.mak
+@@ -18,7 +18,7 @@ PROGPATH_STATIC = $(O)/$(PROG)s
  
  
  ifneq ($(CC), xlc)
@@ -9,16 +11,16 @@
  endif
  
  # for object file
-@@ -138,7 +138,7 @@
+@@ -138,7 +138,7 @@ endif
  
  
  
 -CFLAGS = $(MY_ARCH_2) $(LOCAL_FLAGS) $(CFLAGS_BASE2) $(CFLAGS_BASE) $(CC_SHARED) -o $@
-+CFLAGS = @CCFLAGS@ $(MY_ARCH_2) $(LOCAL_FLAGS) $(CFLAGS_BASE2) $(CFLAGS_BASE) $(CC_SHARED) -o $@
++CFLAGS = @CFLAGS@ $(MY_ARCH_2) $(LOCAL_FLAGS) $(CFLAGS_BASE2) $(CFLAGS_BASE) $(CC_SHARED) -o $@
  
  
  ifdef IS_MINGW
-@@ -179,7 +179,7 @@
+@@ -179,7 +179,7 @@ CXX_WARN_FLAGS =
  #-Wno-invalid-offsetof
  #-Wno-reorder
  
@@ -27,3 +29,12 @@
  
  STATIC_TARGET=
  ifdef COMPL_STATIC
+@@ -192,7 +192,7 @@ all: $(O) $(PROGPATH) $(STATIC_TARGET)
+ $(O):
+ 	$(MY_MKDIR) $(O)
+ 
+-LFLAGS_ALL = -s $(MY_ARCH_2) $(LDFLAGS) $(LD_arch) $(OBJS) $(MY_LIBS) $(LIB2)
++LFLAGS_ALL = -s @CXXFLAGS@ $(MY_ARCH_2) $(LDFLAGS) $(LD_arch) $(OBJS) $(MY_LIBS) $(LIB2)
+ $(PROGPATH): $(OBJS)
+ 	$(CXX) -o $(PROGPATH) $(LFLAGS_ALL)
+ 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/66612

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5, 13.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
