### PR TITLE
proxychains-ng: update to 4.16

### DIFF
--- a/devel/proxychains-ng/Portfile
+++ b/devel/proxychains-ng/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rofl0r proxychains-ng 4.14 v
+github.setup        rofl0r proxychains-ng 4.16 v
 maintainers         nomaintainer
 categories          devel
 license             GPL-2
@@ -18,8 +18,8 @@ master_sites        ${homepage}/archive/
 distname            ${github.tag_prefix}${version}
 worksrcdir          ${name}-${version}
 
-checksums           rmd160  05cb1de5e7c54ed2008cd4087c27fcf1764d5c94 \
-                    sha256  ab31626af7177cc2669433bb244b99a8f98c08031498233bb3df3bcc9711a9cc \
-                    size    37912
+checksums           rmd160  e2268bce89190ce916a40a93b3d6e16031eddd5d \
+                    sha256  5f66908044cc0c504f4a7e618ae390c9a78d108d3f713d7839e440693f43b5e7 \
+                    size    50726
 
 destroot.target-append install-config


### PR DESCRIPTION
#### Description

Update `proxychains-ng` to 4.16

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2 21G320 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
