### PR TITLE
weechat: Fix +python311

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -79,26 +79,36 @@ variant python requires python311 description {Compatibility variant, requires +
 
 variant python37 description "Bindings for Python 3.7 plugins" conflicts python38 python39 python310 python311 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    configure.pkg_config_path-append \
+                            ${frameworks_dir}/Python.framework/Versions/3.7/lib/pkgconfig
     depends_lib-append      port:python37
 }
 
 variant python38 description "Bindings for Python 3.8 plugins" conflicts python37 python39 python310 python311 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    configure.pkg_config_path-append \
+                            ${frameworks_dir}/Python.framework/Versions/3.8/lib/pkgconfig
     depends_lib-append      port:python38
 }
 
 variant python39 description "Bindings for Python 3.9 plugins" conflicts python37 python38 python310 python311 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    configure.pkg_config_path-append \
+                            ${frameworks_dir}/Python.framework/Versions/3.9/lib/pkgconfig
     depends_lib-append      port:python39
 }
 
 variant python310 description "Bindings for Python 3.10 plugins" conflicts python37 python38 python39 python311 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    configure.pkg_config_path-append \
+                            ${frameworks_dir}/Python.framework/Versions/3.10/lib/pkgconfig
     depends_lib-append      port:python310
 }
 
 variant python311 description "Bindings for Python 3.11 plugins" conflicts python37 python38 python39 python310 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    configure.pkg_config_path-append \
+                            ${frameworks_dir}/Python.framework/Versions/3.11/lib/pkgconfig
     depends_lib-append      port:python311
 }
 
@@ -130,19 +140,6 @@ variant ruby32 description "Bindings for Ruby 3.2 plugins" conflicts ruby30 ruby
 
 
 post-patch {
-    # specify Python version for CMake to find and use
-    set patchfile ${worksrcpath}/cmake/FindPython.cmake
-
-    if {[variant_isset python37]} {
-        reinplace -E "s|PYTHON python3|PYTHON python-3.7|g" ${patchfile}
-    } elseif {[variant_isset python38]} {
-        reinplace -E "s|PYTHON python3|PYTHON python-3.8|g" ${patchfile}
-    } elseif {[variant_isset python39]} {
-        reinplace -E "s|PYTHON python3|PYTHON python-3.9|g" ${patchfile}
-    } elseif {[variant_isset python310]} {
-        reinplace -E "s|PYTHON python3|PYTHON python-3.10|g" ${patchfile}
-    }
-
     # specify Ruby version for CMake to find and use
     set patchfile ${worksrcpath}/cmake/FindRuby.cmake
 


### PR DESCRIPTION
#### Description

Append to PKG_CONFIG_PATH instead of patching FindPython.cmake at runtime, because evidently people forget adjusting both the variant definition and the block in post-patch when adding new versions, and this approach does not require source code modification.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2 21G320 arm64
Xcode 14.2 14C18
with `+python311`

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`? (false positives)
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
