### PR TITLE
mvnd: update to 0.9.0

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem      1.0
 
-version         0.8.2
+version         0.9.0
 revision        0
 name            mvnd
 categories      java
@@ -32,21 +32,20 @@ long_description mvnd aims at providing faster Maven builds using techniques kno
 homepage        https://github.com/apache/maven-mvnd
 supported_archs x86_64 arm64
 
-master_sites    https://downloads.apache.org/maven/mvnd/${version}/
+master_sites    https://github.com/apache/maven-mvnd/releases/download/${version}/
 
-use_zip         yes
 use_configure   no
 
 if {${configure.build_arch} eq "x86_64"} {
     distname        maven-mvnd-${version}-darwin-amd64
-    checksums       rmd160  673495348a736fde0d4ca56ca7c0421c4105d575 \
-                    sha256  87b430637038e0700af3e1a22bc4a05594d18e5e3624f1700de7f5e8fd629ce6 \
-                    size    20890053
+    checksums       rmd160  55c61ba1091fdba6ada6f5bf31eb694e862ea964 \
+                    sha256  b94fb24d92cd971b6368df14f44bf77b5614a422dfe9f6f115b32b11860c1d6b \
+                    size    19693811
 } elseif {${configure.build_arch} eq "arm64"} {
     distname        maven-mvnd-${version}-darwin-aarch64
-    checksums       rmd160  61b905860b20583fb4c2a7078be54f06cafec388 \
-                    sha256  48c0bcb1f44ed416c7c42bec6d19c8df2ef8af539a67b5b3f40f8d1e030b8c07 \
-                    size    21072232
+    checksums       rmd160  765eceeacc278517900fe0b5f0907ce783528b95 \
+                    sha256  bca67a44cc3716a7da46926acff41b3864d62e5da6982b9e998eca42d2f9bfac \
+                    size    19882709
 }
 
 build {}


### PR DESCRIPTION
#### Description

Update to Maven Daemon 0.9.0.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?