### PR TITLE
swi-prolog, swi-prolog-devel: fix warning about location of app

### DIFF
--- a/lang/swi-prolog-devel/Portfile
+++ b/lang/swi-prolog-devel/Portfile
@@ -7,7 +7,7 @@ name                swi-prolog-devel
 conflicts           swi-prolog
 epoch               20051223
 version             9.1.3
-revision            0
+revision            1
 
 categories          lang
 universal_variant   no
@@ -60,7 +60,19 @@ cmake.generator     Ninja
 configure.pre_args  -DCMAKE_INSTALL_PREFIX=${prefix} \
                     -DCMAKE_BUILD_TYPE=Release \
                     -DCMAKE_INCLUDE_PATH=${prefix}/include \
-                    -DCMAKE_LIBRARY_PATH=/usr/lib:${prefix}/lib
+                    -DCMAKE_LIBRARY_PATH=/usr/lib:${prefix}/lib \
+                    -DSWIPL_PACKAGES_QT=OFF
+
+variant qt5 description {Add Qt5 GUI} {
+    depends_lib-append          port:qt5-qtbase
+    configure.pre_args-delete   -DSWIPL_PACKAGES_QT=OFF
+}
+
+post-destroot {
+    if {[variant_isset qt5]} {
+        move ${destroot}/${prefix}/swipl-win.app ${destroot}${applications_dir}
+    }
+}
 
 test.run            yes
 test.cmd            ctest --output-on-failure

--- a/lang/swi-prolog/Portfile
+++ b/lang/swi-prolog/Portfile
@@ -7,7 +7,7 @@ name                swi-prolog
 conflicts           swi-prolog-devel
 epoch               20051223
 version             9.0.3
-revision            0
+revision            1
 
 categories          lang
 platforms           darwin
@@ -61,11 +61,23 @@ cmake.generator     Ninja
 configure.pre_args  -DCMAKE_INSTALL_PREFIX=${prefix} \
                     -DCMAKE_BUILD_TYPE=Release \
                     -DCMAKE_INCLUDE_PATH=${prefix}/include \
-                    -DCMAKE_LIBRARY_PATH=/usr/lib:${prefix}/lib
+                    -DCMAKE_LIBRARY_PATH=/usr/lib:${prefix}/lib \
+                    -DSWIPL_PACKAGES_QT=OFF
 
 platform darwin 21 {
     if {[vercmp ${version} 8.4.2] < 0} {
         configure.args-append -DUSE_TCMALLOC=OFF
+    }
+}
+
+variant qt5 description {Add Qt5 GUI} {
+    depends_lib-append          port:qt5-qtbase
+    configure.pre_args-delete   -DSWIPL_PACKAGES_QT=OFF
+}
+
+post-destroot {
+    if {[variant_isset qt5]} {
+        move ${destroot}/${prefix}/swipl-win.app ${destroot}${applications_dir}
     }
 }
 


### PR DESCRIPTION
#### Description

Fix the warning by moving swipl-win.app from ${prefix} to the MacPorts application directory.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
  test fails with one error, but this is not related to this fix
- [x] tried a full install with `sudo port -vs install`?
   -t fails in the extract phase, but this is not related to this fix
- [x] tested basic functionality of all binary files?
