### PR TITLE
minpack: update to current version, unbreak the port

### DIFF
--- a/math/minpack/Portfile
+++ b/math/minpack/Portfile
@@ -5,22 +5,21 @@ PortSystem          1.0
 name                minpack
 version             19961126
 categories          math devel
-license             bsd
-platforms           darwin
+license             BSD
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
-description         Minpack includes software for solving nonlinear equations\
-    and nonlinear least squares problems.
+description         Minpack includes software for solving nonlinear equations \
+                    and nonlinear least squares problems.
 
-long_description    Minpack includes software for solving nonlinear\
-    equations and nonlinear least squares problems.  Five algorithmic\
-    paths each include a core subroutine and an easy-to-use driver.  The\
-    algorithms proceed either from an analytic specification of the\
-    Jacobian matrix or directly from the problem functions.  The paths\
-    include facilities for systems of equations with a banded Jacobian\
-    matrix, for least squares problems with a large amount of data, and\
-    for checking the consistency of the Jacobian matrix with the\
-    functions.
+long_description    Minpack includes software for solving nonlinear equations \
+                    and nonlinear least squares problems. Five algorithmic paths \
+                    each include a core subroutine and an easy-to-use driver. \
+                    The algorithms proceed either from an analytic specification \
+                    of the Jacobian matrix or directly from the problem functions. \
+                    The paths include facilities for systems of equations \
+                    with a banded Jacobian matrix, for least squares problems \
+                    with a large amount of data, and for checking the consistency \
+                    of the Jacobian matrix with the functions.
 
 homepage            http://www.netlib.org/minpack/
 master_sites        http://ftp.debian.org/debian/pool/main/m/minpack/

--- a/math/minpack/Portfile
+++ b/math/minpack/Portfile
@@ -1,9 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           meson 1.0
 
-name                minpack
-version             19961126
+github.setup        fortran-lang minpack c0b5aea9fcd2b83865af921a7a7e881904f8d3c2
+version             20220613
+revision            0
 categories          math devel
 license             BSD
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
@@ -21,49 +25,30 @@ long_description    Minpack includes software for solving nonlinear equations \
                     with a large amount of data, and for checking the consistency \
                     of the Jacobian matrix with the functions.
 
-homepage            http://www.netlib.org/minpack/
-master_sites        http://ftp.debian.org/debian/pool/main/m/minpack/
+checksums           rmd160  7b05267755fbe5720112532a1ea5104adfedb451 \
+                    sha256  750792dc8d9911f0786774c201c14ef5d6037a2b41b33ba938463a79c3690409 \
+                    size    9672292
 
-set patch_version       16
+set py_ver          3.11
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:py${py_ver_nodot}-cffi \
+                    port:python${py_ver_nodot}
 
-distfiles           ${name}_${version}.orig.tar.gz\
-    ${name}_${version}-${patch_version}.diff.gz
+compilers.choose    fc
+compilers.setup     require_fortran
 
-checksums           minpack_${version}.orig.tar.gz \
-                    rmd160  a22ca3230cd3a4cf9f71774a146d456ac48aff70 \
-                    sha256  afd0e514d256f053aca8b48071412a39c36ff74b76ec0d48ab3e9d9be9c48a11 \
-                    minpack_${version}-${patch_version}.diff.gz \
-                    rmd160  df70756913760ada08b7acbefec4f094b9c5db84 \
-                    sha256  5647d2a0f3d494b56c6fb249dd159d583c864a6a4bef9ab90d1717534fdd880a
-
-extract.only        ${name}_${version}.orig.tar.gz
-
-worksrcdir          ${name}-${version}.orig
-
-patchfiles           minpack_${version}-${patch_version}.diff.gz
-patch.pre_args	     -p1
+compiler.c_standard 2011
 
 post-patch {
-    system "chmod +x ${worksrcpath}/configure"
+    reinplace "s,env python,env ${prefix}/bin/python${py_ver}," ${worksrcpath}/config/install-mod.py
 }
 
-variant gcc47 conflicts gcc48 gcc49 description {Use the gcc47 compiler} {
-    configure.compiler  macports-gcc-4.7
-}
-variant gcc48 conflicts gcc47 gcc49 description {Use the gcc48 compiler} {
-    configure.compiler  macports-gcc-4.8
-}
-variant gcc49 conflicts gcc47 gcc48 description {Use the gcc49 compiler} {
-    configure.compiler  macports-gcc-4.9
-}
-if { ![variant_isset gcc48] && ![variant_isset gcc49] } {
-	default_variants      +gcc47
-}
+configure.args-append \
+                    -Dapi=true \
+                    -Dpython=true \
+                    -Dpython_version=${prefix}/bin/python${py_ver}
 
-post-destroot {
-    set docdir ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 755 -d ${docdir}
-    xinstall -m 644 ${worksrcpath}/ex/file06 ${docdir}/minpack-documentation.txt
-    xinstall -m 644 ${worksrcpath}/readme ${docdir}/readme
-    xinstall -m 644 ${worksrcpath}/debian/copyright ${docdir}/copyright
-}
+test.run            yes
+test.target         test


### PR DESCRIPTION
#### Description

`minpack` is archaic and fails across the board: https://ports.macports.org/port/minpack/details/
Fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing minpack
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_minpack/minpack/work/build" && /opt/local/bin/ninja test 
[0/1] Running all tests.
 1/12 minpack:example / hybrd  OK              0.27s
 2/12 minpack:example / hybrd1 OK              0.26s
 3/12 minpack:example / lmder1 OK              0.24s
 4/12 minpack:example / lmdif1 OK              0.22s
 5/12 minpack:example / primes OK              0.20s
 6/12 minpack:unit / chkder    OK              0.18s
 7/12 minpack:unit / hybrd     OK              0.32s
 8/12 minpack:unit / hybrj     OK              0.31s
 9/12 minpack:api / c-api      OK              0.16s
10/12 minpack:unit / lmder     OK              0.26s
11/12 minpack:unit / lmdif     OK              0.24s
12/12 minpack:unit / lmstr     OK              0.22s

Ok:                 12  
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0
```