### PR TITLE
arghandler: add compiler.thread_local_storage yes

### DIFF
--- a/devel/arghandler/Portfile
+++ b/devel/arghandler/Portfile
@@ -15,10 +15,12 @@ long_description    {*}${description}
 checksums           rmd160  34498b93e41f4dd5e4a0a4af7c64c63c0f59cefb \
                     sha256  f0c1900e67459da00fd2e31a022d666a5b0c9195b714030811355925b16b779e \
                     size    101455
+installs_libs       no
 
 patchfiles          0001-Fix-building-tests-on-PPC.patch
 
 compiler.cxx_standard 2011
+compiler.thread_local_storage yes
 
 configure.args-append \
                     -DARGH_MASTER_PROJECT=ON \


### PR DESCRIPTION
#### Description

@herbygillot I apologize for another PR for this port in a row, but turned out TLS is needed, at least on some old systems where Apple Clang is picked.
Case: https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/216288/steps/install-port/logs/stdio
I do not have 10.9 to test, but this should be a fairly straightforward fix.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
