### PR TITLE
metis: fix build on PPC, add requirement for TLS

### DIFF
--- a/math/metis/Portfile
+++ b/math/metis/Portfile
@@ -10,7 +10,6 @@ name                metis
 version             20220130
 revision            0
 categories          math
-platforms           darwin
 maintainers         {@catap korins.ky:kirill} openmaintainer
 license             Apache-2
 
@@ -22,9 +21,13 @@ checksums           rmd160  be3c57a5cd6dc28f34f277598422276e791b52a8 \
                     size    4838826
 
 patchfiles          patch-shared-gklib.diff \
-                    patch-darwin-sources.diff
+                    patch-darwin-sources.diff \
+                    patch-powerpc.diff
 
 depends_lib-append  port:gklib
+
+# /opt/local/include/gk_externs.h:19: error: thread-local storage not supported for this target
+compiler.thread_local_storage yes
 
 pre-configure {
     reinplace       {s|build/xinclude|${CMAKE_SOURCE_DIR}/include|g} \

--- a/math/metis/files/patch-powerpc.diff
+++ b/math/metis/files/patch-powerpc.diff
@@ -1,0 +1,28 @@
+From 1090f554654d563ce1477f52117fa3deb6ea011f Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 20 Jan 2023 03:28:23 +0800
+Subject: [PATCH] Do not use unsupported -march flag on PPC
+
+Signed-off-by: Sergey Fedorov <vital.had@gmail.com>
+---
+ conf/gkbuild.cmake | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/conf/gkbuild.cmake b/conf/gkbuild.cmake
+index 0e70a8e..591ece4 100644
+--- conf/gkbuild.cmake
++++ conf/gkbuild.cmake
+@@ -31,8 +31,13 @@ if(CMAKE_COMPILER_IS_GNUCC)
+   set(GK_COPTIONS "${GK_COPTIONS} -std=c99 -fno-strict-aliasing")
+ if(VALGRIND)
+   set(GK_COPTIONS "${GK_COPTIONS} -march=x86-64 -mtune=generic")
++else()
++# -march=native is not a valid flag on PPC:
++if(CMAKE_SYSTEM_PROCESSOR MATCHES "power|ppc|powerpc|ppc64|powerpc64" OR (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64"))
++  set(GK_COPTIONS "${GK_COPTIONS} -mtune=native")
+ else()
+   set(GK_COPTIONS "${GK_COPTIONS} -march=native")
++endif()
+ endif(VALGRIND)
+   if(NOT MINGW)
+       set(GK_COPTIONS "${GK_COPTIONS} -fPIC")

--- a/math/parmetis/Portfile
+++ b/math/parmetis/Portfile
@@ -28,7 +28,14 @@ patchfiles          patch-shared-metis.diff \
                     patch-powerpc.diff
 
 compilers.choose    cc cxx
-mpi.setup           require
+
+# While fortran is not required, this is a hack until mpi PG is fixed.
+# See: https://trac.macports.org/ticket/66738
+if {${os.platform} eq "darwin" && ${os.arch} eq "powerpc"} {
+    mpi.setup       require require_fortran
+} else {
+    mpi.setup       require
+}
 
 depends_lib         port:metis
 

--- a/math/parmetis/Portfile
+++ b/math/parmetis/Portfile
@@ -24,7 +24,8 @@ checksums           rmd160  c8d35f96a20c9676773d2cadf5c011f6e36637ac \
                     sha256  1b11e6d3ef2dd614ff04ccf1479e75012dd92f3e5f7493a893ee9154212acff7 \
                     size    5312122
 
-patchfiles          patch-shared-metis.diff
+patchfiles          patch-shared-metis.diff \
+                    patch-powerpc.diff
 
 compilers.choose    cc cxx
 mpi.setup           require

--- a/math/parmetis/files/patch-powerpc.diff
+++ b/math/parmetis/files/patch-powerpc.diff
@@ -1,0 +1,27 @@
+From 34ad453fada85b4b1a1b6d15eaf37fe14ef239db Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sun, 22 Jan 2023 15:19:22 +0800
+Subject: [PATCH] Fix compile flags for PPC
+
+Signed-off-by: Sergey Fedorov <vital.had@gmail.com>
+---
+ conf/gkbuild.cmake | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/conf/gkbuild.cmake b/conf/gkbuild.cmake
+index afcafdd..ec91224 100644
+--- conf/gkbuild.cmake
++++ conf/gkbuild.cmake
+@@ -28,7 +28,12 @@ endif(CYGWIN)
+ if(CMAKE_COMPILER_IS_GNUCC)
+ # GCC opts.
+   set(GK_COPTIONS "${GK_COPTIONS} -std=c99 -fno-strict-aliasing")
++# -march=native is not a valid flag on PPC:
++if(CMAKE_SYSTEM_PROCESSOR MATCHES "power|ppc|powerpc|ppc64|powerpc64" OR (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64"))
++  set(GK_COPTIONS "${GK_COPTIONS} -mtune=native")
++else()
+   set(GK_COPTIONS "${GK_COPTIONS} -march=native")
++endif()
+   if(NOT MINGW)
+       set(GK_COPTIONS "${GK_COPTIONS} -fPIC")
+   endif(NOT MINGW)


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66720
Signed-off-by: Sergey Fedorov <vital.had@gmail.com>

#### Description

1. Unbreak the build on PPC: do not use unsupported flag.
2. Add requirement for compiler TLS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
