### PR TITLE
xa: update to 2.3.13

### DIFF
--- a/devel/xa/Portfile
+++ b/devel/xa/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                xa
-version             2.3.10
-revision            1
+version             2.3.13
+revision            0
 categories          devel
 maintainers         {breun.nl:nils @breun} openmaintainer
 description         Open-source 6502 cross assembler
@@ -14,14 +14,14 @@ long_description    xa is a high-speed, two-pass portable cross-assembler. It \
                     ...), CMOS 6502s (65C02 and Rockwell R65C02) and the \
                     65816.
 homepage            https://www.floodgap.com/retrotech/xa/
-platforms           darwin
+platforms           {darwin any}
 license             GPL-2+
 
 master_sites        https://www.floodgap.com/retrotech/xa/dists/
 
-checksums           rmd160  7d6d54be9a31d39220a9bdc0cfcaeb25ad880867 \
-                    sha256  867b5b26b6524be8bcfbad8820ab3efe422b3e0cc9775dcb743284778868ba78 \
-                    size    152433
+checksums           rmd160  1e6462692b9f79f7c57dc3954a2ce2daafddadca \
+                    sha256  a9477af150b6c8a91cd3d41e1cf8c9df552d383326495576830271ca4467bd86 \
+                    size    155606
 
 use_configure       no
 variant universal {}


### PR DESCRIPTION
#### Description

Update to xa 2.3.13.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?