### PR TITLE
npth: fix for old systems

### DIFF
--- a/devel/npth/Portfile
+++ b/devel/npth/Portfile
@@ -4,14 +4,15 @@ PortSystem          1.0
 
 name                npth
 version             1.6
+revision            1
 categories          devel
 license             LGPL-3+ GPL-2+
 maintainers         nomaintainer
 
 description         The New GNU Portable Threads Library
 
-long_description    This is a library to provide the GNU Pth API and thus a \
-                    non-preemptive threads implementation.
+long_description    This is a library to provide the GNU Pth API \
+                    and thus a non-preemptive threads implementation.
 
 homepage            https://gnupg.org/related_software/npth/
 master_sites        gnupg:npth
@@ -21,6 +22,18 @@ use_bzip2           yes
 checksums           rmd160  25756e8cd7711a9e06b377f41b2f88cdcc76d441 \
                     sha256  1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1 \
                     size    300486
+
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        post-extract {
+            copy ${filespath}/darwin_compat.h ${worksrcpath}/src/
+            copy ${filespath}/darwin_compat.c ${worksrcpath}/src/
+        }
+        patchfiles-append   use-darwin-compat.diff
+        use_autoreconf      yes
+        autoreconf.args     -fvi
+    }
+}
 
 livecheck.type      regex
 livecheck.url       https://gnupg.org/ftp/gcrypt/${name}/

--- a/devel/npth/files/darwin_compat.c
+++ b/devel/npth/files/darwin_compat.c
@@ -1,0 +1,247 @@
+ /*
+  * Source: https://github.com/pktgen/sshfs/blob/master/compat/darwin_compat.c
+  * Copyright (c) 2006-2008 Amit Singh/Google Inc.
+  * Copyright (c) 2012 Anatol Pomozov
+  * Copyright (c) 2011-2013 Benjamin Fleischer
+  */
+
+ #include "darwin_compat.h"
+
+ #include <assert.h>
+ #include <errno.h>
+ #include <sys/types.h>
+
+ /*
+  * Semaphore implementation based on:
+  *
+  * Copyright (C) 2000,02 Free Software Foundation, Inc.
+  * This file is part of the GNU C Library.
+  * Written by Ga<EB>l Le Mignot <address@hidden>
+  *
+  * The GNU C Library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Library General Public License as
+  * published by the Free Software Foundation; either version 2 of the
+  * License, or (at your option) any later version.
+  *
+  * The GNU C Library is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  * Library General Public License for more details.
+  *
+  * You should have received a copy of the GNU Library General Public
+  * License along with the GNU C Library; see the file COPYING.LIB.  If not,
+  * write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+  * Boston, MA 02111-1307, USA.
+  */
+
+ /* Semaphores */
+
+ #define __SEM_ID_NONE  ((int)0x0)
+ #define __SEM_ID_LOCAL ((int)0xcafef00d)
+
+ /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_init.html */
+ int
+ darwin_sem_init(darwin_sem_t *sem, int pshared, unsigned int value)
+ {
+     if (pshared) {
+         errno = ENOSYS;
+         return -1;
+     }
+
+     sem->id = __SEM_ID_NONE;
+
+     if (pthread_cond_init(&sem->__data.local.count_cond, NULL)) {
+         goto cond_init_fail;
+     }
+
+     if (pthread_mutex_init(&sem->__data.local.count_lock, NULL)) {
+         goto mutex_init_fail;
+     }
+
+     sem->__data.local.count = value;
+     sem->id = __SEM_ID_LOCAL;
+
+     return 0;
+
+ mutex_init_fail:
+
+     pthread_cond_destroy(&sem->__data.local.count_cond);
+
+ cond_init_fail:
+
+     return -1;
+ }
+
+ /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_destroy.html */
+ int
+ darwin_sem_destroy(darwin_sem_t *sem)
+ {
+     int res = 0;
+
+     pthread_mutex_lock(&sem->__data.local.count_lock);
+
+     sem->id = __SEM_ID_NONE;
+     pthread_cond_broadcast(&sem->__data.local.count_cond);
+
+     if (pthread_cond_destroy(&sem->__data.local.count_cond)) {
+         res = -1;
+     }
+
+     pthread_mutex_unlock(&sem->__data.local.count_lock);
+
+     if (pthread_mutex_destroy(&sem->__data.local.count_lock)) {
+         res = -1;
+     }
+
+     return res;
+ }
+
+ int
+ darwin_sem_getvalue(darwin_sem_t *sem, unsigned int *sval)
+ {
+     int res = 0;
+
+     pthread_mutex_lock(&sem->__data.local.count_lock);
+
+     if (sem->id != __SEM_ID_LOCAL) {
+         res = -1;
+         errno = EINVAL;
+     } else {
+         *sval = sem->__data.local.count;
+     }
+
+     pthread_mutex_unlock(&sem->__data.local.count_lock);
+
+     return res;
+ }
+
+ /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_post.html */
+ int
+ darwin_sem_post(darwin_sem_t *sem)
+ {
+     int res = 0;
+
+     pthread_mutex_lock(&sem->__data.local.count_lock);
+
+     if (sem->id != __SEM_ID_LOCAL) {
+         res = -1;
+         errno = EINVAL;
+     } else if (sem->__data.local.count < DARWIN_SEM_VALUE_MAX) {
+         sem->__data.local.count++;
+         if (sem->__data.local.count == 1) {
+             pthread_cond_signal(&sem->__data.local.count_cond);
+         }
+     } else {
+         errno = ERANGE;
+         res = -1;
+     }
+
+     pthread_mutex_unlock(&sem->__data.local.count_lock);
+
+     return res;
+ }
+
+ /* http://www.opengroup.org/onlinepubs/009695399/functions/sem_timedwait.html */
+ int
+ darwin_sem_timedwait(darwin_sem_t *sem, const struct timespec *abs_timeout)
+ {
+     int res = 0;
+
+     if (abs_timeout &&
+         (abs_timeout->tv_nsec < 0 || abs_timeout->tv_nsec >= 1000000000)) {
+         errno = EINVAL;
+         return -1;
+     }
+
+     pthread_cleanup_push((void(*)(void*))&pthread_mutex_unlock,
+                  &sem->__data.local.count_lock);
+
+     pthread_mutex_lock(&sem->__data.local.count_lock);
+
+     if (sem->id != __SEM_ID_LOCAL) {
+         errno = EINVAL;
+         res = -1;
+     } else {
+         if (!sem->__data.local.count) {
+             res = pthread_cond_timedwait(&sem->__data.local.count_cond,
+                              &sem->__data.local.count_lock,
+                              abs_timeout);
+         }
+         if (res) {
+             assert(res == ETIMEDOUT);
+             res = -1;
+             errno = ETIMEDOUT;
+         } else if (sem->id != __SEM_ID_LOCAL) {
+             res = -1;
+             errno = EINVAL;
+         } else {
+             sem->__data.local.count--;
+         }
+     }
+
+     pthread_cleanup_pop(1);
+
+     return res;
+ }
+
+ /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_trywait.html */
+ int
+ darwin_sem_trywait(darwin_sem_t *sem)
+ {
+     int res = 0;
+
+     pthread_mutex_lock(&sem->__data.local.count_lock);
+
+     if (sem->id != __SEM_ID_LOCAL) {
+         res = -1;
+         errno = EINVAL;
+     } else if (sem->__data.local.count) {
+         sem->__data.local.count--;
+     } else {
+         res = -1;
+         errno = EAGAIN;
+     }
+
+     pthread_mutex_unlock (&sem->__data.local.count_lock);
+
+     return res;
+ }
+
+ /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_wait.html */
+ int
+ darwin_sem_wait(darwin_sem_t *sem)
+ {
+     int res = 0;
+
+     pthread_cleanup_push((void(*)(void*))&pthread_mutex_unlock,
+                  &sem->__data.local.count_lock);
+
+     pthread_mutex_lock(&sem->__data.local.count_lock);
+
+     if (sem->id != __SEM_ID_LOCAL) {
+         errno = EINVAL;
+         res = -1;
+     } else {
+         if (!sem->__data.local.count) {
+             pthread_cond_wait(&sem->__data.local.count_cond,
+                       &sem->__data.local.count_lock);
+             if (!sem->__data.local.count) {
+                 /* spurious wakeup, assume it is an interruption */
+                 res = -1;
+                 errno = EINTR;
+                 goto out;
+             }
+         }
+         if (sem->id != __SEM_ID_LOCAL) {
+             res = -1;
+             errno = EINVAL;
+         } else {
+             sem->__data.local.count--;
+         }
+     }
+
+ out:
+     pthread_cleanup_pop(1);
+
+     return res;
+ }

--- a/devel/npth/files/darwin_compat.h
+++ b/devel/npth/files/darwin_compat.h
@@ -1,0 +1,52 @@
+ /*
+  * Source: https://github.com/pktgen/sshfs/blob/master/compat/darwin_compat.h
+  * Copyright (c) 2006-2008 Amit Singh/Google Inc.
+  * Copyright (c) 2011-2013 Benjamin Fleischer
+  */
+
+ #ifndef _DARWIN_COMPAT_
+ #define _DARWIN_COMPAT_
+
+ #include <pthread.h>
+
+ /* Semaphores */
+
+ struct __local_sem_t
+ {
+     unsigned int    count;
+     pthread_mutex_t count_lock;
+     pthread_cond_t  count_cond;
+ };
+
+ typedef struct fuse_sem {
+     int id;
+     union {
+         struct __local_sem_t local;
+     } __data;
+ } darwin_sem_t;
+
+ #define DARWIN_SEM_VALUE_MAX ((int32_t)32767)
+
+ int darwin_sem_init(darwin_sem_t *sem, int pshared, unsigned int value);
+ int darwin_sem_destroy(darwin_sem_t *sem);
+ int darwin_sem_getvalue(darwin_sem_t *sem, unsigned int *value);
+ int darwin_sem_post(darwin_sem_t *sem);
+ int darwin_sem_timedwait(darwin_sem_t *sem, const struct timespec *abs_timeout);
+ int darwin_sem_trywait(darwin_sem_t *sem);
+ int darwin_sem_wait(darwin_sem_t *sem);
+
+ /* Caller must not include <semaphore.h> */
+
+ typedef darwin_sem_t sem_t;
+
+ #define sem_init(s, p, v)   darwin_sem_init(s, p, v)
+ #define sem_destroy(s)      darwin_sem_destroy(s)
+ #define sem_getvalue(s, v)  darwin_sem_getvalue(s, v)
+ #define sem_post(s)         darwin_sem_post(s)
+ #define sem_timedwait(s, t) darwin_sem_timedwait(s, t)
+ #define sem_trywait(s)      darwin_sem_trywait(s)
+ #define sem_wait(s)         darwin_sem_wait(s)
+
+ #define SEM_VALUE_MAX       DARWIN_SEM_VALUE_MAX
+
+ #endif /* _DARWIN_COMPAT_ */

--- a/devel/npth/files/use-darwin-compat.diff
+++ b/devel/npth/files/use-darwin-compat.diff
@@ -1,0 +1,21 @@
+--- src/Makefile.am~	2017-05-16 09:21:06.000000000 +0200
++++ src/Makefile.am	2020-09-02 10:32:49.000000000 +0200
+@@ -31,6 +31,7 @@
+ endif
+ 
+ libnpth_la_SOURCES = npth.h npth.c npth-sigev.c
++libnpth_la_SOURCES += darwin_compat.h darwin_compat.c
+ 
+ # AM_CPPFLAGS =
+ # AM_CFLAGS =
+--- src/npth.c~	2018-07-16 09:15:59.000000000 +0200
++++ src/npth.c	2020-09-02 10:33:58.000000000 +0200
+@@ -63,7 +63,7 @@
+   return 0;
+ }
+ #else
+-# include <semaphore.h>
++# include "darwin_compat.h"
+ #endif
+ #ifdef HAVE_UNISTD_H
+ # include <unistd.h>


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/56185
Fixes: https://trac.macports.org/ticket/61115

#### Description

`gnupg2` does not work on old systems due to a bug in `npth`. This PR brings a fix for that. (Fix is not mine, it is from the ticket, but I confirmed it works.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
