### PR TITLE
sqlite3: add patch to disable atomics on clang 4 or earlier

### DIFF
--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -44,6 +44,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"}
 
 if {${subport} ne "${name}-tools"} {
     configure.checks.implicit_function_declaration.whitelist-append strchr
+
+    patchfiles      patch-sqlite3_fix-atomic-clang-4.diff
+} else {
+    patchfiles      patch-sqlite3-tools_fix-atomic-clang-4.diff
 }
 
 configure.args      --enable-threadsafe \

--- a/databases/sqlite3/files/patch-sqlite3-tools_fix-atomic-clang-4.diff
+++ b/databases/sqlite3/files/patch-sqlite3-tools_fix-atomic-clang-4.diff
@@ -1,0 +1,12 @@
+--- src/sqliteInt.h.orig
++++ src/sqliteInt.h
+@@ -230,7 +230,8 @@
+ #ifndef __has_extension
+ # define __has_extension(x) 0     /* compatibility with non-clang compilers */
+ #endif
+-#if GCC_VERSION>=4007000 || __has_extension(c_atomic) 
++/* for Xcode 4 (clang < 3.3) the existence of 'atomic' is detected by configure, but it is not fully functional, so key on clang_major > 4 */
++#if ((GCC_VERSION >= 4007000) || __has_extension(c_atomic)) && (defined(__clang_major__) && (__clang_major__ > 4))
+ # define SQLITE_ATOMIC_INTRINSICS 1
+ # define AtomicLoad(PTR)       __atomic_load_n((PTR),__ATOMIC_RELAXED)
+ # define AtomicStore(PTR,VAL)  __atomic_store_n((PTR),(VAL),__ATOMIC_RELAXED)

--- a/databases/sqlite3/files/patch-sqlite3_fix-atomic-clang-4.diff
+++ b/databases/sqlite3/files/patch-sqlite3_fix-atomic-clang-4.diff
@@ -1,0 +1,12 @@
+--- sqlite3.c.orig
++++ sqlite3.c
+@@ -13448,7 +13448,8 @@
+ #ifndef __has_extension
+ # define __has_extension(x) 0     /* compatibility with non-clang compilers */
+ #endif
+-#if GCC_VERSION>=4007000 || __has_extension(c_atomic)
++/* for Xcode 4 (clang < 3.3) the existence of 'atomic' is detected by configure, but it is not fully functional, so key on clang_major > 4 */
++#if ((GCC_VERSION >= 4007000) || __has_extension(c_atomic)) && (defined(__clang_major__) && (__clang_major__ > 4))
+ # define SQLITE_ATOMIC_INTRINSICS 1
+ # define AtomicLoad(PTR)       __atomic_load_n((PTR),__ATOMIC_RELAXED)
+ # define AtomicStore(PTR,VAL)  __atomic_store_n((PTR),(VAL),__ATOMIC_RELAXED)


### PR DESCRIPTION
#### Description

add patch to sqlite3 to disable atomics on clang 4 or earlier

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503
% clang -v
Apple clang version 4.1 (tags/Apple/clang-421.11.66) (based on LLVM 3.1svn)
Target: x86_64-apple-darwin11.4.2
Thread model: posix

also builds cleanly on:

macOS 11.7.3 20G1102 x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
