### PR TITLE
skaffold: update to 2.1.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.0.5 v
+github.setup        GoogleContainerTools skaffold 2.1.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  e6b5d228cb2f90ca6e91d69f769cdd56cda1ef38 \
-                    sha256  4d4c9bbbcf5d5e858f8c11a4d21d760425b313da912c6391222ec25c3e412a2c \
-                    size    41607076
+checksums           rmd160  449849ab3810dccb71c90feec6e0ee7f0ca7dda3 \
+                    sha256  828907f736279130902fb436dd329255d64d1bc3773cf32b5328023144d4d082 \
+                    size    41674607
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.1.0.

###### Tested on

macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?