### PR TITLE
avr-libc: update to 2.1.0, add arm64 build support

### DIFF
--- a/cross/avr-libc/Portfile
+++ b/cross/avr-libc/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    avr-libc
-version                 2.0.0
+version                 2.1.0
 categories              cross
 maintainers             nomaintainer
 supported_archs         noarch
@@ -20,8 +20,9 @@ master_sites            https://download.savannah.gnu.org/releases/avr-libc/
 destroot.violate_mtree  yes
 
 use_bzip2               yes
-checksums               rmd160  3185d66f9c3024ecbf56d272033b87eac4c49ad2 \
-                        sha256  b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97
+checksums               rmd160  7e836c6bac97265cca80083be81264048fc425ec \
+                        sha256  0b84cee5c08b5d5cba67c36125e5aaa85251bc9accfba5773bfa87bc34b654e8 \
+                        size    3638672
 
 depends_lib             port:gettext \
                         port:avr-gcc
@@ -32,3 +33,14 @@ configure.cc            avr-gcc
 livecheck.type          regex
 livecheck.url           ${master_sites}
 livecheck.regex         ${name}-(\[1-9\]\\.\[0-9\]+\\.\[0-9\]+)
+
+depends_build-append    port:automake
+post-patch {
+    # Update config.guess and config.sub to be able to build on arm64. This also
+    # allows x86_64 to be detected properly (instead of as i386), although that
+    # problem did not impair the build on x86_64.
+    set automake_dirs [glob -directory ${prefix}/share automake-*]
+    set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]
+    copy -force ${automake_dir}/config.guess ${automake_dir}/config.sub \
+        ${worksrcpath}
+}


### PR DESCRIPTION
#### Description

The autoconf support files `config.guess` and `config.sub` that ship with `avr-libc` are outdated and fail to recognize mac-arm64. The characteristic of the failure is this error output from `configure`, which may appear in MacPorts’ `avr-libc.config.log`:

```
configure:2502: checking build system type
configure:2513: error: /bin/sh ./config.sub -apple-darwin22.3.0 failed
```

`config.guess` does not recognize mac-arm64:

```
zsh% ./config.guess
-apple-darwin22.3.0
```

When `-apple-darwin22.3.0` is passed to `config.sub`, it interprets it as a command-line option due to the leading hyphen-minus, and fails due to not recognizing the option:

```
zsh% ./config.sub -apple-darwin22.3.0
config.sub: invalid option -apple-darwin22.3.0
Try `config.sub --help' for more information.
```

The `config.guess` that `avr-libc` ships is hopelessly out of date, proudly declaring `timestamp='2003-07-02'`. When it detects `uname -s` as `Darwin`, it only recognizes `uname -p` values matching `*86` (both mac-x86 and mac-x86_64 will report `i386` here) and `powerpc`, but not `arm` as reported by mac-arm64. mac-arm64 can only be properly detected by `config.guess` dated 2020-07-12 and later ([config 2593751ef276](https://git.savannah.gnu.org/gitweb/?p=config.git;a=commit;h=2593751ef276497e312d7c4ce7fd049614c7bf80)).

`config.guess`’ detection of mac-x86_64 is also incorrect. Proper handling requires `config.guess` from 2009-09-18 or later ([config ccf975556a0f](https://git.savannah.gnu.org/gitweb/?p=config.git;a=commit;h=ccf975556a0f6797fe80395cd6f314682a770f15)), but this mistake has been harmless for the purposes of the `avr-libc` build.

As was done in several other ports (such as `libelf` at 64e99412d2390447cbd98bac79cb6851d425ae74) that ship autoconf support files that don’t recognize mac-arm64, this brings in updated versions of those files from the `automake` port, which is added as a build-time dependency. The build otherwise proceeds normally and functions perfectly well on mac-arm64.

Closes: https://trac.macports.org/ticket/66298

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
