### PR TITLE
terragrunt: update to 0.43.0

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -15,7 +15,16 @@ maintainers         {mjrc.nl:macports @mjrc} openmaintainer
 
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
-set latestVersion       terragrunt-0.42
+set latestVersion       terragrunt-0.43
+
+subport terragrunt-0.43 {
+    set dependsOn       1.2
+    set patchNumber     0
+
+    checksums           rmd160 0a90fd170e5328f3ac734a04f35aa6ebb4e81d8a \
+                        sha256 051c912d7d4284485754676f3ecbe57b3bd5d22cfbe5af8713b07698fc4c4fec \
+                        size   2316601
+}
 
 subport terragrunt-0.42 {
     set dependsOn       1.2


### PR DESCRIPTION
#### Description
terragrunt: update to 0.43.0
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?