### PR TITLE
openjdk11-temurin: update to 11.0.18

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.17
-set build    8
+version      11.0.18
+set build    10
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  7734e533a4a79f324ef94c03ff860725de59a658 \
-                 sha256  f408a12f10d93b3205bef851af62707531b699963cef79408d59197d08763c94 \
-                 size    186594836
+    checksums    rmd160  637b246bebddefe76ef71cda8982ccc694d6b786 \
+                 sha256  75d79315d7265cc4b89fd9e844161ff90798bc6482ace8c1ac75f862a5b3b565 \
+                 size    187254949
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  9e3f8874eb2027b4b32db526a7f37ff039cc725c \
-                 sha256  79b18cbd398b67a52ebaf033dfca15c7af4c1a84ec5fa68a88f3bf742bb082f7 \
-                 size    185315542
+    checksums    rmd160  3889af586b13549d678996ed068d7c00c603d17a \
+                 sha256  5c5e9ac08de335d7ed2d6518d3a9cad900874d1e1d572a4046ac64071e239cc7 \
+                 size    185368596
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.18.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?