### PR TITLE
openjdk19-graalvm: update to 22.3.1

### DIFF
--- a/java/openjdk19-graalvm/Portfile
+++ b/java/openjdk19-graalvm/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.3.0
+version      22.3.1
 revision     0
 
 set openjdk_major 19
@@ -27,14 +27,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java${openjdk_major}-darwin-amd64-${version}
-    checksums    rmd160  0c1a4ea206b5ad10114dba876c98951a1641ced9 \
-                 sha256  f3e5e9637bb3df68f59269bfdc98278cf518361384a06a399d784e0a641ebd2c \
-                 size    268362893
+    checksums    rmd160  50497e34131636e5bc0e854f3293a48d168ddb03 \
+                 sha256  4344cabbc1bd1920a21429198dbf18f6e117230ea451175c14e1c677e52079ac \
+                 size    268459645
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-ce-java${openjdk_major}-darwin-aarch64-${version}
-    checksums    rmd160  f06cdb7f114f035e2063927196965235dc28834f \
-                 sha256  01850d79359cf2cdee72fdf80fa7fe789823fcb4a50fd3d04bdf5b94f5c9fe55 \
-                 size    266075348
+    checksums    rmd160  fc509aa712b265a3fe03be3c6b7e495aa734a769 \
+                 sha256  6c32cde0739c8b239d775465f7cc5fd6961b426dc60e8d9e12943b8acac7c926 \
+                 size    266165894
 }
 
 worksrcdir   graalvm-ce-java${openjdk_major}-${version}
@@ -97,15 +97,15 @@ subport ${name}-native-image {
     if {${configure.build_arch} eq "x86_64"} {
         set jar_file native-image-installable-svm-java${openjdk_major}-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  d3ef22aa045f8bd0756afe60c9a7e0d28cdafba0 \
-                     sha256  3b81d7ef58b46a18ae1f3f3daed0e94555ab4eb3a014cfe037f0b6f6b528ea29 \
-                     size    31174308
+        checksums    rmd160  928f963247dea5a1d1b7b22518e229a0305385eb \
+                     sha256  cbb8877c62e7f406215df63e8298eb6379b9074f14126380b4ec09f3bd7549a0 \
+                     size    31253331
     } elseif {${configure.build_arch} eq "arm64"} {
         set jar_file native-image-installable-svm-java${openjdk_major}-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  4f9221037929d4f03fe260af343fde919295ca90 \
-                     sha256  e0aeddc82ee0667314b69cf5232059c82607e43ae1b6eb0b1c9a5e0b3ea73678 \
-                     size    31297315
+        checksums    rmd160  69c4c2d01c8dfe84afb9c7daed57f125a44f08c7 \
+                     sha256  8b23134442c6eddb04be637e7c60b593f3443591fa70f7ee5465a53f1f6ecd35 \
+                     size    31380555
     }
 
     set java_home ${target}/Contents/Home


### PR DESCRIPTION
#### Description

Update to GraalVM 22.3.1.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?