### PR TITLE
spring-boot-cli: update to 3.0.2

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.0.1
+version         3.0.2
 revision        0
 
 categories      java
@@ -26,13 +26,13 @@ long_description The Spring Boot CLI is a command line tool that can be used \
                 off the ground.
 
 homepage        https://projects.spring.io/spring-boot/
-master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/${version}/
+master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${name}/${version}/
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  8d84d3888620e2d5a9d6c7c4dee428b1b803e025 \
-                sha256  58bfd79b4dc6913c45fc82f3f36e9ed52363963b21a2534106e33b4485618b52 \
-                size    4690379
+checksums       rmd160  89c0b698fa618123b8a45d05516390d6ac262d8a \
+                sha256  592e54ffa1e002cfd075385fb08c389252ad24c2a0861c59b7d926df95a94e79 \
+                size    4690467
 
 worksrcdir      spring-${version}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.0.2, and updated download URL [as per this blog post](https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023).

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?