### PR TITLE
libosmium: update to 2.19.0, osmium-tool: update to 1.15.0

### DIFF
--- a/gis/libosmium/Portfile
+++ b/gis/libosmium/Portfile
@@ -5,12 +5,11 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
 
-github.setup        osmcode libosmium 2.18.0 v
+github.setup        osmcode libosmium 2.19.0 v
 github.tarball_from archive
 revision            0
 
 categories          gis
-platforms           darwin
 maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
 
 license             Boost-1 public-domain
@@ -26,9 +25,9 @@ long_description    Low-level: this is designed to be a building block \
                     generated with the Google Protobufs protoc \
                     program.
 
-checksums           rmd160  1b34ad4d161c36cdab9b8b620e6d7219b5753303 \
-                    sha256  c05a3e95c9c811521ebad8637e90f43ab8fb053b310875acce741cc4c17d6f59 \
-                    size    565862
+checksums           rmd160  a1c24ae0e4cf67eee1127cb4858703688638987a \
+                    sha256  6911a8ca8e81d49205357177982df908af11376919f93b814cccf02f1d4d63e3 \
+                    size    565486
 
 installs_libs       no
 
@@ -64,5 +63,4 @@ variant tests description {Build and run unit tests} {
 
     test.run            yes
     test.cmd            ctest --output-on-failure
-
 }

--- a/gis/osmium-tool/Portfile
+++ b/gis/osmium-tool/Portfile
@@ -5,12 +5,11 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
 
-github.setup        osmcode osmium-tool 1.14.0 v
+github.setup        osmcode osmium-tool 1.15.0 v
 github.tarball_from archive
 revision            0
 
 categories          gis
-platforms           darwin
 maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
 
 license             GPL-3+ MIT BSD Boost-1
@@ -20,8 +19,8 @@ description         A command line tool for working with OpenStreetMap
 long_description    A multipurpose command line tool for working with \
                     OpenStreetMap data based on the Osmium library
 
-checksums           rmd160  fb98f00e473f3314fd36e69cb430f1fef527f455 \
-                    sha256  67765fe6b612e791aab276af601dd12410b70486946e983753f6b0442f915233 \
+checksums           rmd160  f376ec33bce1d509c2ef99f1d33a7999f9cff1ec \
+                    sha256  0b3be2f07d60dfb93f65d6a9f1af1fc9cf6ef68e5a460997d841c93079c3377b \
                     size    490366
 
 compiler.cxx_standard 2014


### PR DESCRIPTION
#### Description
* [libosmium changelog](https://github.com/osmcode/libosmium/releases)
* [osmium-tool changelog](https://github.com/osmcode/osmium-tool/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

