### PR TITLE
sqlitestudio: new Portfile

### DIFF
--- a/databases/sqlitestudio/Portfile
+++ b/databases/sqlitestudio/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake  1.1
+
+compiler.cxx_standard           2011
+compiler.thread_local_storage   yes
+
+github.setup            pawelsalawa sqlitestudio 3.4.3
+revision                0
+
+license                 GPL-3
+categories              databases
+platforms               darwin
+maintainers             @Zweihorn openmaintainer
+description             A free, open source, multi-platform SQLite database manager written in C++, with use of Qt framework.
+long_description        ${description} \
+                        \nFind at <https://github.com/pawelsalawa/sqlitestudio/wiki> the SQLiteStudio wiki.
+
+homepage                https://sqlitestudio.pl/
+
+depends_build           port:qt5-qtcreator \
+                        port:qt5-qtdeclarative \
+                        port:qt5-qttools \
+                        port:qt5-qtsvg \
+                        port:tcl \
+                        port:python310
+
+depends_lib             path:lib/libssl.dylib:openssl \
+                        port:readline
+
+checksums               rmd160  93ec72b668af2a96e7022dd2202e8d2264a82593 \
+                        sha256  cfb033ec42552d61cb866532c04c836d9353815b0e7fa668cb283f15b64143d5 \
+                        size    16115661
+
+use_configure           no
+
+build.cmd               ${workpath}/${github.project}-${github.version}/scripts/macosx/compile_build_bundle.sh
+build.target            ${prefix}/libexec/qt5/bin/qmake
+build.args              ${build.jobs}


### PR DESCRIPTION
This PR is a DRAFT and WIP

* add checksums for sqlitestudio 3.4.3
* add depends_build
* use_configure  no
* build using the shell script from upstream
* amends and corrections

#### Description

**SQLiteStudio** is desktop application for browsing and editing SQLite database files.  It is aimed for people, who know what SQLite is, or what relational databases are in general.

Homepage: <https://sqlitestudio.pl/>

Before targeting MacPorts, preliminary work was done with compiling and  testing on Debian 11.6 Bullseye at:
- https://github.com/pawelsalawa/sqlitestudio/issues/4644

This FOSS project was mentioned in the [Minetest (MT) forum](https://forum.minetest.net/viewtopic.php?p=420279#p420279) during my first work on the 'minetest' port.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.7.2 20G1020 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
