### PR TITLE
tk: add patch to allow building on OSX 10.6

### DIFF
--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -38,6 +38,12 @@ patch.dir           ${workpath}/${name}${version}
 # see https://trac.macports.org/ticket/57594
 patchfiles-append   patch-dyld_fallback_library_path.diff
 
+# https://github.com/tcltk/tk/commit/b0cb1a48cb0c4a0118d45e8804476a6b4ab502c8
+# this is the only code that fails on OSX 10.6, so enable it for 10.7 or newer only; see also
+# https://developer.apple.com/documentation/quartzcore/calayer/1410746-contentsscale
+# retina displays were introduced in 2012 with OSX 10.8, so this removal should be safe for 10.6
+patchfiles-append   patch-enable-viewDidChangeBackingProperties-on-10.7-or-newer.diff
+
 configure.checks.implicit_function_declaration.whitelist-append \
                     closedir64 \
                     readdir64 \

--- a/x11/tk/files/patch-enable-viewDidChangeBackingProperties-on-10.7-or-newer.diff
+++ b/x11/tk/files/patch-enable-viewDidChangeBackingProperties-on-10.7-or-newer.diff
@@ -1,0 +1,18 @@
+--- macosx/tkMacOSXWindowEvent.c.orig
++++ macosx/tkMacOSXWindowEvent.c
+@@ -1009,6 +1009,7 @@
+     return NO;
+ }
+ 
++#if !(MAC_OS_X_VERSION_MAX_ALLOWED < 1070)
+ - (void) viewDidChangeBackingProperties
+ {
+ 
+@@ -1021,6 +1022,7 @@
+ 
+     self.layer.contentsScale = self.window.screen.backingScaleFactor;
+ }
++#endif
+ 
+ - (void) addTkDirtyRect: (NSRect) rect
+ {


### PR DESCRIPTION
#### Description

add patch to tk to allow building on OSX 10.6, by removing 10.7+ API call

I think this is relevant to just `+quartz`, but it doesn't hurt to apply it regardless

NOTE: the functionality is relevant for retina displays only, which were introduced in 2012 & 10.8 -- maybe late 10.7 ; retina was not part of 10.6 hardware from what I can determine, so this change should be safe

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.3 20G1102 x86_64
Xcode 12.3 12C33

macOS 10.6.8 10K549 i386
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
