### PR TITLE
misc noarch ports: update platforms

### DIFF
--- a/databases/lmdbxx-cxx17/Portfile
+++ b/databases/lmdbxx-cxx17/Portfile
@@ -6,10 +6,10 @@ PortGroup           github 1.0
 github.setup        hoytech lmdbxx 1.0.0
 name                lmdbxx-cxx17
 categories          databases devel
-platforms           darwin
+platforms           any
 supported_archs     noarch
 license             public-domain
-maintainers         none
+maintainers         nomaintainer
 
 description         C++17 wrapper for the LMDB embedded B+ tree database library.
 

--- a/databases/lmdbxx/Portfile
+++ b/databases/lmdbxx/Portfile
@@ -8,7 +8,7 @@ github.setup        bendiken lmdbxx 0b43ca87
 # we needed a designation for the git version we are pulling.
 version             0.9.14.0.1
 categories          databases devel
-platforms           darwin
+platforms           any
 supported_archs     noarch
 license             public-domain
 maintainers         {bendiken.net:arto @bendiken}

--- a/databases/postgresql10-server/Portfile
+++ b/databases/postgresql10-server/Portfile
@@ -5,13 +5,13 @@ PortSystem 1.0
 name                postgresql10-server
 version             10.19
 categories          databases
-platforms           darwin
+platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
 
 set rname           postgresql10
 description         run ${rname} as server
-long_description    ${description}
+long_description    {*}${description}
 distfiles       
 
 homepage            https://www.postgresql.org/

--- a/databases/postgresql11-server/Portfile
+++ b/databases/postgresql11-server/Portfile
@@ -5,13 +5,13 @@ PortSystem 1.0
 name                postgresql11-server
 version             11.14
 categories          databases
-platforms           darwin
+platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
 
 set rname           postgresql11
 description         run ${rname} as server
-long_description    ${description}
+long_description    {*}${description}
 distfiles       
 
 homepage            https://www.postgresql.org/

--- a/databases/postgresql12-server/Portfile
+++ b/databases/postgresql12-server/Portfile
@@ -5,13 +5,13 @@ PortSystem 1.0
 name                postgresql12-server
 version             12.13
 categories          databases
-platforms           darwin
+platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
 
 set rname           postgresql12
 description         run ${rname} as server
-long_description    ${description}
+long_description    {*}${description}
 distfiles       
 
 homepage            https://www.postgresql.org/

--- a/databases/postgresql13-server/Portfile
+++ b/databases/postgresql13-server/Portfile
@@ -5,13 +5,13 @@ PortSystem 1.0
 name                postgresql13-server
 version             13.5
 categories          databases
-platforms           darwin
+platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
 
 set rname           postgresql13
 description         run ${rname} as server
-long_description    ${description}
+long_description    {*}${description}
 distfiles       
 
 homepage            https://www.postgresql.org/

--- a/databases/postgresql14-server/Portfile
+++ b/databases/postgresql14-server/Portfile
@@ -5,13 +5,13 @@ PortSystem 1.0
 name                postgresql14-server
 version             14.6
 categories          databases
-platforms           darwin
+platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
 
 set rname           postgresql14
 description         run ${rname} as server
-long_description    ${description}
+long_description    {*}${description}
 distfiles       
 
 homepage            https://www.postgresql.org/

--- a/databases/postgresql15-server/Portfile
+++ b/databases/postgresql15-server/Portfile
@@ -5,13 +5,13 @@ PortSystem 1.0
 name                postgresql15-server
 version             15.0
 categories          databases
-platforms           darwin
+platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
 
 set rname           postgresql15
 description         run ${rname} as server
-long_description    ${description}
+long_description    {*}${description}
 distfiles       
 
 homepage            https://www.postgresql.org/

--- a/databases/postgresql93-server/Portfile
+++ b/databases/postgresql93-server/Portfile
@@ -9,13 +9,13 @@ deprecated.upstream_support no
 name			postgresql93-server
 version			9.3.25
 categories		databases
-platforms		darwin
+platforms		{darwin any}
 maintainers		{jwa @jyrkiwahlstedt}
 
 set rname       postgresql93
 license			Permissive
 description		run ${rname} as server
-long_description	${description}
+long_description	{*}${description}
 distfiles       
 
 homepage		https://www.postgresql.org/

--- a/databases/postgresql94-server/Portfile
+++ b/databases/postgresql94-server/Portfile
@@ -5,13 +5,13 @@ PortSystem 1.0
 name			postgresql94-server
 version			9.4.26
 categories		databases
-platforms		darwin
+platforms		{darwin any}
 maintainers		{jwa @jyrkiwahlstedt}
 license			Permissive
 
 set rname       postgresql94
 description		run ${rname} as server
-long_description	${description}
+long_description	{*}${description}
 distfiles       
 
 homepage		https://www.postgresql.org/

--- a/databases/postgresql95-server/Portfile
+++ b/databases/postgresql95-server/Portfile
@@ -5,13 +5,13 @@ PortSystem 1.0
 name			postgresql95-server
 version			9.5.25
 categories		databases
-platforms		darwin
+platforms		{darwin any}
 maintainers		{jwa @jyrkiwahlstedt}
 license			Permissive
 
 set rname       postgresql95
 description		run ${rname} as server
-long_description	${description}
+long_description	{*}${description}
 distfiles       
 
 homepage		https://www.postgresql.org/

--- a/databases/postgresql96-server/Portfile
+++ b/databases/postgresql96-server/Portfile
@@ -9,6 +9,7 @@ categories          databases
 maintainers         {jwa @jyrkiwahlstedt}
 license             Permissive
 supported_archs     noarch
+platforms           {darwin any}
 
 set rname           postgresql96
 

--- a/devel/Drizzle/Portfile
+++ b/devel/Drizzle/Portfile
@@ -11,14 +11,14 @@ checksums                   rmd160  b406bd9df9404d015d4623e3f68adba99a100494 \
                             size    4640697
 
 categories                  devel
-platforms                   darwin
+platforms                   {darwin any}
 maintainers                 {ryandesign @ryandesign}
 license                     GPL-3+
 supported_archs             noarch
 
 description                 tools related to the Myst game franchise
 
-long_description            ${name} is a collection of ${description}. \
+long_description            ${name} is a collection of {*}${description}. \
                             Most notably, it can transform MOUL / Myst 5 / \
                             Crowthistle datafiles into POTS datafiles. \
                             It also allows you to download and install all \

--- a/devel/VillainousStyle/Portfile
+++ b/devel/VillainousStyle/Portfile
@@ -33,13 +33,14 @@ platform darwin 8 {
 
 if {${name} eq ${subport}} {
     supported_archs     noarch
+    platforms           any
     distfiles
-    
+
     depends_run         port:${name}-framework \
                         port:lib${name}
-    
+
     build {}
-    
+
     destroot {
         set docdir ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${docdir}
@@ -48,11 +49,11 @@ if {${name} eq ${subport}} {
 } else {
     fetch.type          git
     git.branch          e05e72da703b39de3d8b1c53b308f4b2a8b62aef
-    
+
     build.dir           ${worksrcpath}/Source
-    
+
     xcode.configuration Release
-    
+
     livecheck.type      none
 }
 

--- a/devel/autoconf/Portfile
+++ b/devel/autoconf/Portfile
@@ -9,7 +9,7 @@ revision            1
 categories          devel
 # the license is GPL-3+ with an exception:
 # https://www.gnu.org/licenses/autoconf-exception.html
-platforms           darwin
+platforms           any
 supported_archs     noarch
 license             {Autoconf GPL-3+}
 maintainers         {larryv @larryv}

--- a/devel/automake17/Portfile
+++ b/devel/automake17/Portfile
@@ -7,7 +7,7 @@ categories	devel
 license		GPL-2+
 maintainers	gmail.com:springer.jonathan
 description	the gnu automake utility for generating Makefile.in
-platforms	darwin freebsd
+platforms	any
 supported_archs	noarch
 long_description	Automake is a tool for automatically generating \
 		Makefile.in files from files called Makefile.am. Each \

--- a/devel/bsdowl/Portfile
+++ b/devel/bsdowl/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 github.setup        michipili bsdowl 2.2.1 v
 revision            1
 categories          devel
-platforms           darwin
+platforms           any
 maintainers         gmail.com:michipili
 license             CeCILL-B
 supported_archs     noarch

--- a/devel/bzr-explorer/Portfile
+++ b/devel/bzr-explorer/Portfile
@@ -6,7 +6,7 @@ epoch         1
 version       1.3.0
 set branch    [join [lrange [split ${version} .] 0 1] .]
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 supported_archs noarch
 license       GPL-2+
 maintainers   {raimue @raimue}

--- a/devel/bzr-fastimport/Portfile
+++ b/devel/bzr-fastimport/Portfile
@@ -6,7 +6,7 @@ epoch           2
 version         0.13.0
 revision        1
 categories      devel python
-platforms       darwin
+platforms       {darwin any}
 supported_archs noarch
 license         GPL-2
 maintainers     {raimue @raimue}

--- a/devel/bzr-git/Portfile
+++ b/devel/bzr-git/Portfile
@@ -5,7 +5,7 @@ name          bzr-git
 version       0.6.8
 set branch    [join [lrange [split ${version} .] 0 1] .]
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 supported_archs noarch
 license       GPL-2+
 maintainers   {raimue @raimue}

--- a/devel/bzr-gtk/Portfile
+++ b/devel/bzr-gtk/Portfile
@@ -6,7 +6,7 @@ version       0.100.0
 revision      3
 set branch    [join [lrange [split ${version} .] 0 1] .]
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 supported_archs noarch
 license       GPL-2+
 maintainers   {raimue @raimue}

--- a/devel/bzr-pager/Portfile
+++ b/devel/bzr-pager/Portfile
@@ -5,13 +5,13 @@ name          bzr-pager
 version       0.1.0
 revision      2
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 supported_archs noarch
 license       GPL-2+
 maintainers   {raimue @raimue}
 
 description   run bzr commands in a pager
-long_description  ${description}
+long_description  {*}${description}
 
 homepage      http://launchpad.net/${name}/
 master_sites  ${homepage}trunk/${version}/+download/

--- a/devel/bzr-rewrite/Portfile
+++ b/devel/bzr-rewrite/Portfile
@@ -4,7 +4,7 @@ PortGroup     python 1.0
 name          bzr-rewrite
 version       0.6.3
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 supported_archs noarch
 license       GPL-2+
 maintainers   {raimue @raimue}

--- a/devel/bzr-stats/Portfile
+++ b/devel/bzr-stats/Portfile
@@ -4,13 +4,13 @@ PortGroup     python 1.0
 name          bzr-stats
 version       0.1.0
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 supported_archs noarch
 license       GPL-2+
 maintainers   {raimue @raimue}
 
 description   Simple statistics plugin for Bazaar
-long_description  ${description}.
+long_description  {*}${description}.
 
 homepage      http://launchpad.net/${name}/
 master_sites  ${homepage}trunk/${version}/+download/

--- a/devel/bzr-svn/Portfile
+++ b/devel/bzr-svn/Portfile
@@ -6,7 +6,7 @@ epoch         1
 version       1.2.2
 set branch    [join [lrange [split ${version} .] 0 1] .]
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 supported_archs noarch
 license       GPL-2+
 maintainers   {raimue @raimue}

--- a/devel/bzr-xmloutput/Portfile
+++ b/devel/bzr-xmloutput/Portfile
@@ -6,7 +6,7 @@ version             0.8.8
 revision            1
 set branch          trunk
 categories          devel python
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 license             GPL-2+
 maintainers         {raimue @raimue}

--- a/devel/bzrtools/Portfile
+++ b/devel/bzrtools/Portfile
@@ -9,7 +9,7 @@ version       2.6.0
 revision      1
 set branch    [join [lrange [split ${version} .] 0 1] .]
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 supported_archs noarch
 license       GPL-2+
 maintainers   {raimue @raimue}

--- a/devel/dejagnu/Portfile
+++ b/devel/dejagnu/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                dejagnu
 version             1.6.2
 categories          devel
-platforms           darwin
+platforms           any
 license             GPL-3+
 maintainers         {larryv @larryv}
 

--- a/devel/flagpoll/Portfile
+++ b/devel/flagpoll/Portfile
@@ -7,6 +7,7 @@ revision          1
 categories        devel
 license           GPL-2+
 supported_archs   noarch
+platforms         {darwin any}
 maintainers       iastate.edu:mccdo
 description       a python based replacement for pkgconfig
 long_description  Flagpoll is a tool for developers to use \

--- a/devel/hg-credentials/Portfile
+++ b/devel/hg-credentials/Portfile
@@ -9,7 +9,7 @@ revision                1
 
 categories              devel
 license                 GPL-2
-platforms               darwin
+platforms               {darwin any}
 supported_archs         noarch
 maintainers             {danchr @danchr}
 

--- a/devel/hg-git/Portfile
+++ b/devel/hg-git/Portfile
@@ -9,7 +9,7 @@ revision                0
 
 categories              devel
 license                 GPL-2
-platforms               darwin
+platforms               {darwin any}
 supported_archs         noarch
 maintainers             {danchr @danchr}
 

--- a/devel/jreleaser/Portfile
+++ b/devel/jreleaser/Portfile
@@ -9,9 +9,9 @@ github.setup     jreleaser jreleaser 1.4.0 v
 revision         0
 
 categories       devel java
-license          Apache-2.0
+license          Apache-2
 maintainers      @aalmiray
-platforms        darwin
+platforms        any
 supported_archs  noarch
 
 description      Release projects quickly and easily with JReleaser

--- a/devel/kick/Portfile
+++ b/devel/kick/Portfile
@@ -5,7 +5,7 @@ PortGroup           bitbucket 1.0
 
 bitbucket.setup     nwehr kick 0.1 v
 categories          devel
-platforms           darwin
+platforms           any
 maintainers         gmail.com:gtolemans
 license             BSD
 supported_archs     noarch

--- a/devel/npm3/Portfile
+++ b/devel/npm3/Portfile
@@ -12,7 +12,7 @@ version             3.10.10
 revision            3
 
 categories          devel
-platforms           darwin
+platforms           any
 license             MIT
 maintainers         {ciserlohn @ci42}
 

--- a/devel/npm4/Portfile
+++ b/devel/npm4/Portfile
@@ -12,7 +12,7 @@ version             4.6.1
 revision            2
 
 categories          devel
-platforms           darwin
+platforms           any
 license             MIT
 maintainers         {ciserlohn @ci42}
 

--- a/devel/play/Portfile
+++ b/devel/play/Portfile
@@ -7,7 +7,7 @@ github.setup        playframework play1 1.5.2
 name                play
 conflicts           sox
 categories          devel java www
-platforms           darwin
+platforms           {darwin any}
 license             Apache-2
 maintainers         {ciserlohn @ci42}
 supported_archs     noarch

--- a/devel/qbzr/Portfile
+++ b/devel/qbzr/Portfile
@@ -5,7 +5,7 @@ name          qbzr
 version       0.23.2
 set branch    [join [lrange [split ${version} .] 0 1] .]
 categories    devel python
-platforms     darwin
+platforms     {darwin any}
 license       GPL-2+
 maintainers   {raimue @raimue}
 

--- a/editors/yaml-mode.el/Portfile
+++ b/editors/yaml-mode.el/Portfile
@@ -7,7 +7,7 @@ github.setup     yoshiki yaml-mode 0.0.8 release-
 name             yaml-mode.el
 categories       editors
 maintainers      gmail.com:michael.dagitses
-platforms        darwin
+platforms        any
 supported_archs  noarch
 license          GPL-2+
 

--- a/emulators/minivmac-devel/Portfile
+++ b/emulators/minivmac-devel/Portfile
@@ -34,6 +34,7 @@ if {${my_subport} eq ${my_name}} {
 
     stub.subport_name           ${my_subport}
     supported_archs             noarch
+    platforms                   any
 
     livecheck.type              regex
     livecheck.url               ${homepage}

--- a/emulators/minivmac/Portfile
+++ b/emulators/minivmac/Portfile
@@ -33,6 +33,7 @@ if {${my_subport} eq ${my_name}} {
 
     stub.subport_name           ${my_subport}
     supported_archs             noarch
+    platforms                   any
 
     livecheck.type              regex
     livecheck.url               ${homepage}doc/download.html

--- a/erlang/rebar/Portfile
+++ b/erlang/rebar/Portfile
@@ -5,7 +5,7 @@ PortGroup       github 1.0
 
 github.setup    rebar rebar 2.6.4
 categories      erlang devel
-platforms       darwin
+platforms       any
 maintainers     {ciserlohn @ci42}
 supported_archs noarch
 license         Apache-2
@@ -32,4 +32,3 @@ use_configure       no
 destroot {
   xinstall -m 755 ${worksrcpath}/rebar ${destroot}${prefix}/bin
 }
-

--- a/erlang/rebar3/Portfile
+++ b/erlang/rebar3/Portfile
@@ -12,6 +12,7 @@ checksums           rmd160  d8d2e0a8ac802b07758591458994bcd968a039bf \
 categories          erlang devel
 maintainers         {ciserlohn @ci42}
 supported_archs     noarch
+platforms           any
 license             Apache-2
 
 description         Rebar3 is an Erlang tool that makes it easy to create, \

--- a/games/alienarena/Portfile
+++ b/games/alienarena/Portfile
@@ -7,7 +7,6 @@ PortSystem          1.0
 
 name                alienarena
 categories          games
-platforms           darwin
 maintainers         {ryandesign @ryandesign}
 license             GPL-2+
 
@@ -132,6 +131,7 @@ subport alienarena-data {
 
     license                     Restrictive
     supported_archs             noarch
+    platforms                   any
     
     description                 Assets for the Alien Arena game
     

--- a/games/mystonline-bootstrap/Portfile
+++ b/games/mystonline-bootstrap/Portfile
@@ -6,7 +6,7 @@ name                        mystonline-bootstrap
 set my_name                 mystonline
 version                     2010
 revision                    1
-platforms                   darwin
+platforms                   any
 categories                  games x11
 maintainers                 ryandesign
 homepage                    http://mystonline.com/
@@ -21,7 +21,7 @@ supported_archs             noarch
 
 description                 Myst Online: URU Live Again
 
-long_description            ${description} (MO:ULagain) bootstrap files for \
+long_description            {*}${description} (MO:ULagain) bootstrap files for \
                             use with the Wine or Cider version
 
 checksums                   md5     6d92e689247a2dc1c9b77f32bec5d887 \

--- a/games/redeclipse/Portfile
+++ b/games/redeclipse/Portfile
@@ -11,12 +11,12 @@ maintainers         @jasonliu--
 
 homepage            https://www.${name}.net
 description         first-person arena shooter game
-long_description    $pretty_name is a fun-filled new take on the \
+long_description    {*}$pretty_name is a fun-filled new take on the \
                     first-person arena shooter, built on the Cube 2 \
                     game engine. Game modes include Capture the Flag, \
                     Defend and Control, Bomber Ball, and Race, as well \
                     as online cooperative map editing. Unlike the \
-                    original Cube 2: Sauerbraten, $pretty_name \
+                    original Cube 2: Sauerbraten, {*}$pretty_name \
                     features parkour movement, such as vaulting and \
                     running along walls, as well as impulse boosts, \
                     dashing, and other tricks.
@@ -133,6 +133,7 @@ if {$subport eq "${name}-data"} {
     use_bzip2           yes
     license             CC-BY-SA-3
     supported_archs     noarch
+    platforms           any
 
     distfiles           ${name}_${version}_combined${extract.suffix}
     distname            ${name}-${version}

--- a/games/sounddecompress/Portfile
+++ b/games/sounddecompress/Portfile
@@ -6,7 +6,7 @@ PortSystem                  1.0
 name                        sounddecompress
 version                     1.11
 revision                    2
-platforms                   darwin
+platforms                   any
 categories                  games audio sysutils
 maintainers                 ryandesign
 supported_archs             noarch

--- a/graphics/bitstream-vera/Portfile
+++ b/graphics/bitstream-vera/Portfile
@@ -7,7 +7,7 @@ maintainers		mac.com:jbenninghoff
 description		Bitstream Vera Fonts for use with Freetype/Fontconfig
 
 long_description \
-	Bittream Vera Fonts consist of four monospace and sans faces (normal, \
+	Bitstream Vera Fonts consist of four monospace and sans faces (normal, \
 	oblique, bold, bold oblique) and two serif faces (normal and bold). \
 	They are designed to be an attractive default font for GNOME-based \
 	X11 apps. (GTK2/Xft2/Freetype/Fontconfig)
@@ -17,7 +17,7 @@ homepage		https://www.gnome.org/fonts/
 master_sites	gnome:sources/ttf-bitstream-vera/${version}/
 distname		ttf-${name}-${version}
 
-platforms		darwin
+platforms		any
 checksums		md5 52559ed969e74f5fca83e527163156df
 
 supported_archs noarch

--- a/graphics/gimp/Portfile
+++ b/graphics/gimp/Portfile
@@ -24,6 +24,7 @@ set branch      [join [lrange [split ${version} .] 0 1] .]
 
 # Leaf port, not intended to be used as a lib dep
 supported_archs noarch
+platforms       any
 
 depends_lib     port:gimp-lqr-plugin \
                 port:gutenprint

--- a/graphics/inkscape-textext/Portfile
+++ b/graphics/inkscape-textext/Portfile
@@ -10,7 +10,7 @@ revision                0
 categories              graphics tex
 maintainers             {gmail.com:jjstickel @jjstickel}
 license                 BSD
-platforms               darwin
+platforms               any
 distname                TexText-Inkscape-${version}
 supported_archs         noarch
 use_configure           no

--- a/kde/qtcurve/Portfile
+++ b/kde/qtcurve/Portfile
@@ -100,6 +100,7 @@ subport ${name}-extra {
     use_configure           no
     installs_libs           no
     supported_archs         noarch
+    platforms               any
     depends_run-append      port:ciment-icons
     fetch.type              standard
     distfiles

--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -8,11 +8,10 @@ epoch                   1
 version                 5.0.1
 revision                5
 categories              lang
-platforms               darwin
 license                 MIT NCSA
 maintainers             {jeremyhu @jeremyhu} {@catap korins.ky:kirill}
 description             libc++ is a new implementation of the C++ standard library with support for C++11 and portions of C++14.
-long_description        ${description} \
+long_description        {*}${description} \
                         Because objects cannot be passed between different versions of the C++ runtime, this port must \
                         replace the host version in order to be used.  On Snow Leopard and earlier, this is done \
                         automatically because there is no existing host version of this library.  On Lion and later, \
@@ -213,6 +212,7 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
     }
 } else {
     supported_archs noarch
+    platforms       any
     distfiles
     depends_extract
     build {}

--- a/lang/logtalk/Portfile
+++ b/lang/logtalk/Portfile
@@ -9,7 +9,7 @@ revision            0
 categories          lang
 maintainers         {logtalk.org:pmoura @pmoura}
 license             Apache-2
-platforms           darwin freebsd linux
+platforms           any
 supported_archs     noarch
 
 description         Logtalk - Open source object-oriented logic programming language

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -2374,6 +2374,7 @@ if {${name} eq ${subport}} {
     version             ${branch}
     revision            0
     supported_archs     noarch
+    platforms           any
     depends_run         port:${php}
 } else {
     # Set an explicit distname so the default from the php portgroup doesn't get used.

--- a/lang/php5-web/Portfile
+++ b/lang/php5-web/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 name                    php5-web
 version                 5.3.5
 categories              lang php www
-platforms               darwin
+platforms               any
 maintainers             ryandesign
 license                 BSD
 supported_archs         noarch

--- a/lang/pure/Portfile
+++ b/lang/pure/Portfile
@@ -109,11 +109,12 @@ subport pure-mode.el {
     categories-append           editors
     license                     GPL-3+
     supported_archs             noarch
+    platforms                   any
     homepage                    ${github.homepage}/wiki/UsingPure#pure-and-emacs
     
     description                 Emacs mode for editing Pure files
     
-    long_description            ${subport} is an ${description}.
+    long_description            ${subport} is an {*}${description}.
     
     depends_lib                 port:emacs
     

--- a/math/cmsvlib/Portfile
+++ b/math/cmsvlib/Portfile
@@ -7,7 +7,7 @@ epoch               1
 version             2013-04-19
 categories          math science
 maintainers         {takeshi @tenomoto}
-platforms           darwin
+platforms           any
 supported_archs     noarch
 
 description         Read and Write IDL SAVE files

--- a/multimedia/audacious/Portfile
+++ b/multimedia/audacious/Portfile
@@ -10,7 +10,7 @@ revision            0
 
 license             BSD GPL-2+
 categories          multimedia
-platforms           darwin
+platforms           any
 maintainers         {ionic @Ionic}
 supported_archs     noarch
 

--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -250,6 +250,7 @@ subport curl-ca-bundle {
     categories                  net
     license                     {MPL-2 LGPL-2.1+}
     supported_archs             noarch
+    platforms                   any
     installs_libs               no
     conflicts                   certsync
 

--- a/net/surfraw/Portfile
+++ b/net/surfraw/Portfile
@@ -10,7 +10,7 @@ long_description \
     Surfraw provides a fast unix command line interface to a variety of \
     popular WWW search engines and other artifacts of power.
 homepage            http://surfraw.alioth.debian.org/
-platforms           darwin
+platforms           any
 supported_archs     noarch
 master_sites        ${homepage}dist/
 

--- a/net/tcl_bonjour/Portfile
+++ b/net/tcl_bonjour/Portfile
@@ -5,9 +5,7 @@ PortGroup           github 1.0
 
 github.setup        dongola7 tcl_bonjour 1.1 v
 categories          net tcl
-platforms           darwin
 maintainers         the-blair.com:blair
-supported_archs     noarch
 
 description         A Tcl package for publishing and subscribing to network \
                     services via Bonjour on OS X.

--- a/net/umit/Portfile
+++ b/net/umit/Portfile
@@ -9,7 +9,7 @@ categories	net
 maintainers	gmail.com:luis.kop
 description	A graphical tool to scanner networks
 homepage	http://www.umitproject.org/
-platforms	darwin freebsd
+platforms	{darwin any} freebsd
 supported_archs noarch
 long_description Umit is a graphical scanner.
 

--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -55,6 +55,7 @@ subport yt-dlp {
 categories          net
 maintainers         {ryandesign @ryandesign}
 supported_archs     noarch
+platforms           {darwin any}
 license             public-domain
 installs_libs       no
 

--- a/net/zenmap/Portfile
+++ b/net/zenmap/Portfile
@@ -13,6 +13,7 @@ maintainers         {darkart.com:opendarwin.org @ghosthound} {geeklair.net:dluke
 # gpl-2 with additional restrictions, so not actually gpl-2
 license             {GPL-2 OpenSSLException} Restrictive/Distributable
 supported_archs     noarch
+platforms           {darwin any}
 
 description         GUI for nmap
 

--- a/office/DepreciateForLedger/Portfile
+++ b/office/DepreciateForLedger/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben DepreciateForLedger 1.0
 categories          office
-platforms           darwin
+platforms           {darwin any}
 maintainers         {unomaha.edu:bosmith @tazzben}
 license             MIT
 supported_archs     noarch

--- a/office/GTDtoCSV/Portfile
+++ b/office/GTDtoCSV/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben GTDtoCSV 1.0
 categories          office
-platforms           darwin
+platforms           {darwin any}
 maintainers         {unomaha.edu:bosmith @tazzben}
 license             MIT
 supported_archs     noarch

--- a/office/LedgerScheduler/Portfile
+++ b/office/LedgerScheduler/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben LedgerScheduler 1.0
 categories          office
-platforms           darwin
+platforms           {darwin any}
 maintainers         {unomaha.edu:bosmith @tazzben}
 license             MIT
 supported_archs     noarch

--- a/office/bournal/Portfile
+++ b/office/bournal/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                bournal
 version             1.5
 categories          office
-platforms           darwin
+platforms           any
 maintainers         perlhacker.org:sepp
 license             GPL-3+
 supported_archs     noarch

--- a/office/csvToLedger/Portfile
+++ b/office/csvToLedger/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben csvToLedger 1.0
 categories          office
-platforms           darwin
+platforms           {darwin any}
 maintainers         {unomaha.edu:bosmith @tazzben}
 license             MIT
 supported_archs     noarch

--- a/office/expense.txt/Portfile
+++ b/office/expense.txt/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben expense.txt 1.0
 categories          office
-platforms           darwin
+platforms           {darwin any}
 maintainers         {unomaha.edu:bosmith @tazzben}
 license             MIT
 supported_archs     noarch

--- a/office/heapCL/Portfile
+++ b/office/heapCL/Portfile
@@ -8,7 +8,7 @@ version             1.08.27
 categories          office www
 
 license             MIT
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 description         Command line tools for Heap CRM
 maintainers         {unomaha.edu:bosmith @tazzben}

--- a/office/time-track-cli/Portfile
+++ b/office/time-track-cli/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                time-track-cli
 version             1.2
 categories          office tcl
-platforms           darwin
+platforms           any
 maintainers         the-blair.com:blair
 supported_archs     noarch
 

--- a/office/time.txt/Portfile
+++ b/office/time.txt/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben time.txt 1.0
 categories          office
-platforms           darwin
+platforms           {darwin any}
 maintainers         {unomaha.edu:bosmith @tazzben}
 license             MIT
 supported_archs     noarch

--- a/office/torchCL/Portfile
+++ b/office/torchCL/Portfile
@@ -8,7 +8,7 @@ version             1.08.31
 categories          office www
 
 license             MIT
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 description         Command line tools for Torch Project Management
 maintainers         {unomaha.edu:bosmith @tazzben}

--- a/perl/p5-cache-memcached/Portfile
+++ b/perl/p5-cache-memcached/Portfile
@@ -7,7 +7,7 @@ perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         Cache-Memcached 1.30
 maintainers         costite.com:ron
 license             {Artistic-1 GPL}
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 
 description         Perl 5 client library for memcached

--- a/perl/p5-dbix-sqlcrosstab/Portfile
+++ b/perl/p5-dbix-sqlcrosstab/Portfile
@@ -16,7 +16,7 @@ long_description    DBIx::SQLCrosstab produces a SQL query to interrogate a \
 checksums           rmd160  86ab818d4707dcfa35479d7ddea6d9021a920276 \
                     sha256  d675cff8a50d86b1b5f0fe7e4bc6c0314b3d1b7f1d41717fcfbcf268026a43ff
 
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 
 if {${perl5.major} != ""} {

--- a/perl/p5-mail-rfc822-address/Portfile
+++ b/perl/p5-mail-rfc822-address/Portfile
@@ -9,10 +9,10 @@ maintainers         sfc.wide.ad.jp:dikshie
 license             MIT
 
 description         Perl extension for validating email addresses according to RFC822
-long_description    ${description}
+long_description    {*}${description}
 
 checksums           rmd160  2e8d6277b1766ecef9fd6f983e1aed693071a7d9 \
                     sha256  351ef4104ecb675ecae69008243fae8243d1a7e53c681eeb759e7b781684c8a7
 
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch

--- a/perl/p5-openoffice-oodoc/Portfile
+++ b/perl/p5-openoffice-oodoc/Portfile
@@ -6,13 +6,13 @@ PortGroup           perl5 1.0
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         OpenOffice-OODoc 2.125
 revision            2
-platforms           darwin
+platforms           {darwin any}
 license             LGPL-2.1
 maintainers         univ-lyon1.fr:clot
 supported_archs     noarch
 
 description         The Open OpenDocument Connector
-long_description    ${description}
+long_description    {*}${description}
 
 checksums           rmd160  d2ac27c2579af423f04133739a7fb8d9421eb32c \
                     sha256  c11448970693c42a8b9e93da48cac913516ce33a9d44a6468400f7ad8791dab6

--- a/perl/p5-text-markdown/Portfile
+++ b/perl/p5-text-markdown/Portfile
@@ -13,7 +13,7 @@ description         Markdown text-to-HTML filter.
 long_description    Markdown text-to-HTML filter. The text format is most \
 			        similar to that of plain text email.
 
-platforms           darwin
+platforms           {darwin any}
 
 checksums           rmd160  c5729937c61090f5474ce57c877fc4285d0f8c92 \
                     sha256  c191c6d5eceb8cb75c0565192360662d202d716bad07a233c4b329a4284dc71b

--- a/pure/pure-docs/Portfile
+++ b/pure/pure-docs/Portfile
@@ -11,12 +11,13 @@ distname                        ${name}-${version}
 categories                      pure lang
 maintainers                     {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 supported_archs                 noarch
+platforms                       any
 license                         GFDL-1.3+
 homepage                        https://agraef.github.io/pure-docs/
 
 description                     documentation for the Pure programming language
 
-long_description                ${name} is an offline copy of the ${description}.
+long_description                ${name} is an offline copy of the {*}${description}.
 
 checksums                       rmd160  3c4763f795d5e45ec63b61ba0f02f1a64a8632fc \
                                 sha256  a2a74fc17ca3bdde2b84fb1587b3fe145d5c7363bac1d79c54f5626dcf4cde94 \

--- a/pure/pure-g2/Portfile
+++ b/pure/pure-g2/Portfile
@@ -5,14 +5,14 @@ PortGroup                       pure 1.0
 
 pure.setup                      pure-g2 0.3
 categories-append               graphics
-platforms                       darwin
+platforms                       any
 maintainers                     {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 license                         BSD
 supported_archs                 noarch
 
 description                     an interface to the g2 graphics library for Pure
 
-long_description                ${name} provides ${description}.
+long_description                ${name} provides {*}${description}.
 
 checksums                       rmd160  6303466e142f685a6b1ea313954d10f008e4f8cc \
                                 sha256  3a5334370594daab25ed1e141c0eb77cd6e6f1a991d4e7b1508571445798447c

--- a/pure/pure-rational/Portfile
+++ b/pure/pure-rational/Portfile
@@ -6,14 +6,14 @@ PortGroup           pure 1.0
 pure.setup          pure-rational 0.1
 revision            1
 categories-append   math
-platforms           darwin
+platforms           any
 maintainers         {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 license             GPL-2+
 supported_archs     noarch
 
 description         a Pure port of Q+Q, Rob Hubbard's rational number library
 
-long_description    ${name} is ${description}. \
+long_description    ${name} is {*}${description}. \
                     It contains rational.pure, a collection of utility \
                     functions for rational numbers, and rat_interval.pure, \
                     a module for doing interval arithmetic needed by \

--- a/python/kerfi-vangasvipur_select/Portfile
+++ b/python/kerfi-vangasvipur_select/Portfile
@@ -10,6 +10,7 @@ version             1.0
 revision            1
 categories          python
 supported_archs     noarch
+platforms           any
 maintainers         {gmail.com:pedro.salgado @steenzout}
 description         common files for selecting default ${real_name} version
 long_description \

--- a/python/pew_select/Portfile
+++ b/python/pew_select/Portfile
@@ -9,6 +9,7 @@ version             0.1
 revision            1
 categories          python
 supported_archs     noarch
+platforms           any
 maintainers         {gmail.com:rubendibattista @rdbisme}
 description         common files for selecting default pew version
 long_description \

--- a/python/py-cairosvg_select/Portfile
+++ b/python/py-cairosvg_select/Portfile
@@ -9,6 +9,7 @@ version             0.1
 revision            1
 categories          python graphics
 supported_archs     noarch
+platforms           any
 description         common files for selecting default cairosvg version
 long_description    This port installs files that allow 'port select' to be used to \
                     create links to the preferred default version of cairosvg.

--- a/python/py-gflags/Portfile
+++ b/python/py-gflags/Portfile
@@ -18,7 +18,7 @@ long_description \
     the source file in which they're used. (This last is its major         \
     difference from OptParse.)
 
-platforms           darwin
+platforms           {darwin any}
 homepage            https://code.google.com/p/python-gflags/
 master_sites        googlecode:python-gflags
 distname            python-gflags-${version}

--- a/python/py-html2text_select/Portfile
+++ b/python/py-html2text_select/Portfile
@@ -9,9 +9,10 @@ version             0.1
 revision            1
 categories          python devel
 supported_archs     noarch
-description         common files for selecting default html2version version
+platforms           any
+description         common files for selecting default html2text version
 long_description    This port installs files that allow 'port select' to be used to \
-                    create links to the preferred default version of pss.
+                    create links to the preferred default version of html2text.
 
 post-destroot {
     select::install py-html2text ${filespath}/base

--- a/python/py-isodate/Portfile
+++ b/python/py-isodate/Portfile
@@ -8,6 +8,7 @@ version             0.6.1
 revision            0
 
 supported_archs     noarch
+platforms           {darwin any}
 license             BSD
 maintainers         {gmail.com:esafak @esafak}
 

--- a/python/py-kerfi-vangasvipur/Portfile
+++ b/python/py-kerfi-vangasvipur/Portfile
@@ -10,11 +10,11 @@ github.setup        steenzout python-kerfi-vangasvipur 1.0.0
 name                py-kerfi-vangasvipur
 version             1.0.0
 maintainers         {gmail.com:pedro.salgado @steenzout}
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 license             Apache-2
 description         Python tool to manipulate OS X system_profiler output.
-long_description    ${description}
+long_description    {*}${description}
 
 checksums           sha256 0513135f4b13c9bb3d1297e0de02ccf77db258bc7d493b44dbe07e868f1ed42a \
                     rmd160 168a81a270feb979da9df562e78283fc581b2642 \

--- a/python/py-minfx/Portfile
+++ b/python/py-minfx/Portfile
@@ -7,7 +7,7 @@ name                py-minfx
 version             1.0.3
 maintainers         {gmail.com:howarth.at.macports @jwhowarth}
 license             GPL-3+
-platforms           darwin freebsd
+platforms           {darwin any} freebsd
 supported_archs     noarch
 distname            minfx-${version}
 description         The minfx optimisation library.

--- a/python/py-novas_de405/Portfile
+++ b/python/py-novas_de405/Portfile
@@ -6,7 +6,7 @@ PortGroup               python 1.0
 name                    py-novas_de405
 version                 1997
 categories-append       science
-platforms               darwin
+platforms               {darwin any}
 supported_archs         noarch
 maintainers             {aronnax @lpsinger}
 description             High-precision JPL DE405 solar system ephemeris

--- a/python/py-pss_select/Portfile
+++ b/python/py-pss_select/Portfile
@@ -9,6 +9,7 @@ version             0.1
 revision            1
 categories          python devel
 supported_archs     noarch
+platforms           any
 description         common files for selecting default pss version
 long_description    This port installs files that allow 'port select' to be used to \
                     create links to the preferred default version of pss.

--- a/python/py-pyke/Portfile
+++ b/python/py-pyke/Portfile
@@ -9,6 +9,7 @@ revision            0
 
 categories-append   lang devel
 supported_archs     noarch
+platforms           {darwin any}
 maintainers         {gmail.com:mahergamal @maherg} {petr @petrrr}
 license             MIT
 description         Python Knowledge Engine (PyKE)

--- a/python/py-sphinxcontrib-blockdiag/Portfile
+++ b/python/py-sphinxcontrib-blockdiag/Portfile
@@ -8,13 +8,13 @@ version             3.0.0
 revision            1
 
 categories-append   textproc devel
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 license             BSD
-maintainers         none
+maintainers         nomaintainer
 
 description         A sphinx extension for embedding block diagrams
-long_description    ${name} is ${description}.
+long_description    ${name} is {*}${description}.
 
 homepage            https://github.com/blockdiag/sphinxcontrib-blockdiag
 

--- a/python/py-twill/Portfile
+++ b/python/py-twill/Portfile
@@ -8,7 +8,7 @@ version             1.8.0
 categories-append   devel www
 license             MIT {BSD ZPL-2.1} PSF
 maintainers         {gmail.com:mahergamal @maherg}
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 
 description         A simple scripting language for web browsing

--- a/ruby/rb-hikidoc/Portfile
+++ b/ruby/rb-hikidoc/Portfile
@@ -12,11 +12,10 @@ long_description	\
 				structurally valid HTML (or XHTML).
 
 categories-append	textproc
-platforms		darwin
+platforms		any
 homepage        https://github.com/hiki/hikidoc
 license			BSD
 supported_archs	noarch
 checksums		md5 64276b86b45f59937f0bb93eb3eff523 \
 				sha1 51a1227f98652e1727a08a26f8bb83291a7e8d61 \
 				rmd160 b831ae737f707f251549deeab7a6187e6d220ab8
-

--- a/ruby/rb-rdtool/Portfile
+++ b/ruby/rb-rdtool/Portfile
@@ -13,7 +13,7 @@ long_description \
 		to handle RD files.
 categories-append	textproc
 license			{Ruby GPL}
-platforms		darwin
+platforms		any
 supported_archs	noarch
 checksums		md5 69dab7c77d62f51ca11e5d1f201c9f84 \
 				rmd160 be9644258c07a1d694a37b3a53636e0cef951430 \
@@ -21,4 +21,3 @@ checksums		md5 69dab7c77d62f51ca11e5d1f201c9f84 \
 
 test.run		yes
 test.cmd		${ruby.bin} -I./lib ./test.rb
-

--- a/ruby/rb-rss/Portfile
+++ b/ruby/rb-rss/Portfile
@@ -2,7 +2,7 @@ PortSystem      1.0
 PortGroup       ruby 1.0
 ruby.setup      rss 0.1.3 setup.rb {README.en README.ja Tutorial.en Tutorial.ja Reference.en Reference.ja sample}
 maintainers     lathi.net:doug
-platforms       darwin
+platforms       any
 supported_archs noarch
 description     RSS Parser in Ruby
 long_description This library can parse RSS(RDF Site Summary) 1.0, RSS \
@@ -13,4 +13,3 @@ long_description This library can parse RSS(RDF Site Summary) 1.0, RSS \
 homepage        http://www.cozmixng.org/~rwiki/?cmd=view&name=RSS+Parser
 master_sites    http://www.cozmixng.org/~kou/download/
 checksums       md5 99667031d77b6829ad839f8e9064f34e
-

--- a/ruby/rb-rttool/Portfile
+++ b/ruby/rb-rttool/Portfile
@@ -15,7 +15,7 @@ checksums		md5 e2eecf5ea3ff0c51b74c22327733765d \
 				rmd160 a2c3023519e712883a1b1f59db11103a632b87cf \
 				sha1 9ecc98f156a42fe84696ce17fc5735c4dd3ee5d0
 
-platforms		darwin
+platforms		any
 homepage        http://www.rubyist.net/~rubikitch/computer/rttool/
 master_sites    http://www.rubyist.net/~rubikitch/archive/
 
@@ -24,4 +24,3 @@ post-build {
 	reinplace "s|^#!.*ruby|#!${ruby.bin}|" ${worksrcpath}/bin/rt/rt2
 	reinplace "s|^#!.*ruby|#!${ruby.bin}|" ${worksrcpath}/bin/rt/rdrt2
 }
-

--- a/science/EGSimulation/Portfile
+++ b/science/EGSimulation/Portfile
@@ -8,7 +8,7 @@ github.setup        tazzben EconScripts 1.2
 name                EGSimulation
 revision            1
 categories          science
-platforms           darwin
+platforms           {darwin any}
 maintainers         ad.wsu.edu:tazz_ben
 license             public-domain
 supported_archs     noarch

--- a/science/TwitterDemandAnalyzer/Portfile
+++ b/science/TwitterDemandAnalyzer/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben TwitterDemandAnalyzer 1.1
 categories          science
-platforms           darwin
+platforms           {darwin any}
 maintainers         ad.wsu.edu:tazz_ben
 license             public-domain
 supported_archs     noarch

--- a/science/TwitterDemandCollector/Portfile
+++ b/science/TwitterDemandCollector/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        tazzben TwitterDemandCollector 1.1
 categories          science
-platforms           darwin
+platforms           {darwin any}
 maintainers         ad.wsu.edu:tazz_ben
 license             public-domain
 supported_archs     noarch

--- a/science/WW/Portfile
+++ b/science/WW/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        tazzben WW 2.2
 
 categories          science education
-platforms           darwin
+platforms           {darwin any}
 maintainers         {unomaha.edu:bosmith @tazzben}
 license             MIT
 supported_archs     noarch

--- a/science/dcw-gmt/Portfile
+++ b/science/dcw-gmt/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                dcw-gmt
 version             2.1.1
 categories          science
-platforms           darwin
+platforms           any
 supported_archs     noarch
 maintainers         {takeshi @tenomoto}
 license             LGPL-3

--- a/science/esorepo/Portfile
+++ b/science/esorepo/Portfile
@@ -7,7 +7,7 @@ version             1.1
 revision            2
 categories          science
 license             GPL-2+
-platforms           darwin
+platforms           any
 supported_archs     noarch
 maintainers         eso.org:usd-help
 

--- a/science/healpix/Portfile
+++ b/science/healpix/Portfile
@@ -13,7 +13,6 @@ long_description \
   Software for pixelization, hierarchical indexing, synthesis, analysis, and \
   visualization of data on the sphere.
 homepage            http://healpix.jpl.nasa.gov/
-platforms           darwin
 master_sites        sourceforge:project/${name}/Healpix_${base_version}/
 distname            Healpix_${version}
 worksrcdir          Healpix_${base_version}
@@ -26,6 +25,7 @@ if {${name} eq ${subport}} {
     PortGroup       stub 1.0
 
     supported_archs noarch
+    platforms       any
 
     depends_run     port:${name}-c \
                     port:${name}-cxx \
@@ -40,9 +40,10 @@ subport ${name}-java {
     PortGroup       java 1.0
 
     description         Java language implementation of HEALPix
-    long_description    ${long_description} This is the ${description}.
+    long_description    {*}${long_description} This is the {*}${description}.
 
     supported_archs noarch
+    platforms       any
 
     java.version    1.4+
     java.fallback   openjdk11

--- a/science/pybombs/Portfile
+++ b/science/pybombs/Portfile
@@ -11,7 +11,7 @@ set default_py_ver    38
 
 categories            science python
 license               GPL-3
-platforms             darwin
+platforms             {darwin any}
 supported_archs       noarch
 maintainers           {michaelld @michaelld}
 

--- a/science/rNMR/Portfile
+++ b/science/rNMR/Portfile
@@ -7,7 +7,7 @@ name                rNMR
 version             1.1.7
 revision            1
 categories          science chemistry
-platforms           darwin
+platforms           {darwin any}
 maintainers         {gmail.com:howarth.at.macports @jwhowarth}
 supported_archs     noarch
 license             GPL-3

--- a/science/rangs-gshhs-ncarg/Portfile
+++ b/science/rangs-gshhs-ncarg/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                rangs-gshhs-ncarg
 version             19990317
 categories          science gis graphics
-platforms           darwin
+platforms           any
 supported_archs     noarch
 maintainers         {takeshi @tenomoto}
 license             LGPL-3

--- a/science/seqan2/Portfile
+++ b/science/seqan2/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                seqan2
 version             2.4.0
 categories          science
-platforms           darwin
+platforms           any
 supported_archs     noarch
 
 license             BSD

--- a/sysutils/bash-completion/Portfile
+++ b/sysutils/bash-completion/Portfile
@@ -7,7 +7,7 @@ github.setup    scop bash-completion 2.11
 epoch           1
 revision        1
 categories      sysutils
-platforms       darwin
+platforms       any
 supported_archs noarch
 license         GPL-2+
 maintainers     {raimue @raimue}

--- a/sysutils/bbcolors/Portfile
+++ b/sysutils/bbcolors/Portfile
@@ -4,15 +4,15 @@ PortSystem                  1.0
 
 name                        bbcolors
 version                     1.0.1
-platforms                   darwin
+platforms                   any
 categories                  sysutils
 maintainers                 {ryandesign @ryandesign}
 license                     {Artistic-1 GPL}
 
 description                 a tool for saving and loading text color \
-                            preference schemes for BBEdit and TextWrangler.
+                            preference schemes for BBEdit and TextWrangler
 
-long_description            ${name} is ${description}.
+long_description            ${name} is {*}${description}.
 
 homepage                    https://daringfireball.net/projects/bbcolors/
 master_sites                https://daringfireball.net/projects/downloads/:main \

--- a/sysutils/clang_select/Portfile
+++ b/sysutils/clang_select/Portfile
@@ -9,6 +9,7 @@ version             2.2
 revision            1
 categories          sysutils
 supported_archs     noarch
+platforms           any
 maintainers         {jeremyhu @jeremyhu}
 description         common files for selecting default clang version
 long_description    clang_select installs files that allow 'port select' to \

--- a/sysutils/duply/Portfile
+++ b/sysutils/duply/Portfile
@@ -5,9 +5,8 @@ PortSystem          1.0
 name                duply
 version             1.9.1
 set branch          [join [lrange [split ${version} .] 0 1] .]
-platforms           darwin
+platforms           any
 categories          sysutils
-platforms           darwin
 maintainers         gmail.com:dmankus
 license             GPL-2
 supported_archs     noarch

--- a/sysutils/edmv/Portfile
+++ b/sysutils/edmv/Portfile
@@ -8,7 +8,7 @@ github.setup            casey edmv 0.1.0
 github.tarball_from     releases
 
 categories              sysutils python
-platforms               darwin
+platforms               any
 license                 permissive
 
 maintainers             rodarmor.com:casey

--- a/sysutils/exec-wrapper/Portfile
+++ b/sysutils/exec-wrapper/Portfile
@@ -6,7 +6,7 @@ name                        exec-wrapper
 version                     1.0.1
 revision                    4
 categories                  sysutils
-platforms                   darwin
+platforms                   any
 maintainers                 ryandesign
 license                     GPL-3
 supported_archs             noarch
@@ -17,7 +17,7 @@ use_bzip2                   yes
 description                 script that creates setuid-wrappers for scripts \
                             and other executables
 
-long_description            ${name} is a ${description}.
+long_description            ${name} is a {*}${description}.
 
 checksums                   md5     a476a0b2ef0bc3e81c3c6983f8c5bda6 \
                             sha1    6007929d97f81ed5e3f4d46f0a8171e2ca5e73d3 \
@@ -34,6 +34,4 @@ use_configure               no
 build.args                  prefix=${prefix} \
                             wrappersdir=${prefix}/libexec/${name}
 
-destroot.args               ${build.args}
-
-universal_variant           no
+destroot.args               {*}${build.args}

--- a/sysutils/llvm_select/Portfile
+++ b/sysutils/llvm_select/Portfile
@@ -9,6 +9,7 @@ version             2
 revision            1
 categories          sysutils
 supported_archs     noarch
+platforms           any
 maintainers         {jeremyhu @jeremyhu}
 description         common files for selecting default llvm version
 long_description    llvm_select installs files that allow 'port select' to \

--- a/sysutils/molly-guard/Portfile
+++ b/sysutils/molly-guard/Portfile
@@ -3,7 +3,7 @@ PortGroup github 1.0
 
 github.setup        raimue molly-guard 0.4.5 macports/
 categories          sysutils
-platforms           darwin
+platforms           any
 supported_archs     noarch
 license             Artistic-2
 maintainers         {raimue @raimue}

--- a/sysutils/mpi_select/Portfile
+++ b/sysutils/mpi_select/Portfile
@@ -9,6 +9,7 @@ version                 0.0
 revision                4
 categories              sysutils
 supported_archs         noarch
+platforms               any
 maintainers             {eborisch @eborisch} {mascguy @mascguy}
 description             common files for selecting default mpi version
 long_description        This port installs files that allow 'port select' to \

--- a/sysutils/php_select/Portfile
+++ b/sysutils/php_select/Portfile
@@ -9,6 +9,7 @@ version             1.0
 revision            1
 categories          sysutils lang
 supported_archs     noarch
+platforms           any
 maintainers         {ryandesign @ryandesign}
 description         common files for selecting default PHP version
 long_description    This port installs files that allow 'port select' to be \

--- a/sysutils/qt4_select/Portfile
+++ b/sysutils/qt4_select/Portfile
@@ -7,7 +7,7 @@ name                    qt4_select
 version                 0.3
 revision                3
 categories              sysutils
-platforms               darwin
+platforms               {darwin any}
 license                 BSD
 maintainers             {michaelld @michaelld}
 supported_archs         noarch

--- a/sysutils/rainbarf/Portfile
+++ b/sysutils/rainbarf/Portfile
@@ -10,9 +10,9 @@ maintainers         gmail.com:creaktive
 categories          sysutils
 license             {Artistic-1 GPL}
 description         CPU/RAM/battery stats chart bar for tmux (and GNU screen)
-long_description    ${name}: ${description}
+long_description    ${name}: {*}${description}
 
-platforms           darwin
+platforms           any
 
 supported_archs     noarch
 

--- a/sysutils/root_select/Portfile
+++ b/sysutils/root_select/Portfile
@@ -9,6 +9,7 @@ version             1.3
 revision            1
 categories          sysutils science
 supported_archs     noarch
+platforms           any
 maintainers         {jonesc @cjones051073} {mojca @mojca}
 description         common files for selecting default ROOT version
 long_description    root_select installs files that allow 'port select' to \

--- a/sysutils/txt2regex/Portfile
+++ b/sysutils/txt2regex/Portfile
@@ -4,7 +4,7 @@ name            txt2regex
 version         0.8
 revision        1
 categories      sysutils
-platforms       darwin freebsd
+platforms       any
 maintainers     technokracy.net:grrr
 supported_archs noarch
 license         GPL-2

--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -27,7 +27,7 @@ homepage            https://dlmf.nist.gov/LaTeXML/
 master_sites        ${homepage}releases/ \
                     https://cpan.metacpan.org/authors/id/B/BR/BRMILLER/
 
-platforms           darwin
+platforms           {darwin any}
 supported_archs     noarch
 
 depends_lib-append \

--- a/tex/biblatex-biber/Portfile
+++ b/tex/biblatex-biber/Portfile
@@ -29,7 +29,7 @@ long_description \
   BibTeX, allowing full Unicode support, no memory limitations,        \
   extensibility, etc.
 
-platforms       darwin
+platforms       {darwin any}
 supported_archs noarch
 
 homepage        http://biblatex-biber.sourceforge.net/

--- a/tex/texlive-common/Portfile
+++ b/tex/texlive-common/Portfile
@@ -14,7 +14,7 @@ long_description    This port provides files that support a MacPorts    \
                     files and the scripts that generate them.
 
 homepage            http://www.tug.org/texlive/
-platforms           darwin
+platforms           any
 supported_archs     noarch
 license             Permissive
 

--- a/tex/texlive-tlpdb/Portfile
+++ b/tex/texlive-tlpdb/Portfile
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
@@ -14,7 +13,7 @@ long_description    This port provides the TeX Live package database \
                     to support scripts such as texdoc that require it
 
 homepage            http://www.tug.org/texlive/
-platforms           darwin
+platforms           any
 supported_archs     noarch
 license             Permissive
 
@@ -43,4 +42,3 @@ destroot {
 }
 
 livecheck.type none
-

--- a/tex/texlive/Portfile
+++ b/tex/texlive/Portfile
@@ -20,7 +20,7 @@ long_description    TeX Live is an easy way to get up and running with TeX. \
 
 
 homepage        https://www.tug.org/texlive/
-platforms       darwin
+platforms       any
 supported_archs noarch
 
 # TeX Live consists of thousands of individual CTAN packages with
@@ -192,4 +192,3 @@ if {![variant_isset minimal]
 livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     "Current release: TeX Live (\[0-9\]+) "
-

--- a/textproc/cowsay/Portfile
+++ b/textproc/cowsay/Portfile
@@ -7,11 +7,11 @@ version             3.03
 revision            3
 categories          textproc amusements games
 license             {Artistic-1 GPL}
-platforms           darwin freebsd
+platforms           any
 maintainers         {grimreaper @grimreaper}
 supported_archs     noarch
 description         Configurable talking characters in ASCII art
-long_description    ${description}
+long_description    {*}${description}
 homepage            http://www.nog.net/~tony/warez/
 master_sites        ftp://ftp.nog.net/pub/tony/cowsay/
 checksums           rmd160  f26b9ffe3d5551ee8049979c628bbe198817044a \

--- a/textproc/docbook-sgml-4.2/Portfile
+++ b/textproc/docbook-sgml-4.2/Portfile
@@ -14,7 +14,7 @@ long_description \
 
 categories      textproc
 license         MIT Permissive
-platforms       darwin
+platforms       any
 maintainers     phlo.org:fgp
 supported_archs noarch
 homepage        http://www.docbook.org/sgml/${version}/

--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -7,7 +7,7 @@ version                 2.08
 categories              textproc pdf
 maintainers             {gmail.com:jjstickel @jjstickel}
 license                 GPL-2
-platforms               darwin
+platforms               any
 homepage                http://www2.warwick.ac.uk/fac/sci/statistics/staff/academic-research/firth/software/pdfjam
 master_sites            ${homepage}
 extract.suffix          .tgz

--- a/www/bbdb/Portfile
+++ b/www/bbdb/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                bbdb
 version             2.35
 categories          www
-platforms           darwin
+platforms           any
 maintainers         yahoo.com:vishketan
 license             GPL-2+
 supported_archs     noarch

--- a/x11/gtk-osx-tiger/Portfile
+++ b/x11/gtk-osx-tiger/Portfile
@@ -7,9 +7,9 @@ version             0.1
 categories          x11 gtk aqua
 maintainers         gmail.com:james.r.haigh
 description         Imitation of Aqua theme from Mac OS X Tiger.
-long_description    $description
+long_description    {*}$description
 homepage            http://gnome-look.org/content/show.php/OSX-Tiger+theme?content=56577
-platforms           darwin
+platforms           any
 supported_archs     noarch
 
 master_sites        http://gnome-look.org/CONTENT/content-files/


### PR DESCRIPTION
#### Description

These ports all set `supported_archs noarch`, and appear (from my inspection of the Portfiles and lists of installed files) to install the same files regardless of OS version. This PR updates the `platforms` option so that we don't build a separate archive per macOS version.

If you know that this is not correct for your port or even have significant doubts, please say so and I will remove it from this PR. This change is an optimisation which has the potential to cause incorrect behaviour if applied inappropriately. In case of doubt, it's better for the maintainer to investigate thoroughly before changing this.

###### Type(s)
- [x] enhancement
