### PR TITLE
fpm: fix build on <10.9

### DIFF
--- a/devel/fpm/Portfile
+++ b/devel/fpm/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
@@ -25,9 +26,11 @@ depends_build-append \
 
 # Change this, once older OSs are moved to gcc12/13.
 platform darwin {
-    if {${os.major} < 11} {
+    if {${os.major} < 13} {
         # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own.
+        # On 10.8.5 git fetch fails with ssl error.
         depends_build-append    port:git
+        git.cmd                 ${prefix}/bin/git
     }
     if {${os.major} < 10} {
         depends_run-append      port:gcc7
@@ -45,8 +48,9 @@ post-patch {
     reinplace "s,@VERSION@,${version},g" ${worksrcpath}/install.sh
 }
 
+# Xcode clang of 10.7 fails with error: invalid instruction mnemonic 'cvtsi2ssl'
 compiler.blacklist-append \
-                    *gcc-4.* macports-gcc-5 macports-gcc-6
+                    {clang < 500} *gcc-4.* macports-gcc-5 macports-gcc-6
 compilers.setup     require_fortran
 
 use_configure       no

--- a/devel/fpm/Portfile
+++ b/devel/fpm/Portfile
@@ -25,10 +25,14 @@ depends_build-append \
 
 # Change this, once older OSs are moved to gcc12/13.
 platform darwin {
+    if {${os.major} < 11} {
+        # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own.
+        depends_build-append    port:git
+    }
     if {${os.major} < 10} {
-        depends_run-append  port:gcc7
+        depends_run-append      port:gcc7
     } else {
-        depends_run-append  port:gcc12
+        depends_run-append      port:gcc12
     }
 }
 


### PR DESCRIPTION
#### Description

A quick fix for 10.6 and earlier: they need a build dependency on port:git.
Otherwise 10.6 fails: https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/138220
(Sorry, I missed that as I have git installed on 10.6.8.)

UPD. Looks like Macports git should be used on <10.9. Also Xcode clang of 10.7 blacklisted, see below.

Now, hopefully, it will build fine across the board.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
