### PR TITLE
totp-cli: Update to version 1.2.5

### DIFF
--- a/security/totp-cli/Portfile
+++ b/security/totp-cli/Portfile
@@ -3,11 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/yitsushi/totp-cli 1.1.17 v
+go.setup            github.com/yitsushi/totp-cli 1.2.5 v
 revision            0
 
 categories          security
 maintainers         {gmail.com:smanojkarthick @manojkarthick} \
+                    {hotmail.com:amtor @RobK88} \
                     openmaintainer
 
 license             MIT
@@ -19,30 +20,35 @@ long_description    A simple TOTP (Time-based One-time Password) CLI tool. \
                     You can manage and organize your accounts with namespaces and protect your data with a password.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  d42b702f844eb4ce66eb9662c180c0f7a12fbe54 \
-                        sha256  aa3aef173136b8674d203649ed96e43451f72c2371a971a2411482e2b3ab10a5 \
-                        size    13698
+                        rmd160  ddc68dc0d963212cffca299323781702b655358a \
+                        sha256  243de9bd4f2552a214cd0428794416546a0e3727a41d36b0ac0b84388125509c \
+                        size    17313
 
 go.vendors          gopkg.in/yaml.v3 \
-                        lock    9f266ea9e77c \
-                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
-                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
-                        size    86890 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
                     gopkg.in/yaml.v2 \
-                        lock    v2.2.2 \
-                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
-                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
-                        size    70676 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
+                    golang.org/x/term \
+                        lock    v0.4.0 \
+                        rmd160  ab690adab1da9bf826e1e2960b3c032c9284a23e \
+                        sha256  fe08b220b0929e25392011fd72353f50b7ac64d52cffff4a868318b0f16beab0 \
+                        size    14800 \
                     golang.org/x/sys \
-                        lock    97732733099d \
-                        rmd160  d83b94fd587bc3799316510e1e5cfda7ff2425e8 \
-                        sha256  62c7cd8777af259c0266055a99d3d67c80a77506104a14a9678547c808010f73 \
-                        size    1350306 \
+                        lock    v0.4.0 \
+                        rmd160  83e9289b4e409a6a5a96cf70f6adda487c3f1170 \
+                        sha256  97f4948f84af5fe499733870e49ce277786e512787690065e3be9828d4a6c738 \
+                        size    1425728 \
                     golang.org/x/crypto \
-                        lock    70a84ac30bf9 \
-                        rmd160  a4669e7e76a0b9e1ff0a29da7637344dba930556 \
-                        sha256  4076b95aeea5ba2226471c2ae2f61cf5df589d92d9d75064df3550c4c2fb2960 \
-                        size    1729956 \
+                        lock    v0.5.0 \
+                        rmd160  d1a21b7260574f31cbc6588e1c392eb8f373a9e6 \
+                        sha256  a21df3765c9643d1fadcfb966fde4173c0c930851fb01a24bdef28abd950f13c \
+                        size    1633695 \
                     github.com/yitsushi/go-commander \
                         lock    v1.1.0 \
                         rmd160  07fc098fe5fc6d166121fa4af9bbaf8cfe5259e6 \
@@ -54,15 +60,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  147f852820301d4e36503b78de1cf768610062e62a9cd717023cb097c0612f18 \
                         size    1730 \
                     github.com/stretchr/testify \
-                        lock    v1.6.1 \
-                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
-                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
-                        size    84248 \
+                        lock    v1.7.0 \
+                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
+                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
+                        size    91096 \
                     github.com/stretchr/objx \
-                        lock    v0.1.0 \
-                        rmd160  fa58b6a0f55fce44b3d4e246b07574f016a1dabf \
-                        sha256  e80eb3ee16d44676befb5b8044459492f73e6f153ad3f28b13949c9f9cfaf558 \
-                        size    109497 \
+                        lock    v0.5.0 \
+                        rmd160  9ff3c4d1d122c7e389f2d8b0b0c5503fd1c15e0a \
+                        sha256  21b1f19a64c553c9ee77ab25f498ceafe839a84aa9380f04154ea28217c60974 \
+                        size    165551 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -79,10 +85,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  ed51f32d6729696e216d051b3955c22161a970aaef01c1819d85ad179e51ba41 \
                         size    4904 \
                     github.com/davecgh/go-spew \
-                        lock    v1.1.0 \
-                        rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \
-                        sha256  810a597004388d68bb92d8aa612375419ba1080dd5fc2c66dd41b58f0ba4442c \
-                        size    42348
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

- Update to version 1.2.5
- Fix build issues on recent versions of macOS
- Add missing dependency - golang.org/x/term
- Update existing dependencies to latest versions
- Add myself as a maintainer of the port

CLOSES:  https://trac.macports.org/ticket/66727

Note:  `port lint --nitpick` creates warnings that I cannot fix.  I suspect there is a bug in Macports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.

-->
macOS 10.7.5 11G63 i386
Xcode 4.6.3 4H1503


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
