### PR TITLE
openjdk13-zulu: update 13.54.17

### DIFF
--- a/java/openjdk13-zulu/Portfile
+++ b/java/openjdk13-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-13-mts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      13.52.15
+version      13.54.17
 revision     0
 
-set openjdk_version 13.0.13
+set openjdk_version 13.0.14
 
 description  Azul Zulu Community OpenJDK 13 (Medium Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  dead16bfa757d4e57c8ff5ac325ea1f52d8e2403 \
-                 sha256  465a0f3d6fc1797c11b105c9cc8b87db93b47f776381d815ca54dcb51e69ba13 \
-                 size    200960531
+    checksums    rmd160  14487acd5dfb32c4e01966119305f16f4484b576 \
+                 sha256  0187b05231d56d696ef733dc5ac139c45430e46fa930a3bafd8ba2b4f97830e1 \
+                 size    201031665
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  220dc7453441a648899706f93fcd8ba275ed832b \
-                 sha256  4daaf1e595166e3455cbb0d30a8df08ba994e1efb3b2fe466970a6c0eb0b6dba \
-                 size    180230216
+    checksums    rmd160  f8ab679b6b4fa9f27a421f4e1936dd31590451ee \
+                 sha256  302553ba18e031736a89df61ca212e265d56f211e293531a7cd27d3663325a2f \
+                 size    180289936
 }
 
 worksrcdir   ${distname}/zulu-13.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 13.54.17 based on OpenJDK 13.0.14.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?