### PR TITLE
avrdude, ipbt: set c_standard 2011 instead of blacklisting old compilers

### DIFF
--- a/cross/avrdude/Portfile
+++ b/cross/avrdude/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 name                avrdude
 version             7.0
@@ -37,8 +36,7 @@ patchfiles          dynamic_lookup-11.patch \
 configure.args      --disable-parport
 
 # https://trac.macports.org/ticket/66722
-compiler.blacklist-append \
-                    *gcc-4.* {clang < 400}
+compiler.c_standard 2011
 
 variant docs description {Installs documentation in PDF, HTML and Info formats. Involves the installation of a TexLive dependency chain, which can dramatically slow down the installation of the AVRDUDE port.} {
     depends_build-append \

--- a/sysutils/ipbt/Portfile
+++ b/sysutils/ipbt/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem 1.0
 PortGroup           cmake 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.1
 
 # clock_gettime: not strictly required, but the build checks for it.
@@ -39,7 +38,7 @@ depends_lib         port:ncurses
 cmake.build_type    Debug
 
 # https://trac.macports.org/ticket/66737
-compiler.blacklist-append *gcc-4.* {clang < 400}
+compiler.c_standard 2011
 
 # This software requires NDEBUG to not be set
 variant debug description {Use debug, required here} {}


### PR DESCRIPTION
#### Description

Following advice of @jmroot 
See:
https://github.com/macports/macports-ports/pull/17420/files#r1083499542
https://github.com/macports/macports-ports/pull/17397/files#r1083790805

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
