### PR TITLE
openjdk11-corretto: update to 11.0.18.10.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-11/releases
 supported_archs  x86_64 arm64
 
-version      11.0.17.8.1
+version      11.0.18.10.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  c5ad3a26b69bbef92e6f6da68e7b9954b60fedb1 \
-                 sha256  a64f436ad92d46a6fb3a2e48dd34c0e11849256b302fd53cc9b2614500c54cbd \
-                 size    187788049
+    checksums    rmd160  c2aec52951941566cefebd1ed0d250f5efe31460 \
+                 sha256  8f075fe7e0b6fb261a005a8cc8b8bddc6ac47cff5da580ad9b0b8a77d4ddccd7 \
+                 size    187836161
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  64d95b55ee6a9be52bb45dae22466538e2720f83 \
-                 sha256  badca7ba0fda3c3d5e2637669525f29c0d4ec7d726b58faedc9e340a806f4fc3 \
-                 size    186148916
+    checksums    rmd160  4ee8c4ee9edce0ffe1d1075cee7674bc381df4c8 \
+                 sha256  ad8c9624f84d3c1e5fe6e381f605e37ba179e922f5c068b7f81492657d156689 \
+                 size    186188061
 }
 
 worksrcdir   amazon-corretto-11.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-11/blob/release-11.0.17.8.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-11/blob/release-11.0.18.10.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.18.10.1.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?