### PR TITLE
openjdk17-temurin: update to 17.0.6

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk17-temurin
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.5
-set build    8
+version      17.0.6
+set build    10
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  76c83a3b980791a14b02b8aa7a3d4f43219d3f51 \
-                 sha256  94fe50982b09a179e603a096e83fd8e59fd12c0ae4bcb37ae35f00ef30a75d64 \
-                 size    187174050
+    checksums    rmd160  fd7b466f49ece8b1e492dcd5d14e7f61eacdd983 \
+                 sha256  faa2927584cf2bd0a35d2ac727b9f22725e23b2b24abfb3b2ac7140f4d65fbb4 \
+                 size    187219587
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  6906e750467b10e3e30bb460fc5906832bf8b2f5 \
-                 sha256  2dc3e425b52d1cd2915d93af5e468596b9e6a90112056abdcebac8b65bf57049 \
-                 size    177335828
+    checksums    rmd160  c3ad5f4a2e5d031e0ee8878df348d91c847f9dd4 \
+                 sha256  e4904557f6e02f62b830644dc257c0910525f03df77bcffaaf92fa02a057230c \
+                 size    177369180
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.6.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?