### PR TITLE
antic: new port in math

### DIFF
--- a/math/antic/Portfile
+++ b/math/antic/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        flintlib antic ba3b457281f492c7f9680247fb2c98208ecfa69c
+version             2022.11.30
+revision            0
+categories          math
+license             LGPL-2.1
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Algebraic Number Theory In C
+long_description    {*}${description}
+checksums           rmd160  2c2b8923b9a9826ba4864f09837a3696cf1cdcdc \
+                    sha256  e1b91e97823cca4fdb1a8932614a2a1f60780a562370d1c06710666e56de0aae \
+                    size    80398
+
+depends_lib-append  port:flint \
+                    port:gmp \
+                    port:mpfr
+
+post-patch {
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/configure
+}
+
+compiler.thread_local_storage yes
+
+platform darwin 10 powerpc {
+    configure.args-append \
+                    --build=ppc-Darwin
+}
+
+test.run            yes
+test.target         check


### PR DESCRIPTION
#### Description

New port in math: https://github.com/flintlib/antic

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass on Rosetta:
```
--->  Testing antic
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_antic/antic/work/antic-ba3b457281f492c7f9680247fb2c98208ecfa69c" && /usr/bin/make check 
make[1]: Nothing to be done for `shared'.
make[1]: Nothing to be done for `static'.
make[2]: Nothing to be done for `shared'.
make[2]: Nothing to be done for `static'.
    CC   ../build/nf/test/t-init_clear
init/clear....PASS
    CC   ../build/nf_elem/test/t-add_sub
    CC   ../build/nf_elem/test/t-div
    CC   ../build/nf_elem/test/t-equal_fmpz_fmpq
    CC   ../build/nf_elem/test/t-get_fmpz_mod_poly
    CC   ../build/nf_elem/test/t-get_nmod_poly
    CC   ../build/nf_elem/test/t-get_set_den
    CC   ../build/nf_elem/test/t-get_set_fmpq_poly
    CC   ../build/nf_elem/test/t-get_set_fmpz_mat_row
    CC   ../build/nf_elem/test/t-init_clear
    CC   ../build/nf_elem/test/t-inv
    CC   ../build/nf_elem/test/t-is_rational_integer
    CC   ../build/nf_elem/test/t-mod_fmpz
    CC   ../build/nf_elem/test/t-mul
    CC   ../build/nf_elem/test/t-mul_div_fmpq
    CC   ../build/nf_elem/test/t-mul_gen
    CC   ../build/nf_elem/test/t-norm
    CC   ../build/nf_elem/test/t-norm_div
    CC   ../build/nf_elem/test/t-pow
    CC   ../build/nf_elem/test/t-rep_mat
    CC   ../build/nf_elem/test/t-rep_mat_fmpz_mat_den
    CC   ../build/nf_elem/test/t-set_coeff_num_fmpz
    CC   ../build/nf_elem/test/t-set_equal
    CC   ../build/nf_elem/test/t-set_equal_si_ui
    CC   ../build/nf_elem/test/t-trace
add/sub....PASS
div....PASS
set_si_ui...PASS
get_fmpz_mod_poly....PASS
get_nmod_poly....PASS
get/set den....PASS
get/set fmpq_poly....PASS
init/clear....PASS
init/clear....PASS
inv....PASS
set_si_ui...PASS
mod_fmpz....PASS
mul....PASS
mul_gen....PASS
norm....PASS
norm_div....PASS
pow....PASS
rep_mat....PASS
rep_mat_fmpz_mat_den....PASS
set_coeff_num_fmpz....PASS
set/equal....PASS
set_si_ui...PASS
trace....PASS
    CC   ../build/qfb/test/t-exponent
    CC   ../build/qfb/test/t-exponent_element
    CC   ../build/qfb/test/t-exponent_grh
    CC   ../build/qfb/test/t-inverse
    CC   ../build/qfb/test/t-nucomp
    CC   ../build/qfb/test/t-nudupl
    CC   ../build/qfb/test/t-pow
    CC   ../build/qfb/test/t-pow_ui
    CC   ../build/qfb/test/t-prime_form
    CC   ../build/qfb/test/t-reduce
    CC   ../build/qfb/test/t-reduced_forms
exponent....PASS
exponent_element....PASS
exponent_grh....PASS
inverse....PASS
nucomp....PASS
nudupl....PASS
pow....PASS
pow_ui....PASS
prime_form....PASS
reduce....PASS
reduced_forms....PASS
```