### PR TITLE
aom: use generic target on PPC, unbreak the port

### DIFF
--- a/multimedia/aom/Portfile
+++ b/multimedia/aom/Portfile
@@ -59,11 +59,12 @@ compiler.blacklist-append           {clang < 800}
 
 # possible values of AOM_TARGET_CPU: arm64 x86_64 x86 ppc generic
 # see https://trac.macports.org/ticket/62611 for CONFIG_RUNTIME_CPU_DETECT
+# PPC assembler and cpu detection are broken; use generic target until someone gets time to fix those.
 set merger_configure_args(arm64)    "-DAOM_TARGET_CPU=arm64 -DCONFIG_RUNTIME_CPU_DETECT=OFF"
 set merger_configure_args(x86_64)   -DAOM_TARGET_CPU=x86_64
 set merger_configure_args(i386)     -DAOM_TARGET_CPU=x86
-set merger_configure_args(ppc)      -DAOM_TARGET_CPU=ppc
-set merger_configure_args(ppc64)    -DAOM_TARGET_CPU=ppc
+set merger_configure_args(ppc)      "-DAOM_TARGET_CPU=generic -DCONFIG_RUNTIME_CPU_DETECT=OFF"
+set merger_configure_args(ppc64)    "-DAOM_TARGET_CPU=generic -DCONFIG_RUNTIME_CPU_DETECT=OFF"
 
 if {${universal_possible} && [variant_isset universal]} {
     if {"x86_64" in ${configure.universal_archs} || "i386" in ${configure.universal_archs}} {


### PR DESCRIPTION
Signed-off-by: Sergey Fedorov <vital.had@gmail.com>

#### Description

The port is broken on PPC for ages. Let us finally fix that. (Since nobody has time to fix assembler, just use generic target, no patches needed.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
