### PR TITLE
hiop: new port in math

### DIFF
--- a/math/hiop/Portfile
+++ b/math/hiop/Portfile
@@ -1,0 +1,72 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           linear_algebra 1.0
+PortGroup           mpi 1.0
+
+github.setup        LLNL hiop 0.7.1 v
+revision            0
+categories          math science
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         HPC solver for non-linear optimization problems
+long_description    HiOp is an optimization solver for solving certain mathematical optimization problems \
+                    expressed as non-linear programming problems. HiOp is a lightweight HPC solver \
+                    that leverages application’s existing data parallelism to parallelize \
+                    the optimization iterations by using specialized parallel linear algebra kernels.
+checksums           rmd160  2b27489df8f388bc7de01a3ccc0bc2db6d4c413e \
+                    sha256  5d2f3fecd233afe0984171f2a792d60b6e66b33d659d744d87da866476266a21 \
+                    size    2539742
+
+depends_lib-append  path:include/eigen3:eigen3
+
+if {${os.platform} eq "darwin" && ${os.arch} eq "powerpc"} {
+    mpi.setup       require require_fortran \
+                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 -gcc6 \
+                    -clang -fortran
+} else {
+    mpi.setup       require require_fortran \
+                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 -gcc6
+}
+
+compiler.cxx_standard   2014
+compilers.setup         require_fortran
+
+# Needed in order for correct version of BLAS to be picked:
+pre-configure {
+    configure.args-append ${cmake_linalglib}
+    if {[variant_isset openblas]} {
+        configure.args-append  \
+                    -DBLAS_LIBRARIES=${prefix}/lib/libopenblas.dylib \
+                    -DLAPACK_LIBRARIES=${prefix}/lib/libopenblas.dylib
+    }
+}
+
+configure.args-append \
+                    -DHIOP_BUILD_SHARED=ON \
+                    -DHIOP_EIGEN_DIR=${prefix}/include/eigen3 \
+                    -DHIOP_USE_EIGEN=ON \
+                    -DHIOP_USE_MPI=ON \
+                    -DHIOP_WITH_MAKETEST=ON \
+                    -DHIOP_BUILD_DOCUMENTATION=OFF \
+                    -DHIOP_BUILD_FORTRAN_EXAMPLE=OFF \
+                    -DHIOP_DEEPCHECKS=OFF \
+                    -DHIOP_DEVELOPER_MODE=OFF \
+                    -DHIOP_SPARSE=OFF \
+                    -DHIOP_USE_COINHSL=OFF \
+                    -DHIOP_USE_GINKGO=OFF \
+                    -DHIOP_USE_GPU=OFF \
+                    -DHIOP_USE_PARDISO=OFF \
+                    -DHIOP_USE_RAJA=OFF \
+                    -DHIOP_USE_STRUMPACK=OFF \
+                    -DHIOP_WITH_KRON_REDUCTION=OFF
+
+# ___atomic_fetch_add_8, ___atomic_load_8
+if {${build_arch} in [list i386 ppc] && [string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append -latomic
+}
+
+test.run            yes
+test.cmd-prepend    DYLD_LIBRARY_PATH=${cmake.build_dir}/src


### PR DESCRIPTION
Signed-off-by: Sergey Fedorov <vital.had@gmail.com>

#### Description

New port in math: https://github.com/LLNL/hiop

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing hiop
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_hiop/hiop/work/build" && DYLD_LIBRARY_PATH=/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_hiop/hiop/work/build/src /usr/bin/make test 
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_hiop/hiop/work/build
      Start  1: VectorTest
 1/24 Test  #1: VectorTest .......................   Passed    0.40 sec
      Start  2: VectorTest_mpi
 2/24 Test  #2: VectorTest_mpi ...................   Passed    0.30 sec
      Start  3: MatrixTest
 3/24 Test  #3: MatrixTest .......................   Passed    0.81 sec
      Start  4: MatrixTest_mpi
 4/24 Test  #4: MatrixTest_mpi ...................   Passed    0.89 sec
      Start  5: SparseMatrixTest
 5/24 Test  #5: SparseMatrixTest .................   Passed    0.24 sec
      Start  6: SymmetricSparseMatrixTest
 6/24 Test  #6: SymmetricSparseMatrixTest ........   Passed    0.20 sec
      Start  7: NlpDenseCons1_5H
 7/24 Test  #7: NlpDenseCons1_5H .................   Passed    0.35 sec
      Start  8: NlpDenseCons1_5K
 8/24 Test  #8: NlpDenseCons1_5K .................   Passed    0.38 sec
      Start  9: NlpDenseCons1_50K
 9/24 Test  #9: NlpDenseCons1_50K ................   Passed    0.83 sec
      Start 10: NlpDenseCons1_50K_mpi
10/24 Test #10: NlpDenseCons1_50K_mpi ............   Passed    0.86 sec
      Start 11: NlpDenseCons2_5H
11/24 Test #11: NlpDenseCons2_5H .................   Passed    0.39 sec
      Start 12: NlpDenseCons2_5K
12/24 Test #12: NlpDenseCons2_5K .................   Passed    0.56 sec
      Start 13: NlpDenseCons2_UN_5K
13/24 Test #13: NlpDenseCons2_UN_5K ..............   Passed    0.51 sec
      Start 14: NlpDenseCons3_5H
14/24 Test #14: NlpDenseCons3_5H .................   Passed    0.43 sec
      Start 15: NlpDenseCons3_5K
15/24 Test #15: NlpDenseCons3_5K .................   Passed    0.71 sec
      Start 16: NlpDenseCons3_50K
16/24 Test #16: NlpDenseCons3_50K ................   Passed    3.77 sec
      Start 17: NlpDenseCons3_50K_mpi
17/24 Test #17: NlpDenseCons3_50K_mpi ............   Passed    4.04 sec
      Start 18: NlpMixedDenseSparse1_1
18/24 Test #18: NlpMixedDenseSparse1_1 ...........   Passed    1.21 sec
      Start 19: NlpMixedDenseSparse1_2
19/24 Test #19: NlpMixedDenseSparse1_2 ...........   Passed    1.20 sec
      Start 20: NlpMixedDenseSparse1_3
20/24 Test #20: NlpMixedDenseSparse1_3 ...........   Passed    1.07 sec
      Start 21: NlpMixedDenseSparse2_1
21/24 Test #21: NlpMixedDenseSparse2_1 ...........   Passed    7.70 sec
      Start 22: NlpMixedDenseSparseCinterface
22/24 Test #22: NlpMixedDenseSparseCinterface ....   Passed    1.31 sec
      Start 23: NlpPriDec1_1
23/24 Test #23: NlpPriDec1_1 .....................   Passed    0.37 sec
      Start 24: NlpPriDec1_mpi
24/24 Test #24: NlpPriDec1_mpi ...................   Passed    1.18 sec

100% tests passed, 0 tests failed out of 24

Total Test time (real) =  29.81 sec
```