### PR TITLE
bzip3: do not use Apple compilers on <10.7, unbreak the build

### DIFF
--- a/archivers/bzip3/Portfile
+++ b/archivers/bzip3/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 github.setup        kspalaiologos bzip3 1.2.1
@@ -16,5 +17,9 @@ long_description    {*}${description}
 checksums           rmd160  3940e049433a348ccc9fe4f0fcc3fe76cbae37ad \
                     sha256  bba90d867f53efa4291de1df9c22da1578e1a93ca819e0fc68881da6fcc4149d \
                     size    399621
+
+# https://trac.macports.org/ticket/66644
+compiler.blacklist-append \
+                    *gcc-4.* {clang < 400}
 
 configure.args      --disable-silent-rules

--- a/archivers/bzip3/Portfile
+++ b/archivers/bzip3/Portfile
@@ -9,7 +9,7 @@ github.tarball_from releases
 categories          archivers
 license             LGPL-3+
 
-maintainers         {@sech1p gmail.com:sech1piam} openmaintainer 
+maintainers         {@sech1p gmail.com:sech1piam} openmaintainer
 
 description         A better and stronger spiritual successor to BZip2.
 long_description    {*}${description}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66644

#### Description

`bzip3` uses on Intel `clang-11`, so the failure with old compilers went unnoticed: https://build.macports.org/builders/ports-10.6_i386-builder/builds/102916/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
