### PR TITLE
snac: update to version 2.19

### DIFF
--- a/net/snac/Portfile
+++ b/net/snac/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           legacysupport 1.1
+PortGroup           makefile 1.0
 
 name                snac
-version             2.18
+version             2.19
 revision            0
 distname            ${version}
 categories          net
@@ -14,22 +15,24 @@ description         A simple, minimalistic ActivityPub instance
 long_description    snac2 Social Networks Are Crap \
                     implemented in C (the original snac was Python). \
                     From the README.md: \
-                    Simple but effective web interface. \
-                    Easily-accessed MUTE button to silence morons. \
-                    Tested interoperability with related software. \
-                    No database needed. \
-                    Totally JavaScript-free. \
-                    No cookies either. \
-                    Not much bullshit.
+                    Lightweight, minimal dependencies \
+                    Extensive support of ActivityPub operations, e.g. write public notes, follow users, be followed, reply to the notes of others, admire wonderful content (like or boost), write private messages... \
+                    Simple but effective web interface \
+                    Multiuser \
+                    Easily-accessed MUTE button to silence morons \
+                    Tested interoperability with related software \
+                    No database needed \
+                    Totally JavaScript-free \
+                    No cookies either \
+                    Not much bullshit
  
 homepage            https://codeberg.org/grunfink/snac2/
 master_sites        ${homepage}archive/
-checksums           rmd160 fc3f76b557b640a669b269a7acfa7e07609574c1 \
-                    sha256 086fd229242dd766f1853d1a6996f81549f116a4a355e86dda3781d36839e7d0 \
-                    size 78216
+checksums           rmd160 185d8046c06a85e4a297d8e71f5c4fa356af1777 \
+                    sha256 6ae58f862835f8f75750b3f537471585b09e84a5f2f6c3ca17ac83ac8d1de1da \
+                    size 79163
 depends_lib         path:lib/libssl.dylib:openssl \
                     port:curl
-use_configure       no
 use_parallel_build  no
 patchfiles          Makefile.patch
 post-patch          {reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/Makefile}


### PR DESCRIPTION
 * added makefile PortGroup per https://trac.macports.org/ticket/66751
 * remove use_configure no
 * updated long_description

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
