### PR TITLE
openjdk11-microsoft: update to 11.0.18

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.17
-set build    8
+version      11.0.18
+set build    10
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  797417ed510a8f91abfc6d0cb1c91ce6fe92994d \
-                 sha256  a73c26cf725d8b9b30847b4c7a7866d1277fe9609fef4b680c45151d6cbf04d1 \
-                 size    187377007
+    checksums    rmd160  86963ff53f3ba89ca52825194b123455d351ed81 \
+                 sha256  176278a8aa13bdd328924df0526c7dc70a72c8a381d4a541131c58f76f9182ee \
+                 size    187433767
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  9bff64e9eb638ea002cb582b41f6d4a006d72d3d \
-                 sha256  c3cfc900c2c186130bb598393f1fbb8f5f17613251a6ed3dec0e2281ee179d6e \
-                 size    184949284
+    checksums    rmd160  947cc17d48d85b68678a4d78fd6f6f2834dbcf2b \
+                 sha256  14078e04becfcd856bd3707a477a84d61418f71f28afde0a55cabaf6de06a518 \
+                 size    185016321
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.18.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?