### PR TITLE
openjdk17-corretto: update to 17.0.6.10.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.5.8.1
+version      17.0.6.10.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  bd49a1d6359563aa2f1c0db4f847e0f6ffda62e3 \
-                 sha256  34fcab7e6386c19be3f4367397c17a3d2061c6901bbacfbd3dc6818755e50ef8 \
-                 size    188047893
+    checksums    rmd160  1ba0deb6888ce1011f9b829bd78d00a408920eb9 \
+                 sha256  1ba7e50d74c2f402431d365eb8e5f7b860b03b18956af59f5f364f6567a8463e \
+                 size    188117863
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  d6b083da56d024a354b3c8cecd77effc54d2e593 \
-                 sha256  fe74ec7b1a81f8afaea09fa76e566350259fa861c49d41e14f6a5fffd5f181e3 \
-                 size    186119535
+    checksums    rmd160  ae84e6dd14eb0690fd1366a919ba2cf9f7e497c4 \
+                 sha256  f7411c1d8a94681e669b133ab57a7ef815aa145b3ecc041c93ca7ff1eb1811b3 \
+                 size    186179802
 }
 
 worksrcdir   amazon-corretto-17.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-17/blob/release-17.0.5.8.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-17/blob/release-17.0.6.10.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.6.10.1.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?