### PR TITLE
py-gmpy2: update to 2.1.5

### DIFF
--- a/python/py-gmpy2/Portfile
+++ b/python/py-gmpy2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-gmpy2
 epoch               1
-version             2.1.2
+version             2.1.5
 maintainers         {@mndavidoff alluvialsw.com:md14-macports} openmaintainer
 license             LGPL-2.1+
 description         General multiple precision arithmetic module for Python
@@ -16,9 +16,9 @@ long_description \
     and complex arithmetic as provided by the MPFR and MPC libraries.
 
 homepage            https://github.com/aleaxit/gmpy
-checksums           rmd160  bd757e8ebea4c163c5e7e9ec6d5bfa206465dba7 \
-                    sha256  da75140bca128ece795895477e53b43773e3748aa90ba6170eae7ca2c74b82d1 \
-                    size    258445
+checksums           rmd160  7ad0106dae052c4d9b3f332ef3d070dec29d3883 \
+                    sha256  bc297f1fd8c377ae67a4f493fc0f926e5d1b157e5c342e30a4d84dc7b9f95d96 \
+                    size    261709
 
 python.versions     37 38 39 310 311
 


### PR DESCRIPTION
#### Description

py-gmpy2: update to 2.1.5

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.6.2 21G320 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?