### PR TITLE
libftdi1: remove unused python27 and swig-python build dependencies

### DIFF
--- a/devel/libftdi/Portfile
+++ b/devel/libftdi/Portfile
@@ -6,9 +6,10 @@ name                libftdi
 if {${name} eq ${subport}} {
     replaced_by         libftdi0
     PortGroup           obsolete 1.0
-    epoch               1
 
+    epoch               1
 }
+
 version             0.20
 categories          devel
 license             GPL-2+
@@ -33,7 +34,8 @@ subport             libftdi0 {
     distname            libftdi-${version}
 
     checksums           rmd160  7406f831a6d7b3ccf8e246504f7275a5208f94e9 \
-                        sha256  3176d5b5986438f33f5208e690a8bfe90941be501cc0a72118ce3d338d4b838e
+                        sha256  3176d5b5986438f33f5208e690a8bfe90941be501cc0a72118ce3d338d4b838e \
+                        size    423570
 
     configure.args-append   --with-boost=no \
                             --without-examples \
@@ -47,7 +49,7 @@ subport             libftdi1 {
     PortGroup           boost 1.0
 
     version             1.5
-    revision            1
+    revision            2
     distname            libftdi1-${version}
     use_bzip2           yes
 
@@ -56,9 +58,7 @@ subport             libftdi1 {
 
     depends_lib-append  port:gettext \
                         port:libconfuse \
-                        path:lib/pkgconfig/libusb-1.0.pc:libusb \
-                        port:python27 \
-                        port:swig-python
+                        path:lib/pkgconfig/libusb-1.0.pc:libusb
 
     boost.depends_type  build
 
@@ -67,12 +67,8 @@ subport             libftdi1 {
                         size    116297
 
     cmake.out_of_source yes
-    configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 \
-                            -DPYTHON_LIBRARY=${frameworks_dir}/Python.framework/Versions/2.7/lib/libpython2.7.dylib \
-                            -DDOCUMENTATION=off \
-                            -DCMAKE_CXX_FLAGS="${configure.cxxflags}" \
-                            -DCMAKE_C_FLAGS="${configure.cflags}" \
-                            -DPYTHON_INCLUDE_DIR=${frameworks_dir}/Python.framework/Versions/2.7/Headers
+    configure.args-append   -DCMAKE_CXX_FLAGS="${configure.cxxflags}" \
+                            -DCMAKE_C_FLAGS="${configure.cflags}"
 
     livecheck.regex     ${subport}-(1(\\.\\d+)+)
 }


### PR DESCRIPTION
Since [libftdi 68d2167bc5ed](http://developer.intra2net.com/git/?p=libftdi;a=commitdiff;h=68d2167bc5ed) (in libftdi 1.5, 2020-07-07), libftdi CMake options with extra dependencies are disabled by default. Since this port doesn’t specify the `PYTHON_BINDINGS` or `LINK_PYTHON_LIBRARY` CMake options, it hasn’t built Python bindings since 9e291172d0a3 (2020-08-03). Since this integration has been missing for 2½ years without any complaint, and since Python 2 is at end-of-life, the integration isn’t restored. Instead, the unused dependencies are removed.

CMake options that had been specified by the Portfile but that are unused or have become libftdi’s own defaults have been removed, including those related to unused Python paths and to documentation.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@nerdling