### PR TITLE
PENF: new port in devel

### DIFF
--- a/devel/PENF/Portfile
+++ b/devel/PENF/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+
+github.setup        szaghi PENF 1.2.3 v
+revision            0
+categories          devel fortran
+license             {BSD GPL-3 MIT}
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Portability Environment for Fortran poor people
+long_description    A KISS library for exploiting codes portability for modern (2003+) Fortran projects.
+checksums           rmd160  2b9eae6ac289f0105062d944a0c066a4c0005dab \
+                    sha256  808e99445d4e9514ec29868b997d866a96d4d57a8edc73fa2ff10d91c2829503 \
+                    size    143277
+
+compilers.choose    fc f90 cc
+compilers.setup     require_fortran
+compiler.blacklist-append \
+                    *gcc-4.* {clang < 421}
+
+configure.args-append \
+                    -DBUILD_TESTING=ON
+
+# Some tests fail on PPC: https://github.com/szaghi/PENF/issues/23
+test.run            yes
+test.cmd            ctest


### PR DESCRIPTION
#### Description

New port: https://github.com/szaghi/PENF

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Some tests fail on PPC (at least in Rosetta): https://github.com/szaghi/PENF/issues/23
```
85% tests passed, 17 tests failed out of 110
```