### PR TITLE
openjdk19-temurin: update to 19.0.2

### DIFF
--- a/java/openjdk19-temurin/Portfile
+++ b/java/openjdk19-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=19
 supported_archs  x86_64 arm64
 
-version      19.0.1
-set build    10
+version      19.0.2
+set build    7
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 19
@@ -26,14 +26,14 @@ master_sites https://github.com/adoptium/temurin19-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK19U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  93436c3f2a3bc3aa7a05889d0c11ac6e1f6142d3 \
-                 sha256  0d80a8787fa97f5fc2f0000a849b54f4d41c5b87726c29ea1de215e382c8380c \
-                 size    195454218
+    checksums    rmd160  d099a6662e0631a5f290d663bfed44abb8efe62c \
+                 sha256  f59d4157b3b53a35e72db283659d47f14aecae0ff5936d5f8078000504299da6 \
+                 size    195407051
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK19U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  74085ee63ccf4c564a73cb52c418b6aa1412541e \
-                 sha256  2be4ffbf7c59b3148886b48ecf3f7d7edb7c745917ceae2a6be145a4678bf014 \
-                 size    185292307
+    checksums    rmd160  71bb0be73dd3238a3ee76e607dec99477e9d0ab8 \
+                 sha256  c419330cc8d6b9974d3bf1937f8f0e747c34c469afd5c546831d35aa19e03d49 \
+                 size    185296974
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 19.0.2.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?