### PR TITLE
openjdk19-corretto: update to 19.0.2.7.1

### DIFF
--- a/java/openjdk19-corretto/Portfile
+++ b/java/openjdk19-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-19/releases
-version      19.0.1.10.1
+version      19.0.2.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK 19 (Short Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  1c3af9efa539e5460663d0ce4c31fe8bf2d577f7 \
-                 sha256  9de65ad7cfcfcb0f28251f2bf11e0a42ebccd7c645e5df128e10df044ebcccd5 \
-                 size    196331530
+    checksums    rmd160  219c0b4b4ae39921339d2b28b5d77e8e3e8cf5d1 \
+                 sha256  ea9129fc264155e8fdb5d53a9742cb5f4a3939b5ac8fd66df6d3fac3f87b2020 \
+                 size    196357389
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  286c413c2a040e24c07256dd4fff3fab90c5f3d5 \
-                 sha256  8a13665c1506410eadd0db4854560dc8e032668073b12483c31bfc96876c72e0 \
-                 size    194488733
+    checksums    rmd160  1d085c6de9febc1e177168ee63c4a263c521396e \
+                 sha256  b45e7541049f20c9d8ed2941b3029d37489342d8b55594279f2ee400e1376807 \
+                 size    194500036
 }
 
 worksrcdir   amazon-corretto-19.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-19/blob/release-19.0.1.10.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-19/blob/release-19.0.2.7.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 19.0.2.7.1.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?