### PR TITLE
weechat: update to 3.8, fix ruby variant build, update {python,ruby} variants

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             3.5
+version             3.8
 revision            0
-checksums           rmd160  726a83435e4678a8ee9059c24ad5b598227146ea \
-                    sha256  ea904e4cec8edd0bd24f3ea17f6d6dff97ca00ee0571ee972e79e54c8c08170c \
-                    size    2693072
+checksums           rmd160  7fc2a475998a1dbcdc25ae2ba939c8b85fd5f3ae \
+                    sha256  f7cb65c200f8c090c56f2cf98c0b184051e516e5f7099a4308cacf86f174bf28 \
+                    size    2777420
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
@@ -75,29 +75,62 @@ configure.args-append \
                     -DENABLE_TCL=OFF \
                     -DENABLE_TESTS=OFF
 
-variant python requires python310 description {Compatibility variant, requires +python310} {}
+variant python requires python311 description {Compatibility variant, requires +python311} {}
 
-variant python37 description "Bindings for Python 3.7 plugins" conflicts python38 python39 python310 {
+variant python37 description "Bindings for Python 3.7 plugins" conflicts python38 python39 python310 python311 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python37
 }
 
-variant python38 description "Bindings for Python 3.8 plugins" conflicts python37 python39 python310 {
+variant python38 description "Bindings for Python 3.8 plugins" conflicts python37 python39 python310 python311 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python38
 }
 
-variant python39 description "Bindings for Python 3.9 plugins" conflicts python37 python38 python310 {
+variant python39 description "Bindings for Python 3.9 plugins" conflicts python37 python38 python310 python311 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python39
 }
 
-variant python310 description "Bindings for Python 3.10 plugins" conflicts python37 python38 python39 {
+variant python310 description "Bindings for Python 3.10 plugins" conflicts python37 python38 python39 python311 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     depends_lib-append      port:python310
 }
 
+variant python311 description "Bindings for Python 3.11 plugins" conflicts python37 python38 python39 python310 {
+    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    depends_lib-append      port:python311
+}
+
+variant ruby requires ruby32 description {Compatibility variant, requires +ruby32} {}
+
+variant ruby30 description "Bindings for Ruby 3.0 plugins" conflicts ruby31 ruby32 {
+    configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
+    configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
+    depends_lib-append      port:ruby30
+
+    patchfiles              FindRuby.cmake.diff
+}
+
+variant ruby31 description "Bindings for Ruby 3.1 plugins" conflicts ruby30 ruby32 {
+    configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
+    configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
+    depends_lib-append      port:ruby31
+
+    patchfiles              FindRuby.cmake.diff
+}
+
+variant ruby32 description "Bindings for Ruby 3.2 plugins" conflicts ruby30 ruby31 {
+    configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
+    configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
+    depends_lib-append      port:ruby32
+
+    patchfiles              FindRuby.cmake.diff
+}
+
+
 post-patch {
+    # specify Python version for CMake to find and use
     set patchfile ${worksrcpath}/cmake/FindPython.cmake
 
     if {[variant_isset python37]} {
@@ -108,6 +141,17 @@ post-patch {
         reinplace -E "s|PYTHON python3|PYTHON python-3.9|g" ${patchfile}
     } elseif {[variant_isset python310]} {
         reinplace -E "s|PYTHON python3|PYTHON python-3.10|g" ${patchfile}
+    }
+
+    # specify Ruby version for CMake to find and use
+    set patchfile ${worksrcpath}/cmake/FindRuby.cmake
+
+    if {[variant_isset ruby30]} {
+        reinplace -E {s|pkg_search_module\(RUBY (.*)\)|pkg_search_module\(RUBY ruby-3.0\)|g} ${patchfile}
+    } elseif {[variant_isset ruby31]} {
+        reinplace -E {s|pkg_search_module\(RUBY (.*)\)|pkg_search_module\(RUBY ruby-3.1\)|g} ${patchfile}
+    } elseif {[variant_isset ruby32]} {
+        reinplace -E {s|pkg_search_module\(RUBY (.*)\)|pkg_search_module\(RUBY ruby-3.2\)|g} ${patchfile}
     }
 }
 
@@ -132,12 +176,6 @@ variant perl description {Bindings for Perl plugins} {
     configure.args-delete   -DENABLE_PERL=OFF
     configure.args-append   -DENABLE_PERL=ON
     depends_lib-append      path:bin/perl:perl5
-}
-
-variant ruby description {Bindings for Ruby plugins} {
-    configure.args-delete   -DENABLE_RUBY=OFF
-    configure.args-append   -DENABLE_RUBY=ON
-    depends_lib-append      port:ruby
 }
 
 variant scheme description {Bindings for Scheme (guile) plugins} {

--- a/irc/weechat/files/FindRuby.cmake.diff
+++ b/irc/weechat/files/FindRuby.cmake.diff
@@ -1,0 +1,18 @@
+--- cmake/FindRuby.cmake.orig	2023-01-21 17:57:16.000000000 -0800
++++ cmake/FindRuby.cmake	2023-01-21 19:29:52.000000000 -0800
+@@ -33,13 +33,9 @@
+ 
+ find_package(PkgConfig)
+ if(PKG_CONFIG_FOUND)
+-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-    # set specific search path for macOS
+-    set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/opt/ruby/lib/pkgconfig")
+-  endif()
+   pkg_search_module(RUBY ruby-3.2 ruby-3.1 ruby-3.0 ruby-2.7 ruby-2.6 ruby-2.5 ruby-2.4 ruby-2.3 ruby-2.2 ruby-2.1 ruby-2.0 ruby-1.9 ruby)
+   if(RUBY_FOUND AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-    # FIXME: weird hack: hardcoding the Ruby lib location on macOS
+-    set(RUBY_LDFLAGS "${RUBY_LDFLAGS} -L/usr/local/opt/ruby/lib")
++    # remove "-arch;xxx;" on macOS
++    STRING(REGEX REPLACE "-arch;(arm64|i386|ppc|ppc64|x86_64);" "" RUBY_LDFLAGS "${RUBY_LDFLAGS}")
+   endif()
+ endif()


### PR DESCRIPTION
#### Description
weechat: update to 3.8, fix ruby variant build, update {python,ruby} variants

* adds variants for ruby 3.0 (+ruby30), 3.1 (+ruby31), and 3.2 (+ruby32) and updates +ruby variant to use ruby 3.2 (+ruby32)

* adds +python311 variant for python 3.11, and updates +python variant to use python 3.11 (+python311)

* adds a patchfile to fix a build error (`error: invalid arch name '-arch -lx86_64'`) when installing the ruby variant

  the patch to one of the CMake files removes the hardcoded paths that ruby is assumed to be installed to, and removes the `-arch ${os.arch}` in RUBY_LDFLAGS provided by pkg-config as the space in between `-arch` and `${os.arch}` led to string substitution errors during the build process

  see the corresponding trac ticket for details

Closes: https://trac.macports.org/ticket/65100

###### Type(s)
- [x] bugfix

###### Tested on
macOS 12.6.2 21G320 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?