### PR TITLE
openjdk19: update to 19.32.13

### DIFF
--- a/java/openjdk19-zulu/Portfile
+++ b/java/openjdk19-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-19-sts&os=macos&package=jdk
-version      19.30.11
+version      19.32.13
 revision     0
 
-set openjdk_version 19.0.1
+set openjdk_version 19.0.2
 
 description  Azul Zulu Community OpenJDK 19 (Short Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  b66e1aa27716ab16739fbf7d1d2309dffd003972 \
-                 sha256  56cfc2fa05b63aafd6c0c316683505069178c9b1edad190d285ef6fb3a9018c0 \
-                 size    201612286
+    checksums    rmd160  104b544fed67d3b671aa2e93f4a46c8a8dd386e3 \
+                 sha256  2804575ae9ac63e39caa910e57610bf52b0f9e2d671928a98d18e2fcc9f62ac1 \
+                 size    201637537
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  8e0cb5a28db5cd1f26cb9ef8b690510ef9c169a2 \
-                 sha256  d362f01e4dbbb92b0dfa938abb2840b3eda7c320c0b908bb4166bb02c319113d \
-                 size    199656100
+    checksums    rmd160  f4127a7dd6a55bdb3fd09b590a4703756630ff6a \
+                 sha256  177d058d968b2fbe7a5ff5eceb18cdc16f6376ce291004f1a3139e78b2fb6391 \
+                 size    199629921
 }
 
 worksrcdir   ${distname}/zulu-19.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 19.32.13 based on OpenJDK 19.0.2.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?