### PR TITLE
lagrange: update to 1.15.0

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake the_Foundation 1.5.0 v
+gitea.setup         skyjake the_Foundation 1.6.0 v
 revision            0
 categories          devel
 license             BSD
@@ -18,9 +18,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  531aed53fc76120ebcfbdddcdab6a86c79e2f1a3 \
-                    sha256  b2609090132ec5d72d7c629c53708fc02d9300f4e8d4c481e0b0950717b8f4d3 \
-                    size    211135
+checksums           rmd160  6780c91a4930c1d13fb2c746fc7b9ed60e92500e \
+                    sha256  15b1491195211f83fedc4b758a75f5ee4999dd9b86c33a94e70a08bc64ed2dfa \
+                    size    212502
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.14.2 v
+gitea.setup         gemini lagrange 1.15.0 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  f25455c33f585867c1eaac229a2f7ef9b18c19ec \
-                    sha256  7a9564a833561096a637321683dfde10e65bcd37cf08c3d3552a4c6351c87a2d \
-                    size    7458439
+checksums           rmd160  41c91419c9e8af345ef358b599e37ca9dbefe76f \
+                    sha256  b12feb2d459bdc7791e22604052a02b580f36377ae32e49b045210c11d33d0fe \
+                    size    7470958
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
