### PR TITLE
primme: new port in math

### DIFF
--- a/math/primme/Portfile
+++ b/math/primme/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           linear_algebra 1.0
+PortGroup           makefile 1.0
+
+github.setup        primme primme 3.2 v
+revision            0
+categories          math
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         PReconditioned Iterative MultiMethod Eigensolver for solving \
+                    symmetric/Hermitian eigenvalue problems and singular value problems
+long_description    {*}${description}
+homepage            https://www.cs.wm.edu/~andreas/software
+checksums           rmd160  7b9ef36623ab4faa90b46b1eabac0300a76088cb \
+                    sha256  2484f53a9d7b9900a6bfd7b2aa4f3a1217fa55815e67df479b892a628109bec7 \
+                    size    17446854
+
+compilers.choose    fc f90 f77 cc
+compilers.setup     require_fortran
+
+# Static lib target is needed to run tests; only dylib is installed.
+build.target        lib solib
+
+test.run            yes
+test.target         test


### PR DESCRIPTION
#### Description

New port in math: https://github.com/primme/primme

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Tests pass in Rosetta:
```
------------------------------------------------
 Test C examples                                
------------------------------------------------
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -Os -arch ppc -arch ppc -DF77UNDERSCORE  -I../include -c ex_eigs_dseq.c -o ex_eigs_dseq.o
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -o ex_eigs_dseq ex_eigs_dseq.o  -I../include ../lib/libprimme.a -llapack -lblas -lm -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-rpath,/opt/local/lib/libgcc -arch ppc -arch ppc 
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -Os -arch ppc -arch ppc -DF77UNDERSCORE  -I../include -c ex_eigs_zseq.c -o ex_eigs_zseq.o
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -o ex_eigs_zseq ex_eigs_zseq.o  -I../include ../lib/libprimme.a -llapack -lblas -lm -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-rpath,/opt/local/lib/libgcc -arch ppc -arch ppc 
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -Os -arch ppc -arch ppc -DF77UNDERSCORE  -I../include -c ex_eigs_zseq_normal.c -o ex_eigs_zseq_normal.o
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -o ex_eigs_zseq_normal ex_eigs_zseq_normal.o  -I../include ../lib/libprimme.a -llapack -lblas -lm -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-rpath,/opt/local/lib/libgcc -arch ppc -arch ppc 
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -Os -arch ppc -arch ppc -DF77UNDERSCORE  -I../include -c ex_svds_dseq.c -o ex_svds_dseq.o
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -o ex_svds_dseq ex_svds_dseq.o  -I../include ../lib/libprimme.a -llapack -lblas -lm -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-rpath,/opt/local/lib/libgcc -arch ppc -arch ppc 
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -Os -arch ppc -arch ppc -DF77UNDERSCORE  -I../include -c ex_svds_zseq.c -o ex_svds_zseq.o
/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_primme/primme/work/compwrap/cc/usr/bin/gcc-4.2 -o ex_svds_zseq ex_svds_zseq.o  -I../include ../lib/libprimme.a -llapack -lblas -lm -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-rpath,/opt/local/lib/libgcc -arch ppc -arch ppc 
All tests passed!
```