### PR TITLE
openjdk15-zulu: update to 15.46.17

### DIFF
--- a/java/openjdk15-zulu/Portfile
+++ b/java/openjdk15-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-15-mts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      15.44.13
+version      15.46.17
 revision     0
 
-set openjdk_version 15.0.9
+set openjdk_version 15.0.10
 
 description  Azul Zulu Community OpenJDK 15 (Medium Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  e43347ce019d6aaedeecc9c15a692ad9ac732902 \
-                 sha256  77bbe87c522fbb99a1989f5bd229fbe251146498a6f7de4cfe2e51317603c987 \
-                 size    202973554
+    checksums    rmd160  3f0c379f858522a9c372bac173e306de485797b7 \
+                 sha256  bb376d5f0cd309287c7b5d98c55ced7780a442a262538234b1d9950fb0c6346d \
+                 size    202824838
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  23db4d5979560d66abbdbfcb7ab99fb986ed84c7 \
-                 sha256  eed59570c2c690cc963d5a0a4f7bdc5409f24c62a66ad36b193055e76a08438a \
-                 size    191782534
+    checksums    rmd160  da8d5dac6eb2ec8b0d13a56e5309cca78dc24d5c \
+                 sha256  2d675dcc821309076cdf4b2366c3e6cff93c659a6f2988876297b3f0f2ca4c1f \
+                 size    191740580
 }
 
 worksrcdir   ${distname}/zulu-15.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 15.46.17 based on OpenJDK 15.0.10.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?