### PR TITLE
stringtoolbox: new port in devel

### DIFF
--- a/devel/stringtoolbox/Portfile
+++ b/devel/stringtoolbox/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        chrberger stringtoolbox eb1d24e848677de160c22dabb01b5d1272291d29
+version             0.0.4
+revision            0
+categories          devel
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         A simple header-only, single-file string toolbox library for C++
+long_description    stringtoolbox is a small and efficient library written in modern C++, \
+                    aimed to provide some features for processing std::strings.
+checksums           rmd160  f25cd63fb9988b4c3cf1e4e09b53ca21cde322f8 \
+                    sha256  a326a354f6602b7962b5965db1d1312d287100ccbaf3635679ba1fc106780c00 \
+                    size    133584
+installs_libs       no
+
+post-patch {
+    # Clang does not understand the following flags:
+    if {[string match *clang* ${configure.compiler}]} {
+        reinplace "s,-Wunused-but-set-parameter,," ${worksrcpath}/CMakeLists.txt
+        reinplace "s,-Wunused-but-set-variable,," ${worksrcpath}/CMakeLists.txt
+    }
+}
+
+compiler.cxx_standard 2011
+
+destroot {
+    copy ${worksrcpath}/stringtoolbox.hpp ${destroot}${prefix}/include/
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} CONTRIBUTING.md LICENSE README.md ${destroot}${docdir}
+}
+
+depends_test-append port:catch2
+
+test.run            yes
+test.cmd            ./${name}-Runner
+test.target


### PR DESCRIPTION
#### Description

New port: https://github.com/chrberger/stringtoolbox

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing stringtoolbox
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_stringtoolbox/stringtoolbox/work/build" && ./stringtoolbox-Runner 
===============================================================================
All tests passed (54 assertions in 6 test cases)
```