### PR TITLE
google-cloud-sdk: update to 414.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             413.0.0
+version             414.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  18f887dd2da1d8fa11cdd7b869467984d43748cb \
-                    sha256  a90d086151eb4f333a3539e35eb0ddeb3d29fd1a7173203907bbc4c18b178a43 \
-                    size    110838137
+    checksums       rmd160  dae06dea5ce2fe8c2358bc256b1675105b8cf138 \
+                    sha256  3cd7c9ee3bdf933ddcbe8d508cc2c82bc0c1587e759b9ae93b8f4a093d40009f \
+                    size    110923662
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  980c9ec6810063f37b316e2be57d997d424303ef \
-                    sha256  595419a93c1fd8c59969aeb02e256002eceeadf2fa58cb393df9c20aa0d8b21d \
-                    size    99803819
+    checksums       rmd160  0d32ee362863107aa21c866f42aa92cd80f0927b \
+                    sha256  d6d354c68e19ebf55f55d44d9bafd884ce240684906c20a03e6191dc7ead32e6 \
+                    size    99888894
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  eff3045b04bc17924cae93f4076a992c90366fff \
-                    sha256  cc247ae59d7c92e18d4a5e5e94b00b755c9e0bb76035b30205190a753c51e122 \
-                    size    98216040
+    checksums       rmd160  9c94ea8f1e1b5d2bb779732bb7795d189356a745 \
+                    sha256  70b268c339bf95948434880d09d4deea855e74b8e591a77692f450092435006a \
+                    size    98297979
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 414.0.0.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?