### PR TITLE
qt5-qtwebengine-gn: disable livecheck, use Python 3.11

### DIFF
--- a/devel/gn-devel/Portfile
+++ b/devel/gn-devel/Portfile
@@ -54,16 +54,16 @@ if {${subport} eq ${name}} {
     # Use same ref as qt5-qtwebengine to reuse distfile,
     # even though bundled GN has not been updated since 5.15.10 (2082566)
     # See https://github.com/qt/qtwebengine-chromium/commits/87-based/gn
-    set qtwebengine_chromium_ref e0fd3a5d3ce79d43dee6e0bad16a71123d9a14b3
+    set qtwebengine_chromium_ref e48df7803c7c98b0b2471c94057d32e44a301ad5
     fetch.type      standard
     dist_subdir     qt5
     distname        qtwebengine-chromium-${qtwebengine_chromium_ref}
 
     master_sites    https://github.com/qt/qtwebengine-chromium/archive/${qtwebengine_chromium_ref}
 
-    checksums       rmd160  d406d6f6386638fab83d98c02949f7a15b94fad4 \
-                    sha256  40280a8c77bb00888e97774e7b3ab37587eecb92633d2ed42750690a9b0b7573 \
-                    size    462748015
+    checksums       rmd160  14b8d9fd1232e3ae4f3a3e5f08b068deadbce614 \
+                    sha256  a91686562b1d4e8b220e0bbcbab5feb64630e2de974b35ac034bf388af771a6c \
+                    size    462748468
 
     # Just extract gn; do not extract all of chromium (~2GB) or ninja
     worksrcdir      ${distname}/gn
@@ -101,13 +101,10 @@ if {${subport} eq ${name}} {
     # Does not affect building qt5-qtwebengine
     test.run        no
 
-    livecheck.type  regex
-    livecheck.url   https://github.com/qt/qtwebengine-chromium/commits/87-based/gn
-    livecheck.version ${hyphen_version}
-    livecheck.regex {<relative-time\s+datetime="(\d{4}-\d{2}-\d{2})T\d{2}:\d{2}:\d{2}Z"}
+    livecheck.type  none
 }
 
-set python_branch   3.10
+set python_branch   3.11
 set python_version  [string map {"." ""} ${python_branch}]
 
 depends_build-append \


### PR DESCRIPTION
#### Description
The gn sourcetree did not change in the qtwebengine 5.15.12 update, so the version change in 99450f0bdff78262168edd874efb0846e6bc4866 causes a livecheck error:

```
Error: livecheck failed for qt5-qtwebengine-gn: extracted version '2022-04-20' is older than livecheck.version '2022-12-09'
```

This PR ~~reverts the version change and tries to explain when to update it~~ disables the livecheck.


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12
Python 3.11

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
