### PR TITLE
openjdk17-graalvm: update to 22.3.1

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.3.0
+version      22.3.1
 revision     0
 
 description  GraalVM Community Edition based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java17-darwin-amd64-${version}
-    checksums    rmd160  cc867360f8a4ee78f53befd071b1d0127ef56128 \
-                 sha256  422cd6abecfb8b40238460c09c42c5a018cb92fab4165de9691be2e3c3d0e8d1 \
-                 size    260752076
+    checksums    rmd160  f1453dbeff665c53920f492d4e5020ba0e483788 \
+                 sha256  e46b539fdafa4117ff2ea81feaeeab7db411f5dc8d13047f0405ed21c5a68c0a \
+                 size    261026390
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-ce-java17-darwin-aarch64-${version}
-    checksums    rmd160  fa4e6707920d95ae417effff07a846cee96d18a6 \
-                 sha256  dfc0c8998b8d00fcca87ef1c866c6e4985fd20b0beba3021f9677f9b166dfaf8 \
-                 size    258085301
+    checksums    rmd160  2243e23de57909f7cb6f88b51d51e623b4f0ca87 \
+                 sha256  e3307c29e71423038960c38a6f8c0525f7c6f430c494d9c16935335c291c7ce1 \
+                 size    258360745
 }
 
 worksrcdir   graalvm-ce-java17-${version}
@@ -95,15 +95,15 @@ subport ${name}-native-image {
     if {${configure.build_arch} eq "x86_64"} {
         set jar_file native-image-installable-svm-java17-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  8b1647a4e8df1a1c7dcefb8f7b3ed0f0a15d4532 \
-                     sha256  9ce13874e62877d3bbe3faa4a57fbbffc766fdc8191971e7b25de0226fe86598 \
-                     size    30512379
+        checksums    rmd160  a137dae8e574aeed7eca0d548970553c89ea82a0 \
+                     sha256  23e2db58a167307ff5ff4397b7dd82e2f8a587e8631392e2fe0b1d64d97672c3 \
+                     size    30664017
     } elseif {${configure.build_arch} eq "arm64"} {
         set jar_file native-image-installable-svm-java17-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  046566633e75733ebaba341b8ccc4f4bb249cc03 \
-                     sha256  b6e44cb03f560bb43db1fd0aa862af36ba1df6717765920d91c18519712adfe9 \
-                     size    30420657
+        checksums    rmd160  c1fe4d16e586fd7302271c8f2a5f8bd22dd10f81 \
+                     sha256  f69cc832db03db6698b41346bbee0a58ef4a5277971b6f7629d82a8f3ae98726 \
+                     size    30569608
     }
 
     set java_home ${target}/Contents/Home


### PR DESCRIPTION
#### Description

Update to GraalVM 22.3.1.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?