### PR TITLE
cpp-peglib: new port in devel

### DIFF
--- a/devel/cpp-peglib/Portfile
+++ b/devel/cpp-peglib/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        yhirose cpp-peglib 1.8.2 v
+revision            0
+categories          devel
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         A single file C++ header-only PEG (Parsing Expression Grammars) library
+long_description    {*}${description}
+checksums           rmd160  8245ab25289f1866a7e85bf529096a86b1e98948 \
+                    sha256  34039a209adec73bd223a879b606a7a725b9ab0cfcea341ea60fdf6a3bb8a626 \
+                    size    213416
+installs_libs       no
+
+# The port needs Gtest for building tests, however linking to external Gtest fails.
+# It uses git to fetch needed branch of Gtest.
+platform darwin {
+    if {${os.major} < 13} {
+        # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own.
+        # On 10.8.5 git fetch fails with ssl error.
+        depends_build-append    port:git
+        git.cmd                 ${prefix}/bin/git
+    }
+}
+
+compiler.cxx_standard 2017
+
+configure.args-append \
+                    -DBUILD_TESTS=ON \
+                    -DTHREADS_PREFER_PTHREAD_FLAG=ON
+
+# We do not a conflict with Gtest port, so implement a manual destroot.
+destroot {
+    copy ${worksrcpath}/peglib.h ${destroot}${prefix}/include/
+    xinstall -d ${destroot}${prefix}/share/${name}
+    fs-traverse f ${worksrcpath}/docs {
+        if {[file exists ${f}] && [file isfile ${f}]} {
+            copy ${f} ${destroot}${prefix}/share/${name}/
+        }
+    }
+}
+
+test.run            yes
+test.cmd            ctest


### PR DESCRIPTION
#### Description

New port: https://github.com/yhirose/cpp-peglib

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing cpp-peglib
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_cpp-peglib/cpp-peglib/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_cpp-peglib/cpp-peglib/work/build
        Start   1: GeneralTest.Simple_syntax_test_with_unicode
  1/167 Test   #1: GeneralTest.Simple_syntax_test_with_unicode .........................   Passed    0.08 sec
        Start   2: GeneralTest.Simple_syntax_test
  2/167 Test   #2: GeneralTest.Simple_syntax_test ......................................   Passed    0.08 sec
        Start   3: GeneralTest.Empty_syntax_test
  3/167 Test   #3: GeneralTest.Empty_syntax_test .......................................   Passed    0.08 sec
        Start   4: GeneralTest.Start_rule_with_ignore_operator_test
  4/167 Test   #4: GeneralTest.Start_rule_with_ignore_operator_test ....................   Passed    0.09 sec
        Start   5: GeneralTest.Invalid_UTF8_text_test
  5/167 Test   #5: GeneralTest.Invalid_UTF8_text_test ..................................   Passed    0.07 sec
        Start   6: GeneralTest.Backslash_escape_sequence_test
  6/167 Test   #6: GeneralTest.Backslash_escape_sequence_test ..........................   Passed    0.07 sec
        Start   7: GeneralTest.Invalid_escape_sequence_test
  7/167 Test   #7: GeneralTest.Invalid_escape_sequence_test ............................   Passed    0.08 sec
        Start   8: GeneralTest.Action_taking_non_const_Semantic_Values_parameter
  8/167 Test   #8: GeneralTest.Action_taking_non_const_Semantic_Values_parameter .......   Passed    0.11 sec
        Start   9: GeneralTest.String_capture_test
  9/167 Test   #9: GeneralTest.String_capture_test .....................................   Passed    0.09 sec
        Start  10: GeneralTest.String_capture_test2
 10/167 Test  #10: GeneralTest.String_capture_test2 ....................................   Passed    0.06 sec
        Start  11: GeneralTest.String_capture_test3
 11/167 Test  #11: GeneralTest.String_capture_test3 ....................................   Passed    0.09 sec
        Start  12: GeneralTest.Cyclic_grammer_test
 12/167 Test  #12: GeneralTest.Cyclic_grammer_test .....................................   Passed    0.06 sec
        Start  13: GeneralTest.Visit_test
 13/167 Test  #13: GeneralTest.Visit_test ..............................................   Passed    0.06 sec
        Start  14: GeneralTest.Token_check_test
 14/167 Test  #14: GeneralTest.Token_check_test ........................................   Passed    0.09 sec
        Start  15: GeneralTest.Lambda_action_test
 15/167 Test  #15: GeneralTest.Lambda_action_test ......................................   Passed    0.08 sec
        Start  16: GeneralTest.enter_leave_handlers_test
 16/167 Test  #16: GeneralTest.enter_leave_handlers_test ...............................   Passed    0.08 sec
        Start  17: GeneralTest.WHITESPACE_test
 17/167 Test  #17: GeneralTest.WHITESPACE_test .........................................   Passed    0.07 sec
        Start  18: GeneralTest.WHITESPACE_test2
 18/167 Test  #18: GeneralTest.WHITESPACE_test2 ........................................   Passed    0.07 sec
        Start  19: GeneralTest.WHITESPACE_test3
 19/167 Test  #19: GeneralTest.WHITESPACE_test3 ........................................   Passed    0.07 sec
        Start  20: GeneralTest.WHITESPACE_test4
 20/167 Test  #20: GeneralTest.WHITESPACE_test4 ........................................   Passed    0.07 sec
        Start  21: GeneralTest.Word_expression_test
 21/167 Test  #21: GeneralTest.Word_expression_test ....................................   Passed    0.07 sec
        Start  22: GeneralTest.Word_expression_test_PrioritizedChoice
 22/167 Test  #22: GeneralTest.Word_expression_test_PrioritizedChoice ..................   Passed    0.08 sec
        Start  23: GeneralTest.Word_expression_test_Dictionary
 23/167 Test  #23: GeneralTest.Word_expression_test_Dictionary .........................   Passed    0.08 sec
        Start  24: GeneralTest.Skip_token_test
 24/167 Test  #24: GeneralTest.Skip_token_test .........................................   Passed    0.07 sec
        Start  25: GeneralTest.Skip_token_test2
 25/167 Test  #25: GeneralTest.Skip_token_test2 ........................................   Passed    0.07 sec
        Start  26: GeneralTest.Custom_AST_test
 26/167 Test  #26: GeneralTest.Custom_AST_test .........................................   Passed    0.07 sec
        Start  27: GeneralTest.Backtracking_test
 27/167 Test  #27: GeneralTest.Backtracking_test .......................................   Passed    0.07 sec
        Start  28: GeneralTest.Backtracking_with_AST
 28/167 Test  #28: GeneralTest.Backtracking_with_AST ...................................   Passed    0.08 sec
        Start  29: GeneralTest.Octal_Hex_Unicode_value_test
 29/167 Test  #29: GeneralTest.Octal_Hex_Unicode_value_test ............................   Passed    0.07 sec
        Start  30: GeneralTest.Ignore_case_literal_test
 30/167 Test  #30: GeneralTest.Ignore_case_literal_test ................................   Passed    0.09 sec
        Start  31: GeneralTest.Ignore_case_character_class_test
 31/167 Test  #31: GeneralTest.Ignore_case_character_class_test ........................   Passed    0.07 sec
        Start  32: GeneralTest.Ignore_case_negate_character_class_test
 32/167 Test  #32: GeneralTest.Ignore_case_negate_character_class_test .................   Passed    0.07 sec
        Start  33: GeneralTest.mutable_lambda_test
 33/167 Test  #33: GeneralTest.mutable_lambda_test .....................................   Passed    0.08 sec
        Start  34: GeneralTest.Simple_calculator_test
 34/167 Test  #34: GeneralTest.Simple_calculator_test ..................................   Passed    0.08 sec
        Start  35: GeneralTest.Simple_calculator_with_recovery_test
 35/167 Test  #35: GeneralTest.Simple_calculator_with_recovery_test ....................   Passed    0.08 sec
        Start  36: GeneralTest.Calculator_test
 36/167 Test  #36: GeneralTest.Calculator_test .........................................   Passed    0.06 sec
        Start  37: GeneralTest.Calculator_test2
 37/167 Test  #37: GeneralTest.Calculator_test2 ........................................   Passed    0.08 sec
        Start  38: GeneralTest.Calculator_test3
 38/167 Test  #38: GeneralTest.Calculator_test3 ........................................   Passed    0.11 sec
        Start  39: GeneralTest.Calculator_test_with_AST
 39/167 Test  #39: GeneralTest.Calculator_test_with_AST ................................   Passed    0.09 sec
        Start  40: GeneralTest.Calculator_test_with_combinators_and_AST
 40/167 Test  #40: GeneralTest.Calculator_test_with_combinators_and_AST ................   Passed    0.06 sec
        Start  41: GeneralTest.Ignore_semantic_value_test
 41/167 Test  #41: GeneralTest.Ignore_semantic_value_test ..............................   Passed    0.08 sec
        Start  42: GeneralTest.Ignore_semantic_value_of_or_predicate_test
 42/167 Test  #42: GeneralTest.Ignore_semantic_value_of_or_predicate_test ..............   Passed    0.08 sec
        Start  43: GeneralTest.Ignore_semantic_value_of_and_predicate_test
 43/167 Test  #43: GeneralTest.Ignore_semantic_value_of_and_predicate_test .............   Passed    0.08 sec
        Start  44: GeneralTest.Literal_token_on_AST_test1
 44/167 Test  #44: GeneralTest.Literal_token_on_AST_test1 ..............................   Passed    0.08 sec
        Start  45: GeneralTest.Literal_token_on_AST_test2
 45/167 Test  #45: GeneralTest.Literal_token_on_AST_test2 ..............................   Passed    0.08 sec
        Start  46: GeneralTest.Literal_token_on_AST_test3
 46/167 Test  #46: GeneralTest.Literal_token_on_AST_test3 ..............................   Passed    0.08 sec
        Start  47: GeneralTest.Literal_token_on_AST_test4
 47/167 Test  #47: GeneralTest.Literal_token_on_AST_test4 ..............................   Passed    0.09 sec
        Start  48: GeneralTest.Missing_missing_definitions_test
 48/167 Test  #48: GeneralTest.Missing_missing_definitions_test ........................   Passed    0.07 sec
        Start  49: GeneralTest.Definition_duplicates_test
 49/167 Test  #49: GeneralTest.Definition_duplicates_test ..............................   Passed    0.08 sec
        Start  50: GeneralTest.Semantic_values_test
 50/167 Test  #50: GeneralTest.Semantic_values_test ....................................   Passed    0.12 sec
        Start  51: GeneralTest.Ordered_choice_count
 51/167 Test  #51: GeneralTest.Ordered_choice_count ....................................   Passed    0.11 sec
        Start  52: GeneralTest.Ordered_choice_count_2
 52/167 Test  #52: GeneralTest.Ordered_choice_count_2 ..................................   Passed    0.07 sec
        Start  53: GeneralTest.Semantic_value_tag
 53/167 Test  #53: GeneralTest.Semantic_value_tag ......................................   Passed    0.08 sec
        Start  54: GeneralTest.Negated_Class_test
 54/167 Test  #54: GeneralTest.Negated_Class_test ......................................   Passed    0.07 sec
        Start  55: GeneralTest.token_to_number_float_test
 55/167 Test  #55: GeneralTest.token_to_number_float_test ..............................   Passed    0.07 sec
        Start  56: GeneralTest.ParentReferencesShouldNotBeExpired
 56/167 Test  #56: GeneralTest.ParentReferencesShouldNotBeExpired ......................   Passed    0.08 sec
        Start  57: GeneralTest.EndOfInputTest
 57/167 Test  #57: GeneralTest.EndOfInputTest ..........................................   Passed    0.08 sec
        Start  58: GeneralTest.DefaultEndOfInputTest
 58/167 Test  #58: GeneralTest.DefaultEndOfInputTest ...................................   Passed    0.08 sec
        Start  59: GeneralTest.DisableEndOfInputCheckTest
 59/167 Test  #59: GeneralTest.DisableEndOfInputCheckTest ..............................   Passed    0.07 sec
        Start  60: GeneralTest.InvalidCutOperator
 60/167 Test  #60: GeneralTest.InvalidCutOperator ......................................   Passed    0.07 sec
        Start  61: GeneralTest.HeuristicErrorTokenTest
 61/167 Test  #61: GeneralTest.HeuristicErrorTokenTest .................................   Passed    0.07 sec
        Start  62: GeneralTest.LiteralContentInAST
 62/167 Test  #62: GeneralTest.LiteralContentInAST .....................................   Passed    0.13 sec
        Start  63: TokenBoundaryTest.Token_boundary_1
 63/167 Test  #63: TokenBoundaryTest.Token_boundary_1 ..................................   Passed    0.08 sec
        Start  64: TokenBoundaryTest.Token_boundary_2
 64/167 Test  #64: TokenBoundaryTest.Token_boundary_2 ..................................   Passed    0.08 sec
        Start  65: TokenBoundaryTest.Token_boundary_3
 65/167 Test  #65: TokenBoundaryTest.Token_boundary_3 ..................................   Passed    0.08 sec
        Start  66: TokenBoundaryTest.Token_boundary_4
 66/167 Test  #66: TokenBoundaryTest.Token_boundary_4 ..................................   Passed    0.08 sec
        Start  67: TokenBoundaryTest.Token_boundary_5
 67/167 Test  #67: TokenBoundaryTest.Token_boundary_5 ..................................   Passed    0.08 sec
        Start  68: TokenBoundaryTest.Token_boundary_6
 68/167 Test  #68: TokenBoundaryTest.Token_boundary_6 ..................................   Passed    0.09 sec
        Start  69: TokenBoundaryTest.Token_boundary_7
 69/167 Test  #69: TokenBoundaryTest.Token_boundary_7 ..................................   Passed    0.10 sec
        Start  70: InfiniteLoopTest.Infinite_loop_1
 70/167 Test  #70: InfiniteLoopTest.Infinite_loop_1 ....................................   Passed    0.08 sec
        Start  71: InfiniteLoopTest.Infinite_loop_2
 71/167 Test  #71: InfiniteLoopTest.Infinite_loop_2 ....................................   Passed    0.07 sec
        Start  72: InfiniteLoopTest.Infinite_loop_3
 72/167 Test  #72: InfiniteLoopTest.Infinite_loop_3 ....................................   Passed    0.07 sec
        Start  73: InfiniteLoopTest.Infinite_loop_4
 73/167 Test  #73: InfiniteLoopTest.Infinite_loop_4 ....................................   Passed    0.07 sec
        Start  74: InfiniteLoopTest.Infinite_loop_5
 74/167 Test  #74: InfiniteLoopTest.Infinite_loop_5 ....................................   Passed    0.07 sec
        Start  75: InfiniteLoopTest.Infinite_loop_6
 75/167 Test  #75: InfiniteLoopTest.Infinite_loop_6 ....................................   Passed    0.06 sec
        Start  76: InfiniteLoopTest.Infinite_loop_7
 76/167 Test  #76: InfiniteLoopTest.Infinite_loop_7 ....................................   Passed    0.07 sec
        Start  77: InfiniteLoopTest.Infinite_loop_8
 77/167 Test  #77: InfiniteLoopTest.Infinite_loop_8 ....................................   Passed    0.07 sec
        Start  78: InfiniteLoopTest.Infinite_loop_9
 78/167 Test  #78: InfiniteLoopTest.Infinite_loop_9 ....................................   Passed    0.07 sec
        Start  79: InfiniteLoopTest.Not_infinite_1
 79/167 Test  #79: InfiniteLoopTest.Not_infinite_1 .....................................   Passed    0.07 sec
        Start  80: InfiniteLoopTest.Not_infinite_2
 80/167 Test  #80: InfiniteLoopTest.Not_infinite_2 .....................................   Passed    0.07 sec
        Start  81: InfiniteLoopTest.Not_infinite_3
 81/167 Test  #81: InfiniteLoopTest.Not_infinite_3 .....................................   Passed    0.07 sec
        Start  82: InfiniteLoopTest.whitespace
 82/167 Test  #82: InfiniteLoopTest.whitespace .........................................   Passed    0.07 sec
        Start  83: InfiniteLoopTest.word
 83/167 Test  #83: InfiniteLoopTest.word ...............................................   Passed    0.07 sec
        Start  84: InfiniteLoopTest.in_sequence
 84/167 Test  #84: InfiniteLoopTest.in_sequence ........................................   Passed    0.09 sec
        Start  85: InfiniteLoopTest.in_prioritized_choice
 85/167 Test  #85: InfiniteLoopTest.in_prioritized_choice ..............................   Passed    0.09 sec
        Start  86: PrecedenceTest.Precedence_climbing
 86/167 Test  #86: PrecedenceTest.Precedence_climbing ..................................   Passed    0.09 sec
        Start  87: PrecedenceTest.Precedence_climbing_with_literal_operator
 87/167 Test  #87: PrecedenceTest.Precedence_climbing_with_literal_operator ............   Passed    0.09 sec
        Start  88: PrecedenceTest.Precedence_climbing_with_macro
 88/167 Test  #88: PrecedenceTest.Precedence_climbing_with_macro .......................   Passed    0.11 sec
        Start  89: PrecedenceTest.Precedence_climbing_error1
 89/167 Test  #89: PrecedenceTest.Precedence_climbing_error1 ...........................   Passed    0.10 sec
        Start  90: PrecedenceTest.Precedence_climbing_error2
 90/167 Test  #90: PrecedenceTest.Precedence_climbing_error2 ...........................   Passed    0.10 sec
        Start  91: PrecedenceTest.Precedence_climbing_error3
 91/167 Test  #91: PrecedenceTest.Precedence_climbing_error3 ...........................   Passed    0.10 sec
        Start  92: PackratTest.Packrat_parser_test_with_whitespace
 92/167 Test  #92: PackratTest.Packrat_parser_test_with_whitespace .....................   Passed    0.08 sec
        Start  93: PackratTest.Packrat_parser_test_with_macro
 93/167 Test  #93: PackratTest.Packrat_parser_test_with_macro ..........................   Passed    0.09 sec
        Start  94: PackratTest.Packrat_parser_test_with_precedence_expression_parser
 94/167 Test  #94: PackratTest.Packrat_parser_test_with_precedence_expression_parser ...   Passed    0.08 sec
        Start  95: BackreferenceTest.Backreference_test
 95/167 Test  #95: BackreferenceTest.Backreference_test ................................   Passed    0.10 sec
        Start  96: BackreferenceTest.Undefined_backreference_test
 96/167 Test  #96: BackreferenceTest.Undefined_backreference_test ......................   Passed    0.09 sec
        Start  97: BackreferenceTest.Invalid_backreference_test
 97/167 Test  #97: BackreferenceTest.Invalid_backreference_test ........................   Passed    0.11 sec
        Start  98: BackreferenceTest.Nested_capture_test
 98/167 Test  #98: BackreferenceTest.Nested_capture_test ...............................   Passed    0.11 sec
        Start  99: BackreferenceTest.Backreference_with_Prioritized_Choice_test
 99/167 Test  #99: BackreferenceTest.Backreference_with_Prioritized_Choice_test ........   Passed    0.09 sec
        Start 100: BackreferenceTest.Backreference_with_Zero_or_More_test
100/167 Test #100: BackreferenceTest.Backreference_with_Zero_or_More_test ..............   Passed    0.08 sec
        Start 101: BackreferenceTest.Backreference_with_One_or_More_test
101/167 Test #101: BackreferenceTest.Backreference_with_One_or_More_test ...............   Passed    0.08 sec
        Start 102: BackreferenceTest.Backreference_with_Option_test
102/167 Test #102: BackreferenceTest.Backreference_with_Option_test ....................   Passed    0.08 sec
        Start 103: RepetitionTest.Repetition_0
103/167 Test #103: RepetitionTest.Repetition_0 .........................................   Passed    0.07 sec
        Start 104: RepetitionTest.Repetition_2_4
104/167 Test #104: RepetitionTest.Repetition_2_4 .......................................   Passed    0.07 sec
        Start 105: RepetitionTest.Repetition_2_1
105/167 Test #105: RepetitionTest.Repetition_2_1 .......................................   Passed    0.07 sec
        Start 106: RepetitionTest.Repetition_2
106/167 Test #106: RepetitionTest.Repetition_2 .........................................   Passed    0.07 sec
        Start 107: RepetitionTest.Repetition__2
107/167 Test #107: RepetitionTest.Repetition__2 ........................................   Passed    0.07 sec
        Start 108: LeftRecursiveTest.Left_recursive_test
108/167 Test #108: LeftRecursiveTest.Left_recursive_test ...............................   Passed    0.07 sec
        Start 109: LeftRecursiveTest.Left_recursive_with_option_test
109/167 Test #109: LeftRecursiveTest.Left_recursive_with_option_test ...................   Passed    0.08 sec
        Start 110: LeftRecursiveTest.Left_recursive_with_zom_test
110/167 Test #110: LeftRecursiveTest.Left_recursive_with_zom_test ......................   Passed    0.07 sec
        Start 111: LeftRecursiveTest.Left_recursive_with_a_ZOM_content_rule
111/167 Test #111: LeftRecursiveTest.Left_recursive_with_a_ZOM_content_rule ............   Passed    0.07 sec
        Start 112: LeftRecursiveTest.Left_recursive_with_empty_string_test
112/167 Test #112: LeftRecursiveTest.Left_recursive_with_empty_string_test .............   Passed    0.07 sec
        Start 113: LeftRecursiveTest.PEG_Definition
113/167 Test #113: LeftRecursiveTest.PEG_Definition ....................................   Passed    0.07 sec
        Start 114: LeftRecursiveTest.PEG_Expression
114/167 Test #114: LeftRecursiveTest.PEG_Expression ....................................   Passed    0.07 sec
        Start 115: LeftRecursiveTest.PEG_Sequence
115/167 Test #115: LeftRecursiveTest.PEG_Sequence ......................................   Passed    0.08 sec
        Start 116: LeftRecursiveTest.PEG_Prefix
116/167 Test #116: LeftRecursiveTest.PEG_Prefix ........................................   Passed    0.07 sec
        Start 117: LeftRecursiveTest.PEG_Suffix
117/167 Test #117: LeftRecursiveTest.PEG_Suffix ........................................   Passed    0.07 sec
        Start 118: LeftRecursiveTest.PEG_Primary
118/167 Test #118: LeftRecursiveTest.PEG_Primary .......................................   Passed    0.07 sec
        Start 119: LeftRecursiveTest.PEG_Identifier
119/167 Test #119: LeftRecursiveTest.PEG_Identifier ....................................   Passed    0.07 sec
        Start 120: LeftRecursiveTest.PEG_IdentStart
120/167 Test #120: LeftRecursiveTest.PEG_IdentStart ....................................   Passed    0.06 sec
        Start 121: LeftRecursiveTest.PEG_IdentRest
121/167 Test #121: LeftRecursiveTest.PEG_IdentRest .....................................   Passed    0.06 sec
        Start 122: LeftRecursiveTest.PEG_Literal
122/167 Test #122: LeftRecursiveTest.PEG_Literal .......................................   Passed    0.07 sec
        Start 123: LeftRecursiveTest.PEG_Class
123/167 Test #123: LeftRecursiveTest.PEG_Class .........................................   Passed    0.06 sec
        Start 124: LeftRecursiveTest.PEG_Negated_Class
124/167 Test #124: LeftRecursiveTest.PEG_Negated_Class .................................   Passed    0.07 sec
        Start 125: LeftRecursiveTest.PEG_Range
125/167 Test #125: LeftRecursiveTest.PEG_Range .........................................   Passed    0.07 sec
        Start 126: LeftRecursiveTest.PEG_Char
126/167 Test #126: LeftRecursiveTest.PEG_Char ..........................................   Passed    0.07 sec
        Start 127: LeftRecursiveTest.PEG_Operators
127/167 Test #127: LeftRecursiveTest.PEG_Operators .....................................   Passed    0.07 sec
        Start 128: LeftRecursiveTest.PEG_Comment
128/167 Test #128: LeftRecursiveTest.PEG_Comment .......................................   Passed    0.06 sec
        Start 129: LeftRecursiveTest.PEG_Space
129/167 Test #129: LeftRecursiveTest.PEG_Space .........................................   Passed    0.06 sec
        Start 130: LeftRecursiveTest.PEG_EndOfLine
130/167 Test #130: LeftRecursiveTest.PEG_EndOfLine .....................................   Passed    0.06 sec
        Start 131: LeftRecursiveTest.PEG_EndOfFile
131/167 Test #131: LeftRecursiveTest.PEG_EndOfFile .....................................   Passed    0.06 sec
        Start 132: UserRuleTest.User_defined_rule_test
132/167 Test #132: UserRuleTest.User_defined_rule_test .................................   Passed    0.08 sec
        Start 133: PredicateTest.Semantic_predicate_test
133/167 Test #133: PredicateTest.Semantic_predicate_test ...............................   Passed    0.07 sec
        Start 134: UnicodeTest.Japanese_character
134/167 Test #134: UnicodeTest.Japanese_character ......................................   Passed    0.08 sec
        Start 135: UnicodeTest.dot_with_a_code
135/167 Test #135: UnicodeTest.dot_with_a_code .........................................   Passed    0.06 sec
        Start 136: UnicodeTest.dot_with_a_char
136/167 Test #136: UnicodeTest.dot_with_a_char .........................................   Passed    0.06 sec
        Start 137: UnicodeTest.character_class
137/167 Test #137: UnicodeTest.character_class .........................................   Passed    0.07 sec
        Start 138: MacroTest.Macro_simple_test
138/167 Test #138: MacroTest.Macro_simple_test .........................................   Passed    0.07 sec
        Start 139: MacroTest.Macro_two_parameters
139/167 Test #139: MacroTest.Macro_two_parameters ......................................   Passed    0.07 sec
        Start 140: MacroTest.Macro_syntax_error
140/167 Test #140: MacroTest.Macro_syntax_error ........................................   Passed    0.06 sec
        Start 141: MacroTest.Macro_missing_argument
141/167 Test #141: MacroTest.Macro_missing_argument ....................................   Passed    0.06 sec
        Start 142: MacroTest.Macro_reference_syntax_error
142/167 Test #142: MacroTest.Macro_reference_syntax_error ..............................   Passed    0.07 sec
        Start 143: MacroTest.Macro_invalid_macro_reference_error
143/167 Test #143: MacroTest.Macro_invalid_macro_reference_error .......................   Passed    0.07 sec
        Start 144: MacroTest.Macro_calculator
144/167 Test #144: MacroTest.Macro_calculator ..........................................   Passed    0.10 sec
        Start 145: MacroTest.Macro_expression_arguments
145/167 Test #145: MacroTest.Macro_expression_arguments ................................   Passed    0.08 sec
        Start 146: MacroTest.Macro_recursive
146/167 Test #146: MacroTest.Macro_recursive ...........................................   Passed    0.07 sec
        Start 147: MacroTest.Macro_recursive2
147/167 Test #147: MacroTest.Macro_recursive2 ..........................................   Passed    0.10 sec
        Start 148: MacroTest.Macro_exclusive_modifiers
148/167 Test #148: MacroTest.Macro_exclusive_modifiers .................................   Passed    0.09 sec
        Start 149: MacroTest.Macro_token_check_test
149/167 Test #149: MacroTest.Macro_token_check_test ....................................   Passed    0.07 sec
        Start 150: MacroTest.Macro_passes_an_arg_to_another_macro
150/167 Test #150: MacroTest.Macro_passes_an_arg_to_another_macro ......................   Passed    0.06 sec
        Start 151: MacroTest.Unreferenced_rule
151/167 Test #151: MacroTest.Unreferenced_rule .........................................   Passed    0.06 sec
        Start 152: MacroTest.Nested_macro_call
152/167 Test #152: MacroTest.Nested_macro_call .........................................   Passed    0.08 sec
        Start 153: MacroTest.Nested_macro_call2
153/167 Test #153: MacroTest.Nested_macro_call2 ........................................   Passed    0.08 sec
        Start 154: LineInformationTest.Line_information_test
154/167 Test #154: LineInformationTest.Line_information_test ...........................   Passed    0.07 sec
        Start 155: DicTest.Dictionary
155/167 Test #155: DicTest.Dictionary ..................................................   Passed    0.06 sec
        Start 156: DicTest.Dictionary_invalid
156/167 Test #156: DicTest.Dictionary_invalid ..........................................   Passed    0.06 sec
        Start 157: ErrorTest.Default_error_handling_1
157/167 Test #157: ErrorTest.Default_error_handling_1 ..................................   Passed    0.08 sec
        Start 158: ErrorTest.Default_error_handling_2
158/167 Test #158: ErrorTest.Default_error_handling_2 ..................................   Passed    0.08 sec
        Start 159: ErrorTest.Default_error_handling_fiblang
159/167 Test #159: ErrorTest.Default_error_handling_fiblang ............................   Passed    0.10 sec
        Start 160: ErrorTest.Error_recovery_1
160/167 Test #160: ErrorTest.Error_recovery_1 ..........................................   Passed    0.09 sec
        Start 161: ErrorTest.Error_recovery_2
161/167 Test #161: ErrorTest.Error_recovery_2 ..........................................   Passed    0.08 sec
        Start 162: ErrorTest.Error_recovery_3
162/167 Test #162: ErrorTest.Error_recovery_3 ..........................................   Passed    0.10 sec
        Start 163: ErrorTest.Error_recovery_Java
163/167 Test #163: ErrorTest.Error_recovery_Java .......................................   Passed    0.10 sec
        Start 164: ErrorTest.Error_message_with_rule_instruction
164/167 Test #164: ErrorTest.Error_message_with_rule_instruction .......................   Passed    0.07 sec
        Start 165: StateTest.Indent
165/167 Test #165: StateTest.Indent ....................................................   Passed    0.08 sec
        Start 166: StateTest.NestedBlocks
166/167 Test #166: StateTest.NestedBlocks ..............................................   Passed    0.08 sec
        Start 167: PEGTest.PEG_Grammar
167/167 Test #167: PEGTest.PEG_Grammar .................................................   Passed    0.06 sec

100% tests passed, 0 tests failed out of 167

Total Test time (real) =  13.42 sec
```