### PR TITLE
jc: update to 1.22.5

### DIFF
--- a/sysutils/jc/Portfile
+++ b/sysutils/jc/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    jc
-version                 1.22.4
+version                 1.22.5
 revision                0
 
 homepage                https://pypi.org/project/jc
@@ -23,9 +23,9 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
 supported_archs         noarch
 platforms               {darwin any}
 
-checksums               rmd160  78a74d3d62ca3d0364c777069fc4d38a2027387e \
-                        sha256  4088d599834eea242538dbd4011d3efd8fa0d2a43887d6813a904309f040bdaa \
-                        size    403005
+checksums               rmd160  e69d70a402a99579d38e1bcee421193c30c9d2b1 \
+                        sha256  79a184b6036d82847ce8d0f0b5f4eaa7023c20878137d909c06b1645d331eec5 \
+                        size    412583
 
 python.default_version  310
 


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/kellyjonbrazil/jc/releases/tag/v1.22.5)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
