### PR TITLE
various: set new extract.rename to yes if it exists

### DIFF
--- a/databases/lmdb/Portfile
+++ b/databases/lmdb/Portfile
@@ -42,6 +42,15 @@ makefile.override-append \
                     CFLAGS \
                     PREFIX
 
+# have to do the extract rename for this port to work
+# this will not do anything in the current release 3.8.0 or prior
+# it will be part of the next release: 3.8.1 or 3.9.0
+# https://trac.macports.org/ticket/66415
+# remove the 'if' clause with the next 'port' release, leaving just the middle line
+if {[exists extract.rename]} {
+    extract.rename  yes
+}
+
 post-destroot {
     # Install pkg-config .pc file because Linux distributions have done
     # so and other software now depends on this but the developer of

--- a/devel/xxhash/Portfile
+++ b/devel/xxhash/Portfile
@@ -25,6 +25,15 @@ if {[string match "*gcc-4.*" ${configure.compiler}]} {
                     patch-Makefile-gcc.diff
 }
 
+# have to do the extract rename for this port to work
+# this will not do anything in the current release 3.8.0 or prior
+# it will be part of the next release: 3.8.1 or 3.9.0
+# https://trac.macports.org/ticket/66415
+# remove the 'if' clause with the next 'port' release, leaving just the middle line
+if {[exists extract.rename]} {
+    extract.rename  yes
+}
+
 subport ${name} {
     revision        2
 

--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -33,6 +33,15 @@ checksums           rmd160  7a4a3f9ffc2c1d40b8da7077648b8e6c0fd41f99 \
 
 use_bzip2           yes
 
+# have to do the extract rename for this port to work
+# this will not do anything in the current release 3.8.0 or prior
+# it will be part of the next release: 3.8.1 or 3.9.0
+# https://trac.macports.org/ticket/66415
+# remove the 'if' clause with the next 'port' release, leaving just the middle line
+if {[exists extract.rename]} {
+    extract.rename  yes
+}
+
 # see https://trac.macports.org/ticket/62618
 # patch can be applied always, but limit to < darwin 10 so no chance of troubles
 if {${os.platform} eq "darwin" && ${os.major} < 10} {

--- a/textproc/asciidoc/Portfile
+++ b/textproc/asciidoc/Portfile
@@ -31,6 +31,15 @@ installs_libs       no
 
 homepage            https://asciidoc-py.github.io/
 
+# have to do the extract rename for this port to work
+# this will not do anything in the current release 3.8.0 or prior
+# it will be part of the next release: 3.8.1 or 3.9.0
+# https://trac.macports.org/ticket/66415
+# remove the 'if' clause with the next 'port' release, leaving just the middle line
+if {[exists extract.rename]} {
+    extract.rename  yes
+}
+
 # Need autoconf to generate and install docs; python 1.0 PG disables configure, we can just re-enable it
 use_autoreconf      yes
 use_configure       yes


### PR DESCRIPTION
#### Description

set new extract.rename to yes if it exists, in various ports

This feature is in current master and will be part of the next MacPorts release. When set to yes, it tries to rename the extracted tarball top-level directory to what the Portfile specifies, if different. Some ports require this while others do not. Here are 4 that I've come across in my recent work; I'm sure there are more.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.3 20G1102 x86_64
Xcode 12.3 12C33

as well as 10.5, 10.6, 10.7, and 10.11 ... same need in each of these with the current MacPorts base master HEAD

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
