### PR TITLE
josm: update to 18622

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18621
+version             18622
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  8d99653904c265790d994bde7dc64de41408e39f \
-                    sha256  49fe668315a3ab6e34535b54072052e8515bd13a63fd03fbc8797ec2f4c87e78 \
-                    size    78113616
+checksums           rmd160  bcb007cc3245ce8b4c2d57ed2244b11737edc4ac \
+                    sha256  ab72abd1859ee899bac0eea1edf30034a2c258a7d4d330e90598d11faeb67928 \
+                    size    78118410
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
Hotfix release: [2023-01-04: Stable release 18622](https://josm.openstreetmap.de/wiki/Changelog#a2023-01-04:Stablerelease1862222.12)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
