### PR TITLE
openjdk17-zulu: update to 17.40.19

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.38.21
+version      17.40.19
 revision     0
 
-set openjdk_version 17.0.5
+set openjdk_version 17.0.6
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  df7e42281a10fd5d6c7c2cef425254069f6ecedd \
-                 sha256  e6317cee4d40995f0da5b702af3f04a6af2bbd55febf67927696987d11113b53 \
-                 size    193801252
+    checksums    rmd160  084086f554bb0f888c9dd6c6c9fa86fcc486203a \
+                 sha256  1710c8b2f53d78760c4f446e29119a32f40afb0a3830f68c02dc37b11799ab6f \
+                 size    193883691
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  7b88361ab6a5fe4de439cd30f793267cb660f1b7 \
-                 sha256  515dd56ec99bb5ae8966621a2088aadfbe72631818ffbba6e4387b7ee292ab09 \
-                 size    191590524
+    checksums    rmd160  82a9757956f1765ca636a21d1f88cbff7a980805 \
+                 sha256  f75ee3fbc1744e661ba61058c4c0c37217f6ffb24710987ba2fbcdf801aa462e \
+                 size    191640717
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.40.19 based on OpenJDK 17.0.6.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?