### PR TITLE
whitebox-tools: add plugins

### DIFF
--- a/gis/whitebox-tools/Portfile
+++ b/gis/whitebox-tools/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        jblindsay whitebox-tools 2.2.0 v
-revision            0
+revision            1
 categories          gis
 platforms           darwin
 maintainers         {@mholling gmail.com:mdholling} openmaintainer
@@ -14,6 +14,8 @@ description         an advanced geospatial data analysis platform
 long_description    {*}${description}
 homepage            https://jblindsay.github.io/ghrg/WhiteboxTools/index.html
 license             MIT
+
+patchfiles          get_plugin_list.patch
 
 checksums           ${distname}${extract.suffix} \
                     rmd160  9ac3e53c91ac3d72e69a035201ebd1644b9f4efb \
@@ -139,7 +141,13 @@ cargo.crates \
     zip                              0.3.3  77ce0ceee93c995954a31f77903925a6a8bb094709445238e344f2107910e29e
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/whitebox_tools ${destroot}${prefix}/bin/
-    xinstall -d ${destroot}${prefix}/share/doc/${name}/manual/img
+    xinstall -d ${destroot}${prefix}/libexec/${name}/bin/plugins
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/whitebox_tools ${destroot}${prefix}/libexec/${name}/bin
+    foreach plugin [glob -tails -directory ${worksrcpath}/whitebox-plugins/src *] {
+        xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${plugin} ${destroot}${prefix}/libexec/${name}/bin/plugins
+        xinstall -m 644 ${worksrcpath}/whitebox-plugins/src/${plugin}/${plugin}.json  ${destroot}${prefix}/libexec/${name}/bin/plugins
+    }
+    ln -s ${prefix}/libexec/${name}/bin/whitebox_tools ${destroot}${prefix}/bin/whitebox_tools
     xinstall -m 644 -W ${worksrcpath} README.md LICENSE.txt ${destroot}${prefix}/share/doc/${name}
 }

--- a/gis/whitebox-tools/files/get_plugin_list.patch
+++ b/gis/whitebox-tools/files/get_plugin_list.patch
@@ -1,0 +1,12 @@
+--- whitebox-tools-app/src/tools/mod.rs
++++ whitebox-tools-app/src/tools/mod.rs
+@@ -1197,7 +1197,8 @@
+ 
+     fn get_plugin_list(&self) -> Result<HashMap<String, serde_json::Value>, Error> {
+         // let exe_path = std::env::current_dir()?.to_str().unwrap_or("No exe path found.").to_string();
+-        let mut dir = env::current_exe()?;
++        let mut exe = env::current_exe()?;
++        let mut dir = fs::canonicalize(exe)?;
+         dir.pop();
+         dir.push("plugins");
+         let plugin_directory = dir.to_str().unwrap_or("No exe path found.").to_string();


### PR DESCRIPTION
#### Description
* whitebox-tools plugins were previously not installed
* now we install the plugin executables to usr/libexec
* small patch needed so the plugins folder can be found

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
