### PR TITLE
py-ruamel-yaml: add python 3.11 variant

### DIFF
--- a/python/py-ruamel-yaml-clib/Portfile
+++ b/python/py-ruamel-yaml-clib/Portfile
@@ -19,7 +19,7 @@ long_description    {*}${description}.
 
 homepage            https://yaml.readthedocs.io/
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ruamel-yaml/Portfile
+++ b/python/py-ruamel-yaml/Portfile
@@ -20,7 +20,7 @@ long_description    ${description}. \
 
 homepage            https://yaml.readthedocs.io/
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

This is in preparation for awscli2 on python 3.11. It's been tested with awscli2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
