### PR TITLE
openjdk11-sap: update to 11.0.18

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.17
+version      11.0.18
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  6c8908c06f5ca02688eb69d7f1f8952a48cf7651 \
-                 sha256  f5a0a04f4fcc0044bdb8f8ba071e996e9686152e9c38ab645d741e2e2ea724ab \
-                 size    187166175
+    checksums    rmd160  3f00e69115cfdbd7b9cae5a25b6715252d34578a \
+                 sha256  50eb0d30c6fc34e6e47763e24b3ad5e3ad9099e222abbf603c634681b7dbce50 \
+                 size    187212349
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  fd85e2fd606a9416df435af22212d6deb9af9a38 \
-                 sha256  3b77efd1a2df2517b98c260a31926700f73ae5336aa4db1aa7ffa3eb1724de8b \
-                 size    185296295
+    checksums    rmd160  ae87b493c5ac5de3ac7695c64192ccb93f46d310 \
+                 sha256  2a026c9083d27b5cf2e6c9690eeb7c6a9373bdd0cd6e29fc25bce8079b9aeb19 \
+                 size    185348676
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.18.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?