### PR TITLE
gegl: add patch to fix build with LIBRAW 0.21

### DIFF
--- a/graphics/gegl/Portfile
+++ b/graphics/gegl/Portfile
@@ -10,7 +10,7 @@ name                gegl
 conflicts           gegl-devel
 set my_name         gegl
 version             0.4.40
-revision            0
+revision            1
 epoch               1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 license             {GPL-3+ LGPL-3+}
@@ -68,6 +68,10 @@ depends_lib-append \
 # proposed fix for 32 bit builds
 # https://trac.macports.org/ticket/58524
 patchfiles-append   patch-gegl-32bit-host-statistics.diff
+
+# temporary fix for LIBRAW update to 0.21
+# https://trac.macports.org/ticket/66667
+patchfiles-append   patch-fix-raw-load.c.diff
 
 post-patch {
     # https://trac.macports.org/ticket/35148

--- a/graphics/gegl/files/patch-fix-raw-load.c.diff
+++ b/graphics/gegl/files/patch-fix-raw-load.c.diff
@@ -1,0 +1,15 @@
+--- operations/external/raw-load.c.orig
++++ operations/external/raw-load.c
+@@ -114,8 +114,11 @@ prepare (GeglOperation *operation)
+         g_warning ("raw-load: Error Initializing raw library");
+       else
+         {
++#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
++          p->LibRaw->rawparams.shot_select = o->image_num;
++#else
+           p->LibRaw->params.shot_select = o->image_num;
+-    
++#endif
+           p->LibRaw->params.aber[0] = 1.0;
+           p->LibRaw->params.aber[2] = 1.0;
+           //p->LibRaw->params.gamm[0] = 1.0 / 2.4;


### PR DESCRIPTION
#### Description

gegl: add patch to fix build with LIBRAW 0.21

Closes: https://trac.macports.org/ticket/66667

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.3 20G1102 x86_64
Xcode 12.3 12C33

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
