### PR TITLE
jdk17: update to 17.0.6

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.5
+version      17.0.6
 revision     0
 
 description  Oracle Java SE Development Kit 17
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  45be176b56050b1251229b1b392974ecbf1ee42f \
-                 sha256  2b3f7aeef5d568e751cf0bb50c28eede4285b3cb5d15479c6a937f589469742d \
-                 size    178596850
+    checksums    rmd160  dccf058127d4b3f4e8b740c37aa989069505fd77 \
+                 sha256  75ff8fd2306fd5b8c14454e4e677dc414ebf50f9dd887b9a790b2ce808ac9d0a \
+                 size    178373401
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  6270fddd40ba5730c3e663357bbda6767808b7f2 \
-                 sha256  73d2bc6f3527061e602d42870a5b51f4a730e2553877abada887bc20b4d80781 \
-                 size    175850363
+    checksums    rmd160  69bddf1ea802e5a9a5c5adfd9ce78164f3be0fe6 \
+                 sha256  efded5026943e43a26d149dbbe84b37c97771c87cf2a26ed2c141a61c8055acf \
+                 size    175659085
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle Java SE 17.0.6.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?