### PR TITLE
openjdk11-zulu: update to 11.62.17

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.60.19
+version      11.62.17
 revision     0
 
-set openjdk_version 11.0.17
+set openjdk_version 11.0.18
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  834beaf15ab5d28e8b6af3bc82e32bdfcabcdfcd \
-                 sha256  f2b2fe82928b99f02ba60ed4df98ae3ad6564323441455fc9787498a79c0f263 \
-                 size    193947542
+    checksums    rmd160  394a69bcf5e5dfc7a835c6bc059aac45f803004c \
+                 sha256  bd171664187064d4d136f026b88054f8714e017cc6518f489cb04e57f07814e3 \
+                 size    194060010
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  a8fde2990037ad063a33d82cb9b785dcc4ab4840 \
-                 sha256  e3f9dbb08c11e116e5197aa37fefee43bb43e92a66dfc6b62c5f1518813c2df7 \
-                 size    192096016
+    checksums    rmd160  56b61e43e29a2fe5b7abc0eabadbeca700f2b8b9 \
+                 sha256  2a3f56af83f9d180dfce5d6e771a292bbbd68a77c7c18ed3bdb607e86d773704 \
+                 size    192162152
 }
 
 worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.62.17 based on OpenJDK 11.0.18.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?