### PR TITLE
new submission: gng (replaces gdub)

### DIFF
--- a/devel/gdub/Portfile
+++ b/devel/gdub/Portfile
@@ -1,39 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           github 1.0
+# Remove after 2023-07-22
+PortSystem       1.0
+PortGroup        obsolete 1.0
 
-github.setup        dougborg gdub ebe14f110153f05f3a50e7ff2eaa8d2704cde9d9
-# Note: gdub does not have a release tag as of 2019-04-14, so an artificial version is used here
-# Consider using upstream versions when available (see https://github.com/dougborg/gdub/issues/30)
-# 0.1.0.1 is greater than upstream's 0.1.0, and 0.1.0.1 is likely to be less than any futher upstream versions.
-version             0.1.0.1
-categories          devel java groovy
-platforms           any
-supported_archs     noarch
-maintainers         {breun.nl:nils @breun} openmaintainer
-license             MIT
-
-description         A gradlew / gradle wrapper
-long_description    gdub (gw on the command line) is a gradle / gradlew wrapper. \
-                    Not to be confused with the Gradle Wrapper, gw invokes ./gradlew on \
-                    projects where one is configured, and falls back to use the gradle \
-                    from the \$PATH if a wrapper is not available. Also, gw is 66% shorter \
-                    to type than gradle and 78% shorter to type than ./gradlew.
-
-homepage            http://www.gdub.rocks/
-
-checksums           rmd160  9100f5eca0cff7050d0acf774d8bc8f7df2167af \
-                    sha256  0651ae907fec2fe0d386259bd5e30c89a7974cbf85d3a811a922deecf8688aab
-
-use_configure       no
-build {}
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java/${name}
-    copy ${worksrcpath}/bin \
-        ${worksrcpath}/LICENSE \
-        ${worksrcpath}/README.md \
-        ${destroot}${prefix}/share/java/${name}
-    ln -s ${prefix}/share/java/${name}/bin/gw ${destroot}${prefix}/bin
-}
+name             gdub
+categories       java devel
+replaced_by      gng
+version          0.1.0.1
+revision         1

--- a/java/gng/Portfile
+++ b/java/gng/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       github 1.0
+
+github.setup    gdubw gng 1.0.4 v
+revision        0
+
+categories      java devel
+maintainers     {breun.nl:nils @breun} openmaintainer
+platforms       {darwin any}
+license         Apache-2
+supported_archs noarch
+
+description     GNG -- Gradle is Not Gradle
+
+long_description GNG (Gradle is Not Gradle) is a script that automatically searches your 'gradlew' script \
+                when you are inside your Gradle project and executes it. It also contains an official Gradle wrapper. \
+                You can create gradle projects from scratch without installing Gradle. \
+                This is originally inspired by gdub and gradlew-bootstrap. \
+                GNG is the successor of gdub. It keeps the original gw command and with more features. \
+                It is written totally in bash script.
+
+homepage        https://gng.dsun.org
+
+checksums       rmd160  5d15c5245b4c97970e9fbf35f607721a4e467168 \
+                sha256  2721a96ad79557b6fedecb20bfd89e4120e6f381e490487283ba677a9723e5f3 \
+                size    71341
+
+depends_run     port:bash
+
+use_configure   no
+
+build {}
+
+destroot {
+    set target ${destroot}${prefix}/share/java/${name}
+
+    # Create the target directory
+    xinstall -m 755 -d ${target}
+
+    # Copy over the needed elements of our directory tree
+    foreach d { LICENSE bin docs gradle lib } {
+        copy ${worksrcpath}/${d} ${target}
+    }
+
+    # Add symlinks to the scripts
+    foreach f { gng gw } {
+        ln -s ../share/java/${name}/bin/${f} ${destroot}${prefix}/bin
+    }
+}


### PR DESCRIPTION
#### Description

New port for [gng](https://github.com/gdubw/gng), which is the successor to gdub. Both provide the `gw` command. This PR also marks `gdub` as replaced by `gng`.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?