### PR TITLE
openjdk17: update to 17.0.6

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk17
 # https://github.com/openjdk/jdk17u/tags
-version             17.0.5
-set build 8
+version             17.0.6
+set build 10
 revision            0
 categories          java devel
 platforms           darwin
@@ -17,11 +17,11 @@ long_description    JDK 17 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
-distname            jdk-${version}+${build}
+distname            jdk-${version}-ga
 
-checksums           rmd160  babea0fc04402a066cf04680f285d2f530a91789 \
-                    sha256  6717fbf68472e9dca520998504a25ad5cfaa610d0066cad169bb7b78a108fbfc \
-                    size    105064912
+checksums           rmd160  a6516dbb66f8dbaad1311badb31529ca96a7d481 \
+                    sha256  f1d1c29ff5ac8254dc81d1635d60f658b6f2b790476acab836ddcb488c8c7fbe \
+                    size    105221267
 
 depends_lib         port:freetype
 depends_build       port:autoconf \
@@ -54,8 +54,8 @@ configure.args      --with-debug-level=release \
                     --with-freetype-lib=${prefix}/lib \
                     --disable-precompiled-headers \
                     --disable-warnings-as-errors \
-                    --with-vendor-name="OpenJDK Porters Group" \
-                    --with-vendor-url="${homepage}" \
+                    --with-vendor-name="MacPorts" \
+                    --with-vendor-url="https://www.macports.org" \
                     --with-vendor-bug-url="${bug_url}" \
                     --with-vendor-vm-bug-url="${bug_url}" \
                     --with-conf-name=release


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.6, change vendor from OpenJDK Porters Group to MacPorts.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?