### PR TITLE
eccodes: update to 2.28.0

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -5,7 +5,7 @@ PortGroup cmake     1.1
 PortGroup compilers 1.0
 
 name                ecCodes
-version             2.27.1
+version             2.28.0
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
@@ -18,9 +18,9 @@ homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
 
-checksums           rmd160  59bbe06a8eca97a4011c9c7cafec5ed972fd768b \
-                    sha256  70405a4540a7394c9edc85a55abbe6fe214678d71acd2543487eebebc9e16bac \
-                    size    12402451
+checksums           rmd160  3fe7c6aed1d0a1ecaff9bde94912e244703437ba \
+                    sha256  2831347b1517af9ebd70dd3cad88ae818a8448d4e6c8671aa728617e73431cd5 \
+                    size    12044211
 
 long_description \
     ecCodes is a package developed by ECMWF which provides an application programming interface and \
@@ -82,7 +82,7 @@ if {[fortran_variant_isset]} {
                             -DENABLE_FORTRAN=ON
 }
 
-variant python27 description {deprecated variant} {
+variant python27 description {Deprecated variant to be removed Q1 2023} {
 }
 
 variant openmp description {Add support for OpenMP} {


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.28.0.
Also indicated target for removal of Python 2 support (Q1 2023).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

No tests are supported in the Portfile since it requires an additional download while testing.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
