### PR TITLE
terragrunt: update to 0.42.8

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -19,11 +19,11 @@ set latestVersion       terragrunt-0.42
 
 subport terragrunt-0.42 {
     set dependsOn       1.2
-    set patchNumber     2
+    set patchNumber     8
 
-    checksums           rmd160  7040741e7d9ed49ccdc2d7efe24c642127f764d9 \
-                        sha256  3cb65b86ecf72781a98f5aa2dd7b55ad773692f6e1d0d84182a17b5542ce8448 \
-                        size    2308445
+    checksums           rmd160  d85c229a2cd33551310159106f0ee6c91ed8d0b1 \
+                        sha256  fb211253b52e4280195db078917085ffca9cae1aa043fefd02bdfa96d5a7aa72 \
+                        size    2316370
 }
 
 subport terragrunt-0.41 {


### PR DESCRIPTION
#### Description
terragrunt: update to 0.42.8
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
