### PR TITLE
minetest: amend for subports

### DIFF
--- a/games/minetest/Portfile
+++ b/games/minetest/Portfile
@@ -1,29 +1,394 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup obsolete  1.0
+# NOTE: See the comprised 'subport' definitions of this Minetest Portfile below.
+#       To install 'minetest' refer to the applicable 'subport' of this Portfile.
 
-name                minetest
-replaced_by         minetest56
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake  1.1
 
-version             5.6.1
-revision            2
+compiler.cxx_standard   2011
+compiler.thread_local_storage  yes
 
-categories          games
-license             LGPL-2.1+
+name                    minetest
+set github-author       ${name}
+set github-project      ${name}
 
-homepage            https://www.minetest.net
+# Set a main revison for all subport definitions.  However, a subport might get an extra revision.
+# NOTE: The additional port "revision 2" identifier in down below text of this Portfile
+#       shall be deleted after the MT 5.7.0 release.
+#       However, this main revision shall remain and be continuously amended as applicable.
+revision                0
 
-# Should not be removed and will be regular replaced by MT stable as applicable.
-#
-# By rev3 the port "irrlichtmt-mt56" provides 'irrlicht 1.9.0mt8' for "minetest56" ports.
-# This should apply until a more stable MT 5.7.1 would be available.
-#
+
+# Provide this main body part to the port only.  Any subport amends this respectively below.
+if { ${subport} eq ${github-project} } {
+
+# Make use of the most recent MT core release version at GitHub.  This is for livecheck also.
+    github.setup        ${github-author} ${github-project} 5.6.1
+
+# However, the MT game version could be different from the MT and subport version
+    set game_version    ${github.version}
+
 # Rationale:  The Minetest application evidently binds to a specific IrrLichtMT fork version.
 # Furthermore, many MT players tend to stick with a certain MT version as long as possible,
 # because their obvious goal is having fun in a self-built kingdom inside a MT game world.
 # However, due to technical quirks and compatibility issues a migration of a MT game world,
 # including virtual assets built by same players for hours or even years, would be risky.
+
+# The MT core needs the MT game and to add on more files to a GitHub portgroup download
+# we have to cache the preset distfiles from the GitHub portgroup respectively.
+    set main_distfile   ${distfiles}
+
+# then add another distfile, with a direct URL as can't use the github PG again
+    set game_distfile   ${game_version}${extract.suffix}
+    set game_mastersite https://github.com/minetest/minetest_game/archive/
+
+    distfiles           ${main_distfile}:main \
+                        ${game_distfile}:game
+
+    master_sites        ${github.master_sites}:main \
+                        ${game_mastersite}:game
+
+# Checksums for both the current MT core and MT game respectively.
+    checksums           ${main_distfile} \
+                        rmd160  7b32331e0007f29003107592522d1c906935e44d \
+                        sha256  425d8e9363212dcb5bc7986dd12460c9c3784aca22eb1b90dad6a7fc2c6ef546 \
+                        size    9925064 \
+                        ${game_distfile} \
+                        rmd160  73d35423b856d141cebfa16396fe5dcf834dcf89 \
+                        sha256  5dc857003d24bb489f126865fcd6bf0d9c0cb146ca4c1c733570699d15abd0e3 \
+                        size    2590582
+}
+
+
+# Provide a part of the main body to the port and any subport respectively.
+
+license                 LGPL-2.1+
+categories              games
+platforms               darwin
+maintainers             @Zweihorn openmaintainer
+description             open source infinite-world block sandbox game with survival and crafting
+
+homepage                https://www.minetest.net
+
+
+######
+# START the comprised Minetest 'subport' definitions to this Portfile.
+##
+
+# New and improved approach with several 'subport' definitions as follows:
 #
-# WIP for MT 5.7.1 and only for the future of this port replacement definition:
-# Later the port "irrlichtmt-mt57" would provide 'irrlicht 1.9.0mt9' for "minetest57" ports.
+# 1. subport "minetest" is a stub and envelope which shall not be installed.
+#
+# 2. subport "minetest54" provides legacy MT 5.4.0 ports by use of the 'irrlicht' port.
+#
+# 3. subport "minetest55" provides legacy  MT 5.5.1 which depends on 'irrlicht 1.9.0mt6'.
+#
+# 4. subport "minetest56" provides stable MT 5.6.1 which depends on 'irrlicht 1.9.0mt8'.
+#
+# 5. subport "minetest57" provides unstable MT 5.7.0 and depends on 'irrlicht 1.9.0mt9'.
+#
+# 6. subport "minetest58" would provide unstable MT 5.8.0 depending on 'irrlicht 1.9.0mtX'
+#    in the foreseeable future.
+#
+# NOTE: Beyond MT 5.8 dev the future of 'irrlicht 1.9.0mtX' might be unsure as
+#       the MT core devs seek to fully integrate the former IrrLicht code into
+#       the code base of MT core and/or might have the goal of SDL2 apparently.
+
+# WIP - There will be variants ...
+
+
+subport "${name}54" {
+
+# The applicable MT 5.4 core release at GitHub.
+    github.setup        ${github-author} ${github-project} 5.4.0
+
+# However, the applicable MT game version could be different from the subport version.
+    set game_version    ${github.version}
+
+# The MT core needs the MT game and to add on more files to a GitHub portgroup download
+# we have to cache the preset distfiles from the GitHub portgroup respectively.
+    set main_distfile   ${distfiles}
+
+# Add another distfile, with a direct URL as reuse of the GitHub Portgroup fails.
+    set game_distfile   ${game_version}${extract.suffix}
+    set game_mastersite https://github.com/minetest/minetest_game/archive/
+
+    distfiles           ${main_distfile}:main \
+                        ${game_distfile}:game
+
+    master_sites        ${github.master_sites}:main \
+                        ${game_mastersite}:game
+
+# Applicable checksums for both the MT 5.4 core and MT game respectively.
+    checksums           ${main_distfile} \
+                        rmd160  8ab28fc0a50ff8bc37a3d46b7c4974f65ac20be5\
+                        sha256  5ccca8c22491086105baea9964b619504ff4eb3e53bcf0762b76411fe7fa1e73 \
+                        size    11205115 \
+                        ${game_distfile} \
+                        rmd160  e7d90f8c53c65bd57b1d9e35f03a40e3312c1181 \
+                        sha256  520d2056085ec11e8806cf5a8f928537797d27a86704770bf408c113ea9881cb \
+                        size    2474273
+
+# NOTE: Minetest 5.4 and earlier had no IrrLichtMT fork version apparently.
+    set port-irrlicht   port:irrlicht
+}
+
+
+subport "${name}55" {
+
+# The applicable MT 5.5 core release at GitHub.
+    github.setup        ${github-author} ${github-project} 5.5.1
+
+# However, the applicable MT game version could be different from the subport version.
+    set game_version    ${github.version}
+
+# The MT core needs the MT game and to add on more files to a GitHub portgroup download
+# we have to cache the preset distfiles from the GitHub portgroup respectively.
+    set main_distfile   ${distfiles}
+
+# Add another distfile, with a direct URL as reuse of the GitHub Portgroup fails.
+    set game_distfile   ${game_version}${extract.suffix}
+    set game_mastersite https://github.com/minetest/minetest_game/archive/
+
+    distfiles           ${main_distfile}:main \
+                        ${game_distfile}:game
+
+    master_sites        ${github.master_sites}:main \
+                        ${game_mastersite}:game
+
+# Applicable checksums for both the MT 5.5 core and MT game respectively.
+    checksums           ${main_distfile} \
+                        rmd160  7e20ef603e036bd28e3c63e2e12d4a2f2adf2300 \
+                        sha256  7108c01554a975ca9ca0d75d150ac4d7ce42800e2ca7cc880100705156a24ebe \
+                        size    9560030 \
+                        ${game_distfile} \
+                        rmd160  d92174c03c06086b73ad6e20375a528f9d707f05 \
+                        sha256  5a24fec4ed838744906f020096c35616e7ba76eeec2b93b980a40af011107e7c \
+                        size    2582897
+
+# The Minetest program evidently binds to a specific IrrLichtMT fork version.
+    set port-irrlicht   port:irrlichtmt-mt55
+}
+
+
+subport "${name}56" {
+
+# NOTE: This is not redundant and is certainly worth the code because of:
+#       1. Easier to copy and paste than to make extra complicated logical traps.
+#       2. This copy will become the original to MT 5.6 after MT 5.7 release anyway.
+
+# The applicable MT 5.5 core release at GitHub.
+    github.setup        ${github-author} ${github-project} 5.6.1
+
+# However, the applicable MT game version could be different from the subport version.
+    set game_version    ${github.version}
+
+# The MT core needs the MT game and to add on more files to a GitHub portgroup download
+# we have to cache the preset distfiles from the GitHub portgroup respectively.
+    set main_distfile   ${distfiles}
+
+# Add another distfile, with a direct URL as reuse of the GitHub Portgroup fails.
+    set game_distfile   ${game_version}${extract.suffix}
+    set game_mastersite https://github.com/minetest/minetest_game/archive/
+
+    distfiles           ${main_distfile}:main \
+                        ${game_distfile}:game
+
+    master_sites        ${github.master_sites}:main \
+                        ${game_mastersite}:game
+
+# Checksums for both the current MT core and MT game respectively.
+    checksums           ${main_distfile} \
+                        rmd160  7b32331e0007f29003107592522d1c906935e44d \
+                        sha256  425d8e9363212dcb5bc7986dd12460c9c3784aca22eb1b90dad6a7fc2c6ef546 \
+                        size    9925064 \
+                        ${game_distfile} \
+                        rmd160  73d35423b856d141cebfa16396fe5dcf834dcf89 \
+                        sha256  5dc857003d24bb489f126865fcd6bf0d9c0cb146ca4c1c733570699d15abd0e3 \
+                        size    2590582
+
+# The Minetest program evidently binds to a specific IrrLichtMT fork version.
+    set port-irrlicht   port:irrlichtmt-mt56
+}
+
+
+subport "${name}57" {
+
+# The applicable MT 5.7 core release at GitHub.
+    github.setup        ${github-author} ${github-project} 5.7.0
+
+    known_fail          yes
+
+# However, the applicable MT game version could be different from the subport version.
+    set game_version    ${github.version}
+
+# The MT core needs the MT game and to add on more files to a GitHub portgroup download
+# we have to cache the preset distfiles from the GitHub portgroup respectively.
+    set main_distfile   ${distfiles}
+
+# Add another distfile, with a direct URL as reuse of the GitHub Portgroup fails.
+    set game_distfile   ${game_version}${extract.suffix}
+    set game_mastersite https://github.com/minetest/minetest_game/archive/
+
+    distfiles           ${main_distfile}:main \
+                        ${game_distfile}:game
+
+    master_sites        ${github.master_sites}:main \
+                        ${game_mastersite}:game
+
+# NOTE: This is a fake and awaiting the MT 5.7 unstable release.  (ETA Feb 2023 ?!)
+# Non-applicable checksums for both the MT 5.7 core and MT game respectively.
+    checksums           ${main_distfile} \
+                        rmd160  8b32331e0007f29003107592522d1c906935e44d \
+                        sha256  825d8e9363212dcb5bc7986dd12460c9c3784aca22eb1b90dad6a7fc2c6ef546 \
+                        size    8925064 \
+                        ${game_distfile} \
+                        rmd160  83d35423b856d141cebfa16396fe5dcf834dcf89 \
+                        sha256  8dc857003d24bb489f126865fcd6bf0d9c0cb146ca4c1c733570699d15abd0e3 \
+                        size    8590582
+
+# The Minetest program evidently binds to a specific IrrLichtMT fork version.
+    set port-irrlicht   port:irrlichtmt-mt57
+}
+
+##
+# END of the 'subport' definitions and on to the common body of this Portfile below.
+######
+
+
+# Main body part to the port only.  Any subport amends this respectively below.
+if { ${subport} eq ${name} } {
+
+    PortGroup obsolete  1.0
+
+    replaced_by         ${name}
+
+    version             ${github.version}
+
+# NOTE: Delete this revision identifier after the MT 5.7.0 release presumably.
+#       This extra revision definition is needed to continue 'port upgrade outdated' for
+#       the legacy MT 5.6 minetest single port.
+    revision            2
+
+    categories          games
+    license             LGPL-2.1+
+
+    homepage            https://www.minetest.net
+
+# The Minetest program evidently binds to a specific IrrLichtMT fork version.
+    set port-irrlicht   port:irrlichtmt
+# NOTE: Obsolete definition 'port:irrlichtmt' needed for 'port -lint --nitpick' checks.
+
+# Should not be removed.
+
+}
+
+
+############
+# START NOTE: The body to port and all subport definitions continues below:
+###
+
+# Continue the main body of the port and any subport respectively.
+
+# rename directory - from github portgroup
+post-extract {
+    if {[file exists [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]] && \
+        [file isdirectory [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]]} {
+        move [glob ${workpath}/${github.author}-${github.project}-*] ${workpath}/${distname}
+    }
+}
+
+if { ${subport} eq ${name} } {
+
+# NOTE: Default description for the obsolete port would be: "minetest is replaced by minetest".
+# Concatenates to: "minetest is replaced by minetest54, minetest55, minetest56, minetest57".
+    long_description    ${description}54, ${name}55, ${name}56, ${name}57
+
+} else {
+
+    long_description    ${description} - \
+                        This ${subport} depends on ${port-irrlicht} to provide the MT ${github.version} game. - \
+                        Find more MT mods at <https://content.minetest.net/> and have fun.
+
+}
+
+depends_build-append    path:bin/doxygen:doxygen \
+                        port:mesa
+
+depends_lib-append      ${port-irrlicht} \
+                        path:include/turbojpeg.h:libjpeg-turbo \
+                        port:libogg \
+                        port:libvorbis \
+                        port:freetype \
+                        port:gettext \
+                        port:leveldb \
+                        port:sqlite3 \
+                        port:zstd \
+                        path:lib/libluajit-5.1.2.dylib:luajit \
+                        port:gmp \
+                        port:curl \
+                        port:jsoncpp \
+                        port:spatialindex \
+                        port:xorg-libX11 \
+                        port:xorg-libXxf86vm
+
+# see https://trac.macports.org/ticket/58315 - possibly fixable?
+universal_variant       no
+supported_archs         x86_64
+
+# 001. the original build calls fixup_bundle to move all the deps into the app bundle.
+#    this doesn't work correctly with macports destrooting, and isn't necessary for a macports install so deleted it
+patchfiles-append       001-patch-src-CMakeLists-disable-bundlefixup.diff
+
+# 002. patch to get the luajit include headers ahead of the system includes, or the build finds the
+#    wrong lua headers if you have a newer version of lua installed
+patchfiles-append       002-patch-cmake-Modules-FindLua-include-LUADIR-before-system.diff
+
+# 003. patch main.cpp to not barf on the unrecognized command-line option -psn from Apple launch
+patchfiles-append       003-patch-ignore-psn-option-mac-bundle.diff
+
+configure.args-append   -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_INSTALL_PREFIX:PATH=${applications_dir} \
+                        -DBUILD_UNITTESTS=OFF \
+                        -DENABLE_UPDATE_CHECKER=OFF \
+                        -DBUILD_CLIENT=ON \
+                        -DBUILD_SERVER=ON \
+                        -DENABLE_SOUND=ON \
+                        -DENABLE_REDIS=OFF \
+                        -DENABLE_POSTGRESQL=OFF \
+                        -DENABLE_LEVELDB=ON \
+                        -DENABLE_FREETYPE=ON \
+                        -DENABLE_CURL=ON \
+                        -DENABLE_GETTEXT=ON \
+                        -DENABLE_SPATIAL=ON \
+                        -DENABLE_SYSTEM_GMP=ON \
+                        -DENABLE_SYSTEM_JSONCPP=ON \
+                        -DCURSES_INCLUDE_PATH:FILEPATH=${prefix}/include \
+                        -DENABLE_LUAJIT=ON \
+                        -DLUA_INCLUDE_DIR:PATH=${prefix}/include/luajit-2.1 \
+                        -DLUA_LIBRARY:FILEPATH=${prefix}/lib/libluajit-5.1.dylib \
+                        -DVERSION_EXTRA=MacPorts-rev${revision}
+
+post-destroot {
+    move ${workpath}/minetest_game-${game_version}   ${destroot}${applications_dir}/minetest.app/Contents/Resources/games/minetest_game
+}
+
+
+# Main body part to the port only.  Any subport amended this respectively above.
+# NOTE: Last not least: The late kill to the port and the early minetest57 subport ...
+if { ${subport} eq ${name} || ${subport} eq "${name}57" } {
+
+    fetch {}
+    extract {}
+    use_configure no
+    build {}
+    destroot {}
+}
+
+
+###
+# END NOTE: The body to all port and subport definitions ends here.
+############
+

--- a/games/minetest/Portfile
+++ b/games/minetest/Portfile
@@ -81,7 +81,7 @@ homepage                https://www.minetest.net
 #
 # 1. subport "minetest" is a stub and envelope which shall not be installed.
 #
-# 2. subport "minetest54" provides legacy MT 5.4.0 ports by use of the 'irrlicht' port.
+# 2. subport "minetest54" would provide legacy MT 5.4.0 ports by 'irrlicht' port. (FAIL)
 #
 # 3. subport "minetest55" provides legacy  MT 5.5.1 which depends on 'irrlicht 1.9.0mt6'.
 #
@@ -103,6 +103,10 @@ subport "${name}54" {
 
 # The applicable MT 5.4 core release at GitHub.
     github.setup        ${github-author} ${github-project} 5.4.0
+
+    known_fail          yes
+
+# WIP - 'irrlicht' would need full XCode apparently and automatic build FAILS.
 
 # However, the applicable MT game version could be different from the subport version.
     set game_version    ${github.version}

--- a/games/minetest/Portfile
+++ b/games/minetest/Portfile
@@ -1,116 +1,29 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
-PortGroup               github 1.0
-PortGroup               cmake 1.1
+PortSystem          1.0
+PortGroup obsolete  1.0
 
-compiler.cxx_standard   2011
-compiler.thread_local_storage   yes
+name                minetest
+replaced_by         minetest56
 
-github.setup            minetest minetest 5.6.1
-revision                1
+version             5.6.1
+revision            2
 
-# the game version could be different from the minetest version
-set game_version        5.6.1
+categories          games
+license             LGPL-2.1+
 
-# to add on more files to a github portgroup download
-# have to cache the preset distfiles from the github PG
-set main_distfile       ${distfiles}
+homepage            https://www.minetest.net
 
-# then add another distfile, with a direct URL as can't use the github PG again
-set game_distfile       ${game_version}${extract.suffix}
-set game_mastersite     https://github.com/minetest/minetest_game/archive/
-
-distfiles               ${main_distfile}:main \
-                        ${game_distfile}:game
-
-master_sites            ${github.master_sites}:main \
-                        ${game_mastersite}:game
-
-checksums               ${main_distfile} \
-                        rmd160  7b32331e0007f29003107592522d1c906935e44d \
-                        sha256  425d8e9363212dcb5bc7986dd12460c9c3784aca22eb1b90dad6a7fc2c6ef546 \
-                        size    9925064 \
-                        ${game_distfile} \
-                        rmd160  73d35423b856d141cebfa16396fe5dcf834dcf89 \
-                        sha256  5dc857003d24bb489f126865fcd6bf0d9c0cb146ca4c1c733570699d15abd0e3 \
-                        size    2590582
-
-# rename directory - from github portgroup
-post-extract {
-    if {[file exists [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]] && \
-        [file isdirectory [glob -nocomplain ${workpath}/${github.author}-${github.project}-*]]} {
-        move [glob ${workpath}/${github.author}-${github.project}-*] ${workpath}/${distname}
-    }
-}
-
-license                 LGPL-2.1+
-categories              games
-platforms               darwin
-maintainers             @Zweihorn openmaintainer
-description             open source infinite-world block sandbox game with survival and crafting
-long_description        ${description} - \
-                        Find more MT mods at <https://content.minetest.net/> and have fun.
-
-homepage                https://www.minetest.net
-
-depends_build-append    path:bin/doxygen:doxygen \
-                        port:mesa
-
-depends_lib-append      port:irrlichtmt \
-                        path:include/turbojpeg.h:libjpeg-turbo \
-                        port:libogg \
-                        port:libvorbis \
-                        port:freetype \
-                        port:gettext \
-                        port:leveldb \
-                        port:sqlite3 \
-                        port:zstd \
-                        path:lib/libluajit-5.1.2.dylib:luajit \
-                        port:gmp \
-                        port:curl \
-                        port:jsoncpp \
-                        port:spatialindex \
-                        port:xorg-libX11 \
-                        port:xorg-libXxf86vm
-
-# see https://trac.macports.org/ticket/58315 - possibly fixable?
-universal_variant       no
-supported_archs         x86_64
-
-# 001. the original build calls fixup_bundle to move all the deps into the app bundle.
-#    this doesn't work correctly with macports destrooting, and isn't necessary for a macports install so deleted it
-patchfiles-append       001-patch-src-CMakeLists-disable-bundlefixup.diff
-
-# 002. patch to get the luajit include headers ahead of the system includes, or the build finds the
-#    wrong lua headers if you have a newer version of lua installed
-patchfiles-append       002-patch-cmake-Modules-FindLua-include-LUADIR-before-system.diff
-
-# 003. patch main.cpp to not barf on the unrecognized command-line option -psn from Apple launch
-patchfiles-append       003-patch-ignore-psn-option-mac-bundle.diff
-
-configure.args-append   -DCMAKE_BUILD_TYPE=Release \
-                        -DCMAKE_INSTALL_PREFIX:PATH=${applications_dir} \
-                        -DBUILD_UNITTESTS=OFF \
-                        -DENABLE_UPDATE_CHECKER=OFF \
-                        -DBUILD_CLIENT=ON \
-                        -DBUILD_SERVER=ON \
-                        -DENABLE_SOUND=ON \
-                        -DENABLE_REDIS=OFF \
-                        -DENABLE_POSTGRESQL=OFF \
-                        -DENABLE_LEVELDB=ON \
-                        -DENABLE_FREETYPE=ON \
-                        -DENABLE_CURL=ON \
-                        -DENABLE_GETTEXT=ON \
-                        -DENABLE_SPATIAL=ON \
-                        -DENABLE_SYSTEM_GMP=ON \
-                        -DENABLE_SYSTEM_JSONCPP=ON \
-                        -DCURSES_INCLUDE_PATH:FILEPATH=${prefix}/include \
-                        -DENABLE_LUAJIT=ON \
-                        -DLUA_INCLUDE_DIR:PATH=${prefix}/include/luajit-2.1 \
-                        -DLUA_LIBRARY:FILEPATH=${prefix}/lib/libluajit-5.1.dylib \
-                        -DVERSION_EXTRA=MacPorts-rev${revision}
-
-post-destroot {
-    move ${workpath}/minetest_game-${game_version}   ${destroot}${applications_dir}/minetest.app/Contents/Resources/games/minetest_game
-}
+# Should not be removed and will be regular replaced by MT stable as applicable.
+#
+# By rev3 the port "irrlichtmt-mt56" provides 'irrlicht 1.9.0mt8' for "minetest56" ports.
+# This should apply until a more stable MT 5.7.1 would be available.
+#
+# Rationale:  The Minetest application evidently binds to a specific IrrLichtMT fork version.
+# Furthermore, many MT players tend to stick with a certain MT version as long as possible,
+# because their obvious goal is having fun in a self-built kingdom inside a MT game world.
+# However, due to technical quirks and compatibility issues a migration of a MT game world,
+# including virtual assets built by same players for hours or even years, would be risky.
+#
+# WIP for MT 5.7.1 and only for the future of this port replacement definition:
+# Later the port "irrlichtmt-mt57" would provide 'irrlicht 1.9.0mt9' for "minetest57" ports.

--- a/games/minetest/Portfile
+++ b/games/minetest/Portfile
@@ -22,7 +22,7 @@ revision                0
 
 
 # Provide this main body part to the port only.  Any subport amends this respectively below.
-if { ${subport} eq ${github-project} } {
+if { ${subport} eq ${name} } {
 
 # Make use of the most recent MT core release version at GitHub.  This is for livecheck also.
     github.setup        ${github-author} ${github-project} 5.6.1
@@ -137,6 +137,7 @@ subport "${name}54" {
 
 # NOTE: Minetest 5.4 and earlier had no IrrLichtMT fork version apparently.
     set port-irrlicht   port:irrlicht
+# WIP - 'irrlicht' would need full XCode apparently and automatic build FAILS.
 }
 
 
@@ -225,6 +226,8 @@ subport "${name}57" {
 
     known_fail          yes
 
+# WIP - This is a stub and awaiting the MT 5.7 unstable release.  (ETA Feb 2023 ?!)
+
 # However, the applicable MT game version could be different from the subport version.
     set game_version    ${github.version}
 
@@ -242,8 +245,8 @@ subport "${name}57" {
     master_sites        ${github.master_sites}:main \
                         ${game_mastersite}:game
 
-# NOTE: This is a fake and awaiting the MT 5.7 unstable release.  (ETA Feb 2023 ?!)
-# Non-applicable checksums for both the MT 5.7 core and MT game respectively.
+# WIP - This is a fake and awaiting the MT 5.7 unstable release.  (ETA Feb 2023 ?!)
+# NOTE: Non-applicable checksums for both the MT 5.7 core and MT game respectively.
     checksums           ${main_distfile} \
                         rmd160  8b32331e0007f29003107592522d1c906935e44d \
                         sha256  825d8e9363212dcb5bc7986dd12460c9c3784aca22eb1b90dad6a7fc2c6ef546 \
@@ -289,10 +292,6 @@ if { ${subport} eq ${name} } {
 
 }
 
-
-############
-# START NOTE: The body to port and all subport definitions continues below:
-###
 
 # Continue the main body of the port and any subport respectively.
 
@@ -390,9 +389,3 @@ if { ${subport} eq ${name} || ${subport} eq "${name}57" } {
     build {}
     destroot {}
 }
-
-
-###
-# END NOTE: The body to all port and subport definitions ends here.
-############
-


### PR DESCRIPTION
This PR is a **DRAFT** and WIP for resolve with `irrlichtmt` maintainer until further notice.

_NOTE: This PR in the end might be closed without merge. Applicable content would be moved into a fresh PR instead._

Most if not all of the `minetest` subport definitions **positively** tried a clean install with `sudo port -vst install` on the local test-bed of the new maintainer. Trust me and trust the power of MacPorts. 😃 

Please note the consecutive build check runs of this PR all have to fail because of the yet **missing `ìrrlichtmt` review.**
However, most if not all of the `minetest` subport definitions are already integrated with `irrlichtmt` and ready to run.

#### Description

This is an `irrlichtmt, minetest:` improved integration effort.

However, first things first and we started with `irrlichtmt` by: #17255 
Certainly _needs the prior availability_ of the `irrlichtmt-mt56` **subport**.

This is second step and the `minetest` follow-up integration amend by:
- amend Portfile for **subport definitions**
- provide two out of three new subport definitions
  1. 'minetest56' with MT 5.6.1 App - variants [+]GLES, debug
  2. 'minetest56-devel' with MT 5.6.1 App - variants [+]GLES, [+]benchmark, debug, gprof
  3. postponed _'minetest56-server' with MT 5.6.1 CLI only_
- well-known patches in folder 'files' respectively
- a.m. subports SHOULD integrate well with amended 'irrlichtmt' Portfile
- bugfix for irrlichtmt GLES & minetest - ref https://trac.macports.org/ticket/66599

CAVEAT: The automatic checks **cannot be successful** before #17255 approval.
Dumped the variants for subports - obsolete ref https://github.com/macports/macports-ports/pull/17153#issuecomment-1374581859

###### Future tasks:

The b.m. Trac ticket should **not hinder** any review of this PR as:
- ref https://trac.macports.org/ticket/66610
and is a **parallel activity** by same maintainer for a later supposed PKG distribution.

Future effort and next subports would be:
- subport 'minetest56-server' with MT 5.6.1 CLI - variants [+]psql, debug - (no App, no GUI)
- subport 'minetest57-devel' with MT 5.7.0 App - variants [+]GLES, [+]benchmark, debug, gprof
- subport 'minetest57-devel' would integrate well with 'irrlichtmt-mt57' subport
- well-known patches in folder 'files'

**Unfinished business** with 'irrlichtmt GLES & minetest' and OpenGL support, but this is of lower priority as of now.
Ref https://github.com/minetest/irrlicht/issues/152

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.7.2 20G1020 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

## Old news

This PR obsoletes #17241 and some older PRs too.

## New Deal

This PR and amend integrate well with the new `irrlichtmt-mt56` port .

Ref #17255 

See former _Addendum_ with some of my notes on this trials as of [2023-01-08](https://github.com/Zweihorn/Zweihorn_fascicle/blob/main/mynotes_mp_by-date/mynotes_mp_2023-01-08a.md)

## Postface

[Don't worry, be happy. - I'm not worried, I'm happy.](https://www.azlyrics.com/lyrics/bobbymcferrin/dontworrybehappy.html)

Hope this helps.

🌻 
