### PR TITLE
openjdk8-zulu: update to 8.68.0.19

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
-version      8.66.0.15
+version      8.68.0.19
 revision     0
 
-set openjdk_version 8.0.352
+set openjdk_version 8.0.362
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  1cfeabb2aabda53adf36872b73e0797e4b46a9e0 \
-                 sha256  685c000870a71f6fa08653f9836d2c7bbf331722188a3d1b7ad63060f993c7e2 \
-                 size    108181745
+    checksums    rmd160  460595dc1b90fc98c9e48499ca5654e5972c8d58 \
+                 sha256  1d4020045b5183407e65b511ca4c805195f896da2e4fc2d572466a9d3bc5e5d4 \
+                 size    106563403
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  2ada5b6c29b752e3ced110da49a30ff4117268a7 \
-                 sha256  7998aec4b6a8084646a2968c7e5e8666d80c998e07508379eb47bfb37040bb27 \
-                 size    106088447
+    checksums    rmd160  71678c5726e55b9b10dd74f7876baeb18413b6a9 \
+                 sha256  8957358fb0e26971371f228e845978f6038a8cbc1b196297c859acb7b4c22409 \
+                 size    104467621
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.68.0.19 based on OpenJDK 8u362.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?