### PR TITLE
libsql: new port (version 0.1.0)

### DIFF
--- a/databases/libsql/Portfile
+++ b/databases/libsql/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+
+github.setup        libsql libsql 0.1.0 libsql-
+github.tarball_from archive
+revision            0
+
+homepage            https://libsql.org
+
+description         Fork of SQLite that is both Open Source, and Open \
+                    Contributions.
+
+long_description    \
+    ${name} is an open source, open contribution fork of SQLite. We aim to \
+    evolve it to suit many more use cases than SQLite was originally designed \
+    for, and plan to use third-party OSS code wherever it makes sense. \
+    ${name} will always be compatible with the SQLite file format. ${name} \
+    will keep 100% compatibility with the SQLite API, but we may add \
+    additional APIs. SQLite is an embedded database that can be consumed as a \
+    single .c file with its accompanying header. ${name} will always be \
+    embeddable, meaning it runs inside your process without needing a network \
+    connection. But we may change the distribution, so that object files are \
+    generated, instead of a single .c file.
+
+categories          databases devel
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+conflicts           sqlite3
+
+checksums           rmd160  7d9c829ea3304836f5c6c87b1612ea09086dbb80 \
+                    sha256  9454d2f32814ae1cb465dfa0e8d0843f23c735cd2f27319909a817502eaf3123 \
+                    size    12462701
+
+depends_lib-append  port:libedit \
+                    port:ncurses \
+                    port:zlib
+
+test.run            yes


### PR DESCRIPTION
New port for LibSQL - https://libsql.org/

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
