### PR TITLE
bitwarden-cli: update to 2023.1.0

### DIFF
--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                bitwarden-cli
-version             2022.11.0
+version             2023.1.0
 revision            0
 
 npm.rootname        @bitwarden/cli
@@ -19,6 +19,6 @@ description         Bitwarden password manager CLI
 long_description    CLI implementation of the Bitwarden password manager.
 homepage            https://bitwarden.com
 
-checksums           rmd160  6ab0b967eb6e0d64cfcb8d0ce54e7846dd15a047 \
-                    sha256  9c234a5b86d8f53503b96aa236da011b6c5af71a2c16f81a9e23aa1a6d9b6ce4 \
-                    size    606735
+checksums           rmd160  92da4b7495903000173a359dedfffd18d8b91a39 \
+                    sha256  bf78a56b28193db7cfd0851ff58a0fe24b89f47e97e57094219ef5f901b1e4d3 \
+                    size    612101


### PR DESCRIPTION
#### Description
bitwarden-cli: update to 2023.1.0
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
