### PR TITLE
fricas: revbump because of sbcl version change

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -7,7 +7,7 @@ name            sbcl
 # Note to maintainers:
 #
 # Please bump the revision of math/maxima (and when it exists
-# math/maxima-devel) when this port changes.
+# math/maxima-devel) and fricas when this port changes.
 version         2.3.1
 revision        0
 

--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fricas
 version             1.3.8
-revision            5
+revision            6
 categories          math
 maintainers         {@pietvo vanoostrum.org:pieter} openmaintainer
 platforms           darwin


### PR DESCRIPTION
#### Description

Every sbcl version change should also revbump fricas. This isn't reflected in the comments on sbcl. I added that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.2 22D49 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
