### PR TITLE
openjdk11: update to 11.0.18

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 
 name                openjdk11
 # https://github.com/openjdk/jdk11u/tags
-# remove 'jdk-' from the latest tag without '-ga' that has commit that corresponds to the latest tag with '-ga'
-version             11.0.17
-set build 8
+version             11.0.18
+set build 10
 revision            0
 categories          java devel
 platforms           darwin
@@ -18,11 +17,11 @@ long_description    JDK 11 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
-distname            jdk-${version}+${build}
+distname            jdk-${version}-ga
 
-checksums           rmd160  056241e275817cca40aeb315b12a2ea6d73e38d6 \
-                    sha256  32488930787e3c8a3dcc1b77b52efa2af19772302145e64fa17676dd12acc0d6 \
-                    size    123287943
+checksums           rmd160  3e3420a28b10abf88c3ddf852f482922c2c79a8b \
+                    sha256  c0560c3480e7ded2a59d783ddf2cb624a44ece9d3036f4a7a7575d597b18fb2e \
+                    size    123369840
 
 depends_lib         port:freetype
 depends_build       port:autoconf \
@@ -56,8 +55,8 @@ configure.args      --with-debug-level=release \
                     --with-freetype-lib=${prefix}/lib \
                     --disable-warnings-as-errors \
                     --disable-precompiled-headers \
-                    --with-vendor-name="OpenJDK Porters Group" \
-                    --with-vendor-url="${homepage}" \
+                    --with-vendor-name="MacPorts" \
+                    --with-vendor-url="https://www.macports.org" \
                     --with-vendor-bug-url="${bug_url}" \
                     --with-vendor-vm-bug-url="${bug_url}" \
                     --with-conf-name=openjdk11


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.18, change vendor from OpenJDK Porters Group to MacPorts.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?