### PR TITLE
i2pd: add tests variant, fix build on 10.13–10.14

### DIFF
--- a/security/i2pd/Portfile
+++ b/security/i2pd/Portfile
@@ -42,6 +42,13 @@ cmake.source_dir        ${worksrcpath}/build
 # Minimum required is C++11, C++17 used if supported.
 compiler.cxx_standard   2011
 
+platform darwin {
+    # https://github.com/PurpleI2P/i2pd/issues/1846
+    if {${os.major} == 17 || ${os.major} == 18} {
+        cmake.set_cxx_standard yes
+    }
+}
+
 # https://github.com/PurpleI2P/i2pd/issues/1798
 compiler.blacklist-append \
                         {clang < 600}
@@ -131,6 +138,14 @@ variant upnp description "Support for UPNP" {
 
 variant logrotate description "Logrotate configuration" {
     depends_run-append  port:logrotate
+}
+
+variant tests description "Build and run tests" {
+    depends_test        port:check
+    configure.args-append \
+                        -DBUILD_TESTING=1
+    test.run            yes
+    test.cmd            ctest
 }
 
 default_variants        +upnp +logrotate


### PR DESCRIPTION
#### Description

@herbygillot Here is the PR for tests. (On PPC one test still fails to pass, to be investigated.)
It is also supposed to fix Clang build on 10.13–10.14, based on: https://github.com/PurpleI2P/i2pd/issues/1846
(Alternative solution would be blacklisting Apple Clang on those systems.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
