### PR TITLE
qepcad: new port in math

### DIFF
--- a/math/qepcad/Portfile
+++ b/math/qepcad/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           github 1.0
+
+github.setup        PetterS qepcad d9b8661bc37bbb50a3ac4a90a3000e602fda8f15
+version             2023.03.12
+revision            0
+categories          math
+license             Restrictive
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Quantifier Elimination by Partial Cylindrical Algebraic Decomposition
+long_description    {*}${description}
+checksums           rmd160  29f12c1c86a0f09811f5d604c4222318b5369b23 \
+                    sha256  47cf38b51af7b76f1184ce2e253a33c5cb11129606e274878a2599fc379c8b43 \
+                    size    4542287
+
+compiler.blacklist-append *gcc-4.* {clang < 421}
+
+if {[string match *clang* ${configure.compiler}]} {
+    # error: implicit declaration of function 'FPCATCH' is invalid in C99
+    configure.cflags-append \
+                    -Wno-error=implicit-function-declaration \
+                    -Wno-error=return-type
+}
+
+destroot {
+    move ${cmake.build_dir}/bin/${name} ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/lib/${name}
+    move {*}[glob ${cmake.build_dir}/lib/*.a ${destroot}${prefix}/lib/${name}]
+}
+
+test.run            yes
+test.cmd            ctest


### PR DESCRIPTION
#### Description

New port: https://github.com/PetterS/qepcad

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing qepcad
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_qepcad/qepcad/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_qepcad/qepcad/work/build
    Start 1: test_problem1
1/8 Test #1: test_problem1 ....................   Passed    0.71 sec
    Start 2: test_problem2
2/8 Test #2: test_problem2 ....................   Passed    0.74 sec
    Start 3: test_problem3
3/8 Test #3: test_problem3 ....................   Passed    0.70 sec
    Start 4: test_problem4
4/8 Test #4: test_problem4 ....................   Passed    0.69 sec
    Start 5: test_problem5
5/8 Test #5: test_problem5 ....................   Passed    0.83 sec
    Start 6: test_problem6
6/8 Test #6: test_problem6 ....................   Passed    1.16 sec
    Start 7: test_problem7
7/8 Test #7: test_problem7 ....................   Passed    0.72 sec
    Start 8: issue_3
8/8 Test #8: issue_3 ..........................   Passed    2.66 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) =   8.27 sec
```