### PR TITLE
py-h5py: fix build issue for python 3.11

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -53,7 +53,7 @@ if {${name} ne ${subport}} {
     destroot.env-append     HDF5_DIR=${prefix}
 
     # see https://github.com/h5py/h5py/pull/2194
-    patchfiles-append       patch-hdf5_version.diff
+    patchfiles-append       patch-hdf5_version.diff patch-oldest-supported-numpy.diff
 
     post-patch {
         reinplace "/=={np_min}/s/==/>=/" setup.py

--- a/python/py-h5py/files/patch-oldest-supported-numpy.diff
+++ b/python/py-h5py/files/patch-oldest-supported-numpy.diff
@@ -1,0 +1,10 @@
+--- pyproject.toml.original	2023-01-19 14:44:30
++++ pyproject.toml	2023-01-19 14:44:46
+@@ -4,7 +4,6 @@
+ requires = [
+     "setuptools",
+     "wheel",
+-    "oldest-supported-numpy",
+     "pkgconfig",
+     "Cython >=0.29; python_version<'3.8'",
+     "Cython >=0.29.14; python_version=='3.8'",


### PR DESCRIPTION
#### Description

Remove `oldest-supported-numpy` from the requires list in `pyproject.toml`. This allows to fix the build issue for the Python 3.11 variant, though it is not clear why it failed in the first place. Nevertheless, MacPorts already ensures that numpy is installed, so there is no downsides to removing this line in `pyproject.toml`.

See: https://trac.macports.org/ticket/66619

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Note: `port lint --nitpick` reports that `any` is not a correct platform. However, this is not relevant to the present issue. So I don't know if I should have changed it.
