### PR TITLE
libopenmpt: new port in audio

### DIFF
--- a/audio/libopenmpt/Portfile
+++ b/audio/libopenmpt/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             libopenmpt
+version          0.7.0
+revision         0
+categories       audio devel multimedia
+license          BSD
+maintainers      nomaintainer
+description      Library to decode tracked music files
+long_description ${name} is a cross-platform C++ and C library to decode \
+    tracked music files (modules) into a raw PCM audio stream.
+homepage         https://lib.openmpt.org/
+
+master_sites     https://lib.openmpt.org/files/libopenmpt/src/
+distname         ${name}-${version}+release.autotools
+checksums        rmd160 1455f0223135a9795ac61f19651e724d51bc8617 \
+                 sha256 411796b55aef73cab09c7a6e65d33f1d7bf4ee7fc2dade6bc8de5138dedcc6d1 \
+                 size   1645663
+livecheck.url    https://lib.openmpt.org/files/libopenmpt/src/
+
+depends_build    port:pkgconfig
+depends_lib      port:flac \
+                 port:libogg \
+                 port:libsndfile \
+                 port:libvorbis \
+                 port:mpg123 \
+                 port:portaudio \
+                 port:zlib
+
+compiler.cxx_standard 2017
+
+configure.args \
+    --disable-dependency-tracking \
+    --disable-silent-rules


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> _(no existing tickets)_
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? _(no existing tests)_
- [ ] tried a full install with `sudo port -vst install`? _(flag_ -t _does not work on my system for any port)_
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? _(no variants)_

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
