### PR TITLE
capstone: fix build on <10.7

### DIFF
--- a/devel/capstone/Portfile
+++ b/devel/capstone/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 github.setup        aquynh capstone 4.0.2
 revision            0
 categories          devel
-platforms           darwin
 maintainers         {gmail.com:aquynh @aquynh}
 license             BSD
 
@@ -19,6 +19,9 @@ homepage            http://www.capstone-engine.org/
 checksums           rmd160  84ace6e5d18614b0ade45b85b1c787c7cb300101 \
                     sha256  de132746050ee08ad7afe3c22548865ad7754cad68cf1a87e313281d18b73ac5 \
                     size    3439580
+
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2 {clang < 400}
 
 patch.pre_args      -p1
 patchfiles          patch-Makefile.diff

--- a/devel/capstone/files/patch-Makefile.diff
+++ b/devel/capstone/files/patch-Makefile.diff
@@ -1,6 +1,16 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -278,16 +278,8 @@
+@@ -285,8 +285,7 @@ endif
+ API_MAJOR=$(shell echo `grep -e CS_API_MAJOR include/capstone/capstone.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
+ VERSION_EXT =
+ 
+-IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __apple_build_version__ | wc -l | tr -d " ")
+-ifeq ($(IS_APPLE),1)
++ifeq ($(OS),Darwin)
+ # on MacOS, do not build in Universal format by default
+ MACOS_UNIVERSAL ?= no
+ ifeq ($(MACOS_UNIVERSAL),yes)
+@@ -295,16 +294,8 @@ LDFLAGS += $(foreach arch,$(LIBARCHS),-arch $(arch))
  endif
  EXT = dylib
  VERSION_EXT = $(API_MAJOR).$(EXT)


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/58624

#### Description

This should fix the build on <10.7. Confirmed on 10.6.8.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
