### PR TITLE
openjdk17-sap: update to 17.0.6

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.5
+version      17.0.6
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  46d889206c72808aa7faecd7588ed794856f487d \
-                 sha256  ced97fe7eef75beede2a70e59263353c3862b05d20153d2381bd7e9fa3d3ebff \
-                 size    180226806
+    checksums    rmd160  64f9afa9a9f6be420e4c31b9825a635a32120ece \
+                 sha256  2332a717bb7e204b93fb017035a9ecca33ee440df652df2c3ab32ab76be4bcc6 \
+                 size    180278103
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  39c853c9d7b7864714ac0c5ca7e9ed580622111d \
-                 sha256  62325dd21f25bdb403e04dc3661241ac485d79444953aaeaf354b1be48040f93 \
-                 size    177943813
+    checksums    rmd160  f922feab54bef43cecdf89fd1babf932e1985328 \
+                 sha256  31c7d36a8dfd4d0b14fcd82edeccb14be408128099dcdd41e89f0698f0882ac9 \
+                 size    177990627
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.6.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?