### PR TITLE
google-cloud-sdk: update to 413.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             412.0.0
+version             413.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  84cdfec6f1887a92db6eb61cc7e6d744285b33b0 \
-                    sha256  226e0adb212eb69070ad1c482af0f6583e8c1a8ef14c30238a0bb56eec01d109 \
-                    size    110533786
+    checksums       rmd160  18f887dd2da1d8fa11cdd7b869467984d43748cb \
+                    sha256  a90d086151eb4f333a3539e35eb0ddeb3d29fd1a7173203907bbc4c18b178a43 \
+                    size    110838137
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  2379b84d826d93430a7041589d45c113e4b1c115 \
-                    sha256  233aecd0ef927ee1aad285d2a8b4cb029df6d9143c91354c3f7a4ac800e5f29c \
-                    size    99504027
+    checksums       rmd160  980c9ec6810063f37b316e2be57d997d424303ef \
+                    sha256  595419a93c1fd8c59969aeb02e256002eceeadf2fa58cb393df9c20aa0d8b21d \
+                    size    99803819
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  976f50c9ef93355a43586d163a301ca15c98ab7a \
-                    sha256  509f7fd522ef2ea36a3742e46e9586b86cbe7793f4b9467e3c967e71bdd36223 \
-                    size    97911731
+    checksums       rmd160  eff3045b04bc17924cae93f4076a992c90366fff \
+                    sha256  cc247ae59d7c92e18d4a5e5e94b00b755c9e0bb76035b30205190a753c51e122 \
+                    size    98216040
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 413.0.0.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?