### PR TITLE
pyxplot: avoid strcpy crash on Ventura

### DIFF
--- a/math/pyxplot/Portfile
+++ b/math/pyxplot/Portfile
@@ -43,6 +43,8 @@ depends_lib-append  port:cfitsio \
 patchfiles          patch-configure.diff \
                     patch-Makefile.skel.diff
 
+patchfiles-append   patch-pyxplot-no-crash-ventura.diff
+
 post-patch {
     reinplace "s|USRDIR=/usr/local|USRDIR=${prefix}|g" \
                 ${worksrcpath}/Makefile.skel

--- a/math/pyxplot/files/patch-pyxplot-no-crash-ventura.diff
+++ b/math/pyxplot/files/patch-pyxplot-no-crash-ventura.diff
@@ -1,0 +1,18 @@
+--- ./src/settings/settingsInit.c.orig	2023-01-07 16:41:23
++++ ./src/settings/settingsInit.c	2023-01-07 16:41:31
+@@ -364,7 +364,14 @@
+   se->session_default.color_rep= SW_TERMCOL_GRN;
+   se->session_default.color_wrn= SW_TERMCOL_BRN;
+   se->session_default.color_err= SW_TERMCOL_RED;
+-  strcpy(se->session_default.homedir, ppl_unixGetHomeDir(&context->errcontext));
++
++  char  *myhomedir;
++  myhomedir = ppl_unixGetHomeDir(&context->errcontext);
++  if (myhomedir == "") {
++  	myhomedir = "~";
++  }
++  strncpy(se->session_default.homedir,&myhomedir,4096);
++  //strcpy(se->session_default.homedir, ppl_unixGetHomeDir(&context->errcontext));
+ 
+   // Estimate the machine precision of the floating point unit we are using
+   ppl_makeMachineEpsilon();


### PR DESCRIPTION
the function ppl_unixGetHomeDir is not returning
a full path to the users home dir, it is instead
returning null it appears, on Ventura at least

the function should be fixed, but for now checking the return value and substituting something reasonable seems to avoid the crash

closes: https://trac.macports.org/ticket/66098

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
