### PR TITLE
fixing pangox-compat build on Ventura (probably Monterey too)

### DIFF
--- a/x11/pangox-compat/Portfile
+++ b/x11/pangox-compat/Portfile
@@ -19,12 +19,16 @@ master_sites        gnome:sources/${name}/${branch}
 use_xz              yes
 
 checksums           rmd160  4c1f8f0b23037bdba0eef9a905aa234a7dff78a4 \
-                    sha256  552092b3b6c23f47f4beee05495d0f9a153781f62a1c4b7ec53857a37dfce046
+                    sha256  552092b3b6c23f47f4beee05495d0f9a153781f62a1c4b7ec53857a37dfce046 \
+                    size    267396
 
 depends_build       port:pkgconfig
 
 depends_lib         path:lib/pkgconfig/pango.pc:pango \
                     port:xorg-libX11
+
+patchfiles          no-findshaper-fix.diff \
+                    pango_h-declarations-fix.diff
 
 configure.args      --disable-silent-rules
 

--- a/x11/pangox-compat/files/no-findshaper-fix.diff
+++ b/x11/pangox-compat/files/no-findshaper-fix.diff
@@ -1,0 +1,10 @@
+--- pangox.c.orig	2023-01-22 13:24:23
++++ pangox.c	2023-01-22 13:25:14
+@@ -279,7 +279,6 @@
+ 
+   font_class->describe = pango_x_font_describe;
+   font_class->get_coverage = pango_x_font_get_coverage;
+-  font_class->find_shaper = pango_x_font_find_shaper;
+   font_class->get_glyph_extents = pango_x_font_get_glyph_extents;
+   font_class->get_metrics = pango_x_font_get_metrics;
+   font_class->get_font_map = pango_x_font_get_font_map;

--- a/x11/pangox-compat/files/pango_h-declarations-fix.diff
+++ b/x11/pangox-compat/files/pango_h-declarations-fix.diff
@@ -1,0 +1,13 @@
+--- pangox.h.orig	2023-01-22 13:45:04
++++ pangox.h	2023-01-22 13:45:45
+@@ -66,6 +66,10 @@
+ 					   int               x,
+ 					   int               y);
+ 
++PangoFontMetrics *    pango_font_metrics_new (void);
++char *   pango_config_key_get (const char  *key);
++
++
+ /* API for rendering modules
+  */
+ typedef guint16 PangoXSubfont;


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Fixing pangox-compat build on Ventura (probably Monterey too)
2 patches added:
- `find_shaper` is long gone in modern pango
- missing function declarations added to pangox.h to make compiler happy

In theory should fix https://trac.macports.org/ticket/64228  (at least builds of dependent ports dont fail)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.1 22C65 arm64
Xcode 14.1 14B47b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
