### PR TITLE
openjdk8-corretto: update to 8.362.08.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.352.08.1
+version      8.362.08.1
 revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  a65407ecbab9a079a44baaab25455f936bb86f51 \
-                 sha256  73d363cf04a6ab923df6e7166c21c462e20973578d02dd74c8282ca555ebd7fa \
-                 size    118776147
+    checksums    rmd160  4a026a80e17c0993e7fa1f723cf5f0a3ed07b5f2 \
+                 sha256  2f6a307970a74440a6020e33ab166856f602fa644cb94352bd6efd91de515989 \
+                 size    118782619
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  e636acbb012814cb21ab724df6aaa6c0ed34e860 \
-                 sha256  19300a5b56732d6a42104a07cfd2955e100e4e48de76186c29a9219d5bb4b291 \
-                 size    104206983
+    checksums    rmd160  9c2dd9d57a9fddd26d8be1e8ca8b3f9e1b469eb1 \
+                 sha256  4e6781effb34b37b49603e25d8c4fd6951aff3aadae3116b52313257a66675d9 \
+                 size    104216967
 }
 
 worksrcdir   amazon-corretto-8.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-8/blob/release-8.352.08.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-8/blob/release-8.362.08.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.362.08.1.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?