### PR TITLE
fsdb: update to 3.1

### DIFF
--- a/perl/fsdb/Portfile
+++ b/perl/fsdb/Portfile
@@ -11,12 +11,12 @@ perl5.default_branch    5.34
 perl5.create_variants   ${perl5.branches}
 
 name                fsdb
-perl5.setup         Fsdb 3.0 ../../authors/id/J/JO/JOHNH
+perl5.setup         Fsdb 3.1 ../../authors/id/J/JO/JOHNH
 revision            0
 epoch               1
-checksums           rmd160  946592b64a7f58a871319dc5a92a4d8f6661a3de \
-                    sha256  347eb0cb06088e88c267a042c48fa88ae936acdf6fa2dddc5985a7f15f91d0b3 \
-                    size    512975
+checksums           rmd160  12fd7e7df33a95d11274bcb780db027f36cfa8c1 \
+                    sha256  0e38e2a7534d52a2e93aa835e05ccb27711c0ab2966083c71e3df6e0019af0f1 \
+                    size    514313
 
 categories-append   textproc
 


### PR DESCRIPTION
#### Description
fsdb: update to 3.1

###### Tested on
macOS 12.6.1 21G217 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
