### PR TITLE
ansible-lint: update to 6.10.2

### DIFF
--- a/devel/yamllint/Portfile
+++ b/devel/yamllint/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        adrienverge yamllint 1.29.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          devel python
 supported_archs     noarch
@@ -24,7 +24,8 @@ checksums           rmd160  448d8ca2757cf45b0401f687b90a7a4c74613787 \
                     sha256  8593180056e788b595e476b3d093146988dcc04452b72ae9d41dfc9d25e484cb \
                     size    122426
 
-python.default_version 311
+# Keep Python version compatible with ansible-lint
+python.default_version 310
 
 depends_build       port:py${python.version}-setuptools
 depends_run         port:py${python.version}-pathspec \

--- a/sysutils/ansible-lint/Portfile
+++ b/sysutils/ansible-lint/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        ansible-community ansible-lint 6.9.1 v
+github.setup        ansible-community ansible-lint 6.10.2 v
 revision            0
 
 categories          sysutils
@@ -19,9 +19,9 @@ description         Best practices checker for Ansible playbooks
 long_description \
     ansible-lint checks playbooks for practices and behaviour that could potentially be improved
 
-checksums           rmd160  e295dbc57a91ccba570cd3464744163a550232c3 \
-                    sha256  7827211ac60e3f0714770bb7ebb4c61b76cacefd273c4b15ea118379a6c03efd \
-                    size    388382
+checksums           rmd160  dca4c08e0df20c23c1cab6ee15da571ab530a94f \
+                    sha256  f24bb073b9cdc1580c204e52bf18c8f2c19033ac954ed401626d21513adee5ae \
+                    size    397647
 
 python.default_version      310
 python.link_binaries_suffix
@@ -47,9 +47,6 @@ depends_lib-append  port:py${python.version}-enrich \
 
 # Stop setuptools from using the scm version which doesn't exist in this context
 patchfiles          patch-disable_use_scm_version.diff
-post-patch {
-    reinplace "s|@@VERSION@@|${version}|g" ${worksrcpath}/setup.cfg
-}
 
 python.pep517       yes
 

--- a/sysutils/ansible-lint/files/patch-disable_use_scm_version.diff
+++ b/sysutils/ansible-lint/files/patch-disable_use_scm_version.diff
@@ -1,32 +1,11 @@
---- pyproject.toml.orig	2022-03-23 10:12:03.000000000 +0200
-+++ pyproject.toml	2022-03-25 11:27:17.000000000 +0200
-@@ -1,8 +1,6 @@
+--- pyproject.toml.orig	2023-01-13 23:35:54
++++ pyproject.toml	2023-01-13 23:35:53
+@@ -1,7 +1,6 @@
  [build-system]
  requires = [
--  "setuptools >= 42.0.0", # required by pyproject+setuptools_scm integration
--  "setuptools_scm[toml] >= 3.5.0", # required for "no-local-version" scheme
--  "setuptools_scm_git_archive >= 1.0",
-+  "setuptools >= 42.0.0",
-   "wheel",
+-  "setuptools >= 63.0.0", # required by pyproject+setuptools_scm integration
+-  "setuptools_scm[toml] >= 7.0.5", # required for "no-local-version" scheme
++  "setuptools >= 63.0.0"
+
  ]
  build-backend = "setuptools.build_meta"
-
---- setup.cfg.orig	2022-11-21 02:17:27.000000000 +0200
-+++ setup.cfg	2022-11-22 21:17:08.322183925 +0200
-@@ -1,6 +1,7 @@
- # spell-checker:ignore apidoc programoutput sphinxcontrib
- [metadata]
- name = ansible-lint
-+version = @@VERSION@@
- url = https://github.com/ansible/ansible-lint
- project_urls =
-   Bug Tracker = https://github.com/ansible/ansible-lint/issues
-@@ -55,7 +56,6 @@
-   lint
- 
- [options]
--use_scm_version = True
- python_requires = >=3.8
- package_dir =
-   = src
-


### PR DESCRIPTION
#### Description
ansible-lint: update to 6.10.2
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
