### PR TITLE
ofc: add fixes by upstream

### DIFF
--- a/lang/ofc/Portfile
+++ b/lang/ofc/Portfile
@@ -10,7 +10,7 @@ PortGroup           makefile 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        CodethinkLabs ofc 1 release/
-revision            0
+revision            1
 categories          lang
 license             Apache-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -23,12 +23,13 @@ checksums           rmd160  3435ba4379233f0a55014aa9509d68f5979dfac7 \
                     size    196221
 installs_libs       no
 
+# See: https://github.com/CodethinkLabs/ofc/issues/45
+patchfiles          patch-upstream.diff
+
 compiler.blacklist  *gcc-4.* {clang < 421}
 
 post-patch {
     reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/Makefile
-    # https://github.com/CodethinkLabs/ofc/issues/45
-    reinplace "s|-Werror||" ${worksrcpath}/Makefile
 
     if {${os.platform} eq "darwin" && ${os.major} < 11} {
         reinplace "s|LDFLAGS = -lm|LDFLAGS = -lm -lMacportsLegacySupport|" ${worksrcpath}/Makefile

--- a/lang/ofc/files/patch-upstream.diff
+++ b/lang/ofc/files/patch-upstream.diff
@@ -1,0 +1,74 @@
+--- src/colstr.c.orig	2017-10-24 19:11:59.000000000 +0800
++++ src/colstr.c	2023-02-02 19:44:09.000000000 +0800
+@@ -179,6 +179,9 @@
+ 	const char* prefix, char quote,
+ 	const char* base, unsigned size)
+ {
++	if (!base)
++		return false;
++
+ 	if (size < 2)
+ 	{
+ 		return ofc_colstr_atomic_writef(
+
+--- src/file.c.orig	2017-10-24 19:11:59.000000000 +0800
++++ src/file.c	2023-02-02 19:45:17.000000000 +0800
+@@ -286,6 +286,7 @@
+ 			case '\r':
+ 				/* Support Windows line endings when running on cygwin. */
+ 				if (file->strz[i + 1] == '\n') i++;
++				__attribute__ ((fallthrough));
+ 			case '\n':
+ 				r += 1;
+ 				c = 0;
+
+--- src/sema/typeval.c.orig	2017-10-24 19:11:59.000000000 +0800
++++ src/sema/typeval.c	2023-02-02 19:46:31.000000000 +0800
+@@ -1116,6 +1116,7 @@
+ 	ofc_sema_typeval_t tv;
+ 	tv.type = type;
+ 	tv.src  = typeval->src;
++	tv.integer = 0;
+ 
+ 	unsigned tsize, csize;
+ 	if (!ofc_sema_type_base_size(typeval->type, &tsize)
+@@ -1158,7 +1159,6 @@
+ 		ofc_sparse_ref_warning(typeval->src,
+ 			"Casting CHARACTER to INTEGER");
+ 
+-		tv.integer = 0;
+ 		memcpy(&tv.integer, typeval->character, csize);
+ 		return ofc_sema_typeval__alloc(tv);
+ 	}
+
+--- src/parse/lhs.c.orig	2017-10-24 19:11:59.000000000 +0800
++++ src/parse/lhs.c	2023-02-02 19:48:52.000000000 +0800
+@@ -65,7 +65,7 @@
+ 	if (!src || !dst)
+ 		return NULL;
+ 
+-	ofc_parse_lhs_t clone;
++	ofc_parse_lhs_t clone = {0};
+ 	clone.type = src->type;
+ 	clone.src  = src->src;
+ 
+@@ -456,7 +456,7 @@
+ 			return NULL;
+ 		}
+ 
+-		lhs->type = OFC_PARSE_EXPR_IMPLICIT_DO;
++		lhs->type = OFC_PARSE_LHS_IMPLICIT_DO;
+ 		lhs->src  = ofc_sparse_ref(src, ptr, l);
+ 		lhs->implicit_do = id;
+ 
+--- src/sema/expr.c.orig	2017-10-24 19:11:59.000000000 +0800
++++ src/sema/expr.c	2023-02-02 19:48:20.000000000 +0800
+@@ -2405,7 +2405,7 @@
+ 	for (i = 0; i < list->count; i++)
+ 	{
+ 		ofc_sema_expr_t* expr;
+-		if ((list->expr[i]->type == OFC_PARSE_EXPR_IMPLICIT_DO))
++		if (list->expr[i]->type == OFC_PARSE_EXPR_IMPLICIT_DO)
+ 		{
+ 			if (!allow_implicit_do)
+ 			{


### PR DESCRIPTION
See: https://github.com/CodethinkLabs/ofc/issues/45#issuecomment-1375907666

#### Description

Adds upstream fixes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
