### PR TITLE
acpica: update to 20221022

### DIFF
--- a/devel/acpica/Portfile
+++ b/devel/acpica/Portfile
@@ -1,14 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 PortGroup           makefile 1.0
 
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-name                acpica
-version             20220331
+github.setup        acpica acpica R10_20_22
+version             20221022
 revision            0
 categories          devel
 # Comes with a restrictive Intel license in the source files, but the included
@@ -21,15 +22,10 @@ description         ACPI compiler
 long_description    A compiler for ACPI DSDT .asl files.
 
 homepage            https://acpica.org/
-master_sites        ${homepage}sites/acpica/files/ \
-                    https://ftp.OpenBSD.org/pub/OpenBSD/distfiles/ \
-                    https://mirror.sobukus.de/files/grimoire/devel/
 
-distname            acpica-unix-${version}
-
-checksums           rmd160  7a37d369701692eff82f2a9bd6b81da33e21ea69 \
-                    sha256  acaff68b14f1e0804ebbfc4b97268a4ccbefcfa053b02ed9924f2b14d8a98e21 \
-                    size    1911044
+checksums           rmd160  5e3bc16d798e4344035e0abac744b3e04f1c0e45 \
+                    sha256  1e2edbb00d76863d42df3fa2078b411d4bd2c86408ea71d350223dd24bf48635 \
+                    size    7478059
 
 depends_build       port:bison
 depends_skip_archcheck-append \
@@ -43,6 +39,8 @@ makefile.override-delete \
 
 # CFLAGS has MacPorts optimization
 build.args-append   OPT_CFLAGS=""
+
+supported_archs     x86_64 i386
 
 livecheck.regex     ${name}-unix-(\[0-9.\]+)${extract.suffix}
 livecheck.url       ${homepage}downloads/


### PR DESCRIPTION
moved to github

set supported_archs... this is Intel-specific software

closes: https://trac.macports.org/ticket/63811

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
