### PR TITLE
linalg: new port in math

### DIFF
--- a/math/linalg/Portfile
+++ b/math/linalg/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           linear_algebra 1.0
+
+github.setup        jchristopherson linalg 9807650d97243f3b04728b299ebb245308b598f5
+version             1.7.1
+revision            0
+categories          math science
+license             GPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Linear algebra library that provides a user-friendly interface \
+                    to several BLAS and LAPACK routines
+long_description    {*}${description}
+checksums           rmd160  91add2f5843a568d59415fbae093e4ee5ce7f772 \
+                    sha256  7b64f6e1aba6c3a5980c1c87b344cc24d86abcbad010bf8fa8df8779795c53d2 \
+                    size    825395
+
+depends_lib-append  port:qrupdate
+
+if {${os.major} < 11} {
+    # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own.
+    depends_build-append \
+                    port:git
+    git.cmd         ${prefix}/bin/git
+}
+
+compilers.choose    fc cc
+compilers.setup     require_fortran
+
+compiler.c_standard 2011
+
+configure.args-append \
+                    -DBUILD_C_API=ON \
+                    -DBUILD_TESTING=ON \
+                    -DBUILD_LINALG_EXAMPLES=OFF
+
+# This is needed for correct implementation to be picked:
+if {[variant_isset accelerate]} {
+    configure.args-append \
+                    -DBLAS_LIBRARIES=vecLibFort \
+                    -DLAPACK_LIBRARIES=vecLibFort
+}
+
+test.run            yes
+test.cmd            ctest


### PR DESCRIPTION
#### Description

New port in math: https://github.com/jchristopherson/linalg

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing linalg
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_linalg/linalg/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_linalg/linalg/work/build
    Start 1: linalg_test
1/3 Test #1: linalg_test ......................   Passed    0.75 sec
    Start 2: linalg_c_test
2/3 Test #2: linalg_c_test ....................   Passed    0.28 sec
    Start 3: fth_test
3/3 Test #3: fth_test .........................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   1.13 sec
```