### PR TITLE
arghandler: new port in devel

### DIFF
--- a/devel/arghandler/Portfile
+++ b/devel/arghandler/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        adishavit argh 1.3.2 v
+name                arghandler
+revision            0
+categories          devel
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Argh! A minimalist argument handler
+long_description    {*}${description}
+checksums           rmd160  34498b93e41f4dd5e4a0a4af7c64c63c0f59cefb \
+                    sha256  f0c1900e67459da00fd2e31a022d666a5b0c9195b714030811355925b16b779e \
+                    size    101455
+
+patchfiles          0001-Fix-building-tests-on-PPC.patch
+
+compiler.cxx_standard 2011
+
+configure.args-append \
+                    -DARGH_MASTER_PROJECT=ON \
+                    -DBUILD_EXAMPLES=OFF \
+                    -DBUILD_TESTS=ON
+
+test.run            yes
+test.cmd            ./argh_tests
+test.target

--- a/devel/arghandler/files/0001-Fix-building-tests-on-PPC.patch
+++ b/devel/arghandler/files/0001-Fix-building-tests-on-PPC.patch
@@ -1,0 +1,23 @@
+From a9eef13d5c7939ae1f0e5974b35310eb9f3671d3 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 16 Jan 2023 02:11:18 +0800
+Subject: [PATCH] Fix building tests on PPC
+
+---
+ doctest.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/doctest.h b/doctest.h
+index 42eb039..0fe4405 100644
+--- doctest.h
++++ doctest.h
+@@ -370,6 +370,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
+ #elif defined(DOCTEST_PLATFORM_MAC)
+ #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
+ #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT (hicpp-no-assembler)
++#elif defined(__POWERPC__)
++#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
++        : : : "memory","r0","r3","r4" ) // NOLINT
+ #else
+ #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT (hicpp-no-assembler)
+ #endif


### PR DESCRIPTION
#### Description

New port: https://github.com/adishavit/argh

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing arghandler
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_arghandler/arghandler/work/build" && ./argh_tests 
[doctest] doctest version is "2.4.6"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  29 |  29 passed | 0 failed | 0 skipped
[doctest] assertions: 367 | 367 passed | 0 failed |
[doctest] Status: SUCCESS!
```