### PR TITLE
openjdk17-microsoft: update to 17.0.6

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.5
-set build    8
+version      17.0.6
+set build    10
 revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  1a7b656ac5638063897b218e9ee455c38e101868 \
-                 sha256  45548b3788eb6f4e912412a0a2805f42ccee7ca1c67c4f7ae09887c0e16c50c1 \
-                 size    187548732
+    checksums    rmd160  261645167231eb218701bff3d1737739fb04e89b \
+                 sha256  8dce6849b8bab15c636ae9071e3a7d6cb4951df210c6119233d9c2bd4b6edf16 \
+                 size    187604848
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  fd3e2effa227b1307c9b4ddede5de26b868675f6 \
-                 sha256  d14e4af5c175efdde2b71678a0cb012be5fceb8ae12db15273fd331b5e64073a \
-                 size    177713686
+    checksums    rmd160  6fd388010bddd3026e6fad9cdf7a8ceb15d72f1d \
+                 sha256  fcf089eb05cfe5684ed4b33edfb55696f5573c3508d4b2ecf745846e5fc78a9e \
+                 size    177759316
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.6.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?