### PR TITLE
gegl, babl: fixes for PPC and <10.6 Intel

### DIFF
--- a/graphics/babl-devel/Portfile
+++ b/graphics/babl-devel/Portfile
@@ -39,6 +39,14 @@ depends_lib-append  port:lcms2 \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:bin/vala:vala
 
+# Vapigen is broken on PPC: https://gitlab.gnome.org/GNOME/vala/-/issues/1297
+platform darwin powerpc {
+    depends_lib-delete \
+                    path:bin/vala:vala
+    configure.args-append \
+                    -Denable-vapi=false
+}
+
 patchfiles-append   patch-babl-linker-fix-darwin.diff
 patchfiles-append   patch-babl-allow-non-clang-compilers-on-darwin.diff
 

--- a/graphics/babl/Portfile
+++ b/graphics/babl/Portfile
@@ -39,6 +39,14 @@ depends_lib-append  port:lcms2 \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:bin/vala:vala
 
+# Vapigen is broken on PPC: https://gitlab.gnome.org/GNOME/vala/-/issues/1297
+platform darwin powerpc {
+    depends_lib-delete \
+                    path:bin/vala:vala
+    configure.args-append \
+                    -Denable-vapi=false
+}
+
 patchfiles-append   patch-babl-linker-fix-darwin.diff
 patchfiles-append   patch-babl-allow-non-clang-compilers-on-darwin.diff
 

--- a/graphics/gegl-devel/Portfile
+++ b/graphics/gegl-devel/Portfile
@@ -55,7 +55,6 @@ depends_lib-append \
                     port:libraw \
                     path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
                     path:lib/libavcodec.dylib:ffmpeg \
-                    port:libsdl2 \
                     port:libspiro \
                     port:openexr \
                     port:poly2tri-c \
@@ -64,6 +63,17 @@ depends_lib-append \
                     port:SuiteSparse_UMFPACK \
                     port:tiff \
                     port:webp
+
+# libsdl2 requires minimum Xcode 10.7 SDK to build successfully, but builds on 10.6 x86.
+# On earlier systems and all PPC use libsdl1 instead.
+if {${os.platform} eq "darwin" && (${os.major} < 10 || ${build_arch} in [list ppc ppc64])} {
+    depends_lib-append  port:libsdl
+    configure.args-append \
+                        -Dsdl2=disabled \
+                        -Dsdl1=enabled
+} else {
+    depends_lib-append  port:libsdl2
+}
 
 # proposed fix for 32 bit builds
 # https://trac.macports.org/ticket/58524

--- a/graphics/gegl-devel/Portfile
+++ b/graphics/gegl-devel/Portfile
@@ -79,6 +79,17 @@ if {${os.platform} eq "darwin" && (${os.major} < 10 || ${build_arch} in [list pp
 # https://trac.macports.org/ticket/58524
 patchfiles-append   patch-gegl-32bit-host-statistics.diff
 
+# https://trac.macports.org/ticket/66233
+if {[string match *gcc* ${configure.compiler}]} {
+    patchfiles-append patch-use-gcc.diff
+}
+
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        patchfiles-append patch-gegl-opencl-fix-Leopard-and-less-only.diff
+    }
+}
+
 post-patch {
     # https://trac.macports.org/ticket/35148
     if {${os.major} < 10} {
@@ -105,7 +116,7 @@ configure.args-append       -Dvapigen=disabled \
 # at present, luajit does not build on PowerPC
 platform darwin powerpc {
     depends_lib-delete path:lib/libluajit-5.1.2.dylib:luajit
-    configure.args-append -Dlua=false
+    configure.args-append -Dlua=disabled
 }
 
 # TODO
@@ -163,7 +174,10 @@ if {![variant_isset quartz]} {
     default_variants +x11
 }
 
-default_variants-append +vala
+# Vapigen is broken on PPC: https://gitlab.gnome.org/GNOME/vala/-/issues/1297
+if {${os.arch} ne "powerpc"} {
+    default_variants-append +vala
+}
 
 livecheck.type      regex
 livecheck.url       https://download.gimp.org/pub/${my_name}/${branch}/

--- a/graphics/gegl-devel/files/patch-gegl-opencl-fix-Leopard-and-less-only.diff
+++ b/graphics/gegl-devel/files/patch-gegl-opencl-fix-Leopard-and-less-only.diff
@@ -1,0 +1,26 @@
+diff --git gegl/meson.build gegl/meson.build
+index 12c753c..95ed1b6 100644
+--- gegl/meson.build
++++ gegl/meson.build
+@@ -80,7 +80,7 @@ install_headers(gegl_headers,
+   subdir: api_name
+ )
+ 
+-gegl_ldflags = os_osx ? ['-framework', 'OpenCL'] : []
++gegl_ldflags = []
+ 
+ gegl_lib = library(api_name,
+   gegl_sources,
+diff --git gegl/opencl/gegl-cl-init.c gegl/opencl/gegl-cl-init.c
+index 22bdbb8..07d8ec8 100644
+--- gegl/opencl/gegl-cl-init.c
++++ gegl/opencl/gegl-cl-init.c
+@@ -689,7 +689,7 @@ gegl_cl_init_common (cl_device_type          requested_device_type,
+           if (!gegl_cl_init_get_gl_sharing_props (gl_contex_props, error))
+             return FALSE;
+ 
+-#ifdef __APPLE__
++#if __APPLE__ && MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__POWERPC__)
+           /* Create context */
+           ctx = gegl_clCreateContext (gl_contex_props, 0, 0, NULL, 0, &err);
+ 

--- a/graphics/gegl-devel/files/patch-use-gcc.diff
+++ b/graphics/gegl-devel/files/patch-use-gcc.diff
@@ -1,0 +1,16 @@
+--- meson.build.orig	2023-01-21 03:46:59.000000000 +0800
++++ meson.build	2023-01-21 03:47:31.000000000 +0800
+@@ -139,9 +139,10 @@
+ os_android= host_os.contains('android')
+ os_osx    = host_os.contains('darwin')
+ 
+-if os_osx and cc.get_id() != 'clang'
+-  error('You should use Clang on OSx.')
+-endif
++# if os_osx and cc.get_id() != 'clang'
++#  error('You should use Clang on OSx.')
++# endif
++# Not necessarily.
+ 
+ host_cpu_family = host_machine.cpu_family()
+ if   host_cpu_family == 'x86'

--- a/graphics/gegl/Portfile
+++ b/graphics/gegl/Portfile
@@ -55,7 +55,6 @@ depends_lib-append \
                     port:libraw \
                     path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
                     path:lib/libavcodec.dylib:ffmpeg \
-                    port:libsdl2 \
                     port:libspiro \
                     port:openexr \
                     port:poly2tri-c \
@@ -64,6 +63,17 @@ depends_lib-append \
                     port:SuiteSparse_UMFPACK \
                     port:tiff \
                     port:webp
+
+# libsdl2 requires minimum Xcode 10.7 SDK to build successfully, but builds on 10.6 x86.
+# On earlier systems and all PPC use libsdl1 instead.
+if {${os.platform} eq "darwin" && (${os.major} < 10 || ${build_arch} in [list ppc ppc64])} {
+    depends_lib-append  port:libsdl
+    configure.args-append \
+                        -Dsdl2=disabled \
+                        -Dsdl1=enabled
+} else {
+    depends_lib-append  port:libsdl2
+}
 
 # proposed fix for 32 bit builds
 # https://trac.macports.org/ticket/58524

--- a/graphics/gegl/Portfile
+++ b/graphics/gegl/Portfile
@@ -79,6 +79,17 @@ if {${os.platform} eq "darwin" && (${os.major} < 10 || ${build_arch} in [list pp
 # https://trac.macports.org/ticket/58524
 patchfiles-append   patch-gegl-32bit-host-statistics.diff
 
+# https://trac.macports.org/ticket/66233
+if {[string match *gcc* ${configure.compiler}]} {
+    patchfiles-append patch-use-gcc.diff
+}
+
+platform darwin {
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        patchfiles-append patch-gegl-opencl-fix-Leopard-and-less-only.diff
+    }
+}
+
 post-patch {
     # https://trac.macports.org/ticket/35148
     if {${os.major} < 10} {
@@ -105,7 +116,7 @@ configure.args-append       -Dvapigen=disabled \
 # at present, luajit does not build on PowerPC
 platform darwin powerpc {
     depends_lib-delete path:lib/libluajit-5.1.2.dylib:luajit
-    configure.args-append -Dlua=false
+    configure.args-append -Dlua=disabled
 }
 
 # TODO
@@ -163,7 +174,10 @@ if {![variant_isset quartz]} {
     default_variants +x11
 }
 
-default_variants-append +vala
+# Vapigen is broken on PPC: https://gitlab.gnome.org/GNOME/vala/-/issues/1297
+if {${os.arch} ne "powerpc"} {
+    default_variants-append +vala
+}
 
 livecheck.type      regex
 livecheck.url       https://download.gimp.org/pub/${my_name}/${branch}/

--- a/graphics/gegl/files/patch-gegl-opencl-fix-Leopard-and-less-only.diff
+++ b/graphics/gegl/files/patch-gegl-opencl-fix-Leopard-and-less-only.diff
@@ -1,0 +1,26 @@
+diff --git gegl/meson.build gegl/meson.build
+index 12c753c..95ed1b6 100644
+--- gegl/meson.build
++++ gegl/meson.build
+@@ -80,7 +80,7 @@ install_headers(gegl_headers,
+   subdir: api_name
+ )
+ 
+-gegl_ldflags = os_osx ? ['-framework', 'OpenCL'] : []
++gegl_ldflags = []
+ 
+ gegl_lib = library(api_name,
+   gegl_sources,
+diff --git gegl/opencl/gegl-cl-init.c gegl/opencl/gegl-cl-init.c
+index 22bdbb8..07d8ec8 100644
+--- gegl/opencl/gegl-cl-init.c
++++ gegl/opencl/gegl-cl-init.c
+@@ -689,7 +689,7 @@ gegl_cl_init_common (cl_device_type          requested_device_type,
+           if (!gegl_cl_init_get_gl_sharing_props (gl_contex_props, error))
+             return FALSE;
+ 
+-#ifdef __APPLE__
++#if __APPLE__ && MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__POWERPC__)
+           /* Create context */
+           ctx = gegl_clCreateContext (gl_contex_props, 0, 0, NULL, 0, &err);
+ 

--- a/graphics/gegl/files/patch-use-gcc.diff
+++ b/graphics/gegl/files/patch-use-gcc.diff
@@ -1,0 +1,16 @@
+--- meson.build.orig	2023-01-21 03:46:59.000000000 +0800
++++ meson.build	2023-01-21 03:47:31.000000000 +0800
+@@ -139,9 +139,10 @@
+ os_android= host_os.contains('android')
+ os_osx    = host_os.contains('darwin')
+ 
+-if os_osx and cc.get_id() != 'clang'
+-  error('You should use Clang on OSx.')
+-endif
++# if os_osx and cc.get_id() != 'clang'
++#  error('You should use Clang on OSx.')
++# endif
++# Not necessarily.
+ 
+ host_cpu_family = host_machine.cpu_family()
+ if   host_cpu_family == 'x86'


### PR DESCRIPTION
#### Description

This PR addresses a few bugs:

1. Invalid option in meson.build used for PPC (cannot be boolean): https://trac.macports.org/ticket/66233
2. No OpenCL on <10.6 Intel and any PPC (has been thrown away prior to release or not implemented at all).
3. Blacklisting GCC – no reason for that, GCC works fine. Moreover, on PPC it is the only compiler.
4. Vapigen is broken on PPC, related default variants should not be used there.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
