### PR TITLE
scifor: new port in science

### DIFF
--- a/science/scifor/Portfile
+++ b/science/scifor/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+
+github.setup        QcmPlab SciFortran 4.10.5
+name                scifor
+revision            0
+categories          science math
+license             LGPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         A library of Fortran modules and routines for scientific calculations
+long_description    This is a unitary collection of Fortran modules and procedures \
+                    for scientific calculations. The library aims to provide a simple \
+                    and generic environment for any scientific or mathematic computations. \
+                    The project is largely inspired by SciPy for Python \
+                    and tries to closely follow its guidelines and naming convention.
+homepage            https://QcmPlab.github.io/SciFortran
+checksums           rmd160  e291341d3d66eca758516615713ed4d6326a9906 \
+                    sha256  e916d06c34c31bd59e4877c1bd5e15fed4069cb9e72d6da5dc666eef53f38970 \
+                    size    4114223
+
+cmake.generator     Ninja
+
+depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS
+
+patchfiles          patch-prefix.diff \
+                    patch-scifor.pc.diff
+
+post-patch {
+    reinplace "s,@PREFIX@,${prefix}," ${worksrcpath}/cmake/MainConfig.cmake
+    reinplace "s,@PREFIX@,${prefix}," ${worksrcpath}/etc/scifor.pc.in
+    reinplace "s,@VERSION@,${version}," ${worksrcpath}/etc/scifor.pc.in
+}
+
+compilers.choose    fc f90
+compilers.setup     require_fortran
+
+configure.args-append \
+                    -DUSE_MPI=OFF \
+                    -DWITH_BLAS_LAPACK=OFF \
+                    -DWITH_SCALAPACK=OFF
+
+# Provided install scripts are a mess, avoid them.
+destroot {
+    copy ${build.dir}/libscifor.a ${destroot}/${prefix}/lib/
+    xinstall -d ${destroot}${prefix}/lib/pkgconfig
+    move ${worksrcpath}/etc/scifor.pc.in ${destroot}${prefix}/lib/pkgconfig/scifor.pc
+    xinstall -d ${destroot}${prefix}/include/${name}
+    fs-traverse f ${build.dir}/include {
+        if {[file isfile ${f}] && [file extension ${f}] == ".mod"} {
+            copy ${f} ${destroot}${prefix}/include/${name}/
+        }
+    }
+}

--- a/science/scifor/files/patch-prefix.diff
+++ b/science/scifor/files/patch-prefix.diff
@@ -1,0 +1,67 @@
+--- cmake/MainConfig.cmake.orig	2022-11-21 21:28:02.000000000 +0700
++++ cmake/MainConfig.cmake	2023-01-07 11:41:57.000000000 +0700
+@@ -1,44 +1,8 @@
+ SET(USER_HOME $ENV{HOME})
+ SET(USER $ENV{USER})
+ 
+-STRING(TOLOWER "${CMAKE_Fortran_COMPILER_ID}" FC_ID)
+-STRING(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
+-
+-#default prefix is $HOME/opt/<libname>/<fc_id>/[<git_branch>[/<debug>]]/<version>
+-SET(PREFIX_DEF_LOC "$ENV{HOME}/opt")
+-SET(PREFIX_PROJ "${PROJECT_NAME}")
+-SET(PREFIX_PATH "${FC_ID}")
+-
+ #user can change the default location of the library but not the remaining naming conventions 
+-SET(PREFIX  "${PREFIX_DEF_LOC}" CACHE PATH "Prefix prepended to install directories")
+-
+-#if prefix has not be changed use default module name conventions
+-IF(PREFIX STREQUAL "${PREFIX_DEF_LOC}")
+-  SET(USE_DEFAULT_MODULE_NAME TRUE)
+-ENDIF()
+-
+-#if not master branch, include simplified branch name
+-IF( (NOT GIT_BRANCH MATCHES "master") )
+-    SET(PREFIX_PATH  "${PREFIX_PATH}/${GIT_BRANCH}")
+-ENDIF()
+-
+-#If DEBUG, add /debug to 
+-IF("${BUILD_TYPE}" MATCHES "debug")
+-  SET(PREFIX_PATH  "${PREFIX_PATH}/${BUILD_TYPE}")
+-ENDIF()
++SET(PREFIX "@PREFIX@" CACHE PATH "Prefix prepended to install directories")
+ 
+ #set default prefix:
+-SET(FULL_VER "${PREFIX_PATH}/${VERSION}")
+-SET(VERSION_PATH "${PREFIX_PROJ}/${PREFIX_PATH}")
+-SET(DEFAULT_PREFIX "${PREFIX}/${PREFIX_PROJ}/${PREFIX_PATH}/${VERSION}")
+-SET(CMAKE_INSTALL_PREFIX "${DEFAULT_PREFIX}" CACHE INTERNAL "Prefix prepended to install directories" FORCE)
+-
+-#Now set module name corresponding to given prefix:
+-#if prefix is default nothing to be done.
+-#if user defined prefix prepend
+-IF(USE_DEFAULT_MODULE_NAME)
+-  SET(MODULE_NAME "${PREFIX_PROJ}/${PREFIX_PATH}/${VERSION}")
+-ELSE()
+-  SET(MODULE_NAME "${PREFIX_PROJ}/user_prefix/${PREFIX_PATH}/${VERSION}")
+-ENDIF()
+-
++SET(CMAKE_INSTALL_PREFIX "${PREFIX}" CACHE INTERNAL "Prefix prepended to install directories" FORCE)
+
+--- CMakeLists.txt.orig	2022-11-21 21:28:02.000000000 +0700
++++ CMakeLists.txt	2023-01-07 13:24:23.000000000 +0700
+@@ -285,14 +285,3 @@
+   GROUP_WRITE GROUP_READ GROUP_EXECUTE
+   WORLD_WRITE WORLD_READ WORLD_EXECUTE)
+ 
+-
+-#Build the PKG-CONFIG file
+-INCLUDE(${CMAKE_MODULE_PATH}/BuildPkgConfigFile.cmake)
+-SET(TMP_PKCONFIG_FILE ${LIB_TMP_ETC}/${PROJECT_NAME}.pc)
+-BUILD_PKCONFIG(${TMP_PKCONFIG_FILE})
+-
+-############################################################
+-############################################################
+-############################################################
+-
+-INCLUDE(${CMAKE_MODULE_PATH}/PostConfig.cmake)

--- a/science/scifor/files/patch-scifor.pc.diff
+++ b/science/scifor/files/patch-scifor.pc.diff
@@ -1,0 +1,18 @@
+--- etc/scifor.pc.in.orig	2022-11-21 21:28:02.000000000 +0700
++++ etc/scifor.pc.in	2023-01-07 10:54:55.000000000 +0700
+@@ -1,11 +1,10 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
++prefix=@PREFIX@
+ exec_prefix=${prefix}/bin
+ includedir=${prefix}/include
+ libdir=${prefix}/lib
+ 
+ Name: scifor
+ Description: The SciFortran library
+-Version:@VERSION@
+-Cflags: -I${includedir}
+-Libs: @SF_LIBDIR@
+-
++Version: @VERSION@
++Cflags: -I${includedir}/scifor
++Libs: -L${libdir} -lscifor -llapack -lblas


### PR DESCRIPTION
#### Description

New port: https://github.com/QcmPlab/SciFortran
(I will add MPI variant later on, after this is confirmed to build and is merged.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
