### PR TITLE
gperftools: enable tests; fix for Rosetta

### DIFF
--- a/devel/gperftools/Portfile
+++ b/devel/gperftools/Portfile
@@ -17,5 +17,10 @@ checksums           rmd160  54e35f78813b5409bc6f82e0894b0b8e42ad711a \
                     sha256  83e3bfdd28b8bcf53222c3798d4d395d52dadbbae59e8730c4a6d31a9c3732d8 \
                     size    1616679
 
+patchfiles          patch-rosetta.diff
+
 compiler.cxx_standard \
                     2011
+
+test.run            yes
+test.target         check

--- a/devel/gperftools/files/patch-rosetta.diff
+++ b/devel/gperftools/files/patch-rosetta.diff
@@ -1,0 +1,15 @@
+--- src/libc_override_osx.h.orig	2021-12-13 14:28:06.000000000 +0800
++++ src/libc_override_osx.h	2023-01-19 20:14:36.000000000 +0800
+@@ -276,9 +276,11 @@
+     MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
+   // Switch to version 6 on OSX 10.6 to support memalign.
+   tcmalloc_zone.version = 6;
+-  tcmalloc_zone.free_definite_size = &mz_free_definite_size;
+   tcmalloc_zone.memalign = &mz_memalign;
++#ifndef __POWERPC__
++  tcmalloc_zone.free_definite_size = &mz_free_definite_size;
+   tcmalloc_introspection.zone_locked = &mi_zone_locked;
++#endif
+ 
+   // Request the default purgable zone to force its creation. The
+   // current default zone is registered with the purgable zone for


### PR DESCRIPTION
#### Description

Enable tests, they work.
Add a small fix for Rosetta.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
