### PR TITLE
miniflux: update to 2.0.41

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.40
+go.setup            github.com/miniflux/v2 2.0.41
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  7bd074b4c6518a9d5234c9efddea1ac83e1ab581 \
-                        sha256  a9db26c6454dd9c1bca62b54ecaacf09be19c66c6fbd2ac6104085fe8aefdb52 \
-                        size    575536
+                        rmd160  96be8023542f903303c06fabfa920943cc41f546 \
+                        sha256  d0cb753298580c2736001d7a458142b1b50403549f87c07c42d6d3f4c158835d \
+                        size    576000
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -49,35 +49,35 @@ go.vendors          mvdan.cc/xurls \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/text \
-                        lock    v0.4.0 \
-                        rmd160  a3215f5c266b2d6cc0ae945858b543031fcb5a54 \
-                        sha256  c4e794a9e732f422df4e005f87ddba1e640b5bb7d6ce10ad56e40fa8c7d56ee2 \
-                        size    8359157 \
+                        lock    v0.5.0 \
+                        rmd160  22d952d3a5226707a3ab3575c75ad6269ab28851 \
+                        sha256  ae1308be329a9c8a939243c5f44410d5155594d3d31c274bd6daa2399784ce33 \
+                        size    8354318 \
                     golang.org/x/term \
-                        lock    v0.2.0 \
-                        rmd160  894d17de2efa3045dc1077de72531dfa05cded6b \
-                        sha256  1675ff5e6b8f7240131e8a339147410faa635c5b190bfd9fcf22ce7293f87eeb \
-                        size    14797 \
+                        lock    v0.3.0 \
+                        rmd160  14a60f913597d05ed7df0b6d6fbca50ca672b594 \
+                        sha256  c5e084b265e4c0dfb37ef0a0e7aa5b5ff4f9afe55c71452d13789a85abcd46c9 \
+                        size    14800 \
                     golang.org/x/sys \
-                        lock    v0.2.0 \
-                        rmd160  53bf24ad63b9d629d4fdc4cab68d58ae36200691 \
-                        sha256  debd08cbdc76c5b059f7bb051dc06007a429e63a652fea2d5bb208318dd3987b \
-                        size    1411246 \
+                        lock    v0.3.0 \
+                        rmd160  17c78e6210a6f938db21fa772584ab8c7d4e06c1 \
+                        sha256  b04ddf676ead57e0d3e367e9aa17db1b11fc20af719e479d1ca56873a2bdf06b \
+                        size    1411264 \
                     golang.org/x/oauth2 \
-                        lock    v0.2.0 \
-                        rmd160  48360c3782cbcbf4bee62b295f25e78dd1a2b232 \
-                        sha256  f9d6706b090000deeaff12aec7bba2bfff89968f0740650297677de1f30467f4 \
-                        size    85700 \
+                        lock    v0.3.0 \
+                        rmd160  9feed440ae9739cf5f54b84c5a2d5d68ebe3ed92 \
+                        sha256  60061bd7d2c4b0e7744e581eea0974ae5172c506c8b087301f63a4e4c21cca36 \
+                        size    87101 \
                     golang.org/x/net \
-                        lock    v0.2.0 \
-                        rmd160  7adf55ca4f01e48fec9ec13a7229ae72f4d87f6a \
-                        sha256  4bb6aeb594dffce819760e8888ab952124a0647a55a6bc2968cfd43b638e319a \
-                        size    1243767 \
+                        lock    v0.4.0 \
+                        rmd160  c003f74a2dd1696a79f5fa52e78d12d95e58a3a2 \
+                        sha256  22ce878356e58045cc8509555dab771ac53d6a0541448d3d58fc24d9ba462cd9 \
+                        size    1237072 \
                     golang.org/x/crypto \
-                        lock    v0.2.0 \
-                        rmd160  bffcd0123418d8fb0d5d891c3600f7bf996221b8 \
-                        sha256  466bed7b7ebc652403ff0b6775944b569124d856a46981fc66027ee3ec0ed0d5 \
-                        size    1633095 \
+                        lock    v0.4.0 \
+                        rmd160  5669817509812aad1d04b5dc12d2217d28d954d8 \
+                        sha256  d2340a6bb7fa26df5f5e309cada4e2666652e721307fa512923f352a17b7a14e \
+                        size    1633555 \
                     github.com/yuin/goldmark \
                         lock    v1.5.3 \
                         rmd160  19ec5216062b33aa1442099e489ffc81fef34679 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.41)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
