### PR TITLE
openjdk8: update to 8u362

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -7,10 +7,10 @@ name                openjdk8
 # https://guide.macports.org/chunked/reference.portgroup.html#reference.portgroup.java
 # https://github.com/openjdk/jdk8u/tags
 # Tags: https://github.com/openjdk/jdk8u/tags
-# remove 'jdk' from the latest tag without '-ga' that has commit that corresponds to the latest tag with '-ga'
 set major 8
-set update 352
-set build 08
+set update 362
+# Set to the build of the 'jdk8u${update}-b${build}' tag that corresponds to the latest tag with '-ga'
+set build 09
 version             ${major}u${update}
 revision            0
 categories          java devel
@@ -23,11 +23,11 @@ long_description    JDK 8 and JRE 8 builds of OpenJDK, the Open-Source implement
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk8u/archive/refs/tags/
-distname            jdk${major}u${update}-b${build}
+distname            jdk${major}u${update}-ga
 
-checksums           rmd160  27a2974269ef605d45f0332098c6012c0809b703 \
-                    sha256  eee2286a432c1c612aae9b4d97c5c10f4dd6d58f29b84d67c2cd982a192202c8 \
-                    size    87952054
+checksums           rmd160  f06e80750049168a3c7995b0c49c0a12a0a986dd \
+                    sha256  dd3606bd274d25c96f2dc2e63b7cab36a2b03d82b0ce4f312cfb53056f758d9f \
+                    size    87939909
 
 patchfiles          0001-8181503-Can-t-compile-hotspot-with-c-11.patch \
                     0002-Support-XCode-3-14.patch \


### PR DESCRIPTION
#### Description

Update to OpenJDK 8u362.

###### Tested on

I sadly cannot test this update, because I only have an arm64 machine, but it seems ok according to CI.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?