### PR TITLE
dnscontrol: update to 3.25.0

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/StackExchange/dnscontrol 3.23.0 v
+go.setup            github.com/StackExchange/dnscontrol 3.25.0 v
 
-checksums           rmd160  97d954b7b4f4b9cd95ca75bfd391e3c73dfff184 \
-                    sha256  f2af2b7cd5d8a75d92bbad0bc403706b91f01f7d8bdf8d96c4ed29954c22cf42 \
-                    size    4968765
+checksums           rmd160  16d5aff35ca295f874265a22c96510cb32858211 \
+                    sha256  ddcf08942e1ffb15a2fb9c711344f49aca923727c8673b14957ea36f4e7f2670 \
+                    size    6380479
 
 homepage            https://stackexchange.github.io/dnscontrol/
 description         Synchronize your DNS to multiple providers from a simple DSL


### PR DESCRIPTION
#### Description
dnscontrol: update to 3.25.0
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?