### PR TITLE
openjdk19-oracle: update to 19.0.2

### DIFF
--- a/java/openjdk19-oracle/Portfile
+++ b/java/openjdk19-oracle/Portfile
@@ -14,24 +14,24 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/19/
-version      19.0.1
+version      19.0.2
 revision     0
 
 description  Oracle OpenJDK 19
 long_description Open-source Oracle build of OpenJDK 19, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/afdd2e245b014143b62ccb916125e3ce/10/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/fdb695a9d9064ad6b064dc6df578380c/7/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  34f4e6c8a9f9a06c3877f96842d76a84da06d0ab \
-                 sha256  469af195906979f96c1dc862c2f539a5e280d0daece493a95ebeb91962512161 \
-                 size    192577932
+    checksums    rmd160  cd7cd7da70bbf9247b3daf1772ff872eeda1ef41 \
+                 sha256  c57c7c511706738fff6540945e0159e97b8b328777e6460977dd64e00f4c2c0b \
+                 size    192580989
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  e1ce718a011d334d67d6156b6768ac5c04836e57 \
-                 sha256  915054b18fc17216410cea7aba2321c55b82bd414e1ef3c7e1bafc7beb6856c8 \
-                 size    190630653
+    checksums    rmd160  522dfae403bb90de79775796062f5a212a0bbd8b \
+                 sha256  4317442e14c5c2f4f698db0e41347df99d050a32137b2a02dfec28ed856577cc \
+                 size    190625723
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 19.0.2.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?