### PR TITLE
perlN: add supported platforms

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -216,6 +216,11 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
             }
         }
 
+        # https://trac.macports.org/ticket/66478
+        if {${perl5.major} < 5.28} {
+            platforms           {darwin < 22} freebsd linux
+        }
+
         post-configure {
             if {[variant_exists universal] && [variant_isset universal]} {
                 system "cd ${worksrcpath} && ed - ${worksrcpath}/config.h < ${filespath}/${perl5.major}/config.h.ed"


### PR DESCRIPTION
this is kind of a new process, and the perl ports are more complicated than usual, but this seems to do the right thing.

As far as I can see, you have to actually run a portindex on the modified port file for it to actually pick up the platform changes in the subports.