### PR TITLE
gklib: unbreak build on PPC

### DIFF
--- a/math/gklib/Portfile
+++ b/math/gklib/Portfile
@@ -19,6 +19,8 @@ checksums           rmd160  a6ad0814ebf3cc0c39bdd68601c95cadbc37499d \
                     sha256  66e6881fe1568b703e75c625f80de9707e23e1fa2b72e8501914516295b7626b \
                     size    186076
 
+patchfiles          0001-Do-not-use-invalid-march-flag-on-PPC-fix-the-build.patch
+
 compiler.thread_local_storage   yes
 
 configure.args-append \

--- a/math/gklib/files/0001-Do-not-use-invalid-march-flag-on-PPC-fix-the-build.patch
+++ b/math/gklib/files/0001-Do-not-use-invalid-march-flag-on-PPC-fix-the-build.patch
@@ -1,0 +1,27 @@
+From df55144625685640b9f170761ddd789a352a78a3 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 11 Jan 2023 20:50:54 +0700
+Subject: [PATCH] Do not use invalid -march= flag on PPC, fix the build
+
+---
+ GKlibSystem.cmake | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/GKlibSystem.cmake b/GKlibSystem.cmake
+index a8aa155..31a1cf1 100644
+--- GKlibSystem.cmake
++++ GKlibSystem.cmake
+@@ -33,8 +33,13 @@ if(CMAKE_COMPILER_IS_GNUCC)
+   set(GKlib_COPTIONS "${GKlib_COPTIONS} -std=c99 -fno-strict-aliasing")
+ if(VALGRIND)
+   set(GKlib_COPTIONS "${GK_COPTIONS} -march=x86-64 -mtune=generic")
++else()
++# -march=native is not a valid flag on PPC:
++if(CMAKE_SYSTEM_PROCESSOR MATCHES "power|ppc|powerpc|ppc64|powerpc64" OR (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64"))
++  set(GKlib_COPTIONS "${GKlib_COPTIONS} -mtune=native")
+ else()
+   set(GKlib_COPTIONS "${GKlib_COPTIONS} -march=native")
++endif()
+ endif(VALGRIND)
+   if(NOT MINGW)
+       set(GKlib_COPTIONS "${GKlib_COPTIONS} -fPIC")


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66662

#### Description

Usual problem, `-march=native` is breaking PPC. Use `-mtune=native` instead. See: https://gcc.gnu.org/onlinedocs/gcc/RS_002f6000-and-PowerPC-Options.html
PR to upstream: https://github.com/KarypisLab/GKlib/pull/22

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
