### PR TITLE
audiowmark: avoid Xcode Clang

### DIFF
--- a/audio/audiowmark/Portfile
+++ b/audio/audiowmark/Portfile
@@ -42,9 +42,10 @@ depends_lib         port:fftw-3-single \
 
 compiler.cxx_standard \
                     2014
-# Random generator is incompatible with LLVM 15
+# Random generator is incompatible with LLVM 15;
+# also do not use Xcode Clang due to failing buildbots
 # https://github.com/swesterfeld/audiowmark/issues/29
-compiler.blacklist {macports-clang-15}
+compiler.blacklist  {clang} macports-clang-15
 
 variant ffmpeg description {Build with HTTP Live Streaming support} {
      depends_lib-append path:lib/libavcodec.dylib:ffmpeg


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
