### PR TITLE
clingo: fix build on 10.10–10.14; clingcon: fix build on aarch64

### DIFF
--- a/math/clingcon/Portfile
+++ b/math/clingcon/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 
 github.setup        potassco clingcon 5.2.0 v
@@ -30,6 +31,9 @@ depends_lib-append  port:clingo
 patchfiles          0001-catch.hpp-fix-for-aarch64-and-powerpc.patch
 
 compiler.cxx_standard 2017
+# Use the same blacklist as with its dependency clingo
+compiler.blacklist-append \
+                    {clang < 1200}
 
 configure.args-append \
                     -DPYCLINGCON_ENABLE=OFF \

--- a/math/clingcon/Portfile
+++ b/math/clingcon/Portfile
@@ -26,6 +26,9 @@ checksums           rmd160  2d10c0889c4cd987622119cfafdba4b282f83322 \
 
 depends_lib-append  port:clingo
 
+# https://github.com/potassco/clingcon/issues/99
+patchfiles          0001-catch.hpp-fix-for-aarch64-and-powerpc.patch
+
 compiler.cxx_standard 2017
 
 configure.args-append \

--- a/math/clingcon/Portfile
+++ b/math/clingcon/Portfile
@@ -9,7 +9,7 @@ github.setup        potassco clingcon 5.2.0 v
 categories          math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
-description         An Answer Set Programming system to ground and solve logic programs.
+description         Extension of clingo to handle constraints over integers
 long_description    Clingcon is an answer set solver for constraint logic programs, \
                     building upon the answer set solver clingo. It extends the high-level \
                     modeling language of ASP with constraint solving capacities. \

--- a/math/clingcon/files/0001-catch.hpp-fix-for-aarch64-and-powerpc.patch
+++ b/math/clingcon/files/0001-catch.hpp-fix-for-aarch64-and-powerpc.patch
@@ -1,0 +1,29 @@
+From f718d737563a76d31941ae484843ed3447daae92 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 11 Jan 2023 00:13:20 +0700
+Subject: [PATCH] catch.hpp: fix for aarch64 and powerpc
+
+---
+ libclingcon/tests/catch.hpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/libclingcon/tests/catch.hpp b/libclingcon/tests/catch.hpp
+index 51618b3..a514b84 100644
+--- libclingcon/tests/catch.hpp
++++ libclingcon/tests/catch.hpp
+@@ -7878,7 +7878,14 @@ namespace Catch {
+ 
+ #ifdef CATCH_PLATFORM_MAC
+ 
+-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
++    #if defined(__i386__) || defined(__x86_64__)
++        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
++    #elif defined(__aarch64__)
++        #define CATCH_TRAP() __asm__(".inst 0xd4200000")
++    #elif defined(__POWERPC__)
++        #define CATCH_TRAP() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
++        : : : "memory","r0","r3","r4" ) /* NOLINT */
++    #endif
+ 
+ #elif defined(CATCH_PLATFORM_IPHONE)
+ 

--- a/math/clingo/Portfile
+++ b/math/clingo/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 # posix_memalign
 PortGroup           legacysupport 1.1
@@ -33,6 +34,9 @@ checksums           rmd160  663e2df243efbf5ccca351ed5b55a82b2f1ce95c \
 conflicts           clasp
 
 compiler.cxx_standard   2014
+# https://github.com/potassco/clingo/issues/404
+compiler.blacklist-append \
+                        {clang < 1200}
 
 # TODO: Variants for enabling the python & lua libs.
 configure.args-append \

--- a/math/clingo/Portfile
+++ b/math/clingo/Portfile
@@ -5,8 +5,9 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
-# posix_memalign
 PortGroup           legacysupport 1.1
+
+# posix_memalign
 legacysupport.newest_darwin_requires_legacy 9
 
 github.setup        potassco clingo 5.6.2 v


### PR DESCRIPTION
#### Description

See: https://github.com/potassco/clingcon/issues/99
https://github.com/potassco/clingo/issues/404

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
