### PR TITLE
nco: update to 5.1.4

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.1.3
+github.setup        nco nco 5.1.4
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
@@ -21,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  24bad8ca743b6e59ac26c6fae9c103d80ebf90c0 \
-                    sha256  e38b6533912f3fbb39749b21088742bfca84c11ef1b3927f2eb04873ca5f7427 \
-                    size    6440692
+checksums           rmd160  e739fead0522aca07111988a9cb7c8bdae76e9eb \
+                    sha256  99fe7bea1e7ba3b433876725d1e4c1908ec73ec944fabb5570b78c02ea7e0bdc \
+                    size    6454205
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Simple update to upstream version 5.1.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 x86_64
Command Line Tools 14.2.0.0.1.1668646533
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
