### PR TITLE
openjdk19-sap: update to 19.0.2

### DIFF
--- a/java/openjdk19-sap/Portfile
+++ b/java/openjdk19-sap/Portfile
@@ -13,7 +13,7 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-version      19.0.1
+version      19.0.2
 revision     0
 
 description  SAP Machine 19
@@ -23,14 +23,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  f349018e8029319269f01ee85cf9edaabc94a344 \
-                 sha256  720d2a956fa7ad4ea89b5f3d9f9ee1c9c2e464bccc54f9cb72f8e2bb40850505 \
-                 size    187898408
+    checksums    rmd160  c84187e2a07d8e2a89d05e6c3d9a58818467759a \
+                 sha256  526d827d243c97dcee965a40ec5735fc82dcb8d8b32ab5b118a9ce9199d213f9 \
+                 size    187912853
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  43a20161a1e55f01e8c67ab6177be674d20fdb00 \
-                 sha256  19830ca15d0038c01a888794588547079ad747a2696b62f4b0a3d263138eb189 \
-                 size    185937953
+    checksums    rmd160  5fff841e1f27644d5f781cf26f182ba55c52e6bc \
+                 sha256  9378c84c6773fb93d4c65742aeff3d006fa636b12d9657e421a0ed2ebbd2040b \
+                 size    185942139
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 19.0.2.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?