### PR TITLE
openjdk17: update to 17.0.6

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk17
 # https://github.com/openjdk/jdk17u/tags
-version             17.0.5
-set build 8
+version             17.0.6
+set build 9
 revision            0
 categories          java devel
 platforms           darwin
@@ -19,9 +19,9 @@ homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
 distname            jdk-${version}+${build}
 
-checksums           rmd160  babea0fc04402a066cf04680f285d2f530a91789 \
-                    sha256  6717fbf68472e9dca520998504a25ad5cfaa610d0066cad169bb7b78a108fbfc \
-                    size    105064912
+checksums           rmd160  555cbfd088990c825826d4e490c63cd8e42f5b23 \
+                    sha256  e038b1837725bf3bd85aeeeb4df9cd06b82e22ebd153d84fb8d35d60eab3c31f \
+                    size    105221837
 
 depends_lib         port:freetype
 depends_build       port:autoconf \
@@ -54,8 +54,8 @@ configure.args      --with-debug-level=release \
                     --with-freetype-lib=${prefix}/lib \
                     --disable-precompiled-headers \
                     --disable-warnings-as-errors \
-                    --with-vendor-name="OpenJDK Porters Group" \
-                    --with-vendor-url="${homepage}" \
+                    --with-vendor-name="MacPorts" \
+                    --with-vendor-url="https://www.macports.org" \
                     --with-vendor-bug-url="${bug_url}" \
                     --with-vendor-vm-bug-url="${bug_url}" \
                     --with-conf-name=release


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.6, and change vendor from OpenJDK Porters Group to MacPorts.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?