### PR TITLE
jdk19: update to 19.0.2

### DIFF
--- a/java/jdk19/Portfile
+++ b/java/jdk19/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk19-mac
-version      19.0.1
+version      19.0.2
 revision     0
 
 description  Oracle Java SE Development Kit 19
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/19/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  969af56173678efb2a08c0cd54f10095cd1bbfef \
-                 sha256  44dbb6e9c4db2e1fc08fac922ce95a94e51e54429132b4ef5811b0c4709d2077 \
-                 size    186160766
+    checksums    rmd160  e67fd2674d8575c5f5fa2d6b32aa7f5fc2abed72 \
+                 sha256  50f60a959bbc12703aa3c493d0e4bb1bd58accd4b3cfc00cf06e8ee1e294fe2a \
+                 size    186187327
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  57acc6ee6371b03da25b2e2d0e2f8e2d63404bc4 \
-                 sha256  cd6fab160195d5b72ecb43fd7e3bfc5e4bc4523172ad306f33f8ee2b9fe28c54 \
-                 size    184200706
+    checksums    rmd160  4079a2ed95db857aa6af530824993e71911ddcb9 \
+                 sha256  5787befa778fd16032c8385d3e682aac6987181ce3ba3a4983de04c3621b6111 \
+                 size    184210656
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle Java SE 19.0.2.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?