### PR TITLE
google-cloud-sdk: update to 415.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             414.0.0
+version             415.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  dae06dea5ce2fe8c2358bc256b1675105b8cf138 \
-                    sha256  3cd7c9ee3bdf933ddcbe8d508cc2c82bc0c1587e759b9ae93b8f4a093d40009f \
-                    size    110923662
+    checksums       rmd160  fdf9cc84190304b7f5d951bc70258cefc0631eba \
+                    sha256  3a62ede9386954b45e571e3295cf5ce8ea2076b4478d4d5ba1726a17a345faa9 \
+                    size    110955394
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  0d32ee362863107aa21c866f42aa92cd80f0927b \
-                    sha256  d6d354c68e19ebf55f55d44d9bafd884ce240684906c20a03e6191dc7ead32e6 \
-                    size    99888894
+    checksums       rmd160  37bee03a30c17e6c28a6150b6e9033f7cdf72c01 \
+                    sha256  f05cc45ffc6c1f3ff73854989f3ea3d6bee40287d23047917e4c845aeb027f98 \
+                    size    131276439
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  9c94ea8f1e1b5d2bb779732bb7795d189356a745 \
-                    sha256  70b268c339bf95948434880d09d4deea855e74b8e591a77692f450092435006a \
-                    size    98297979
+    checksums       rmd160  535e423329a067d398ea17c1d25da4166376c3b4 \
+                    sha256  974ed4f37f8bde2f7a9731eba90b033f7c97d24d835ecc62b58eee87c8f29776 \
+                    size    128117291
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 415.0.0.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?