### PR TITLE
jello: update to 1.5.5

### DIFF
--- a/sysutils/jello/Portfile
+++ b/sysutils/jello/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    jello
-version                 1.5.4
+version                 1.5.5
 revision                0
 
 homepage                https://kellyjonbrazil.github.io/jello/
@@ -22,9 +22,9 @@ maintainers             {ajhall.us:macports @ajhall} \
 supported_archs         noarch
 platforms               {darwin any}
 
-checksums               rmd160  265e60aabc0d550e4cd30405ba0d145277b42aef \
-                        sha256  6e536485ffd7a30e4d187ca1e2719452e833f1939c3b34330d75a831dabfcda9 \
-                        size    25574
+checksums               rmd160  ba36016d240d76d3ce53ff378d806d720e63c070 \
+                        sha256  a7bc8762867db5c479323e308bd1d6074b5d5b0cafe3fdf340481764c7851487 \
+                        size    25837
 
 python.default_version  310
 


### PR DESCRIPTION
#### Description
jello: update to 1.5.5
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?