### PR TITLE
py-dulwich: add python3.7 subport

### DIFF
--- a/python/py-dulwich/Portfile
+++ b/python/py-dulwich/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  75b0e9721c937b038855b504007e29515c07c714 \
                     sha256  50a941796b2c675be39be728d540c16b5b7ce77eb9e1b3f855650ece6832d2be \
                     size    430389
 
-python.versions     27 38 39 310 311
+python.versions     27 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     # 0.20 dropped support for Python 2.7


### PR DESCRIPTION
#### Description

Dulwich supports 3.6+, and 3.7 is a dependency of poetry 3.7, so add it here. Looking at the Portfile history it seems just an oversight that dulwich was not provided on 3.7.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
