### PR TITLE
openjdk17-openj9: update to 17.0.5

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      17.0.4.1
+version      17.0.5
 revision     0
 
-set build    1
-set openj9_version 0.33.1
+set build    8
+set openj9_version 0.35.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  0ace9d4d0ae0772c0518c3bd9b429f6edc1e9d1b \
-                 sha256  7de428bd9637081126ffe945bd178367015da32ef03903feb183efad6158d88b \
-                 size    209034425
+    checksums    rmd160  99e6c3aae742194651c8e564778dad4d1dfbb7a2 \
+                 sha256  a8b5aefd73cfee2f46ece159728b3d22af10e841e4a7bb55aaef6dba3aa09e2c \
+                 size    209390651
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  1b60da1879940004ee3f6c0b26b9bc836b6c3c3e \
-                 sha256  50e4c324e7ffcf18c2e3ea7b1bfa870672203dab3fe61520c09fb2bdbe81f2c0 \
-                 size    202255954
+    checksums    rmd160  8aa3c776576406ae46dcb1e514894a975a52a625 \
+                 sha256  094281b40696e31fe54dc6aa3a59387d4bc50208209195de735d0c3c56eafd70 \
+                 size    202728941
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.5.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?