### PR TITLE
linalg: updates from upstream, fix build on 10.7–10.9

### DIFF
--- a/math/linalg/Portfile
+++ b/math/linalg/Portfile
@@ -6,23 +6,24 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 PortGroup           linear_algebra 1.0
 
-github.setup        jchristopherson linalg 9807650d97243f3b04728b299ebb245308b598f5
+github.setup        jchristopherson linalg 0434bc8dba254e021643c8992a57868b7511e7bb
 version             1.7.1
-revision            0
+revision            1
 categories          math science
 license             GPL-3
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Linear algebra library that provides a user-friendly interface \
                     to several BLAS and LAPACK routines
 long_description    {*}${description}
-checksums           rmd160  91add2f5843a568d59415fbae093e4ee5ce7f772 \
-                    sha256  7b64f6e1aba6c3a5980c1c87b344cc24d86abcbad010bf8fa8df8779795c53d2 \
-                    size    825395
+checksums           rmd160  0382c5c36e26de70bfb6e3334a240fdf82c770ab \
+                    sha256  321bae3508d190a14263144b4d3c25bf856a4380438c49e8dd2c4451d83ccb66 \
+                    size    829618
 
 depends_lib-append  port:qrupdate
 
-if {${os.major} < 11} {
+if {${os.major} < 14} {
     # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own.
+    # However Lion through Mavericks fail with SSL errors.
     depends_build-append \
                     port:git
     git.cmd         ${prefix}/bin/git
@@ -33,17 +34,15 @@ compilers.setup     require_fortran
 
 compiler.c_standard 2011
 
+# Needed in order for correct version of BLAS to be picked:
+pre-configure {
+    configure.args-append ${cmake_linalglib}
+}
+
 configure.args-append \
                     -DBUILD_C_API=ON \
                     -DBUILD_TESTING=ON \
                     -DBUILD_LINALG_EXAMPLES=OFF
-
-# This is needed for correct implementation to be picked:
-if {[variant_isset accelerate]} {
-    configure.args-append \
-                    -DBLAS_LIBRARIES=vecLibFort \
-                    -DLAPACK_LIBRARIES=vecLibFort
-}
 
 test.run            yes
 test.cmd            ctest


### PR DESCRIPTION
#### Description

1. Update to tests from upstream: https://github.com/jchristopherson/linalg/issues/9#issuecomment-1396297049
2. Fix build on 10.7–10.9 where Xcode git fails: https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/216289/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
