### PR TITLE
muchsync: Bump to version 7

### DIFF
--- a/mail/muchsync/Portfile
+++ b/mail/muchsync/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                muchsync
-version             6
+version             7
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -17,9 +17,9 @@ long_description    Muchsync brings Notmuch to all of your computers by \
 homepage            http://www.muchsync.org/
 master_sites        http://www.muchsync.org/src/
 
-checksums           rmd160  64ec49ded927ada6a72061bf7d16972377680912 \
-                    sha256  0b3de3b4d885edb9f887a07dcbc8b596e7fef2038c61e682cfa55a13fa4ce9e8 \
-                    size    137023
+checksums           rmd160  14ebb34b74f9ada485085390cfbcd00f69704f87 \
+                    sha256  f83e2f6fcd0ef4813475fddc8d39285686654da5f41565a1e9a9acd781a3beac \
+                    size    140748
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? Muchsync has no tests
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
