### PR TITLE
mbusd: new port

### DIFF
--- a/net/mbusd/Portfile
+++ b/net/mbusd/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        3cky mbusd 0.5.1 v
+revision            0
+categories          net
+license             BSD
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+description         Modbus TCP to Modbus RTU (RS-232/485) gateway
+long_description    {*}${description}
+
+checksums           rmd160  4d72656f0c1cd41f0bcec407dafb55123544fae7 \
+                    sha256  c1e21b246e542df505f7a4f95d1921d11c4414aac6c60950739fd20558d5b134 \
+                    size    43630
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
#### Description
**[mbusd](https://github.com/3cky/mbusd)** is open-source [Modbus TCP to Modbus RTU (RS-232/485)](https://en.wikipedia.org/wiki/Modbus) gateway.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
