### PR TITLE
symengine: update to 0.9.0, allow build with GCC, unbreak PPC

### DIFF
--- a/math/symengine/Portfile
+++ b/math/symengine/Portfile
@@ -5,8 +5,8 @@ PortGroup               github                        1.0
 PortGroup               cmake                         1.1
 PortGroup               legacysupport                 1.1
 
-github.setup            symengine symengine 0.8.1 v
-revision                1
+github.setup            symengine symengine 0.9.0 v
+revision                0
 categories              math science
 license                 MIT
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -14,9 +14,9 @@ platforms               darwin
 description             a fast symbolic manipulation library
 long_description        ${name} is ${description}, written in C++.
 
-checksums               rmd160  f86051602728f1ac8cf655430c0a0d3ddd512c61 \
-                        sha256  feaec7883e5d6692c626782970f029db552efb13f514a3a1b7ae57ee93a96777 \
-                        size    733059
+checksums               rmd160  2f7dcd8cc26281ccefcff1cdce9958fba24992f8 \
+                        sha256  4d5237fd10a95655ea58a1fdb8d90a85fbf4f76562020d662109f8d5445c8418 \
+                        size    878683
 
 set llvm_version        11
 

--- a/math/symengine/Portfile
+++ b/math/symengine/Portfile
@@ -10,7 +10,6 @@ revision                0
 categories              math science
 license                 MIT
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
-platforms               darwin
 description             a fast symbolic manipulation library
 long_description        ${name} is ${description}, written in C++.
 
@@ -23,8 +22,11 @@ set llvm_version        11
 depends_lib-append      port:gmp \
                         port:mpfr \
                         port:libmpc \
-                        port:flint \
-                        port:llvm-${llvm_version}
+                        port:flint
+
+if {[string match *clang* ${configure.compiler}]} {
+    depends_lib-append  port:llvm-${llvm_version}
+}
 
 if {[variant_isset debug]} {
     cmake.build_type    Debug
@@ -43,14 +45,20 @@ configure.args-append   -DWITH_GMP=on \
                         -DWITH_MPFR=on \
                         -DWITH_MPC=on \
                         -DINTEGER_CLASS=flint \
-                        -DWITH_LLVM=on \
                         -DWITH_SYMENGINE_THREAD_SAFE=on
+
+if {[string match *clang* ${configure.compiler}]} {
+    configure.args-append \
+                        -DWITH_LLVM=on
+}
 
 #see https://github.com/symengine/symengine/issues/1671
 configure.args-append   -DWITH_COTIRE=OFF
 
-cmake.module_path-append \
+if {[string match *clang* ${configure.compiler}]} {
+    cmake.module_path-append \
                         ${prefix}/libexec/llvm-${llvm_version}/lib/cmake/llvm
+}
 
 compiler.cxx_standard   2014
 
@@ -59,6 +67,15 @@ legacysupport.use_static                     yes
 legacysupport.newest_darwin_requires_legacy  13
 
 # Use MP's clang based on above LLVM version for consistency with used includes/libs
-compiler.blacklist-append *gcc* clang
-compiler.fallback  macports-clang-${llvm_version}
-compiler.whitelist macports-clang-${llvm_version}
+compiler.blacklist-append clang
+
+if {${build_arch} ni [list ppc ppc64]} {
+    compiler.fallback   macports-clang-${llvm_version}
+    compiler.whitelist  macports-clang-${llvm_version}
+}
+
+# ___atomic_store_8
+if {${build_arch} in [list i386 ppc] && [string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append \
+                        -latomic
+}


### PR DESCRIPTION
#### Description

LLVM is forced in this port for no good reason: upstream disables it by default, and it builds fine with GCC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
