### PR TITLE
llvm-15 fixes: fix -fopenmp and i386/x86_64 build

### DIFF
--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -28,7 +28,7 @@ version                 ${llvm_version}.0.6
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision 0 }
-subport                 clang-${llvm_version} { revision 0 }
+subport                 clang-${llvm_version} { revision 1 }
 subport                 lldb-${llvm_version}  { revision 0 }
 subport                 flang-${llvm_version} { revision 0 }
 

--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -133,7 +133,8 @@ patchfiles-append \
     0014-Fix-float.h-to-work-on-Snow-Leopard-and-earlier.patch \
     0015-Fixup-libstdc-header-search-paths-for-older-versions.patch \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
-    0025-lldb-add-defines-needed-for-older-SDKs.patch
+    0025-lldb-add-defines-needed-for-older-SDKs.patch \
+    0999-i386-fix.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     patchfiles-append \

--- a/lang/llvm-15/files/0001-MacPorts-only-clang-use-MP-omp-locations.patch
+++ b/lang/llvm-15/files/0001-MacPorts-only-clang-use-MP-omp-locations.patch
@@ -26,25 +26,33 @@ diff --git a/clang/lib/Driver/ToolChains/CommonArgs.cpp b/clang/lib/Driver/ToolC
 index bcaea71dca94..a88833055be7 100644
 --- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
 +++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
-@@ -668,12 +668,18 @@ bool tools::addOpenMPRuntime(ArgStringList &CmdArgs, const ToolChain &TC,
+@@ -652,25 +652,17 @@
  
-   switch (RTKind) {
-   case Driver::OMPRT_OMP:
-+    // Automatically find MacPorts' libomp
-+    CmdArgs.push_back("-L@@PREFIX@@/lib/libomp");
-     CmdArgs.push_back("-lomp");
-     break;
-   case Driver::OMPRT_GOMP:
-+    // Automatically find MacPorts' libomp
-+    CmdArgs.push_back("-L@@PREFIX@@/lib/libomp");
-     CmdArgs.push_back("-lgomp");
-     break;
-   case Driver::OMPRT_IOMP5:
-+    // Automatically find MacPorts' libomp
-+    CmdArgs.push_back("-L@@PREFIX@@/lib/libomp");
-     CmdArgs.push_back("-liomp5");
-     break;
-   case Driver::OMPRT_Unknown:
--- 
-2.21.1 (Apple Git-122.3)
-
+   if (Args.hasFlag(options::OPT_fopenmp_implicit_rpath,
+                    options::OPT_fno_openmp_implicit_rpath, true)) {
+-    // Default to clang lib / lib64 folder, i.e. the same location as device
+-    // runtime
+-    SmallString<256> DefaultLibPath =
+-        llvm::sys::path::parent_path(TC.getDriver().Dir);
+-    llvm::sys::path::append(DefaultLibPath, Twine("lib") + CLANG_LIBDIR_SUFFIX);
++    // MacPorts's runtime
+     CmdArgs.push_back("-rpath");
+-    CmdArgs.push_back(Args.MakeArgString(DefaultLibPath));
++    CmdArgs.push_back("@@PREFIX@@/lib/libomp");
+   }
+ }
+ 
+ void tools::addOpenMPRuntimeLibraryPath(const ToolChain &TC,
+                                         const ArgList &Args,
+                                         ArgStringList &CmdArgs) {
+-  // Default to clang lib / lib64 folder, i.e. the same location as device
+-  // runtime.
+-  SmallString<256> DefaultLibPath =
+-      llvm::sys::path::parent_path(TC.getDriver().Dir);
+-  llvm::sys::path::append(DefaultLibPath, Twine("lib") + CLANG_LIBDIR_SUFFIX);
+-  CmdArgs.push_back(Args.MakeArgString("-L" + DefaultLibPath));
++  // Automatically find MacPorts's libomp
++  CmdArgs.push_back("-L@@PREFIX@@/lib/libomp");
+ }
+ 
+ void tools::addArchSpecificRPath(const ToolChain &TC, const ArgList &Args,

--- a/lang/llvm-15/files/0999-i386-fix.diff
+++ b/lang/llvm-15/files/0999-i386-fix.diff
@@ -1,0 +1,29 @@
+On x86_64 systems, assembly files are included in the build
+(see https://github.com/llvm/llvm-project/blob/1095870e8ceddc5371f446f4e7c3473f89a461cd/llvm/lib/Support/BLAKE3/CMakeLists.txt#L63).
+These assembly files files add symbols.       
+
+On i386  systems, the assembly files are not included but the symbols are never used.
+(see https://github.com/llvm/llvm-project/blob/1095870e8ceddc5371f446f4e7c3473f89a461cd/llvm/lib/Support/BLAKE3/CMakeLists.txt#L14).
+
+On i386/x86_64 universal builds, the symbols are used but do not exist, causing a link error.
+
+This patch attempts to prevent the use of nonexistent symbols.
+
+See https://github.com/llvm/llvm-project/issues/59965
+
+--- a/llvm/lib/Support/BLAKE3/blake3_impl.h	2022-11-29 03:05:58.000000000 -0700
++++ b/llvm/lib/Support/BLAKE3/blake3_impl.h	2023-01-11 11:28:42.000000000 -0700
+@@ -78,6 +78,13 @@
+ #define MAX_SIMD_DEGREE 1
+ #endif
+ 
++#if defined(__i386__)
++#define BLAKE3_NO_AVX512
++#define BLAKE3_NO_AVX2
++#define BLAKE3_NO_SSE41
++#define BLAKE3_NO_SSE2
++#endif
++
+ // There are some places where we want a static size that's equal to the
+ // MAX_SIMD_DEGREE, but also at least 2.
+ #define MAX_SIMD_DEGREE_OR_2 (MAX_SIMD_DEGREE > 2 ? MAX_SIMD_DEGREE : 2)


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
