### PR TITLE
starpu: new port in devel

### DIFF
--- a/devel/starpu/Portfile
+++ b/devel/starpu/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           linear_algebra 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
+
+github.setup        starpu-runtime starpu 1.3.10 starpu-
+revision            0
+categories          devel
+license             LGPL-2.1
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Unified runtime system for heterogeneous multicore architectures
+long_description    StarPU is a runtime system that offers support for heterogeneous multicore machines. \
+                    While many efforts are devoted to design efficient computation kernels \
+                    for those architectures (e.g. to implement BLAS kernels on GPUs), StarPU \
+                    not only takes care of offloading such kernels (and implementing data coherency \
+                    across the machine), but it also makes sure the kernels are executed as efficiently as possible.
+homepage            https://starpu.gitlabpages.inria.fr
+checksums           rmd160  ae47346b93868ff74d0ade50a9d1130028bf901d \
+                    sha256  fa0788a426d8025f6c5650f13784a30d7f4fd0ea7d23420eb56e48d15f50fcda \
+                    size    7295360
+
+compiler.blacklist-append \
+                    *gcc-4.* {clang < 400}
+compilers.choose    fc f90 f77 cc
+compilers.setup     require_fortran
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool \
+                    port:pkgconfig
+depends_lib-append  port:hdf5 \
+                    port:hwloc
+
+test.run            yes
+test.target         check


### PR DESCRIPTION
#### Description

New port: https://starpu.gitlabpages.inria.fr
https://github.com/starpu-runtime/starpu

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Tests mostly pass in Rosetta:
```
--->  Testing starpu
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_starpu/starpu/work/starpu-1.3.10" && /usr/bin/make check 
Making check in src
make[2]: Nothing to be done for `check-am'.
Making check in tools
/usr/bin/make    starpu_machine_display starpu_sched_display starpu_perfmodel_display starpu_perfmodel_plot
make[3]: `starpu_machine_display' is up to date.
make[3]: `starpu_sched_display' is up to date.
make[3]: `starpu_perfmodel_display' is up to date.
make[3]: `starpu_perfmodel_plot' is up to date.
/usr/bin/make  check-TESTS
PASS: starpu_machine_display
PASS: starpu_sched_display
PASS: starpu_perfmodel_display
PASS: starpu_perfmodel_plot
============================================================================
Testsuite summary for StarPU 1.3.10
============================================================================
# TOTAL: 4
# PASS:  4
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
/usr/bin/make  check-recursive
/usr/bin/make  loader main/callback main/bind main/mkdtemp main/execute_schedule main/insert_task_pack main/insert_task_nullcodelet main/multithreaded_init main/empty_task main/empty_task_chain main/starpu_worker_exists main/codelet_null_callback datawizard/allocate datawizard/acquire_cb datawizard/deps datawizard/user_interaction_implicit datawizard/interfaces/copy_interfaces datawizard/numa_overflow datawizard/locality datawizard/variable_size errorcheck/starpu_init_noworker errorcheck/invalid_tasks helper/cublas_init helper/cusparse_init helper/pinned_memory helper/execute_on_all microbenchs/display_structures_size microbenchs/local_pingpong overlap/overlap sched_ctx/sched_ctx_list sched_ctx/sched_ctx_policy_data openmp/init_exit_01 openmp/init_exit_02 openmp/environment openmp/api_01 openmp/parallel_01 openmp/parallel_02 openmp/parallel_03 openmp/parallel_barrier_01 openmp/parallel_master_01 openmp/parallel_master_inline_01 openmp/parallel_single_wait_01 openmp/parallel_single_nowait_01 openmp/parallel_single_inline_01 openmp/parallel_single_copyprivate_01 openmp/parallel_single_copyprivate_inline_01 openmp/parallel_critical_01 openmp/parallel_critical_inline_01 openmp/parallel_critical_named_01 openmp/parallel_critical_named_inline_01 openmp/parallel_simple_lock_01 openmp/parallel_nested_lock_01 openmp/parallel_for_01 openmp/parallel_for_02 openmp/parallel_for_ordered_01 openmp/parallel_sections_01 openmp/parallel_sections_combined_01 openmp/task_01 openmp/task_02 openmp/task_03 openmp/taskloop openmp/taskwait_01 openmp/taskgroup_01 openmp/taskgroup_02 openmp/array_slice_01 openmp/cuda_task_01 perfmodels/value_nan sched_policies/workerids  main/deprecated_func main/driver_api/init_run_deinit main/driver_api/run_driver main/deploop main/display_binding main/execute_on_a_specific_worker main/insert_task main/insert_task_value main/insert_task_dyn_handles main/insert_task_array main/insert_task_many main/insert_task_where main/job main/multithreaded main/starpu_task_bundle main/starpu_task_wait_for_all main/starpu_task_wait main/static_restartable main/static_restartable_using_initializer main/static_restartable_tag main/regenerate main/regenerate_pipeline main/restart main/wait_all_regenerable_tasks main/subgraph_repeat main/subgraph_repeat_tag main/subgraph_repeat_regenerate main/subgraph_repeat_regenerate_tag main/subgraph_repeat_regenerate_tag_cycle main/empty_task_sync_point main/empty_task_sync_point_tasks main/tag_wait_api main/tag_get_task main/task_wait_api main/declare_deps_in_callback main/declare_deps_after_submission main/declare_deps_after_submission_synchronous main/get_current_task main/starpu_init main/submit main/pause_resume main/pack main/get_children_tasks main/hwloc_cpuset main/task_end_dep datawizard/acquire_cb_insert datawizard/acquire_release datawizard/acquire_release2 datawizard/acquire_try datawizard/bcsr datawizard/cache datawizard/commute datawizard/commute2 datawizard/copy datawizard/data_implicit_deps datawizard/data_lookup datawizard/scratch datawizard/scratch_reuse datawizard/sync_and_notify_data datawizard/sync_and_notify_data_implicit datawizard/dsm_stress datawizard/double_parameter datawizard/write_only_tmp_buffer datawizard/data_invalidation datawizard/dining_philosophers datawizard/manual_reduction datawizard/readers_and_writers datawizard/unpartition datawizard/sync_with_data_with_mem datawizard/sync_with_data_with_mem_non_blocking datawizard/sync_with_data_with_mem_non_blocking_implicit datawizard/mpi_like datawizard/mpi_like_async datawizard/critical_section_with_void_interface datawizard/increment_init datawizard/increment_redux datawizard/increment_redux_v2 datawizard/increment_redux_lazy datawizard/handle_to_pointer datawizard/lazy_allocation datawizard/lazy_unregister datawizard/no_unregister datawizard/noreclaim datawizard/nowhere datawizard/interfaces/block/block_interface datawizard/interfaces/bcsr/bcsr_interface datawizard/interfaces/coo/coo_interface datawizard/interfaces/csr/csr_interface datawizard/interfaces/matrix/matrix_interface datawizard/interfaces/multiformat/multiformat_interface datawizard/interfaces/multiformat/advanced/multiformat_cuda_opencl datawizard/interfaces/multiformat/advanced/multiformat_data_release datawizard/interfaces/multiformat/advanced/multiformat_worker datawizard/interfaces/multiformat/advanced/multiformat_handle_conversion datawizard/interfaces/multiformat/advanced/same_handle datawizard/interfaces/variable/variable_interface datawizard/interfaces/vector/vector_interface datawizard/interfaces/void/void_interface datawizard/in_place_partition datawizard/partition_dep datawizard/partition_lazy datawizard/partition_init datawizard/gpu_register datawizard/gpu_ptr_register datawizard/variable_parameters datawizard/wt_host datawizard/wt_broadcast datawizard/readonly datawizard/specific_node datawizard/task_with_multiple_time_the_same_handle datawizard/test_arbiter datawizard/invalidate_pending_requests datawizard/temporary_partition datawizard/partitioned_initialization datawizard/partitioned_acquire datawizard/temporary_partition_implicit datawizard/redux_acquire disk/disk_copy disk/disk_copy_unpack disk/disk_copy_to_disk disk/disk_compute disk/disk_pack disk/mem_reclaim errorcheck/invalid_blocking_calls errorcheck/workers_cpuid helper/starpu_data_cpy helper/starpu_create_sync_task microbenchs/async_tasks_overhead microbenchs/sync_tasks_overhead microbenchs/tasks_overhead microbenchs/tasks_size_overhead microbenchs/prefetch_data_on_node microbenchs/redundant_buffer microbenchs/matrix_as_vector microbenchs/bandwidth overlap/gpu_concurrency parallel_tasks/explicit_combined_worker parallel_tasks/parallel_kernels parallel_tasks/parallel_kernels_trivial parallel_tasks/parallel_kernels_spmd parallel_tasks/spmd_peager parallel_tasks/cuda_only perfmodels/regression_based perfmodels/non_linear_regression_based perfmodels/feed perfmodels/user_base perfmodels/valid_model perfmodels/memory sched_policies/data_locality sched_policies/execute_all_tasks sched_policies/prio sched_policies/simple_deps sched_policies/simple_cpu_gpu_sched sched_ctx/sched_ctx_hierarchy fortran90/init_01 
make[4]: `loader' is up to date.
make[4]: `main/callback' is up to date.
make[4]: `main/bind' is up to date.
make[4]: `main/mkdtemp' is up to date.
make[4]: `main/execute_schedule' is up to date.
make[4]: `main/insert_task_pack' is up to date.
make[4]: `main/insert_task_nullcodelet' is up to date.
make[4]: `main/multithreaded_init' is up to date.
make[4]: `main/empty_task' is up to date.
make[4]: `main/empty_task_chain' is up to date.
make[4]: `main/starpu_worker_exists' is up to date.
make[4]: `main/codelet_null_callback' is up to date.
make[4]: `datawizard/allocate' is up to date.
make[4]: `datawizard/acquire_cb' is up to date.
make[4]: `datawizard/deps' is up to date.
make[4]: `datawizard/user_interaction_implicit' is up to date.
make[4]: `datawizard/interfaces/copy_interfaces' is up to date.
make[4]: `datawizard/numa_overflow' is up to date.
make[4]: `datawizard/locality' is up to date.
make[4]: `datawizard/variable_size' is up to date.
make[4]: `errorcheck/starpu_init_noworker' is up to date.
make[4]: `errorcheck/invalid_tasks' is up to date.
make[4]: `helper/cublas_init' is up to date.
make[4]: `helper/cusparse_init' is up to date.
make[4]: `helper/pinned_memory' is up to date.
make[4]: `helper/execute_on_all' is up to date.
make[4]: `microbenchs/display_structures_size' is up to date.
make[4]: `microbenchs/local_pingpong' is up to date.
make[4]: `overlap/overlap' is up to date.
make[4]: `sched_ctx/sched_ctx_list' is up to date.
make[4]: `sched_ctx/sched_ctx_policy_data' is up to date.
make[4]: `openmp/init_exit_01' is up to date.
make[4]: `openmp/init_exit_02' is up to date.
make[4]: `openmp/environment' is up to date.
make[4]: `openmp/api_01' is up to date.
make[4]: `openmp/parallel_01' is up to date.
make[4]: `openmp/parallel_02' is up to date.
make[4]: `openmp/parallel_03' is up to date.
make[4]: `openmp/parallel_barrier_01' is up to date.
make[4]: `openmp/parallel_master_01' is up to date.
make[4]: `openmp/parallel_master_inline_01' is up to date.
make[4]: `openmp/parallel_single_wait_01' is up to date.
make[4]: `openmp/parallel_single_nowait_01' is up to date.
make[4]: `openmp/parallel_single_inline_01' is up to date.
make[4]: `openmp/parallel_single_copyprivate_01' is up to date.
make[4]: `openmp/parallel_single_copyprivate_inline_01' is up to date.
make[4]: `openmp/parallel_critical_01' is up to date.
make[4]: `openmp/parallel_critical_inline_01' is up to date.
make[4]: `openmp/parallel_critical_named_01' is up to date.
make[4]: `openmp/parallel_critical_named_inline_01' is up to date.
make[4]: `openmp/parallel_simple_lock_01' is up to date.
make[4]: `openmp/parallel_nested_lock_01' is up to date.
make[4]: `openmp/parallel_for_01' is up to date.
make[4]: `openmp/parallel_for_02' is up to date.
make[4]: `openmp/parallel_for_ordered_01' is up to date.
make[4]: `openmp/parallel_sections_01' is up to date.
make[4]: `openmp/parallel_sections_combined_01' is up to date.
make[4]: `openmp/task_01' is up to date.
make[4]: `openmp/task_02' is up to date.
make[4]: `openmp/task_03' is up to date.
make[4]: `openmp/taskloop' is up to date.
make[4]: `openmp/taskwait_01' is up to date.
make[4]: `openmp/taskgroup_01' is up to date.
make[4]: `openmp/taskgroup_02' is up to date.
make[4]: `openmp/array_slice_01' is up to date.
make[4]: `openmp/cuda_task_01' is up to date.
make[4]: `perfmodels/value_nan' is up to date.
make[4]: `sched_policies/workerids' is up to date.
make[4]: `main/deprecated_func' is up to date.
make[4]: `main/driver_api/init_run_deinit' is up to date.
make[4]: `main/driver_api/run_driver' is up to date.
make[4]: `main/deploop' is up to date.
make[4]: `main/display_binding' is up to date.
make[4]: `main/execute_on_a_specific_worker' is up to date.
make[4]: `main/insert_task' is up to date.
make[4]: `main/insert_task_value' is up to date.
make[4]: `main/insert_task_dyn_handles' is up to date.
make[4]: `main/insert_task_array' is up to date.
make[4]: `main/insert_task_many' is up to date.
make[4]: `main/insert_task_where' is up to date.
make[4]: `main/job' is up to date.
make[4]: `main/multithreaded' is up to date.
make[4]: `main/starpu_task_bundle' is up to date.
make[4]: `main/starpu_task_wait_for_all' is up to date.
make[4]: `main/starpu_task_wait' is up to date.
make[4]: `main/static_restartable' is up to date.
make[4]: `main/static_restartable_using_initializer' is up to date.
make[4]: `main/static_restartable_tag' is up to date.
make[4]: `main/regenerate' is up to date.
make[4]: `main/regenerate_pipeline' is up to date.
make[4]: `main/restart' is up to date.
make[4]: `main/wait_all_regenerable_tasks' is up to date.
make[4]: `main/subgraph_repeat' is up to date.
make[4]: `main/subgraph_repeat_tag' is up to date.
make[4]: `main/subgraph_repeat_regenerate' is up to date.
make[4]: `main/subgraph_repeat_regenerate_tag' is up to date.
make[4]: `main/subgraph_repeat_regenerate_tag_cycle' is up to date.
make[4]: `main/empty_task_sync_point' is up to date.
make[4]: `main/empty_task_sync_point_tasks' is up to date.
make[4]: `main/tag_wait_api' is up to date.
make[4]: `main/tag_get_task' is up to date.
make[4]: `main/task_wait_api' is up to date.
make[4]: `main/declare_deps_in_callback' is up to date.
make[4]: `main/declare_deps_after_submission' is up to date.
make[4]: `main/declare_deps_after_submission_synchronous' is up to date.
make[4]: `main/get_current_task' is up to date.
make[4]: `main/starpu_init' is up to date.
make[4]: `main/submit' is up to date.
make[4]: `main/pause_resume' is up to date.
make[4]: `main/pack' is up to date.
make[4]: `main/get_children_tasks' is up to date.
make[4]: `main/hwloc_cpuset' is up to date.
make[4]: `main/task_end_dep' is up to date.
make[4]: `datawizard/acquire_cb_insert' is up to date.
make[4]: `datawizard/acquire_release' is up to date.
make[4]: `datawizard/acquire_release2' is up to date.
make[4]: `datawizard/acquire_try' is up to date.
make[4]: `datawizard/bcsr' is up to date.
make[4]: `datawizard/cache' is up to date.
make[4]: `datawizard/commute' is up to date.
make[4]: `datawizard/commute2' is up to date.
make[4]: `datawizard/copy' is up to date.
make[4]: `datawizard/data_implicit_deps' is up to date.
make[4]: `datawizard/data_lookup' is up to date.
make[4]: `datawizard/scratch' is up to date.
make[4]: `datawizard/scratch_reuse' is up to date.
make[4]: `datawizard/sync_and_notify_data' is up to date.
make[4]: `datawizard/sync_and_notify_data_implicit' is up to date.
make[4]: `datawizard/dsm_stress' is up to date.
make[4]: `datawizard/double_parameter' is up to date.
make[4]: `datawizard/write_only_tmp_buffer' is up to date.
make[4]: `datawizard/data_invalidation' is up to date.
make[4]: `datawizard/dining_philosophers' is up to date.
make[4]: `datawizard/manual_reduction' is up to date.
make[4]: `datawizard/readers_and_writers' is up to date.
make[4]: `datawizard/unpartition' is up to date.
make[4]: `datawizard/sync_with_data_with_mem' is up to date.
make[4]: `datawizard/sync_with_data_with_mem_non_blocking' is up to date.
make[4]: `datawizard/sync_with_data_with_mem_non_blocking_implicit' is up to date.
make[4]: `datawizard/mpi_like' is up to date.
make[4]: `datawizard/mpi_like_async' is up to date.
make[4]: `datawizard/critical_section_with_void_interface' is up to date.
make[4]: `datawizard/increment_init' is up to date.
make[4]: `datawizard/increment_redux' is up to date.
make[4]: `datawizard/increment_redux_v2' is up to date.
make[4]: `datawizard/increment_redux_lazy' is up to date.
make[4]: `datawizard/handle_to_pointer' is up to date.
make[4]: `datawizard/lazy_allocation' is up to date.
make[4]: `datawizard/lazy_unregister' is up to date.
make[4]: `datawizard/no_unregister' is up to date.
make[4]: `datawizard/noreclaim' is up to date.
make[4]: `datawizard/nowhere' is up to date.
make[4]: `datawizard/interfaces/block/block_interface' is up to date.
make[4]: `datawizard/interfaces/bcsr/bcsr_interface' is up to date.
make[4]: `datawizard/interfaces/coo/coo_interface' is up to date.
make[4]: `datawizard/interfaces/csr/csr_interface' is up to date.
make[4]: `datawizard/interfaces/matrix/matrix_interface' is up to date.
make[4]: `datawizard/interfaces/multiformat/multiformat_interface' is up to date.
make[4]: `datawizard/interfaces/multiformat/advanced/multiformat_cuda_opencl' is up to date.
make[4]: `datawizard/interfaces/multiformat/advanced/multiformat_data_release' is up to date.
make[4]: `datawizard/interfaces/multiformat/advanced/multiformat_worker' is up to date.
make[4]: `datawizard/interfaces/multiformat/advanced/multiformat_handle_conversion' is up to date.
make[4]: `datawizard/interfaces/multiformat/advanced/same_handle' is up to date.
make[4]: `datawizard/interfaces/variable/variable_interface' is up to date.
make[4]: `datawizard/interfaces/vector/vector_interface' is up to date.
make[4]: `datawizard/interfaces/void/void_interface' is up to date.
make[4]: `datawizard/in_place_partition' is up to date.
make[4]: `datawizard/partition_dep' is up to date.
make[4]: `datawizard/partition_lazy' is up to date.
make[4]: `datawizard/partition_init' is up to date.
make[4]: `datawizard/gpu_register' is up to date.
make[4]: `datawizard/gpu_ptr_register' is up to date.
make[4]: `datawizard/variable_parameters' is up to date.
make[4]: `datawizard/wt_host' is up to date.
make[4]: `datawizard/wt_broadcast' is up to date.
make[4]: `datawizard/readonly' is up to date.
make[4]: `datawizard/specific_node' is up to date.
make[4]: `datawizard/task_with_multiple_time_the_same_handle' is up to date.
make[4]: `datawizard/test_arbiter' is up to date.
make[4]: `datawizard/invalidate_pending_requests' is up to date.
make[4]: `datawizard/temporary_partition' is up to date.
make[4]: `datawizard/partitioned_initialization' is up to date.
make[4]: `datawizard/partitioned_acquire' is up to date.
make[4]: `datawizard/temporary_partition_implicit' is up to date.
make[4]: `datawizard/redux_acquire' is up to date.
make[4]: `disk/disk_copy' is up to date.
make[4]: `disk/disk_copy_unpack' is up to date.
make[4]: `disk/disk_copy_to_disk' is up to date.
make[4]: `disk/disk_compute' is up to date.
make[4]: `disk/disk_pack' is up to date.
make[4]: `disk/mem_reclaim' is up to date.
make[4]: `errorcheck/invalid_blocking_calls' is up to date.
make[4]: `errorcheck/workers_cpuid' is up to date.
make[4]: `helper/starpu_data_cpy' is up to date.
make[4]: `helper/starpu_create_sync_task' is up to date.
make[4]: `microbenchs/async_tasks_overhead' is up to date.
make[4]: `microbenchs/sync_tasks_overhead' is up to date.
make[4]: `microbenchs/tasks_overhead' is up to date.
make[4]: `microbenchs/tasks_size_overhead' is up to date.
make[4]: `microbenchs/prefetch_data_on_node' is up to date.
make[4]: `microbenchs/redundant_buffer' is up to date.
make[4]: `microbenchs/matrix_as_vector' is up to date.
make[4]: `microbenchs/bandwidth' is up to date.
make[4]: `overlap/gpu_concurrency' is up to date.
make[4]: `parallel_tasks/explicit_combined_worker' is up to date.
make[4]: `parallel_tasks/parallel_kernels' is up to date.
make[4]: `parallel_tasks/parallel_kernels_trivial' is up to date.
make[4]: `parallel_tasks/parallel_kernels_spmd' is up to date.
make[4]: `parallel_tasks/spmd_peager' is up to date.
make[4]: `parallel_tasks/cuda_only' is up to date.
make[4]: `perfmodels/regression_based' is up to date.
make[4]: `perfmodels/non_linear_regression_based' is up to date.
make[4]: `perfmodels/feed' is up to date.
make[4]: `perfmodels/user_base' is up to date.
make[4]: `perfmodels/valid_model' is up to date.
make[4]: `perfmodels/memory' is up to date.
make[4]: `sched_policies/data_locality' is up to date.
make[4]: `sched_policies/execute_all_tasks' is up to date.
make[4]: `sched_policies/prio' is up to date.
make[4]: `sched_policies/simple_deps' is up to date.
make[4]: `sched_policies/simple_cpu_gpu_sched' is up to date.
make[4]: `sched_ctx/sched_ctx_hierarchy' is up to date.
make[4]: `fortran90/init_01' is up to date.
/usr/bin/make  check-TESTS
PASS: microbenchs/tasks_data_overhead.sh
PASS: microbenchs/sync_tasks_data_overhead.sh
PASS: microbenchs/async_tasks_data_overhead.sh
PASS: microbenchs/tasks_size_overhead_scheds.sh
SKIP: datawizard/locality.sh
PASS: microbenchs/bandwidth_scheds.sh
PASS: overlap/overlap.sh
PASS: main/callback
PASS: main/bind
PASS: main/mkdtemp
PASS: main/execute_schedule
PASS: main/insert_task_pack
PASS: main/insert_task_nullcodelet
PASS: main/multithreaded_init
PASS: main/empty_task
PASS: main/empty_task_chain
PASS: main/starpu_worker_exists
PASS: main/codelet_null_callback
PASS: datawizard/allocate
PASS: datawizard/acquire_cb
PASS: datawizard/deps
PASS: datawizard/user_interaction_implicit
PASS: datawizard/interfaces/copy_interfaces
SKIP: datawizard/numa_overflow
PASS: datawizard/locality
PASS: datawizard/variable_size
PASS: errorcheck/starpu_init_noworker
PASS: errorcheck/invalid_tasks
PASS: helper/cublas_init
PASS: helper/cusparse_init
PASS: helper/pinned_memory
PASS: helper/execute_on_all
PASS: microbenchs/display_structures_size
PASS: microbenchs/local_pingpong
PASS: overlap/overlap
PASS: sched_ctx/sched_ctx_list
FAIL: sched_ctx/sched_ctx_policy_data
SKIP: openmp/init_exit_01
SKIP: openmp/init_exit_02
SKIP: openmp/environment
SKIP: openmp/api_01
SKIP: openmp/parallel_01
SKIP: openmp/parallel_02
SKIP: openmp/parallel_03
SKIP: openmp/parallel_barrier_01
SKIP: openmp/parallel_master_01
SKIP: openmp/parallel_master_inline_01
SKIP: openmp/parallel_single_wait_01
SKIP: openmp/parallel_single_nowait_01
SKIP: openmp/parallel_single_inline_01
SKIP: openmp/parallel_single_copyprivate_01
SKIP: openmp/parallel_single_copyprivate_inline_01
SKIP: openmp/parallel_critical_01
SKIP: openmp/parallel_critical_inline_01
SKIP: openmp/parallel_critical_named_01
SKIP: openmp/parallel_critical_named_inline_01
SKIP: openmp/parallel_simple_lock_01
SKIP: openmp/parallel_nested_lock_01
SKIP: openmp/parallel_for_01
SKIP: openmp/parallel_for_02
SKIP: openmp/parallel_for_ordered_01
SKIP: openmp/parallel_sections_01
SKIP: openmp/parallel_sections_combined_01
SKIP: openmp/task_01
SKIP: openmp/task_02
SKIP: openmp/task_03
SKIP: openmp/taskloop
SKIP: openmp/taskwait_01
SKIP: openmp/taskgroup_01
SKIP: openmp/taskgroup_02
SKIP: openmp/array_slice_01
SKIP: openmp/cuda_task_01
PASS: perfmodels/value_nan
PASS: sched_policies/workerids
PASS: main/deprecated_func
PASS: main/driver_api/init_run_deinit
PASS: main/driver_api/run_driver
PASS: main/deploop
PASS: main/display_binding
PASS: main/execute_on_a_specific_worker
PASS: main/insert_task
PASS: main/insert_task_value
PASS: main/insert_task_dyn_handles
PASS: main/insert_task_array
PASS: main/insert_task_many
PASS: main/insert_task_where
PASS: main/job
PASS: main/multithreaded
PASS: main/starpu_task_bundle
PASS: main/starpu_task_wait_for_all
PASS: main/starpu_task_wait
PASS: main/static_restartable
PASS: main/static_restartable_using_initializer
FAIL: main/static_restartable_tag
PASS: main/regenerate
PASS: main/regenerate_pipeline
PASS: main/restart
PASS: main/wait_all_regenerable_tasks
PASS: main/subgraph_repeat
PASS: main/subgraph_repeat_tag
PASS: main/subgraph_repeat_regenerate
PASS: main/subgraph_repeat_regenerate_tag
PASS: main/subgraph_repeat_regenerate_tag_cycle
PASS: main/empty_task_sync_point
PASS: main/empty_task_sync_point_tasks
PASS: main/tag_wait_api
PASS: main/tag_get_task
PASS: main/task_wait_api
PASS: main/declare_deps_in_callback
PASS: main/declare_deps_after_submission
PASS: main/declare_deps_after_submission_synchronous
PASS: main/get_current_task
PASS: main/starpu_init
PASS: main/submit
PASS: main/pause_resume
PASS: main/pack
PASS: main/get_children_tasks
PASS: main/hwloc_cpuset
PASS: main/task_end_dep
PASS: datawizard/acquire_cb_insert
PASS: datawizard/acquire_release
PASS: datawizard/acquire_release2
PASS: datawizard/acquire_try
PASS: datawizard/bcsr
PASS: datawizard/cache
PASS: datawizard/commute
PASS: datawizard/commute2
SKIP: datawizard/copy
PASS: datawizard/data_implicit_deps
PASS: datawizard/data_lookup
PASS: datawizard/scratch
SKIP: datawizard/scratch_reuse
PASS: datawizard/sync_and_notify_data
PASS: datawizard/sync_and_notify_data_implicit
PASS: datawizard/dsm_stress
PASS: datawizard/double_parameter
PASS: datawizard/write_only_tmp_buffer
PASS: datawizard/data_invalidation
PASS: datawizard/dining_philosophers
PASS: datawizard/manual_reduction
PASS: datawizard/readers_and_writers
PASS: datawizard/unpartition
PASS: datawizard/sync_with_data_with_mem
PASS: datawizard/sync_with_data_with_mem_non_blocking
PASS: datawizard/sync_with_data_with_mem_non_blocking_implicit
PASS: datawizard/mpi_like
PASS: datawizard/mpi_like_async
PASS: datawizard/critical_section_with_void_interface
PASS: datawizard/increment_init
PASS: datawizard/increment_redux
PASS: datawizard/increment_redux_v2
PASS: datawizard/increment_redux_lazy
PASS: datawizard/handle_to_pointer
PASS: datawizard/lazy_allocation
PASS: datawizard/lazy_unregister
PASS: datawizard/no_unregister
PASS: datawizard/noreclaim
PASS: datawizard/nowhere
PASS: datawizard/interfaces/block/block_interface
PASS: datawizard/interfaces/bcsr/bcsr_interface
PASS: datawizard/interfaces/coo/coo_interface
PASS: datawizard/interfaces/csr/csr_interface
PASS: datawizard/interfaces/matrix/matrix_interface
PASS: datawizard/interfaces/multiformat/multiformat_interface
SKIP: datawizard/interfaces/multiformat/advanced/multiformat_cuda_opencl
PASS: datawizard/interfaces/multiformat/advanced/multiformat_data_release
SKIP: datawizard/interfaces/multiformat/advanced/multiformat_worker
SKIP: datawizard/interfaces/multiformat/advanced/multiformat_handle_conversion
SKIP: datawizard/interfaces/multiformat/advanced/same_handle
PASS: datawizard/interfaces/variable/variable_interface
PASS: datawizard/interfaces/vector/vector_interface
PASS: datawizard/interfaces/void/void_interface
PASS: datawizard/in_place_partition
PASS: datawizard/partition_dep
PASS: datawizard/partition_lazy
PASS: datawizard/partition_init
SKIP: datawizard/gpu_register
SKIP: datawizard/gpu_ptr_register
PASS: datawizard/variable_parameters
PASS: datawizard/wt_host
PASS: datawizard/wt_broadcast
SKIP: datawizard/readonly
PASS: datawizard/specific_node
PASS: datawizard/task_with_multiple_time_the_same_handle
PASS: datawizard/test_arbiter
SKIP: datawizard/invalidate_pending_requests
PASS: datawizard/temporary_partition
PASS: datawizard/partitioned_initialization
PASS: datawizard/partitioned_acquire
PASS: datawizard/temporary_partition_implicit
PASS: datawizard/redux_acquire
PASS: disk/disk_copy
PASS: disk/disk_copy_unpack
PASS: disk/disk_copy_to_disk
PASS: disk/disk_compute
PASS: disk/disk_pack
FAIL: disk/mem_reclaim
XFAIL: errorcheck/invalid_blocking_calls
PASS: errorcheck/workers_cpuid
PASS: helper/starpu_data_cpy
PASS: helper/starpu_create_sync_task
PASS: microbenchs/async_tasks_overhead
PASS: microbenchs/sync_tasks_overhead
PASS: microbenchs/tasks_overhead
PASS: microbenchs/tasks_size_overhead
PASS: microbenchs/prefetch_data_on_node
PASS: microbenchs/redundant_buffer
PASS: microbenchs/matrix_as_vector
PASS: microbenchs/bandwidth
SKIP: overlap/gpu_concurrency
PASS: parallel_tasks/explicit_combined_worker
PASS: parallel_tasks/parallel_kernels
PASS: parallel_tasks/parallel_kernels_trivial
PASS: parallel_tasks/parallel_kernels_spmd
PASS: parallel_tasks/spmd_peager
SKIP: parallel_tasks/cuda_only
PASS: perfmodels/regression_based
PASS: perfmodels/non_linear_regression_based
SKIP: perfmodels/feed
PASS: perfmodels/user_base
PASS: perfmodels/valid_model
PASS: perfmodels/memory
SKIP: sched_policies/data_locality
PASS: sched_policies/execute_all_tasks
PASS: sched_policies/prio
PASS: sched_policies/simple_deps
SKIP: sched_policies/simple_cpu_gpu_sched
FAIL: sched_ctx/sched_ctx_hierarchy
PASS: fortran90/init_01
============================================================================
Testsuite summary for StarPU 1.3.10
============================================================================
# TOTAL: 229
# PASS:  172
# SKIP:  52
# XFAIL: 1
# FAIL:  4
# XPASS: 0
# ERROR: 0
============================================================================
See tests/test-suite.log
Please report to starpu-devel@inria.fr
============================================================================
```