### PR TITLE
openjdk11-graalvm: update to 22.3.1

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.3.0
+version      22.3.1
 revision     0
 
 description  GraalVM Community Edition based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java11-darwin-amd64-${version}
-    checksums    rmd160  c0c8bc78bea75f7b8dec958ede569d1ad0263d37 \
-                 sha256  b8b39d6a3e3a9ed6348c2776ff071fc64ca90f98999ee846e6ca7e5fdc746a8b \
-                 size    254057238
+    checksums    rmd160  2905f35da1e544301215f832b97cd8813b73bfed \
+                 sha256  325afad5f1c4a07a458c95e7c444cff63514a6afa6f2655c12b4f494dccf2228 \
+                 size    254200487
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-ce-java11-darwin-aarch64-${version}
-    checksums    rmd160  0e8e04f543c80044eceac29066522c0d3c5b18f8 \
-                 sha256  c9657e902c2ba674931c3cf233a38c4de3d5186ae5d70452f9df75ac0c4cacff \
-                 size    249005669
+    checksums    rmd160  3421d1754a491b0cfa44d09df798ff5053fcefc8 \
+                 sha256  c59f32289d92671bea46a34f4227fef484a4aa9eeece159e59a486205aaa6c31 \
+                 size    249144742
 }
 
 worksrcdir   graalvm-ce-java11-${version}
@@ -95,15 +95,15 @@ subport ${name}-native-image {
     if {${configure.build_arch} eq "x86_64"} {
         set jar_file native-image-installable-svm-java11-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  a24346538f1be6ae1fcde9b4c050cec01af22828 \
-                     sha256  00fe13c42813f581955eb35370bb8409ba17c7fdc83971d000baf695be2a0cb5 \
-                     size    28340748
+        checksums    rmd160  844176cbaca0f02bc46c326a2b8bdc24c5aff647 \
+                     sha256  2aae087a4a012e86b0db4afb1fe0c8cf25345e35088c8c659d8668d66a4bdc0c \
+                     size    28427632
     } elseif {${configure.build_arch} eq "arm64"} {
         set jar_file native-image-installable-svm-java11-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  00a17b9ea645aadbe57c9785b5fd063bfb2d8d86 \
-                     sha256  dd9f91a970c7270b3f7fe8e711ba1ae081d34ed433c75f2bb0459aaf19e0fbe7 \
-                     size    28417062
+        checksums    rmd160  65a84d8dd894be0830673ffdf7e77a0ca19cf1ac \
+                     sha256  df923df186826dcb7cb0eac0f5e93c3e215584f0377bad0c76310e09d7dc58cd \
+                     size    28504616
     }
 
     set java_home ${target}/Contents/Home


### PR DESCRIPTION
#### Description

Update to GraalVM 22.3.1.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?