### PR TITLE
pipenv: update to 2022.12.19

### DIFF
--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                pipenv
-version             2022.11.5
+version             2022.12.19
 revision            0
 categories-append   devel
 platforms           {darwin any}
@@ -34,11 +34,11 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  b50f874bec35cd315c841a730729eb8d76bc5f72 \
-                    sha256  af8595e38f1d87af3b00d209390bce41c97b10fca1c956e9ba1208438af55c6a \
-                    size    4786517
+checksums           rmd160  fea387e0799b8e43f66dc673bb61a1da408be233 \
+                    sha256  56a0e9305912293a8205e23b836b4abb9bca912fd5ef131214cdcdbc1861a1cc \
+                    size    4763988
 
-python.default_version 310
+python.default_version 311
 
 depends_lib-append \
     port:py${python.version}-certifi \

--- a/python/py-virtualenv-clone/Portfile
+++ b/python/py-virtualenv-clone/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-virtualenv-clone
 version             0.5.7
-revision            1
+revision            2
 
 categories-append   devel
 maintainers         nomaintainer
@@ -23,7 +23,7 @@ checksums           rmd160  885b90024880e4cd45410caeab0014d5a160d14a \
                     sha256  418ee935c36152f8f153c79824bb93eaf6f0f7984bae31d3f48f350b9183501a \
                     size    6454
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-virtualenv-clone/virtualenv-clone311
+++ b/python/py-virtualenv-clone/virtualenv-clone311
@@ -1,0 +1,1 @@
+bin/virtualenv-clone-3.11


### PR DESCRIPTION
#### Description

Also add python3.11 variant for virtualenv-clone. Tested out with a basic package setup, looks fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
