### PR TITLE
libgit2: update to 1.5.1

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.0
 PortGroup           muniversal 1.0
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 1.5.0 v
+github.setup        libgit2 libgit2 1.5.1 v
 github.tarball_from archive
 revision            0
 epoch               1
@@ -26,9 +26,9 @@ long_description    libgit2 is a portable, pure C implementation of the \
 
 homepage            https://libgit2.org/
 
-checksums           rmd160  d2045232d561b0e6b23829d8461efef12d990407 \
-                    sha256  8de872a0f201b33d9522b817c92e14edb4efad18dae95cf156cf240b2efff93e \
-                    size    5893437
+checksums           rmd160  0a347520ea2fe8bf8480ee2d80f2cd8142b54c72 \
+                    sha256  7074f1e2697992b82402501182db254fe62d64877b12f6e4c64656516f4cde88 \
+                    size    5895483
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
