### PR TITLE
poetry: update to 1.3.2

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    poetry
-version                 1.3.0
+version                 1.3.2
 revision                0
 categories-append       devel
 platforms               {darwin any}
@@ -23,9 +23,9 @@ long_description        Poetry: Dependency Management for Python. \
 
 homepage                https://python-poetry.org/
 
-checksums               rmd160  9f28632277cae2e3da04ef8b391c321de15e8678 \
-                        sha256  d42943b44e80f5afafebdb696393cbdbcc750aecfaa6801174a4da42147c73fc \
-                        size    871885
+checksums               rmd160  8e1f1ece9286749419abfcae7627d1595231b8cd \
+                        sha256  26ded25f0cf67943243ca4f0aafd47ec4668bdb62845dbb8c2b0e3d9cd280bf4 \
+                        size    871903
 
 variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
 variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
@@ -33,8 +33,8 @@ variant python39 conflicts python37 python38 python310 python311 description {Us
 variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
 variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python311]} {
-    default_variants +python310
+if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+    default_variants +python311
 }
 
 foreach pv {311 310 39 38 37} {


### PR DESCRIPTION
Set Python 3.11 as default variant


#### Description

Tested out locally with a basic poetry setup - things are working fine, packages are all installing under python3.11.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
