### PR TITLE
zofu, fson: new pors: unit-testing for Fortran; Fortran 95 JSON Parser

### DIFF
--- a/devel/fson/Portfile
+++ b/devel/fson/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           meson 1.0
+
+# CMake fails to build tests, therefore using Meson:
+# https://github.com/josephalevin/fson/issues/32
+github.setup        josephalevin fson 1.0.5 v
+revision            0
+categories          devel fortran
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Fortran 95 JSON Parser
+long_description    {*}${description}
+checksums           rmd160  b00692ec7197bebefa464eeb561048f91736ea93 \
+                    sha256  0bce1e2d9789de60ee252e3870a761a202a40b6002e473771601bd58e6a067c3 \
+                    size    33787
+
+depends_build-append \
+                    port:pkgconfig \
+                    port:zofu
+
+compilers.choose    fc cc
+compilers.setup     require_fortran
+
+configure.args-append \
+                    -Dincludedir=${prefix}/include/${name}
+
+post-destroot {
+    # Delete build objects, keep .mod files:
+    fs-traverse f ${destroot}${prefix}/include/${name} {
+        if {[file isfile ${f}] && !([file extension ${f}] == ".mod")} {
+            delete ${f}
+        }
+    }
+}
+
+depends_test-append port:ninja \
+                    port:zofu
+
+test.run            yes
+test.target         test

--- a/devel/zofu/Portfile
+++ b/devel/zofu/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           meson 1.0
+
+# CMake builds it, but Meson works better.
+github.setup        acroucher zofu 1.1.1 v
+revision            0
+categories          devel fortran
+license             LGPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Object-oriented Fortran Unit-testing
+long_description    Zofu is a framework for carrying out unit testing of Fortran code modules. \
+                    As the name suggests, it makes use of the object-oriented features of Fortran 2003.
+checksums           rmd160  a3790282236c0a3f1ff223bebb4996f5d6df4d20 \
+                    sha256  b785a4e2fa87cd08a0dced8a69d6b2d4634bd5c0c70a9de16b76d9864527c9f5 \
+                    size    37820
+
+depends_build-append \
+                    port:pkgconfig
+
+compilers.choose    fc cc
+compilers.setup     require_fortran
+
+configure.args-append \
+                    -Dincludedir=${prefix}/include/${name}
+
+post-destroot {
+    # Delete build objects, keep .mod files:
+    fs-traverse f ${destroot}${prefix}/include/${name} {
+        if {[file isfile ${f}] && !([file extension ${f}] == ".mod")} {
+            delete ${f}
+        }
+    }
+}
+
+depends_test-append port:ninja
+
+test.run            yes
+test.target         test


### PR DESCRIPTION
#### Description

New port, unit-testing framework for Fortran: https://github.com/acroucher/zofu
And Fortran 95 JSON Parser: https://github.com/josephalevin/fson
Together, because `fson` uses `zofu` for tests.

UPD. Switched to Meson, since CMake does not really work correctly here.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

_All tests pass in Rosetta._

**Zofu**:
```
--->  Testing zofu
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_zofu/zofu/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_zofu/zofu/work/build
    Start 1: test_complex_asserts
1/8 Test #1: test_complex_asserts .............   Passed    0.06 sec
    Start 2: test_double_asserts
2/8 Test #2: test_double_asserts ..............   Passed    0.03 sec
    Start 3: test_integer_asserts
3/8 Test #3: test_integer_asserts .............   Passed    0.03 sec
    Start 4: test_logical_asserts
4/8 Test #4: test_logical_asserts .............   Passed    0.03 sec
    Start 5: test_real_asserts
5/8 Test #5: test_real_asserts ................   Passed    0.03 sec
    Start 6: test_string_asserts
6/8 Test #6: test_string_asserts ..............   Passed    0.03 sec
    Start 7: test_str_utils
7/8 Test #7: test_str_utils ...................   Passed    0.02 sec
    Start 8: test_zofu_scan
8/8 Test #8: test_zofu_scan ...................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) =   0.39 sec
```

**Fson**:
```
--->  Testing fson
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_fson/fson/work/build" && /opt/local/bin/ninja test 
[0/1] Running all tests.
1/2 fson_test  OK              0.09s
2/2 fson_test2 OK              0.17s

Ok:                 2   
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0
```