### PR TITLE
flux: update to 0.38.3

### DIFF
--- a/sysutils/flux/Portfile
+++ b/sysutils/flux/Portfile
@@ -3,12 +3,12 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/fluxcd/flux2 0.38.2 v
+go.setup                github.com/fluxcd/flux2 0.38.3 v
 name                    flux
 
-checksums               rmd160  4dd14b020a395acb92e35ffcfa66d8020616a0d7 \
-                        sha256  e24dfe2569c2292e2ae8edf19023a96ff784ea09646a817ecd85f9b97f375451 \
-                        size    388229
+checksums               rmd160  4d53205f20658196044c38d8b8a34cec8a6cb7a1 \
+                        sha256  ce0d9d914c6b9d9de47bd86f3765dc382f85f41d0e9df900ef85290086203c65 \
+                        size    388252
 
 homepage                https://fluxcd.io/
 description             Flux CLI


### PR DESCRIPTION
#### Description
flux: update to 0.38.3
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
