### PR TITLE
asciidoctor: Revert to last fully working version of Ruby (3.0)

### DIFF
--- a/textproc/asciidoctor/Portfile
+++ b/textproc/asciidoctor/Portfile
@@ -3,9 +3,11 @@
 PortSystem          1.0
 PortGroup           ruby 1.0
 
-ruby.setup          asciidoctor 2.0.18 gem {} rubygems ruby31
+# The version of Ruby chosen here works across all OS versions and CPU
+# architectures.  Don't change it without preserving this property.
+ruby.setup          asciidoctor 2.0.18 gem {} rubygems ruby30
 name                asciidoctor
-revision            1
+revision            2
 
 # Prevent addition of the ruby interpreter version number as suffix to command line tools
 ruby.link_binaries_suffix
@@ -15,7 +17,7 @@ platforms           {darwin any}
 supported_archs     noarch
 
 license             MIT
-maintainers         nomaintainer
+maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A fast text processor & publishing toolchain for \
                     converting AsciiDoc to HTML5, DocBook & more
 long_description    Asciidoctor is a fast, open source, Ruby-based \


### PR DESCRIPTION
Ruby 3.1 doesn't currently build for 10.4-10.5 x86, or 10.8-10.9, and fixing that doesn't appear to be a simple matter of applying the same fixes as for 2.7 and 3.0.  Ruby 3.0 now builds for all OS versions and CPU architectures, making it a more compatible choice, particularly given that asciidoctor isn't fussy about the Ruby version.

Also adds myself as a maintainer, mainly to keep dependency changes from slipping through in the future.

Closes: https://trac.macports.org/ticket/66409

TESTED:
Built gpsd and ntpsec docs on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-10.15 x86_64, and 11.x-13.x arm64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e
macOS 11.7.2 20G1020, arm64, Xcode 13.2.1 13C100
macOS 12.6.2 21G320, arm64, Xcode 14.2 14C18
macOS 13.1 22C65, arm64, Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [N/A] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
