### PR TITLE
gjs, remove dbus dependency

### DIFF
--- a/gnome/gjs-devel/Portfile
+++ b/gnome/gjs-devel/Portfile
@@ -9,7 +9,7 @@ conflicts           gjs
 set my_name         gjs
 
 version             1.72.2
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
@@ -35,7 +35,6 @@ depends_build       port:pkgconfig \
 
 depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    port:dbus \
                     port:libffi \
                     path:lib/pkgconfig/cairo.pc:cairo \
                     port:mozjs91 \
@@ -62,7 +61,8 @@ configure.python    ${prefix}/bin/python3.10
 configure.args-append \
                     -Dprofiler=disabled \
                     -Dbsymbolic_functions=false \
-                    -Dskip_gtk_tests=true
+                    -Dskip_gtk_tests=true \
+                    -Dskip_dbus_tests=true
 
 gobject_introspection yes
 

--- a/gnome/gjs/Portfile
+++ b/gnome/gjs/Portfile
@@ -9,7 +9,7 @@ conflicts           gjs-devel
 set my_name         gjs
 
 version             1.72.2
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
@@ -35,7 +35,6 @@ depends_build       port:pkgconfig \
 
 depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    port:dbus \
                     port:libffi \
                     path:lib/pkgconfig/cairo.pc:cairo \
                     port:mozjs91 \
@@ -62,7 +61,8 @@ configure.python    ${prefix}/bin/python3.10
 configure.args-append \
                     -Dprofiler=disabled \
                     -Dbsymbolic_functions=false \
-                    -Dskip_gtk_tests=true
+                    -Dskip_gtk_tests=true \
+                    -Dskip_dbus_tests=true
 
 gobject_introspection yes
 


### PR DESCRIPTION
#### Description

This improves on #16144 which added in the dbus dependency. It turns out dbus is only needed for running dbus tests so we can avoid the dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? Tests fail
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Tests are failing, but previous version tests are also failing.