### PR TITLE
AtomicParsley: update to 20221229.172126.d813aa6

### DIFF
--- a/multimedia/AtomicParsley/Portfile
+++ b/multimedia/AtomicParsley/Portfile
@@ -1,50 +1,37 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
 
 name                AtomicParsley
-version             0.9.0
-revision            1
+github.setup        wez atomicparsley 20221229.172126.d813aa6
+github.tarball_from archive
+revision            0
+
 categories          multimedia
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-2+
 
 description         MPEG-4 command line tool
 
 long_description    AtomicParsley is a lightweight command line program \
-                    for reading, parsing and setting metadata into MPEG-4 files.
+                    for reading, parsing and setting metadata into MPEG-4 \
+                    files, in particular, iTunes-style metadata.
 
-homepage            http://atomicparsley.sourceforge.net
-master_sites        sourceforge:project/atomicparsley/atomicparsley/AtomicParsley%20v${version}
-distname            ${name}-source-${version}
-use_zip             yes
-
-checksums           md5     681e6ecec2921c98e07a9262bdcd6cf2 \
-                    sha1    6a73aed6ba569e693fe94a313e7e9e9ce204d038 \
-                    rmd160  53026ab6b251614eb3a649fe611f86d68e06dc8e
+checksums           rmd160  57fa2cbe3f7d4b54cb14a1b857b8d5ba98649218 \
+                    sha256  2f095a251167dc771e8f4434abe4a9c7af7d8e13c718fb8439a0e0d97078899b \
+                    size    230461
 
 conflicts           AtomicParsley-devel
 
-variant universal {}
+depends_lib         port:zlib
+
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    patchfiles-append   patch-use-deprecated.diff
+}
 
 post-patch {
-    reinplace "s|g++ |${configure.cxx} ${configure.cxxflags} [get_canonical_archflags cxx] |g" ${worksrcpath}/build
-    reinplace "s|-O2 ||g" ${worksrcpath}/build
-
-    # fix usage of private type, b0rked in Leopard
-    # -eridius
-    reinplace -locale en_US.ISO8859-1 "s|_NSBitmapImageFileType|NSBitmapImageFileType|g" ${worksrcpath}/AP_NSImage.mm
-
-    # fix initializing a variable of type 'char *' with an rvalue of type 'const char *' b0rked in High Sierra
-    reinplace -locale en_US.ISO8859-1 -W ${worksrcpath} "s|= strrchr|= (char*)strrchr|g" AP_NSFile_utils.mm AP_NSImage.mm AtomicParsley.cpp
+    reinplace "s|$\{\PACKAGE_VERSION\}\|${version}|g" ${worksrcpath}/CMakeLists.txt
+    reinplace "s|$\{\BUILD_INFO\}\|${cmake.build_type}|g" ${worksrcpath}/CMakeLists.txt
 }
-
-use_configure       no
-build.cmd           ./build
-
-destroot {
-    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
-}
-
-livecheck.regex     ${name}-source-(\\d+(?:\\.\\d+)+)${extract.suffix}

--- a/multimedia/AtomicParsley/files/patch-use-deprecated.diff
+++ b/multimedia/AtomicParsley/files/patch-use-deprecated.diff
@@ -1,0 +1,42 @@
+Use deprecated methods for macOS <10.12
+--- src/nsimage.mm
++++ src/nsimage.mm
+@@ -100,7 +100,7 @@ static NSImage *DoResize(NSImage *sourceImage, NSSize newSize) {
+                             graphicsContextWithBitmapImageRep:rep]];
+   [sourceImage drawInRect:NSMakeRect(0, 0, newSize.width, newSize.height)
+                  fromRect:NSZeroRect
+-                operation:NSCompositingOperationCopy
++                operation:NSCompositeCopy
+                  fraction:1.0];
+   [NSGraphicsContext restoreGraphicsState];
+ 
+@@ -117,6 +117,7 @@ bool ResizeGivenImage(const char *filePath,
+ 
+   NSImage *source = [[NSImage alloc]
+       initWithContentsOfFile:[NSString stringWithUTF8String:filePath]];
++  [source setScalesWhenResized:YES];
+   if (source == nil) {
+     fprintf(stderr, "Image '%s' could not be loaded.\n", filePath);
+     exit(1);
+@@ -223,10 +224,10 @@ bool ResizeGivenImage(const char *filePath,
+     NSDictionary *props;
+ 
+     if ((isPNG && !myPicPrefs.allJPEG) || myPicPrefs.allPNG) {
+-      filetype = NSBitmapImageFileTypePNG;
++      filetype = NSPNGFileType;
+       props = nil;
+     } else {
+-      filetype = NSBitmapImageFileTypeJPEG;
++      filetype = NSJPEGFileType;
+       props = [NSDictionary dictionaryWithObject:[NSNumber numberWithFloat:0.7]
+                                           forKey:NSImageCompressionFactor];
+     }
+@@ -236,7 +237,7 @@ bool ResizeGivenImage(const char *filePath,
+     int iter = 0;
+     float compression = 0.65;
+     if ((myPicPrefs.max_Kbytes != 0) &&
+-        (filetype == NSBitmapImageFileTypeJPEG)) {
++        (filetype == NSJPEGFileType)) {
+       while ((dataLength > (unsigned)myPicPrefs.max_Kbytes) && (iter < 10)) {
+         props = [NSDictionary
+             dictionaryWithObject:[NSNumber numberWithFloat:compression]


### PR DESCRIPTION
The original SourceForge repository was abandoned years ago. This fork is under active development and has added support for 4K trailers.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
