### PR TITLE
micronaut: update to 3.8.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.8.0 v
+github.setup    micronaut-projects micronaut-starter 3.8.1 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  4c322c39c43d91525288fdafde6fb1b587ee954e \
-                sha256  c544be48c8c97fba84949af60411fc639970e669e3eb770d3a0221508452eccc \
-                size    20149328
+checksums       rmd160  895814ff30d16c3d667d8146d6ca85c7bd00e86d \
+                sha256  465ea729e69b0b322d6f6a016d6030ce3d5545af7183729a6e9761c8afb4b99c \
+                size    20146370
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.8.1.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?