### PR TITLE
vile: Update to 9.8y

### DIFF
--- a/editors/vile/Portfile
+++ b/editors/vile/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                vile
-version             9.8x
+version             9.8y
 revision            0
-checksums           rmd160  e584dabaa84e0ad6b0e32478b09c8ce1523826e6 \
-                    sha256  8fe0dfa60179d4b7dd2750f116cd4396d4cd3e07d8a54d142a36c84f4a82feef \
-                    size    2476108
+checksums           rmd160  0a278c188d356c208afbe8e0dded769a8c1ad7e4 \
+                    sha256  1b67f1ef34f5f2075722ab46184bb149735e8538fa912fc07c985c92f78fe381 \
+                    size    2477410
 
 categories          editors
 platforms           darwin


### PR DESCRIPTION
Signed-off-by: Thomas E. Dickey <dickey@invisible-island.net>

#### Description

Bug-fix (for UTF-8 insertion), and compiler-warning fixes in configure script (for clang).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2 21G320 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
