### PR TITLE
adept2: new port in math

### DIFF
--- a/math/adept2/Portfile
+++ b/math/adept2/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+
+github.setup        rjhogan Adept-2 752e4b3bd702d56369e4ff10b81ac3e065671e95
+name                adept2
+version             2023.01.13
+revision            0
+categories          math
+license             Apache-2
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Fast automatic differentiation library in C++
+long_description    Combined array and automatic differentiation library in C++.
+homepage            https://www.met.reading.ac.uk/clouds/adept
+checksums           rmd160  4a27d647c2c9ffc586b4e80a99ce23124117febd \
+                    sha256  4c81246b3d7b5e6669f3755788c0fef084e965327b886a35b736487a51a6e569 \
+                    size    327096
+
+use_autoreconf      yes
+
+depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS
+
+compilers.choose    fc f90 f77
+compilers.setup     require_fortran
+
+# https://github.com/rjhogan/Adept-2/issues/25
+# Until this is fixed: https://github.com/iains/darwin-toolchains-start-here/discussions/41
+compiler.blacklist-append \
+                    macports-gcc-12
+compiler.thread_local_storage yes
+
+# https://github.com/rjhogan/Adept-2/issues/24
+patchfiles          patch-include.diff
+
+post-patch {
+    reinplace "s|include <cblas.h>|include <cblas_openblas.h>|" ${worksrcpath}/configure.ac
+    reinplace "s|cblas.h|cblas_openblas.h|" ${worksrcpath}/adept/settings.cpp
+}
+
+pre-configure {
+    configure.args-append \
+                    --with-blas="-L${prefix}/lib -lopenblas"
+}
+
+depends_test-append port:gsl
+
+test.run            yes
+test.target         check

--- a/math/adept2/files/patch-include.diff
+++ b/math/adept2/files/patch-include.diff
@@ -1,0 +1,29 @@
+--- include/create_adept_source_header.orig	2022-12-18 04:01:21.000000000 +0700
++++ include/create_adept_source_header	2023-01-13 05:25:29.000000000 +0700
+@@ -48,23 +48,16 @@
+ 
+ */
+ 
+-/* Feel free to delete this warning: */
+-#ifdef _MSC_FULL_VER 
+-#pragma message(\"warning: the adept_source.h header file has not been edited so BLAS matrix multiplication and LAPACK linear-algebra support have been disabled\")
+-#else
+-#warning \"The adept_source.h header file has not been edited so BLAS matrix multiplication and LAPACK linear-algebra support have been disabled\"
+-#endif
+-
+ /* Uncomment this if you are linking to the BLAS library (header file
+    not required) to enable matrix multiplication */
+-//#define HAVE_BLAS 1
++#define HAVE_BLAS 1
+ 
+ /* Uncomment this if you are linking to the LAPACK library (header
+    file not required) */
+-//#define HAVE_LAPACK 1
++#define HAVE_LAPACK 1
+ 
+ /* Uncomment this if you have the cblas.h header from OpenBLAS */
+-//#define HAVE_OPENBLAS_CBLAS_HEADER
++#define HAVE_OPENBLAS_CBLAS_HEADER
+ 
+ /*
+ 


### PR DESCRIPTION
#### Description

New port in math: https://github.com/rjhogan/Adept-2
http://www.met.reading.ac.uk/clouds/adept

Github version is used since several bugs were just fixed there.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
test_adept... PASSED
test_adept_with_and_without_ad... PASSED
test_radiances... PASSED
test_gsl_interface... PASSED
test_misc... PASSED
test_checkpoint... PASSED
test_thread_safe... PASSED
test_array_speed... PASSED
test_no_lib... PASSED
test_radiances_array... PASSED
test_constructors... PASSED
test_arrays... PASSED
test_arrays_active... PASSED
test_arrays_active_pausable... PASSED
test_fixed_arrays... PASSED
test_fixed_arrays_active... PASSED
test_derivatives... PASSED
test_array_derivatives... PASSED
test_thread_safe_arrays... PASSED
test_complex_arrays... PASSED
test_packet_operations... PASSED
test_fastexp... PASSED
test_reduce_active... PASSED
test_minimizer... PASSED

All test programs ran successfully
```